### PR TITLE
fix(ui): Remove theme classname on switch

### DIFF
--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -9,6 +9,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import {createFuzzySearch} from 'sentry/utils/fuzzySearch';
+import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
 
 import type {ChildProps, ResultItem} from './types';
 
@@ -45,8 +46,7 @@ const ACTIONS: Action[] = [
     description: t('Toggle dark mode (superuser only atm)'),
     requiresSuperuser: true,
     action: () => {
-      // Remove any existing theme class from when the page was loaded
-      document.body.classList.remove('theme-light', 'theme-dark', 'theme-system');
+      removeBodyTheme();
       ConfigStore.set('theme', ConfigStore.get('theme') === 'dark' ? 'light' : 'dark');
     },
   },

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -44,8 +44,11 @@ const ACTIONS: Action[] = [
     title: t('Toggle dark mode'),
     description: t('Toggle dark mode (superuser only atm)'),
     requiresSuperuser: true,
-    action: () =>
-      ConfigStore.set('theme', ConfigStore.get('theme') === 'dark' ? 'light' : 'dark'),
+    action: () => {
+      // Remove any existing theme class from when the page was loaded
+      document.body.classList.remove('theme-light', 'theme-dark', 'theme-system');
+      ConfigStore.set('theme', ConfigStore.get('theme') === 'dark' ? 'light' : 'dark');
+    },
   },
 
   {

--- a/static/app/data/forms/accountPreferences.tsx
+++ b/static/app/data/forms/accountPreferences.tsx
@@ -28,6 +28,10 @@ const formGroups: JsonFormObject[] = [
           {value: 'system', label: t('Default to system')},
         ],
         getData: transformOptions,
+        onChange: () => {
+          // Remove any existing theme class from when the page was loaded
+          document.body.classList.remove('theme-light', 'theme-dark', 'theme-system');
+        },
       },
       {
         name: 'language',

--- a/static/app/data/forms/accountPreferences.tsx
+++ b/static/app/data/forms/accountPreferences.tsx
@@ -2,6 +2,7 @@ import type {JsonFormObject} from 'sentry/components/forms/types';
 import languages from 'sentry/data/languages';
 import {timezoneOptions} from 'sentry/data/timezones';
 import {t} from 'sentry/locale';
+import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/account/details/';
@@ -29,8 +30,7 @@ const formGroups: JsonFormObject[] = [
         ],
         getData: transformOptions,
         onChange: () => {
-          // Remove any existing theme class from when the page was loaded
-          document.body.classList.remove('theme-light', 'theme-dark', 'theme-system');
+          removeBodyTheme();
         },
       },
       {

--- a/static/app/utils/removeBodyTheme.tsx
+++ b/static/app/utils/removeBodyTheme.tsx
@@ -1,0 +1,9 @@
+/**
+ * Removes any theme class from the body element.
+ *
+ * These classes are added in base-react.html to avoid white flash when
+ * the page loads in dark mode before the app is loaded.
+ */
+export const removeBodyTheme = (): void => {
+  document.body.classList.remove('theme-light', 'theme-dark', 'theme-system');
+};

--- a/static/app/utils/removeBodyTheme.tsx
+++ b/static/app/utils/removeBodyTheme.tsx
@@ -2,7 +2,7 @@
  * Removes any theme class from the body element.
  *
  * These classes are added in base-react.html to avoid white flash when
- * the page loads in dark mode before the app is loaded.
+ * the page loads in dark mode before the react app is bootstrapped.
  */
 export const removeBodyTheme = (): void => {
   document.body.classList.remove('theme-light', 'theme-dark', 'theme-system');

--- a/static/app/views/settings/account/accountDetails.spec.tsx
+++ b/static/app/views/settings/account/accountDetails.spec.tsx
@@ -1,6 +1,6 @@
 import {UserDetailsFixture} from 'sentry-fixture/userDetails';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import AccountDetails from 'sentry/views/settings/account/accountDetails';
 
@@ -51,6 +51,32 @@ describe('AccountDetails', () => {
       render(<AccountDetails />);
 
       expect(await screen.findByRole('textbox', {name: 'Username'})).toBeDisabled();
+    });
+  });
+
+  describe('Theme', () => {
+    it('can be toggled', async () => {
+      const mockUserUpdate = MockApiClient.addMockResponse({
+        url: '/users/me/',
+        method: 'PUT',
+        body: UserDetailsFixture(),
+      });
+      render(<AccountDetails />);
+
+      expect(await screen.findByLabelText('Theme')).toBeInTheDocument();
+      // Emulate the page being loaded with a light theme
+      document.body.classList.add('theme-light');
+
+      await userEvent.click(screen.getByText('Light'));
+      await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Dark'}));
+
+      await waitFor(() => {
+        expect(mockUserUpdate).toHaveBeenCalledWith(
+          '/users/me/',
+          expect.objectContaining({data: {options: {theme: 'dark'}}})
+        );
+      });
+      expect(document.body).not.toHaveClass('theme-light');
     });
   });
 });

--- a/static/app/views/settings/account/accountDetails.spec.tsx
+++ b/static/app/views/settings/account/accountDetails.spec.tsx
@@ -55,7 +55,7 @@ describe('AccountDetails', () => {
   });
 
   describe('Theme', () => {
-    it('can toggle between light and dark and remove the theme class from body', async () => {
+    it('toggles between light and dark and removes the theme class from body', async () => {
       const mockUserUpdate = MockApiClient.addMockResponse({
         url: '/users/me/',
         method: 'PUT',

--- a/static/app/views/settings/account/accountDetails.spec.tsx
+++ b/static/app/views/settings/account/accountDetails.spec.tsx
@@ -55,7 +55,7 @@ describe('AccountDetails', () => {
   });
 
   describe('Theme', () => {
-    it('can be toggled', async () => {
+    it('can toggle between light and dark and remove the theme class from body', async () => {
       const mockUserUpdate = MockApiClient.addMockResponse({
         url: '/users/me/',
         method: 'PUT',


### PR DESCRIPTION
removes the classname when toggling between themes

related https://github.com/getsentry/sentry/pull/81611