### PR TITLE
fix(trace-view): Fix missing instrumentation profile preview

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
@@ -72,7 +72,7 @@ export function MissingInstrumentationNodeDetails(
       {event?.projectSlug ? (
         <ProfilesProvider
           orgSlug={organization.slug}
-          projectSlug={node.event?.projectSlug ?? ''}
+          projectSlug={event?.projectSlug ?? ''}
           profileId={profileId || ''}
         >
           <ProfileContext.Consumer>


### PR DESCRIPTION
A missing instrumentation node does not have an event so this was always undefined. We want to try the previous/next event to fetch the project slug.