### PR TITLE
fix(autofix): Hide controls if could not find a fix

### DIFF
--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -354,7 +354,8 @@ function AutofixMessageBox({
 
   const isDisabled =
     step?.status === AutofixStatus.ERROR ||
-    (step?.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && step.causes?.length === 0);
+    (step?.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && step.causes?.length === 0) ||
+    (step?.type === AutofixStepType.CHANGES && changes.length === 0);
 
   useEffect(() => {
     if (contentRef.current) {
@@ -436,45 +437,47 @@ function AutofixMessageBox({
               }}
             />
           </ContentArea>
-          <ActionBar>
-            {isRootCauseSelectionStep && (
-              <Fragment>
-                <SegmentedControl
-                  size="xs"
-                  value={rootCauseMode}
-                  onChange={setRootCauseMode}
-                  aria-label={t('Root cause selection')}
-                >
-                  <SegmentedControl.Item key="suggested_root_cause">
-                    {t('Use suggested root cause')}
-                  </SegmentedControl.Item>
-                  <SegmentedControl.Item key="custom_root_cause">
-                    {t('Propose your own root cause')}
-                  </SegmentedControl.Item>
-                </SegmentedControl>
-              </Fragment>
-            )}
-            {isChangesStep && !prsMade && (
-              <Fragment>
-                <SegmentedControl
-                  size="xs"
-                  value={changesMode}
-                  onChange={setChangesMode}
-                  aria-label={t('Changes selection')}
-                >
-                  <SegmentedControl.Item key="give_feedback">
-                    {t('Give feedback')}
-                  </SegmentedControl.Item>
-                  <SegmentedControl.Item key="add_tests">
-                    {t('Add tests')}
-                  </SegmentedControl.Item>
-                  <SegmentedControl.Item key="create_prs">
-                    {t('Approve changes')}
-                  </SegmentedControl.Item>
-                </SegmentedControl>
-              </Fragment>
-            )}
-          </ActionBar>
+          {!isDisabled && (
+            <ActionBar>
+              {isRootCauseSelectionStep && (
+                <Fragment>
+                  <SegmentedControl
+                    size="xs"
+                    value={rootCauseMode}
+                    onChange={setRootCauseMode}
+                    aria-label={t('Root cause selection')}
+                  >
+                    <SegmentedControl.Item key="suggested_root_cause">
+                      {t('Use suggested root cause')}
+                    </SegmentedControl.Item>
+                    <SegmentedControl.Item key="custom_root_cause">
+                      {t('Propose your own root cause')}
+                    </SegmentedControl.Item>
+                  </SegmentedControl>
+                </Fragment>
+              )}
+              {isChangesStep && !prsMade && (
+                <Fragment>
+                  <SegmentedControl
+                    size="xs"
+                    value={changesMode}
+                    onChange={setChangesMode}
+                    aria-label={t('Changes selection')}
+                  >
+                    <SegmentedControl.Item key="give_feedback">
+                      {t('Give feedback')}
+                    </SegmentedControl.Item>
+                    <SegmentedControl.Item key="add_tests">
+                      {t('Add tests')}
+                    </SegmentedControl.Item>
+                    <SegmentedControl.Item key="create_prs">
+                      {t('Approve changes')}
+                    </SegmentedControl.Item>
+                  </SegmentedControl>
+                </Fragment>
+              )}
+            </ActionBar>
+          )}
         </ContentWrapper>
       </AnimatedContent>
       <InputSection>


### PR DESCRIPTION
Hides the controls when we don't have a fix to avoid confusion.

(yes, the message is bad, but that's a Seer change so it's not in this PR)

<img width="683" alt="Screenshot 2024-12-09 at 3 23 24 PM" src="https://github.com/user-attachments/assets/02bad3ae-e325-4b1b-8c47-1f5175ff27a8">
