### PR TITLE
feat(trace-view): Set Web Vitals indicators color based on perf score

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -21,6 +21,10 @@ import {replayPlayerTimestampEmitter} from 'sentry/utils/replays/replayPlayerTim
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {
+  scoreToStatus,
+  STATUS_TEXT,
+} from 'sentry/views/insights/browser/webVitals/utils/scoreToStatus';
 
 import {TraceTree} from './traceModels/traceTree';
 import type {TraceTreeNode} from './traceModels/traceTreeNode';
@@ -397,14 +401,19 @@ export function Trace({
       >
         {trace.indicators.length > 0
           ? trace.indicators.map((indicator, i) => {
+              const score = indicator.score
+                ? Math.round(indicator.score * 100)
+                : undefined;
+              const status = score ? STATUS_TEXT[scoreToStatus(score)] : 'none';
+
               return (
                 <div
                   key={i}
                   ref={r => manager.registerIndicatorRef(r, i, indicator)}
                   className={`TraceIndicator ${indicator.poor ? 'Errored' : ''}`}
                 >
-                  <div className="TraceIndicatorLabel">{indicator.label}</div>
-                  <div className="TraceIndicatorLine" />
+                  <div className={`TraceIndicatorLabel ${status}`}>{indicator.label}</div>
+                  <div className={`TraceIndicatorLine ${status}`} />
                 </div>
               );
             })
@@ -875,6 +884,24 @@ const TraceStylingWrapper = styled('div')`
       line-height: 1;
       margin-top: 2px;
       white-space: nowrap;
+
+      &.Poor {
+        color: ${p => p.theme.red300};
+        border: 1px solid ${p => p.theme.red300};
+        background: ${p => p.theme.red100};
+      }
+
+      &.Meh {
+        color: ${p => p.theme.yellow400};
+        border: 1px solid ${p => p.theme.yellow300};
+        background: ${p => p.theme.yellow100};
+      }
+
+      &.Good {
+        color: ${p => p.theme.green300};
+        border: 1px solid ${p => p.theme.green300};
+        background: ${p => p.theme.green100};
+      }
     }
 
     .TraceIndicatorLine {
@@ -883,13 +910,40 @@ const TraceStylingWrapper = styled('div')`
       top: 20px;
       position: absolute;
       left: 50%;
-      transform: translateX(-2px);
+      transform: translate(-2px, -7px);
       background: repeating-linear-gradient(
           to bottom,
           transparent 0 4px,
           ${p => p.theme.textColor} 4px 8px
         )
         80%/2px 100% no-repeat;
+
+      &.Poor {
+        background: repeating-linear-gradient(
+            to bottom,
+            transparent 0 4px,
+            ${p => p.theme.red300} 4px 8px
+          )
+          80%/2px 100% no-repeat;
+      }
+
+      &.Meh {
+        background: repeating-linear-gradient(
+            to bottom,
+            transparent 0 4px,
+            ${p => p.theme.yellow300} 4px 8px
+          )
+          80%/2px 100% no-repeat;
+      }
+
+      &.Good {
+        background: repeating-linear-gradient(
+            to bottom,
+            transparent 0 4px,
+            ${p => p.theme.green300} 4px 8px
+          )
+          80%/2px 100% no-repeat;
+      }
     }
 
     .Indicator {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
@@ -153,6 +153,7 @@ export function collectTraceMeasurements(
         : false,
       type: measurement as TraceTree.Indicator['type'],
       label: (MEASUREMENT_ACRONYM_MAPPING[measurement] ?? measurement).toUpperCase(),
+      score,
     };
 
     indicators.push(indicator);

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -195,6 +195,7 @@ export declare namespace TraceTree {
     poor: boolean;
     start: number;
     type: 'cls' | 'fcp' | 'fp' | 'lcp' | 'ttfb';
+    score?: number;
   };
 
   type CollectedVital = {key: string; measurement: Measurement; score?: number};


### PR DESCRIPTION
Updates the indicators in the trace view to change based on the score of the respective web vital (good, meh, poor)

![image](https://github.com/user-attachments/assets/479b17e1-3e9b-476b-aebb-904052006541)

Not locking this change behind a feature flag as it is a small and general enhancement.