### PR TITLE
ref(insights): Simplify `SpanTimeCharts`

### DIFF
--- a/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
+++ b/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
@@ -31,7 +31,6 @@ const CHART_HEIGHT = 140;
 
 type Props = {
   appliedFilters: ModuleFilters;
-  eventView?: EventView;
   extraQuery?: string[];
 };
 

--- a/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
+++ b/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
@@ -38,6 +38,7 @@ type Props = {
 type ChartProps = {
   filters: ModuleFilters;
   throughputUnit: RateUnit;
+  title: string;
   extraQuery?: string[];
 };
 
@@ -62,35 +63,35 @@ export function ResourceLandingPageCharts({
 
   useSynchronizeCharts(1, !isPending);
 
-  const charts = [
-    {
-      title: getThroughputChartTitle(moduleName, throughputUnit),
-      Comp: ThroughputChart,
-    },
-    {
-      title: getDurationChartTitle(moduleName),
-      Comp: DurationChart,
-    },
-  ];
-
   return (
     <ChartsContainer>
-      {charts.map(({title, Comp}) => (
-        <ChartsContainerItem key={title}>
-          <ChartPanel title={title}>
-            <Comp
-              filters={appliedFilters}
-              throughputUnit={throughputUnit}
-              extraQuery={extraQuery}
-            />
-          </ChartPanel>
-        </ChartsContainerItem>
-      ))}
+      <ChartsContainerItem>
+        <ThroughputChart
+          title={getThroughputChartTitle(moduleName, throughputUnit)}
+          filters={appliedFilters}
+          throughputUnit={throughputUnit}
+          extraQuery={extraQuery}
+        />
+      </ChartsContainerItem>
+
+      <ChartsContainerItem>
+        <DurationChart
+          title={getDurationChartTitle(moduleName)}
+          filters={appliedFilters}
+          throughputUnit={throughputUnit}
+          extraQuery={extraQuery}
+        />
+      </ChartsContainerItem>
     </ChartsContainer>
   );
 }
 
-function ThroughputChart({filters, throughputUnit, extraQuery}: ChartProps): JSX.Element {
+function ThroughputChart({
+  title,
+  filters,
+  throughputUnit,
+  extraQuery,
+}: ChartProps): JSX.Element {
   const pageFilters = usePageFilters();
   const eventView = getEventView(pageFilters.selection, filters);
   if (extraQuery) {
@@ -131,30 +132,32 @@ function ThroughputChart({filters, throughputUnit, extraQuery}: ChartProps): JSX
   });
 
   return (
-    <Chart
-      height={CHART_HEIGHT}
-      data={throughputTimeSeries}
-      loading={isPending}
-      grid={{
-        left: '0',
-        right: '0',
-        top: '8px',
-        bottom: '0',
-      }}
-      definedAxisTicks={4}
-      aggregateOutputFormat="rate"
-      rateUnit={throughputUnit}
-      stacked
-      type={ChartType.LINE}
-      chartColors={[THROUGHPUT_COLOR]}
-      tooltipFormatterOptions={{
-        valueFormatter: value => formatRate(value, throughputUnit),
-      }}
-    />
+    <ChartPanel title={title}>
+      <Chart
+        height={CHART_HEIGHT}
+        data={throughputTimeSeries}
+        loading={isPending}
+        grid={{
+          left: '0',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
+        definedAxisTicks={4}
+        aggregateOutputFormat="rate"
+        rateUnit={throughputUnit}
+        stacked
+        type={ChartType.LINE}
+        chartColors={[THROUGHPUT_COLOR]}
+        tooltipFormatterOptions={{
+          valueFormatter: value => formatRate(value, throughputUnit),
+        }}
+      />
+    </ChartPanel>
   );
 }
 
-function DurationChart({filters, extraQuery}: ChartProps): JSX.Element {
+function DurationChart({title, filters, extraQuery}: ChartProps): JSX.Element {
   const pageFilters = usePageFilters();
   const eventView = getEventView(pageFilters.selection, filters);
   if (extraQuery) {
@@ -189,21 +192,23 @@ function DurationChart({filters, extraQuery}: ChartProps): JSX.Element {
   });
 
   return (
-    <Chart
-      height={CHART_HEIGHT}
-      data={[...avgSeries]}
-      loading={isPending}
-      grid={{
-        left: '0',
-        right: '0',
-        top: '8px',
-        bottom: '0',
-      }}
-      definedAxisTicks={4}
-      stacked
-      type={ChartType.LINE}
-      chartColors={[AVG_COLOR]}
-    />
+    <ChartPanel title={title}>
+      <Chart
+        height={CHART_HEIGHT}
+        data={[...avgSeries]}
+        loading={isPending}
+        grid={{
+          left: '0',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
+        definedAxisTicks={4}
+        stacked
+        type={ChartType.LINE}
+        chartColors={[AVG_COLOR]}
+      />
+    </ChartPanel>
   );
 }
 

--- a/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
+++ b/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
@@ -55,7 +55,7 @@ function getSegmentLabel(moduleName: ModuleName) {
   return moduleName === ModuleName.DB ? 'Queries' : 'Requests';
 }
 
-export function SpanTimeCharts({
+export function ResourceLandingPageCharts({
   moduleName,
   appliedFilters,
   spanCategory,

--- a/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
+++ b/static/app/views/insights/browser/resources/components/charts/resourceLandingPageCharts.tsx
@@ -4,13 +4,11 @@ import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
-import type {Series} from 'sentry/types/echarts';
 import EventView from 'sentry/utils/discover/eventView';
 import {RateUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {formatRate} from 'sentry/utils/formatters';
 import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {AVG_COLOR, THROUGHPUT_COLOR} from 'sentry/views/insights/colors';
 import Chart, {
@@ -21,7 +19,6 @@ import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/insights/common/utils/constants';
 import {
-  DataTitles,
   getDurationChartTitle,
   getThroughputChartTitle,
 } from 'sentry/views/insights/common/views/spans/types';
@@ -56,7 +53,6 @@ export function ResourceLandingPageCharts({
 }: Props) {
   const moduleName = ModuleName.RESOURCE;
   const {selection} = usePageFilters();
-  const {features} = useOrganization();
 
   const eventView = getEventView(selection, appliedFilters, spanCategory);
   if (extraQuery) {
@@ -81,10 +77,6 @@ export function ResourceLandingPageCharts({
       Comp: DurationChart,
     },
   ];
-
-  if (features.includes('starfish-browser-resource-module-bundle-analysis')) {
-    charts.push({title: DataTitles.bundleSize, Comp: BundleSizeChart});
-  }
 
   return (
     <ChartsContainer>
@@ -216,71 +208,6 @@ function DurationChart({filters, extraQuery}: ChartProps): JSX.Element {
       stacked
       type={ChartType.LINE}
       chartColors={[AVG_COLOR]}
-    />
-  );
-}
-
-/** This fucntion is just to generate mock data based on other time stamps we have found */
-const useMockSeries = ({filters, extraQuery}: ChartProps) => {
-  const pageFilters = usePageFilters();
-  const eventView = getEventView(pageFilters.selection, filters);
-  if (extraQuery) {
-    eventView.query += ` ${extraQuery.join(' ')}`;
-  }
-
-  const label = `avg(${SPAN_SELF_TIME})`;
-
-  const {isPending, data} = useSpansQuery<
-    {
-      'avg(span.self_time)': number;
-      interval: number;
-      'spm()': number;
-    }[]
-  >({
-    eventView,
-    initialData: [],
-    referrer: 'api.starfish.span-time-charts',
-  });
-  const dataByGroup = {[label]: data};
-
-  const avgSeries = Object.keys(dataByGroup).map(groupName => {
-    const groupData = dataByGroup[groupName];
-
-    return {
-      seriesName: label,
-      data: (groupData ?? []).map(datum => ({
-        value: datum[`avg(${SPAN_SELF_TIME})`],
-        name: datum.interval,
-      })),
-    };
-  });
-  const seriesTimes = avgSeries[0].data.map(({name}) => name);
-  const assetTypes = ['javascript', 'css', 'fonts', 'images'];
-
-  const mockData: Series[] = assetTypes.map(
-    type =>
-      ({
-        seriesName: type,
-        data: seriesTimes.map((time, i) => ({
-          name: time,
-          value: 1000 + Math.ceil(i / 100) * 100,
-        })),
-      }) satisfies Series
-  );
-
-  return {isPending, data: mockData};
-};
-
-function BundleSizeChart(props: ChartProps) {
-  const {isPending, data} = useMockSeries(props);
-  return (
-    <Chart
-      stacked
-      type={ChartType.AREA}
-      loading={isPending}
-      data={data}
-      aggregateOutputFormat="size"
-      height={CHART_HEIGHT}
     />
   );
 }

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -27,9 +27,10 @@ import {
 import {useResourceSort} from 'sentry/views/insights/browser/resources/utils/useResourceSort';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {TransactionSelector} from 'sentry/views/insights/common/views/spans/selectors/transactionSelector';
-import {SpanTimeCharts} from 'sentry/views/insights/common/views/spans/spanTimeCharts';
 import type {ModuleFilters} from 'sentry/views/insights/common/views/spans/useModuleFilters';
 import {ModuleName} from 'sentry/views/insights/types';
+
+import {ResourceLandingPageCharts} from './charts/resourceLandingPageCharts';
 
 const {
   SPAN_OP: RESOURCE_TYPE,
@@ -63,7 +64,7 @@ function ResourceView() {
   return (
     <Fragment>
       <SpanTimeChartsContainer>
-        <SpanTimeCharts
+        <ResourceLandingPageCharts
           moduleName={ModuleName.RESOURCE}
           appliedFilters={spanTimeChartsFilters}
           throughputUnit={RESOURCE_THROUGHPUT_UNIT}

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -28,7 +28,6 @@ import {useResourceSort} from 'sentry/views/insights/browser/resources/utils/use
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {TransactionSelector} from 'sentry/views/insights/common/views/spans/selectors/transactionSelector';
 import type {ModuleFilters} from 'sentry/views/insights/common/views/spans/useModuleFilters';
-import {ModuleName} from 'sentry/views/insights/types';
 
 import {ResourceLandingPageCharts} from './charts/resourceLandingPageCharts';
 
@@ -65,7 +64,6 @@ function ResourceView() {
     <Fragment>
       <SpanTimeChartsContainer>
         <ResourceLandingPageCharts
-          moduleName={ModuleName.RESOURCE}
           appliedFilters={spanTimeChartsFilters}
           throughputUnit={RESOURCE_THROUGHPUT_UNIT}
           extraQuery={extraQuery}

--- a/static/app/views/insights/browser/resources/components/resourceView.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceView.tsx
@@ -15,10 +15,7 @@ import {
   FONT_FILE_EXTENSIONS,
   IMAGE_FILE_EXTENSIONS,
 } from 'sentry/views/insights/browser/resources/constants';
-import {
-  DEFAULT_RESOURCE_TYPES,
-  RESOURCE_THROUGHPUT_UNIT,
-} from 'sentry/views/insights/browser/resources/settings';
+import {DEFAULT_RESOURCE_TYPES} from 'sentry/views/insights/browser/resources/settings';
 import {ResourceSpanOps} from 'sentry/views/insights/browser/resources/types';
 import {
   BrowserStarfishFields,
@@ -65,7 +62,6 @@ function ResourceView() {
       <SpanTimeChartsContainer>
         <ResourceLandingPageCharts
           appliedFilters={spanTimeChartsFilters}
-          throughputUnit={RESOURCE_THROUGHPUT_UNIT}
           extraQuery={extraQuery}
         />
       </SpanTimeChartsContainer>


### PR DESCRIPTION
`SpanTimeCharts` is a very old component with a lot of issues, since it uses all kinds of old hooks for fetching, and have a lot of dead code.

Importantly, it's only used in _one place_! The Resources landing page. This PR renames it, moves it, and removes any code that isn't needed for that page.

There's still old data loading, and other issues, but one thing at a time.
