### PR TITLE
feat(suspect-commits): Add user ID to suspect commit analytics events

### DIFF
--- a/src/sentry/analytics/events/groupowner_assignment.py
+++ b/src/sentry/analytics/events/groupowner_assignment.py
@@ -9,6 +9,9 @@ class GroupOwnerAssignment(analytics.Event):
         analytics.Attribute("project_id"),
         analytics.Attribute("group_id"),
         analytics.Attribute("new_assignment", type=bool),
+        analytics.Attribute("user_id", required=False),
+        analytics.Attribute("group_owner_type"),
+        analytics.Attribute("method", required=False),
     )
 
 

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -231,6 +231,9 @@ def process_commit_context(
                 project_id=project.id,
                 group_id=group_id,
                 new_assignment=created,
+                user_id=group_owner.user_id,
+                group_owner_type=group_owner.type,
+                method="scm_integration",
             )
     except UnableToAcquireLock:
         pass

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -4,6 +4,7 @@ from typing import cast
 
 from django.utils import timezone
 
+from sentry import analytics
 from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
@@ -103,6 +104,17 @@ def _process_suspect_commits(
                                             "project": project_id,
                                         },
                                     )
+                            analytics.record(
+                                "groupowner.assignment",
+                                organization_id=project.organization_id,
+                                project_id=project.id,
+                                group_id=group_id,
+                                new_assignment=created,
+                                user_id=go.user_id,
+                                group_owner_type=go.type,
+                                method="release_commit",
+                            )
+
                     except GroupOwner.MultipleObjectsReturned:
                         GroupOwner.objects.filter(
                             group_id=group_id,


### PR DESCRIPTION
The reason for these changes is that, if we want to do a Rollback next year, we want to more accurately track suspect commits.

- Adds `user_id` to the `groupowner.assignment` analytic event
- Adds `group_owner_type` to distinguish this event being used here vs other methods of updating group assignment
- Adds `method` so that we can track the old release commit method from the newer SCM (git blame) method
- The old method wasn't tracking any sort of analytic event on success, so adds a call to `groupowner.assignment` to match the new method