### PR TITLE
feat(devservices): More descriptive error message when kafka not running for devserver

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -355,6 +355,7 @@ def devserver(
     # Create all topics if the Kafka eventstream is selected
     if kafka_consumers:
         use_new_devservices = os.environ.get("USE_NEW_DEVSERVICES") == "1"
+        valid_kafka_container_names = ["kafka-kafka-1", "sentry_kafka"]
         kafka_container_name = "kafka-kafka-1" if use_new_devservices else "sentry_kafka"
         kafka_container_warning_message = (
             f"""
@@ -365,7 +366,7 @@ Please run `devservices up` to start it. If you would like to use devserver with
 Devserver is configured to work with `sentry devservices`. Looks like the `{kafka_container_name}` container is not running.
 Please run `sentry devservices up kafka` to start it. If you would like to use devserver with the revamped devservices, set `USE_NEW_DEVSERVICES=1` in your environment."""
         )
-        if kafka_container_name not in containers:
+        if not any(name in containers for name in valid_kafka_container_names):
             raise click.ClickException(
                 f"""
 Devserver is configured to start some kafka consumers, but Kafka

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -354,8 +354,16 @@ def devserver(
 
     # Create all topics if the Kafka eventstream is selected
     if kafka_consumers:
-        kafka_container_name = (
-            "kafka-kafka-1" if os.environ.get("USE_NEW_DEVSERVICES") == "1" else "sentry_kafka"
+        use_new_devservices = os.environ.get("USE_NEW_DEVSERVICES") == "1"
+        kafka_container_name = "kafka-kafka-1" if use_new_devservices else "sentry_kafka"
+        kafka_container_warning_message = (
+            f"""
+Devserver is configured to work with the revamped devservices. Looks like the `{kafka_container_name}` container is not running.
+Please run `devservices up` to start it. If you would like to use devserver with `sentry devservices`, set `USE_NEW_DEVSERVICES=0` in your environment."""
+            if use_new_devservices
+            else f"""
+Devserver is configured to work with `sentry devservices`. Looks like the `{kafka_container_name}` container is not running.
+Please run `sentry devservices up kafka` to start it. If you would like to use devserver with the revamped devservices, set `USE_NEW_DEVSERVICES=1` in your environment."""
         )
         if kafka_container_name not in containers:
             raise click.ClickException(
@@ -373,7 +381,7 @@ or:
 
     SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
 
-and run `sentry devservices up kafka`.
+{kafka_container_warning_message}
 
 Alternatively, run without --workers.
         """


### PR DESCRIPTION
Folks are running into issues when kafka is not running for devserver with the new revamped devservices. Turns out, it's because they're not properly setting the environment variable. This message is more descriptive, allowing people to debug the errors much easier.

Changed the logic to also check for ALL valid kafka container names, not just one or the other