### PR TITLE
fix(dashboards): Improve rendering of X axis in `LineChartWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -69,9 +69,7 @@ export default storyBook(LineChartWidget, story => {
         <p>
           The visualization of <JSXNode name="LineChartWidget" /> a line chart. It has
           some bells and whistles including automatic axes labels, and a hover tooltip.
-          Like other widgets, it automatically fills the parent element. The{' '}
-          <code>utc</code> prop controls whether the X Axis timestamps are shown in UTC or
-          not.
+          Like other widgets, it automatically fills the parent element.
         </p>
         <SmallSizingWindow>
           <LineChartWidget
@@ -105,7 +103,6 @@ export default storyBook(LineChartWidget, story => {
                 shiftTimeserieToNow(durationTimeSeries1),
                 shiftTimeserieToNow(durationTimeSeries2),
               ]}
-              utc
               meta={{
                 fields: {
                   'p99(span.duration)': 'duration',

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
@@ -55,7 +55,6 @@ export function LineChartWidget(props: Props) {
           <LineChartWidgetVisualization
             timeseries={timeseries}
             releases={props.releases}
-            utc={props.utc}
             meta={props.meta}
             dataCompletenessDelay={props.dataCompletenessDelay}
           />

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -16,6 +16,7 @@ import type {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
 import {useWidgetSyncContext} from '../../contexts/widgetSyncContext';
 import {ReleaseSeries} from '../common/releaseSeries';
@@ -29,12 +30,14 @@ export interface LineChartWidgetVisualizationProps {
   dataCompletenessDelay?: number;
   meta?: Meta;
   releases?: Release[];
-  utc?: boolean;
 }
 
 export function LineChartWidgetVisualization(props: LineChartWidgetVisualizationProps) {
   const chartRef = useRef<EChartsReactCore | null>(null);
   const {register: registerWithWidgetSyncContext} = useWidgetSyncContext();
+
+  const pageFilters = usePageFilters();
+  const {start, end, period, utc} = pageFilters.selection.datetime;
   const {meta} = props;
 
   const dataCompletenessDelay = props.dataCompletenessDelay ?? 0;
@@ -55,7 +58,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
       );
     };
 
-    releaseSeries = ReleaseSeries(theme, props.releases, onClick, props.utc ?? false);
+    releaseSeries = ReleaseSeries(theme, props.releases, onClick, utc ?? false);
   }
 
   const chartZoomProps = useChartZoom({
@@ -135,7 +138,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
         return formatChartValue(value, type, unit);
       },
       truncate: true,
-      utc: props.utc ?? false,
+      utc: utc ?? false,
     })(deDupedParams, asyncTicket);
   };
 
@@ -181,7 +184,6 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
             data: [],
           }),
       ].filter(defined)}
-      utc={props.utc}
       grid={{
         left: 0,
         top: props.timeseries.length > 1 ? 25 : 10,
@@ -224,6 +226,10 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
       }}
       {...chartZoomProps}
       isGroupedByDate
+      start={start ? new Date(start) : undefined}
+      end={end ? new Date(end) : undefined}
+      period={period}
+      utc={utc ?? undefined}
     />
   );
 }


### PR DESCRIPTION
Pass along the current date range selection, which helps the formatter work correctly! It will use more terse formats for short ranges.

I'm also going to dump the `utc` prop since instead I'm doing to always respect the current page date range selection, if available.
