### PR TITLE
feat(dashboards): add pin favorites as parameter to endpoint

### DIFF
--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -105,6 +105,7 @@ function DashboardGrid({
   async function handleFavorite(dashboard: DashboardListItem, isFavorited: boolean) {
     try {
       await updateDashboardFavorite(api, organization.slug, dashboard.id, isFavorited);
+      onDashboardsChange();
     } catch (error) {
       throw error;
     }

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -60,6 +60,7 @@ type FavoriteButtonProps = {
   api: Client;
   dashboardId: string;
   isFavorited: boolean;
+  onDashboardsChange: () => void;
   organization: Organization;
 };
 
@@ -68,6 +69,7 @@ function FavoriteButton({
   api,
   organization,
   dashboardId,
+  onDashboardsChange,
 }: FavoriteButtonProps) {
   const [favorited, setFavorited] = useState(isFavorited);
   return (
@@ -93,6 +95,7 @@ function FavoriteButton({
               dashboardId,
               !favorited
             );
+            onDashboardsChange();
           } catch (error) {
             // If the api call fails, revert the state
             setFavorited(favorited);
@@ -177,6 +180,8 @@ function DashboardTable({
           api={api}
           organization={organization}
           dashboardId={dataRow.id}
+          onDashboardsChange={onDashboardsChange}
+          key={dataRow.id}
         />
       );
     }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -120,6 +120,9 @@ function ManageDashboards() {
         query: {
           ...pick(location.query, ['cursor', 'query']),
           sort: getActiveSort().value,
+          ...(organization.features.includes('dashboards-favourite')
+            ? {pin: 'favorites'}
+            : {}),
           per_page:
             dashboardsLayout === GRID ? rowCount * columnCount : DASHBOARD_TABLE_NUM_ROWS,
         },


### PR DESCRIPTION
Add `pin: favourites` as parameter to dashboards list endpoint. This will result in the favourite dashboards always showing up first in the dashboards grid and table view.

Related backend change: https://github.com/getsentry/sentry/pull/81811
Issue: #78023 
