### PR TITLE
feat(widget-builder): Make widget builder preview draggable

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -93,10 +93,10 @@ const _SlideOverPanel = styled(motion.div, {
 }>`
   position: fixed;
 
-  top: ${space(2)};
-  right: 0;
+  top: ${p => (p.slidePosition === 'left' ? '54px' : space(2))};
+  right: ${p => (p.slidePosition === 'left' ? space(2) : 0)};
   bottom: ${space(2)};
-  left: ${space(2)};
+  left: ${p => (p.slidePosition === 'left' ? 0 : space(2))};
 
   overflow: auto;
   pointer-events: auto;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useEffect, useState} from 'react';
 import {DndContext, type Translate, useDraggable} from '@dnd-kit/core';
-import {css} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
@@ -141,10 +141,15 @@ function WidgetPreviewContainer({
   const {state} = useWidgetBuilderContext();
   const organization = useOrganization();
   const location = useLocation();
+  const theme = useTheme();
+
+  const isDragEnabled =
+    window.innerWidth < parseInt(theme.breakpoints.small.replace('px', ''), 10);
 
   const {attributes, listeners, setNodeRef, isDragging} = useDraggable({
     id: WIDGET_PREVIEW_DRAG_ID,
-    // disabled: true,
+    disabled: !isDragEnabled,
+    // May need to add 'handle' prop if we want to drag the preview by a specific area
   });
 
   return (
@@ -165,7 +170,9 @@ function WidgetPreviewContainer({
                 ref={setNodeRef}
                 id={WIDGET_PREVIEW_DRAG_ID}
                 style={{
-                  transform: `translate3d(${translate?.x ?? 0}px, ${translate?.y ?? 0}px, 0)`,
+                  transform: isDragEnabled
+                    ? `translate3d(${translate?.x ?? 0}px, ${translate?.y ?? 0}px, 0)`
+                    : undefined,
                   opacity: isDragging ? 0.5 : 1,
                 }}
                 {...attributes}
@@ -236,6 +243,15 @@ const DraggableWidgetContainer = styled(`div`)`
 
   &:active {
     cursor: grabbing;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    transform: none;
+    cursor: auto;
+
+    &:active {
+      cursor: auto;
+    }
   }
 `;
 


### PR DESCRIPTION
The responsive design for the widget builder allows for a draggable preview on smaller screens. The preview is now draggable by the dnd-kit library. It is only draggable when the slideout is the full screen width (on small screens), otherwise it is not draggable. The preview is on top of the widget builder and can be shifted around for easy access to the fields. It looks like this yayyy:


https://github.com/user-attachments/assets/66cedf76-f2a1-4c18-aedb-c4c1ef02f011

Closes https://github.com/getsentry/sentry/issues/81804