### PR TITLE
feat(similarity): Do not send more than 30 frames to Seer

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -238,7 +238,6 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
         if (
             platform not in SYSTEM_FRAME_CHECK_BLACKLIST_PLATFORMS
             and frame_metrics["is_frames_truncated"]
-            and not app_hash
         ):
             raise TooManyOnlySystemFramesException
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -411,7 +411,7 @@ def get_stacktrace_string_with_metrics(
             metrics.incr(
                 key,
                 sample_rate=sample_rate,
-                tags={"call_made": False, "blocker": "over-threshold-only-system-frames"},
+                tags={"call_made": False, "blocker": "over-threshold-frames"},
             )
     except Exception:
         logger.exception("Unexpected exception in stacktrace string formatting")

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -341,7 +341,7 @@ class GetSeerSimilarIssuesTest(TestCase):
             )
 
     @patch("sentry.seer.similarity.utils.metrics")
-    def test_too_many_only_system_frames(self, mock_metrics: Mock) -> None:
+    def test_too_many_frames(self, mock_metrics: Mock) -> None:
         type = "FailedToFetchError"
         value = "Charlie didn't bring the ball back"
         context_line = f"raise {type}('{value}')"
@@ -391,12 +391,12 @@ class GetSeerSimilarIssuesTest(TestCase):
             sample_rate=1.0,
             tags={
                 "call_made": False,
-                "blocker": "over-threshold-only-system-frames",
+                "blocker": "over-threshold-frames",
             },
         )
 
     @patch("sentry.seer.similarity.utils.metrics")
-    def test_too_many_only_system_frames_invalid_platform(self, mock_metrics: Mock) -> None:
+    def test_too_many_frames_allowed_platform(self, mock_metrics: Mock) -> None:
         type = "FailedToFetchError"
         value = "Charlie didn't bring the ball back"
         context_line = f"raise {type}('{value}')"
@@ -441,7 +441,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 sample_rate=1.0,
                 tags={
                     "call_made": False,
-                    "blocker": "over-threshold-only-system-frames",
+                    "blocker": "over-threshold-frames",
                 },
             )
             not in mock_metrics.incr.call_args_list
@@ -561,7 +561,7 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
             sample_rate=1.0,
             tags={
                 "call_made": False,
-                "blocker": "over-threshold-only-system-frames",
+                "blocker": "over-threshold-frames",
             },
         )
 

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -562,7 +562,7 @@ class GetStacktraceStringTest(TestCase):
                 ),
             ),
         ]
-        stacktrace_str = get_stacktrace_string(data_chained_exception)
+        stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
 
         # The stacktrace string should be:
         #    25 frames from OuterExcepton (with lines counting up from 1 to 25), followed by
@@ -614,7 +614,7 @@ class GetStacktraceStringTest(TestCase):
                 ),
             ),
         ]
-        stacktrace_str = get_stacktrace_string(data_chained_exception)
+        stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
 
         # The stacktrace string should be:
         #    15 frames from OuterExcepton (with lines counting up from 1 to 15), followed by
@@ -668,7 +668,7 @@ class GetStacktraceStringTest(TestCase):
                     ),
                 ),
             ]
-            stacktrace_str = get_stacktrace_string(data_chained_exception)
+            stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
 
             assert (
                 stacktrace_str.count("outer line")
@@ -688,7 +688,7 @@ class GetStacktraceStringTest(TestCase):
             )
             for i in range(1, MAX_FRAME_COUNT + 2)
         ]
-        stacktrace_str = get_stacktrace_string(data_chained_exception)
+        stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
         for i in range(2, MAX_FRAME_COUNT + 2):
             assert f"exception {i} message!" in stacktrace_str
         assert "exception 1 message!" not in stacktrace_str
@@ -784,7 +784,7 @@ class GetStacktraceStringTest(TestCase):
         data_frames["app"]["component"]["values"][0]["values"][0]["values"] += self.create_frames(
             20, True, 41
         )
-        stacktrace_str = get_stacktrace_string(data_frames, "java")
+        stacktrace_str = get_stacktrace_string(data_frames, platform="javascript")
 
         num_frames = 0
         for i in range(1, 11):
@@ -812,7 +812,7 @@ class GetStacktraceStringTest(TestCase):
                     ),
                 ),
             ]
-            stacktrace_str = get_stacktrace_string(data_frames)
+            stacktrace_str = get_stacktrace_string(data_frames, platform="javascript")
 
             assert stacktrace_str.count("context line") == expected_frame_count
 


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/81385.

This prevents both *in-app* and *system* frames from being sent to Seer when we have more than 30 frames since we can't guarantee that we're not overgrouping.