### PR TITLE
fix(flags): Disable flagpole integration

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -26,7 +26,8 @@ from sentry.conf.types.sdk_config import SdkConfig
 from sentry.features.rollout import in_random_rollout
 from sentry.utils import metrics
 from sentry.utils.db import DjangoAtomicIntegration
-from sentry.utils.flag import FlagPoleIntegration
+
+# from sentry.utils.flag import FlagPoleIntegration
 from sentry.utils.rust import RustInfoIntegration
 
 # Can't import models in utils because utils should be the bottom of the food chain
@@ -465,7 +466,8 @@ def configure_sdk():
             RustInfoIntegration(),
             RedisIntegration(),
             ThreadingIntegration(propagate_hub=True),
-            FlagPoleIntegration(),
+            # Temporarily disabled.
+            # FlagPoleIntegration(),
         ],
         **sdk_options,
     )


### PR DESCRIPTION
Removing until we fix an issue in the SDK where a loop never terminates.