### PR TITLE
feat(alerts): Renames eap metrics in ui to spans

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -93,7 +93,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   llm_cost: t('LLM cost'),
   llm_tokens: t('LLM token usage'),
   uptime_monitor: t('Uptime Monitor'),
-  eap_metrics: t('EAP Metric'),
+  eap_metrics: t('Spans'),
 };
 
 /**

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -187,7 +187,7 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     illustration: diagramUptime,
   },
   eap_metrics: {
-    description: t('Alert on eap metrics.'),
+    description: t('Alert on spans.'),
     examples: [
       t('When your average time in queue exceeds 100ms.'),
       t('When your app runs more than 1000 queries in a minute.'),


### PR DESCRIPTION
Renames `EAP Metric` to `Spans`