### PR TITLE
Slack integration for Sentry on private domains.

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -123,7 +123,7 @@ class SlackIntegrationProvider(IntegrationProvider):
         identity_pipeline_config = {
             "oauth_scopes": self.identity_oauth_scopes,
             "user_scopes": self.user_scopes,
-            "redirect_url": absolute_uri("/extensions/slack/setup/"),
+            "redirect_url": absolute_uri("/extensions/slack/setup/", options.get("slack.url-prefix")),
         }
 
         identity_pipeline_view = NestedPipelineView(

--- a/src/sentry/integrations/slack/views/__init__.py
+++ b/src/sentry/integrations/slack/views/__init__.py
@@ -13,7 +13,7 @@ SALT = "sentry-slack-integration"
 
 def build_linking_url(endpoint: str, **kwargs: Any) -> str:
     """TODO(mgaeta): Remove cast once sentry/utils/http.py is typed."""
-    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}))
+    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}), options.get("slack.url-prefix"))
     return url
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -529,6 +529,7 @@ register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # signing-secret is preferred, but need to keep verification-token for apps that use it
 register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register("slack.url-prefix", default=None, flags=FLAG_PRIORITIZE_DISK )
 
 
 # Codecov Integration


### PR DESCRIPTION
If Sentry is behind private domain, it's impossible to set up slack integration. This PR should fix it by adding `slack.url-prefix` option, allowed you to use external domain to set up slack integration.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
