### PR TITLE
feat(rpc): Validate intervals

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -46,17 +46,19 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
 # The RPC limits us to 1000 points per timeseries
 MAX_ROLLUP_POINTS = 1000
-# Copied from snuba
-VALID_GRANULARITIES = {
-    15,
-    30,
-    60,  # seconds
-    2 * 60,
-    5 * 60,
-    10 * 60,
-    30 * 60,  # minutes
-    1 * 3600,
-    3 * 3600,
-    12 * 3600,
-    24 * 3600,  # hours
-}
+# Copied from snuba, a number of total seconds
+VALID_GRANULARITIES = frozenset(
+    {
+        15,
+        30,
+        60,  # seconds
+        2 * 60,
+        5 * 60,
+        10 * 60,
+        30 * 60,  # minutes
+        1 * 3600,
+        3 * 3600,
+        12 * 3600,
+        24 * 3600,  # hours
+    }
+)

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -42,3 +42,21 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
     "percentage": FLOAT,
     "string": STRING,
 }
+
+# https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
+# The RPC limits us to 1000 points per timeseries
+MAX_ROLLUP_POINTS = 1000
+# Copied from snuba
+VALID_GRANULARITIES = {
+    15,
+    30,
+    60,  # seconds
+    2 * 60,
+    5 * 60,
+    10 * 60,
+    30 * 60,  # minutes
+    1 * 3600,
+    3 * 3600,
+    12 * 3600,
+    24 * 3600,  # hours
+}

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -7,8 +7,9 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeAggregation
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import AndFilter, OrFilter, TraceItemFilter
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.columns import ResolvedColumn, ResolvedFunction
-from sentry.search.eap.constants import FLOAT, INT, STRING
+from sentry.search.eap.constants import FLOAT, INT, MAX_ROLLUP_POINTS, STRING, VALID_GRANULARITIES
 from sentry.search.eap.spans import SearchResolver
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse, SearchResolverConfig
 from sentry.search.events.fields import get_function_alias, is_function
@@ -177,6 +178,22 @@ def get_timeseries_query(
     )
 
 
+def validate_granularity(
+    params: SnubaParams,
+    granularity_secs: int,
+) -> None:
+    """The granularity has already been somewhat validated by src/sentry/utils/dates.py:validate_granularity
+    but the RPC adds additional rules on validation so those are checked here"""
+    if params.date_range.total_seconds() / granularity_secs > MAX_ROLLUP_POINTS:
+        raise InvalidSearchQuery(
+            "Selected interval would create too many buckets for the timeseries"
+        )
+    if granularity_secs not in VALID_GRANULARITIES:
+        raise InvalidSearchQuery(
+            f"Selected interval is not allowed, allowed intervals are: {sorted(VALID_GRANULARITIES)}"
+        )
+
+
 def run_timeseries_query(
     params: SnubaParams,
     query_string: str,
@@ -186,6 +203,7 @@ def run_timeseries_query(
     config: SearchResolverConfig,
 ) -> SnubaTSResult:
     """Make the query"""
+    validate_granularity(params, granularity_secs)
     rpc_request = get_timeseries_query(
         params, query_string, y_axes, [], referrer, config, granularity_secs
     )
@@ -277,6 +295,7 @@ def run_top_events_timeseries_query(
     This is because at time of writing, the query construction is very straightforward, if that changes perhaps we can
     change this"""
     """Make a table query first to get what we need to filter by"""
+    validate_granularity(params, granularity_secs)
     search_resolver = SearchResolver(params, config)
     top_events = run_table_query(
         params,
@@ -289,6 +308,8 @@ def run_top_events_timeseries_query(
         config,
         search_resolver=search_resolver,
     )
+    if len(top_events["data"]) == 0:
+        return {}
     # Need to change the project slug columns to project.id because timeseries requests don't take virtual_column_contexts
     groupby_columns = [col for col in raw_groupby if not is_function(col)]
     groupby_columns_without_project = [

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -525,6 +525,23 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 assert result[1][0]["count"] == expected, key
         assert response.data["Other"]["meta"]["dataset"] == self.dataset
 
+    def test_top_events_with_no_data(self):
+        # Each of these denotes how many events to create in each minute
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "project.id", "sum(span.self_time)"],
+                "orderby": ["-sum_span_self_time"],
+                "dataset": self.dataset,
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
 
 class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsStatsSpansMetricsEndpointTest):
     is_eap = True
@@ -728,3 +745,35 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     @pytest.mark.xfail(reason="epm not implemented yet")
     def test_throughput_eps_minute_rollup(self):
         super().test_throughput_eps_minute_rollup()
+
+    def test_invalid_intervals(self):
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum_span_self_time"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "20s",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum_span_self_time"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
- This adds validation to the intervals passed to the RPC, which need to be validated differently than in snql
- Also fixes a bug i found while writing a test for intervals where top events would fail if there wasn't any data