### PR TITLE
ref(trace-view): Remove Trace and Web Vitals tabs

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -204,9 +204,10 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       return;
     }
 
-    const newTabs = [TRACE_TAB];
+    // New trace UI has the trace info and web vitalsin the bottom drawer
+    const newTabs = hasTraceNewUi ? [] : [TRACE_TAB];
 
-    if (props.tree.vitals.size > 0) {
+    if (props.tree.vitals.size > 0 && !hasTraceNewUi) {
       const types = Array.from(props.tree.vital_types.values());
       const label = types.length > 1 ? t('Vitals') : capitalize(types[0]) + ' Vitals';
 


### PR DESCRIPTION
Since the web vitals and trace info has been moved to the context drawer in the bottom of the page, we no longer need the tabs here. We do not include these tabs if `hasTraceNewUi` is true.

![image](https://github.com/user-attachments/assets/524d0569-179d-4ec6-9ac3-252df5b6a07f)
