### PR TITLE
fix(alerts): Fix EAP alert filter bar to behave more like explore

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -768,15 +768,11 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                           <EAPSpanSearchQueryBuilder
                             numberTags={tags?.number ?? {}}
                             stringTags={tags?.string ?? {}}
-                            initialQuery={initialData?.query ?? ''}
+                            initialQuery={value ?? ''}
                             searchSource="alerts"
                             onSearch={(query, {parsedQuery}) => {
                               onFilterSearch(query, parsedQuery);
                               onChange(query, {});
-                            }}
-                            onBlur={(query, {parsedQuery}) => {
-                              onFilterSearch(query, parsedQuery);
-                              onBlur(query);
                             }}
                             supportedAggregates={ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
                             projects={[parseInt(project.id, 10)]}


### PR DESCRIPTION
Updates the search bar in the EAP Alert edit page to behave more like explore:
- User must explicitly save changes on the search (hitting enter) for updates to take effect. Same as explore.
- Removed onBlur handler

This also fixes an issue where the chart visualization updates, but saving the alert rule doesn't actually save the changed filter because it was not actually committed