### PR TITLE
chore(settings): Fix disabled state for scraping

### DIFF
--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -2,6 +2,7 @@ import {createFilter} from 'react-select';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import type {Field} from 'sentry/components/forms/types';
 import platforms from 'sentry/data/platforms';
 import {t, tct, tn} from 'sentry/locale';
@@ -149,7 +150,8 @@ export const fields: Record<string, Field> = {
     name: 'scrapeJavaScript',
     type: 'boolean',
     // if this is off for the organization, it cannot be enabled for the project
-    disabled: ({organization, name}) => !organization[name],
+    disabled: ({organization, project, name}) =>
+      !organization[name] || !hasEveryAccess(['project:write'], {organization, project}),
     disabledReason: ORG_DISABLED_REASON,
     // `props` are the props given to FormField
     setValue: (val, props) => props.organization?.[props.name] && val,


### PR DESCRIPTION
right now in project settings, the JS source fetching setting isn't disabled for members, even though if they try to update the setting it won't work. this pr fixes it so it is disabled correctly 

fixes https://github.com/getsentry/sentry/issues/70604