### PR TITLE
feat(insights): add eap to http landing page

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -5,6 +5,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useWrappedDiscoverQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {useEapOptions} from 'sentry/views/insights/common/views/spans/selectors/eapSelector';
 import type {
   EAPSpanProperty,
   EAPSpanResponse,
@@ -15,7 +16,7 @@ import type {
   SpanMetricsProperty,
   SpanMetricsResponse,
 } from 'sentry/views/insights/types';
-
+// We can probably rename this to `UseDiscoverOptions` to be more accurate
 interface UseMetricsOptions<Fields> {
   cursor?: string;
   enabled?: boolean;
@@ -25,6 +26,10 @@ interface UseMetricsOptions<Fields> {
   pageFilters?: PageFilters;
   search?: MutableSearch | string; // TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
   sorts?: Sort[];
+  /**
+   * Whether or not to use RPCs instead of SnQL requests in the backend.
+   */
+  useRpc?: boolean;
 }
 
 export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
@@ -76,6 +81,8 @@ const useDiscover = <T extends Extract<keyof ResponseType, string>[], ResponseTy
   dataset: DiscoverDatasets,
   referrer: string
 ) => {
+  const {useRpc: useRpcFromQueryParam} = useEapOptions();
+
   const {
     fields = [],
     search = undefined,
@@ -84,6 +91,7 @@ const useDiscover = <T extends Extract<keyof ResponseType, string>[], ResponseTy
     cursor,
     pageFilters: pageFiltersFromOptions,
     noPagination,
+    useRpc,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -104,6 +112,7 @@ const useDiscover = <T extends Extract<keyof ResponseType, string>[], ResponseTy
     referrer,
     cursor,
     noPagination,
+    useRpc: useRpc ?? useRpcFromQueryParam,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -6,7 +6,9 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSeriesEventView} from 'sentry/views/insights/common/queries/getSeriesEventView';
 import {useWrappedDiscoverTimeseriesQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {useEapOptions} from 'sentry/views/insights/common/views/spans/selectors/eapSelector';
 import type {
+  EAPSpanProperty,
   MetricsProperty,
   SpanFunctions,
   SpanIndexedField,
@@ -41,6 +43,13 @@ export const useMetricsSeries = <Fields extends MetricsProperty[]>(
   return useDiscoverSeries<Fields>(options, DiscoverDatasets.METRICS, referrer);
 };
 
+export const useEapSeries = <Fields extends EAPSpanProperty[]>(
+  options: UseMetricsSeriesOptions<Fields> = {},
+  referrer: string
+) => {
+  return useDiscoverSeries<Fields>(options, DiscoverDatasets.SPANS_EAP, referrer);
+};
+
 /**
  * TODO: Remove string type, added to fix types for 'count()'
  */
@@ -63,6 +72,7 @@ const useDiscoverSeries = <T extends string[]>(
   dataset: DiscoverDatasets,
   referrer: string
 ) => {
+  const {useRpc} = useEapOptions();
   const {search = undefined, yAxis = [], interval = undefined} = options;
 
   const pageFilters = usePageFilters();
@@ -86,6 +96,7 @@ const useDiscoverSeries = <T extends string[]>(
     referrer,
     enabled: options.enabled,
     overriddenRoute: options.overriddenRoute,
+    useRpc: useRpc,
   });
 
   const parsedData = keyBy(

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -70,6 +70,7 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
   referrer,
   cursor,
   overriddenRoute,
+  useRpc,
 }: {
   eventView: EventView;
   cursor?: string;
@@ -77,10 +78,17 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
   initialData?: any;
   overriddenRoute?: string;
   referrer?: string;
+  useRpc?: boolean;
 }) {
   const location = useLocation();
   const organization = useOrganization();
   const {isReady: pageFiltersReady} = usePageFilters();
+
+  const queryExtras: Record<string, string> = {};
+
+  if (useRpc) {
+    queryExtras.useRPC = '1';
+  }
   const result = useGenericDiscoverQuery<
     {
       data: any[];
@@ -90,6 +98,7 @@ export function useWrappedDiscoverTimeseriesQuery<T>({
   >({
     route: overriddenRoute ?? 'events-stats',
     eventView,
+    queryExtras,
     location,
     orgSlug: organization.slug,
     getRequestPayload: () => ({
@@ -138,6 +147,7 @@ export function useWrappedDiscoverQuery<T>({
   cursor,
   noPagination,
   allowAggregateConditions,
+  useRpc,
 }: {
   eventView: EventView;
   allowAggregateConditions?: boolean;
@@ -147,6 +157,7 @@ export function useWrappedDiscoverQuery<T>({
   limit?: number;
   noPagination?: boolean;
   referrer?: string;
+  useRpc?: boolean;
 }) {
   const location = useLocation();
   const organization = useOrganization();
@@ -156,6 +167,10 @@ export function useWrappedDiscoverQuery<T>({
 
   if (allowAggregateConditions !== undefined) {
     queryExtras.allowAggregateConditions = allowAggregateConditions ? '1' : '0';
+  }
+
+  if (useRpc) {
+    queryExtras.useRPC = '1';
   }
 
   const result = useDiscoverQuery({

--- a/static/app/views/insights/common/views/spans/selectors/eapSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/eapSelector.tsx
@@ -1,0 +1,88 @@
+import {
+  CompactSelect,
+  type SelectOption,
+  type SelectProps,
+} from 'sentry/components/compactSelect';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type EapOption = 'useEap' | 'noEap' | 'useEapRpc';
+
+/**
+ * This selector allows us to with and without EAP enabled
+ * @returns
+ */
+export function EapSelector() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const {features} = useOrganization();
+  const {useEap, useRpc} = useEapOptions();
+  const hasEAPFeature = features.includes('insights-use-eap');
+
+  type Options = SelectProps<EapOption>['options'];
+
+  const options: Options = [
+    {
+      value: 'noEap',
+      label: "Don't use EAP",
+    },
+    {
+      value: 'useEap',
+      label: 'Use EAP',
+    },
+    {
+      value: 'useEapRpc',
+      label: 'Use RPC EAP',
+    },
+  ];
+
+  let value: EapOption = 'useEap';
+  if (!useEap) {
+    value = 'noEap';
+  } else if (useRpc) {
+    value = 'useEapRpc';
+  }
+
+  if (hasEAPFeature) {
+    return (
+      <CompactSelect
+        options={options}
+        value={value}
+        onChange={(selectedOption: SelectOption<EapOption>) =>
+          navigate({
+            ...location,
+            query: {
+              ...location.query,
+              eap_option: selectedOption.value,
+            },
+          })
+        }
+      />
+    );
+  }
+
+  return undefined;
+}
+
+export function useEapOptions(): {useEap: boolean; useRpc: boolean} {
+  const location = useLocation();
+  const {features} = useOrganization();
+  const hasEAPFeature = features.includes('insights-use-eap');
+
+  if (!hasEAPFeature) {
+    return {useEap: false, useRpc: false};
+  }
+
+  const eapOption = location.query.eap_option as EapOption;
+  switch (eapOption) {
+    case 'noEap':
+      return {useEap: false, useRpc: false};
+    case 'useEap':
+      return {useEap: true, useRpc: false};
+    case 'useEapRpc':
+      return {useEap: true, useRpc: true};
+    default:
+      return {useEap: true, useRpc: false};
+  }
+}

--- a/static/app/views/insights/common/views/spans/selectors/eapSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/eapSelector.tsx
@@ -18,7 +18,7 @@ export function EapSelector() {
   const location = useLocation();
   const {features} = useOrganization();
   const {useEap, useRpc} = useEapOptions();
-  const hasEAPFeature = features.includes('insights-use-eap');
+  const hasEAPFeature = features.includes('insights-use-eap-wip');
 
   type Options = SelectProps<EapOption>['options'];
 
@@ -68,7 +68,7 @@ export function EapSelector() {
 export function useEapOptions(): {useEap: boolean; useRpc: boolean} {
   const location = useLocation();
   const {features} = useOrganization();
-  const hasEAPFeature = features.includes('insights-use-eap');
+  const hasEAPFeature = features.includes('insights-use-eap-wip');
 
   if (!hasEAPFeature) {
     return {useEap: false, useRpc: false};

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -165,7 +165,7 @@ export function HTTPLandingPage() {
         'http_response_rate(3)',
         'http_response_rate(4)',
         'http_response_rate(5)',
-      ] as any, // TODO - change this
+      ] as any, // TODO - This casting is temporary until we have these functions available
       enabled: useEap,
     },
     Referrer.LANDING_RESPONSE_CODE_CHART

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -113,18 +113,20 @@ export function HTTPLandingPage() {
     });
   };
 
-  const eapThroughputDataResponse = useEapSeries(
-    {
-      search: MutableSearch.fromQueryObject(chartFilters),
-      yAxis: ['spm()'],
-    },
-    Referrer.LANDING_THROUGHPUT_CHART
-  );
-
   const throughtputDataResponse = useSpanMetricsSeries(
     {
       search: MutableSearch.fromQueryObject(chartFilters),
       yAxis: ['spm()'],
+      enabled: !useEap,
+    },
+    Referrer.LANDING_THROUGHPUT_CHART
+  );
+
+  const eapThroughputDataResponse = useEapSeries(
+    {
+      search: MutableSearch.fromQueryObject(chartFilters),
+      yAxis: ['spm()'],
+      enabled: useEap,
     },
     Referrer.LANDING_THROUGHPUT_CHART
   );
@@ -133,6 +135,7 @@ export function HTTPLandingPage() {
     {
       search: MutableSearch.fromQueryObject(chartFilters),
       yAxis: [`avg(span.self_time)`],
+      enabled: !useEap,
     },
     Referrer.LANDING_DURATION_CHART
   );
@@ -141,6 +144,7 @@ export function HTTPLandingPage() {
     {
       search: MutableSearch.fromQueryObject(chartFilters),
       yAxis: [`avg(span.self_time)`],
+      enabled: useEap,
     },
     Referrer.LANDING_DURATION_CHART
   );
@@ -149,6 +153,7 @@ export function HTTPLandingPage() {
     {
       search: MutableSearch.fromQueryObject(chartFilters),
       yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
+      enabled: !useEap,
     },
     Referrer.LANDING_RESPONSE_CODE_CHART
   );
@@ -161,6 +166,7 @@ export function HTTPLandingPage() {
         'http_response_rate(4)',
         'http_response_rate(5)',
       ] as any, // TODO - change this
+      enabled: useEap,
     },
     Referrer.LANDING_RESPONSE_CODE_CHART
   );


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/81750

This PR adds the following to the http landing page
1. Adds a selector to the top right that allows u to query for Non-eap, eap + snuba or eap + rpc (This selector is purely for dev/testing purposes and under a flag)
2. Adds a associated hook to the previous selector to get the value
3. Collect the currently available data from eap for all charts/tables. 

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/4d698466-a469-4750-b1e8-220c3dc30f7e">
