### PR TITLE
perf(access-requests): utilize get_attrs to improve access req perf

### DIFF
--- a/src/sentry/api/serializers/models/organization_access_request.py
+++ b/src/sentry/api/serializers/models/organization_access_request.py
@@ -5,17 +5,41 @@ from sentry.users.services.user.service import user_service
 
 @register(OrganizationAccessRequest)
 class OrganizationAccessRequestSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
-        serialized_user = None
-        if obj.requester_id:
-            serialized_users = user_service.serialize_many(filter=dict(user_ids=[obj.requester_id]))
-            if serialized_users:
-                serialized_user = serialized_users[0]
+    def get_attrs(self, item_list, user, **kwargs):
 
-        d = {
-            "id": str(obj.id),
-            "member": serialize(obj.member),
-            "team": serialize(obj.team),
-            "requester": serialized_user,
+        serialized_requesters = user_service.serialize_many(
+            filter=dict(user_ids=[item.requester_id for item in item_list if item.requester_id])
+        )
+
+        serialized_requesters_by_id = {
+            int(requester["id"]): requester for requester in serialized_requesters
         }
-        return d
+
+        serialized_members = serialize(
+            [item.member for item in item_list],
+            user,
+        )
+
+        serialized_members_by_id = {int(member["id"]): member for member in serialized_members}
+
+        serialized_teams = serialize([item.team for item in item_list], user)
+
+        serialized_teams_by_id = {int(team["id"]): team for team in serialized_teams}
+
+        return {
+            item: {
+                "requester": serialized_requesters_by_id.get(item.requester_id),
+                "member": serialized_members_by_id.get(item.member_id),
+                "team": serialized_teams_by_id.get(item.team_id),
+            }
+            for item in item_list
+        }
+
+    def serialize(self, obj, attrs, user, **kwargs):
+        serialized_access_request = {
+            "id": str(obj.id),
+            "member": attrs["member"],
+            "team": attrs["team"],
+            "requester": attrs["requester"],
+        }
+        return serialized_access_request


### PR DESCRIPTION
utilize get_attrs and batch the serialization/hybrid cloud calls of objects to hopefully improve performance of the access request endpoint, who's slowness was reported by customers.

Fixes https://github.com/getsentry/team-issues/issues/46

example slow trace:

https://sentry.sentry.io/performance/trace/cbb64eae1b9c4ad895bac44442498f0e/