### PR TITLE
ref(feedback): remove client_source tag from metrics

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -230,7 +230,6 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
         "feedback.create_feedback_issue.entered",
         tags={
             "referrer": source.value,
-            "client_source": get_path(event, "contexts", "feedback", "source"),
         },
     )
 
@@ -257,7 +256,6 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
                 tags={
                     "is_spam": is_message_spam,
                     "referrer": source.value,
-                    "client_source": event["contexts"]["feedback"].get("source"),
                 },
                 sample_rate=1.0,
             )
@@ -345,7 +343,6 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
         "feedback.create_feedback_issue.produced_occurrence",
         tags={
             "referrer": source.value,
-            "client_source": event["contexts"]["feedback"].get("source"),
         },
         sample_rate=1.0,
     )


### PR DESCRIPTION
This is a user-defined field so cardinality is unbounded. There's only 8 values right now but let's remove it to save costs
![Screenshot 2024-12-09 at 12 28 37 PM](https://github.com/user-attachments/assets/1f81bdd4-5b18-46ac-a461-5edc6ff5218d)
