### PR TITLE
fix(grouping): Use app hash when hashes match

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -250,14 +250,14 @@ class Strategy(Generic[ConcreteInterface]):
         prevent_contribution = None
 
         for variant_name, component in components_by_variant.items():
-            is_mandatory = variant_name.startswith("!")
+            is_priority = variant_name.startswith("!")
             variant_name = variant_name.lstrip("!")
 
-            if is_mandatory:
+            if is_priority:
                 has_mandatory_hashes = True
 
             if component.contributes:
-                if is_mandatory:
+                if is_priority:
                     priority_contributing_variants_by_hash[component.get_hash()] = variant_name
                 else:
                     optional_contributing_variants.append(variant_name)

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -246,7 +246,7 @@ class Strategy(Generic[ConcreteInterface]):
         final_components_by_variant = {}
         has_mandatory_hashes = False
         priority_contributing_variants_by_hash = {}
-        optional_contributing_variants = []
+        non_priority_contributing_variants = []
         prevent_contribution = None
 
         for variant_name, component in components_by_variant.items():
@@ -260,13 +260,13 @@ class Strategy(Generic[ConcreteInterface]):
                 if is_priority:
                     priority_contributing_variants_by_hash[component.get_hash()] = variant_name
                 else:
-                    optional_contributing_variants.append(variant_name)
+                    non_priority_contributing_variants.append(variant_name)
 
             final_components_by_variant[variant_name] = component
 
         prevent_contribution = has_mandatory_hashes and not priority_contributing_variants_by_hash
 
-        for variant_name in optional_contributing_variants:
+        for variant_name in non_priority_contributing_variants:
             component = final_components_by_variant[variant_name]
 
             # In case this variant contributes we need to check two things

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -252,6 +252,8 @@ class Strategy(Generic[ConcreteInterface]):
             variant_name = variant_name.lstrip("!")
 
             if component.contributes:
+                # Track priority and non-priority contributing hashes separately, so the latter can
+                # be deduped against the former
                 if is_priority:
                     priority_contributing_variants_by_hash[component.get_hash()] = variant_name
                 else:
@@ -259,14 +261,9 @@ class Strategy(Generic[ConcreteInterface]):
 
             final_components_by_variant[variant_name] = component
 
+        # Mark any non-priority duplicates of priority hashes as non-contributing
         for variant_name in non_priority_contributing_variants:
             component = final_components_by_variant[variant_name]
-
-            # In case this variant contributes we need to check two things
-            # here: if we did not have a system match we need to prevent
-            # it from contributing.  Additionally if it matches the system
-            # component we also do not want the variant to contribute but
-            # with a different message.
             hash_value = component.get_hash()
             duplicate_of = priority_contributing_variants_by_hash.get(hash_value)
             if duplicate_of is not None:

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -245,7 +245,7 @@ class Strategy(Generic[ConcreteInterface]):
 
         final_components_by_variant = {}
         has_mandatory_hashes = False
-        mandatory_contributing_variants_by_hash = {}
+        priority_contributing_variants_by_hash = {}
         optional_contributing_variants = []
         prevent_contribution = None
 
@@ -258,13 +258,13 @@ class Strategy(Generic[ConcreteInterface]):
 
             if component.contributes:
                 if is_mandatory:
-                    mandatory_contributing_variants_by_hash[component.get_hash()] = variant_name
+                    priority_contributing_variants_by_hash[component.get_hash()] = variant_name
                 else:
                     optional_contributing_variants.append(variant_name)
 
             final_components_by_variant[variant_name] = component
 
-        prevent_contribution = has_mandatory_hashes and not mandatory_contributing_variants_by_hash
+        prevent_contribution = has_mandatory_hashes and not priority_contributing_variants_by_hash
 
         for variant_name in optional_contributing_variants:
             component = final_components_by_variant[variant_name]
