### PR TITLE
fix(alerts): Correct EAP Alert unfurl timeseries queries attaching transaction filter

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -266,7 +266,7 @@ def build_metric_alert_chart(
     query_str = build_query_strings(subscription=subscription, snuba_query=snuba_query).query_string
     query = (
         query_str
-        if is_crash_free_alert
+        if is_crash_free_alert or dataset == Dataset.EventsAnalyticsPlatform
         else apply_dataset_query_conditions(
             SnubaQuery.Type(snuba_query.type),
             query_str,

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -1,9 +1,13 @@
 import datetime
+from unittest.mock import patch
 
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
-from sentry.incidents.charts import incident_date_range
+from sentry.incidents.charts import build_metric_alert_chart, incident_date_range
+from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models.incident import Incident
+from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -62,3 +66,36 @@ class IncidentDateRangeTest(TestCase):
             "start": "2022-02-04T20:28:00",
             "end": now,
         }
+
+
+class BuildMetricAlertChartTest(TestCase):
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    @patch("sentry.incidents.charts.client.get")
+    def test_eap_alert(self, mock_client_get, mock_generate_chart):
+        mock_client_get.return_value.data = {"data": []}
+        alert_rule = self.create_alert_rule(
+            query="span.op:pageload", dataset=Dataset.EventsAnalyticsPlatform
+        )
+        incident = self.create_incident(
+            status=2,
+            organization=self.organization,
+            projects=[self.project],
+            alert_rule=alert_rule,
+            date_started=timezone.now() - datetime.timedelta(minutes=2),
+        )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+
+        url = build_metric_alert_chart(
+            self.organization,
+            alert_rule,
+            selected_incident=incident,
+        )
+
+        assert url == "chart-url"
+        mock_client_get.assert_called()
+        mock_generate_chart.assert_called()
+        assert mock_client_get.call_args[1]["params"]["dataset"] == "spans"
+        assert mock_client_get.call_args[1]["params"]["query"] == "span.op:pageload"

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -420,6 +420,10 @@ class UnfurlTest(TestCase):
             alert_rule=alert_rule,
             date_started=timezone.now() - timedelta(minutes=2),
         )
+        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}"
         links = [

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -409,7 +409,7 @@ class UnfurlTest(TestCase):
 
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
     def test_unfurl_metric_alerts_chart_eap_spans(self, mock_generate_chart):
-        # Using the transactions dataset
+        # Using the EventsAnalyticsPlatform dataset
         alert_rule = self.create_alert_rule(
             query="span.op:foo", dataset=Dataset.EventsAnalyticsPlatform
         )
@@ -473,7 +473,7 @@ class UnfurlTest(TestCase):
     def test_unfurl_metric_alerts_chart_eap_spans_events_stats_call(
         self, mock_generate_chart, mock_get_event_stats_data
     ):
-        # Using the transactions dataset
+        # Using the EventsAnalyticsPlatform dataset
         alert_rule = self.create_alert_rule(
             query="span.op:foo", dataset=Dataset.EventsAnalyticsPlatform
         )


### PR DESCRIPTION
Removes the `event.type:transaction` filter getting applied to EAP queries