### PR TITLE
fix(dashboards): prevent duplicates in favourites dashboard list endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -449,7 +449,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         )
 
         dashboard_B.favorited_by = [self.user.id]
-        dashboard_D.favorited_by = [self.user.id]
+        dashboard_D.favorited_by = [self.user.id, user_1.id]
         dashboard_E.favorited_by = [self.user.id]
         dashboard_C.favorited_by = [user_1.id]
 
@@ -499,7 +499,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             organization=self.organization,
         )
 
-        dashboard_B.favorited_by = [self.user.id]
+        dashboard_B.favorited_by = [self.user.id, user_1.id]
         dashboard_D.favorited_by = [self.user.id]
         dashboard_E.favorited_by = [self.user.id]
         dashboard_C.favorited_by = [user_1.id]


### PR DESCRIPTION
Fixes duplicate entries in the favourites dashboard list by updating the ordering logic to prevent duplicates.

The m2m relationship with favourite dashboards was resulting in duplicate dashboards in the `order_by` `queryset` when multiple users favourite a single dashboard.