### PR TITLE
feat(dashboards): Use multiline x-axis date labels

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -278,6 +278,10 @@ export interface BaseChartProps {
    */
   transformSinglePointToLine?: boolean;
   /**
+   * Use multiline date formatting for xAxis if grouped by date
+   */
+  useMultilineDate?: boolean;
+  /**
    * Use short date formatting for xAxis
    */
   useShortDate?: boolean;
@@ -341,6 +345,7 @@ function BaseChartUnwrapped({
   minutesThresholdToDisplaySeconds,
   showTimeInTooltip,
   useShortDate,
+  useMultilineDate,
   start,
   end,
   period,
@@ -519,6 +524,7 @@ function BaseChartUnwrapped({
             ...xAxis,
             theme,
             useShortDate,
+            useMultilineDate,
             start,
             end,
             period,
@@ -533,6 +539,7 @@ function BaseChartUnwrapped({
               ...axis,
               theme,
               useShortDate,
+              useMultilineDate,
               start,
               end,
               period,
@@ -580,6 +587,7 @@ function BaseChartUnwrapped({
     graphic,
     isGroupedByDate,
     useShortDate,
+    useMultilineDate,
     start,
     end,
     period,

--- a/static/app/components/charts/components/xAxis.spec.tsx
+++ b/static/app/components/charts/components/xAxis.spec.tsx
@@ -58,6 +58,26 @@ describe('Chart XAxis', function () {
           expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 9 12:00 AM');
         });
       });
+
+      describe('Multiline', () => {
+        beforeEach(function () {
+          xAxisObj = XAxis({
+            ...props,
+            useMultilineDate: true,
+            period: '7d',
+          });
+
+          axisLabelFormatter = xAxisObj.axisLabel.formatter;
+        });
+
+        it('formats axis label for first data point', function () {
+          expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 8\n5:00 PM');
+        });
+
+        it('formats axis label for second data point', function () {
+          expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 8\n5:00 PM');
+        });
+      });
     });
 
     describe('With Period <= 24h', function () {
@@ -94,6 +114,27 @@ describe('Chart XAxis', function () {
 
         it('formats axis label for first data point', function () {
           expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 9 12:00 AM');
+        });
+
+        it('formats axis label for second data point', function () {
+          expect(axisLabelFormatter(timestamp, 1)).toEqual('12:00 AM');
+        });
+      });
+
+      describe('Multiline', () => {
+        beforeEach(function () {
+          xAxisObj = XAxis({
+            ...props,
+            useMultilineDate: true,
+            period: '24h',
+            utc: true,
+          });
+
+          axisLabelFormatter = xAxisObj.axisLabel.formatter;
+        });
+
+        it('formats axis label for first data point', function () {
+          expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 9\n12:00 AM');
         });
 
         it('formats axis label for second data point', function () {

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -56,7 +56,7 @@ export function truncationFormatter(
 /**
  * Use a shorter interval if the time difference is <= 24 hours.
  */
-function computeShortInterval(datetimeObj: DateTimeObject): boolean {
+export function computeShortInterval(datetimeObj: DateTimeObject): boolean {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
   return diffInMinutes <= TWENTY_FOUR_HOURS;
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -388,6 +388,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
     const chartOptions = {
       autoHeightResize: shouldResize ?? true,
+      useMultilineDate: true,
       grid: {
         left: 0,
         right: 4,

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -194,7 +194,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
       grid={{
         left: 0,
         top: showLegend ? 25 : 10,
-        right: 1,
+        right: 4,
         bottom: 0,
         containLabel: true,
       }}
@@ -212,6 +212,13 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
           type: 'cross',
         },
         formatter,
+      }}
+      xAxis={{
+        axisLabel: {
+          padding: [0, 10, 0, 10],
+          width: 60,
+        },
+        splitNumber: 0,
       }}
       yAxis={{
         axisLabel: {
@@ -233,6 +240,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
       }}
       {...chartZoomProps}
       isGroupedByDate
+      useMultilineDate
       start={start ? new Date(start) : undefined}
       end={end ? new Date(end) : undefined}
       period={period}


### PR DESCRIPTION
By design request! Split up dates into two lines, if both date and time are shown. Turning this one for Dashboards only for now. Closes https://github.com/getsentry/sentry/issues/81809

I also tweaked the default `LineChartWidget` to better accommodate this by increasing the number of ticks.

**e.g.,**
<img width="764" alt="Screenshot 2024-12-06 at 12 28 21 PM" src="https://github.com/user-attachments/assets/b666e151-95c8-4f0d-8f8a-31dc67444770">
