### PR TITLE
chore(trace-view): Adjust some colours to match design

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -110,5 +110,5 @@ const TraceInnerLayout = styled('div')`
   flex: 1 1 100%;
   padding: ${space(2)};
 
-  background-color: ${p => p.theme.background};
+  background-color: ${p => p.theme.surface100};
 `;

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -736,6 +736,7 @@ const TraceStylingWrapper = styled('div')`
     padding-top: 44px;
 
     &:before {
+      background-color: ${p => p.theme.background};
       height: 44px;
 
       .TraceScrollbarContainer {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -668,7 +668,7 @@ const TabsHeightContainer = styled('div')<{
   layout: 'drawer bottom' | 'drawer left' | 'drawer right';
   absolute?: boolean;
 }>`
-  background: ${p => p.theme.backgroundSecondary};
+  background: ${p => p.theme.background};
   left: ${p => (p.layout === 'drawer left' ? '0' : 'initial')};
   right: ${p => (p.layout === 'drawer right' ? '0' : 'initial')};
   position: ${p => (p.absolute ? 'absolute' : 'relative')};
@@ -726,7 +726,7 @@ const TabLayoutControlItem = styled('li')`
   margin: 0;
   position: relative;
   z-index: 10;
-  background-color: ${p => p.theme.backgroundSecondary};
+  background-color: ${p => p.theme.background};
 `;
 
 const Tab = styled('li')`

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -233,6 +233,7 @@ const ProjectsRendererWrapper = styled('div')`
 `;
 
 const HeaderLayout = styled(Layout.Header)`
+  background-color: ${p => p.theme.background};
   padding: ${space(2)} ${space(2)} 0 !important;
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -858,6 +858,7 @@ export const TraceGrid = styled('div')<{
   --autogrouped: ${p => p.theme.blue300};
   --performance-issue: ${p => p.theme.blue300};
 
+  background-color: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
   flex: 1 1 100%;
   display: grid;


### PR DESCRIPTION
Slight adjustments to some colours to match the design, a bit hard to see from these screenshots but the background colour has been made darker, and the header colours are changed to white

## Before
![Screenshot 2024-12-05 at 5 32 09 PM](https://github.com/user-attachments/assets/8395604b-9e61-4ec8-b5c8-6665862fafc5)

## After
![Screenshot 2024-12-05 at 5 28 41 PM](https://github.com/user-attachments/assets/e109a80b-f343-4d86-814e-0f31eefb3730)