### PR TITLE
fix(insights): Load domain tables if `span.system` is unknown

### DIFF
--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -20,7 +20,10 @@ type Props = {
 export function DatabasePageFilters(props: Props) {
   const {system, databaseCommand, table} = props;
 
-  const additionalQuery = useMemo(() => [`span.system:${system}`], [system]);
+  const additionalQuery = useMemo(
+    () => (system ? [`span.system:${system}`] : []),
+    [system]
+  );
 
   return (
     <PageFilterWrapper>


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/81904. In cases where no `span.system` is available, the domain selector issues a query that filters by `"span.system:undefined"` which returns nothing.

Instead, if there are no known systems, query for all domains.
