### PR TITLE
♻️ ref(slo): Add `acount_inactive` for Slack Post Message

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -35,9 +35,7 @@ from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.channel import SlackChannelIdData, get_channel_id
 from sentry.integrations.slack.utils.errors import (
-    ACCOUNT_INACTIVE,
-    CHANNEL_ARCHIVED,
-    CHANNEL_NOT_FOUND,
+    SLACK_SDK_HALT_ERROR_CATEGORIES,
     unpack_slack_api_error,
 )
 from sentry.integrations.utils.metrics import EventLifecycle
@@ -244,7 +242,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     if (
                         (reason := unpack_slack_api_error(e))
                         and reason is not None
-                        and reason in (CHANNEL_NOT_FOUND, CHANNEL_ARCHIVED, ACCOUNT_INACTIVE)
+                        and reason in SLACK_SDK_HALT_ERROR_CATEGORIES
                     ):
                         lifecycle.record_halt(reason.message)
                     else:

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -35,6 +35,7 @@ from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.channel import SlackChannelIdData, get_channel_id
 from sentry.integrations.slack.utils.errors import (
+    ACCOUNT_INACTIVE,
     CHANNEL_ARCHIVED,
     CHANNEL_NOT_FOUND,
     unpack_slack_api_error,
@@ -243,11 +244,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     if (
                         (reason := unpack_slack_api_error(e))
                         and reason is not None
-                        and reason
-                        in (
-                            CHANNEL_NOT_FOUND,
-                            CHANNEL_ARCHIVED,
-                        )
+                        and reason in (CHANNEL_NOT_FOUND, CHANNEL_ARCHIVED, ACCOUNT_INACTIVE)
                     ):
                         lifecycle.record_halt(reason.message)
                     else:

--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -20,6 +20,15 @@ SLACK_SDK_ERROR_CATEGORIES = (
     RATE_LIMITED := SlackSdkErrorCategory("ratelimited"),
 )
 
+"""
+Errors that are user configuration errors and should be recorded as a halt for SLOs.
+"""
+SLACK_SDK_HALT_ERROR_CATEGORIES = (
+    ACCOUNT_INACTIVE,
+    CHANNEL_NOT_FOUND,
+    CHANNEL_ARCHIVED,
+)
+
 _CATEGORIES_BY_MESSAGE = {c.message: c for c in SLACK_SDK_ERROR_CATEGORIES}
 
 

--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -13,10 +13,11 @@ class SlackSdkErrorCategory:
 
 
 SLACK_SDK_ERROR_CATEGORIES = (
-    RATE_LIMITED := SlackSdkErrorCategory("ratelimited"),
+    ACCOUNT_INACTIVE := SlackSdkErrorCategory("account_inactive"),
     CHANNEL_NOT_FOUND := SlackSdkErrorCategory("channel_not_found"),
     CHANNEL_ARCHIVED := SlackSdkErrorCategory("is_archived"),
     MODAL_NOT_FOUND := SlackSdkErrorCategory("not_found"),
+    RATE_LIMITED := SlackSdkErrorCategory("ratelimited"),
 )
 
 _CATEGORIES_BY_MESSAGE = {c.message: c for c in SLACK_SDK_ERROR_CATEGORIES}

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -35,9 +35,7 @@ from sentry.integrations.slack.metrics import (
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.errors import (
-    ACCOUNT_INACTIVE,
-    CHANNEL_ARCHIVED,
-    CHANNEL_NOT_FOUND,
+    SLACK_SDK_HALT_ERROR_CATEGORIES,
     unpack_slack_api_error,
 )
 from sentry.models.options.organization_option import OrganizationOption
@@ -181,12 +179,7 @@ def send_incident_alert_notification(
             if (
                 (reason := unpack_slack_api_error(e))
                 and reason is not None
-                and reason
-                in (
-                    CHANNEL_NOT_FOUND,
-                    CHANNEL_ARCHIVED,
-                    ACCOUNT_INACTIVE,
-                )
+                and reason in SLACK_SDK_HALT_ERROR_CATEGORIES
             ):
                 lifecycle.record_halt(reason.message)
             else:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -35,6 +35,7 @@ from sentry.integrations.slack.metrics import (
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.errors import (
+    ACCOUNT_INACTIVE,
     CHANNEL_ARCHIVED,
     CHANNEL_NOT_FOUND,
     unpack_slack_api_error,
@@ -184,6 +185,7 @@ def send_incident_alert_notification(
                 in (
                     CHANNEL_NOT_FOUND,
                     CHANNEL_ARCHIVED,
+                    ACCOUNT_INACTIVE,
                 )
             ):
                 lifecycle.record_halt(reason.message)


### PR DESCRIPTION
[SENTRY-3K4C](https://sentry.sentry.io/issues/6116162311/) exposed `account_inactive` as another user configuration reason that postMessage fails.

i refactored the logic to record halts for these cases and added a test.