### PR TITLE
Upgrade Python SDK to 2.19.2

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.37
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.3
-sentry-sdk[http2]>=2.19.1
+sentry-sdk[http2]>=2.19.2
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -191,7 +191,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.37
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.3
-sentry-sdk==2.19.1
+sentry-sdk==2.19.2
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.37
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.3
-sentry-sdk==2.19.1
+sentry-sdk==2.19.2
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
Version `2.19.2` of the Sentry Python SDK includes a fix (https://github.com/getsentry/sentry-python/issues/3862) that is important for the new feature flag support in Sentry.