### PR TITLE
fix(alerts): Updates alerts y axis duration formatting to show decimals

### DIFF
--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -8,7 +8,10 @@ import toArray from 'sentry/utils/array/toArray';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
-import {formatMetricUsingFixedUnit} from 'sentry/utils/metrics/formatters';
+import {
+  formatMetricUsingFixedUnit,
+  formatMetricUsingUnit,
+} from 'sentry/utils/metrics/formatters';
 import {parseField, parseMRI} from 'sentry/utils/metrics/mri';
 import {
   Dataset,
@@ -142,7 +145,13 @@ export function alertAxisFormatter(value: number, seriesName: string, aggregate:
     return formatMetricUsingFixedUnit(value, unit, aggregation);
   }
 
-  return axisLabelFormatter(value, aggregateOutputType(seriesName));
+  const type = aggregateOutputType(seriesName);
+
+  if (type === 'duration') {
+    return formatMetricUsingUnit(value, 'milliseconds');
+  }
+
+  return axisLabelFormatter(value, type);
 }
 
 export function alertTooltipValueFormatter(


### PR DESCRIPTION
Updates the Duration Y Axis labels in Alerts charts to render with dynamic decimals. This resolves an issue where Y Axis Duration Labels with close enough values end up rounding to the same displayed value. 
<img width="133" alt="image" src="https://github.com/user-attachments/assets/ae0f9c56-8bd2-4f2f-88e1-050ba49d1581" />
