### PR TITLE
feat(explore): New hooks for explore page params

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
@@ -1,0 +1,37 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export function defaultDataset(): DiscoverDatasets {
+  return DiscoverDatasets.SPANS_EAP;
+}
+
+export function getDatasetFromLocation(location: Location): DiscoverDatasets {
+  const rawDataset = decodeScalar(location.query.dataset);
+  return parseDataset(rawDataset);
+}
+
+export function parseDataset(rawDataset: string | undefined) {
+  if (rawDataset === 'spansIndexed') {
+    return DiscoverDatasets.SPANS_INDEXED;
+  }
+
+  if (rawDataset === 'spansRpc') {
+    return DiscoverDatasets.SPANS_EAP_RPC;
+  }
+
+  return defaultDataset();
+}
+
+export function updateLocationWithDataset(
+  location: Location,
+  dataset: DiscoverDatasets | null | undefined
+) {
+  if (defined(dataset)) {
+    location.query.dataset = dataset;
+  } else if (dataset === null) {
+    delete location.query.dataset;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -1,0 +1,29 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeList} from 'sentry/utils/queryString';
+
+export function defaultFields(): string[] {
+  return ['id', 'project', 'span.op', 'span.description', 'span.duration', 'timestamp'];
+}
+
+export function getFieldsFromLocation(location: Location): string[] {
+  const fields = decodeList(location.query.field);
+
+  if (fields.length) {
+    return fields;
+  }
+
+  return defaultFields();
+}
+
+export function updateLocationWithFields(
+  location: Location,
+  fields: string[] | undefined | null
+) {
+  if (defined(fields)) {
+    location.query.field = fields;
+  } else if (fields === null) {
+    delete location.query.field;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/groupBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/groupBys.tsx
@@ -1,0 +1,31 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeList} from 'sentry/utils/queryString';
+
+export const UNGROUPED = '';
+
+export function defaultGroupBys(): string[] {
+  return [UNGROUPED];
+}
+
+export function getGroupBysFromLocation(location: Location): string[] {
+  const rawGroupBys = decodeList(location.query.groupBy);
+
+  if (rawGroupBys.length) {
+    return rawGroupBys;
+  }
+
+  return defaultGroupBys();
+}
+
+export function updateLocationWithGroupBys(
+  location: Location,
+  groupBys: string[] | null | undefined
+) {
+  if (defined(groupBys)) {
+    location.query.groupBy = groupBys;
+  } else if (groupBys === null) {
+    delete location.query.groupBy;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -1,0 +1,442 @@
+import {act, render} from 'sentry-test/reactTestingLibrary';
+
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {
+  PageParamsProvider,
+  useExplorePageParams,
+  useSetExploreDataset,
+  useSetExploreFields,
+  useSetExploreGroupBys,
+  useSetExploreMode,
+  useSetExplorePageParams,
+  useSetExploreQuery,
+  useSetExploreSortBys,
+  useSetExploreVisualizes,
+} from 'sentry/views/explore/contexts/pageParamsContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+describe('PageParamsProvider', function () {
+  let pageParams, setPageParams;
+  let setDataset, setFields, setGroupBys, setMode, setQuery, setSortBys, setVisualizes;
+
+  function Component() {
+    pageParams = useExplorePageParams();
+    setPageParams = useSetExplorePageParams();
+    setDataset = useSetExploreDataset();
+    setFields = useSetExploreFields();
+    setGroupBys = useSetExploreGroupBys();
+    setMode = useSetExploreMode();
+    setQuery = useSetExploreQuery();
+    setSortBys = useSetExploreSortBys();
+    setVisualizes = useSetExploreVisualizes();
+    return <br />;
+  }
+
+  function renderTestComponent(defaultPageParams?) {
+    render(
+      <PageParamsProvider>
+        <Component />
+      </PageParamsProvider>,
+      {disableRouterMocks: true}
+    );
+
+    act(() =>
+      setPageParams({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        groupBys: ['span.op'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        visualizes: [
+          {
+            chartType: ChartType.AREA,
+            label: 'A',
+            yAxes: ['count(span.self_time)'],
+          },
+        ],
+        ...defaultPageParams,
+      })
+    );
+  }
+
+  it('has expected default', function () {
+    render(
+      <PageParamsProvider>
+        <Component />
+      </PageParamsProvider>,
+      {disableRouterMocks: true}
+    );
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP,
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'timestamp',
+      ],
+      groupBys: [''],
+      mode: Mode.SAMPLES,
+      query: '',
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.LINE,
+          label: 'A',
+          yAxes: ['avg(span.duration)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates dataset', function () {
+    renderTestComponent();
+
+    act(() => setDataset(DiscoverDatasets.SPANS_EAP));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates fields', function () {
+    renderTestComponent();
+
+    act(() => setFields(['id', 'span.op', 'timestamp']));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'span.op', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates groupBys', function () {
+    renderTestComponent();
+
+    act(() => setGroupBys(['browser.name', 'sdk.name']));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['browser.name', 'sdk.name'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates mode from samples to aggregates', function () {
+    renderTestComponent({mode: Mode.SAMPLES});
+
+    act(() => setMode(Mode.AGGREGATE));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates mode from aggregates to sample without group bys', function () {
+    renderTestComponent({mode: Mode.AGGREGATE, groupBys: [''], sortBys: null});
+
+    act(() => setMode(Mode.SAMPLES));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: [''],
+      mode: Mode.SAMPLES,
+      query: '',
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates mode from aggregates to sample with group bys', function () {
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      sortBys: null,
+      fields: ['id', 'sdk.name', 'sdk.version', 'timestamp'],
+      groupBys: ['sdk.name', 'sdk.version', 'span.op', ''],
+    });
+
+    act(() => setMode(Mode.SAMPLES));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'sdk.name', 'sdk.version', 'timestamp', 'span.op'],
+      groupBys: ['sdk.name', 'sdk.version', 'span.op', ''],
+      mode: Mode.SAMPLES,
+      query: '',
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates query', function () {
+    renderTestComponent();
+
+    act(() => setQuery('foo:bar'));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: 'foo:bar',
+      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates sort bys in samples mode with known field', function () {
+    renderTestComponent({mode: Mode.SAMPLES});
+
+    act(() => setSortBys([{field: 'id', kind: 'desc'}]));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.SAMPLES,
+      query: '',
+      sortBys: [{field: 'id', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates sort bys in samples mode with unknown field', function () {
+    renderTestComponent({mode: Mode.SAMPLES});
+
+    act(() => setSortBys([{field: 'span.op', kind: 'desc'}]));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.SAMPLES,
+      query: '',
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates sort bys in aggregates mode with known y axis', function () {
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+        },
+      ],
+    });
+
+    act(() => setSortBys([{field: 'max(span.duration)', kind: 'desc'}]));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'max(span.duration)', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates sort bys in aggregates mode with unknown y axis', function () {
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+        },
+      ],
+    });
+
+    act(() => setSortBys([{field: 'avg(span.duration)', kind: 'desc'}]));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates sort bys in aggregates mode with known group by', function () {
+    renderTestComponent({mode: Mode.AGGREGATE, groupBys: ['sdk.name']});
+
+    act(() => setSortBys([{field: 'sdk.name', kind: 'desc'}]));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['sdk.name'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'sdk.name', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates sort bys in aggregates mode with unknown group by', function () {
+    renderTestComponent({mode: Mode.AGGREGATE, groupBys: ['sdk.name']});
+
+    act(() => setSortBys([{field: 'sdk.version', kind: 'desc'}]));
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['sdk.name'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
+  });
+
+  it('correctly updates visualizes with labels', function () {
+    renderTestComponent();
+
+    act(() =>
+      setVisualizes([
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['count(span.self_time)'],
+        },
+        {
+          chartType: ChartType.LINE,
+          yAxes: ['avg(span.duration)', 'avg(span.self_time)'],
+        },
+      ])
+    );
+
+    expect(pageParams).toEqual({
+      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      fields: ['id', 'timestamp'],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+      visualizes: [
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+        {
+          chartType: ChartType.LINE,
+          label: 'B',
+          yAxes: ['avg(span.duration)', 'avg(span.self_time)'],
+        },
+      ],
+    });
+  });
+});

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -1,0 +1,254 @@
+import type React from 'react';
+import {createContext, useCallback, useContext, useMemo} from 'react';
+
+import type {Sort} from 'sentry/utils/discover/fields';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+import {
+  defaultDataset,
+  getDatasetFromLocation,
+  updateLocationWithDataset,
+} from './dataset';
+import {defaultFields, getFieldsFromLocation, updateLocationWithFields} from './fields';
+import {
+  defaultGroupBys,
+  getGroupBysFromLocation,
+  updateLocationWithGroupBys,
+} from './groupBys';
+import {defaultMode, getModeFromLocation, Mode, updateLocationWithMode} from './mode';
+import {defaultQuery, getQueryFromLocation, updateLocationWithQuery} from './query';
+import {
+  defaultSortBys,
+  getSortBysFromLocation,
+  updateLocationWithSortBys,
+} from './sortBys';
+import {
+  defaultVisualizes,
+  getVisualizesFromLocation,
+  updateLocationWithVisualizes,
+  type Visualize,
+} from './visualizes';
+
+interface ReadablePageParams {
+  dataset: DiscoverDatasets;
+  fields: string[];
+  groupBys: string[];
+  mode: Mode;
+  query: string;
+  sortBys: Sort[];
+  visualizes: Visualize[];
+}
+
+interface WritablePageParams {
+  dataset?: DiscoverDatasets | null;
+  fields?: string[] | null;
+  groupBys?: string[] | null;
+  mode?: Mode | null;
+  query?: string | null;
+  sortBys?: Sort[] | null;
+  visualizes?: Omit<Visualize, 'label'>[] | null;
+}
+
+function defaultPageParams(): ReadablePageParams {
+  const dataset = defaultDataset();
+  const fields = defaultFields();
+  const groupBys = defaultGroupBys();
+  const mode = defaultMode();
+  const query = defaultQuery();
+  const visualizes = defaultVisualizes();
+  const sortBys = defaultSortBys(mode, fields, visualizes);
+
+  return {
+    dataset,
+    fields,
+    groupBys,
+    mode,
+    query,
+    sortBys,
+    visualizes,
+  };
+}
+
+const PageParamsContext = createContext<ReadablePageParams>(defaultPageParams());
+
+interface PageParamsProviderProps {
+  children: React.ReactNode;
+}
+
+export function PageParamsProvider({children}: PageParamsProviderProps) {
+  const location = useLocation();
+
+  const pageParams: ReadablePageParams = useMemo(() => {
+    const dataset = getDatasetFromLocation(location);
+    const fields = getFieldsFromLocation(location);
+    const groupBys = getGroupBysFromLocation(location);
+    const mode = getModeFromLocation(location);
+    const query = getQueryFromLocation(location);
+    const visualizes = getVisualizesFromLocation(location);
+    const sortBys = getSortBysFromLocation(location, mode, fields, groupBys, visualizes);
+
+    return {
+      dataset,
+      fields,
+      groupBys,
+      mode,
+      query,
+      sortBys,
+      visualizes,
+    };
+  }, [location]);
+
+  return (
+    <PageParamsContext.Provider value={pageParams}>{children}</PageParamsContext.Provider>
+  );
+}
+
+export function useExplorePageParams(): ReadablePageParams {
+  return useContext(PageParamsContext);
+}
+
+export function useExploreDataset(): DiscoverDatasets {
+  const pageParams = useExplorePageParams();
+  return pageParams.dataset;
+}
+
+export function useExploreFields(): string[] {
+  const pageParams = useExplorePageParams();
+  return pageParams.fields;
+}
+
+export function useExploreGroupBys(): string[] {
+  const pageParams = useExplorePageParams();
+  return pageParams.groupBys;
+}
+
+export function useExploreMode(): Mode {
+  const pageParams = useExplorePageParams();
+  return pageParams.mode;
+}
+
+export function useExploreQuery(): string {
+  const pageParams = useExplorePageParams();
+  return pageParams.query;
+}
+
+export function useExploreSortBys(): Sort[] {
+  const pageParams = useExplorePageParams();
+  return pageParams.sortBys;
+}
+
+export function useExploreVisualizes(): Visualize[] {
+  const pageParams = useExplorePageParams();
+  return pageParams.visualizes;
+}
+
+export function useSetExplorePageParams() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (pageParams: WritablePageParams) => {
+      const target = {...location, query: {...location.query}};
+      updateLocationWithDataset(target, pageParams.dataset);
+      updateLocationWithFields(target, pageParams.fields);
+      updateLocationWithGroupBys(target, pageParams.groupBys);
+      updateLocationWithMode(target, pageParams.mode);
+      updateLocationWithQuery(target, pageParams.query);
+      updateLocationWithSortBys(target, pageParams.sortBys);
+      updateLocationWithVisualizes(target, pageParams.visualizes);
+      navigate(target);
+    },
+    [location, navigate]
+  );
+}
+
+export function useSetExploreDataset() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (dataset: DiscoverDatasets) => {
+      setPageParams({dataset});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreFields() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (fields: string[]) => {
+      setPageParams({fields});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreGroupBys() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (groupBys: string[]) => {
+      setPageParams({groupBys});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreMode() {
+  const pageParams = useExplorePageParams();
+  const setPageParams = useSetExplorePageParams();
+
+  return useCallback(
+    (mode: Mode) => {
+      if (mode === Mode.SAMPLES && pageParams.groupBys.some(groupBy => groupBy !== '')) {
+        // When switching from the aggregates to samples mode, carry
+        // over any group bys as they are helpful context when looking
+        // for examples.
+        const fields = [...pageParams.fields];
+        for (const groupBy of pageParams.groupBys) {
+          if (groupBy !== '' && !fields.includes(groupBy)) {
+            fields.push(groupBy);
+          }
+        }
+
+        setPageParams({
+          mode,
+          fields,
+        });
+      } else {
+        setPageParams({mode});
+      }
+    },
+    [pageParams, setPageParams]
+  );
+}
+
+export function useSetExploreQuery() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (query: string) => {
+      setPageParams({query});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreSortBys() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (sortBys: Sort[]) => {
+      setPageParams({sortBys});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreVisualizes() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (visualizes: Omit<Visualize, 'label'>[]) => {
+      setPageParams({visualizes});
+    },
+    [setPageParams]
+  );
+}

--- a/static/app/views/explore/contexts/pageParamsContext/mode.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/mode.tsx
@@ -1,0 +1,32 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export enum Mode {
+  SAMPLES = 'samples',
+  AGGREGATE = 'aggregate',
+}
+
+export function defaultMode(): Mode {
+  return Mode.SAMPLES;
+}
+
+export function getModeFromLocation(location: Location): Mode {
+  const rawMode = decodeScalar(location.query.mode);
+  if (rawMode === 'aggregate') {
+    return Mode.AGGREGATE;
+  }
+  return defaultMode();
+}
+
+export function updateLocationWithMode(
+  location: Location,
+  mode: Mode | null | undefined
+) {
+  if (defined(mode)) {
+    location.query.mode = mode;
+  } else if (mode === null) {
+    delete location.query.mode;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/query.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/query.tsx
@@ -1,0 +1,23 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeQuery} from 'sentry/utils/discover/eventView';
+
+export function defaultQuery(): string {
+  return '';
+}
+
+export function getQueryFromLocation(location: Location) {
+  return decodeQuery(location);
+}
+
+export function updateLocationWithQuery(
+  location: Location,
+  query: string | null | undefined
+) {
+  if (defined(query)) {
+    location.query.query = query;
+  } else if (query === null) {
+    delete location.query.query;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
@@ -1,0 +1,89 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {decodeSorts} from 'sentry/utils/queryString';
+
+import {Mode} from './mode';
+import type {Visualize} from './visualizes';
+
+export function defaultSortBys(
+  mode: Mode,
+  fields: string[],
+  visualizes: Visualize[]
+): Sort[] {
+  if (mode === Mode.SAMPLES) {
+    if (fields.includes('timestamp')) {
+      return [
+        {
+          field: 'timestamp',
+          kind: 'desc' as const,
+        },
+      ];
+    }
+
+    if (fields.length) {
+      return [
+        {
+          field: fields[0],
+          kind: 'desc' as const,
+        },
+      ];
+    }
+  }
+
+  if (mode === Mode.AGGREGATE) {
+    if (visualizes[0]?.yAxes?.[0]) {
+      return [
+        {
+          field: visualizes[0].yAxes[0],
+          kind: 'desc' as const,
+        },
+      ];
+    }
+  }
+
+  return [];
+}
+
+export function getSortBysFromLocation(
+  location: Location,
+  mode: Mode,
+  fields: string[],
+  groupBys: string[],
+  visualizes: Visualize[]
+): Sort[] {
+  const sortBys = decodeSorts(location.query.sort);
+
+  if (sortBys.length > 0) {
+    if (mode === Mode.SAMPLES && sortBys.every(sortBy => fields.includes(sortBy.field))) {
+      return sortBys;
+    }
+
+    if (
+      mode === Mode.AGGREGATE &&
+      sortBys.every(
+        sortBy =>
+          groupBys.includes(sortBy.field) ||
+          visualizes.some(visualize => visualize.yAxes.includes(sortBy.field))
+      )
+    ) {
+      return sortBys;
+    }
+  }
+
+  return defaultSortBys(mode, fields, visualizes);
+}
+
+export function updateLocationWithSortBys(
+  location: Location,
+  sortBys: Sort[] | null | undefined
+) {
+  if (defined(sortBys)) {
+    location.query.sort = sortBys.map(sortBy =>
+      sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
+    );
+  } else if (sortBys === null) {
+    delete location.query.sort;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -1,0 +1,87 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {parseFunction} from 'sentry/utils/discover/fields';
+import {
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  ALLOWED_EXPLORE_VISUALIZE_FIELDS,
+} from 'sentry/utils/fields';
+import {decodeList} from 'sentry/utils/queryString';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+export const MAX_VISUALIZES = 4;
+
+export const DEFAULT_VISUALIZATION = `${ALLOWED_EXPLORE_VISUALIZE_AGGREGATES[0]}(${ALLOWED_EXPLORE_VISUALIZE_FIELDS[0]})`;
+
+export function defaultVisualizes(): Visualize[] {
+  return [
+    {
+      chartType: ChartType.LINE,
+      yAxes: [DEFAULT_VISUALIZATION],
+      label: 'A',
+    },
+  ];
+}
+
+export type Visualize = {
+  chartType: ChartType;
+  label: string;
+  yAxes: string[];
+};
+
+export function getVisualizesFromLocation(location: Location): Visualize[] {
+  const rawVisualizes = decodeList(location.query.visualize);
+
+  const result: Visualize[] = rawVisualizes
+    .map(parseVisualizes)
+    .filter(defined)
+    .filter(parsed => parsed.yAxes.length > 0)
+    .map((parsed, i) => {
+      return {
+        chartType: parsed.chartType,
+        yAxes: parsed.yAxes,
+        label: String.fromCharCode(65 + i), // starts from 'A'
+      };
+    });
+
+  return result.length ? result : defaultVisualizes();
+}
+
+function parseVisualizes(raw: string): Omit<Visualize, 'label'> | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!defined(parsed) || !Array.isArray(parsed.yAxes)) {
+      return null;
+    }
+
+    const yAxes = parsed.yAxes.filter(parseFunction);
+    if (yAxes.length <= 0) {
+      return null;
+    }
+
+    let chartType = Number(parsed.chartType);
+    if (isNaN(chartType) || !Object.values(ChartType).includes(chartType)) {
+      chartType = ChartType.LINE;
+    }
+
+    return {yAxes, chartType};
+  } catch (error) {
+    return null;
+  }
+}
+
+export function updateLocationWithVisualizes(
+  location: Location,
+  visualizes: Omit<Visualize, 'label'>[] | null | undefined
+) {
+  if (defined(visualizes)) {
+    location.query.visualize = visualizes.map(visualize =>
+      JSON.stringify({
+        chartType: visualize.chartType,
+        yAxes: visualize.yAxes,
+      })
+    );
+  } else if (visualizes === null) {
+    delete location.query.visualize;
+  }
+}


### PR DESCRIPTION
The existing hooks have served well up to a certain point but there's more dependencies between the params than originally expected and has led to some not so good patterns. This creates a context with all the page params together so they can be handled accordingly.