### PR TITLE
fix(flags): strict type validation for event flags in EventFeatureFlagList

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -122,7 +122,7 @@ export function EventFeatureFlagList({
         typeof f.result === 'boolean'
     );
   }, [event]);
-  
+
   const hasFlags = hasFlagContext && eventFlags.length > 0;
 
   const showCTA =

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -69,7 +69,6 @@ export function EventFeatureFlagList({
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const organization = useOrganization();
   const eventView = useIssueDetailsEventView({group});
-
   const {data: rawFlagData} = useOrganizationFlagLog({
     organization,
     query: {

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -103,7 +103,7 @@ export function EventFeatureFlagList({
     const rawFlags = event.contexts?.flags?.values ?? [];
     return rawFlags.filter(
       (f): f is Required<FeatureFlag> =>
-        f !== null &&
+        f &&
         typeof f === 'object' &&
         typeof f.flag === 'string' &&
         typeof f.result === 'boolean'


### PR DESCRIPTION
Relates to
- https://github.com/getsentry/team-replay/issues/512
- https://github.com/getsentry/sentry/pull/81770
- https://github.com/getsentry/sentry/pull/81601

Forces the types of f.flag and f.result to be string and boolean, respectively. Also a refactor/reordering, so if there are no **valid** flags, we'd show CTA.