### PR TITLE
Fix sdk crash detection pthread_getcpuclockid path

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -227,7 +227,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 function_and_path_patterns=[
                     FunctionAndPathPattern(
                         function_pattern=r"*pthread_getcpuclockid*",
-                        path_pattern=r"/apex/com.android.art/lib64/bionic/libc.so",
+                        path_pattern=r"/apex/com.android.runtime/lib64/bionic/libc.so",
                     ),
                     FunctionAndPathPattern(
                         function_pattern=r"*art::Trace::StopTracing*",

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_java.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_java.py
@@ -148,31 +148,31 @@ def test_sdk_crash_is_reported_with_android_paths(
     [
         (
             "pthread_getcpuclockid",
-            "/apex/com.android.art/lib64/bionic/libc.so",
+            "/apex/com.android.runtime/lib64/bionic/libc.so",
             "/apex/com.android.art/lib64/libart.so",
             True,
         ),
         (
             "__pthread_getcpuclockid",
-            "/apex/com.android.art/lib64/bionic/libc.so",
+            "/apex/com.android.runtime/lib64/bionic/libc.so",
             "/apex/com.android.art/lib64/libart.so",
             True,
         ),
         (
             "pthread_getcpuclockid(void*)",
-            "/apex/com.android.art/lib64/bionic/libc.so",
+            "/apex/com.android.runtime/lib64/bionic/libc.so",
             "/apex/com.android.art/lib64/libart.so",
             True,
         ),
         (
             "pthread_getcpuclocki",
-            "/apex/com.android.art/lib64/bionic/libc.so",
+            "/apex/com.android.runtime/lib64/bionic/libc.so",
             "/apex/com.android.art/lib64/libart.so",
             False,
         ),
         (
             "pthread_getcpuclockid",
-            "/apex/com.android.art/lib64/bionic/libc.s",
+            "/apex/com.android.runtime/lib64/bionic/libc.s",
             "/apex/com.android.art/lib64/libart.so",
             False,
         ),


### PR DESCRIPTION
Update `pthread_getcpuclockid` path_pattern as it should be `/apex/com.android.runtime/lib64/bionic/libc.so` instead of `/apex/com.android.art/lib64/bionic/libc.so`