### PR TITLE
feat(hydration error): Improve messaging and links to docs

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -2,9 +2,11 @@ import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LearnMoreButton from 'sentry/components/replays/diff/learnMoreButton';
 import ReplayDiffChooser from 'sentry/components/replays/diff/replayDiffChooser';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconInfo} from 'sentry/icons/iconInfo';
@@ -37,55 +39,58 @@ export default function ReplayComparisonModal({
 
   return (
     <OrganizationContext.Provider value={organization}>
-      <Header closeButton>
-        <ModalHeader>
-          <Title>
-            {t('Hydration Error')}
-            <Tooltip
-              isHoverable
-              title={tct(
-                'This modal helps with debugging hydration errors by diffing the DOM before and after the app hydrated. [boldBefore:Before] refers to the HTML rendered on the server. [boldAfter:After] refers to the HTML rendered on the client. Read more about [link:resolving hydration errors]',
-                {
-                  boldBefore: <Before />,
-                  boldAfter: <After />,
-                  link: (
-                    <ExternalLink href="https://sentry.io/answers/hydration-error-nextjs/" />
-                  ),
-                }
+      <AnalyticsArea name="hydration-error-modal">
+        <Header closeButton>
+          <ModalHeader>
+            <Title>
+              {t('Hydration Error')}
+              <Tooltip
+                isHoverable
+                title={tct(
+                  'This modal helps with debugging hydration errors by diffing the DOM before and after the app hydrated. [boldBefore:Before] refers to the HTML rendered on the server. [boldAfter:After] refers to the HTML rendered on the client. Read more about [link:resolving hydration errors].',
+                  {
+                    boldBefore: <Before />,
+                    boldAfter: <After />,
+                    link: (
+                      <ExternalLink href="https://sentry.io/answers/hydration-error-nextjs/" />
+                    ),
+                  }
+                )}
+              >
+                <IconInfo />
+              </Tooltip>
+            </Title>
+            <LearnMoreButton />
+            {focusTrap ? (
+              <FeedbackWidgetButton
+                optionOverrides={{
+                  onFormOpen: () => {
+                    focusTrap.pause();
+                  },
+                  onFormClose: () => {
+                    focusTrap.unpause();
+                  },
+                }}
+              />
+            ) : null}
+          </ModalHeader>
+        </Header>
+        <Body>
+          {isSameTimestamp ? (
+            <Alert type="warning" showIcon>
+              {t(
+                "Cannot display diff for this hydration error. Sentry wasn't able to identify the correct event."
               )}
-            >
-              <IconInfo />
-            </Tooltip>
-          </Title>
-          {focusTrap ? (
-            <FeedbackWidgetButton
-              optionOverrides={{
-                onFormOpen: () => {
-                  focusTrap.pause();
-                },
-                onFormClose: () => {
-                  focusTrap.unpause();
-                },
-              }}
-            />
+            </Alert>
           ) : null}
-        </ModalHeader>
-      </Header>
-      <Body>
-        {isSameTimestamp ? (
-          <Alert type="warning" showIcon>
-            {t(
-              "Cannot display diff for this hydration error. Sentry wasn't able to identify the correct event."
-            )}
-          </Alert>
-        ) : null}
 
-        <ReplayDiffChooser
-          replay={replay}
-          leftOffsetMs={leftOffsetMs}
-          rightOffsetMs={rightOffsetMs}
-        />
-      </Body>
+          <ReplayDiffChooser
+            replay={replay}
+            leftOffsetMs={leftOffsetMs}
+            rightOffsetMs={rightOffsetMs}
+          />
+        </Body>
+      </AnalyticsArea>
     </OrganizationContext.Provider>
   );
 }

--- a/static/app/components/replays/diff/diffFeedbackBanner.tsx
+++ b/static/app/components/replays/diff/diffFeedbackBanner.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {tct} from 'sentry/locale';
+
+export default function DiffFeedbackBanner() {
+  return (
+    <StyledAlert type="info" showIcon>
+      {tct(
+        `The diff tools are based on a best-effort implementation to highlight the DOM state before and after a hydration event is thrown.
+        React itself does not provide any details about what caused the problem, therefore it's not 100% reliable as sometimes no diff is found.
+        Please see [link: this ticket] for more details and share your feedback.`,
+        {
+          link: <ExternalLink href="https://github.com/getsentry/sentry/issues/80092" />,
+        }
+      )}
+    </StyledAlert>
+  );
+}
+
+export const StyledAlert = styled(Alert)`
+  margin: 0;
+`;

--- a/static/app/components/replays/diff/diffFeedbackBanner.tsx
+++ b/static/app/components/replays/diff/diffFeedbackBanner.tsx
@@ -9,8 +9,8 @@ export default function DiffFeedbackBanner() {
     <StyledAlert type="info" showIcon>
       {tct(
         `The diff tools are based on a best-effort implementation to highlight the DOM state before and after a hydration event is thrown.
-        React itself does not provide any details about what caused the problem, therefore it's not 100% reliable as sometimes no diff is found.
-        Please see [link: this ticket] for more details and share your feedback.`,
+        React itself does not provide any details about what caused the problem; therefore, it's not 100% reliable, as sometimes no diff is found.
+        Please see [link: this ticket] for more details and to share your feedback.`,
         {
           link: <ExternalLink href="https://github.com/getsentry/sentry/issues/80092" />,
         }

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -43,12 +43,12 @@ function Buttons() {
       <Resource
         title={t('Debugging Hydration Errors')}
         subtitle={t(
-          'Learn about the tools Sentry has to help debug why a Hydration Error is happening.'
+          'Learn about the tools Sentry offers to help debug why a Hydration Error is happening.'
         )}
         link="https://docs.sentry.io/product/issues/issue-details/replay-issues/hydration-error/#debugging-hydration-errors"
       />
       <Resource
-        title={t('Fixing hydration errors')}
+        title={t('Fixing Hydration Errors')}
         subtitle={t(
           'Read more about why Hydration Errors occur, and how to prevent them.'
         )}

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -1,0 +1,115 @@
+import type {ReactNode} from 'react';
+import {ClassNames} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import AnalyticsArea, {useAnalyticsArea} from 'sentry/components/analyticsArea';
+import {Button, LinkButton} from 'sentry/components/button';
+import {Hovercard} from 'sentry/components/hovercard';
+import {IconOpen, IconQuestion} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+function Resource({
+  title,
+  subtitle,
+  link,
+}: {
+  link: string;
+  subtitle: ReactNode;
+  title: string;
+}) {
+  const analyticsArea = useAnalyticsArea();
+  return (
+    <StyledLinkButton
+      icon={<IconOpen />}
+      borderless
+      external
+      href={link}
+      analyticsEventKey="learn-more-resource.clicked"
+      analyticsEventName="Clicked learn more resource"
+      analyticsParams={{surface: analyticsArea, title}}
+    >
+      <ButtonContent>
+        <ButtonTitle>{title}</ButtonTitle>
+        <ButtonSubtitle>{subtitle}</ButtonSubtitle>
+      </ButtonContent>
+    </StyledLinkButton>
+  );
+}
+
+function Buttons() {
+  return (
+    <ButtonContainer>
+      <Resource
+        title={t('Debugging Hydration Errors')}
+        subtitle={t(
+          'Learn about the tools Sentry has to help debug why a Hydration Error is happening.'
+        )}
+        link="https://docs.sentry.io/product/issues/issue-details/replay-issues/hydration-error/#debugging-hydration-errors"
+      />
+      <Resource
+        title={t('Fixing hydration errors')}
+        subtitle={t(
+          'Read more about why Hydration Errors occur, and how to prevent them.'
+        )}
+        link="https://sentry.io/answers/hydration-error-nextjs/"
+      />
+    </ButtonContainer>
+  );
+}
+
+export default function LearnMoreButton() {
+  return (
+    <ClassNames>
+      {({css}) => (
+        <AnalyticsArea name="learn-more">
+          <Hovercard
+            body={<Buttons />}
+            bodyClassName={css`
+              padding: ${space(1)};
+            `}
+            position="top-end"
+          >
+            <Button
+              size="sm"
+              icon={<IconQuestion />}
+              aria-label={t('learn more about hydration errors')}
+            >
+              {t('Learn More')}
+            </Button>
+          </Hovercard>
+        </AnalyticsArea>
+      )}
+    </ClassNames>
+  );
+}
+
+const ButtonContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  align-items: flex-start;
+`;
+
+const ButtonContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  white-space: pre-line;
+  gap: ${space(0.25)};
+`;
+
+const ButtonTitle = styled('div')`
+  font-weight: ${p => p.theme.fontWeightNormal};
+`;
+
+const ButtonSubtitle = styled('div')`
+  color: ${p => p.theme.gray300};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const StyledLinkButton = styled(LinkButton)`
+  padding: ${space(1)};
+  height: auto;
+`;

--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {ReplayMutationTree} from 'sentry/components/replays/diff/replayMutationTree';
 import {ReplaySideBySideImageDiff} from 'sentry/components/replays/diff/replaySideBySideImageDiff';
 import {ReplaySliderDiff} from 'sentry/components/replays/diff/replaySliderDiff';
@@ -43,12 +42,8 @@ export default function ReplayDiffChooser({
         <TabList>
           <TabList.Item key={DiffType.SLIDER}>{t('Slider Diff')}</TabList.Item>
           <TabList.Item key={DiffType.VISUAL}>{t('Side By Side Diff')}</TabList.Item>
-          <TabList.Item key={DiffType.MUTATIONS}>
-            {t('Mutations')} <FeatureBadge type={'beta'} />
-          </TabList.Item>
-          <TabList.Item key={DiffType.HTML}>
-            {t('HTML Diff')} <FeatureBadge type={'beta'} />
-          </TabList.Item>
+          <TabList.Item key={DiffType.MUTATIONS}>{t('Mutations')}</TabList.Item>
+          <TabList.Item key={DiffType.HTML}>{t('HTML Diff')}</TabList.Item>
         </TabList>
 
         <StyledTabPanels>

--- a/static/app/components/replays/diff/replayMutationTree.tsx
+++ b/static/app/components/replays/diff/replayMutationTree.tsx
@@ -1,6 +1,8 @@
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import DiffFeedbackBanner from 'sentry/components/replays/diff/diffFeedbackBanner';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import useExtractDiffMutations from 'sentry/utils/replays/hooks/useExtractDiffMutations';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -12,7 +14,7 @@ interface Props {
 }
 
 export function ReplayMutationTree({replay, leftOffsetMs, rightOffsetMs}: Props) {
-  const {data} = useExtractDiffMutations({
+  const {data, isLoading} = useExtractDiffMutations({
     leftOffsetMs,
     replay,
     rightOffsetMs,
@@ -29,19 +31,24 @@ export function ReplayMutationTree({replay, leftOffsetMs, rightOffsetMs}: Props)
   );
 
   return (
-    <ScrollWrapper>
-      <StructuredEventData
-        key={data?.size}
-        data={timeIndexedMutations}
-        maxDefaultDepth={4}
-        css={css`
-          flex: auto 1 1;
-          & > pre {
-            margin: 0;
-          }
-        `}
-      />
-    </ScrollWrapper>
+    <Fragment>
+      {!isLoading && Object.keys(timeIndexedMutations).length === 0 ? (
+        <DiffFeedbackBanner />
+      ) : null}
+      <ScrollWrapper>
+        <StructuredEventData
+          key={data?.size}
+          data={timeIndexedMutations}
+          maxDefaultDepth={4}
+          css={css`
+            flex: auto 1 1;
+            & > pre {
+              margin: 0;
+            }
+          `}
+        />
+      </ScrollWrapper>
+    </Fragment>
   );
 }
 
@@ -50,4 +57,8 @@ const ScrollWrapper = styled('div')`
   height: 0;
   display: flex;
   flex-grow: 1;
+
+  & pre {
+    margin: 0;
+  }
 `;

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -23,6 +23,8 @@ interface Props {
   minHeight?: `${number}px` | `${number}%`;
 }
 
+const BORDER_WIDTH = 3;
+
 export function ReplaySliderDiff({
   minHeight = '0px',
   leftOffsetMs,
@@ -79,15 +81,16 @@ function DiffSides({
     initialSize: viewDimensions.width / 2,
     min: 0,
     onResize: newSize => {
+      const maxWidth = viewDimensions.width - BORDER_WIDTH;
       if (beforeElemRef.current) {
         beforeElemRef.current.style.width =
           viewDimensions.width === 0
             ? '100%'
-            : toPixels(Math.min(viewDimensions.width, newSize)) ?? '0px';
+            : toPixels(Math.max(BORDER_WIDTH, Math.min(maxWidth, newSize))) ?? '0px';
       }
       if (dividerElem.current) {
         dividerElem.current.style.left =
-          toPixels(Math.min(viewDimensions.width, newSize)) ?? '0px';
+          toPixels(Math.max(BORDER_WIDTH, Math.min(maxWidth, newSize))) ?? '0px';
       }
     },
   });
@@ -153,7 +156,7 @@ const Positioned = styled('div')`
 `;
 
 const Cover = styled('div')`
-  border: 3px solid;
+  border: ${BORDER_WIDTH}px solid;
   border-radius: ${space(0.5)};
   height: 100%;
   overflow: hidden;
@@ -163,7 +166,7 @@ const Cover = styled('div')`
 
   border-color: ${p => p.theme.green300};
   & + & {
-    border: 3px solid;
+    border: ${BORDER_WIDTH}px solid;
     border-radius: ${space(0.5)} 0 0 ${space(0.5)};
     border-color: ${p => p.theme.red300};
     border-right-width: 0;

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -2,12 +2,11 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
-import Alert from 'sentry/components/alert';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
-import ExternalLink from 'sentry/components/links/externalLink';
+import DiffFeedbackBanner from 'sentry/components/replays/diff/diffFeedbackBanner';
 import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import SplitDiff from 'sentry/components/splitDiff';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useExtractPageHtml from 'sentry/utils/replays/hooks/useExtractPageHtml';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -19,7 +18,7 @@ interface Props {
 }
 
 export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
-  const {data} = useExtractPageHtml({
+  const {data, isLoading} = useExtractPageHtml({
     replay,
     offsetMsToStopAt: [leftOffsetMs, rightOffsetMs],
   });
@@ -31,16 +30,7 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
 
   return (
     <Container>
-      <StyledAlert type="info" showIcon>
-        {tct(
-          `The HTML Diff is currently in beta and has known issues (e.g. the 'Before' is sometimes empty). We are exploring different options to replace this view. Please see [link: this ticket] for more details and share your feedback.`,
-          {
-            link: (
-              <ExternalLink href="https://github.com/getsentry/sentry/issues/80092" />
-            ),
-          }
-        )}
-      </StyledAlert>
+      {!isLoading && leftBody === rightBody ? <DiffFeedbackBanner /> : null}
       <DiffHeader>
         <Before>
           <CopyToClipboardButton
@@ -74,10 +64,6 @@ const Container = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
-`;
-
-const StyledAlert = styled(Alert)`
-  margin: 0;
 `;
 
 const SplitDiffScrollWrapper = styled('div')`


### PR DESCRIPTION
Added a "Learn More" button like what replays have, to link to more docs about what are hydration errors, and how to change the code to resolve them:
![SCR-20241205-nxfc](https://github.com/user-attachments/assets/141083e6-e6bb-40b2-b643-984c27b005a8)


Also you're going to see messages whenever the diff is actually not a diff in the mutations and html diff panels:

| Mutations | HTML |
| --- | --- |
| ![SCR-20241205-myfj](https://github.com/user-attachments/assets/dec25848-0bf7-4153-aa62-bb4becba1d0a) | ![SCR-20241205-myei](https://github.com/user-attachments/assets/b28e0028-105e-4e24-abb7-330a81a81d21) |

Finally some other little tweaks snuck in here too
- margin below the mutations lowers. More space for content
- Slider diff has better min/max limits
    - Before the purple line could go all the way to the edge: 
        - ![SCR-20241205-nxwe](https://github.com/user-attachments/assets/7acc03ad-e9cf-42fa-a589-0c0957f5d42c)
        - ![SCR-20241205-nxwy](https://github.com/user-attachments/assets/e6fe0d28-3ae9-4b9c-a954-963aff77e45a)
    - After the purple line is stopped at the colored border on either side:
        - ![SCR-20241205-nxod](https://github.com/user-attachments/assets/5c4dbd5d-5b99-4dab-8815-7bdc5744972a)
        - ![SCR-20241205-nxot](https://github.com/user-attachments/assets/f03c455a-8567-4194-83cc-89e181cd1db0)


