### PR TITLE
fix(dashboards): Account for "Releases" as a series when formatting `LineChartWidget` legend

### DIFF
--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -139,6 +139,13 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
     })(deDupedParams, asyncTicket);
   };
 
+  let visibleSeriesCount = props.timeseries.length;
+  if (releaseSeries) {
+    visibleSeriesCount += 1;
+  }
+
+  const showLegend = visibleSeriesCount > 1;
+
   return (
     <BaseChart
       ref={e => {
@@ -184,13 +191,13 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
       utc={props.utc}
       grid={{
         left: 0,
-        top: props.timeseries.length > 1 ? 25 : 10,
+        top: showLegend ? 25 : 10,
         right: 1,
         bottom: 0,
         containLabel: true,
       }}
       legend={
-        props.timeseries.length > 1
+        showLegend
           ? {
               top: 0,
               left: 0,


### PR DESCRIPTION
Account for it when determining whether to show the legend. If one series is shown, no legend. If one series _and releases_ are shown, show the legend!
