### PR TITLE
fix(explore): Ensure RPC charts use at most 1000 buckets

### DIFF
--- a/static/app/views/explore/hooks/useChartInterval.spec.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.spec.tsx
@@ -1,8 +1,9 @@
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 
-import {useChartInterval} from './useChartInterval';
+import {getIntervalOptionsForPageFilter, useChartInterval} from './useChartInterval';
 
 describe('useChartInterval', function () {
   beforeEach(() => {
@@ -22,9 +23,9 @@ describe('useChartInterval', function () {
 
     expect(intervalOptions).toEqual([
       {value: '1h', label: '1 hour'},
-      {value: '4h', label: '4 hours'},
+      {value: '3h', label: '3 hours'},
+      {value: '12h', label: '12 hours'},
       {value: '1d', label: '1 day'},
-      {value: '1w', label: '1 week'},
     ]);
     expect(chartInterval).toEqual('1h'); // default
 
@@ -51,4 +52,37 @@ describe('useChartInterval', function () {
     });
     expect(chartInterval).toEqual('1m');
   });
+});
+
+describe('getIntervalOptionsForPageFilter', function () {
+  it.each([
+    '1h',
+    '23h',
+    '1d',
+    '6d',
+    '7d',
+    '13d',
+    '14d',
+    '29d',
+    '30d',
+    '59d',
+    '60d',
+    '89d',
+    '90d',
+  ])(
+    'returns interval options with resulting in less than 1000 buckets',
+    function (period) {
+      const periodInHours = parsePeriodToHours(period);
+      const options = getIntervalOptionsForPageFilter({
+        period,
+        start: null,
+        end: null,
+        utc: null,
+      });
+      options.forEach(({value}) => {
+        const intervalInHours = parsePeriodToHours(value);
+        expect(periodInHours / intervalInHours).toBeLessThan(1000);
+      });
+    }
+  );
 });

--- a/static/app/views/explore/hooks/useChartInterval.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.tsx
@@ -1,11 +1,22 @@
 import {useCallback, useMemo} from 'react';
 import type {Location} from 'history';
 
+import {
+  FORTY_EIGHT_HOURS,
+  getDiffInMinutes,
+  GranularityLadder,
+  ONE_WEEK,
+  SIX_HOURS,
+  THIRTY_DAYS,
+  TWO_WEEKS,
+} from 'sentry/components/charts/utils';
+import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {getIntervalOptionsForStatsPeriod} from 'sentry/views/metrics/utils/useMetricsIntervalParam';
 
 interface Options {
   location: Location;
@@ -36,9 +47,10 @@ function useChartIntervalImpl({
   intervalOptions: {label: string; value: string}[],
 ] {
   const {datetime} = pagefilters.selection;
-  const intervalOptions = useMemo(() => {
-    return getIntervalOptionsForStatsPeriod(datetime);
-  }, [datetime]);
+  const intervalOptions = useMemo(
+    () => getIntervalOptionsForPageFilter(datetime),
+    [datetime]
+  );
 
   const interval: string = useMemo(() => {
     const decodedInterval = decodeScalar(location.query.interval);
@@ -63,4 +75,52 @@ function useChartIntervalImpl({
   );
 
   return [interval, setInterval, intervalOptions];
+}
+
+const ALL_INTERVAL_OPTIONS = [
+  {value: '1m', label: t('1 minute')},
+  {value: '5m', label: t('5 minutes')},
+  {value: '15m', label: t('15 minutes')},
+  {value: '30m', label: t('30 minutes')},
+  {value: '1h', label: t('1 hour')},
+  {value: '3h', label: t('3 hours')},
+  {value: '12h', label: t('12 hours')},
+  {value: '1d', label: t('1 day')},
+];
+
+/**
+ * The minimum interval is chosen in such a way that there will be
+ * at most 1000 data points per series for the chosen period.
+ */
+const MINIMUM_INTERVAL = new GranularityLadder([
+  [THIRTY_DAYS, '3h'],
+  [TWO_WEEKS, '1h'],
+  [ONE_WEEK, '30m'],
+  [FORTY_EIGHT_HOURS, '15m'],
+  [SIX_HOURS, '5m'],
+  [0, '1m'],
+]);
+
+const MAXIMUM_INTERVAL = new GranularityLadder([
+  [THIRTY_DAYS, '1d'],
+  [TWO_WEEKS, '1d'],
+  [ONE_WEEK, '1d'],
+  [FORTY_EIGHT_HOURS, '4h'],
+  [SIX_HOURS, '1h'],
+  [0, '15m'],
+]);
+
+export function getIntervalOptionsForPageFilter(datetime: PageFilters['datetime']) {
+  const diffInMinutes = getDiffInMinutes(datetime);
+
+  const minimumOption = MINIMUM_INTERVAL.getInterval(diffInMinutes);
+  const minimumOptionInHours = parsePeriodToHours(minimumOption);
+
+  const maximumOption = MAXIMUM_INTERVAL.getInterval(diffInMinutes);
+  const maximumOptionInHours = parsePeriodToHours(maximumOption);
+
+  return ALL_INTERVAL_OPTIONS.filter(option => {
+    const optionInHours = parsePeriodToHours(option.value);
+    return optionInHours >= minimumOptionInHours && optionInHours <= maximumOptionInHours;
+  });
 }


### PR DESCRIPTION
The timeseries RPC has a limit of 1000 buckets per timeseries. Change the available interval options so that this is always true.

Requires getsentry/eap-planning#120