### PR TITLE
fix(trace-view): Fix missing background colours

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -231,6 +231,7 @@ const Flex = styled('div')<{gap?: number}>`
 `;
 
 const MeterBarContainer = styled('div')<{clickable?: boolean}>`
+  background-color: ${p => p.theme.background};
   flex: 1;
   position: relative;
   padding: 0;

--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -155,6 +155,7 @@ const VitalMetersContainer = styled('div')`
 `;
 
 const TraceTagsContainer = styled('div')`
+  background-color: ${p => p.theme.background};
   width: 100%;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};


### PR DESCRIPTION
Some of the components in the trace view context had no background colour assigned which resulted in them seeming transparent.

![image](https://github.com/user-attachments/assets/d347833c-4a30-4b14-8357-aa8df5b62b83)
