### PR TITLE
ref(widget-builder): Split out tests

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
@@ -1,0 +1,46 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {useNavigate} from 'sentry/utils/useNavigate';
+import DatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+
+jest.mock('sentry/utils/useNavigate', () => ({
+  useNavigate: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
+describe('DatasetSelector', function () {
+  let router;
+  let organization;
+  beforeEach(function () {
+    router = RouterFixture();
+    organization = OrganizationFixture({});
+  });
+
+  it('changes the dataset', async function () {
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    render(
+      <WidgetBuilderProvider>
+        <DatasetSelector />
+      </WidgetBuilderProvider>,
+      {
+        router,
+        organization,
+      }
+    );
+
+    await userEvent.click(await screen.findByLabelText('Issues'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...router.location,
+        query: expect.objectContaining({dataset: 'issue'}),
+      })
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -1,0 +1,65 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {useNavigate} from 'sentry/utils/useNavigate';
+import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+
+jest.mock('sentry/utils/useNavigate', () => ({
+  useNavigate: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
+
+describe('WidgetBuilder', () => {
+  let router;
+  let organization;
+  beforeEach(function () {
+    router = RouterFixture({
+      location: {
+        pathname: '/organizations/org-slug/dashboard/1/',
+        query: {project: '-1'},
+      },
+      params: {},
+    });
+    organization = OrganizationFixture({});
+  });
+
+  it('edits name and description', async function () {
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderNameAndDescription />
+      </WidgetBuilderProvider>,
+      {
+        router,
+        organization,
+      }
+    );
+
+    await userEvent.type(await screen.findByPlaceholderText('Name'), 'some name');
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        ...router.location,
+        query: expect.objectContaining({title: 'some name'}),
+      })
+    );
+
+    await userEvent.click(await screen.findByTestId('add-description'));
+
+    await userEvent.type(
+      await screen.findByPlaceholderText('Description'),
+      'some description'
+    );
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        ...router.location,
+        query: expect.objectContaining({description: 'some description'}),
+      })
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -150,46 +150,6 @@ describe('NewWidgetBuiler', function () {
     });
   });
 
-  it('edits name and description', async function () {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
-      <WidgetBuilderV2
-        isOpen
-        onClose={onCloseMock}
-        dashboard={DashboardFixture([])}
-        dashboardFilters={{}}
-        onSave={onSaveMock}
-      />,
-      {
-        router,
-        organization,
-      }
-    );
-
-    await userEvent.type(await screen.findByPlaceholderText('Name'), 'some name');
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        ...router.location,
-        query: expect.objectContaining({title: 'some name'}),
-      })
-    );
-
-    await userEvent.click(await screen.findByTestId('add-description'));
-
-    await userEvent.type(
-      await screen.findByPlaceholderText('Description'),
-      'some description'
-    );
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        ...router.location,
-        query: expect.objectContaining({description: 'some description'}),
-      })
-    );
-  });
-
   it('changes the dataset', async function () {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -150,34 +150,6 @@ describe('NewWidgetBuiler', function () {
     });
   });
 
-  it('changes the dataset', async function () {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
-      <WidgetBuilderV2
-        isOpen
-        onClose={onCloseMock}
-        dashboard={DashboardFixture([])}
-        dashboardFilters={{}}
-        onSave={onSaveMock}
-      />,
-      {
-        router,
-        organization,
-      }
-    );
-
-    await userEvent.click(await screen.findByLabelText('Issues'));
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ...router.location,
-        query: expect.objectContaining({dataset: 'issue'}),
-      })
-    );
-  });
-
   it('changes the visualization type', async function () {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -7,7 +7,6 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 
 const {organization, projects, router} = initializeOrg({
@@ -25,12 +24,6 @@ const {organization, projects, router} = initializeOrg({
     params: {},
   },
 });
-
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: jest.fn(),
-}));
-
-const mockUseNavigate = jest.mocked(useNavigate);
 
 describe('NewWidgetBuiler', function () {
   const onCloseMock = jest.fn();
@@ -148,37 +141,6 @@ describe('NewWidgetBuiler', function () {
     await waitFor(() => {
       expect(screen.queryByText('Group by')).not.toBeInTheDocument();
     });
-  });
-
-  it('changes the visualization type', async function () {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
-      <WidgetBuilderV2
-        isOpen
-        onClose={onCloseMock}
-        dashboard={DashboardFixture([])}
-        dashboardFilters={{}}
-        onSave={onSaveMock}
-      />,
-      {
-        router,
-        organization,
-      }
-    );
-
-    // click dropdown
-    await userEvent.click(await screen.findByText('Table'));
-    // select new option
-    await userEvent.click(await screen.findByText('Bar'));
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ...router.location,
-        query: expect.objectContaining({displayType: 'bar'}),
-      })
-    );
   });
 
   it('render the filter alias field and add filter button on chart widgets', async function () {

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -4,7 +4,7 @@ import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useNavigate} from 'sentry/utils/useNavigate';
-import DatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
+import TypeSelector from 'sentry/views/dashboards/widgetBuilder/components/typeSelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 
 jest.mock('sentry/utils/useNavigate', () => ({
@@ -13,7 +13,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 
 const mockUseNavigate = jest.mocked(useNavigate);
 
-describe('DatasetSelector', function () {
+describe('TypeSelector', () => {
   let router;
   let organization;
   beforeEach(function () {
@@ -21,13 +21,13 @@ describe('DatasetSelector', function () {
     organization = OrganizationFixture({});
   });
 
-  it('changes the dataset', async function () {
+  it('changes the visualization type', async function () {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);
 
     render(
       <WidgetBuilderProvider>
-        <DatasetSelector />
+        <TypeSelector />
       </WidgetBuilderProvider>,
       {
         router,
@@ -35,12 +35,15 @@ describe('DatasetSelector', function () {
       }
     );
 
-    await userEvent.click(await screen.findByLabelText('Issues'));
+    // click dropdown
+    await userEvent.click(await screen.findByText('Table'));
+    // select new option
+    await userEvent.click(await screen.findByText('Bar'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         ...router.location,
-        query: expect.objectContaining({dataset: 'issue'}),
+        query: expect.objectContaining({displayType: 'bar'}),
       })
     );
   });


### PR DESCRIPTION
Splits up some of these tests so they don't rely on the whole widget builder to test. I'm hoping that this makes them run better with my other context changes.