### PR TITLE
fix(migrations): ignore proxy models in backup tests

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -433,7 +433,7 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
             if model._meta.app_label in {"sessions", "sites", "test", "getsentry"}:
                 continue
 
-            # exclude proxy models since the back up test is already done on parent if needed
+            # exclude proxy models since the backup test is already done on a parent if needed
             if model._meta.proxy:
                 continue
 

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -433,6 +433,10 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
             if model._meta.app_label in {"sessions", "sites", "test", "getsentry"}:
                 continue
 
+            # exclude proxy models since the back up test is already done on parent if needed
+            if model._meta.proxy:
+                continue
+
             foreign_keys: dict[str, ForeignField] = dict()
             uniques: set[frozenset[str]] = {
                 frozenset(combo) for combo in model._meta.unique_together


### PR DESCRIPTION
We should not run backup tests on proxy models since, if needed, the backup tests are run already on parent model.

For example [these tests ](https://github.com/getsentry/sentry/actions/runs/12281940201/job/34271981313?pr=81950) were failing for the proxy model in [this PR](https://github.com/getsentry/sentry/pull/81950).

Just like we ignore models from specific apps, we can ignore proxy models.