### PR TITLE
feat(aci milestone 3): call process_data_sources in subscription processor

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -541,6 +541,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-m3-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable the new workflow for processing subscription updates (see: alerts create issues)
+    manager.add("organizations:workflow-engine-m3-process", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable reading from new ACI tables for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-m3-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new workflow_engine UI (see: alerts create issues)

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -42,7 +42,7 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
             resource_id=None,
             evidence_data={},
             evidence_display=[],
-            type=MetricIssuePOC,
+            type=MetricAlertFire,
             detection_time=datetime.now(timezone.utc),
             level="error",
             culprit="Some culprit",

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -1,15 +1,47 @@
 from dataclasses import dataclass
+from typing import Any
 
 from sentry.incidents.endpoints.validators import MetricAlertsDetectorValidator
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
+from sentry.workflow_engine.handlers.detector.base import DetectorEvaluationResult
+from sentry.workflow_engine.models.data_source import DataPacket
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
 class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate]):
-    pass
+    def evaluate(
+        self, data_packet: DataPacket[QuerySubscriptionUpdate]
+    ) -> dict[str | None, DetectorEvaluationResult]:
+        return {
+            "dummy_group": DetectorEvaluationResult(
+                group_key="dummy_group",
+                is_active=True,
+                priority=DetectorPriorityLevel.HIGH,
+                result=None,
+                event_data=None,
+            )
+        }
+
+    def build_occurrence_and_event_data(
+        self, group_key: str | None, value: int, new_status: PriorityLevel
+    ) -> tuple[IssueOccurrence, dict[str, Any]]:
+        return super().build_occurrence_and_event_data(group_key, value, new_status)
+
+    def counter_names(self):
+        return []
+
+    def get_dedupe_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
+        return super().get_dedupe_value(data_packet)
+
+    def get_group_key_values(
+        self, data_packet: DataPacket[QuerySubscriptionUpdate]
+    ) -> dict[str, int]:
+        return super().get_group_key_values(data_packet)
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from sentry.incidents.endpoints.validators import MetricAlertsDetectorValidator
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
-from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.issues.grouptype import GroupCategory, GroupType, MetricIssuePOC
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
@@ -30,18 +31,44 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
     def build_occurrence_and_event_data(
         self, group_key: str | None, value: int, new_status: PriorityLevel
     ) -> tuple[IssueOccurrence, dict[str, Any]]:
-        return super().build_occurrence_and_event_data(group_key, value, new_status)
+        # placeholder return for now
+        occurrence = IssueOccurrence(
+            id="eb4b0acffadb4d098d48cb14165ab578",
+            project_id=123,
+            event_id="43878ab4419f4ab181f6379ac376d5aa",
+            fingerprint=["abc123"],
+            issue_title="Some Issue",
+            subtitle="Some subtitle",
+            resource_id=None,
+            evidence_data={},
+            evidence_display=[],
+            type=MetricIssuePOC,
+            detection_time=datetime.now(timezone.utc),
+            level="error",
+            culprit="Some culprit",
+            initial_issue_priority=new_status.value,
+        )
+        event_data = {
+            "timestamp": occurrence.detection_time,
+            "project_id": occurrence.project_id,
+            "event_id": occurrence.event_id,
+            "platform": "python",
+            "received": occurrence.detection_time,
+            "tags": {},
+        }
+        return occurrence, event_data
 
-    def counter_names(self):
-        return []
+    @property
+    def counter_names(self) -> list[str]:
+        return []  # placeholder return for now
 
     def get_dedupe_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
-        return super().get_dedupe_value(data_packet)
+        return 0  # placeholder return for now
 
     def get_group_key_values(
         self, data_packet: DataPacket[QuerySubscriptionUpdate]
     ) -> dict[str, int]:
-        return super().get_group_key_values(data_packet)
+        return {"dummy": 0}  # placeholder return for now
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -371,8 +371,7 @@ class SubscriptionProcessor:
             )
             detectors = process_data_sources([data_packet], query_type=self.subscription.type)
             results = []
