### PR TITLE
fix(releases): Show onboarding panel

### DIFF
--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -252,7 +252,7 @@ describe('ReleasesList', () => {
       statusCode: 400,
     });
 
-    render(<ReleasesList {...props} />, {
+    render(<ReleasesList {...props} selection={{...props.selection, projects: [3]}} />, {
       router,
       organization,
     });
@@ -261,7 +261,7 @@ describe('ReleasesList', () => {
 
     // we want release header to be visible despite the error message
     expect(
-      await screen.getByRole('combobox', {
+      await screen.findByRole('combobox', {
         name: 'Add a search term',
       })
     ).toBeInTheDocument();

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -187,6 +187,12 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
   getSelectedProject(): Project | undefined {
     const {selection, projects} = this.props;
 
+    // Return the first project when 'All Projects' is displayed.
+    // This ensures the onboarding panel is shown correctly, for example.
+    if (selection.projects.length === 0) {
+      return projects[0];
+    }
+
     const selectedProjectId =
       selection.projects && selection.projects.length === 1 && selection.projects[0];
     return projects?.find(p => p.id === `${selectedProjectId}`);


### PR DESCRIPTION
**Problem**

On the releases page, when no project is selected, we display "All Projects." However, the page appears very empty because the UI requires a selected project to display the onboarding panel.

**Solution**

Similar to the approach used on the issue stream page, we automatically select the first project when "All Projects" is shown. This ensures the onboarding panel is displayed as expected.

closes https://github.com/getsentry/sentry/issues/66490

