### PR TITLE
fix(tags): Better tooltip on graph distribution

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -6,7 +6,7 @@ import {DeviceName} from 'sentry/components/deviceName';
 import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {percent} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -78,8 +78,15 @@ export function TagBar({
 }) {
   const percentage = percent(count, total);
   const displayPercentage = percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
+
   return (
-    <Tooltip delay={300} title={`${count} / ${total}`} skipWrapper>
+    <Tooltip
+      title={tct('[count] of [total] tagged events', {
+        count: count.toLocaleString(),
+        total: total.toLocaleString(),
+      })}
+      skipWrapper
+    >
       <TagBarContainer
         displayPercentage={displayPercentage}
         widthPercent={percentage}


### PR DESCRIPTION
Better number formatting, plain text to understand the fraction.

<img width="324" alt="image" src="https://github.com/user-attachments/assets/66e23cf7-025f-40fc-863b-7de24652becf" />
