### PR TITLE
fix(grouping): Fix test of excessive system frames

### DIFF
--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -388,14 +388,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             hashes.update({group_id: self.group_hashes[group_id]})
         # Create one event where the stacktrace has over MAX_FRAME_COUNT system only frames
         exception = copy.deepcopy(EXCEPTION)
-        exception["values"][0]["stacktrace"]["frames"] += [
+        exception["values"][0]["stacktrace"]["frames"] = [
             {
                 "function": f"divide_by_zero_{i}",
                 "module": "__main__",
-                "filename": "python_onboarding_{i}.py",
-                "abs_path": "/Users/user/python_onboarding/python_onboarding_{i}.py",
+                "filename": "java_onboarding_{i}.java",
+                "abs_path": "/Users/user/java_onboarding/java_onboarding_{i}.java",
                 "lineno": i,
-                "in_app": True,
+                "in_app": False,
             }
             for i in range(MAX_FRAME_COUNT + 1)
         ]


### PR DESCRIPTION
Currently, our test testing the restriction on sending excessively long stacktraces with no in-app frames to Seer relies on the app and system hashes matching (and the app hash therefore being discarded) in order to produce an event which seems to have no in-app frames in its stacktrace. In fact, though, when creating that event 1) we add frames to the existing stacktrace, which already has an in-app frame in it, and 2) the frames we add are all in-app. This fixes that by 1) replacing the existing stacktrace rather than adding to it, and 2) using only non-in-app frames when we do so. That way, we're guaranteed to have an event with only a system hash.

It also changes the details in the frames from ones that seem like they come from a Python event to ones which might come from a Java event, since Python isn't subject to the restriction we're testing and I was therefore initially confused reading the test.