### PR TITLE
feat(issue summary): Add event link and refresh button to issue summary

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -1,20 +1,26 @@
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
+import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
-import {IconFatal, IconFocus, IconSpan} from 'sentry/icons';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {IconFatal, IconFocus, IconRefresh, IconSpan} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import marked from 'sentry/utils/marked';
-import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+import {type ApiQueryKey, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
 interface GroupSummaryData {
   groupId: string;
   headline: string;
+  eventId?: string | null;
   possibleCause?: string | null;
   trace?: string | null;
   whatsWrong?: string | null;
@@ -22,46 +28,117 @@ interface GroupSummaryData {
 
 export const makeGroupSummaryQueryKey = (
   organizationSlug: string,
-  groupId: string
+  groupId: string,
+  eventId?: string
 ): ApiQueryKey => [
   `/organizations/${organizationSlug}/issues/${groupId}/summarize/`,
-  {method: 'POST'},
+  {
+    method: 'POST',
+    data: eventId ? {event_id: eventId} : undefined,
+  },
 ];
 
 export function useGroupSummary(
   group: Group,
   event: Event | null | undefined,
-  project: Project
+  project: Project,
+  forceEvent: boolean = false
 ) {
   const organization = useOrganization();
-
   const aiConfig = useAiConfig(group, event, project);
+  const enabled = aiConfig.hasSummary;
+  const queryClient = useQueryClient();
+  const queryKey = makeGroupSummaryQueryKey(
+    organization.slug,
+    group.id,
+    forceEvent ? event?.id : undefined
+  );
 
-  const queryData = useApiQuery<GroupSummaryData>(
-    makeGroupSummaryQueryKey(organization.slug, group.id),
+  const {data, isLoading, isFetching, isError, refetch} = useApiQuery<GroupSummaryData>(
+    queryKey,
     {
-      staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
-      enabled: aiConfig.hasSummary,
+      staleTime: Infinity,
+      enabled,
     }
   );
+
+  const refresh = () => {
+    queryClient.invalidateQueries({
+      queryKey: [`/organizations/${organization.slug}/issues/${group.id}/summarize/`],
+      exact: false,
+    });
+    refetch();
+  };
+
   return {
-    ...queryData,
-    isPending: aiConfig.isAutofixSetupLoading || queryData.isPending,
-    isError: queryData.isError,
+    data,
+    isPending: aiConfig.isAutofixSetupLoading || isLoading || isFetching,
+    isError,
+    refresh,
   };
 }
 
 export function GroupSummary({
-  data,
-  isError,
-  isPending,
+  group,
+  event,
+  project,
   preview = false,
 }: {
-  data: GroupSummaryData | undefined;
-  isError: boolean;
-  isPending: boolean;
+  event: Event | null | undefined;
+  group: Group;
+  project: Project;
   preview?: boolean;
 }) {
+  const organization = useOrganization();
+  const [forceEvent, setForceEvent] = useState(false);
+  const {data, isPending, isError, refresh} = useGroupSummary(
+    group,
+    event,
+    project,
+    forceEvent
+  );
+
+  useEffect(() => {
+    if (forceEvent && !isPending) {
+      refresh();
+      setForceEvent(false);
+    }
+  }, [forceEvent, isPending, refresh]);
+
+  const tooltipContent = data?.eventId ? (
+    event?.id === data.eventId ? (
+      t('Based on this event')
+    ) : (
+      <TooltipContentWrapper>
+        <span>
+          {t('Based on event ')}
+          <EventLink
+            to={
+              window.location.origin +
+              normalizeUrl(
+                `/organizations/${organization.slug}/issues/${data.groupId}/events/${data.eventId}/`
+              )
+            }
+          >
+            {data.eventId.substring(0, 8)}
+          </EventLink>
+        </span>
+        <Button
+          size="xs"
+          icon={<IconRefresh size="xs" />}
+          busy={isPending}
+          aria-label={t('Summarize this event instead')}
+          title={t('Summarize this event instead')}
+          onClick={() => {
+            setForceEvent(true);
+          }}
+        />
+      </TooltipContentWrapper>
+    )
+  ) : (
+    ''
+  );
+
   const insightCards = [
     {
       id: 'whats_wrong',
@@ -90,10 +167,18 @@ export function GroupSummary({
     <div data-testid="group-summary">
       {isError ? <div>{t('Error loading summary')}</div> : null}
       <Content>
+        {data?.eventId && !isPending && (
+          <TooltipWrapper id="group-summary-tooltip-wrapper">
+            <QuestionTooltip
+              size="sm"
+              position="left"
+              isHoverable
+              title={tooltipContent}
+            />
+          </TooltipWrapper>
+        )}
         <InsightGrid>
           {insightCards.map(card => {
-            // Hide the card if we're not loading and there's no insight
-            // Also hide if we're loading and the card shouldn't show when loading
             if ((!isPending && !card.insight) || (isPending && !card.showWhenLoading)) {
               return null;
             }
@@ -139,6 +224,7 @@ const Content = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+  position: relative;
 `;
 
 const InsightGrid = styled('div')`
@@ -208,4 +294,24 @@ const CardContent = styled('div')`
     word-break: break-all;
   }
   flex: 1;
+`;
+
+const TooltipWrapper = styled('div')`
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
+
+const EventLink = styled(Link)`
+  color: ${p => p.theme.linkColor};
+  :hover {
+    color: ${p => p.theme.linkHoverColor};
+  }
+`;
+
+const TooltipContentWrapper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(1)};
 `;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -194,7 +194,7 @@ export function GroupSummary({
             <Button
               ref={buttonRef}
               size="xs"
-              icon={<IconEllipsis size="xs" />}
+              icon={<StyledIconEllipsis size="xs" />}
               aria-label={t('Event details')}
               borderless
               onClick={() => setShowEventDetails(!showEventDetails)}
@@ -355,4 +355,8 @@ const EventDetailsPopup = styled('div')`
   box-shadow: ${p => p.theme.dropShadowHeavy};
   z-index: 0;
   white-space: nowrap;
+`;
+
+const StyledIconEllipsis = styled(IconEllipsis)`
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -14,7 +14,7 @@ import {AutofixSetupContent} from 'sentry/components/events/autofix/autofixSetup
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
-import {GroupSummary, useGroupSummary} from 'sentry/components/group/groupSummary';
+import {GroupSummary} from 'sentry/components/group/groupSummary';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import Input from 'sentry/components/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -134,11 +134,6 @@ const AiSetupDataConsent = HookOrDefault({
 
 export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerProps) {
   const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
-  const {
-    data: summaryData,
-    isError,
-    isPending: isSummaryLoading,
-  } = useGroupSummary(group, event, project);
   const aiConfig = useAiConfig(group, event, project);
 
   useRouteAnalyticsParams({
@@ -225,11 +220,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
           <Fragment>
             {aiConfig.hasSummary && (
               <StyledCard>
-                <GroupSummary
-                  data={summaryData}
-                  isError={isError}
-                  isPending={isSummaryLoading}
-                />
+                <GroupSummary group={group} event={event} project={project} />
               </StyledCard>
             )}
             {aiConfig.hasAutofix && (

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
@@ -5,7 +5,7 @@ import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Button} from 'sentry/components/button';
 import {Chevron} from 'sentry/components/chevron';
 import useDrawer from 'sentry/components/globalDrawer';
-import {GroupSummary, useGroupSummary} from 'sentry/components/group/groupSummary';
+import {GroupSummary} from 'sentry/components/group/groupSummary';
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -50,7 +50,8 @@ export default function SolutionsSection({
             viewAllButton?.contains(element) ||
             document.getElementById('sentry-feedback')?.contains(element) ||
             document.getElementById('autofix-rethink-input')?.contains(element) ||
-            document.getElementById('autofix-write-access-modal')?.contains(element)
+            document.getElementById('autofix-write-access-modal')?.contains(element) ||
+            element.closest('[data-overlay="true"]')
           ) {
             return false;
           }
@@ -60,12 +61,6 @@ export default function SolutionsSection({
       }
     );
   };
-
-  const {
-    data: summaryData,
-    isPending: isSummaryLoading,
-    isError: isSummaryError,
-  } = useGroupSummary(group, event, project);
 
   const aiConfig = useAiConfig(group, event, project);
 
@@ -107,16 +102,10 @@ export default function SolutionsSection({
       );
     }
 
-    // Show the summary's loading state if we're still loading the autofix setup
     if (aiConfig.hasSummary) {
       return (
         <Summary>
-          <GroupSummary
-            data={summaryData ?? undefined}
-            isError={isSummaryError}
-            isPending={isSummaryLoading}
-            preview
-          />
+          <GroupSummary group={group} event={event} project={project} preview />
         </Summary>
       );
     }


### PR DESCRIPTION
Adds a button with a popup that tells the user which event was used to generate the summary. Includes a link to see that event if it's not the current event and a button to re-generate the summary on the current event.


<img width="349" alt="Screenshot 2024-12-09 at 9 54 09 AM" src="https://github.com/user-attachments/assets/b5c308fa-4a1c-4b3c-b7b7-28ddaa6b68c6">
<img width="349" alt="Screenshot 2024-12-09 at 9 54 18 AM" src="https://github.com/user-attachments/assets/3208c79b-0811-4b59-8a37-886e91edfc57">
