### PR TITLE
fix(dashboards): Add missing propagated props in `LineChartWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
@@ -47,6 +47,11 @@ export function LineChartWidget(props: LineChartWidgetProps) {
       title={props.title}
       description={props.description}
       actions={props.actions}
+      actionsDisabled={props.actionsDisabled}
+      actionsMessage={props.actionsMessage}
+      badgeProps={props.badgeProps}
+      onFullScreenViewClick={props.onFullScreenViewClick}
+      warnings={props.warnings}
       error={error}
       onRetry={props.onRetry}
     >


### PR DESCRIPTION
Whoops! Forgot these.
