### PR TITLE
ref(grouping): Rename lots of things for clarity

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -311,10 +311,10 @@ def _get_calculated_grouping_variants_for_event(
             "default": DefaultGroupingComponent,
             "system": SystemGroupingComponent,
         }
-        component = component_class_by_variant[variant](values=components)
-        if not component.contributes and precedence_hint:
-            component.update(hint=precedence_hint)
-        rv[variant] = component
+        root_component = component_class_by_variant[variant](values=components)
+        if not root_component.contributes and precedence_hint:
+            root_component.update(hint=precedence_hint)
+        rv[variant] = root_component
 
     return rv
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -294,7 +294,7 @@ def _get_component_trees_for_variants(
             if winning_strategy is None:
                 if component.contributes:
                     winning_strategy = strategy.name
-                    variants_hint = "/".join(
+                    variant_descriptor = "/".join(
                         sorted(
                             k
                             for k, v in current_strategy_components_by_variant.items()
@@ -303,7 +303,7 @@ def _get_component_trees_for_variants(
                     )
                     precedence_hint = "{} take{} precedence".format(
                         (
-                            f"{strategy.name} of {variants_hint}"
+                            f"{strategy.name} of {variant_descriptor}"
                             if variant != "default"
                             else strategy.name
                         ),

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -378,12 +378,12 @@ def get_grouping_variants_for_event(
     # fingerprint and mark all other variants as non-contributing
     if defaults_referenced == 0:
         rv = {}
-        for key, component in components.items():
+        for variant_name, component in components.items():
             component.update(
                 contributes=False,
                 hint="custom fingerprint takes precedence",
             )
-            rv[key] = ComponentVariant(component, context.config)
+            rv[variant_name] = ComponentVariant(component, context.config)
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
         if fingerprint_info.get("matched_rule", {}).get("is_builtin") is True:
@@ -394,15 +394,15 @@ def get_grouping_variants_for_event(
     # If only the default is referenced, we can use the variants as is
     elif defaults_referenced == 1 and len(fingerprint) == 1:
         rv = {}
-        for key, component in components.items():
-            rv[key] = ComponentVariant(component, context.config)
+        for variant_name, component in components.items():
+            rv[variant_name] = ComponentVariant(component, context.config)
 
     # Otherwise we need to "salt" our variants with the custom fingerprint value(s)
     else:
         rv = {}
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
-        for key, component in components.items():
-            rv[key] = SaltedComponentVariant(
+        for variant_name, component in components.items():
+            rv[variant_name] = SaltedComponentVariant(
                 fingerprint, component, context.config, fingerprint_info
             )
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -300,8 +300,8 @@ def _get_component_trees_for_variants(
                     winning_strategy = strategy.name
                     variant_descriptor = "/".join(
                         sorted(
-                            k
-                            for k, v in current_strategy_components_by_variant.items()
+                            variant_name
+                            for variant_name, v in current_strategy_components_by_variant.items()
                             if v.contributes
                         )
                     )

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -288,8 +288,8 @@ def _get_component_trees_for_variants(
         current_strategy_components_by_variant = strategy.get_grouping_component_variants(
             event, context=context
         )
-        for variant, component in current_strategy_components_by_variant.items():
-            all_strategies_components_by_variant.setdefault(variant, []).append(component)
+        for variant_name, component in current_strategy_components_by_variant.items():
+            all_strategies_components_by_variant.setdefault(variant_name, []).append(component)
 
             if winning_strategy is None:
                 if component.contributes:
@@ -304,7 +304,7 @@ def _get_component_trees_for_variants(
                     precedence_hint = "{} take{} precedence".format(
                         (
                             f"{strategy.name} of {variant_descriptor}"
-                            if variant != "default"
+                            if variant_name != "default"
                             else strategy.name
                         ),
                         "" if strategy.name.endswith("s") else "s",
@@ -313,16 +313,16 @@ def _get_component_trees_for_variants(
                 component.update(contributes=False, hint=precedence_hint)
 
     rv = {}
-    for variant, components in all_strategies_components_by_variant.items():
+    for variant_name, components in all_strategies_components_by_variant.items():
         component_class_by_variant = {
             "app": AppGroupingComponent,
             "default": DefaultGroupingComponent,
             "system": SystemGroupingComponent,
         }
-        root_component = component_class_by_variant[variant](values=components)
+        root_component = component_class_by_variant[variant_name](values=components)
         if not root_component.contributes and precedence_hint:
             root_component.update(hint=precedence_hint)
-        rv[variant] = root_component
+        rv[variant_name] = root_component
 
     return rv
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -378,12 +378,12 @@ def get_grouping_variants_for_event(
     # fingerprint and mark all other variants as non-contributing
     if defaults_referenced == 0:
         rv = {}
-        for variant_name, component in component_trees_by_variant.items():
-            component.update(
+        for variant_name, root_component in component_trees_by_variant.items():
+            root_component.update(
                 contributes=False,
                 hint="custom fingerprint takes precedence",
             )
-            rv[variant_name] = ComponentVariant(component, context.config)
+            rv[variant_name] = ComponentVariant(root_component, context.config)
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
         if fingerprint_info.get("matched_rule", {}).get("is_builtin") is True:
@@ -394,16 +394,16 @@ def get_grouping_variants_for_event(
     # If only the default is referenced, we can use the variants as is
     elif defaults_referenced == 1 and len(fingerprint) == 1:
         rv = {}
-        for variant_name, component in component_trees_by_variant.items():
-            rv[variant_name] = ComponentVariant(component, context.config)
+        for variant_name, root_component in component_trees_by_variant.items():
+            rv[variant_name] = ComponentVariant(root_component, context.config)
 
     # Otherwise we need to "salt" our variants with the custom fingerprint value(s)
     else:
         rv = {}
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
-        for variant_name, component in component_trees_by_variant.items():
+        for variant_name, root_component in component_trees_by_variant.items():
             rv[variant_name] = SaltedComponentVariant(
-                fingerprint, component, context.config, fingerprint_info
+                fingerprint, root_component, context.config, fingerprint_info
             )
 
     # Ensure we have a fallback hash if nothing else works out

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -372,13 +372,13 @@ def get_grouping_variants_for_event(
 
     # At this point we need to calculate the default event values.  If the
     # fingerprint is salted we will wrap it.
-    components = _get_component_trees_for_variants(event, context)
+    component_trees_by_variant = _get_component_trees_for_variants(event, context)
 
     # If no defaults are referenced we produce a single completely custom
     # fingerprint and mark all other variants as non-contributing
     if defaults_referenced == 0:
         rv = {}
-        for variant_name, component in components.items():
+        for variant_name, component in component_trees_by_variant.items():
             component.update(
                 contributes=False,
                 hint="custom fingerprint takes precedence",
@@ -394,14 +394,14 @@ def get_grouping_variants_for_event(
     # If only the default is referenced, we can use the variants as is
     elif defaults_referenced == 1 and len(fingerprint) == 1:
         rv = {}
-        for variant_name, component in components.items():
+        for variant_name, component in component_trees_by_variant.items():
             rv[variant_name] = ComponentVariant(component, context.config)
 
     # Otherwise we need to "salt" our variants with the custom fingerprint value(s)
     else:
         rv = {}
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
-        for variant_name, component in components.items():
+        for variant_name, component in component_trees_by_variant.items():
             rv[variant_name] = SaltedComponentVariant(
                 fingerprint, component, context.config, fingerprint_info
             )

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -276,7 +276,7 @@ def apply_server_fingerprinting(
         event["_fingerprint_info"] = fingerprint_info
 
 
-def _get_calculated_grouping_variants_for_event(
+def _get_component_trees_for_variants(
     event: Event, context: GroupingContext
 ) -> dict[str, AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent]:
     winning_strategy: str | None = None
@@ -364,7 +364,7 @@ def get_grouping_variants_for_event(
 
     # At this point we need to calculate the default event values.  If the
     # fingerprint is salted we will wrap it.
-    components = _get_calculated_grouping_variants_for_event(event, context)
+    components = _get_component_trees_for_variants(event, context)
 
     # If no defaults are referenced we produce a single completely custom
     # fingerprint and mark all other variants as non-contributing

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -264,7 +264,7 @@ def apply_server_fingerprinting(
 
     fingerprint_match = fingerprinting_config.get_fingerprint_values_for_event(event)
     if fingerprint_match is not None:
-        rule, new_fingerprint, attributes = fingerprint_match
+        matched_rule, new_fingerprint, attributes = fingerprint_match
 
         # A custom title attribute is stored in the event to override the
         # default title.
@@ -274,7 +274,7 @@ def apply_server_fingerprinting(
 
         # Persist the rule that matched with the fingerprint in the event
         # dictionary for later debugging.
-        fingerprint_info["matched_rule"] = rule.to_json()
+        fingerprint_info["matched_rule"] = matched_rule.to_json()
 
     if fingerprint_info:
         event["_fingerprint_info"] = fingerprint_info

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -241,11 +241,11 @@ def get_fingerprinting_config_for_project(
         return FingerprintingRules.from_json(config_json, bases=bases)
 
     try:
-        rv = FingerprintingRules.from_config_string(raw_rules, bases=bases)
+        rules = FingerprintingRules.from_config_string(raw_rules, bases=bases)
     except InvalidFingerprintingConfig:
-        rv = FingerprintingRules([], bases=bases)
-    cache.set(cache_key, rv.to_json())
-    return rv
+        rules = FingerprintingRules([], bases=bases)
+    cache.set(cache_key, rules.to_json())
+    return rules
 
 
 def apply_server_fingerprinting(

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -281,7 +281,7 @@ def _get_component_trees_for_variants(
 ) -> dict[str, AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent]:
     winning_strategy: str | None = None
     precedence_hint: str | None = None
-    per_variant_components: dict[str, list[BaseGroupingComponent]] = {}
+    all_strategies_components_by_variant: dict[str, list[BaseGroupingComponent]] = {}
 
     for strategy in context.config.iter_strategies():
         # Defined in src/sentry/grouping/strategies/base.py
@@ -289,7 +289,7 @@ def _get_component_trees_for_variants(
             event, context=context
         )
         for variant, component in current_strategy_components_by_variant.items():
-            per_variant_components.setdefault(variant, []).append(component)
+            all_strategies_components_by_variant.setdefault(variant, []).append(component)
 
             if winning_strategy is None:
                 if component.contributes:
@@ -313,7 +313,7 @@ def _get_component_trees_for_variants(
                 component.update(contributes=False, hint=precedence_hint)
 
     rv = {}
-    for variant, components in per_variant_components.items():
+    for variant, components in all_strategies_components_by_variant.items():
         component_class_by_variant = {
             "app": AppGroupingComponent,
             "default": DefaultGroupingComponent,

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -99,18 +99,18 @@ class GroupingConfigLoader:
         cache_key = (
             cache_prefix + md5_text(f"{enhancements_base}|{project_enhancements}").hexdigest()
         )
-        rv = cache.get(cache_key)
-        if rv is not None:
-            return rv
+        enhancements = cache.get(cache_key)
+        if enhancements is not None:
+            return enhancements
 
         try:
-            rv = Enhancements.from_config_string(
+            enhancements = Enhancements.from_config_string(
                 project_enhancements, bases=[enhancements_base]
             ).dumps()
         except InvalidEnhancerConfig:
-            rv = get_default_enhancements()
-        cache.set(cache_key, rv)
-        return rv
+            enhancements = get_default_enhancements()
+        cache.set(cache_key, enhancements)
+        return enhancements
 
     def _get_config_id(self, project):
         raise NotImplementedError

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -289,7 +289,7 @@ def _get_component_trees_for_variants(
 
     for strategy in context.config.iter_strategies():
         # Defined in src/sentry/grouping/strategies/base.py
-        current_strategy_components_by_variant = strategy.get_grouping_component_variants(
+        current_strategy_components_by_variant = strategy.get_grouping_components(
             event, context=context
         )
         for variant_name, component in current_strategy_components_by_variant.items():

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -285,14 +285,22 @@ def _get_component_trees_for_variants(
 
     for strategy in context.config.iter_strategies():
         # Defined in src/sentry/grouping/strategies/base.py
-        rv = strategy.get_grouping_component_variants(event, context=context)
-        for variant, component in rv.items():
+        current_strategy_components_by_variant = strategy.get_grouping_component_variants(
+            event, context=context
+        )
+        for variant, component in current_strategy_components_by_variant.items():
             per_variant_components.setdefault(variant, []).append(component)
 
             if winning_strategy is None:
                 if component.contributes:
                     winning_strategy = strategy.name
-                    variants_hint = "/".join(sorted(k for k, v in rv.items() if v.contributes))
+                    variants_hint = "/".join(
+                        sorted(
+                            k
+                            for k, v in current_strategy_components_by_variant.items()
+                            if v.contributes
+                        )
+                    )
                     precedence_hint = "{} take{} precedence".format(
                         (
                             f"{strategy.name} of {variants_hint}"

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -301,8 +301,8 @@ def _get_component_trees_for_variants(
                     variant_descriptor = "/".join(
                         sorted(
                             variant_name
-                            for variant_name, v in current_strategy_components_by_variant.items()
-                            if v.contributes
+                            for variant_name, component in current_strategy_components_by_variant.items()
+                            if component.contributes
                         )
                     )
                     precedence_hint = "{} take{} precedence".format(

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -228,20 +228,20 @@ def get_fingerprinting_config_for_project(
     from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
 
     bases = get_projects_default_fingerprinting_bases(project, config_id=config_id)
-    rules = project.get_option("sentry:fingerprinting_rules")
-    if not rules:
+    raw_rules = project.get_option("sentry:fingerprinting_rules")
+    if not raw_rules:
         return FingerprintingRules([], bases=bases)
 
     from sentry.utils.cache import cache
     from sentry.utils.hashlib import md5_text
 
-    cache_key = "fingerprinting-rules:" + md5_text(rules).hexdigest()
+    cache_key = "fingerprinting-rules:" + md5_text(raw_rules).hexdigest()
     config_json = cache.get(cache_key)
     if config_json is not None:
         return FingerprintingRules.from_json(config_json, bases=bases)
 
     try:
-        rv = FingerprintingRules.from_config_string(rules, bases=bases)
+        rv = FingerprintingRules.from_config_string(raw_rules, bases=bases)
     except InvalidFingerprintingConfig:
         rv = FingerprintingRules([], bases=bases)
     cache.set(cache_key, rv.to_json())

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -236,9 +236,9 @@ def get_fingerprinting_config_for_project(
     from sentry.utils.hashlib import md5_text
 
     cache_key = "fingerprinting-rules:" + md5_text(rules).hexdigest()
-    rv = cache.get(cache_key)
-    if rv is not None:
-        return FingerprintingRules.from_json(rv, bases=bases)
+    config_json = cache.get(cache_key)
+    if config_json is not None:
+        return FingerprintingRules.from_json(config_json, bases=bases)
 
     try:
         rv = FingerprintingRules.from_config_string(rules, bases=bases)

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -312,7 +312,7 @@ def _get_component_trees_for_variants(
             elif component.contributes and winning_strategy != strategy.name:
                 component.update(contributes=False, hint=precedence_hint)
 
-    rv = {}
+    component_trees_by_variant = {}
     for variant_name, components in all_strategies_components_by_variant.items():
         component_class_by_variant = {
             "app": AppGroupingComponent,
@@ -322,9 +322,9 @@ def _get_component_trees_for_variants(
         root_component = component_class_by_variant[variant_name](values=components)
         if not root_component.contributes and precedence_hint:
             root_component.update(hint=precedence_hint)
-        rv[variant_name] = root_component
+        component_trees_by_variant[variant_name] = root_component
 
-    return rv
+    return component_trees_by_variant
 
 
 # This is called by the Event model in get_grouping_variants()

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -84,7 +84,7 @@ class GroupingConfigLoader:
         }
 
     def _get_enhancements(self, project) -> str:
-        enhancements = project.get_option("sentry:grouping_enhancements")
+        project_enhancements = project.get_option("sentry:grouping_enhancements")
 
         config_id = self._get_config_id(project)
         enhancements_base = CONFIGURATIONS[config_id].enhancements_base
@@ -96,13 +96,17 @@ class GroupingConfigLoader:
 
         cache_prefix = self.cache_prefix
         cache_prefix += f"{LATEST_VERSION}:"
-        cache_key = cache_prefix + md5_text(f"{enhancements_base}|{enhancements}").hexdigest()
+        cache_key = (
+            cache_prefix + md5_text(f"{enhancements_base}|{project_enhancements}").hexdigest()
+        )
         rv = cache.get(cache_key)
         if rv is not None:
             return rv
 
         try:
-            rv = Enhancements.from_config_string(enhancements, bases=[enhancements_base]).dumps()
+            rv = Enhancements.from_config_string(
+                project_enhancements, bases=[enhancements_base]
+            ).dumps()
         except InvalidEnhancerConfig:
             rv = get_default_enhancements()
         cache.set(cache_key, rv)

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -262,9 +262,9 @@ def apply_server_fingerprinting(
     if client_fingerprint and not client_fingerprint_is_default:
         fingerprint_info["client_fingerprint"] = client_fingerprint
 
-    rv = fingerprinting_config.get_fingerprint_values_for_event(event)
-    if rv is not None:
-        rule, new_fingerprint, attributes = rv
+    fingerprint_match = fingerprinting_config.get_fingerprint_values_for_event(event)
+    if fingerprint_match is not None:
+        rule, new_fingerprint, attributes = fingerprint_match
 
         # A custom title attribute is stored in the event to override the
         # default title.

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -245,7 +245,9 @@ def get_fingerprinting_config_for_project(
 
 
 def apply_server_fingerprinting(
-    event: MutableMapping[str, Any], config: FingerprintingRules, allow_custom_title: bool = True
+    event: MutableMapping[str, Any],
+    fingerprinting_config: FingerprintingRules,
+    allow_custom_title: bool = True,
 ) -> None:
     fingerprint_info = {}
 
@@ -256,7 +258,7 @@ def apply_server_fingerprinting(
     if client_fingerprint and not client_fingerprint_is_default:
         fingerprint_info["client_fingerprint"] = client_fingerprint
 
-    rv = config.get_fingerprint_values_for_event(event)
+    rv = fingerprinting_config.get_fingerprint_values_for_event(event)
     if rv is not None:
         rule, new_fingerprint, attributes = rv
 

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -140,10 +140,10 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
 
     def shallow_copy(self) -> Self:
         """Creates a shallow copy."""
-        rv = object.__new__(self.__class__)
-        rv.__dict__.update(self.__dict__)
-        rv.values = list(self.values)
-        return rv
+        copy = object.__new__(self.__class__)
+        copy.__dict__.update(self.__dict__)
+        copy.values = list(self.values)
+        return copy
 
     def iter_values(self) -> Generator[str | int]:
         """Recursively walks the component and flattens it into a list of

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -169,7 +169,7 @@ class Enhancements:
 
     def assemble_stacktrace_component(
         self,
-        components: list[FrameGroupingComponent],
+        frame_components: list[FrameGroupingComponent],
         frames: list[dict[str, Any]],
         platform: str | None,
         exception_data: dict[str, Any] | None = None,
@@ -182,7 +182,7 @@ class Enhancements:
         """
         match_frames = [create_match_frame(frame, platform) for frame in frames]
 
-        rust_components = [RustComponent(contributes=c.contributes) for c in components]
+        rust_components = [RustComponent(contributes=c.contributes) for c in frame_components]
 
         rust_results = self.rust_enhancements.assemble_stacktrace_component(
             match_frames, make_rust_exception_data(exception_data), rust_components
@@ -193,13 +193,13 @@ class Enhancements:
         # to Seer
         frame_counts: Counter[str] = Counter()
 
-        for py_component, rust_component in zip(components, rust_components):
+        for py_component, rust_component in zip(frame_components, rust_components):
             py_component.update(contributes=rust_component.contributes, hint=rust_component.hint)
             key = f"{"in_app" if py_component.in_app else "system"}_{"contributing" if py_component.contributes else "non_contributing"}_frames"
             frame_counts[key] += 1
 
         stacktrace_component = StacktraceGroupingComponent(
-            values=components,
+            values=frame_components,
             hint=rust_results.hint,
             contributes=rust_results.contributes,
             frame_counts=frame_counts,

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -198,14 +198,14 @@ class Enhancements:
             key = f"{"in_app" if py_component.in_app else "system"}_{"contributing" if py_component.contributes else "non_contributing"}_frames"
             frame_counts[key] += 1
 
-        component = StacktraceGroupingComponent(
+        stacktrace_component = StacktraceGroupingComponent(
             values=components,
             hint=rust_results.hint,
             contributes=rust_results.contributes,
             frame_counts=frame_counts,
         )
 
-        return component, rust_results.invert_stacktrace
+        return stacktrace_component, rust_results.invert_stacktrace
 
     def as_dict(self, with_rules=False):
         rv = {

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sentry.grouping.utils import get_rule_bool
+from sentry.grouping.utils import bool_from_string
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.utils import metrics
@@ -202,7 +202,7 @@ class FrameMatch(EnhancementMatch):
         if self.key == "family":
             arg = "".join(_f for _f in [FAMILIES.get(x) for x in self.pattern.split(",")] if _f)
         elif self.key == "app":
-            arg = {True: "1", False: "0"}.get(get_rule_bool(self.pattern), "")
+            arg = {True: "1", False: "0"}.get(bool_from_string(self.pattern), "")
         else:
             arg = self.pattern
         return ("!" if self.negated else "") + MATCH_KEYS[self.key] + arg
@@ -258,7 +258,7 @@ class FamilyMatch(FrameMatch):
 class InAppMatch(FrameMatch):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._ref_val = get_rule_bool(self.pattern)
+        self._ref_val = bool_from_string(self.pattern)
 
     def _positive_frame_match(self, match_frame, exception_data, cache):
         ref_val = self._ref_val

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -273,9 +273,9 @@ class FingerprintingRules:
             return None
         access = EventAccess(event)
         for rule in self.iter_rules():
-            new_values = rule.get_fingerprint_values_for_event_access(access)
-            if new_values is not None:
-                return FingerprintRuleMatch(rule, new_values.fingerprint, new_values.attributes)
+            match = rule.get_fingerprint_values_for_event_access(access)
+            if match is not None:
+                return FingerprintRuleMatch(rule, match.fingerprint, match.attributes)
         return None
 
     @classmethod

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -156,7 +156,7 @@ class EventDatastore:
         self._family: list[_FamilyInfo] | None = None
         self._release: list[_ReleaseInfo] | None = None
 
-    def get_messages(self) -> list[_MessageInfo]:
+    def _get_messages(self) -> list[_MessageInfo]:
         if self._messages is None:
             self._messages = []
             message = get_path(self.event, "logentry", "formatted", filter=True)
@@ -164,7 +164,7 @@ class EventDatastore:
                 self._messages.append({"message": message})
         return self._messages
 
-    def get_log_info(self) -> list[_LogInfo]:
+    def _get_log_info(self) -> list[_LogInfo]:
         if self._log_info is None:
             log_info: _LogInfo = {}
             logger = get_path(self.event, "logger", filter=True)
@@ -179,7 +179,7 @@ class EventDatastore:
                 self._log_info = []
         return self._log_info
 
-    def get_exceptions(self) -> list[_ExceptionInfo]:
+    def _get_exceptions(self) -> list[_ExceptionInfo]:
         if self._exceptions is None:
             self._exceptions = []
             for exc in get_path(self.event, "exception", "values", filter=True) or ():
@@ -191,7 +191,7 @@ class EventDatastore:
                 )
         return self._exceptions
 
-    def get_frames(self) -> list[_FrameInfo]:
+    def _get_frames(self) -> list[_FrameInfo]:
         if self._frames is None:
             self._frames = frames = []
 
@@ -212,35 +212,35 @@ class EventDatastore:
             find_stack_frames(self.event, _push_frame)
         return self._frames
 
-    def get_toplevel(self) -> list[_MessageInfo | _ExceptionInfo]:
+    def _get_toplevel(self) -> list[_MessageInfo | _ExceptionInfo]:
         if self._toplevel is None:
-            self._toplevel = [*self.get_messages(), *self.get_exceptions()]
+            self._toplevel = [*self._get_messages(), *self._get_exceptions()]
         return self._toplevel
 
-    def get_tags(self) -> list[dict[str, str]]:
+    def _get_tags(self) -> list[dict[str, str]]:
         if self._tags is None:
             self._tags = [
                 {"tags.%s" % k: v for (k, v) in get_path(self.event, "tags", filter=True) or ()}
             ]
         return self._tags
 
-    def get_sdk(self) -> list[_SdkInfo]:
+    def _get_sdk(self) -> list[_SdkInfo]:
         if self._sdk is None:
             self._sdk = [{"sdk": normalized_sdk_tag_from_event(self.event)}]
         return self._sdk
 
-    def get_family(self) -> list[_FamilyInfo]:
+    def _get_family(self) -> list[_FamilyInfo]:
         self._family = self._family or [
             {"family": get_behavior_family_for_platform(self.event.get("platform"))}
         ]
         return self._family
 
-    def get_release(self) -> list[_ReleaseInfo]:
+    def _get_release(self) -> list[_ReleaseInfo]:
         self._release = self._release or [{"release": self.event.get("release")}]
         return self._release
 
     def get_values(self, match_group: str) -> list[dict[str, Any]]:
-        return getattr(self, "get_" + match_group)()
+        return getattr(self, "_get_" + match_group)()
 
 
 class FingerprintingRules:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -11,7 +11,7 @@ from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor, RegexNode
 
-from sentry.grouping.utils import get_rule_bool
+from sentry.grouping.utils import bool_from_string
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.utils.event_frames import find_stack_frames
@@ -459,7 +459,7 @@ class FingerprintMatcher:
             if self._positive_path_match(value):
                 return True
         elif self.key == "app":
-            ref_val = get_rule_bool(self.pattern)
+            ref_val = bool_from_string(self.pattern)
             if ref_val is not None and ref_val == value:
                 return True
         elif glob_match(value, self.pattern, ignorecase=self.key in ("level", "value")):

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -473,14 +473,14 @@ class FingerprintMatch:
         return [key, self.pattern]
 
     @classmethod
-    def _from_config_structure(cls, obj: list[str]) -> Self:
-        key = obj[0]
+    def _from_config_structure(cls, matcher: list[str]) -> Self:
+        key = matcher[0]
         if key.startswith("!"):
             key = key[1:]
             negated = True
         else:
             negated = False
-        return cls(key, obj[1], negated)
+        return cls(key, matcher[1], negated)
 
     @property
     def text(self) -> str:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -507,11 +507,11 @@ class FingerprintRule:
     def test_for_match_with_event(
         self, event_datastore: EventDatastore
     ) -> None | FingerprintWithAttributes:
-        by_match_type: dict[str, list[FingerprintMatcher]] = {}
+        matchers_by_match_type: dict[str, list[FingerprintMatcher]] = {}
         for matcher in self.matchers:
-            by_match_type.setdefault(matcher.match_type, []).append(matcher)
+            matchers_by_match_type.setdefault(matcher.match_type, []).append(matcher)
 
-        for match_type, matchers in by_match_type.items():
+        for match_type, matchers in matchers_by_match_type.items():
             for values in event_datastore.get_values(match_type):
                 if all(x.matches(values) for x in matchers):
                     break

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -271,9 +271,9 @@ class FingerprintingRules:
     ) -> None | FingerprintRuleMatch:
         if not (self.bases or self.rules):
             return None
-        access = EventDatastore(event)
+        event_datastore = EventDatastore(event)
         for rule in self.iter_rules():
-            match = rule.get_fingerprint_values_for_event_access(access)
+            match = rule.get_fingerprint_values_for_event_access(event_datastore)
             if match is not None:
                 return FingerprintRuleMatch(rule, match.fingerprint, match.attributes)
         return None

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -143,7 +143,7 @@ class FingerprintRuleMatch(NamedTuple):
     attributes: FingerprintRuleAttributes
 
 
-class EventAccess:
+class EventDatastore:
     def __init__(self, event: Mapping[str, Any]) -> None:
         self.event = event
         self._exceptions: list[_ExceptionInfo] | None = None
@@ -271,7 +271,7 @@ class FingerprintingRules:
     ) -> None | FingerprintRuleMatch:
         if not (self.bases or self.rules):
             return None
-        access = EventAccess(event)
+        access = EventDatastore(event)
         for rule in self.iter_rules():
             match = rule.get_fingerprint_values_for_event_access(access)
             if match is not None:
@@ -505,7 +505,7 @@ class FingerprintRule:
         self.is_builtin = is_builtin
 
     def get_fingerprint_values_for_event_access(
-        self, event_access: EventAccess
+        self, event_access: EventDatastore
     ) -> None | FingerprintWithAttributes:
         by_match_group: dict[str, list[FingerprintMatch]] = {}
         for matcher in self.matchers:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -273,7 +273,7 @@ class FingerprintingRules:
             return None
         event_datastore = EventDatastore(event)
         for rule in self.iter_rules():
-            match = rule.get_fingerprint_values_for_event_access(event_datastore)
+            match = rule.test_for_match_with_event(event_datastore)
             if match is not None:
                 return FingerprintRuleMatch(rule, match.fingerprint, match.attributes)
         return None
@@ -504,7 +504,7 @@ class FingerprintRule:
         self.attributes = attributes
         self.is_builtin = is_builtin
 
-    def get_fingerprint_values_for_event_access(
+    def test_for_match_with_event(
         self, event_datastore: EventDatastore
     ) -> None | FingerprintWithAttributes:
         by_match_type: dict[str, list[FingerprintMatcher]] = {}

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -374,7 +374,7 @@ MATCHERS = {
 }
 
 
-class FingerprintMatch:
+class FingerprintMatcher:
     def __init__(self, key: str, pattern: str, negated: bool = False) -> None:
         if key.startswith("tags."):
             self.key = key
@@ -494,7 +494,7 @@ class FingerprintMatch:
 class FingerprintRule:
     def __init__(
         self,
-        matchers: Sequence[FingerprintMatch],
+        matchers: Sequence[FingerprintMatcher],
         fingerprint: list[str],
         attributes: FingerprintRuleAttributes,
         is_builtin: bool = False,
@@ -507,7 +507,7 @@ class FingerprintRule:
     def get_fingerprint_values_for_event_access(
         self, event_access: EventDatastore
     ) -> None | FingerprintWithAttributes:
-        by_match_group: dict[str, list[FingerprintMatch]] = {}
+        by_match_group: dict[str, list[FingerprintMatcher]] = {}
         for matcher in self.matchers:
             by_match_group.setdefault(matcher.match_group, []).append(matcher)
 
@@ -536,7 +536,7 @@ class FingerprintRule:
     @classmethod
     def _from_config_structure(cls, config: FingerprintRuleConfig | FingerprintRuleJSON) -> Self:
         return cls(
-            [FingerprintMatch._from_config_structure(x) for x in config["matchers"]],
+            [FingerprintMatcher._from_config_structure(x) for x in config["matchers"]],
             config["fingerprint"],
             config.get("attributes") or {},
             config.get("is_builtin") or False,
@@ -609,7 +609,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         self,
         _: object,
         children: tuple[
-            object, list[FingerprintMatch], object, object, object, FingerprintWithAttributes
+            object, list[FingerprintMatcher], object, object, object, FingerprintWithAttributes
         ],
     ) -> FingerprintRule:
         _, matcher, _, _, _, (fingerprint, attributes) = children
@@ -617,9 +617,9 @@ class FingerprintingVisitor(NodeVisitorBase):
 
     def visit_matcher(
         self, _: object, children: tuple[object, list[str], str, object, str]
-    ) -> FingerprintMatch:
+    ) -> FingerprintMatcher:
         _, negation, key, _, pattern = children
-        return FingerprintMatch(key, pattern, bool(negation))
+        return FingerprintMatcher(key, pattern, bool(negation))
 
     def visit_matcher_type(self, _: object, children: list[str]) -> str:
         return children[0]

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -534,12 +534,12 @@ class FingerprintRule:
         return config_structure
 
     @classmethod
-    def _from_config_structure(cls, obj: FingerprintRuleConfig | FingerprintRuleJSON) -> Self:
+    def _from_config_structure(cls, config: FingerprintRuleConfig | FingerprintRuleJSON) -> Self:
         return cls(
-            [FingerprintMatch._from_config_structure(x) for x in obj["matchers"]],
-            obj["fingerprint"],
-            obj.get("attributes") or {},
-            obj.get("is_builtin") or False,
+            [FingerprintMatch._from_config_structure(x) for x in config["matchers"]],
+            config["fingerprint"],
+            config.get("attributes") or {},
+            config.get("is_builtin") or False,
         )
 
     def to_json(self) -> FingerprintRuleJSON:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -239,8 +239,8 @@ class EventDatastore:
         self._release = self._release or [{"release": self.event.get("release")}]
         return self._release
 
-    def get_values(self, match_group: str) -> list[dict[str, Any]]:
-        return getattr(self, "_get_" + match_group)()
+    def get_values(self, match_type: str) -> list[dict[str, Any]]:
+        return getattr(self, "_get_" + match_type)()
 
 
 class FingerprintingRules:
@@ -387,7 +387,7 @@ class FingerprintMatcher:
         self.negated = negated
 
     @property
-    def match_group(self) -> str:
+    def match_type(self) -> str:
         if self.key == "message":
             return "toplevel"
         if self.key in ("logger", "level"):
@@ -507,12 +507,12 @@ class FingerprintRule:
     def get_fingerprint_values_for_event_access(
         self, event_access: EventDatastore
     ) -> None | FingerprintWithAttributes:
-        by_match_group: dict[str, list[FingerprintMatcher]] = {}
+        by_match_type: dict[str, list[FingerprintMatcher]] = {}
         for matcher in self.matchers:
-            by_match_group.setdefault(matcher.match_group, []).append(matcher)
+            by_match_type.setdefault(matcher.match_type, []).append(matcher)
 
-        for match_group, matchers in by_match_group.items():
-            for values in event_access.get_values(match_group):
+        for match_type, matchers in by_match_type.items():
+            for values in event_access.get_values(match_type):
                 if all(x.matches(values) for x in matchers):
                     break
             else:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -618,8 +618,8 @@ class FingerprintingVisitor(NodeVisitorBase):
     def visit_matcher(
         self, _: object, children: tuple[object, list[str], str, object, str]
     ) -> FingerprintMatch:
-        _, negation, ty, _, argument = children
-        return FingerprintMatch(ty, argument, bool(negation))
+        _, negation, key, _, argument = children
+        return FingerprintMatch(key, argument, bool(negation))
 
     def visit_matcher_type(self, _: object, children: list[str]) -> str:
         return children[0]

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -505,14 +505,14 @@ class FingerprintRule:
         self.is_builtin = is_builtin
 
     def get_fingerprint_values_for_event_access(
-        self, event_access: EventDatastore
+        self, event_datastore: EventDatastore
     ) -> None | FingerprintWithAttributes:
         by_match_type: dict[str, list[FingerprintMatcher]] = {}
         for matcher in self.matchers:
             by_match_type.setdefault(matcher.match_type, []).append(matcher)
 
         for match_type, matchers in by_match_type.items():
-            for values in event_access.get_values(match_type):
+            for values in event_datastore.get_values(match_type):
                 if all(x.matches(values) for x in matchers):
                     break
             else:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -618,8 +618,8 @@ class FingerprintingVisitor(NodeVisitorBase):
     def visit_matcher(
         self, _: object, children: tuple[object, list[str], str, object, str]
     ) -> FingerprintMatch:
-        _, negation, key, _, argument = children
-        return FingerprintMatch(key, argument, bool(negation))
+        _, negation, key, _, pattern = children
+        return FingerprintMatch(key, pattern, bool(negation))
 
     def visit_matcher_type(self, _: object, children: list[str]) -> str:
         return children[0]

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -100,14 +100,14 @@ def create_or_update_grouphash_metadata_if_needed(
     event: Event,
     project: Project,
     grouphash: GroupHash,
-    created: bool,
+    grouphash_is_new: bool,
     grouping_config: str,
     variants: dict[str, BaseVariant],
 ) -> None:
     # TODO: Do we want to expand this to backfill metadata for existing grouphashes? If we do,
     # we'll have to override the metadata creation date for them.
 
-    if created:
+    if grouphash_is_new:
         with metrics.timer(
             "grouping.grouphashmetadata.get_hash_basis_and_metadata"
         ) as metrics_timer_tags:

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -245,7 +245,7 @@ class Strategy(Generic[ConcreteInterface]):
 
         assert isinstance(components_by_variant, dict)
 
-        rv = {}
+        final_components_by_variant = {}
         has_mandatory_hashes = False
         mandatory_contributing_variants_by_hash = {}
         optional_contributing_variants = []
@@ -264,12 +264,12 @@ class Strategy(Generic[ConcreteInterface]):
                 else:
                     optional_contributing_variants.append(variant_name)
 
-            rv[variant_name] = component
+            final_components_by_variant[variant_name] = component
 
         prevent_contribution = has_mandatory_hashes and not mandatory_contributing_variants_by_hash
 
         for variant_name in optional_contributing_variants:
-            component = rv[variant_name]
+            component = final_components_by_variant[variant_name]
 
             # In case this variant contributes we need to check two things
             # here: if we did not have a system match we need to prevent
@@ -296,8 +296,13 @@ class Strategy(Generic[ConcreteInterface]):
                     )
 
         if self.variant_processor_func is not None:
-            rv = self._invoke(self.variant_processor_func, rv, event=event, context=context)
-        return rv
+            final_components_by_variant = self._invoke(
+                self.variant_processor_func,
+                final_components_by_variant,
+                event=event,
+                context=context,
+            )
+        return final_components_by_variant
 
 
 class StrategyConfiguration:

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -189,7 +189,7 @@ class Strategy(Generic[ConcreteInterface]):
         self.id = id
         self.strategy_class = id.split(":", 1)[0]
         self.name = name
-        self.interface = interface
+        self.interface_name = interface
         self.score = score
         self.func = func
         self.variant_processor_func: VariantProcessor | None = None
@@ -221,7 +221,7 @@ class Strategy(Generic[ConcreteInterface]):
     ) -> None | BaseGroupingComponent | ReturnedVariants:
         """Given a specific variant this calculates the grouping component."""
         args = []
-        iface = event.interfaces.get(self.interface)
+        iface = event.interfaces.get(self.interface_name)
         if iface is None:
             return None
         args.append(iface)
@@ -400,13 +400,13 @@ def create_strategy_configuration(
     new_delegates = set()
     for strategy_id in delegates or ():
         strategy = lookup_strategy(strategy_id)
-        if strategy.interface in new_delegates:
+        if strategy.interface_name in new_delegates:
             raise RuntimeError(
                 "duplicate interface match for "
-                "delegate %r (conflict on %r)" % (id, strategy.interface)
+                "delegate %r (conflict on %r)" % (id, strategy.interface_name)
             )
-        NewStrategyConfiguration.delegates[strategy.interface] = strategy
-        new_delegates.add(strategy.interface)
+        NewStrategyConfiguration.delegates[strategy.interface_name] = strategy
+        new_delegates.add(strategy.interface_name)
 
     if initial_context:
         NewStrategyConfiguration.initial_context.update(initial_context)

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -251,25 +251,25 @@ class Strategy(Generic[ConcreteInterface]):
         optional_contributing_variants = []
         prevent_contribution = None
 
-        for variant, component in components_by_variant.items():
-            is_mandatory = variant.startswith("!")
-            variant = variant.lstrip("!")
+        for variant_name, component in components_by_variant.items():
+            is_mandatory = variant_name.startswith("!")
+            variant_name = variant_name.lstrip("!")
 
             if is_mandatory:
                 has_mandatory_hashes = True
 
             if component.contributes:
                 if is_mandatory:
-                    mandatory_contributing_hashes[component.get_hash()] = variant
+                    mandatory_contributing_hashes[component.get_hash()] = variant_name
                 else:
-                    optional_contributing_variants.append(variant)
+                    optional_contributing_variants.append(variant_name)
 
-            rv[variant] = component
+            rv[variant_name] = component
 
         prevent_contribution = has_mandatory_hashes and not mandatory_contributing_hashes
 
-        for variant in optional_contributing_variants:
-            component = rv[variant]
+        for variant_name in optional_contributing_variants:
+            component = rv[variant_name]
 
             # In case this variant contributes we need to check two things
             # here: if we did not have a system match we need to prevent

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -247,7 +247,7 @@ class Strategy(Generic[ConcreteInterface]):
 
         rv = {}
         has_mandatory_hashes = False
-        mandatory_contributing_hashes = {}
+        mandatory_contributing_variants_by_hash = {}
         optional_contributing_variants = []
         prevent_contribution = None
 
@@ -260,13 +260,13 @@ class Strategy(Generic[ConcreteInterface]):
 
             if component.contributes:
                 if is_mandatory:
-                    mandatory_contributing_hashes[component.get_hash()] = variant_name
+                    mandatory_contributing_variants_by_hash[component.get_hash()] = variant_name
                 else:
                     optional_contributing_variants.append(variant_name)
 
             rv[variant_name] = component
 
-        prevent_contribution = has_mandatory_hashes and not mandatory_contributing_hashes
+        prevent_contribution = has_mandatory_hashes and not mandatory_contributing_variants_by_hash
 
         for variant_name in optional_contributing_variants:
             component = rv[variant_name]
@@ -281,14 +281,14 @@ class Strategy(Generic[ConcreteInterface]):
                     contributes=False,
                     hint="ignored because %s variant is not used"
                     % (
-                        list(mandatory_contributing_hashes.values())[0]
-                        if len(mandatory_contributing_hashes) == 1
+                        list(mandatory_contributing_variants_by_hash.values())[0]
+                        if len(mandatory_contributing_variants_by_hash) == 1
                         else "other mandatory"
                     ),
                 )
             else:
                 hash_value = component.get_hash()
-                duplicate_of = mandatory_contributing_hashes.get(hash_value)
+                duplicate_of = mandatory_contributing_variants_by_hash.get(hash_value)
                 if duplicate_of is not None:
                     component.update(
                         contributes=False,

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -478,13 +478,13 @@ def call_with_variants(
 
     rv = {}
 
-    for variant in variants:
+    for variant_name in variants:
         with context:
-            context["variant"] = variant.lstrip("!")
+            context["variant"] = variant_name.lstrip("!")
             rv_variants = f(*args, **kwargs)
             assert len(rv_variants) == 1
-            component = rv_variants[variant.lstrip("!")]
+            component = rv_variants[variant_name.lstrip("!")]
 
-        rv[variant] = component
+        rv[variant_name] = component
 
     return rv

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -239,11 +239,11 @@ class Strategy(Generic[ConcreteInterface]):
         """
 
         # strategy can decide on its own which variants to produce and which contribute
-        variants = self.get_grouping_component(event, variant=None, context=context)
-        if variants is None:
+        components_by_variant = self.get_grouping_component(event, variant=None, context=context)
+        if components_by_variant is None:
             return {}
 
-        assert isinstance(variants, dict)
+        assert isinstance(components_by_variant, dict)
 
         rv = {}
         has_mandatory_hashes = False
@@ -251,7 +251,7 @@ class Strategy(Generic[ConcreteInterface]):
         optional_contributing_variants = []
         prevent_contribution = None
 
-        for variant, component in variants.items():
+        for variant, component in components_by_variant.items():
             is_mandatory = variant.startswith("!")
             variant = variant.lstrip("!")
 

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -231,9 +231,7 @@ class Strategy(Generic[ConcreteInterface]):
                 context["variant"] = variant
             return self(event=event, context=context, *args)
 
-    def get_grouping_component_variants(
-        self, event: Event, context: GroupingContext
-    ) -> ReturnedVariants:
+    def get_grouping_components(self, event: Event, context: GroupingContext) -> ReturnedVariants:
         """This returns a dictionary of all components by variant that this
         strategy can produce.
         """

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -464,7 +464,10 @@ def produces_variants(
 
 
 def call_with_variants(
-    f: Callable[..., ReturnedVariants], variants: Sequence[str], *args: Any, **kwargs: Any
+    f: Callable[..., ReturnedVariants],
+    variants_to_produce: Sequence[str],
+    *args: Any,
+    **kwargs: Any,
 ) -> ReturnedVariants:
     context = kwargs["context"]
     if context["variant"] is not None:
@@ -473,12 +476,15 @@ def call_with_variants(
         #
         # To ensure the function can deal with the particular value we assert
         # the variant name is one of our own though.
-        assert context["variant"] in variants or "!" + context["variant"] in variants
+        assert (
+            context["variant"] in variants_to_produce
+            or "!" + context["variant"] in variants_to_produce
+        )
         return f(*args, **kwargs)
 
     rv = {}
 
-    for variant_name in variants:
+    for variant_name in variants_to_produce:
         with context:
             context["variant"] = variant_name.lstrip("!")
             rv_variants = f(*args, **kwargs)

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -117,7 +117,7 @@ class GroupingContext:
     def pop(self) -> None:
         self._stack.pop()
 
-    def get_grouping_component(
+    def get_grouping_components_by_variant(
         self, interface: Interface, *, event: Event, **kwargs: Any
     ) -> ReturnedVariants:
         """Invokes a delegate grouping strategy.  If no such delegate is

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -402,7 +402,7 @@ def frame_legacy(
 def stacktrace_legacy(
     interface: Stacktrace, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    variant = context["variant"]
+    variant_name = context["variant"]
     frames = interface.frames
     contributes = None
     hint = None
@@ -417,7 +417,7 @@ def stacktrace_legacy(
     if len(frames) == 1 and not frames[0].function and frames[0].is_url():
         contributes = False
         hint = "ignored single frame stack"
-    elif variant == "app":
+    elif variant_name == "app":
         total_frames = len(frames)
         in_app_count = sum(1 if f.in_app else 0 for f in frames)
         if in_app_count == 0:
@@ -435,13 +435,13 @@ def stacktrace_legacy(
     frames_for_filtering = []
     for frame in frames:
         frame_component = context.get_single_grouping_component(
-            frame, event=event, variant=variant, **meta
+            frame, event=event, variant=variant_name, **meta
         )
-        if variant == "app" and not frame.in_app and not all_frames_considered_in_app:
+        if variant_name == "app" and not frame.in_app and not all_frames_considered_in_app:
             frame_component.update(contributes=False, hint="non app frame")
         elif prev_frame is not None and is_recursion_legacy(frame, prev_frame):
             frame_component.update(contributes=False, hint="ignored due to recursion")
-        elif variant == "app" and not frame.in_app and all_frames_considered_in_app:
+        elif variant_name == "app" and not frame.in_app and all_frames_considered_in_app:
             frame_component.update(hint="frame considered in-app because no frame is in-app")
         frame_components.append(frame_component)
         frames_for_filtering.append(frame.get_raw_data())
@@ -451,7 +451,7 @@ def stacktrace_legacy(
         frame_components, frames_for_filtering, event.platform
     )
     stacktrace_component.update(contributes=contributes, hint=hint)
-    return {variant: stacktrace_component}
+    return {variant_name: stacktrace_component}
 
 
 @strategy(ids=["threads:legacy"], interface=Threads, score=1900)

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -447,11 +447,11 @@ def stacktrace_legacy(
         frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
-    rv, _ = context.config.enhancements.assemble_stacktrace_component(
+    stacktrace_component, _ = context.config.enhancements.assemble_stacktrace_component(
         values, frames_for_filtering, event.platform
     )
-    rv.update(contributes=contributes, hint=hint)
-    return {variant: rv}
+    stacktrace_component.update(contributes=contributes, hint=hint)
+    return {variant: stacktrace_component}
 
 
 @strategy(ids=["threads:legacy"], interface=Threads, score=1900)

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -430,7 +430,7 @@ def stacktrace_legacy(
             contributes = False
             hint = "less than 10% of frames are in-app"
 
-    values = []
+    frame_components = []
     prev_frame: Frame | None = None
     frames_for_filtering = []
     for frame in frames:
@@ -443,12 +443,12 @@ def stacktrace_legacy(
             frame_component.update(contributes=False, hint="ignored due to recursion")
         elif variant == "app" and not frame.in_app and all_frames_considered_in_app:
             frame_component.update(hint="frame considered in-app because no frame is in-app")
-        values.append(frame_component)
+        frame_components.append(frame_component)
         frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
     stacktrace_component, _ = context.config.enhancements.assemble_stacktrace_component(
-        values, frames_for_filtering, event.platform
+        frame_components, frames_for_filtering, event.platform
     )
     stacktrace_component.update(contributes=contributes, hint=hint)
     return {variant: stacktrace_component}

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -646,15 +646,15 @@ def chained_exception(
 
     rv = {}
 
-    for name, component_list in exception_components_by_variant.items():
+    for name, variant_exception_components in exception_components_by_variant.items():
         # Calculate an aggregate tally of the different types of frames (in-app vs system,
         # contributing or not) across all of the exceptions in the chain
         total_frame_counts: Counter[str] = Counter()
-        for exception_component in component_list:
+        for exception_component in variant_exception_components:
             total_frame_counts += exception_component.frame_counts
 
         rv[name] = ChainedExceptionGroupingComponent(
-            values=component_list,
+            values=variant_exception_components,
             frame_counts=total_frame_counts,
         )
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -552,7 +552,7 @@ def single_exception(
 
     rv = {}
 
-    for variant, stacktrace_component in stacktrace_variants.items():
+    for variant_name, stacktrace_component in stacktrace_variants.items():
         values: list[
             ErrorTypeGroupingComponent
             | ErrorValueGroupingComponent
@@ -560,7 +560,7 @@ def single_exception(
             | StacktraceGroupingComponent
         ] = [
             stacktrace_component,
-            system_type_component if variant == "system" else type_component,
+            system_type_component if variant_name == "system" else type_component,
         ]
 
         if ns_error_component is not None:
@@ -599,7 +599,7 @@ def single_exception(
 
             values.append(value_component)
 
-        rv[variant] = ExceptionGroupingComponent(
+        rv[variant_name] = ExceptionGroupingComponent(
             values=values, frame_counts=stacktrace_component.frame_counts
         )
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -342,7 +342,7 @@ def frame(
     if context_line_component is not None:
         values.append(context_line_component)
 
-    rv = FrameGroupingComponent(values=values, in_app=frame.in_app)
+    frame_component = FrameGroupingComponent(values=values, in_app=frame.in_app)
 
     # if we are in javascript fuzzing mode we want to disregard some
     # frames consistently.  These force common bad stacktraces together
@@ -368,12 +368,12 @@ def frame(
             "eval code",
             "<anonymous>",
         ):
-            rv.update(contributes=False, hint="ignored low quality javascript frame")
+            frame_component.update(contributes=False, hint="ignored low quality javascript frame")
 
     if context["is_recursion"]:
-        rv.update(contributes=False, hint="ignored due to recursion")
+        frame_component.update(contributes=False, hint="ignored due to recursion")
 
-    return {context["variant"]: rv}
+    return {context["variant"]: frame_component}
 
 
 def get_contextline_component(

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -542,17 +542,17 @@ def single_exception(
     if exception.stacktrace is not None:
         with context:
             context["exception_data"] = exception.to_json()
-            stacktrace_variants: dict[str, StacktraceGroupingComponent] = (
+            stacktrace_components_by_variant: dict[str, StacktraceGroupingComponent] = (
                 context.get_grouping_component(exception.stacktrace, event=event, **meta)
             )
     else:
-        stacktrace_variants = {
+        stacktrace_components_by_variant = {
             "app": StacktraceGroupingComponent(),
         }
 
     exception_components_by_variant = {}
 
-    for variant_name, stacktrace_component in stacktrace_variants.items():
+    for variant_name, stacktrace_component in stacktrace_components_by_variant.items():
         values: list[
             ErrorTypeGroupingComponent
             | ErrorValueGroupingComponent

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -818,10 +818,10 @@ def _filtered_threads(
 
     rv = {}
 
-    for name, stacktrace_component in context.get_grouping_component(
+    for variant_name, stacktrace_component in context.get_grouping_component(
         stacktrace, event=event, **meta
     ).items():
-        rv[name] = ThreadsGroupingComponent(values=[stacktrace_component])
+        rv[variant_name] = ThreadsGroupingComponent(values=[stacktrace_component])
 
     return rv
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -648,7 +648,7 @@ def chained_exception(
         for variant_name, component in exception_components_by_exception[id(exception)].items():
             exception_components_by_variant.setdefault(variant_name, []).append(component)
 
-    rv = {}
+    chained_exception_components_by_variant = {}
 
     for variant_name, variant_exception_components in exception_components_by_variant.items():
         # Calculate an aggregate tally of the different types of frames (in-app vs system,
@@ -657,12 +657,12 @@ def chained_exception(
         for exception_component in variant_exception_components:
             total_frame_counts += exception_component.frame_counts
 
-        rv[variant_name] = ChainedExceptionGroupingComponent(
+        chained_exception_components_by_variant[variant_name] = ChainedExceptionGroupingComponent(
             values=variant_exception_components,
             frame_counts=total_frame_counts,
         )
 
-    return rv
+    return chained_exception_components_by_variant
 
 
 # See https://github.com/getsentry/rfcs/blob/main/text/0079-exception-groups.md#sentry-issue-grouping

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -610,7 +610,7 @@ def chained_exception(
     all_exceptions = interface.exceptions()
 
     # Get the grouping components for all exceptions up front, as we'll need them in a few places and only want to compute them once.
-    exception_components = {
+    exception_components_by_exception = {
         id(exception): context.get_grouping_component(exception, event=event, **meta)
         for exception in all_exceptions
     }
@@ -618,7 +618,7 @@ def chained_exception(
     # Filter the exceptions according to rules for handling exception groups.
     try:
         exceptions = filter_exceptions_for_exception_groups(
-            all_exceptions, exception_components, event
+            all_exceptions, exception_components_by_exception, event
         )
     except Exception:
         # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
@@ -635,13 +635,13 @@ def chained_exception(
     # Case 1: we have a single exception, use the single exception
     # component directly to avoid a level of nesting
     if len(exceptions) == 1:
-        return exception_components[id(exceptions[0])]
+        return exception_components_by_exception[id(exceptions[0])]
 
     # Case 2: produce a component for each chained exception
     by_name: dict[str, list[ExceptionGroupingComponent]] = {}
 
     for exception in exceptions:
-        for name, component in exception_components[id(exception)].items():
+        for name, component in exception_components_by_exception[id(exception)].items():
             by_name.setdefault(name, []).append(component)
 
     rv = {}

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -550,7 +550,7 @@ def single_exception(
             "app": StacktraceGroupingComponent(),
         }
 
-    rv = {}
+    exception_components_by_variant = {}
 
     for variant_name, stacktrace_component in stacktrace_variants.items():
         values: list[
@@ -599,11 +599,11 @@ def single_exception(
 
             values.append(value_component)
 
-        rv[variant_name] = ExceptionGroupingComponent(
+        exception_components_by_variant[variant_name] = ExceptionGroupingComponent(
             values=values, frame_counts=stacktrace_component.frame_counts
         )
 
-    return rv
+    return exception_components_by_variant
 
 
 @strategy(ids=["chained-exception:v1"], interface=ChainedException, score=2000)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -643,19 +643,19 @@ def chained_exception(
     exception_components_by_variant: dict[str, list[ExceptionGroupingComponent]] = {}
 
     for exception in exceptions:
-        for name, component in exception_components_by_exception[id(exception)].items():
-            exception_components_by_variant.setdefault(name, []).append(component)
+        for variant_name, component in exception_components_by_exception[id(exception)].items():
+            exception_components_by_variant.setdefault(variant_name, []).append(component)
 
     rv = {}
 
-    for name, variant_exception_components in exception_components_by_variant.items():
+    for variant_name, variant_exception_components in exception_components_by_variant.items():
         # Calculate an aggregate tally of the different types of frames (in-app vs system,
         # contributing or not) across all of the exceptions in the chain
         total_frame_counts: Counter[str] = Counter()
         for exception_component in variant_exception_components:
             total_frame_counts += exception_component.frame_counts
 
-        rv[name] = ChainedExceptionGroupingComponent(
+        rv[variant_name] = ChainedExceptionGroupingComponent(
             values=variant_exception_components,
             frame_counts=total_frame_counts,
         )

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -427,7 +427,7 @@ def _single_stacktrace_variant(
 
     frames = stacktrace.frames
 
-    values = []
+    frame_components = []
     prev_frame = None
     frames_for_filtering = []
     found_in_app_frame = False
@@ -445,7 +445,7 @@ def _single_stacktrace_variant(
                 # the rust enhancer doesn't know about system vs app variants
                 frame_component.update(contributes=False, hint="non app frame")
 
-        values.append(frame_component)
+        frame_components.append(frame_component)
         frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
@@ -454,15 +454,17 @@ def _single_stacktrace_variant(
     # for grouping.
     if (
         len(frames) == 1
-        and values[0].contributes
+        and frame_components[0].contributes
         and get_behavior_family_for_platform(frames[0].platform or event.platform) == "javascript"
         and not frames[0].function
         and frames[0].is_url()
     ):
-        values[0].update(contributes=False, hint="ignored single non-URL JavaScript frame")
+        frame_components[0].update(
+            contributes=False, hint="ignored single non-URL JavaScript frame"
+        )
 
     stacktrace_component, _ = context.config.enhancements.assemble_stacktrace_component(
-        values,
+        frame_components,
         frames_for_filtering,
         event.platform,
         exception_data=context["exception_data"],

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -543,7 +543,9 @@ def single_exception(
         with context:
             context["exception_data"] = exception.to_json()
             stacktrace_components_by_variant: dict[str, StacktraceGroupingComponent] = (
-                context.get_grouping_component(exception.stacktrace, event=event, **meta)
+                context.get_grouping_components_by_variant(
+                    exception.stacktrace, event=event, **meta
+                )
             )
     else:
         stacktrace_components_by_variant = {
@@ -615,7 +617,7 @@ def chained_exception(
 
     # Get the grouping components for all exceptions up front, as we'll need them in a few places and only want to compute them once.
     exception_components_by_exception = {
-        id(exception): context.get_grouping_component(exception, event=event, **meta)
+        id(exception): context.get_grouping_components_by_variant(exception, event=event, **meta)
         for exception in all_exceptions
     }
 
@@ -820,7 +822,7 @@ def _filtered_threads(
 
     thread_components_by_variant = {}
 
-    for variant_name, stacktrace_component in context.get_grouping_component(
+    for variant_name, stacktrace_component in context.get_grouping_components_by_variant(
         stacktrace, event=event, **meta
     ).items():
         thread_components_by_variant[variant_name] = ThreadsGroupingComponent(

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -818,14 +818,16 @@ def _filtered_threads(
     if not stacktrace:
         return {"app": ThreadsGroupingComponent(contributes=False, hint="thread has no stacktrace")}
 
-    rv = {}
+    thread_components_by_variant = {}
 
     for variant_name, stacktrace_component in context.get_grouping_component(
         stacktrace, event=event, **meta
     ).items():
-        rv[variant_name] = ThreadsGroupingComponent(values=[stacktrace_component])
+        thread_components_by_variant[variant_name] = ThreadsGroupingComponent(
+            values=[stacktrace_component]
+        )
 
-    return rv
+    return thread_components_by_variant
 
 
 @threads.variant_processor

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -461,7 +461,7 @@ def _single_stacktrace_variant(
     ):
         values[0].update(contributes=False, hint="ignored single non-URL JavaScript frame")
 
-    main_variant, _ = context.config.enhancements.assemble_stacktrace_component(
+    stacktrace_component, _ = context.config.enhancements.assemble_stacktrace_component(
         values,
         frames_for_filtering,
         event.platform,
@@ -473,7 +473,7 @@ def _single_stacktrace_variant(
     # number of contributing frames isn't big enough. In that case it also sets `contributes` to
     # false, as it does when there are no contributing frames. In this latter case it doesn't set a
     # hint, though, so we do it here.
-    if not main_variant.hint and not main_variant.contributes:
+    if not stacktrace_component.hint and not stacktrace_component.contributes:
         if len(frames) == 0:
             frames_description = "frames"
         elif variant == "system":
@@ -486,9 +486,9 @@ def _single_stacktrace_variant(
             else:
                 frames_description = "in-app frames"
 
-        main_variant.hint = f"ignored because it contains no {frames_description}"
+        stacktrace_component.hint = f"ignored because it contains no {frames_description}"
 
-    return {variant: main_variant}
+    return {variant: stacktrace_component}
 
 
 @stacktrace.variant_processor

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -423,7 +423,7 @@ def stacktrace(
 def _single_stacktrace_variant(
     stacktrace: Stacktrace, event: Event, context: GroupingContext, meta: dict[str, Any]
 ) -> ReturnedVariants:
-    variant = context["variant"]
+    variant_name = context["variant"]
 
     frames = stacktrace.frames
 
@@ -437,7 +437,7 @@ def _single_stacktrace_variant(
             context["is_recursion"] = is_recursive_frames(frame, prev_frame)
             frame_component = context.get_single_grouping_component(frame, event=event, **meta)
 
-        if variant == "app":
+        if variant_name == "app":
             if frame.in_app:
                 found_in_app_frame = True
             else:
@@ -478,9 +478,9 @@ def _single_stacktrace_variant(
     if not stacktrace_component.hint and not stacktrace_component.contributes:
         if len(frames) == 0:
             frames_description = "frames"
-        elif variant == "system":
+        elif variant_name == "system":
             frames_description = "contributing frames"
-        elif variant == "app":
+        elif variant_name == "app":
             # If there are in-app frames but the stacktrace nontheless doesn't contribute, it must
             # be because all of the frames got marked as non-contributing in the enhancer
             if found_in_app_frame:
@@ -490,7 +490,7 @@ def _single_stacktrace_variant(
 
         stacktrace_component.hint = f"ignored because it contains no {frames_description}"
 
-    return {variant: stacktrace_component}
+    return {variant_name: stacktrace_component}
 
 
 @stacktrace.variant_processor

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -638,15 +638,15 @@ def chained_exception(
         return exception_components_by_exception[id(exceptions[0])]
 
     # Case 2: produce a component for each chained exception
-    by_name: dict[str, list[ExceptionGroupingComponent]] = {}
+    exception_components_by_variant: dict[str, list[ExceptionGroupingComponent]] = {}
 
     for exception in exceptions:
         for name, component in exception_components_by_exception[id(exception)].items():
-            by_name.setdefault(name, []).append(component)
+            exception_components_by_variant.setdefault(name, []).append(component)
 
     rv = {}
 
-    for name, component_list in by_name.items():
+    for name, component_list in exception_components_by_variant.items():
         # Calculate an aggregate tally of the different types of frames (in-app vs system,
         # contributing or not) across all of the exceptions in the chain
         total_frame_counts: Counter[str] = Counter()

--- a/src/sentry/grouping/strategies/utils.py
+++ b/src/sentry/grouping/strategies/utils.py
@@ -14,13 +14,13 @@ def remove_non_stacktrace_variants(variants: ReturnedVariants) -> ReturnedVarian
 
     # In case any of the variants has a contributing stacktrace, we want
     # to make all other variants non contributing.
-    for key, component in variants.items():
+    for variant_name, component in variants.items():
         stacktrace_iter = component.iter_subcomponents(
             id="stacktrace", recursive=True, only_contributing=True
         )
         if next(stacktrace_iter, None) is not None:
             any_stacktrace_contributes = True
-            stacktrace_variants.add(key)
+            stacktrace_variants.add(variant_name)
         else:
             non_contributing_components.append(component)
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -57,12 +57,12 @@ def get_fingerprint_value(var, data):
         return func or "<no-function>"
     elif var in ("path", "stack.abs_path"):
         frame = get_crash_frame_from_event_data(data)
-        func = frame.get("abs_path") or frame.get("filename") if frame else None
-        return func or "<no-abs-path>"
+        abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
+        return abs_path or "<no-abs-path>"
     elif var == "stack.filename":
         frame = get_crash_frame_from_event_data(data)
-        func = frame.get("filename") or frame.get("abs_path") if frame else None
-        return func or "<no-filename>"
+        filename = frame.get("filename") or frame.get("abs_path") if frame else None
+        return filename or "<no-filename>"
     elif var in ("module", "stack.module"):
         frame = get_crash_frame_from_event_data(data)
         mod = frame.get("module") if frame else None

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -26,7 +26,7 @@ def hash_from_values(values):
     return result.hexdigest()
 
 
-def get_rule_bool(value):
+def bool_from_string(value):
     if value:
         value = value.lower()
         if value in ("1", "yes", "true"):

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -156,9 +156,11 @@ class ComponentVariant(BaseVariant):
         return super().__repr__() + f" contributes={self.contributes} ({self.description})"
 
 
-def expose_fingerprint_dict(values: list[str], info: FingerprintInfo) -> FingerprintVariantMetadata:
+def expose_fingerprint_dict(
+    fingerprint: list[str], info: FingerprintInfo
+) -> FingerprintVariantMetadata:
     rv: FingerprintVariantMetadata = {
-        "values": values,
+        "values": fingerprint,
     }
 
     client_values = info.get("client_fingerprint")
@@ -183,8 +185,8 @@ class CustomFingerprintVariant(BaseVariant):
 
     type = "custom_fingerprint"
 
-    def __init__(self, values: list[str], fingerprint_info: FingerprintInfo):
-        self.values = values
+    def __init__(self, fingerprint: list[str], fingerprint_info: FingerprintInfo):
+        self.values = fingerprint
         self.info = fingerprint_info
 
     @property
@@ -215,13 +217,13 @@ class SaltedComponentVariant(ComponentVariant):
 
     def __init__(
         self,
-        values: list[str],
+        fingerprint: list[str],
         component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
         config: StrategyConfiguration,
         fingerprint_info: FingerprintInfo,
     ):
         ComponentVariant.__init__(self, component, config)
-        self.values = values
+        self.values = fingerprint
         self.info = fingerprint_info
 
     @property

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -133,10 +133,10 @@ class ComponentVariant(BaseVariant):
     def __init__(
         self,
         component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
-        config: StrategyConfiguration,
+        strategy_config: StrategyConfiguration,
     ):
         self.component = component
-        self.config = config
+        self.config = strategy_config
 
     @property
     def description(self):
@@ -219,10 +219,10 @@ class SaltedComponentVariant(ComponentVariant):
         self,
         fingerprint: list[str],
         component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
-        config: StrategyConfiguration,
+        strategy_config: StrategyConfiguration,
         fingerprint_info: FingerprintInfo,
     ):
-        ComponentVariant.__init__(self, component, config)
+        ComponentVariant.__init__(self, component, strategy_config)
         self.values = fingerprint
         self.info = fingerprint_info
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -163,11 +163,11 @@ def expose_fingerprint_dict(
         "values": fingerprint,
     }
 
-    client_values = fingerprint_info.get("client_fingerprint")
-    if client_values and (
-        len(client_values) != 1 or not is_default_fingerprint_var(client_values[0])
+    client_fingerprint = fingerprint_info.get("client_fingerprint")
+    if client_fingerprint and (
+        len(client_fingerprint) != 1 or not is_default_fingerprint_var(client_fingerprint[0])
     ):
-        rv["client_values"] = client_values
+        rv["client_values"] = client_fingerprint
 
     matched_rule = fingerprint_info.get("matched_rule")
     if matched_rule:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -157,19 +157,19 @@ class ComponentVariant(BaseVariant):
 
 
 def expose_fingerprint_dict(
-    fingerprint: list[str], info: FingerprintInfo
+    fingerprint: list[str], fingerprint_info: FingerprintInfo
 ) -> FingerprintVariantMetadata:
     rv: FingerprintVariantMetadata = {
         "values": fingerprint,
     }
 
-    client_values = info.get("client_fingerprint")
+    client_values = fingerprint_info.get("client_fingerprint")
     if client_values and (
         len(client_values) != 1 or not is_default_fingerprint_var(client_values[0])
     ):
         rv["client_values"] = client_values
 
-    matched_rule = info.get("matched_rule")
+    matched_rule = fingerprint_info.get("matched_rule")
     if matched_rule:
         # TODO: Before late October 2024, we didn't store the rule text along with the matched rule,
         # meaning there are still events out there whose `_fingerprint_info` entry doesn't have it.

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -420,7 +420,7 @@ def test_load_configs_empty_doesnt_blow_up(tmp_path):
         assert _load_configs() == {}
 
 
-def test_load_configs_nx_path_doesnt_blow_up(tmp_path):
+def test_load_configs_non_existent_path_doesnt_blow_up(tmp_path):
     tmp_path.rmdir()
     with mock.patch("sentry.grouping.fingerprinting.CONFIGS_DIR", tmp_path):
         assert _load_configs() == {}

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -32,7 +32,7 @@ def test_default_bases(default_bases):
     assert FINGERPRINTING_BASES
     assert set(default_bases) == set(FINGERPRINTING_BASES.keys())
     assert {
-        k: [r._to_config_structure() for r in ruleset]
+        k: [rule._to_config_structure() for rule in ruleset]
         for k, ruleset in FINGERPRINTING_BASES.items()
     } == {
         "javascript@2024-02-02": [

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -32,7 +32,8 @@ def test_default_bases(default_bases):
     assert FINGERPRINTING_BASES
     assert set(default_bases) == set(FINGERPRINTING_BASES.keys())
     assert {
-        k: [r._to_config_structure() for r in rs] for k, rs in FINGERPRINTING_BASES.items()
+        k: [r._to_config_structure() for r in ruleset]
+        for k, ruleset in FINGERPRINTING_BASES.items()
     } == {
         "javascript@2024-02-02": [
             {

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -32,8 +32,8 @@ def test_default_bases(default_bases):
     assert FINGERPRINTING_BASES
     assert set(default_bases) == set(FINGERPRINTING_BASES.keys())
     assert {
-        k: [rule._to_config_structure() for rule in ruleset]
-        for k, ruleset in FINGERPRINTING_BASES.items()
+        fingerprinting_base: [rule._to_config_structure() for rule in ruleset]
+        for fingerprinting_base, ruleset in FINGERPRINTING_BASES.items()
     } == {
         "javascript@2024-02-02": [
             {

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -559,8 +559,8 @@ class BuiltInFingerprintingTest(TestCase):
     def test_built_in_chunkload_rules_variants(self):
         event = self._get_event_for_trace(stacktrace=self.chunkload_error_trace)
         variants = {
-            k: v.as_dict()
-            for k, v in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
+            k: variant.as_dict()
+            for k, variant in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
         }
         assert "built_in_fingerprint" in variants
 
@@ -706,8 +706,8 @@ class BuiltInFingerprintingTest(TestCase):
             data=data_transaction_no_tx, project_id=self.project
         )
         variants = {
-            k: v.as_dict()
-            for k, v in event_transaction_no_tx.get_grouping_variants(
+            k: variant.as_dict()
+            for k, variant in event_transaction_no_tx.get_grouping_variants(
                 force_config=GROUPING_CONFIG
             ).items()
         }

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -559,8 +559,10 @@ class BuiltInFingerprintingTest(TestCase):
     def test_built_in_chunkload_rules_variants(self):
         event = self._get_event_for_trace(stacktrace=self.chunkload_error_trace)
         variants = {
-            k: variant.as_dict()
-            for k, variant in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
+            variant_name: variant.as_dict()
+            for variant_name, variant in event.get_grouping_variants(
+                force_config=GROUPING_CONFIG
+            ).items()
         }
         assert "built_in_fingerprint" in variants
 
@@ -706,8 +708,8 @@ class BuiltInFingerprintingTest(TestCase):
             data=data_transaction_no_tx, project_id=self.project
         )
         variants = {
-            k: variant.as_dict()
-            for k, variant in event_transaction_no_tx.get_grouping_variants(
+            variant_name: variant.as_dict()
+            for variant_name, variant in event_transaction_no_tx.get_grouping_variants(
                 force_config=GROUPING_CONFIG
             ).items()
         }


### PR DESCRIPTION
This is a boatload of renaming I've done over the past month or so as I've been wandering around in the grouping code weeds (mostly to help myself keep track of what's what), primarily affecting the code which does fingerprinting and building of grouping component trees. Not an entirely scientific/systematic undertaking, but I tried to do a few things consistently:

- Variants are objects, and we pass them and the components they wrap around in dictionaries a lot, keyed by which variant they're from. In all of those cases, use `variant_name` rather than `variant` to distinguish what's a key and what's an object.

- Where possible, identify components with what they are or what purpose they serve (`frame_component` or `root_component` rather than just `component`).

- There are many moving parts to the system, and they all can be configured, so identify config data as `fingerprint_comfig` or `strategy_config` (etc.) rather than just `config`.

- Differentiate between lists and dicts by reserving simple plurals (`components`) for lists and using `x_by_y` (`components_by_variant`) for dicts.

- Stop using generic, utterly undescriptive names for things, so no `obj` if we actually know what it is, no `rv` just because it's the result of calling a function, etc.

Past that, there are also a few places where we just had copy-pasta or I thought something could be described more accurately. Hopefully this will also make reviewing future PRs a little easier, since the code will be a little easier to understand even if you haven't been swimming in it for months.