### PR TITLE
fix(visibility): Preserve function aliases in Snuba serializer

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -57,8 +57,17 @@ def get_query_columns(columns, rollup):
     return [column_map.get(column, column) for column in columns]
 
 
-def resolve_axis_column(column: str, index: int = 0) -> str:
-    return get_function_alias(column) if not is_equation(column) else f"equation[{index}]"
+def resolve_axis_column(
+    column: str, index: int = 0, transform_alias_to_input_format: bool = True
+) -> str:
+    if is_equation(column):
+        return f"equation[{index}]"
+
+    # Function columns on input have names like `"p95(duration)"`. By default, we convert them to their aliases like `"p95_duration"`. Here, we want to preserve the original name, so we return the column as-is
+    if transform_alias_to_input_format:
+        return column
+
+    return get_function_alias(column)
 
 
 class OrganizationEventsEndpointBase(OrganizationEndpoint):
@@ -418,6 +427,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         comparison_delta: timedelta | None = None,
         additional_query_columns: list[str] | None = None,
         dataset: Any | None = None,
+        transform_alias_to_input_format: bool = False,
     ) -> dict[str, Any]:
         with handle_query_errors():
             with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_query_creation"):
@@ -495,7 +505,9 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     else:
                         results[key] = serializer.serialize(
                             event_result,
-                            column=resolve_axis_column(query_columns[0]),
+                            column=resolve_axis_column(
+                                query_columns[0], 0, transform_alias_to_input_format
+                            ),
                             allow_partial_buckets=allow_partial_buckets,
                             zerofill_results=zerofill_results,
                         )
@@ -521,6 +533,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     allow_partial_buckets,
                     zerofill_results=zerofill_results,
                     dataset=dataset,
+                    transform_alias_to_input_format=transform_alias_to_input_format,
                 )
                 if top_events > 0 and isinstance(result, SnubaTSResult):
                     serialized_result = {"": serialized_result}
@@ -530,7 +543,9 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     extra_columns = ["comparisonCount"]
                 serialized_result = serializer.serialize(
                     result,
-                    resolve_axis_column(query_columns[0]),
+                    column=resolve_axis_column(
+                        query_columns[0], 0, transform_alias_to_input_format
+                    ),
                     allow_partial_buckets=allow_partial_buckets,
                     zerofill_results=zerofill_results,
                     extra_columns=extra_columns,
@@ -573,6 +588,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         allow_partial_buckets: bool,
         zerofill_results: bool = True,
         dataset: Any | None = None,
+        transform_alias_to_input_format: bool = False,
     ) -> dict[str, Any]:
         # Return with requested yAxis as the key
         result = {}
@@ -588,7 +604,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         for index, query_column in enumerate(query_columns):
             result[columns[index]] = serializer.serialize(
                 event_result,
-                resolve_axis_column(query_column, equations),
+                resolve_axis_column(query_column, equations, transform_alias_to_input_format),
                 order=index,
                 allow_partial_buckets=allow_partial_buckets,
                 zerofill_results=zerofill_results,

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -58,7 +58,7 @@ def get_query_columns(columns, rollup):
 
 
 def resolve_axis_column(
-    column: str, index: int = 0, transform_alias_to_input_format: bool = True
+    column: str, index: int = 0, transform_alias_to_input_format: bool = False
 ) -> str:
     if is_equation(column):
         return f"equation[{index}]"

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -184,6 +184,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
 
     def get(self, request: Request, organization: Organization) -> Response:
         query_source = self.get_request_source(request)
+
+        transform_alias_to_input_format = request.GET.get("transformAliasToInputFormat") == "1"
+
         with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
             span.set_data("organization", organization)
 
@@ -337,8 +340,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         use_aggregate_conditions=False,
                     ),
                 )
-
-            transform_alias_to_input_format = request.GET.get("transformAliasToInputFormat") == "1"
 
             return scoped_dataset.timeseries_query(
                 selected_columns=query_columns,
@@ -569,6 +570,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     zerofill_results=zerofill_results,
                     comparison_delta=comparison_delta,
                     dataset=dataset,
+                    transform_alias_to_input_format=transform_alias_to_input_format,
                 ),
                 status=200,
             )

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -488,6 +488,22 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
 
     def test_throughput_meta(self):
         project = self.create_project()
+        # Each of these denotes how many events to create in each hour
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_event(
+                    data={
+                        "event_id": str(uuid.uuid1()),
+                        "message": "very bad",
+                        "timestamp": (
+                            self.day_ago + timedelta(hours=hour, minutes=minute)
+                        ).isoformat(),
+                        "fingerprint": ["group1"],
+                        "tags": {"sentry:user": self.user.email},
+                    },
+                    project_id=project.id,
+                )
 
         for axis in ["epm()", "tpm()"]:
             response = self.do_request(
@@ -506,6 +522,13 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
                 axis: "rate",
             }
             assert meta["units"] == {"time": None, axis: "1/minute"}
+
+            data = response.data["data"]
+            assert len(data) == 6
+
+            rows = data[0:6]
+            for test in zip(event_counts, rows):
+                assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
         for axis in ["eps()", "tps()"]:
             response = self.do_request(


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/81606/. Turns out that `SnubaTSResultSerializer` must also be made aware of the aliasing. It, by default, converts _all_ function names to their aliases. As a result, it start looking for `"spm"` in data that only has `"spm()"` and returns 0 instead.
