### PR TITLE
fix(trace-view): Incorrect indicator scores

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -401,7 +401,8 @@ export function Trace({
       >
         {trace.indicators.length > 0
           ? trace.indicators.map((indicator, i) => {
-              const status = score === undefined ? 'none' :  STATUS_TEXT[scoreToStatus(score)];
+              const status =
+                score === undefined ? 'none' : STATUS_TEXT[scoreToStatus(score)];
 
               return (
                 <div

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -402,7 +402,9 @@ export function Trace({
         {trace.indicators.length > 0
           ? trace.indicators.map((indicator, i) => {
               const status =
-                score === undefined ? 'none' : STATUS_TEXT[scoreToStatus(score)];
+                indicator.score === undefined
+                  ? 'none'
+                  : STATUS_TEXT[scoreToStatus(indicator.score)];
 
               return (
                 <div

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -401,7 +401,6 @@ export function Trace({
       >
         {trace.indicators.length > 0
           ? trace.indicators.map((indicator, i) => {
-              const score = indicator.score ? indicator.score : undefined;
               const status = score ? STATUS_TEXT[scoreToStatus(score)] : 'none';
 
               return (

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -401,9 +401,7 @@ export function Trace({
       >
         {trace.indicators.length > 0
           ? trace.indicators.map((indicator, i) => {
-              const score = indicator.score
-                ? Math.round(indicator.score * 100)
-                : undefined;
+              const score = indicator.score ? indicator.score : undefined;
               const status = score ? STATUS_TEXT[scoreToStatus(score)] : 'none';
 
               return (

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -401,7 +401,7 @@ export function Trace({
       >
         {trace.indicators.length > 0
           ? trace.indicators.map((indicator, i) => {
-              const status = score ? STATUS_TEXT[scoreToStatus(score)] : 'none';
+              const status = score === undefined ? 'none' :  STATUS_TEXT[scoreToStatus(score)];
 
               return (
                 <div


### PR DESCRIPTION
In a previous PR, the score set on the indicator is already multiplied by 100 beforehand, so the multiplication in here is incorrect and is inflating the score value.