### PR TITLE
feat(issue-details): Add editing for comments in streamlined experience

### DIFF
--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -14,6 +14,7 @@ type InputProps = React.ComponentProps<typeof NoteInput>;
 type Props = {
   itemKey: string;
   storageKey: string;
+  onCancel?: () => void;
   onLoad?: (data: string) => string;
   onSave?: (data: string) => string;
   source?: string;
@@ -145,6 +146,7 @@ function NoteInputWithStorage({
         placeholder={props.placeholder}
         noteId={props.noteId}
         onUpdate={props.onUpdate}
+        onCancel={props.onCancel}
       />
     );
   }

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -163,6 +163,13 @@ describe('StreamlinedActivitySection', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
 
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(await screen.findByText('Group Test')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
+
     await userEvent.type(screen.getByRole('textbox', {name: 'Edit comment'}), ' Updated');
     await userEvent.click(screen.getByRole('button', {name: 'Save comment'}));
 

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -9,6 +9,7 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
+import * as indicators from 'sentry/actionCreators/indicator';
 import ConfigStore from 'sentry/stores/configStore';
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -128,6 +129,45 @@ describe('StreamlinedActivitySection', function () {
     expect(deleteMock).toHaveBeenCalledTimes(1);
 
     expect(screen.queryByText('Test Note')).not.toBeInTheDocument();
+  });
+
+  it('renders note and allows for edit', async function () {
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    const editGroup = GroupFixture({
+      id: '1123',
+      activity: [
+        {
+          type: GroupActivityType.NOTE,
+          id: 'note-1',
+          data: {text: 'Group Test'},
+          dateCreated: '2020-01-01T00:00:00',
+          user: user,
+          project,
+        },
+      ],
+      project,
+    });
+    const editMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1123/comments/note-1/',
+      method: 'PUT',
+      body: {
+        id: 'note-1',
+        data: {text: 'Group Test Updated'},
+      },
+    });
+
+    render(<StreamlinedActivitySection group={editGroup} />);
+    expect(await screen.findByText('Group Test')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Edit comment'}), ' Updated');
+    await userEvent.click(screen.getByRole('button', {name: 'Submit comment'}));
+
+    expect(editMock).toHaveBeenCalledTimes(1);
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Comment updated');
   });
 
   it('renders note but does not allow for deletion if written by someone else', async function () {

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -163,7 +163,10 @@ describe('StreamlinedActivitySection', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
 
+    await userEvent.type(screen.getByRole('textbox', {name: 'Edit comment'}), ' Updated');
     await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(editMock).not.toHaveBeenCalled();
 
     expect(await screen.findByText('Group Test')).toBeInTheDocument();
 

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -164,7 +164,7 @@ describe('StreamlinedActivitySection', function () {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
 
     await userEvent.type(screen.getByRole('textbox', {name: 'Edit comment'}), ' Updated');
-    await userEvent.click(screen.getByRole('button', {name: 'Submit comment'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Save comment'}));
 
     expect(editMock).toHaveBeenCalledTimes(1);
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Comment updated');

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -72,8 +72,8 @@ function TimelineItem({
           {item.type === GroupActivityType.NOTE && !editing && (
             <TitleDropdown
               onDelete={() => handleDelete(item)}
-              user={item.user}
               onEdit={() => setEditing(true)}
+              user={item.user}
             />
           )}
         </Flex>
@@ -100,6 +100,7 @@ function TimelineItem({
             handleUpdate(item, n);
             setEditing(false);
           }}
+          onCancel={() => setEditing(false)}
         />
       ) : typeof message === 'string' ? (
         <NoteWrapper>

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -16,7 +16,7 @@ import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
 import type {NoteType} from 'sentry/types/alerts';
-import type {Group, GroupActivity} from 'sentry/types/group';
+import type {Group, GroupActivity, GroupActivityNote} from 'sentry/types/group';
 import {GroupActivityType} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
@@ -36,15 +36,18 @@ import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRou
 function TimelineItem({
   item,
   handleDelete,
+  handleUpdate,
   group,
   teams,
 }: {
   group: Group;
   handleDelete: (item: GroupActivity) => void;
+  handleUpdate: (item: GroupActivity, n: NoteType) => void;
   item: GroupActivity;
   teams: Team[];
 }) {
   const organization = useOrganization();
+  const [editing, setEditing] = useState(false);
   const authorName = item.user ? item.user.name : 'Sentry';
   const {title, message} = getGroupActivityItem(
     item,
@@ -66,8 +69,12 @@ function TimelineItem({
           <TitleTooltip title={title} showOnlyOnOverflow>
             {title}
           </TitleTooltip>
-          {item.type === GroupActivityType.NOTE && (
-            <TitleDropdown onDelete={() => handleDelete(item)} user={item.user} />
+          {item.type === GroupActivityType.NOTE && !editing && (
+            <TitleDropdown
+              onDelete={() => handleDelete(item)}
+              user={item.user}
+              onEdit={() => setEditing(true)}
+            />
           )}
         </Flex>
       }
@@ -82,7 +89,19 @@ function TimelineItem({
         )
       }
     >
-      {typeof message === 'string' ? (
+      {item.type === GroupActivityType.NOTE && editing ? (
+        <NoteInputWithStorage
+          itemKey={item.id}
+          storageKey={`groupinput:${item.id}`}
+          source="issue-details"
+          text={item.data.text}
+          noteId={item.id}
+          onUpdate={n => {
+            handleUpdate(item, n);
+            setEditing(false);
+          }}
+        />
+      ) : typeof message === 'string' ? (
         <NoteWrapper>
           <NoteBody text={message} />
         </NoteWrapper>
@@ -155,6 +174,26 @@ export default function StreamlinedActivitySection({
     [group.activity, mutators, group.id, organization]
   );
 
+  const handleUpdate = useCallback(
+    (item: GroupActivity, n: NoteType) => {
+      mutators.handleUpdate(n, item.id, group.activity, {
+        onError: () => {
+          addErrorMessage(t('Unable to update comment'));
+        },
+        onSuccess: data => {
+          const d = data as GroupActivityNote;
+          GroupStore.updateActivity(group.id, data.id, {text: d.data.text});
+          addSuccessMessage(t('Comment updated'));
+          trackAnalytics('issue_details.comment_updated', {
+            organization,
+            streamline: true,
+          });
+        },
+      });
+    },
+    [group.activity, mutators, group.id, organization]
+  );
+
   const handleCreate = useCallback(
     (n: NoteType, _me: User) => {
       mutators.handleCreate(n, group.activity, {
@@ -221,6 +260,7 @@ export default function StreamlinedActivitySection({
               <TimelineItem
                 item={item}
                 handleDelete={handleDelete}
+                handleUpdate={handleUpdate}
                 group={group}
                 teams={teams}
                 key={item.id}
@@ -234,6 +274,7 @@ export default function StreamlinedActivitySection({
                 <TimelineItem
                   item={item}
                   handleDelete={handleDelete}
+                  handleUpdate={handleUpdate}
                   group={group}
                   teams={teams}
                   key={item.id}

--- a/static/app/views/issueDetails/streamline/sidebar/note.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/note.tsx
@@ -172,15 +172,15 @@ function StreamlinedNoteInput({
           appendSpaceOnAdd
         />
       </MentionsInput>
-      {isSubmitVisible && (
+      {(isSubmitVisible || existingItem) && (
         <Button
           priority="primary"
           size="xs"
           disabled={!canSubmit}
-          aria-label={t('Submit comment')}
+          aria-label={existingItem ? t('Save comment') : t('Submit comment')}
           type="submit"
         >
-          {t('Comment')}
+          {existingItem ? t('Save') : t('Comment')}
         </Button>
       )}
     </NoteInputForm>

--- a/static/app/views/issueDetails/streamline/sidebar/note.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/note.tsx
@@ -143,7 +143,7 @@ function StreamlinedNoteInput({
   return (
     <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
       <MentionsInput
-        aria-label={t('Add a comment')}
+        aria-label={existingItem ? t('Edit comment') : t('Add a comment')}
         aria-errormessage={errorMessage ? errorId : undefined}
         style={{
           ...mentionStyle({theme, minHeight: 14, streamlined: true}),

--- a/static/app/views/issueDetails/streamline/sidebar/note.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/note.tsx
@@ -12,6 +12,7 @@ import type {
   Mentioned,
 } from 'sentry/components/activity/note/types';
 import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {NoteType} from 'sentry/types/alerts';
@@ -26,6 +27,7 @@ type Props = {
    * you are editing an existing item
    */
   noteId?: string;
+  onCancel?: () => void;
   onChange?: (e: MentionChangeEvent, extra: {updating?: boolean}) => void;
   onCreate?: (data: NoteType) => void;
   onUpdate?: (data: NoteType) => void;
@@ -41,6 +43,7 @@ function StreamlinedNoteInput({
   onCreate,
   onChange,
   onUpdate,
+  onCancel,
   noteId,
   errorJSON,
   placeholder,
@@ -173,15 +176,22 @@ function StreamlinedNoteInput({
         />
       </MentionsInput>
       {(isSubmitVisible || existingItem) && (
-        <Button
-          priority="primary"
-          size="xs"
-          disabled={!canSubmit}
-          aria-label={existingItem ? t('Save comment') : t('Submit comment')}
-          type="submit"
-        >
-          {existingItem ? t('Save') : t('Comment')}
-        </Button>
+        <ButtonBar gap={0.5}>
+          {existingItem && (
+            <Button size="xs" onClick={onCancel}>
+              {t('Cancel')}
+            </Button>
+          )}
+          <Button
+            priority="primary"
+            size="xs"
+            disabled={!canSubmit}
+            aria-label={existingItem ? t('Save comment') : t('Submit comment')}
+            type="submit"
+          >
+            {existingItem ? t('Save') : t('Comment')}
+          </Button>
+        </ButtonBar>
       )}
     </NoteInputForm>
   );

--- a/static/app/views/issueDetails/streamline/sidebar/noteDropdown.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/noteDropdown.tsx
@@ -7,10 +7,16 @@ import {useUser} from 'sentry/utils/useUser';
 
 type Props = {
   onDelete: () => void;
+  onEdit: () => void;
   user?: User | null;
 };
 
-function NoteDropdown({user, onDelete, ...props}: Props & Partial<DropdownMenuProps>) {
+function NoteDropdown({
+  user,
+  onDelete,
+  onEdit,
+  ...props
+}: Props & Partial<DropdownMenuProps>) {
   const activeUser = useUser();
   const canEdit = activeUser && (activeUser.isSuperuser || user?.id === activeUser.id);
 
@@ -44,6 +50,14 @@ function NoteDropdown({user, onDelete, ...props}: Props & Partial<DropdownMenuPr
             }),
           tooltip: activeUser.isSuperuser
             ? t('You can delete this comment due to your superuser status')
+            : undefined,
+        },
+        {
+          key: 'edit',
+          label: t('Edit'),
+          onAction: onEdit,
+          tooltip: activeUser.isSuperuser
+            ? t('You can edit this comment due to your superuser status')
             : undefined,
         },
       ]}

--- a/static/app/views/issueDetails/streamline/sidebar/noteDropdown.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/noteDropdown.tsx
@@ -37,6 +37,14 @@ function NoteDropdown({
       }}
       items={[
         {
+          key: 'edit',
+          label: t('Edit'),
+          onAction: onEdit,
+          tooltip: activeUser.isSuperuser
+            ? t('You can edit this comment due to your superuser status')
+            : undefined,
+        },
+        {
           key: 'delete',
           label: t('Remove'),
           priority: 'danger',
@@ -50,14 +58,6 @@ function NoteDropdown({
             }),
           tooltip: activeUser.isSuperuser
             ? t('You can delete this comment due to your superuser status')
-            : undefined,
-        },
-        {
-          key: 'edit',
-          label: t('Edit'),
-          onAction: onEdit,
-          tooltip: activeUser.isSuperuser
-            ? t('You can edit this comment due to your superuser status')
             : undefined,
         },
       ]}


### PR DESCRIPTION
this pr adds back editing for activity comments in the streamlined experience. this existed in the past but didn't make it in the initial version of the activity side. 

<img width="277" alt="Screenshot 2024-12-05 at 1 50 03 PM" src="https://github.com/user-attachments/assets/cc71e70c-5adc-44fc-acd1-2e627ede09d4">
