### PR TITLE
fix(status): Check group status when updating to avoid resetting the same status

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -459,6 +459,10 @@ def handle_resolve_in_release(
         except IndexError:
             release = None
     for group in group_list:
+        # If the group is already resolved, we don't need to do anything
+        if group.status == GroupStatus.RESOLVED:
+            continue
+
         with transaction.atomic(router.db_for_write(Group)):
             process_group_resolution(
                 group,
@@ -706,9 +710,6 @@ def handle_other_status_updates(
     new_substatus = infer_substatus(new_status, new_substatus, status_details, group_list)
 
     with transaction.atomic(router.db_for_write(Group)):
-        # TODO(gilbert): update() doesn't call pre_save and bypasses any substatus defaulting we have there
-        #                we should centralize the logic for validating and defaulting substatus values
-        #                and refactor pre_save and the above new_substatus assignment to account for this
         status_updated = queryset.exclude(status=new_status).update(
             status=new_status, substatus=new_substatus
         )

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4558,6 +4558,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def test_selective_status_update(self) -> None:
         group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group1.resolved_at = timezone.now()
+        group1.save()
         group2 = self.create_group(status=GroupStatus.UNRESOLVED)
         group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(


### PR DESCRIPTION
Updating groups to `RESOLVED` doesn't perform a preliminary check to ensure the group hasn't already been resolved. The UI disallows this sort of behavior, but integrations and API-based updates can still end up resolving a single issue multiple times. This PR adds a check to prevent this behavior.

Fixes #69252 and #69250