### PR TITLE
fix(event tracker) change logger name

### DIFF
--- a/src/sentry/utils/event_tracker.py
+++ b/src/sentry/utils/event_tracker.py
@@ -25,7 +25,7 @@ class TransactionStageStatus(StrEnum):
     POST_PROCESS_FINISHED = "post_process_finished"
 
 
-logger = logging.getLogger("EventTracker")
+logger = logging.getLogger(__name__)
 
 
 def track_sampled_event(


### PR DESCRIPTION
changing to `__name__` should make the logs visible in celery pods. Currently hardcoding the logger name make the logs not show up 