### PR TITLE
fix(issue summary): Skip summary cache if event id provided

### DIFF
--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -188,12 +188,12 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         ):
             return Response({"detail": "Feature flag not enabled"}, status=400)
 
-        cache_key = "ai-group-summary-v2:" + str(group.id)
-        if cached_summary := cache.get(cache_key):
-            return Response(convert_dict_key_case(cached_summary, snake_to_camel_case), status=200)
-
         data = orjson.loads(request.body) if request.body else {}
         force_event_id = data.get("event_id", None)
+
+        cache_key = "ai-group-summary-v2:" + str(group.id)
+        if not force_event_id and (cached_summary := cache.get(cache_key)):
+            return Response(convert_dict_key_case(cached_summary, snake_to_camel_case), status=200)
 
         serialized_event, event = self._get_event(
             group, request.user, provided_event_id=force_event_id


### PR DESCRIPTION
In order for users to be able to refresh the summary for a specific event they choose, we need to skip the cache if a specific event is provided.