### PR TITLE
fix(devtoolbar): make org and project parsing more robust in api analytics

### DIFF
--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -3,9 +3,10 @@ import logging
 from django.http import HttpRequest, HttpResponse
 
 from sentry import analytics, options
+from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.utils.http import origin_from_request
 from sentry.utils.http import query_string as get_query_string
-from sentry.utils.urls import parse_id_or_slug_param
 
 logger = logging.getLogger(__name__)
 
@@ -28,36 +29,104 @@ class DevToolbarAnalyticsMiddleware:
         return response
 
 
-def _record_api_request(request: HttpRequest, response: HttpResponse) -> None:
-    resolver_match = request.resolver_match
-    if resolver_match is None:
-        raise ValueError(f"Request URL not resolved: {request.path_info}")
+def _get_org_identifiers_from_request(request: HttpRequest) -> tuple[str | None, int | None]:
+    """
+    Get the slug or id of the Sentry organization targeted by an API request. Since it's run in middleware, this
+    function should NOT talk to external services (e.g. Postgres) or do any expensive operations.
 
-    kwargs, route, view_name = (
-        resolver_match.kwargs,
-        resolver_match.route,
-        resolver_match.view_name,
+    Args:
+        request - a resolved HTTP request. request.resolver_match must be non-None.
+    Returns:
+        The organization's slug and id. Possible results:
+        (slug, None) - prioritized if any org info can be parsed.
+        (None, id)   - returned if a slug could not be parsed.
+        (None, None) - no org info could be parsed.
+    """
+    if request.resolver_match is None:
+        raise ValueError(f"Request URL not resolved: {request.path_info}")
+    kwargs = request.resolver_match.kwargs
+
+    # If the request has been processed, some endpoints will have done a Postgres query for us.
+    org_obj = kwargs.get("organization")
+    if isinstance(org_obj, Organization):
+        return org_obj.slug, None
+
+    # Try all conceivable URL params, regardless of current URL patterns.
+    org_id_or_slug = (
+        kwargs.get("organization_slug")
+        or kwargs.get("organization_id_or_slug")
+        or kwargs.get("organization_id")
     )
 
-    org_id_or_slug = kwargs.get("organization_id_or_slug", kwargs.get("organization_slug"))
-    org_id, org_slug = parse_id_or_slug_param(org_id_or_slug)
-    project_id_or_slug = kwargs.get("project_id_or_slug")
-    project_id, project_slug = parse_id_or_slug_param(project_id_or_slug)
+    if isinstance(org_id_or_slug, int):
+        return None, org_id_or_slug
 
+    if isinstance(org_id_or_slug, str):
+        if org_id_or_slug.isnumeric():
+            return None, int(org_id_or_slug)
+        return org_id_or_slug, None
+
+    return None, None
+
+
+def _get_project_identifiers_from_request(request: HttpRequest) -> tuple[str | None, int | None]:
+    """
+    Get the slug or id of the Sentry project targeted by an API request. Since it's run in middleware, this
+    function should NOT make queries to external services (e.g. Postgres), or any other expensive operations.
+
+    Args:
+        request - a resolved HTTP request. request.resolver_match must be non-None.
+    Returns:
+        The project's slug and id. Possible results:
+        (slug, None) - prioritized if any project info can be parsed.
+        (None, id)   - returned if a slug could not be parsed.
+        (None, None) - no project info could be parsed.
+    """
+    if request.resolver_match is None:
+        raise ValueError(f"Request URL not resolved: {request.path_info}")
+    kwargs = request.resolver_match.kwargs
+
+    # If the request has been processed, some endpoints will have done a Postgres query for us.
+    proj_obj = kwargs.get("project")
+    if isinstance(proj_obj, Project):
+        return proj_obj.slug
+
+    # Try all conceivable URL params, regardless of current URL patterns.
+    proj_id_or_slug = (
+        kwargs.get("project_slug") or kwargs.get("project_id_or_slug") or kwargs.get("project_id")
+    )
+
+    if isinstance(proj_id_or_slug, int):
+        return None, proj_id_or_slug
+
+    if isinstance(proj_id_or_slug, str):
+        if proj_id_or_slug.isnumeric():
+            return None, int(proj_id_or_slug)
+        return proj_id_or_slug, None
+
+    return None, None
+
+
+def _record_api_request(request: HttpRequest, response: HttpResponse) -> None:
+    if request.resolver_match is None:
+        raise ValueError(f"Request URL not resolved: {request.path_info}")
+
+    org_slug, org_id = _get_org_identifiers_from_request(request)
+    proj_slug, proj_id = _get_project_identifiers_from_request(request)
     origin = origin_from_request(request)
     query_string: str = get_query_string(request)  # starts with ? if non-empty
 
     analytics.record(
         "devtoolbar.api_request",
-        view_name=view_name,
-        route=route,
+        view_name=request.resolver_match.view_name,
+        route=request.resolver_match.route,
         query_string=query_string,
         origin=origin,
         method=request.method,
         status_code=response.status_code,
-        organization_id=org_id or None,
+        organization_id=org_id,
         organization_slug=org_slug,
-        project_id=project_id or None,
-        project_slug=project_slug,
+        project_id=proj_id,
+        project_slug=proj_slug,
         user_id=request.user.id if hasattr(request, "user") and request.user else None,
     )

