### PR TITLE
fix(groups): Add an `all_user_count` property that doesn't filter by env

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -156,7 +156,10 @@ class SeenStats(TypedDict):
     times_seen: int
     first_seen: datetime | None
     last_seen: datetime | None
+    # User count filtered by the current environment selection
     user_count: int
+    # User count across all environments
+    all_user_count: int
 
 
 class GroupSerializerBase(Serializer, ABC):
@@ -750,6 +753,7 @@ class GroupSerializerBase(Serializer, ABC):
             "userCount": attrs["user_count"],
             "firstSeen": attrs["first_seen"],
             "lastSeen": attrs["last_seen"],
+            "allUserCount": attrs["all_user_count"],
         }
 
 
@@ -813,6 +817,12 @@ class GroupSerializer(GroupSerializerBase):
             environment_ids=environment and [environment.id],
             tenant_ids=tenant_ids,
         )
+        all_user_counts: Mapping[int, int] = user_counts_func(
+            [project_id],
+            item_ids,
+            environment_ids=None,
+            tenant_ids=tenant_ids,
+        )
         first_seen: MutableMapping[int, datetime] = {}
         last_seen: MutableMapping[int, datetime] = {}
         times_seen: MutableMapping[int, int] = {}
@@ -843,6 +853,7 @@ class GroupSerializer(GroupSerializerBase):
                 "first_seen": first_seen.get(item.id),
                 "last_seen": last_seen.get(item.id),
                 "user_count": user_counts.get(item.id, 0),
+                "all_user_count": all_user_counts.get(item.id, 0),
             }
             for item in issue_list
         }
@@ -1146,6 +1157,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
                 "first_seen": first_seen.get(item.id),
                 "last_seen": last_seen.get(item.id),
                 "user_count": user_counts.get(item.id, 0),
+                "all_user_count": user_counts.get(item.id, 0),
             }
             for item in item_list
         }

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -541,18 +541,28 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             start=self.start,
             end=self.end,
         )
+        partial_execute_seen_stats_query_no_env = functools.partial(
+            seen_stats_func,
+            item_list=error_issue_list,
+            start=self.start,
+            end=self.end,
+        )
         time_range_result = self._parse_seen_stats_results(
-            partial_execute_seen_stats_query(),
-            error_issue_list,
-            self.start or self.end or self.conditions,
-            self.environment_ids,
+            result=partial_execute_seen_stats_query(),
+            result_without_env=partial_execute_seen_stats_query_no_env(),
+            item_list=error_issue_list,
+            use_result_first_seen_times_seen=self.start or self.end or self.conditions,
+            environment_ids=self.environment_ids,
         )
         filtered_result = (
             self._parse_seen_stats_results(
-                partial_execute_seen_stats_query(conditions=self.conditions),
-                error_issue_list,
-                self.start or self.end or self.conditions,
-                self.environment_ids,
+                result=partial_execute_seen_stats_query(conditions=self.conditions),
+                result_without_env=partial_execute_seen_stats_query_no_env(
+                    conditions=self.conditions
+                ),
+                item_list=error_issue_list,
+                use_result_first_seen_times_seen=self.start or self.end or self.conditions,
+                environment_ids=self.environment_ids,
             )
             if self.conditions and not self._collapse("filtered")
             else None

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -392,6 +392,8 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["count"] == "3"
         assert iso_format(result["lastSeen"]) == iso_format(self.min_ago)
         assert result["firstSeen"] == group.first_seen
+        assert result["userCount"] == 3
+        assert result["allUserCount"] == 3
 
         # update this to something different to make sure it's being used
         group_env = GroupEnvironment.objects.get(group_id=group_id, environment_id=environment.id)
@@ -402,7 +404,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
 
         result = serialize(
             group,
-            serializer=GroupSerializerSnuba(environment_ids=[environment.id, environment2.id]),
+            serializer=GroupSerializerSnuba(environment_ids=[environment.id]),
         )
         assert result["count"] == "3"
         # result is rounded down to nearest second
@@ -410,7 +412,8 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert iso_format(result["firstSeen"]) == iso_format(group_env.first_seen)
         assert group_env2.first_seen is not None
         assert group_env2.first_seen > group_env.first_seen
-        assert result["userCount"] == 3
+        assert result["userCount"] == 2
+        assert result["allUserCount"] == 3
 
         result = serialize(
             group,
@@ -435,6 +438,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
                         "first_seen": None,
                         "times_seen": 0,
                         "user_count": 0,
+                        "all_user_count": 0,
                     }
                 }
             )


### PR DESCRIPTION
Works toward resolving https://github.com/getsentry/sentry/issues/60581, needs a frontend PR after.

It looks like the serializer was intentionally filtering user count by the environment, but the frontend wasn't always making this consideration. It seems the two places `userCount` is used is the stream and the header on issue details. After this is merged we'll need the header to user `allUserCount` instead to avoid it changing when a new env is picked.