### PR TITLE
fix(dashboards): Prevent fetch thrashing in Project Details pages

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -61,7 +61,7 @@ const useApdex = (props: Props) => {
         },
       },
     ],
-    {staleTime: 0, enabled: isEnabled}
+    {staleTime: Infinity, enabled: isEnabled}
   );
 
   const isPreviousPeriodEnabled = shouldFetchPreviousPeriod({
@@ -82,7 +82,7 @@ const useApdex = (props: Props) => {
       },
     ],
     {
-      staleTime: 0,
+      staleTime: Infinity,
       enabled: isEnabled && isPreviousPeriodEnabled,
     }
   );

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -68,7 +68,7 @@ const useCrashFreeRate = (props: Props) => {
         },
       },
     ],
-    {staleTime: 0, enabled: isEnabled}
+    {staleTime: Infinity, enabled: isEnabled}
   );
 
   const isPreviousPeriodEnabled = shouldFetchPreviousPeriod({
@@ -89,7 +89,7 @@ const useCrashFreeRate = (props: Props) => {
       },
     ],
     {
-      staleTime: 0,
+      staleTime: Infinity,
       enabled: isEnabled && isPreviousPeriodEnabled,
     }
   );

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -50,7 +50,7 @@ const useReleaseCount = (props: Props) => {
         },
       },
     ],
-    {staleTime: 0, enabled: isEnabled}
+    {staleTime: Infinity, enabled: isEnabled}
   );
 
   const isPreviousPeriodEnabled = shouldFetchPreviousPeriod({
@@ -71,7 +71,7 @@ const useReleaseCount = (props: Props) => {
       },
     ],
     {
-      staleTime: 0,
+      staleTime: Infinity,
       enabled: isEnabled && isPreviousPeriodEnabled,
     }
   );
@@ -97,7 +97,7 @@ const useReleaseCount = (props: Props) => {
       },
     ],
     {
-      staleTime: 0,
+      staleTime: Infinity,
       enabled: isEnabled && isAllTimePeriodEnabled,
     }
   );


### PR DESCRIPTION
Under some conditions, project score cards keep re-fetching data. A data fetch finishes, the component re-renders, and this re-runs the `useApi` hooks since the second timestamp has changed.

This is easy to side-step by setting a high `staleTime`. In this case, we do not want _any_ passive refetches, so an infinite stale time makes sure that's the case.
