### PR TITLE
feat(feedback): suggest 'trace' filter in feedback index

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2343,6 +2343,7 @@ export const FEEDBACK_FIELDS = [
   FieldKey.SDK_NAME,
   FieldKey.SDK_VERSION,
   FieldKey.TIMESTAMP,
+  FieldKey.TRACE,
   FieldKey.TRANSACTION,
   FeedbackFieldKey.URL,
   FieldKey.USER_EMAIL,


### PR DESCRIPTION
This filter is already supported and defined in [EVENT_FIELD_DEFINITIONS](https://github.com/getsentry/sentry/blob/a22d6be64d143364a0e53dea3ca73f0f94b3eb3a/static/app/utils/fields/index.ts#L1698-L1702). This just exposes it to the search bar autocomplete

From dev-ui:
![SCR-20241209-kadg](https://github.com/user-attachments/assets/f87fe358-23a3-4af0-963a-1078a4ec1bc3)

Successful search 
for [JAVASCRIPT-2VVV](https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A5862391397&project=11276) using the ID of [this trace](https://sentry.sentry.io/performance/trace/c6c8ff768da34b25a52b6d7a82d7b115/?eventId=348caa15762a4c50bc7a0f1fad05c8c6&feedbackSlug=javascript%3A5862391397&groupId=5862391397&mailbox=resolved&pageEnd=2024-09-17T21%3A39%3A49.462&pageStart=2024-09-16T21%3A39%3A49.462&project=11276&query=%21transaction%3A%22%22&referrer=feedback_list_page&source=feedback_details&timestamp=1726565910):
![SCR-20241209-kasa](https://github.com/user-attachments/assets/097f2bf1-119f-424a-8dbe-445620ac6372)

Closes https://github.com/getsentry/team-replay/issues/513