### PR TITLE
feat(issue summary): Store event id in summary cache, allow specified event

### DIFF
--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -57,9 +57,18 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
     }
 
     def _get_event(
-        self, group: Group, user: AbstractBaseUser | AnonymousUser
+        self,
+        group: Group,
+        user: AbstractBaseUser | AnonymousUser,
+        provided_event_id: str | None = None,
     ) -> tuple[dict[str, Any] | None, GroupEvent | None]:
-        event = group.get_recommended_event_for_environments()
+        event = None
+        if provided_event_id:
+            event = eventstore.backend.get_event_by_id(
+                group.project.id, provided_event_id, group_id=group.id
+            )
+        else:
+            event = group.get_recommended_event_for_environments()
         if not event:
             event = group.get_latest_event()
 
@@ -179,7 +188,12 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         if cached_summary := cache.get(cache_key):
             return Response(convert_dict_key_case(cached_summary, snake_to_camel_case), status=200)
 
-        serialized_event, event = self._get_event(group, request.user)
+        data = orjson.loads(request.body) if request.body else {}
+        force_event_id = data.get("event_id", None)
+
+        serialized_event, event = self._get_event(
+            group, request.user, provided_event_id=force_event_id
+        )
 
         if not serialized_event or not event:
             return Response({"detail": "Could not find an event for the issue"}, status=400)
@@ -197,9 +211,9 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         issue_summary = self._call_seer(
             group, serialized_event, connected_issues, serialized_events_for_connected_issues
         )
+        summary_dict = issue_summary.dict()
+        summary_dict["event_id"] = event.event_id
 
-        cache.set(cache_key, issue_summary.dict(), timeout=int(timedelta(days=7).total_seconds()))
+        cache.set(cache_key, summary_dict, timeout=int(timedelta(days=7).total_seconds()))
 
-        return Response(
-            convert_dict_key_case(issue_summary.dict(), snake_to_camel_case), status=200
-        )
+        return Response(convert_dict_key_case(summary_dict, snake_to_camel_case), status=200)

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -19,7 +19,7 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.constants import ObjectStatus
-from sentry.eventstore.models import GroupEvent
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
@@ -68,7 +68,9 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
                 group.project.id, provided_event_id, group_id=group.id
             )
             if provided_event:
-                event = provided_event.for_group(group)
+                if isinstance(provided_event, Event):
+                    provided_event = provided_event.for_group(group)
+                event = provided_event
         else:
             event = group.get_recommended_event_for_environments()
         if not event:

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -62,11 +62,11 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         user: AbstractBaseUser | AnonymousUser,
         provided_event_id: str | None = None,
     ) -> tuple[dict[str, Any] | None, GroupEvent | None]:
-        event: GroupEvent | None = None
+        event = None
         if provided_event_id:
             event = eventstore.backend.get_event_by_id(
                 group.project.id, provided_event_id, group_id=group.id
-            )
+            ).for_group(group)
         else:
             event = group.get_recommended_event_for_environments()
         if not event:

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -64,9 +64,11 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
     ) -> tuple[dict[str, Any] | None, GroupEvent | None]:
         event = None
         if provided_event_id:
-            event = eventstore.backend.get_event_by_id(
+            provided_event = eventstore.backend.get_event_by_id(
                 group.project.id, provided_event_id, group_id=group.id
-            ).for_group(group)
+            )
+            if provided_event:
+                event = provided_event.for_group(group)
         else:
             event = group.get_recommended_event_for_environments()
         if not event:

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -62,7 +62,7 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         user: AbstractBaseUser | AnonymousUser,
         provided_event_id: str | None = None,
     ) -> tuple[dict[str, Any] | None, GroupEvent | None]:
-        event = None
+        event: GroupEvent | None = None
         if provided_event_id:
             event = eventstore.backend.get_event_by_id(
                 group.project.id, provided_event_id, group_id=group.id

--- a/tests/sentry/api/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/api/endpoints/test_group_ai_summary.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import orjson
 
@@ -69,12 +69,12 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         self, mock_get_event, mock_call_seer, mock_get_connected_issues
     ):
         event = Mock(
-            id="test_event_id",
+            event_id="test_event_id",
             data="test_event_data",
             trace_id="test_trace",
             datetime=datetime.datetime.now(),
         )
