### PR TITLE
chore(docs): Add statusDetails info to endpoint doc

### DIFF
--- a/api-docs/paths/events/issue-details.json
+++ b/api-docs/paths/events/issue-details.json
@@ -216,7 +216,7 @@
               },
               "statusDetails": {
                 "type": "object",
-                "description": "Additional details about the status of the issue.",
+                "description": "Additional details about the resolution. Valid values are `\"inRelease\"`, `\"inNextRelease\"`, `\"inCommit\"`, `\"ignoreDuration\"`, `\"ignoreCount\"`, `\"ignoreWindow\"`, `\"ignoreUserCount\"`, and `\"ignoreUserWindow\"`.",
                 "properties": {
                   "inNextRelease": {
                     "type": "boolean",

--- a/api-docs/paths/events/issue-details.json
+++ b/api-docs/paths/events/issue-details.json
@@ -216,7 +216,7 @@
               },
               "statusDetails": {
                 "type": "object",
-                "description": "Additional details about the resolution. Valid values are `\"inRelease\"`, `\"inNextRelease\"`, `\"inCommit\"`, `\"ignoreDuration\"`, `\"ignoreCount\"`, `\"ignoreWindow\"`, `\"ignoreUserCount\"`, and `\"ignoreUserWindow\"`.",
+                "description": "Additional details about the resolution. Supported values are `\"inRelease\"`, `\"inNextRelease\"`, `\"inCommit\"`, `\"ignoreDuration\"`, `\"ignoreCount\"`, `\"ignoreWindow\"`, `\"ignoreUserCount\"`, and `\"ignoreUserWindow\"`.",
                 "properties": {
                   "inNextRelease": {
                     "type": "boolean",

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -329,6 +329,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :param string status: the new status for the issue.  Valid values
                               are ``"resolved"``, ``resolvedInNextRelease``,
                               ``"unresolved"``, and ``"ignored"``.
+        :param map statusDetails: additional details about the resolution.
+                                  Valid values are ``"inRelease"``, ``"inNextRelease"``,
+                                  ``"inCommit"``,  ``"ignoreDuration"``, ``"ignoreCount"``,
+                                  ``"ignoreWindow"``, ``"ignoreUserCount"``, and
+                                  ``"ignoreUserWindow"``.
         :param string assignedTo: the user or team that should be assigned to
                                   this issue. Can be of the form ``"<user_id>"``,
                                   ``"user:<user_id>"``, ``"<username>"``,

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -329,11 +329,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :param string status: the new status for the issue.  Valid values
                               are ``"resolved"``, ``resolvedInNextRelease``,
                               ``"unresolved"``, and ``"ignored"``.
-        :param map statusDetails: additional details about the resolution.
-                                  Valid values are ``"inRelease"``, ``"inNextRelease"``,
-                                  ``"inCommit"``,  ``"ignoreDuration"``, ``"ignoreCount"``,
-                                  ``"ignoreWindow"``, ``"ignoreUserCount"``, and
-                                  ``"ignoreUserWindow"``.
         :param string assignedTo: the user or team that should be assigned to
                                   this issue. Can be of the form ``"<user_id>"``,
                                   ``"user:<user_id>"``, ``"<username>"``,


### PR DESCRIPTION
Add more details about statusDetails to Update an Issue endpoint doc
Doc now matches the info for the bulk endpoint: https://docs.sentry.io/api/events/bulk-mutate-a-list-of-issues/

fixes https://github.com/getsentry/sentry/issues/66402