### PR TITLE
ref(grouping): Minor refactor & test improvements

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -29,8 +29,6 @@ from sentry.tasks.embeddings_grouping.utils import (
 )
 from sentry.utils import metrics
 
-BACKFILL_NAME = "backfill_grouping_records"
-BULK_DELETE_METADATA_CHUNK_SIZE = 100
 SEER_ACCEPTABLE_FAILURE_REASONS = ["Gateway Timeout", "Service Unavailable"]
 EVENT_INFO_EXCEPTIONS = (GroupingConfigNotFound, ResourceDoesNotExist, InvalidEnhancerConfig)
 

--- a/src/sentry/tasks/embeddings_grouping/constants.py
+++ b/src/sentry/tasks/embeddings_grouping/constants.py
@@ -1,0 +1,3 @@
+BACKFILL_NAME = "backfill_grouping_records"
+BACKFILL_BULK_DELETE_METADATA_CHUNK_SIZE = 100
+PROJECT_BACKFILL_COMPLETED = "sentry:similarity_backfill_completed"

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -50,6 +50,7 @@ BACKFILL_NAME = "backfill_grouping_records"
 BULK_DELETE_METADATA_CHUNK_SIZE = 100
 SNUBA_RETRY_EXCEPTIONS = (RateLimitExceeded, QueryTooManySimultaneous)
 NODESTORE_RETRY_EXCEPTIONS = (ServiceUnavailable, DeadlineExceeded)
