### PR TITLE
feat(alerts): Updates open in discover button to open in explore for EAP alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -254,13 +254,20 @@ class MetricChart extends PureComponent<Props, State> {
             </StyledSectionValue>
           </Fragment>
         </StyledInlineContainer>
-        {!isSessionAggregate(rule.aggregate) && (
-          <Feature features="discover-basic">
-            <Button size="sm" {...props}>
-              {buttonText}
-            </Button>
-          </Feature>
-        )}
+        {!isSessionAggregate(rule.aggregate) &&
+          (getAlertTypeFromAggregateDataset(rule) === 'eap_metrics' ? (
+            <Feature features="visibility-explore-view">
+              <Button size="sm" {...props}>
+                {buttonText}
+              </Button>
+            </Feature>
+          ) : (
+            <Feature features="discover-basic">
+              <Button size="sm" {...props}>
+                {buttonText}
+              </Button>
+            </Feature>
+          ))}
       </StyledChartControls>
     );
   }

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -8,8 +8,9 @@ import {getMetricsUrl} from 'sentry/utils/metrics';
 import {parseField} from 'sentry/utils/metrics/mri';
 import {MetricDisplayType} from 'sentry/utils/metrics/types';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
-import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, type MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {isCustomMetricField} from 'sentry/views/alerts/rules/metric/utils/isCustomMetricField';
+import {getExploreUrl} from 'sentry/views/alerts/rules/utils';
 import {getMetricRuleDiscoverUrl} from 'sentry/views/alerts/utils/getMetricRuleDiscoverUrl';
 
 interface PresetCta {
@@ -50,6 +51,17 @@ export function makeDefaultCta({
     return {
       buttonText: t('Open in Discover'),
       to: '',
+    };
+  }
+  if (rule.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
+    return {
+      buttonText: t('Open in Explore'),
+      to: getExploreUrl({
+        rule,
+        orgSlug,
+        period: timePeriod.period,
+        projectId: projects[0].id,
+      }),
     };
   }
 

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -156,7 +156,10 @@ const EAP_AVAILABLE_TIME_PERIODS = {
   [TimeWindow.ONE_DAY]: [TimePeriod.SEVEN_DAYS],
 };
 
-const TIME_WINDOW_TO_SESSION_INTERVAL = {
+export const TIME_WINDOW_TO_INTERVAL = {
+  [TimeWindow.FIVE_MINUTES]: '5m',
+  [TimeWindow.TEN_MINUTES]: '10m',
+  [TimeWindow.FIFTEEN_MINUTES]: '15m',
   [TimeWindow.THIRTY_MINUTES]: '30m',
   [TimeWindow.ONE_HOUR]: '1h',
   [TimeWindow.TWO_HOURS]: '2h',
@@ -579,7 +582,7 @@ class TriggersChart extends PureComponent<Props, State> {
         environment: environment ? [environment] : undefined,
         statsPeriod: period,
         query: query,
-        interval: TIME_WINDOW_TO_SESSION_INTERVAL[timeWindow],
+        interval: TIME_WINDOW_TO_INTERVAL[timeWindow],
         field: SESSION_AGGREGATE_TO_FIELD[aggregate],
         groupBy: ['session.status'],
         children: noop,

--- a/static/app/views/alerts/rules/utils.spec.tsx
+++ b/static/app/views/alerts/rules/utils.spec.tsx
@@ -1,0 +1,24 @@
+import {MetricRuleFixture} from 'sentry-fixture/metricRule';
+
+import {Dataset, TimeWindow} from 'sentry/views/alerts/rules/metric/types';
+import {getExploreUrl} from 'sentry/views/alerts/rules/utils';
+
+describe('getExploreUrl', () => {
+  it('should return the correct url', () => {
+    const rule = MetricRuleFixture();
+    rule.dataset = Dataset.EVENTS_ANALYTICS_PLATFORM;
+    rule.timeWindow = TimeWindow.THIRTY_MINUTES;
+    rule.aggregate = 'p75(span.duration)';
+    rule.query = 'span.op:http.client';
+    rule.environment = 'prod';
+    const url = getExploreUrl({
+      rule,
+      orgSlug: 'slug',
+      period: '7d',
+      projectId: '1',
+    });
+    expect(url).toEqual(
+      '/organizations/slug/traces/?dataset=spansRpc&environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&statsPeriod=7d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
+    );
+  });
+});


### PR DESCRIPTION
Updates the "Open in Discover" button in the alert detail page to "Open in Explore"
<img width="240" alt="image" src="https://github.com/user-attachments/assets/71dcd826-9a8a-4629-a5fa-046c6e102b31" />