### PR TITLE
feat(perf): New copy for Web Vitals tooltips and blog post links

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -41,12 +41,18 @@ const WEB_VITAL_FULL_NAME_MAP = {
   ttfb: t('Time to First Byte'),
 };
 
-const VITAL_DESCRIPTIONS: Partial<
-  Record<WebVital, {description: string; link?: React.ReactNode}>
+export const VITAL_DESCRIPTIONS: Partial<
+  Record<
+    WebVital,
+    {longDescription: string; shortDescription: string; link?: React.ReactNode}
+  >
 > = {
   [WebVital.FCP]: {
-    description: t(
+    shortDescription: t(
       'Time for first DOM content to render. Bad FCP makes users feel like the page isn’t responding or loading.'
+    ),
+    longDescription: t(
+      'First Contentful Paint (FCP) measures the amount of time the first content takes to render in the viewport. Like FP, this could also show up in any form from the document object model (DOM), such as images, SVGs, or text blocks.'
     ),
     link: (
       <ExternalLink
@@ -58,8 +64,11 @@ const VITAL_DESCRIPTIONS: Partial<
     ),
   },
   [WebVital.CLS]: {
-    description: t(
+    shortDescription: t(
       'Measures content ‘shifting’ during load. Bad CLS indicates a janky website, degrading UX and trust.'
+    ),
+    longDescription: t(
+      'Cumulative Layout Shift (CLS) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. Imagine navigating to an article and trying to click a link before the page finishes loading. Before your cursor even gets there, the link may have shifted down due to an image rendering. Rather than using duration for this Web Vital, the CLS score represents the degree of disruptive and visually unstable shifts.'
     ),
     link: (
       <ExternalLink
@@ -71,8 +80,11 @@ const VITAL_DESCRIPTIONS: Partial<
     ),
   },
   [WebVital.LCP]: {
-    description: t(
+    shortDescription: t(
       'Time to render the largest item in the viewport. Bad LCP frustrates users because the website feels slow to load.'
+    ),
+    longDescription: t(
+      'Largest Contentful Paint (LCP) measures the render time for the largest content to appear in the viewport. This may be in any form from the document object model (DOM), such as images, SVGs, or text blocks. It’s the largest pixel area in the viewport, thus most visually defining. LCP helps developers understand how long it takes to see the main content on the page.'
     ),
     link: (
       <ExternalLink
@@ -84,8 +96,11 @@ const VITAL_DESCRIPTIONS: Partial<
     ),
   },
   [WebVital.TTFB]: {
-    description: t(
+    shortDescription: t(
       'Time until first byte is delivered to the client. Bad TTFB makes the server feel unresponsive.'
+    ),
+    longDescription: t(
+      'Time to First Byte (TTFB) is a foundational metric for measuring connection setup time and web server responsiveness in both the lab and the field. It helps identify when a web server is too slow to respond to requests. In the case of navigation requests—that is, requests for an HTML document—it precedes every other meaningful loading performance metric.'
     ),
     link: (
       <ExternalLink
@@ -97,8 +112,11 @@ const VITAL_DESCRIPTIONS: Partial<
     ),
   },
   [WebVital.INP]: {
-    description: t(
+    shortDescription: t(
       'Latency between user input and visual response. Bad INP makes users feel like the site is laggy, outdated, and unresponsive. '
+    ),
+    longDescription: t(
+      "Interaction to Next Paint (INP) is a metric that assesses a page's overall responsiveness to user interactions by observing the latency of all click, tap, and keyboard interactions that occur throughout the lifespan of a user's visit to a page. The final INP value is the longest interaction observed, ignoring outliers."
     ),
     link: (
       <ExternalLink openInNewTab href="https://blog.sentry.io/what-is-inp/">
@@ -186,13 +204,13 @@ export function WebVitalTagsDetailHeader({
 }
 
 export function WebVitalDescription({score, value, webVital}: Props) {
-  const {description, link} = VITAL_DESCRIPTIONS[WebVital[webVital.toUpperCase()]];
+  const {longDescription, link} = VITAL_DESCRIPTIONS[WebVital[webVital.toUpperCase()]];
 
   return (
     <div>
       <WebVitalDetailHeader score={score} value={value} webVital={webVital} />
       <DescriptionWrapper>
-        {description}
+        {longDescription}
         {link}
       </DescriptionWrapper>
 

--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -2,6 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {COUNTRY_CODE_TO_NAME_MAP} from 'sentry/data/countryCodesMap';
 import {IconCheckmark} from 'sentry/icons/iconCheckmark';
@@ -40,22 +41,71 @@ const WEB_VITAL_FULL_NAME_MAP = {
   ttfb: t('Time to First Byte'),
 };
 
-const VITAL_DESCRIPTIONS: Partial<Record<WebVital, string>> = {
-  [WebVital.FCP]: t(
-    'First Contentful Paint (FCP) measures the amount of time the first content takes to render in the viewport. Like FP, this could also show up in any form from the document object model (DOM), such as images, SVGs, or text blocks.'
-  ),
-  [WebVital.CLS]: t(
-    'Cumulative Layout Shift (CLS) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. Imagine navigating to an article and trying to click a link before the page finishes loading. Before your cursor even gets there, the link may have shifted down due to an image rendering. Rather than using duration for this Web Vital, the CLS score represents the degree of disruptive and visually unstable shifts.'
-  ),
-  [WebVital.LCP]: t(
-    'Largest Contentful Paint (LCP) measures the render time for the largest content to appear in the viewport. This may be in any form from the document object model (DOM), such as images, SVGs, or text blocks. It’s the largest pixel area in the viewport, thus most visually defining. LCP helps developers understand how long it takes to see the main content on the page.'
-  ),
-  [WebVital.TTFB]: t(
-    'Time to First Byte (TTFB) is a foundational metric for measuring connection setup time and web server responsiveness in both the lab and the field. It helps identify when a web server is too slow to respond to requests. In the case of navigation requests—that is, requests for an HTML document—it precedes every other meaningful loading performance metric.'
-  ),
-  [WebVital.INP]: t(
-    "Interaction to Next Paint (INP) is a metric that assesses a page's overall responsiveness to user interactions by observing the latency of all click, tap, and keyboard interactions that occur throughout the lifespan of a user's visit to a page. The final INP value is the longest interaction observed, ignoring outliers."
-  ),
+const VITAL_DESCRIPTIONS: Partial<
+  Record<WebVital, {description: string; link?: React.ReactNode}>
+> = {
+  [WebVital.FCP]: {
+    description: t(
+      'Time for first DOM content to render. Bad FCP makes users feel like the page isn’t responding or loading.'
+    ),
+    link: (
+      <ExternalLink
+        openInNewTab
+        href="https://blog.sentry.io/how-to-make-your-web-page-faster-before-it-even-loads/"
+      >
+        How can I fix my FCP?
+      </ExternalLink>
+    ),
+  },
+  [WebVital.CLS]: {
+    description: t(
+      'Measures content ‘shifting’ during load. Bad CLS indicates a janky website, degrading UX and trust.'
+    ),
+    link: (
+      <ExternalLink
+        openInNewTab
+        href="https://blog.sentry.io/from-lcp-to-cls-improve-your-core-web-vitals-with-image-loading-best/"
+      >
+        How can I fix my CLS?
+      </ExternalLink>
+    ),
+  },
+  [WebVital.LCP]: {
+    description: t(
+      'Time to render the largest item in the viewport. Bad LCP frustrates users because the website feels slow to load.'
+    ),
+    link: (
+      <ExternalLink
+        openInNewTab
+        href="https://blog.sentry.io/from-lcp-to-cls-improve-your-core-web-vitals-with-image-loading-best/"
+      >
+        How can I fix my LCP?
+      </ExternalLink>
+    ),
+  },
+  [WebVital.TTFB]: {
+    description: t(
+      'Time until first byte is delivered to the client. Bad TTFB makes the server feel unresponsive.'
+    ),
+    link: (
+      <ExternalLink
+        openInNewTab
+        href="https://blog.sentry.io/how-i-fixed-my-brutal-ttfb/"
+      >
+        How can I fix my TTFB?
+      </ExternalLink>
+    ),
+  },
+  [WebVital.INP]: {
+    description: t(
+      'Latency between user input and visual response. Bad INP makes users feel like the site is laggy, outdated, and unresponsive. '
+    ),
+    link: (
+      <ExternalLink openInNewTab href="https://blog.sentry.io/what-is-inp/">
+        How can I fix my INP?
+      </ExternalLink>
+    ),
+  },
 };
 
 type WebVitalDetailHeaderProps = {
@@ -136,11 +186,16 @@ export function WebVitalTagsDetailHeader({
 }
 
 export function WebVitalDescription({score, value, webVital}: Props) {
-  const description: string = VITAL_DESCRIPTIONS[WebVital[webVital.toUpperCase()]];
+  const {description, link} = VITAL_DESCRIPTIONS[WebVital[webVital.toUpperCase()]];
+
   return (
     <div>
       <WebVitalDetailHeader score={score} value={value} webVital={webVital} />
-      <p>{description}</p>
+      <DescriptionWrapper>
+        {description}
+        {link}
+      </DescriptionWrapper>
+
       <p>
         <b>
           {tct(
@@ -183,6 +238,12 @@ const Header = styled('span')`
   display: flex;
   justify-content: space-between;
   margin-bottom: ${space(3)};
+`;
+
+const DescriptionWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: ${space(2)};
 `;
 
 const Value = styled('h2')`

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -10,6 +10,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import getDuration from 'sentry/utils/duration/getDuration';
+import {VITAL_DESCRIPTIONS} from 'sentry/views/insights/browser/webVitals/components/webVitalDescription';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
 import type {
   ProjectScore,
@@ -129,6 +130,9 @@ export function VitalMeter({
       <NoValue />
     );
 
+  const webVitalKey = `measurements.${webVital}`;
+  const {shortDescription} = VITAL_DESCRIPTIONS[webVitalKey];
+
   const headerText = webVitalsConfig[webVital].name;
   const meterBody = (
     <Fragment>
@@ -139,13 +143,7 @@ export function VitalMeter({
             size="xs"
             title={
               <span>
-                {tct(
-                  `The p75 [webVital] value and aggregate [webVital] score of your selected project(s).
-                      Scores and values may share some (but not perfect) correlation.`,
-                  {
-                    webVital: webVital.toUpperCase(),
-                  }
-                )}
+                {shortDescription}
                 <br />
                 <ExternalLink href={`${MODULE_DOC_LINK}#performance-score`}>
                   {t('Find out how performance scores are calculated here.')}

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -156,7 +156,7 @@ describe('WebVitalsDetailPanel', function () {
     expect(screen.getByText('Largest Contentful Paint (P75)')).toBeInTheDocument();
     expect(screen.getByText('—')).toBeInTheDocument();
     expect(
-      screen.getByText(/Largest Contentful Paint \(LCP\) measures the render/)
+      screen.getByText(/Time to render the largest item in the viewport/)
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -156,7 +156,7 @@ describe('WebVitalsDetailPanel', function () {
     expect(screen.getByText('Largest Contentful Paint (P75)')).toBeInTheDocument();
     expect(screen.getByText('—')).toBeInTheDocument();
     expect(
-      screen.getByText(/Time to render the largest item in the viewport/)
+      screen.getByText(/Largest Contentful Paint \(LCP\) measures the render/)
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Here's what's new in this PR:

## Tooltips
Web Vitals tooltips have been changed to something that actually explains what the web vital is. I've kept the link that explains how performance scores are calculated in here

**Before**
![image](https://github.com/user-attachments/assets/abd6f0ac-43cd-4739-bfa5-9956f28c7b38)


**After**
![image](https://github.com/user-attachments/assets/1b469ab6-4be3-4e7a-a942-88d46acdaaaf)

## Slideout panels
The slideout panel keeps the long description as before, but now includes a link to @whitep4nth3r's blog posts

**Before**
![image](https://github.com/user-attachments/assets/26861fd3-534d-4dab-aea8-418d6b6e03b6)

**After**
![image](https://github.com/user-attachments/assets/22188de9-aa95-4952-ac72-46e25f5cb109)


