### PR TITLE
chore(insights): Remove bundle analysis UI flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -460,8 +460,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:standalone-span-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the aggregate span waterfall view
     manager.add("organizations:starfish-aggregate-span-waterfall", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable bundle analysis ui and endpoint
-    manager.add("organizations:starfish-browser-resource-module-bundle-analysis", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the resource module ui
     manager.add("organizations:starfish-browser-resource-module-image-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the resource module ui


### PR DESCRIPTION
We did not finish this project. The UI code is removed in https://github.com/getsentry/sentry/pull/81931
