### PR TITLE
fix(replays): Sort video events for timeline gap

### DIFF
--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -16,14 +16,13 @@ interface Props {
 
 export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}: Props) {
   const organization = useOrganization();
-  const sortedVideoEvents = videoEvents.sort((a, b) => a.timestamp - b.timestamp);
 
   const gaps = useMemo(() => {
     const ranges: Array<{left: string; width: string}> = [];
     let previousVideoEnd = startTimestampMs;
 
     // create gap in timeline when there is a gap between video events larger than 1.1s
-    for (const video of sortedVideoEvents) {
+    for (const video of videoEvents) {
       if (video.timestamp - previousVideoEnd > 1100) {
         ranges.push({
           left: toPercent((previousVideoEnd - startTimestampMs) / durationMs),
@@ -34,7 +33,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
     }
 
     // add gap at the end if the last video segment ends before the replay ends
-    if (sortedVideoEvents.length && previousVideoEnd < startTimestampMs + durationMs) {
+    if (videoEvents.length && previousVideoEnd < startTimestampMs + durationMs) {
       ranges.push({
         left: toPercent((previousVideoEnd - startTimestampMs) / durationMs),
         width: toPercent(durationMs / durationMs),
@@ -42,7 +41,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
     }
 
     return ranges;
-  }, [durationMs, sortedVideoEvents, startTimestampMs]);
+  }, [durationMs, videoEvents, startTimestampMs]);
 
   useEffect(() => {
     trackAnalytics('replay.gaps_detected', {

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -16,13 +16,14 @@ interface Props {
 
 export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}: Props) {
   const organization = useOrganization();
+  const sortedVideoEvents = videoEvents.sort((a, b) => a.timestamp - b.timestamp);
 
   const gaps = useMemo(() => {
     const ranges: Array<{left: string; width: string}> = [];
     let previousVideoEnd = startTimestampMs;
 
     // create gap in timeline when there is a gap between video events larger than 1.1s
-    for (const video of videoEvents) {
+    for (const video of sortedVideoEvents) {
       if (video.timestamp - previousVideoEnd > 1100) {
         ranges.push({
           left: toPercent((previousVideoEnd - startTimestampMs) / durationMs),
@@ -33,7 +34,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
     }
 
     // add gap at the end if the last video segment ends before the replay ends
-    if (videoEvents.length && previousVideoEnd < startTimestampMs + durationMs) {
+    if (sortedVideoEvents.length && previousVideoEnd < startTimestampMs + durationMs) {
       ranges.push({
         left: toPercent((previousVideoEnd - startTimestampMs) / durationMs),
         width: toPercent(durationMs / durationMs),
@@ -41,7 +42,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
     }
 
     return ranges;
-  }, [durationMs, startTimestampMs, videoEvents]);
+  }, [durationMs, sortedVideoEvents, startTimestampMs]);
 
   useEffect(() => {
     trackAnalytics('replay.gaps_detected', {

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -41,7 +41,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
     }
 
     return ranges;
-  }, [durationMs, videoEvents, startTimestampMs]);
+  }, [durationMs, startTimestampMs, videoEvents]);
 
   useEffect(() => {
     trackAnalytics('replay.gaps_detected', {

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -249,7 +249,7 @@ export default class ReplayReader {
     this._errors = errorFrames.sort(sortFrames);
     // RRWeb Events are not sorted here, they are fetched in sorted order.
     this._sortedRRWebEvents = rrwebFrames;
-    this._videoEvents = videoFrames;
+    this._videoEvents = videoFrames.sort((a, b) => a.timestamp - b.timestamp);
     // Breadcrumbs must be sorted. Crumbs like `slowClick` and `multiClick` will
     // have the same timestamp as the click breadcrumb, but will be emitted a
     // few seconds later.


### PR DESCRIPTION
Make sure video events are sorted before creating the timeline gaps