### PR TITLE
fix(merged): Always show a link for latests event of a merged group

### DIFF
--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -78,5 +78,8 @@ describe('Issues -> Merged View', function () {
     expect(title.parentElement).toHaveTextContent(
       'Fingerprints included in this issue (2)'
     );
+
+    const links = await screen.findAllByRole('button', {name: 'View latest event'});
+    expect(links).toHaveLength(mockData.merged.length);
   });
 });

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -147,7 +147,7 @@ export function MergedItem({fingerprint, totalFingerprint}: Props) {
               <LinkButton
                 to={issueLink}
                 icon={<IconLink color={'linkColor'} />}
-                aria-label={t('Latest Event')}
+                aria-label={t('View latest event')}
                 borderless
                 size="xs"
                 style={{marginLeft: space(1)}}

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -10,35 +10,24 @@ import {t} from 'sentry/locale';
 import type {Fingerprint} from 'sentry/stores/groupingStore';
 import GroupingStore from 'sentry/stores/groupingStore';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
+import useOrganization from 'sentry/utils/useOrganization';
 
-type Props = {
+interface Props {
   fingerprint: Fingerprint;
-  organization: Organization;
   totalFingerprint: number;
-};
+}
 
-type State = {
-  busy: boolean;
-  checked: boolean;
-  collapsed: boolean;
-};
+export function MergedItem({fingerprint, totalFingerprint}: Props) {
+  const organization = useOrganization();
+  const [busy, setBusy] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
+  const [checked, setChecked] = useState(false);
 
-class MergedItem extends Component<Props, State> {
-  state: State = {
-    collapsed: false,
-    checked: false,
-    busy: false,
-  };
-
-  listener = GroupingStore.listen(data => this.onGroupChange(data), undefined);
-
-  onGroupChange = ({unmergeState}) => {
+  function onGroupChange({unmergeState}) {
     if (!unmergeState) {
       return;
     }
 
-    const {fingerprint} = this.props;
     const stateForId = unmergeState.has(fingerprint.id)
       ? unmergeState.get(fingerprint.id)
       : undefined;
@@ -48,42 +37,37 @@ class MergedItem extends Component<Props, State> {
     }
 
     Object.keys(stateForId).forEach(key => {
-      if (stateForId[key] === this.state[key]) {
-        return;
+      if (key === 'collapsed') {
+        setCollapsed(Boolean(stateForId[key]));
+      } else if (key === 'checked') {
+        setChecked(Boolean(stateForId[key]));
+      } else if (key === 'busy') {
+        setBusy(Boolean(stateForId[key]));
       }
-
-      this.setState(prevState => ({...prevState, [key]: stateForId[key]}));
     });
-  };
-
-  handleToggleEvents = () => {
-    const {fingerprint} = this.props;
-    GroupingStore.onToggleCollapseFingerprint(fingerprint.id);
-  };
-
-  // Disable default behavior of toggling checkbox
-  handleLabelClick(event: React.MouseEvent) {
-    event.preventDefault();
   }
 
-  handleToggle = () => {
-    const {fingerprint} = this.props;
+  function handleToggleEvents() {
+    GroupingStore.onToggleCollapseFingerprint(fingerprint.id);
+  }
+
+  function handleToggle() {
     const {latestEvent} = fingerprint;
 
-    if (this.state.busy) {
+    if (busy) {
       return;
     }
 
     // clicking anywhere in the row will toggle the checkbox
     GroupingStore.onToggleUnmerge([fingerprint.id, latestEvent.id]);
-  };
+  }
 
-  handleCheckClick() {
+  function handleCheckClick() {
     // noop because of react warning about being a controlled input without `onChange`
     // we handle change via row click
   }
 
-  renderFingerprint(id: string, label?: string) {
+  function renderFingerprint(id: string, label?: string) {
     if (!label) {
       return id;
     }
@@ -95,69 +79,70 @@ class MergedItem extends Component<Props, State> {
     );
   }
 
-  render() {
-    const {fingerprint, organization, totalFingerprint} = this.props;
-    const {latestEvent, id, label} = fingerprint;
-    const {collapsed, busy, checked} = this.state;
-    const checkboxDisabled = busy || totalFingerprint === 1;
+  useEffect(
+    () => {
+      GroupingStore.listen(data => onGroupChange(data), undefined);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
-    // `latestEvent` can be null if last event w/ fingerprint is not within retention period
-    return (
-      <MergedGroup busy={busy}>
-        <Controls expanded={!collapsed}>
-          <FingerprintLabel onClick={this.handleToggle}>
-            <Tooltip
-              containerDisplayMode="flex"
-              disabled={!checkboxDisabled}
-              title={
-                checkboxDisabled && totalFingerprint === 1
-                  ? t('To check, the list must contain 2 or more items')
-                  : undefined
-              }
-            >
-              <Checkbox
-                value={id}
-                checked={checked}
-                disabled={checkboxDisabled}
-                onChange={this.handleCheckClick}
-                size="xs"
-              />
-            </Tooltip>
+  const {latestEvent, id, label} = fingerprint;
+  const checkboxDisabled = busy || totalFingerprint === 1;
 
-            {this.renderFingerprint(id, label)}
-          </FingerprintLabel>
-
-          <Button
-            aria-label={
-              collapsed
-                ? t('Show %s fingerprints', id)
-                : t('Collapse %s fingerprints', id)
+  // `latestEvent` can be null if last event w/ fingerprint is not within retention period
+  return (
+    <MergedGroup busy={busy}>
+      <Controls expanded={!collapsed}>
+        <FingerprintLabel onClick={handleToggle}>
+          <Tooltip
+            containerDisplayMode="flex"
+            disabled={!checkboxDisabled}
+            title={
+              checkboxDisabled && totalFingerprint === 1
+                ? t('To check, the list must contain 2 or more items')
+                : undefined
             }
-            size="zero"
-            borderless
-            icon={<IconChevron direction={collapsed ? 'down' : 'up'} size="xs" />}
-            onClick={this.handleToggleEvents}
-          />
-        </Controls>
+          >
+            <Checkbox
+              value={id}
+              checked={checked}
+              disabled={checkboxDisabled}
+              onChange={handleCheckClick}
+              size="xs"
+            />
+          </Tooltip>
+          {renderFingerprint(id, label)}
+        </FingerprintLabel>
 
-        {!collapsed && (
-          <MergedEventList className="event-list">
-            {latestEvent && (
-              <EventDetails className="event-details">
-                <EventOrGroupHeader
-                  data={latestEvent}
-                  organization={organization}
-                  hideIcons
-                  hideLevel
-                  source="merged-item"
-                />
-              </EventDetails>
-            )}
-          </MergedEventList>
-        )}
-      </MergedGroup>
-    );
-  }
+        <Button
+          aria-label={
+            collapsed ? t('Show %s fingerprints', id) : t('Collapse %s fingerprints', id)
+          }
+          size="zero"
+          borderless
+          icon={<IconChevron direction={collapsed ? 'down' : 'up'} size="xs" />}
+          onClick={handleToggleEvents}
+        />
+      </Controls>
+
+      {!collapsed && (
+        <MergedEventList className="event-list">
+          {latestEvent && (
+            <EventDetails className="event-details">
+              <EventOrGroupHeader
+                data={latestEvent}
+                organization={organization}
+                hideIcons
+                hideLevel
+                source="merged-item"
+              />
+            </EventDetails>
+          )}
+        </MergedEventList>
+      )}
+    </MergedGroup>
+  );
 }
 
 const MergedGroup = styled('div')<{busy: boolean}>`

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -83,13 +83,13 @@ export function MergedItem({fingerprint, totalFingerprint}: Props) {
     );
   }
 
-  useEffect(
-    () => {
-      GroupingStore.listen(data => onGroupChange(data), undefined);
-    },
+  useEffect(() => {
+    const teardown = GroupingStore.listen(data => onGroupChange(data), undefined);
+    return () => {
+      teardown();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+  }, []);
 
   const {latestEvent, id, label} = fingerprint;
   const checkboxDisabled = busy || totalFingerprint === 1;

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -147,6 +147,7 @@ export function MergedItem({fingerprint, totalFingerprint}: Props) {
               <LinkButton
                 to={issueLink}
                 icon={<IconLink color={'linkColor'} />}
+                title={t('View latest event')}
                 aria-label={t('View latest event')}
                 borderless
                 size="xs"

--- a/static/app/views/issueDetails/groupMerged/mergedList.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedList.tsx
@@ -70,7 +70,6 @@ function MergedList({
           {fingerprintsWithLatestEvent.map(fingerprint => (
             <MergedItem
               key={fingerprint.id}
-              organization={organization}
               fingerprint={fingerprint}
               totalFingerprint={fingerprintsWithLatestEvent.length}
             />


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/51294 but only the UX issues.

It seems like the rendering is only a byproduct of a different issue. Either way, if we can generate a link, we'll do so here, though the subtitle/title showing up blank is better described by https://github.com/getsentry/sentry/issues/57383

Also converts the component to an FC, so the change looks bigger than it is.

<img width="216" alt="image" src="https://github.com/user-attachments/assets/7d129eb2-08ac-440b-b189-9d94131faf2d">


