### PR TITLE
feat(taskworker) Add tracing continutation to taskworker tasks

### DIFF
--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -57,11 +57,19 @@ class TaskNamespace:
         return self._producer
 
     def get(self, name: str) -> Task[Any, Any]:
+        """
+        Get a registered task by name
+
+        Raises KeyError when an unknown task is provided.
+        """
         if name not in self._registered_tasks:
             raise KeyError(f"No task registered with the name {name}. Check your imports")
         return self._registered_tasks[name]
 
     def contains(self, name: str) -> bool:
+        """
+        Check if a task name has been registered
+        """
         return name in self._registered_tasks
 
     def register(
@@ -80,6 +88,7 @@ class TaskNamespace:
         asynchronously via taskworkers.
 
         Parameters
+        ----------
 
         name: str
             The name of the task. This is serialized and must be stable across deploys.


### PR DESCRIPTION
Add sentry-trace and baggage to task headers. With these headers we can continue traces from within workers so that spawned tasks are included in the trace they originated from.

![Screenshot 2024-12-06 at 3 31 23 PM](https://github.com/user-attachments/assets/b5de55d5-6281-482f-b96f-05cd5b6d40c3)

This screenshot shows a task that was spawned by `OrganizationDetails.get()` included in the trace from the endpoint.

Refs #80054
Refs #80254