### PR TITLE
feat(widget-builder): Support aggregates with no arguments in visualize

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -145,11 +145,6 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('option', {name: 'p95'}));
 
     expect(screen.getByRole('button', {name: 'Column Selection'})).toBeEnabled();
-    // await waitFor(() => {
-    //   expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
-    //     'transaction.duration'
-    //   );
-    // });
     expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
       'transaction.duration'
     );

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -91,6 +91,103 @@ describe('Visualize', () => {
     expect(screen.queryAllByRole('button', {name: 'Remove field'})[0]).toBeDisabled();
   });
 
+  it('disables the column selection when the aggregate has no parameters', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              yAxis: ['max(spans.db)'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toBeEnabled();
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'count'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toBeEnabled();
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveValue('');
+  });
+
+  it('adds the default value for the column selection when the aggregate has parameters', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              yAxis: ['count()'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'p95'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toBeEnabled();
+    // await waitFor(() => {
+    //   expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+    //     'transaction.duration'
+    //   );
+    // });
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'transaction.duration'
+    );
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'p95'
+    );
+  });
+
+  it('maintains the selected aggregate when the column selection is changed and there are parameters', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              yAxis: ['max(spans.db)'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'p95'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'spans.db'
+    );
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'p95'
+    );
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {


### PR DESCRIPTION
Handles aggregates without any arguments by implementing the following behaviour:
- If an aggregate with no parameters is selected (e.g. `count()` in transactions/errors) then the column is wiped clear and disabled
- After that, if an aggregate _with_ a column is selected, set the column to the default value
- If an aggregate is selected that allows for a column, and a column is already set, persist that column


https://github.com/user-attachments/assets/73248571-2b8e-47e3-bf06-604fb6f956f5