+PROJECT_BACKFILL_COMPLETED = "sentry:similarity_backfill_completed"
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -40,17 +40,18 @@ from sentry.seer.similarity.utils import (
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.delete_seer_grouping_records import delete_seer_grouping_records_by_hash
+from sentry.tasks.embeddings_grouping.constants import (
+    BACKFILL_BULK_DELETE_METADATA_CHUNK_SIZE,
+    BACKFILL_NAME,
+)
 from sentry.utils import json, metrics
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.safe import get_path
 from sentry.utils.snuba import QueryTooManySimultaneous, RateLimitExceeded, bulk_snuba_queries
 
-BACKFILL_NAME = "backfill_grouping_records"
-BULK_DELETE_METADATA_CHUNK_SIZE = 100
 SNUBA_RETRY_EXCEPTIONS = (RateLimitExceeded, QueryTooManySimultaneous)
 NODESTORE_RETRY_EXCEPTIONS = (ServiceUnavailable, DeadlineExceeded)
-PROJECT_BACKFILL_COMPLETED = "sentry:similarity_backfill_completed"
 
 logger = logging.getLogger(__name__)
 
@@ -720,7 +721,7 @@ def delete_seer_grouping_records(
         RangeQuerySetWrapper(
             Group.objects.filter(project_id=project_id, type=ErrorGroupType.type_id)
         ),
-        BULK_DELETE_METADATA_CHUNK_SIZE,
+        BACKFILL_BULK_DELETE_METADATA_CHUNK_SIZE,
     ):
         groups_with_seer_metadata = [
             group

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -23,6 +23,7 @@ from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.issues.occurrence_consumer import EventLookupError
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
+from sentry.models.project import Project
 from sentry.seer.similarity.grouping_records import CreateGroupingRecordData
 from sentry.seer.similarity.types import RawSeerSimilarIssueData
 from sentry.seer.similarity.utils import MAX_FRAME_COUNT
@@ -32,6 +33,7 @@ from sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project
     backfill_seer_grouping_records_for_project,
 )
 from sentry.tasks.embeddings_grouping.utils import (
+    PROJECT_BACKFILL_COMPLETED,
     _make_postgres_call_with_filter,
     get_data_from_snuba,
     get_events_from_nodestore,
@@ -115,6 +117,10 @@ EVENT_WITH_THREADS_STACKTRACE = {
 
 @django_db_all
 class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
+    def create_project(self, **kwargs) -> Project:
+        """We overwrite the default create_project method to make sure that all created projects are seer eligible."""
+        return super().create_project(**kwargs, platform=kwargs.get("platform", "python"))
+
     def create_exception_values(self, function_name: str, type: str, value: str):
         return {
             "values": [
@@ -175,6 +181,9 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
     def setUp(self):
         super().setUp()
+        # Make the project seer eligible
+        self.project.platform = "python"
+        self.project.save()
         bulk_data = self.create_group_event_rows(5)
         self.bulk_rows, self.bulk_events = (
             bulk_data["rows"],
@@ -1690,7 +1699,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             "backfill_seer_grouping_records.enable_ingestion",
             extra={"project_id": self.project.id},
         )
-        assert self.project.get_option("sentry:similarity_backfill_completed") is not None
+        assert self.project.get_option(PROJECT_BACKFILL_COMPLETED) is not None
 
     @with_feature("projects:similarity-embeddings-backfill")
     @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
@@ -1712,7 +1721,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 "request_hash": self.group_hashes[group.id],
             }
 
-        assert self.project.get_option("sentry:similarity_backfill_completed") is None
+        assert self.project.get_option(PROJECT_BACKFILL_COMPLETED) is None
 
     @with_feature("projects:similarity-embeddings-backfill")
     @patch("sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project.logger")
@@ -1721,7 +1730,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         Test that projects that have a backfill completed project option are skipped when passed
         the skip_processed_projects flag.
         """
-        self.project.update_option("sentry:similarity_backfill_completed", int(time.time()))
+        self.project.update_option(PROJECT_BACKFILL_COMPLETED, int(time.time()))
         with TaskRunner():
             backfill_seer_grouping_records_for_project(
                 self.project.id, None, skip_processed_projects=True
@@ -1764,7 +1773,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         passed the skip_processed_projects flag.
         """
         mock_post_bulk_grouping_records.return_value = {"success": True, "groups_with_neighbor": {}}
-        self.project.update_option("sentry:similarity_backfill_completed", int(time.time()))
+        self.project.update_option(PROJECT_BACKFILL_COMPLETED, int(time.time()))
         with TaskRunner():
             backfill_seer_grouping_records_for_project(self.project.id, None)
 
@@ -2101,8 +2110,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         # Create 2 seer eligible projects that project_id % thread_number == worker_number
         thread_number = options.get("similarity.backfill_total_worker_count")
         worker_number = self.project.id % thread_number
-        self.project.platform = "python"
-        self.project.save()
 
         project_same_cohort = self.create_project(
             organization=self.organization, id=self.project.id + thread_number
@@ -2212,8 +2219,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         # Create 1 seer eligible project that project_id % thread_number == worker_number
         thread_number = options.get("similarity.backfill_total_worker_count")
         worker_number = self.project.id % thread_number
-        self.project.platform = "python"
-        self.project.save()
 
         # Create 1 non seer eligible project that project_id % thread_number != worker_number
         project_same_cohort_not_eligible = self.create_project(
@@ -2314,8 +2319,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         # Create 2 seer eligible projects that project_id % thread_number == worker_number
         thread_number = options.get("similarity.backfill_total_worker_count")
         worker_number = self.project.id % thread_number
-        self.project.platform = "python"
-        self.project.save()
 
         project_same_worker = self.create_project(
             organization=self.organization, id=self.project.id + thread_number

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -32,8 +32,8 @@ from sentry.snuba.referrer import Referrer
 from sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project import (
     backfill_seer_grouping_records_for_project,
 )
+from sentry.tasks.embeddings_grouping.constants import PROJECT_BACKFILL_COMPLETED
 from sentry.tasks.embeddings_grouping.utils import (
-    PROJECT_BACKFILL_COMPLETED,
     _make_postgres_call_with_filter,
     get_data_from_snuba,
     get_events_from_nodestore,


### PR DESCRIPTION
Changes included:
* Make sure that `self.project` is a seer-eligible project
* Make all created projects to be seer eligible
* Centralize constants