### PR TITLE
nit(oauth): surface error when token exchange fails in oauth

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -357,7 +357,7 @@ class OAuth2CallbackView(PipelineView):
                 lifecycle.record_failure(
                     "token_exchange_error", extra={"failure_info": ERR_INVALID_STATE}
                 )
-                return pipeline.error(ERR_INVALID_STATE + f": {error}")
+                return pipeline.error(ERR_INVALID_STATE + f"\nError: {error}")
 
             if state != pipeline.fetch_state("state"):
                 pipeline.logger.info(
@@ -384,7 +384,7 @@ class OAuth2CallbackView(PipelineView):
 
         if "error" in data:
             pipeline.logger.info("identity.token-exchange-error", extra={"error": data["error"]})
-            return pipeline.error(ERR_TOKEN_RETRIEVAL)
+            return pipeline.error(ERR_TOKEN_RETRIEVAL + f"\nError: {data['error']}")
 
         # we can either expect the API to be implicit and say "im looking for
         # blah within state data" or we need to pass implementation + call a

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -357,7 +357,7 @@ class OAuth2CallbackView(PipelineView):
                 lifecycle.record_failure(
                     "token_exchange_error", extra={"failure_info": ERR_INVALID_STATE}
                 )
-                return pipeline.error(ERR_INVALID_STATE + f"\nError: {error}")
+                return pipeline.error(f"{ERR_INVALID_STATE}\nError: {error}")
 
             if state != pipeline.fetch_state("state"):
                 pipeline.logger.info(
@@ -384,7 +384,7 @@ class OAuth2CallbackView(PipelineView):
 
         if "error" in data:
             pipeline.logger.info("identity.token-exchange-error", extra={"error": data["error"]})
-            return pipeline.error(ERR_TOKEN_RETRIEVAL + f"\nError: {data['error']}")
+            return pipeline.error(f"{ERR_TOKEN_RETRIEVAL}\nError: {data['error']}")
 
         # we can either expect the API to be implicit and say "im looking for
         # blah within state data" or we need to pass implementation + call a

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -357,7 +357,7 @@ class OAuth2CallbackView(PipelineView):
                 lifecycle.record_failure(
                     "token_exchange_error", extra={"failure_info": ERR_INVALID_STATE}
                 )
-                return pipeline.error(ERR_INVALID_STATE)
+                return pipeline.error(ERR_INVALID_STATE + f": {error}")
 
             if state != pipeline.fetch_state("state"):
                 pipeline.logger.info(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1d731d11-40fa-4aa2-a0e8-33ecae26fef5)

When something fails in our oauth flow, we have a generic error message, but the error exists in the url. Instead, lets surface it in the html we render.

`pipeline.error` will render the html here:
https://github.com/getsentry/sentry/blob/67c99a3f80384ba767504cebb665f52acb41f616/src/sentry/pipeline/base.py#L208-L212

Now, the html we render will look like
![image](https://github.com/user-attachments/assets/48f1a276-1e38-48c1-b25c-a8bc517a37b2)
