### PR TITLE
chore(deps): bump django to 5.1.4

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -14,7 +14,7 @@ datadog>=0.49
 django-crispy-forms>=1.14.0
 django-csp>=3.8
 django-pg-zero-downtime-migrations>=0.16
-Django>=5.1.1
+Django>=5.1.4
 djangorestframework>=3.15.1
 drf-spectacular>=0.26.3
 email-reply-parser>=0.5.12
@@ -75,7 +75,7 @@ sentry-sdk[http2]>=2.19.2
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6
-sqlparse>=0.4.4
+sqlparse>=0.5.2
 statsd>=3.3
 structlog>=22
 symbolic==12.12.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -39,7 +39,7 @@ datadog==0.49.1
 devservices==1.0.5
 distlib==0.3.8
 distro==1.8.0
-django==5.1.1
+django==5.1.4
 django-crispy-forms==1.14.0
 django-csp==3.8
 django-pg-zero-downtime-migrations==0.16
@@ -200,7 +200,7 @@ sniffio==1.3.1
 snuba-sdk==3.0.43
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
-sqlparse==0.5.0
+sqlparse==0.5.2
 statsd==3.3.0
 stripe==3.1.0
 structlog==22.1.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -32,7 +32,7 @@ cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
 distro==1.8.0
-django==5.1.1
+django==5.1.4
 django-crispy-forms==1.14.0
 django-csp==3.8
 django-pg-zero-downtime-migrations==0.16
@@ -138,7 +138,7 @@ slack-sdk==3.27.2
 sniffio==1.3.1
 snuba-sdk==3.0.43
 soupsieve==2.3.2.post1
-sqlparse==0.5.0
+sqlparse==0.5.2
 statsd==3.3.0
 stripe==3.1.0
 structlog==22.1.0


### PR DESCRIPTION
Resolve Dependabot alerts.

- https://github.com/getsentry/sentry/security/dependabot/312
- https://github.com/getsentry/sentry/security/dependabot/310