### PR TITLE
chore(profiling): remove profiling.stack_trace_rules.allowed_project_ids option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2916,15 +2916,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# list of project IDs for which we'll apply
-# stack trace rules to the profiles in case
-# there are any rules defined
-register(
-    "profiling.stack_trace_rules.allowed_project_ids",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "performance.event-tracker.sample-rate.transactions",
     default=0.0,


### PR DESCRIPTION
Removing the option again as it was reverted in commit d0bea1aa696d2aa3ad435a33933840d6bc93570e