### PR TITLE
feat(taskworker) Add autoreload to taskworker

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1332,7 +1332,10 @@ BGTASKS = {
 # The list of modules that workers will import after starting up
 # Like celery, taskworkers need to import task modules to make tasks
 # accessible to the worker.
-TASKWORKER_IMPORTS: tuple[str, ...] = ()
+TASKWORKER_IMPORTS: tuple[str, ...] = (
+    # Used for tests
+    "sentry.taskworker.tasks.examples",
+)
 TASKWORKER_ROUTER: str = "sentry.taskworker.router.DefaultRouter"
 TASKWORKER_ROUTES: dict[str, str] = {}
 

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -3,11 +3,54 @@ from __future__ import annotations
 import logging
 
 from sentry.taskworker.registry import taskregistry
+from sentry.taskworker.retry import LastAction, Retry, RetryError
 
 logger = logging.getLogger(__name__)
+
 exampletasks = taskregistry.create_namespace(name="examples")
 
 
 @exampletasks.register(name="examples.say_hello")
 def say_hello(name: str) -> None:
-    print(f"Hello {name}")  # noqa
+    logger.info("Hello %s", name)
+
+
+@exampletasks.register(
+    name="examples.retry_deadletter", retry=Retry(times=2, times_exceeded=LastAction.Deadletter)
+)
+def retry_deadletter() -> None:
+    raise RetryError
+
+
+@exampletasks.register(
+    name="examples.will_retry",
+    retry=Retry(times=3, on=(RuntimeError,), times_exceeded=LastAction.Discard),
+)
+def will_retry(failure: str) -> None:
+    if failure == "retry":
+        logger.info("going to retry with explicit retry error")
+        raise RetryError
+    if failure == "raise":
+        logger.info("raising runtimeerror")
+        raise RuntimeError("oh no")
+    logger.info("got %s", failure)
+
+
+@exampletasks.register(name="examples.simple_task")
+def simple_task() -> None:
+    logger.info("simple_task complete")
+
+
+@exampletasks.register(name="examples.retry_task", retry=Retry(times=2))
+def retry_task() -> None:
+    raise RetryError
+
+
+@exampletasks.register(name="examples.fail_task")
+def fail_task() -> None:
+    raise ValueError("nope")
+
+
+@exampletasks.register(name="examples.at_most_once", at_most_once=True)
+def at_most_once_task() -> None:
+    pass

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-from django.test import override_settings
 from sentry_protos.sentry.v1.taskworker_pb2 import (
     TASK_ACTIVATION_STATUS_COMPLETE,
     TASK_ACTIVATION_STATUS_FAILURE,
@@ -9,57 +8,30 @@ from sentry_protos.sentry.v1.taskworker_pb2 import (
     TaskActivation,
 )
 
-from sentry.taskworker.registry import taskregistry
-from sentry.taskworker.retry import Retry, RetryError
+import sentry.taskworker.tasks.examples as example_tasks
 from sentry.taskworker.worker import TaskWorker
 from sentry.testutils.cases import TestCase
 
-test_namespace = taskregistry.create_namespace(
-    name="tests",
-    retry=Retry(times=2),
-)
-
-
-@test_namespace.register(name="test.simple_task")
-def simple_task():
-    pass
-
-
-@test_namespace.register(name="test.retry_task")
-def retry_task():
-    raise RetryError
-
-
-@test_namespace.register(name="test.fail_task")
-def fail_task():
-    raise ValueError("nope")
-
-
-@test_namespace.register(name="test.at_most_once", at_most_once=True)
-def at_most_once_task():
-    pass
-
-
 SIMPLE_TASK = TaskActivation(
     id="111",
-    taskname="test.simple_task",
-    namespace="tests",
+    taskname="examples.simple_task",
+    namespace="examples",
     parameters='{"args": [], "kwargs": {}}',
     processing_deadline_duration=1,
 )
 
 RETRY_TASK = TaskActivation(
     id="222",
-    taskname="test.retry_task",
-    namespace="tests",
+    taskname="examples.retry_task",
+    namespace="examples",
     parameters='{"args": [], "kwargs": {}}',
     processing_deadline_duration=1,
 )
 
 FAIL_TASK = TaskActivation(
     id="333",
-    taskname="test.fail_task",
-    namespace="tests",
+    taskname="examples.fail_task",
+    namespace="examples",
     parameters='{"args": [], "kwargs": {}}',
     processing_deadline_duration=1,
 )
@@ -74,15 +46,19 @@ UNDEFINED_TASK = TaskActivation(
 
 AT_MOST_ONCE_TASK = TaskActivation(
     id="555",
-    taskname="test.at_most_once",
-    namespace="tests",
+    taskname="examples.at_most_once",
+    namespace="examples",
     parameters='{"args": [], "kwargs": {}}',
     processing_deadline_duration=1,
 )
 
 
-@override_settings(TASKWORKER_IMPORTS=("tests.sentry.taskworker.test_worker",))
 class TestTaskWorker(TestCase):
+    def test_tasks_exist(self) -> None:
+        assert example_tasks.simple_task
+        assert example_tasks.retry_task
+        assert example_tasks.at_most_once_task
+
     def test_fetch_task(self) -> None:
         taskworker = TaskWorker(rpc_host="127.0.0.1:50051", max_task_count=100)
         with mock.patch.object(taskworker.client, "get_task") as mock_get:


### PR DESCRIPTION
Enable code reloading for `sentry run taskworker` to improve DX when working locally.

Reloading was interacting poorly with our fork strategy, so I switched back to spawn. Going to spawn required moving the test tasks into a 'real' module and ensuring those tasks are loaded by worker processess in the initializer hook.

Refs #81243