### PR TITLE
feat(sdk_crash_detection): Detect ANRs based on mechanism type

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_android.py
+++ b/fixtures/sdk_crash_detection/crash_event_android.py
@@ -98,7 +98,7 @@ def get_apex_crash_event(
 
 def get_exception(
     frames: Sequence[Mapping[str, str]],
-    mechanism: Mapping[str, object] = None,
+    mechanism=None,
 ) -> dict[str, object]:
     if mechanism is None:
         # linter complains about mutable arguments otherwise

--- a/fixtures/sdk_crash_detection/crash_event_android.py
+++ b/fixtures/sdk_crash_detection/crash_event_android.py
@@ -96,6 +96,22 @@ def get_apex_crash_event(
     )
 
 
+def get_exception(
+    frames: Sequence[Mapping[str, str]],
+    mechanism: Mapping[str, object] = None,
+) -> dict[str, object]:
+    if mechanism is None:
+        # linter complains about mutable arguments otherwise
+        mechanism = {"type": "onerror", "handled": False}
+    return {
+        "type": "IllegalArgumentException",
+        "value": "SDK Crash",
+        "module": "java.lang",
+        "stacktrace": {"frames": frames},
+        "mechanism": mechanism,
+    }
+
+
 def get_crash_event_with_frames(frames: Sequence[Mapping[str, str]], **kwargs) -> dict[str, object]:
     result = {
         "event_id": "0a52a8331d3b45089ebd74f8118d4fa1",
@@ -103,17 +119,7 @@ def get_crash_event_with_frames(frames: Sequence[Mapping[str, str]], **kwargs) -
         "dist": "2",
         "platform": "java",
         "environment": "debug",
-        "exception": {
-            "values": [
-                {
-                    "type": "IllegalArgumentException",
-                    "value": "SDK Crash",
-                    "module": "java.lang",
-                    "stacktrace": {"frames": frames},
-                    "mechanism": {"type": "onerror", "handled": False},
-                }
-            ]
-        },
+        "exception": {"values": [get_exception(frames)]},
         "key_id": "1336851",
         "level": "fatal",
         "contexts": {

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -59,6 +59,8 @@ class SDKCrashDetectionConfig:
     report_fatal_errors: bool
     """The mechanism types to ignore. For example, {"console", "unhandledrejection"}. If empty, all mechanism types are captured."""
     ignore_mechanism_type: set[str]
+    """The mechanism types to capture. For example, {"ANR", "AppExitInfo"}. Useful when you want to detect events that are neither unhandled nor fatal."""
+    allow_mechanism_type: set[str]
     """The system library path patterns to detect system frames. For example, `System/Library/*` """
     system_library_path_patterns: set[str]
     """The configuration for detecting SDK frames."""
@@ -103,6 +105,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             },
             report_fatal_errors=False,
             ignore_mechanism_type=set(),
+            allow_mechanism_type=set(),
             system_library_path_patterns={r"/System/Library/**", r"/usr/lib/**"},
             sdk_frame_config=SDKFrameConfig(
                 function_patterns={
@@ -138,6 +141,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             # used by the JS/RN SDKs
             # https://github.com/getsentry/sentry-javascript/blob/dafd51054d8b2ab2030fa0b16ad0fd70493b6e08/packages/core/src/integrations/captureconsole.ts#L60
             ignore_mechanism_type={"console"},
+            allow_mechanism_type=set(),
             system_library_path_patterns={
                 r"**/react-native/Libraries/**",
                 r"**/react-native-community/**",
@@ -211,6 +215,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             },
             report_fatal_errors=False,
             ignore_mechanism_type=set(),
+            allow_mechanism_type={"ANR", "AppExitInfo"},
             system_library_path_patterns={
                 r"java.**",
                 r"javax.**",
@@ -273,6 +278,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             },
             report_fatal_errors=False,
             ignore_mechanism_type=set(),
+            allow_mechanism_type=set(),
             system_library_path_patterns={
                 # well known locations for unix paths
                 r"/lib/**",
@@ -324,6 +330,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             },
             report_fatal_errors=True,
             ignore_mechanism_type=set(),
+            allow_mechanism_type=set(),
             system_library_path_patterns={
                 # Dart
                 r"org-dartlang-sdk:///**",

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -63,6 +63,9 @@ class SDKCrashDetector:
         if is_fatal and self.config.report_fatal_errors:
             return True
 
+        if mechanism_type in ["AppExitInfo", "ANR"]:
+            return True
+
         return False
 
     def is_sdk_crash(self, frames: Sequence[Mapping[str, Any]]) -> bool:

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -53,6 +53,9 @@ class SDKCrashDetector:
         if mechanism_type and mechanism_type in self.config.ignore_mechanism_type:
             return False
 
+        if mechanism_type and mechanism_type in self.config.allow_mechanism_type:
+            return True
+
         is_unhandled = (
             get_path(event_data, "exception", "values", -1, "mechanism", "handled") is False
         )
@@ -61,9 +64,6 @@ class SDKCrashDetector:
 
         is_fatal = get_path(event_data, "level") == "fatal"
         if is_fatal and self.config.report_fatal_errors:
-            return True
-
-        if mechanism_type in ["AppExitInfo", "ANR"]:
             return True
 
         return False

--- a/tests/sentry/utils/sdk_crashes/conftest.py
+++ b/tests/sentry/utils/sdk_crashes/conftest.py
@@ -26,6 +26,7 @@ def empty_cocoa_config() -> SDKCrashDetectionConfig:
         sdk_names={},
         report_fatal_errors=False,
         ignore_mechanism_type=set(),
+        allow_mechanism_type=set(),
         system_library_path_patterns=set(),
         sdk_frame_config=SDKFrameConfig(
             function_patterns=set(),

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_java.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_java.py
@@ -354,14 +354,35 @@ def test_anr_detected(mock_sdk_crash_reporter, mock_random, store_event, configs
                         sdk_frame_module="io.sentry.Hub",
                         system_frame_module="java.lang.reflect.Method",
                     ),
-                    mechanism={"type": "AppExitInfo"},
+                    mechanism={"type": "ANR", "handled": True},
                 ),
+            ]
+        }
+    )
+
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 1
+
+
+@decorators
+def test_appexitinfo_detected(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(
+        exception={
+            "values": [
                 get_exception(
                     frames=get_frames(
                         sdk_frame_module="io.sentry.Hub",
                         system_frame_module="java.lang.reflect.Method",
                     ),
-                    mechanism={"type": "ANR", "handled": True},
+                    mechanism={"type": "AppExitInfo"},
                 ),
             ]
         }

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_java.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_java.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-from fixtures.sdk_crash_detection.crash_event_android import get_apex_crash_event, get_crash_event
+from fixtures.sdk_crash_detection.crash_event_android import (
+    get_apex_crash_event,
+    get_crash_event,
+    get_exception,
+    get_frames,
+)
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.safe import get_path, set_path
@@ -337,3 +342,38 @@ def test_native_sdk_version_too_low_not_detected(
     )
 
     assert mock_sdk_crash_reporter.report.call_count == 0
+
+
+@decorators
+def test_anr_detected(mock_sdk_crash_reporter, mock_random, store_event, configs):
+    event_data = get_crash_event(
+        exception={
+            "values": [
+                get_exception(
+                    frames=get_frames(
+                        sdk_frame_module="io.sentry.Hub",
+                        system_frame_module="java.lang.reflect.Method",
+                    ),
+                    mechanism={"type": "AppExitInfo"},
+                ),
+                get_exception(
+                    frames=get_frames(
+                        sdk_frame_module="io.sentry.Hub",
+                        system_frame_module="java.lang.reflect.Method",
+                    ),
+                    mechanism={"type": "ANR", "handled": True},
+                ),
+            ]
+        }
+    )
+
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    assert mock_sdk_crash_reporter.report.call_count == 1


### PR DESCRIPTION
I noticed we were not reporting ANRs caused by the SDK, and realized they do not have `handled:false` set on the mechanism, so I've just added a mechanism type check and I think that should be enough.