### PR TITLE
fix(stats-v2): disallow minute resolution

### DIFF
--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -195,7 +195,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         if project_ids:
             params["project_id"] = project_ids
 
-        return QueryDefinition.from_query_dict(request.GET, params)
+        return QueryDefinition.from_query_dict(request.GET, params, allow_minute_resolution=False)
 
     def _get_projects_for_orgstats_query(self, request: Request, organization):
         # look at the raw project_id filter passed in, if its empty


### PR DESCRIPTION
The underlying queries don't return data for minute resolution, docs also state that 1h is the minimum.


Replaces https://github.com/getsentry/sentry/pull/81579

Closes https://github.com/getsentry/projects/issues/480