### PR TITLE
feat(trace-view): Add faint project badges to span rows

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -1,5 +1,7 @@
 import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
 import clamp from 'lodash/clamp';
+import {PlatformIcon} from 'platformicons';
 
 import {TraceIcons} from '../traceIcons';
 import type {TraceTree} from '../traceModels/traceTree';
@@ -95,3 +97,8 @@ export function TracePerformanceIssueIcons(props: TracePerformanceIssueIconsProp
     </Fragment>
   );
 }
+
+export const SpanProjectIcon = styled(PlatformIcon)`
+  opacity: 0.2;
+  filter: grayscale(1);
+`;

--- a/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceIcons.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import clamp from 'lodash/clamp';
 import {PlatformIcon} from 'platformicons';
 
+import {useHasTraceNewUi} from 'sentry/views/performance/newTraceDetails/useHasTraceNewUi';
+
 import {TraceIcons} from '../traceIcons';
 import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
@@ -98,7 +100,17 @@ export function TracePerformanceIssueIcons(props: TracePerformanceIssueIconsProp
   );
 }
 
-export const SpanProjectIcon = styled(PlatformIcon)`
+export function SpanProjectIcon({platform}: {platform: string}) {
+  const hasTraceNewUi = useHasTraceNewUi();
+
+  if (!hasTraceNewUi) {
+    return null;
+  }
+
+  return <FaintProjectIcon platform={platform} />;
+}
+
+const FaintProjectIcon = styled(PlatformIcon)`
   opacity: 0.2;
   filter: grayscale(1);
 `;

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -1,3 +1,5 @@
+import {SpanProjectIcon} from 'sentry/views/performance/newTraceDetails/traceRow/traceIcons';
+
 import {TraceIcons} from '../traceIcons';
 import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
@@ -57,6 +59,9 @@ export function TraceSpanRow(props: TraceRowProps<TraceTreeNode<TraceTree.Span>>
               </TraceChildrenButton>
             ) : null}
           </div>
+          <SpanProjectIcon
+            platform={props.projects[props.node.metadata.project_slug ?? ''] ?? 'default'}
+          />
           <span className="TraceOperation">{props.node.value.op ?? '<unknown>'}</span>
           <strong className="TraceEmDash"> — </strong>
           <span className="TraceDescription" title={props.node.value.description}>


### PR DESCRIPTION
As per the new designs, adds faint project badges to span rows. I have not added them to autogrouped rows, as I am unsure whether they should have them or not 🤔

We can explore adding them to autogroup span rows if necessary

![image](https://github.com/user-attachments/assets/1e2622a6-62ad-43d8-9813-49c4bcfc487e)