-            for pair in detectors:
-                data_packet, detectors = pair
+            for data_packet, detectors in detectors:
                 results.append(process_detectors(data_packet, detectors))
             logger.info(
                 "Results from process detectors",

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -362,7 +362,7 @@ class SubscriptionProcessor:
             return
 
         if features.has(
-            "organizations:workflow-engine-m3-dual-write", self.subscription.project.organization
+            "organizations:workflow-engine-m3-process", self.subscription.project.organization
         ):
             # NOTE: feed the data through the new pipeline, but don't do anything with it yet.
             # This will change at some point.

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -373,17 +373,10 @@ class SubscriptionProcessor:
             results = []
             for data_packet, detectors in detectors:
                 results.append(process_detectors(data_packet, detectors))
-            # NOTE: this is temporary, to verify in the tests that the right information is flowing through the pipeline.
-            logger_results = []
-            for result_list in results:
-                logger_result_list = []
-                for detector, result in result_list:
-                    logger_result_list.append((detector.id, result))
-                logger_results.append(logger_result_list)
             logger.info(
                 "Results from process_detectors",
                 extra={
-                    "results": logger_results,
+                    "results": results,
                 },
             )
         self.last_update = subscription_update["timestamp"]

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -366,7 +366,7 @@ class SubscriptionProcessor:
         ):
             # NOTE: feed the data through the new pipeline, but don't do anything with it yet.
             # This will change at some point.
-            data_packet = DataPacket(
+            data_packet = DataPacket[QuerySubscriptionUpdate](
                 query_id=self.subscription.snuba_query.id, packet=subscription_update
             )
             detectors = process_data_sources([data_packet], query_type=self.subscription.type)

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -364,6 +364,8 @@ class SubscriptionProcessor:
         if features.has(
             "organizations:workflow-engine-m3-dual-write", self.subscription.project.organization
         ):
+            # NOTE: feed the data through the new pipeline, but don't do anything with it yet.
+            # This will change at some point.
             data_packet = DataPacket(
                 query_id=self.subscription.snuba_query.id, packet=subscription_update
             )
@@ -378,7 +380,6 @@ class SubscriptionProcessor:
                     "result": results,
                 },
             )
-            return None
         self.last_update = subscription_update["timestamp"]
 
         if (

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -373,10 +373,17 @@ class SubscriptionProcessor:
             results = []
             for data_packet, detectors in detectors:
                 results.append(process_detectors(data_packet, detectors))
+            # NOTE: this is temporary, to verify in the tests that the right information is flowing through the pipeline.
+            logger_results = []
+            for result_list in results:
+                logger_result_list = []
+                for detector, result in result_list:
+                    logger_result_list.append((detector.id, result))
+                logger_results.append(logger_result_list)
             logger.info(
-                "Results from process detectors",
+                "Results from process_detectors",
                 extra={
-                    "result": results,
+                    "results": logger_results,
                 },
             )
         self.last_update = subscription_update["timestamp"]

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -367,7 +367,7 @@ class SubscriptionProcessor:
             # NOTE: feed the data through the new pipeline, but don't do anything with it yet.
             # This will change at some point.
             data_packet = DataPacket[QuerySubscriptionUpdate](
-                query_id=self.subscription.snuba_query.id, packet=subscription_update
+                query_id=self.subscription.id, packet=subscription_update
             )
             detectors = process_data_sources([data_packet], query_type=self.subscription.type)
             results = []

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2956,6 +2956,15 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert status_change.new_status == GroupStatus.RESOLVED
         assert occurrence.fingerprint == status_change.fingerprint
 
+    @with_feature("organizations:workflow-engine-m3-dual-write")
+    def test_process_data_sources(self):
+        rule = self.rule
+        detector = self.create_detector(name="hojicha", type="metric_alert_fire")
+        data_source = self.create_data_source(query_id=rule.snuba_query.id, type="incidents")
+        data_source.detectors.set([detector])
+        self.send_update(rule, 10)
+        # TODO: the rest of this
+
 
 class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetricsTestCase):
     @pytest.fixture(autouse=True)

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -72,8 +72,6 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.group import PriorityLevel
 from sentry.utils import json
-from sentry.workflow_engine.handlers.detector.base import DetectorEvaluationResult
-from sentry.workflow_engine.types import DetectorPriorityLevel
 
 EMPTY = object()
 
@@ -2966,29 +2964,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         data_source = self.create_data_source(query_id=rule.snuba_query.id, type="incidents")
         data_source.detectors.set([detector])
         self.send_update(rule, 10)
-        mock_logger.info.assert_called_with(
-            "Results from process_detectors",
-            extra={
-                "results": (
-                    [
-                        [
-                            (
-                                1,
-                                {
-                                    "dummy_group": DetectorEvaluationResult(
-                                        group_key="dummy_group",
-                                        is_active=True,
-                                        priority=DetectorPriorityLevel.HIGH,
-                                        result=None,
-                                        event_data=None,
-                                    )
-                                },
-                            )
-                        ]
-                    ]
-                )
-            },
-        )
 
 
 class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetricsTestCase):


### PR DESCRIPTION
Wrap the subscription update in a `DataPacket` and call `process_data_sources`, then feed the results into `process_detectors` and log the result (`process_detectors` calls a dummy `evaluate` function for now). Step one of the pipeline.