### PR TITLE
chore(stacktrace): Make source map tooltip aligned

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -364,15 +364,13 @@ export class DeprecatedLine extends Component<Props, State> {
           {this.isExpandable() ? <InteractionStateLayer /> : null}
           <DefaultLineTitleWrapper isInAppFrame={data.inApp}>
             <LeftLineTitle>
-              <div>
-                {this.renderLeadHint()}
-                <DefaultTitle
-                  frame={data}
-                  platform={this.props.platform ?? 'other'}
-                  isHoverPreviewed={isHoverPreviewed}
-                  meta={this.props.frameMeta}
-                />
-              </div>
+              {this.renderLeadHint()}
+              <DefaultTitle
+                frame={data}
+                platform={this.props.platform ?? 'other'}
+                isHoverPreviewed={isHoverPreviewed}
+                meta={this.props.frameMeta}
+              />
             </LeftLineTitle>
           </DefaultLineTitleWrapper>
           <DefaultLineTagWrapper>
@@ -508,6 +506,7 @@ const DefaultLineTitleWrapper = styled('div')<{isInAppFrame: boolean}>`
 const LeftLineTitle = styled('div')`
   display: flex;
   align-items: center;
+  gap: ${space(0.25)};
 `;
 
 const RepeatedContent = styled(LeftLineTitle)`


### PR DESCRIPTION
this has annoyed me since forever

before: 

![image](https://github.com/user-attachments/assets/33733ee9-646b-4949-a18d-6a29e16b6028)


after: (notice the tooltip is aligned with the stack trace file path now) 

![image](https://github.com/user-attachments/assets/2e199d45-1126-4878-84ea-41e11d50130c)


(This changes applies to both the old and new issue details pages) 