--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -114,7 +114,7 @@ def get_project_identifiers_from_request(request: HttpRequest) -> tuple[str | No
     # If the request has been processed, some endpoints will have done a Postgres query for us.
     proj_obj = kwargs.get("project")
     if isinstance(proj_obj, Project):
-        return proj_obj.slug
+        return proj_obj.slug, None
 
     # Try all conceivable URL params, regardless of current URL patterns.
     proj_id_or_slug = (

--- a/src/sentry/utils/urls.py
+++ b/src/sentry/utils/urls.py
@@ -73,12 +73,3 @@ def urlsplit_best_effort(s: str) -> tuple[str, str, str, str]:
         return scheme, netloc, path, query
     else:
         return parsed.scheme, parsed.netloc, parsed.path, parsed.query
-
-
-def parse_id_or_slug_param(id_or_slug: str | None) -> tuple[int | None, str | None]:
-    if not id_or_slug:
-        return None, None
-
-    if id_or_slug.isnumeric():
-        return int(id_or_slug), None
-    return None, id_or_slug

--- a/tests/sentry/middleware/test_devtoolbar.py
+++ b/tests/sentry/middleware/test_devtoolbar.py
@@ -5,13 +5,17 @@ from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
 
 from sentry.api import DevToolbarApiRequestEvent
-from sentry.middleware.devtoolbar import DevToolbarAnalyticsMiddleware
+from sentry.middleware.devtoolbar import (
+    DevToolbarAnalyticsMiddleware,
+    get_org_identifiers_from_request,
+    get_project_identifiers_from_request,
+)
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import override_options
 from sentry.types.group import GroupSubStatus
 
 
-class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
+class DevToolbarAnalyticsMiddlewareTest(TestCase):
     middleware = cached_property(DevToolbarAnalyticsMiddleware)
     analytics_event_name = DevToolbarApiRequestEvent.type
 
@@ -261,3 +265,17 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             project_slug=None,
             user_id=self.user.id,
         )
+
+
+class DevToolbarAnalyticsUtilsTest(TestCase):
+    def setUp(self):
+        # TODO:
+        pass
+
+    def test_get_org_identifiers_from_request(self):
+        # TODO:
+        pass
+
+    def test_get_project_identifiers_from_request(self):
+        # TODO:
+        pass

--- a/tests/sentry/middleware/test_devtoolbar.py
+++ b/tests/sentry/middleware/test_devtoolbar.py
@@ -268,14 +268,20 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
 
 
 class DevToolbarAnalyticsUtilsTest(TestCase):
-    def setUp(self):
-        # TODO:
-        pass
+    @cached_property
+    def factory(self):
+        return RequestFactory()
 
-    def test_get_org_identifiers_from_request(self):
-        # TODO:
-        pass
+    def test_get_org_identifiers_from_request_has_object(self):
+        request = self.factory.get("/issues/")
+        request.resolver_match = MagicMock()
+        request.resolver_match.kwargs = {"organization": self.organization}
+        org_slug, org_id = get_org_identifiers_from_request(request)
+        assert org_slug == self.organization.slug or org_id == self.organization.id
 
-    def test_get_project_identifiers_from_request(self):
-        # TODO:
-        pass
+    def test_get_project_identifiers_from_request_has_object(self):
+        request = self.factory.get("/issues/")
+        request.resolver_match = MagicMock()
+        request.resolver_match.kwargs = {"project": self.project}
+        proj_slug, proj_id = get_project_identifiers_from_request(request)
+        assert proj_slug == self.project.slug or proj_id == self.project.id


### PR DESCRIPTION
Our redash queries are showing none of the `devtoolbar.api_request` events are recording an org slug OR id. Although we're not able to replicate in a test environment, we suspect this is because our middleware runs _after_ the endpoint processes the request. Endpoints are popping `"organization_id_or_slug"`, etc from `kwargs` and replacing them with postgres `organization` and `project` objects. 

This PR handles this case by checking for "organization" or "project" kwargs. Parsed URL params are the fallback, and we cover multiple formats to make this resilient to future API changes. It also does some refactoring to improve readability