### PR TITLE
feat(devservices): Use https for repo links

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -8,14 +8,14 @@ x-sentry-service-config:
       remote:
         repo_name: snuba
         branch: master
-        repo_link: git@github.com:getsentry/snuba.git
+        repo_link: https://github.com/getsentry/snuba.git
         mode: containerized
     relay:
       description: Service event forwarding and ingestion service
       remote:
         repo_name: relay
         branch: master
-        repo_link: git@github.com:getsentry/relay.git
+        repo_link: https://github.com/getsentry/relay.git
         mode: containerized
     postgres:
       description: Database used to store Sentry data
@@ -24,7 +24,7 @@ x-sentry-service-config:
       remote:
         repo_name: sentry-shared-redis
         branch: main
-        repo_link: git@github.com:getsentry/sentry-shared-redis.git
+        repo_link: https://github.com/getsentry/sentry-shared-redis.git
   modes:
     default: [snuba, postgres, relay]
     migrations: [postgres, redis]


### PR DESCRIPTION
We decided to move forwards with https for these reasons:

1. devservices should not commit changes and should only care about configuration files in read only mode
2. It is not easy to integrate ssh authentication for CI
3. devservices will prompt for ssh key locally if ssh authentication is not set up