### PR TITLE
feat(dashboards): enable 'pinning' favorites in dashboards endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -192,6 +192,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                     )
                 ]
                 dashboards = dashboards.order_by(*order_by_favorites, *order_by)
+            else:
+                dashboards = dashboards.order_by(*order_by)
         else:
             dashboards = dashboards.order_by(*order_by)
 

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -183,9 +183,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
         if features.has("organizations:dashboards-favourite", organization, actor=request.user):
             pin_by = request.query_params.get("pin")
-
-            if True or pin_by == "favorites":
-                # order so that favorites are first
+            if pin_by == "favorites":
                 order_by_favorites = [
                     Case(
                         When(dashboardfavoriteuser__user_id=request.user.id, then=-1),

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -215,19 +215,14 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             serialized.extend(serialize(dashboards, request.user, serializer=list_serializer))
             return serialized
 
+        render_pre_built_dashboard = False
+        if features.has("organizations:dashboards-favourite", organization, actor=request.user):
+            if filter_by and filter_by == "onlyFavorites" or pin_by and pin_by == "favorites":
+                render_pre_built_dashboard = True
+
         return self.paginate(
             request=request,
-            sources=(
-                [dashboards]
-                if features.has(
-                    "organizations:dashboards-favourite", organization, actor=request.user
-                )
-                and filter_by
-                and filter_by == "onlyFavorites"
-                or pin_by
-                and pin_by == "favorites"
-                else [prebuilt, dashboards]
-            ),
+            sources=([dashboards] if render_pre_built_dashboard else [prebuilt, dashboards]),
             paginator_cls=ChainPaginator,
             on_results=handle_results,
         )

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -215,14 +215,14 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             serialized.extend(serialize(dashboards, request.user, serializer=list_serializer))
             return serialized
 
-        render_pre_built_dashboard = False
+        render_pre_built_dashboard = True
         if features.has("organizations:dashboards-favourite", organization, actor=request.user):
             if filter_by and filter_by == "onlyFavorites" or pin_by and pin_by == "favorites":
-                render_pre_built_dashboard = True
+                render_pre_built_dashboard = False
 
         return self.paginate(
             request=request,
-            sources=([dashboards] if render_pre_built_dashboard else [prebuilt, dashboards]),
+            sources=([prebuilt, dashboards] if render_pre_built_dashboard else [dashboards]),
             paginator_cls=ChainPaginator,
             on_results=handle_results,
         )

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -177,6 +177,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 Case(When(created_by_id=request.user.id, then=-1), default=1),
                 "-last_visited",
             ]
+
         else:
             order_by = ["title"]
 

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -192,7 +192,6 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                     )
                 ]
                 dashboards = dashboards.order_by(*order_by_favorites, *order_by)
-
         else:
             dashboards = dashboards.order_by(*order_by)
 


### PR DESCRIPTION
Add new parameter, `pin` to the `dashboards` endpoint.

This will enable pinning favourited dashboards (i.e. always on top) in the dashboards grid and table views.

Issue: #78023 