### PR TITLE
feat(label): adding label to container

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -58,6 +58,8 @@ services:
       - 127.0.0.1:5432:5432
     extra_hosts:
       - host.docker.internal:host-gateway
+    labels:
+      - orchestrator=devservices
     restart: unless-stopped
 
 networks:


### PR DESCRIPTION
Adding a label to the docker compose config to signify that devservices is the orchestrator.