### PR TITLE
feat(widget-builder): Support equations in visualize

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -183,6 +183,44 @@ describe('Visualize', () => {
     );
   });
 
+  it('allows adding equations', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              yAxis: ['count()'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Equation'}));
+
+    expect(screen.getByLabelText('Equation')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Equation'));
+
+    // Check the menu items
+    const headers = screen.getAllByRole('banner');
+    expect(headers[0]).toHaveTextContent('Fields');
+    expect(headers[1]).toHaveTextContent('Operators');
+    expect(screen.getByRole('listitem', {name: 'count()'})).toBeInTheDocument();
+
+    // Make a selection and type in the equation
+    await userEvent.click(screen.getByRole('listitem', {name: 'count()'}));
+    await userEvent.type(screen.getByLabelText('Equation'), '* 2');
+
+    expect(screen.getByLabelText('Equation')).toHaveValue('count() * 2');
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -24,6 +24,7 @@ type DropdownOptionGroup = {
 
 type DefaultProps = {
   options: Column[];
+  className?: string;
 };
 
 type Props = DefaultProps &
@@ -259,11 +260,11 @@ export default class ArithmeticInput extends PureComponent<Props, State> {
   }
 
   render() {
-    const {onUpdate: _onUpdate, options: _options, ...props} = this.props;
+    const {onUpdate: _onUpdate, options: _options, className, ...props} = this.props;
     const {dropdownVisible, dropdownOptionGroups} = this.state;
 
     return (
-      <Container isOpen={dropdownVisible}>
+      <Container isOpen={dropdownVisible} className={className}>
         <Input
           {...props}
           ref={this.input}
@@ -317,7 +318,7 @@ function TermDropdown({isOpen, optionGroups, handleSelect}: TermDropdownProps) {
             return (
               <Fragment key={title}>
                 <ListItem>
-                  <DropdownTitle>{title}</DropdownTitle>
+                  <DropdownTitle aria-label={title}>{title}</DropdownTitle>
                 </ListItem>
                 {options.map(option => {
                   return (


### PR DESCRIPTION
Adds support for equations.

- Clicking "Add Equation" will render a text box that the user can edit
- For timeseries charts, this will fully trigger the request with the equation in it.
  - There's an issue with tables, but I'll check that later. For now my concern is to support charts.