@@ -279,14 +279,14 @@ class Strategy(Generic[ConcreteInterface]):
                     contributes=False,
                     hint="ignored because %s variant is not used"
                     % (
-                        list(mandatory_contributing_variants_by_hash.values())[0]
-                        if len(mandatory_contributing_variants_by_hash) == 1
+                        list(priority_contributing_variants_by_hash.values())[0]
+                        if len(priority_contributing_variants_by_hash) == 1
                         else "other mandatory"
                     ),
                 )
             else:
                 hash_value = component.get_hash()
-                duplicate_of = mandatory_contributing_variants_by_hash.get(hash_value)
+                duplicate_of = priority_contributing_variants_by_hash.get(hash_value)
                 if duplicate_of is not None:
                     component.update(
                         contributes=False,

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -412,7 +412,7 @@ def stacktrace(
 
     return call_with_variants(
         _single_stacktrace_variant,
-        ["!system", "app"],
+        ["!app", "system"],
         interface,
         event=event,
         context=context,
@@ -549,7 +549,7 @@ def single_exception(
             )
     else:
         stacktrace_components_by_variant = {
-            "app": StacktraceGroupingComponent(),
+            "!app": StacktraceGroupingComponent(),
         }
 
     exception_components_by_variant = {}

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:13.965272+00:00'
+created: '2024-12-06T19:45:37.706347+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,8 +25,8 @@ variants:
     - my-route
     - '{{ default }}'
     component:
-      contributes: false
-      hint: exception of system takes precedence
+      contributes: true
+      hint: null
     type: salted_component
     values:
     - my-route
@@ -36,8 +36,8 @@ variants:
     - my-route
     - '{{ default }}'
     component:
-      contributes: true
-      hint: null
+      contributes: false
+      hint: exception of app takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.302941+00:00'
+created: '2024-12-06T19:45:39.610879+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,8 +25,8 @@ variants:
     - my-route
     - '{{ default }}'
     component:
-      contributes: false
-      hint: exception of system takes precedence
+      contributes: true
+      hint: null
     type: salted_component
     values:
     - my-route
@@ -36,8 +36,8 @@ variants:
     - my-route
     - '{{ default }}'
     component:
-      contributes: true
-      hint: null
+      contributes: false
+      hint: exception of app takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:17.074388+00:00'
+created: '2024-12-06T19:45:40.127492+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,8 +25,8 @@ variants:
     - my-route
     - '{{ default }}'
     component:
-      contributes: false
-      hint: exception of system takes precedence
+      contributes: true
+      hint: null
     type: salted_component
     values:
     - my-route
@@ -36,8 +36,8 @@ variants:
     - my-route
     - '{{ default }}'
     component:
-      contributes: true
-      hint: null
+      contributes: false
+      hint: exception of app takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:21.276433+00:00'
+created: '2024-12-06T19:44:36.156321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "9509e122c6175606d52862fa4f64853c"
     component:
-      system*
+      app*
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:21.331408+00:00'
+created: '2024-12-06T19:44:36.197784+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 2,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "True",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     component:
-      system*
+      app*
         chained-exception*
           exception*
             stacktrace*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:22.621198+00:00'
+created: '2024-12-06T19:44:37.250444+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "82639bcdd4eca16551e8cd3448f48ed4"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:23.309634+00:00'
+created: '2024-12-06T19:44:37.629273+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "e0e7c4713e9092dc77635d5a0d5db31d"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:23.927453+00:00'
+created: '2024-12-06T19:44:38.257704+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "278cdd35be92e2ffde1d0a40524e7786"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:24.002276+00:00'
+created: '2024-12-06T19:44:38.300549+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "d1fe4234d1bddc3823d08dcc529fb161"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:24.087117+00:00'
+created: '2024-12-06T19:44:38.344186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "d1fe4234d1bddc3823d08dcc529fb161"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:30.654787+00:00'
+created: '2024-12-06T19:44:43.065241+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "thread",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "thread",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "1a11687556cf74559f0ae90b1c87e2fd"
     component:
-      system*
+      app*
         threads*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:32.149626+00:00'
+created: '2024-12-06T19:44:44.442805+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "9509e122c6175606d52862fa4f64853c"
     component:
-      system*
+      app*
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:32.194315+00:00'
+created: '2024-12-06T19:44:44.488122+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 2,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "True",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     component:
-      system*
+      app*
         chained-exception*
           exception*
             stacktrace*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:33.912446+00:00'
+created: '2024-12-06T19:44:46.468730+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "82639bcdd4eca16551e8cd3448f48ed4"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:34.472398+00:00'
+created: '2024-12-06T19:44:47.335106+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "e0e7c4713e9092dc77635d5a0d5db31d"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:35.011870+00:00'
+created: '2024-12-06T19:44:48.260808+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "278cdd35be92e2ffde1d0a40524e7786"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:35.057039+00:00'
+created: '2024-12-06T19:44:48.371154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "d1fe4234d1bddc3823d08dcc529fb161"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:35.102683+00:00'
+created: '2024-12-06T19:44:48.455680+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "top-level",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "top-level",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "d1fe4234d1bddc3823d08dcc529fb161"
     component:
-      system*
+      app*
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:43.508299+00:00'
+created: '2024-12-06T19:44:56.141410+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "thread",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "thread",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "1a11687556cf74559f0ae90b1c87e2fd"
     component:
-      system*
+      app*
         threads*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:45.563342+00:00'
+created: '2024-12-06T19:44:56.523127+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "thread",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "thread",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
     component:
-      system*
+      app*
         threads*
           stacktrace*
             frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:51.463977+00:00'
+created: '2024-12-06T19:44:57.682024+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "9509e122c6175606d52862fa4f64853c"
     component:
-      system*
+      app*
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:51.544069+00:00'
+created: '2024-12-06T19:44:57.725502+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 2,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "True",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     component:
-      system*
+      app*
         chained-exception*
           exception*
             stacktrace*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:57.855118+00:00'
+created: '2024-12-06T19:45:03.081531+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -21,10 +21,10 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "be36642f41f047346396f018f62375d3"
     component:
-      system*
+      app*
         exception*
           type*
             "Error"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:26:59.597452+00:00'
+created: '2024-12-06T19:45:06.412333+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -21,10 +21,10 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "be36642f41f047346396f018f62375d3"
     component:
-      system*
+      app*
         exception*
           type*
             "Error"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-20T21:27:00.622664+00:00'
+created: '2024-12-06T19:45:08.686612+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "thread",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,15 +18,15 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "thread",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
+  app*
     hash: "1a11687556cf74559f0ae90b1c87e2fd"
     component:
-      system*
+      app*
         threads*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-02-15T10:11:51.448335Z'
+created: '2024-12-06T19:43:05.350724+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "9509e122c6175606d52862fa4f64853c"
   component:
-    app (exception of system takes precedence)
-      exception (ignored because hash matches system variant)
+    app*
+      exception*
         stacktrace*
           frame*
             filename*
@@ -18,10 +18,10 @@ app:
           "hello world"
 --------------------------------------------------------------------------
 system:
-  hash: "9509e122c6175606d52862fa4f64853c"
+  hash: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-02-15T10:11:51.105902Z'
+created: '2024-12-06T19:43:05.412099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "669cb6664e0f5fed38665da04e464f7e"
   component:
-    app (exception of system takes precedence)
-      chained-exception (ignored because hash matches system variant)
+    app*
+      chained-exception*
         exception*
           stacktrace*
             frame*
@@ -28,10 +28,10 @@ app:
             "hello world"
 --------------------------------------------------------------------------
 system:
-  hash: "669cb6664e0f5fed38665da04e464f7e"
+  hash: null
   component:
-    system*
-      chained-exception*
+    system (exception of app takes precedence)
+      chained-exception (ignored because hash matches app variant)
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_dartlang_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-08-23T14:18:12.669833Z'
+created: '2024-12-06T19:43:07.127290+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "82639bcdd4eca16551e8cd3448f48ed4"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "async_patch.dart"
@@ -15,10 +15,10 @@ app:
             "_asyncStartSync"
 --------------------------------------------------------------------------
 system:
-  hash: "82639bcdd4eca16551e8cd3448f48ed4"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "async_patch.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_flutter_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-09-20T12:35:57.972681Z'
+created: '2024-12-06T19:43:07.610210+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "e0e7c4713e9092dc77635d5a0d5db31d"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
@@ -17,10 +17,10 @@ app:
             "_flushPointerEventQueue"
 --------------------------------------------------------------------------
 system:
-  hash: "e0e7c4713e9092dc77635d5a0d5db31d"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_packages.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-06-05T14:22:36.817822+00:00'
+created: '2024-12-06T19:43:08.103653+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "sentry_logging.dart"
@@ -45,10 +45,10 @@ app:
             "SentryDrift.drift"
 --------------------------------------------------------------------------
 system:
-  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "sentry_logging.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-05-28T08:21:40.346389+00:00'
+created: '2024-12-06T19:43:08.148248+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "sentry_exception_factory.dart"
@@ -15,10 +15,10 @@ app:
             "SentryExceptionFactory.getSentryException"
 --------------------------------------------------------------------------
 system:
-  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "sentry_exception_factory.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-05-28T08:13:50.258870+00:00'
+created: '2024-12-06T19:43:08.196242+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "sentry_exception_factory.dart"
@@ -15,10 +15,10 @@ app:
             "SentryExceptionFactory.getSentryException"
 --------------------------------------------------------------------------
 system:
-  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "sentry_exception_factory.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-02-15T10:11:52.576902Z'
+created: '2024-12-06T19:43:13.356592+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "1a11687556cf74559f0ae90b1c87e2fd"
   component:
-    app (threads of system take precedence)
-      threads (ignored because hash matches system variant)
+    app*
+      threads*
         stacktrace*
           frame*
             filename*
@@ -16,10 +16,10 @@ app:
               "main"
 --------------------------------------------------------------------------
 system:
-  hash: "1a11687556cf74559f0ae90b1c87e2fd"
+  hash: null
   component:
-    system*
-      threads*
+    system (threads of app take precedence)
+      threads (ignored because hash matches app variant)
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_2.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-02-15T10:11:55.005190Z'
+created: '2024-12-06T19:43:14.909585+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "9509e122c6175606d52862fa4f64853c"
   component:
-    app (exception of system takes precedence)
-      exception (ignored because hash matches system variant)
+    app*
+      exception*
         stacktrace*
           frame*
             filename*
@@ -18,10 +18,10 @@ app:
           "hello world"
 --------------------------------------------------------------------------
 system:
-  hash: "9509e122c6175606d52862fa4f64853c"
+  hash: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_3.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-02-15T10:11:54.704396Z'
+created: '2024-12-06T19:43:14.959819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "669cb6664e0f5fed38665da04e464f7e"
   component:
-    app (exception of system takes precedence)
-      chained-exception (ignored because hash matches system variant)
+    app*
+      chained-exception*
         exception*
           stacktrace*
             frame*
@@ -28,10 +28,10 @@ app:
             "hello world"
 --------------------------------------------------------------------------
 system:
-  hash: "669cb6664e0f5fed38665da04e464f7e"
+  hash: null
   component:
-    system*
-      chained-exception*
+    system (exception of app takes precedence)
+      chained-exception (ignored because hash matches app variant)
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_dartlang_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-08-23T14:18:12.940781Z'
+created: '2024-12-06T19:43:16.298385+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "82639bcdd4eca16551e8cd3448f48ed4"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "async_patch.dart"
@@ -15,10 +15,10 @@ app:
             "_asyncStartSync"
 --------------------------------------------------------------------------
 system:
-  hash: "82639bcdd4eca16551e8cd3448f48ed4"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "async_patch.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_flutter_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-09-20T12:35:59.674725Z'
+created: '2024-12-06T19:43:16.947203+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "e0e7c4713e9092dc77635d5a0d5db31d"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
@@ -17,10 +17,10 @@ app:
             "_flushPointerEventQueue"
 --------------------------------------------------------------------------
 system:
-  hash: "e0e7c4713e9092dc77635d5a0d5db31d"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_packages.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-06-05T14:22:38.794583+00:00'
+created: '2024-12-06T19:43:17.670985+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "278cdd35be92e2ffde1d0a40524e7786"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "sentry_logging.dart"
@@ -45,10 +45,10 @@ app:
             "SentryDrift.drift"
 --------------------------------------------------------------------------
 system:
-  hash: "278cdd35be92e2ffde1d0a40524e7786"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "sentry_logging.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-05-28T08:21:42.682278+00:00'
+created: '2024-12-06T19:43:17.742374+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "sentry_exception_factory.dart"
@@ -15,10 +15,10 @@ app:
             "SentryExceptionFactory.getSentryException"
 --------------------------------------------------------------------------
 system:
-  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "sentry_exception_factory.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-05-28T08:13:52.924648+00:00'
+created: '2024-12-06T19:43:17.829665+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "d1fe4234d1bddc3823d08dcc529fb161"
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
+    app*
+      stacktrace*
         frame*
           filename*
             "sentry_exception_factory.dart"
@@ -15,10 +15,10 @@ app:
             "SentryExceptionFactory.getSentryException"
 --------------------------------------------------------------------------
 system:
-  hash: "d1fe4234d1bddc3823d08dcc529fb161"
+  hash: null
   component:
-    system*
-      stacktrace*
+    system (stacktrace of app takes precedence)
+      stacktrace (ignored because hash matches app variant)
         frame*
           filename*
             "sentry_exception_factory.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_compute_hashes.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2021-02-15T10:11:56.222183Z'
+created: '2024-12-06T19:43:26.699818+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "1a11687556cf74559f0ae90b1c87e2fd"
   component:
-    app (threads of system take precedence)
-      threads (ignored because hash matches system variant)
+    app*
+      threads*
         stacktrace*
           frame*
             filename*
@@ -16,10 +16,10 @@ app:
               "main"
 --------------------------------------------------------------------------
 system:
-  hash: "1a11687556cf74559f0ae90b1c87e2fd"
+  hash: null
   component:
-    system*
-      threads*
+    system (threads of app take precedence)
+      threads (ignored because hash matches app variant)
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-03-22T11:57:57.243126+00:00'
+created: '2024-12-06T19:38:41.166212+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
   component:
-    app (threads of system take precedence)
-      threads (ignored because hash matches system variant)
+    app*
+      threads*
         stacktrace*
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
@@ -22,15 +22,15 @@ app:
 default:
   hash: null
   component:
-    default (threads of system take precedence)
-      message (threads of system take precedence)
+    default (threads of app take precedence)
+      message (threads of app take precedence)
         "Foo"
 --------------------------------------------------------------------------
 system:
-  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  hash: null
   component:
-    system*
-      threads*
+    system (threads of app take precedence)
+      threads (ignored because hash matches app variant)
         stacktrace*
           frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2023-01-11T11:41:28.150918Z'
+created: '2024-12-06T19:38:42.696655+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "9509e122c6175606d52862fa4f64853c"
   component:
-    app (exception of system takes precedence)
-      exception (ignored because hash matches system variant)
+    app*
+      exception*
         stacktrace*
           frame*
             filename*
@@ -18,10 +18,10 @@ app:
           "hello world"
 --------------------------------------------------------------------------
 system:
-  hash: "9509e122c6175606d52862fa4f64853c"
+  hash: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace*
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2023-01-11T11:41:27.928557Z'
+created: '2024-12-06T19:38:42.754752+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "669cb6664e0f5fed38665da04e464f7e"
   component:
-    app (exception of system takes precedence)
-      chained-exception (ignored because hash matches system variant)
+    app*
+      chained-exception*
         exception*
           stacktrace*
             frame*
@@ -28,10 +28,10 @@ app:
             "hello world"
 --------------------------------------------------------------------------
 system:
-  hash: "669cb6664e0f5fed38665da04e464f7e"
+  hash: null
   component:
-    system*
-      chained-exception*
+    system (exception of app takes precedence)
+      chained-exception (ignored because hash matches app variant)
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-10-24T14:20:33.386709+00:00'
+created: '2024-12-06T19:38:48.267216+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "be36642f41f047346396f018f62375d3"
   component:
-    app (exception of system takes precedence)
-      exception (ignored because hash matches system variant)
+    app*
+      exception*
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (module:@babel/** -app -group))
             module*
@@ -30,10 +30,10 @@ app:
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "be36642f41f047346396f018f62375d3"
+  hash: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (module:@babel/** -app -group))
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2024-10-24T14:21:52.204150+00:00'
+created: '2024-12-06T19:38:50.537127+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "be36642f41f047346396f018f62375d3"
   component:
-    app (exception of system takes precedence)
-      exception (ignored because hash matches system variant)
+    app*
+      exception*
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (function:processTicksAndRejections -app -group))
             module*
@@ -27,10 +27,10 @@ app:
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "be36642f41f047346396f018f62375d3"
+  hash: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (function:processTicksAndRejections -app -group))
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2023-01-11T11:41:29.245137Z'
+created: '2024-12-06T19:38:51.652327+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "1a11687556cf74559f0ae90b1c87e2fd"
   component:
-    app (threads of system take precedence)
-      threads (ignored because hash matches system variant)
+    app*
+      threads*
         stacktrace*
           frame*
             filename*
@@ -16,10 +16,10 @@ app:
               "main"
 --------------------------------------------------------------------------
 system:
-  hash: "1a11687556cf74559f0ae90b1c87e2fd"
+  hash: null
   component:
-    system*
-      threads*
+    system (threads of app take precedence)
+      threads (ignored because hash matches app variant)
         stacktrace*
           frame*
             filename*


### PR DESCRIPTION
Currently, when the app and system variants produce the same hash (as happens when all frames are in app, for example), we consider it system hash, and discard the app hash as a non-contributing duplicate. This doesn't affect how events are grouped (since all we use is the value, not the variant designation), but is nonetheless not ideal, for two main reasons:

- We say that we prioritize the app hash (because in-app frames should matter more for grouping than third-party ones), and the current behavior seemingly contradicts that rule, which is confusing for users (and Sentry devs just getting introduced to the grouping codebase, which is complicated enough). (I say "seemingly" because in fact, we're still grouping on the same hash value, whatever we call it, so it doesn't _actually_ contradict the logic, it just appears to.) Also, regardless of what we say about precedence, it's confusing to look at a stacktrace full of in-app frames and have the grouping info indicate that we're not grouping on them.

- We've now introduced logic which will prevent events with only a system hash and a more-than-30-frame-long stacktrace from being sent to Seer. In cases where the hashes match, "only having a system hash" doesn't actually mean we're expecting it to, i.e., that there was no app hash. It just means we named the shared hash "system" rather than "app." We therefore end up blocking events we shouldn't.

This fixes those problems by prioritizing the app hash over the system hash in cases where they match.

Notes:

- We currently have this idea of variants being "mandatory," such that if we don't have a hash for that variant, no variants' hashes should count. (This is denoted by the variant's name starting with a `!`, and currently only applies to the system variant.) A secondary effect of this designation is to mark duplicate hashes as discarded if they come from non-mandatory variants.

  In practice, the only variants that can coexist are app and system, and there's no way to have an app hash without also having a system hash, so the mandatory-ness part of the logic is unused. The secondary (deduplication) part is used, and is the thing this PR is fixing. Therefore, the easiest way to make the change was to a) remove the mandatory-ness logic, and b) mark app rather than system with the magic `!`. In the long run, I'd like to clean up this logic to make it less opaque, but this was the most straightforward way to do it given the current state of things.

- This only affects newstyle grouping, not legacy grouping. Reviewers will also notice that it doesn't affect an identical set of snapshots in each newstyle config. This is because the different configs mark frames in or out of app differently, and so even though app and system hashes might match under one config, they might not under a different config.
