### PR TITLE
feat(alerts): Limits eap alert time windows and periods

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -288,6 +288,19 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       ]);
     }
 
+    if (this.props.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
+      options = pick(TIME_WINDOW_MAP, [
+        TimeWindow.FIVE_MINUTES,
+        TimeWindow.TEN_MINUTES,
+        TimeWindow.FIFTEEN_MINUTES,
+        TimeWindow.THIRTY_MINUTES,
+        TimeWindow.ONE_HOUR,
+        TimeWindow.TWO_HOURS,
+        TimeWindow.FOUR_HOURS,
+        TimeWindow.ONE_DAY,
+      ]);
+    }
+
     return Object.entries(options).map(([value, label]) => ({
       value: parseInt(value, 10),
       label: tct('[timeWindow] interval', {

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -138,6 +138,23 @@ export const AVAILABLE_TIME_PERIODS: Record<TimeWindow, readonly TimePeriod[]> =
   [TimeWindow.ONE_DAY]: [TimePeriod.FOURTEEN_DAYS],
 };
 
+const MOST_EAP_TIME_PERIOD = [
+  TimePeriod.ONE_DAY,
+  TimePeriod.THREE_DAYS,
+  TimePeriod.SEVEN_DAYS,
+];
+
+const EAP_AVAILABLE_TIME_PERIODS = {
+  [TimeWindow.FIVE_MINUTES]: MOST_EAP_TIME_PERIOD,
+  [TimeWindow.TEN_MINUTES]: MOST_EAP_TIME_PERIOD,
+  [TimeWindow.FIFTEEN_MINUTES]: MOST_EAP_TIME_PERIOD,
+  [TimeWindow.THIRTY_MINUTES]: MOST_EAP_TIME_PERIOD,
+  [TimeWindow.ONE_HOUR]: MOST_EAP_TIME_PERIOD,
+  [TimeWindow.TWO_HOURS]: MOST_EAP_TIME_PERIOD,
+  [TimeWindow.FOUR_HOURS]: [TimePeriod.SEVEN_DAYS],
+  [TimeWindow.ONE_DAY]: [TimePeriod.SEVEN_DAYS],
+};
+
 const TIME_WINDOW_TO_SESSION_INTERVAL = {
   [TimeWindow.THIRTY_MINUTES]: '30m',
   [TimeWindow.ONE_HOUR]: '1h',
@@ -244,6 +261,10 @@ class TriggersChart extends PureComponent<Props, State> {
         ...AVAILABLE_TIME_PERIODS,
         [TimeWindow.THIRTY_MINUTES]: [TimePeriod.SIX_HOURS],
       };
+    }
+
+    if (this.props.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
+      return EAP_AVAILABLE_TIME_PERIODS;
     }
 
     return AVAILABLE_TIME_PERIODS;

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -145,6 +145,7 @@ const MOST_EAP_TIME_PERIOD = [
 ];
 
 const EAP_AVAILABLE_TIME_PERIODS = {
+  [TimeWindow.ONE_MINUTE]: [], // One minute intervals are not allowed on EAP Alerts
   [TimeWindow.FIVE_MINUTES]: MOST_EAP_TIME_PERIOD,
   [TimeWindow.TEN_MINUTES]: MOST_EAP_TIME_PERIOD,
   [TimeWindow.FIFTEEN_MINUTES]: MOST_EAP_TIME_PERIOD,


### PR DESCRIPTION
Updates EAP alerts to only allow up to 2016 buckets queried in the visualization. 
- Removes 14 day visualizations
- Removes 1 minute intervals