### PR TITLE
fix(event tracker): change location of where redis deleted is logged

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -560,12 +560,6 @@ def post_process_group(
                 return
             with metrics.timer("tasks.post_process.delete_event_cache"):
                 processing_store.delete_by_key(cache_key)
-            if eventstream_type == EventStreamEventType.Transaction.value:
-                track_sampled_event(
-                    data["event_id"],
-                    ConsumerType.Transactions,
-                    TransactionStageStatus.REDIS_DELETED,
-                )
             occurrence = None
             event = process_event(data, group_id)
         else:

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -579,6 +579,12 @@ def _do_save_event(
             # Delete the event payload from cache since it won't show up in post-processing.
             if cache_key:
                 processing_store.delete_by_key(cache_key)
+                if consumer_type == ConsumerType.Transactions:
+                    track_sampled_event(
+                        data["event_id"],
+                        ConsumerType.Transactions,
+                        TransactionStageStatus.REDIS_DELETED,
+                    )
         except Exception:
             metrics.incr("events.save_event.exception", tags={"event_type": event_type})
             raise

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -593,12 +593,11 @@ def _do_save_event(
                 # so we can delete it from the cache now.
                 if cache_key:
                     processing_store.delete_by_key(cache_key)
-                    if consumer_type == ConsumerType.Transactions:
-                        track_sampled_event(
-                            data["event_id"],
-                            ConsumerType.Transactions,
-                            TransactionStageStatus.REDIS_DELETED,
-                        )
+                    track_sampled_event(
+                        data["event_id"],
+                        ConsumerType.Transactions,
+                        TransactionStageStatus.REDIS_DELETED,
+                    )
 
             reprocessing2.mark_event_reprocessed(data)
             if cache_key and has_attachments:

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -579,12 +579,6 @@ def _do_save_event(
             # Delete the event payload from cache since it won't show up in post-processing.
             if cache_key:
                 processing_store.delete_by_key(cache_key)
-                if consumer_type == ConsumerType.Transactions:
-                    track_sampled_event(
-                        data["event_id"],
-                        ConsumerType.Transactions,
-                        TransactionStageStatus.REDIS_DELETED,
-                    )
         except Exception:
             metrics.incr("events.save_event.exception", tags={"event_type": event_type})
             raise
@@ -599,6 +593,12 @@ def _do_save_event(
                 # so we can delete it from the cache now.
                 if cache_key:
                     processing_store.delete_by_key(cache_key)
+                    if consumer_type == ConsumerType.Transactions:
+                        track_sampled_event(
+                            data["event_id"],
+                            ConsumerType.Transactions,
+                            TransactionStageStatus.REDIS_DELETED,
+                        )
 
             reprocessing2.mark_event_reprocessed(data)
             if cache_key and has_attachments:


### PR DESCRIPTION
`redis_deleted` is not being logged currently. Josh Ferge made a change to remove transactions from post process, so this PR logs `redis_deleted` at the right spot