### PR TITLE
fix(explore): Add sidebar icon for Discover in errors-only deploys

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -34,6 +34,7 @@ import {
   IconSiren,
   IconStats,
   IconSupport,
+  IconTelescope,
   IconTimer,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -260,7 +261,8 @@ function Sidebar() {
     >
       <SidebarItem
         {...sidebarItemProps}
-        icon={<SubitemDot collapsed />}
+        // In errors-only deploys, Discover isn't a nested link, so it needs a proper icon
+        icon={isSelfHostedErrorsOnly ? <IconTelescope /> : <SubitemDot collapsed />}
         label={<GuideAnchor target="discover">{t('Discover')}</GuideAnchor>}
         to={getDiscoverLandingUrl(organization)}
         id="discover-v2"

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -252,7 +252,7 @@ function Sidebar() {
     />
   );
 
-  const discover2 = hasOrganization && (
+  const discover = hasOrganization && (
     <Feature
       hookName="feature-disabled:discover2-sidebar-item"
       features="discover-basic"
@@ -502,7 +502,7 @@ function Sidebar() {
       {metrics}
       {profiling}
       {replays}
-      {discover2}
+      {discover}
     </SidebarAccordion>
   );
 
@@ -565,7 +565,7 @@ function Sidebar() {
                   <Fragment>
                     <SidebarSection hasNewNav={hasNewNav}>
                       {alerts}
-                      {discover2}
+                      {discover}
                       {dashboards}
                       {releases}
                       {userFeedback}


### PR DESCRIPTION
Closes https://github.com/getsentry/self-hosted/issues/3323
