### PR TITLE
fix(stack-trace): Allow sections to be expanded regardless of stack view setting

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -80,7 +80,6 @@ function NativeFrame({
   frame,
   nextFrame,
   prevFrame,
-  includeSystemFrames,
   isUsedForGrouping,
   maxLengthOfRelativeAddress,
   image,
@@ -134,16 +133,13 @@ function NativeFrame({
     (hasStreamlinedUI ? !!debugSectionConfig : true);
 
   const leadsToApp = !frame.inApp && (nextFrame?.inApp || !nextFrame);
-  const expandable =
-    !leadsToApp || includeSystemFrames
-      ? isExpandable({
-          frame,
-          registers,
-          platform,
-          emptySourceNotation,
-          isOnlyFrame,
-        })
-      : false;
+  const expandable = isExpandable({
+    frame,
+    registers,
+    platform,
+    emptySourceNotation,
+    isOnlyFrame,
+  });
 
   const inlineFrame =
     prevFrame &&


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/81173. Allows only the helper function to determine whether a section is expandable, allowing for registers to show even if the view isn't set to `Full Stack Trace`. 

This will also prevent a weird case where you toggle the view, expand a section, toggle back and then can't close it.
https://sentry-sdks.sentry.io/issues/6075426538/events/e30a73a001b341972a3d1fa8cf49a949/?project=4506178389999616

Before:
<img width="859" alt="image" src="https://github.com/user-attachments/assets/4dfab46c-efa9-4085-a019-370855fa12b9" />

After:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/2b2c9509-e9fb-482b-be71-2348bbf11daa" />

