### PR TITLE
chore(codecov): Do not fail the codecov check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,8 +12,8 @@ coverage:
       backend:
         # codecov will not fail status checks for master
         only_pulls: true
-        informational: false # Fail the check
-        target: 90%
+        informational: true # Do not fail the check
+        target: 50%
         flags:
           - backend
   ignore:


### PR DESCRIPTION
We have the comment in place to let us know if there's something to do. The check always turns red and we do nothing about it.