### PR TITLE
feat(sdk): Upgrade sentry-sdk to 2.19.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.37
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.3
-sentry-sdk[http2]>=2.18.0
+sentry-sdk[http2]>=2.19.1
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -191,7 +191,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.37
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.3
-sentry-sdk==2.18.0
+sentry-sdk==2.19.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.37
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.3
-sentry-sdk==2.18.0
+sentry-sdk==2.19.1
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
This version comes with an important fix regarding Django cache spans which may allow us to enable this again. It also has various Spotlight related improvements and fixes.
