### PR TITLE
feat(integrations): Ignore duplicate group resolution

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -230,7 +230,7 @@ def sync_status_inbound(
         # which would override the in-app resolution
         resolvable_groups = []
         for group in affected_groups:
-            if group.status != GroupStatus.RESOLVED and not group_was_recently_resolved(group):
+            if group.status != GroupStatus.RESOLVED or not group_was_recently_resolved(group):
                 resolvable_groups.append(group)
 
         if not resolvable_groups:

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -173,6 +173,9 @@ def group_was_recently_resolved(group: Group) -> bool:
     """
     Check if the group was resolved in the last 3 minutes
     """
+    if group.status != GroupStatus.RESOLVED:
+        return False
+
     try:
         group_resolution = GroupResolution.objects.get(group=group)
         return group_resolution.datetime > django_timezone.now() - timedelta(minutes=3)
@@ -230,7 +233,7 @@ def sync_status_inbound(
         # which would override the in-app resolution
         resolvable_groups = []
         for group in affected_groups:
-            if group.status != GroupStatus.RESOLVED or not group_was_recently_resolved(group):
+            if not group_was_recently_resolved(group):
                 resolvable_groups.append(group)
 
         if not resolvable_groups:

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -228,9 +228,14 @@ def sync_status_inbound(
         # Check if the group was recently resolved and we should skip the request
         # Avoid resolving the group in-app and then re-resolving via the integration webhook
         # which would override the in-app resolution
+        recently_resolved_groups = []
         for group in affected_groups:
             if group.status == GroupStatus.RESOLVED and group_was_recently_resolved(group):
-                affected_groups.remove(group)
+                recently_resolved_groups.append(group)
+
+        affected_groups = [
+            group for group in affected_groups if group not in recently_resolved_groups
+        ]
 
         (
             resolutions_by_group_id,

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -237,6 +237,9 @@ def sync_status_inbound(
             group for group in affected_groups if group not in recently_resolved_groups
         ]
 
+        if len(affected_groups) == 0:
+            return
+
         (
             resolutions_by_group_id,
             activity_type,

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -237,7 +237,7 @@ def sync_status_inbound(
             group for group in affected_groups if group not in recently_resolved_groups
         ]
 
-        if len(affected_groups) == 0:
+        if not affected_groups:
             return
 
         (

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -188,6 +188,10 @@ class IssueSyncIntegration(TestCase):
             }
 
     def test_sync_status_does_not_override_existing_recent_group_resolution(self):
+        """
+        Test that the sync_status_inbound does not override the existing group resolution
+        if the group was recently resolved
+        """
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release2 = Release.objects.create(organization_id=self.project.organization_id, version="b")
         release.add_project(self.project)

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -187,6 +187,77 @@ class IssueSyncIntegration(TestCase):
                 "version": release2.version,
             }
 
+    def test_sync_status_does_not_override_existing_recent_group_resolution(self):
+        release = Release.objects.create(organization_id=self.project.organization_id, version="a")
+        release2 = Release.objects.create(organization_id=self.project.organization_id, version="b")
+        release.add_project(self.project)
+        release2.add_project(self.project)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        # add releases in the reverse order
+        self.create_group_release(group=group, release=release2)
+        self.create_group_release(group=group, release=release)
+
+        assert group.status == GroupStatus.UNRESOLVED
+
+        # Resolve the group in old_release
+        group.update(status=GroupStatus.RESOLVED, substatus=None)
+        resolution = GroupResolution.objects.create(release=release, group=group)
+        assert resolution.current_release_version is None
+        assert resolution.release == release
+        activity = Activity.objects.create(
+            group=group,
+            project=group.project,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+            ident=resolution.id,
+            data={"version": release.version},
+        )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = self.create_provider_integration(provider="example", external_id="123456")
+            integration.add_organization(group.organization, self.user)
+
+            for oi in OrganizationIntegration.objects.filter(
+                integration_id=integration.id, organization_id=group.organization.id
+            ):
+                oi.update(
+                    config={
+                        "sync_comments": True,
+                        "sync_status_outbound": True,
+                        "sync_status_inbound": True,
+                        "sync_assignee_outbound": True,
+                        "sync_assignee_inbound": True,
+                        "resolution_strategy": "resolve_next_release",
+                    }
+                )
+
+        external_issue = ExternalIssue.objects.create(
+            organization_id=group.organization.id, integration_id=integration.id, key="APP-123"
+        )
+
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+        )
+
+        installation = integration.get_installation(group.organization.id)
+        assert isinstance(installation, ExampleIntegration)
+
+        with self.feature("organizations:integrations-issue-sync"), self.tasks():
+            installation.sync_status_inbound(
+                external_issue.key,
+                {"project_id": "APP", "status": {"id": "12345", "category": "done"}},
+            )
+
+            assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+            resolution.refresh_from_db()
+            assert resolution.release == release
+            assert resolution.current_release_version is None
+            activity.refresh_from_db()
+            assert activity.data["version"] == release.version
+
     def test_sync_status_resolve_in_next_release_with_semver(self):
         release = Release.objects.create(
             organization_id=self.project.organization_id, version="app@1.2.4"


### PR DESCRIPTION
On integrations that sync status like jira, it can override the user's in-app resolution.

Problem Workflow:
- User marks an issue as resolved in specific release
- Group activity is recorded saying user resolved in release and matching Group Resolution created
- We sync status to jira resolving the linked issue
- Jira webhooks us back attempting to sync status (resolve in next release)
- We update the Group Resolution to resolve in next release but we don't create an activity. When the issue regresses it is confusing since the GroupResolution and Group Activities don't make sense

This change would ignore the jira webhook if the group is already resolved and was resolved in the last 3 minutes. 

fixes #74448
[more internal notion docs](https://www.notion.so/sentry/Regression-version-comparison-incorrectly-identified-issue-as-regressed-Mobile-Team-dc5ab7e59bcb4f7fb1fdc291e58a129b)

will follow up with a PR to test that GroupResolution and Group Activity always make sense