### PR TITLE
fix(ai): Add feature flag check

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -43,7 +43,8 @@ export const useAiConfig = (
 
   const areAiFeaturesAllowed =
     !organization.hideAiFeatures &&
-    getRegionDataFromOrganization(organization)?.name !== 'de';
+    getRegionDataFromOrganization(organization)?.name !== 'de' &&
+    organization.features.includes('gen-ai-features');
 
   const isSummaryEnabled = issueTypeConfig.issueSummary.enabled;
   const isAutofixEnabled = issueTypeConfig.autofix;

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -24,7 +24,11 @@ describe('SolutionsSection', () => {
   });
   const mockGroup = GroupFixture();
   const mockProject = ProjectFixture();
-  const organization = OrganizationFixture({genAIConsent: true, hideAiFeatures: false});
+  const organization = OrganizationFixture({
+    genAIConsent: true,
+    hideAiFeatures: false,
+    features: ['gen-ai-features'],
+  });
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -125,6 +129,7 @@ describe('SolutionsSection', () => {
     const customOrganization = OrganizationFixture({
       hideAiFeatures: true,
       genAIConsent: false,
+      features: ['gen-ai-features'],
     });
 
     render(
@@ -168,6 +173,7 @@ describe('SolutionsSection', () => {
       const customOrganization = OrganizationFixture({
         genAIConsent: false,
         hideAiFeatures: false,
+        features: ['gen-ai-features'],
       });
 
       MockApiClient.addMockResponse({


### PR DESCRIPTION
Fixes an edge case where we weren't checking the AI feature flag if resources were present and AI would otherwise be available in the Solutions Hub.