### PR TITLE
fix(flags): don't show cta if some recent event has flags

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -34,6 +34,10 @@ jest.spyOn(window.Element.prototype, 'getBoundingClientRect').mockImplementation
 describe('EventFeatureFlagList', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1/events/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/flags/logs/',
       body: {data: []},
     });

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -11,6 +11,7 @@ import {
 import FeatureFlagInlineCTA from 'sentry/components/events/featureFlags/featureFlagInlineCTA';
 import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
 import {useFeatureFlagOnboarding} from 'sentry/components/events/featureFlags/useFeatureFlagOnboarding';
+import useIssueEvents from 'sentry/components/events/featureFlags/useIssueEvents';
 import {
   FlagControlOptions,
   OrderBy,
@@ -77,6 +78,13 @@ export function EventFeatureFlagList({
       statsPeriod: eventView.statsPeriod,
     },
   });
+
+  const {
+    data: events,
+    isPending: isEventsPending,
+    isError: isEventsError,
+  } = useIssueEvents({issueId: group.id});
+
   const {activateSidebarSkipConfigure} = useFeatureFlagOnboarding();
 
   const {
@@ -91,6 +99,10 @@ export function EventFeatureFlagList({
   });
 
   const hasFlagContext = Boolean(event.contexts?.flags?.values);
+  const anyEventHasContext =
+    isEventsPending || isEventsError
+      ? false
+      : events.filter(e => Boolean(e.contexts?.flags?.values)).length > 0;
   const flagValues = useMemo(() => {
     return event.contexts?.flags?.values ?? [];
   }, [event]);
@@ -98,6 +110,7 @@ export function EventFeatureFlagList({
 
   const showCTA =
     !hasFlagContext &&
+    !anyEventHasContext &&
     featureFlagOnboardingPlatforms.includes(project.platform ?? 'other') &&
     organization.features.includes('feature-flag-cta');
 

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -80,9 +80,9 @@ export function EventFeatureFlagList({
   });
 
   const {
-    data: events,
-    isPending: isEventsPending,
-    isError: isEventsError,
+    data: relatedEvents,
+    isPending: isRelatedEventsPending,
+    isError: isRelatedEventsError,
   } = useIssueEvents({issueId: group.id});
 
   const {activateSidebarSkipConfigure} = useFeatureFlagOnboarding();
@@ -100,9 +100,9 @@ export function EventFeatureFlagList({
 
   const hasFlagContext = Boolean(event.contexts?.flags?.values);
   const anyEventHasContext =
-    isEventsPending || isEventsError
+    isRelatedEventsPending || isRelatedEventsError
       ? false
-      : events.filter(e => Boolean(e.contexts?.flags?.values)).length > 0;
+      : relatedEvents.filter(e => Boolean(e.contexts?.flags?.values)).length > 0;
   const flagValues = useMemo(() => {
     return event.contexts?.flags?.values ?? [];
   }, [event]);

--- a/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
@@ -31,6 +31,10 @@ async function renderFlagDrawer() {
 describe('FeatureFlagDrawer', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1/events/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/flags/logs/',
       body: {data: []},
     });

--- a/static/app/components/events/featureFlags/useIssueEvents.tsx
+++ b/static/app/components/events/featureFlags/useIssueEvents.tsx
@@ -1,0 +1,21 @@
+import type {Event} from '@sentry/types';
+
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useIssueEvents({issueId}: {issueId: string}) {
+  const organization = useOrganization();
+  return useApiQuery<Event[]>(
+    [
+      `/organizations/${organization.slug}/issues/${issueId}/events/`,
+      {
+        query: {
+          statsPeriod: '14d',
+          limit: 20,
+          full: true,
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -160,6 +160,10 @@ const mockGroupApis = (
   trace?: QuickTraceEvent
 ) => {
   MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/issues/1/events/',
+    body: [],
+  });
+  MockApiClient.addMockResponse({
     url: '/organizations/org-slug/flags/logs/',
     body: {data: []},
   });


### PR DESCRIPTION
relates to https://github.com/getsentry/team-replay/issues/508.

sometimes the recommended event is not necessarily the latest event, so the recommended event may not have `event.contexts.flags` set (but the latest one does). we don't want to show the flag cta if the issue already has flags present in at least 1 recent event.