-        serialized_event = {"id": "test_event_id", "data": "test_event_data"}
+        serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
         mock_get_event.return_value = [serialized_event, event]
         mock_summary = SummarizeIssueResponse(
             group_id=str(self.group.id),
@@ -86,10 +86,15 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         mock_call_seer.return_value = mock_summary
         mock_get_connected_issues.return_value = [self.group, self.group]
 
+        expected_response_summary = mock_summary.dict()
+        expected_response_summary["event_id"] = event.event_id
+
         response = self.client.post(self.url, format="json")
 
         assert response.status_code == 200
-        assert response.data == convert_dict_key_case(mock_summary.dict(), snake_to_camel_case)
+        assert response.data == convert_dict_key_case(
+            expected_response_summary, snake_to_camel_case
+        )
         mock_get_event.assert_called_with(self.group, ANY)
         assert mock_get_event.call_count == 3
         mock_call_seer.assert_called_once_with(
@@ -101,18 +106,18 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
 
         # Check if the cache was set correctly
         cached_summary = cache.get(f"ai-group-summary-v2:{self.group.id}")
-        assert cached_summary == mock_summary.dict()
+        assert cached_summary == expected_response_summary
 
     @patch("sentry.api.endpoints.group_ai_summary.requests.post")
     @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._get_event")
     def test_ai_summary_call_seer(self, mock_get_event, mock_post):
         event = Mock(
-            id="test_event_id",
+            event_id="test_event_id",
             data="test_event_data",
             trace_id=None,
             datetime=datetime.datetime.now(),
         )
-        serialized_event = {"id": "test_event_id", "data": "test_event_data"}
+        serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
         mock_get_event.return_value = [serialized_event, event]
         mock_response = Mock()
         mock_response.json.return_value = {
@@ -124,15 +129,18 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         }
         mock_post.return_value = mock_response
 
+        expected_response_summary = mock_response.json.return_value
+        expected_response_summary["event_id"] = event.event_id
+
         response = self.client.post(self.url, format="json")
 
         assert response.status_code == 200
         assert response.data == convert_dict_key_case(
-            mock_response.json.return_value, snake_to_camel_case
+            expected_response_summary, snake_to_camel_case
         )
         mock_post.assert_called_once()
 
-        assert cache.get(f"ai-group-summary-v2:{self.group.id}") == mock_response.json.return_value
+        assert cache.get(f"ai-group-summary-v2:{self.group.id}") == expected_response_summary
 
     def test_ai_summary_cache_write_read(self):
         # First request to populate the cache
@@ -145,12 +153,12 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
             ) as mock_call_seer,
         ):
             event = Mock(
-                id="test_event_id",
+                event_id="test_event_id",
                 data="test_event_data",
                 trace_id=None,
                 datetime=datetime.datetime.now(),
             )
-            serialized_event = {"id": "test_event_id", "data": "test_event_data"}
+            serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
             mock_get_event.return_value = [serialized_event, event]
 
             mock_summary = SummarizeIssueResponse(
@@ -162,9 +170,14 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
             )
             mock_call_seer.return_value = mock_summary
 
+            expected_response_summary = mock_summary.dict()
+            expected_response_summary["event_id"] = event.event_id
+
             response = self.client.post(self.url, format="json")
             assert response.status_code == 200
-            assert response.data == convert_dict_key_case(mock_summary.dict(), snake_to_camel_case)
+            assert response.data == convert_dict_key_case(
+                expected_response_summary, snake_to_camel_case
+            )
 
         # Second request should use cached data
         with (
@@ -177,7 +190,9 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         ):
             response = self.client.post(self.url, format="json")
             assert response.status_code == 200
-            assert response.data == convert_dict_key_case(mock_summary.dict(), snake_to_camel_case)
+            assert response.data == convert_dict_key_case(
+                expected_response_summary, snake_to_camel_case
+            )
 
             # Verify that _get_event and _call_seer were not called for the second request
             mock_get_event.assert_not_called()
@@ -195,12 +210,12 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
             ) as mock_get_connected_issues,
         ):
             serialized_event = {
-                "id": "test_event_id",
+                "event_id": "test_event_id",
                 "data": "test_event_data",
                 "project_id": self.project.id,
             }
             event = Mock(
-                id="test_event_id",
+                event_id="test_event_id",
                 data="test_event_data",
                 trace_id=None,
                 project_id=self.project.id,
@@ -357,3 +372,33 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         mock_group.get_recommended_event_for_environments.assert_called_once()
         mock_group.get_latest_event.assert_called_once()
         mock_get_event_by_id.assert_not_called()
+
+    @patch("sentry.api.endpoints.group_ai_summary.eventstore.backend.get_event_by_id")
+    @patch("sentry.api.endpoints.group_ai_summary.serialize")
+    def test_get_event_provided(self, mock_serialize, mock_get_event_by_id):
+        mock_group = Mock()
+        mock_event = Mock()
+        mock_user = Mock()
+        mock_event.event_id = "test_event_id"
+        mock_group.project.id = "test_project_id"
+        mock_group.id = "test_group_id"
+
+        mock_get_event_by_id.return_value = mock_event
+
+        mock_serialized_event = {"serialized": "event"}
+        mock_serialize.return_value = mock_serialized_event
+
+        result = GroupAiSummaryEndpoint()._get_event(
+            mock_group, mock_user, provided_event_id="test_event_id"
+        )
+
+        assert result == (mock_serialized_event, mock_event)
+        mock_group.get_recommended_event_for_environments.assert_not_called()
+        mock_group.get_latest_event.assert_not_called()
+        mock_get_event_by_id.assert_has_calls(
+            [
+                call("test_project_id", "test_event_id", group_id="test_group_id"),
+                call("test_project_id", "test_event_id", group_id="test_group_id"),
+            ]
+        )
+        mock_serialize.assert_called_once()


### PR DESCRIPTION
Stores the event ID used to generate the issue summary in the cache alongside the summary.
Also allows the request to the endpoint to optionally specify an event ID to use for the summary. If none is provided, we use the existing logic for finding a recommended event to summarize.

Will follow up with a frontend PR to actually make use of these changes.