### PR TITLE
ref(replay): add resource about identifying users in configure card

### DIFF
--- a/static/app/components/replays/configureReplayCard.tsx
+++ b/static/app/components/replays/configureReplayCard.tsx
@@ -55,6 +55,11 @@ function ResourceButtons() {
         link="https://docs.sentry.io/platforms/javascript/session-replay/privacy/#privacy-configuration"
       />
       <Resource
+        title={t('Identify Users')}
+        subtitle={t('Identify your users through a specific format, such as email.')}
+        link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#identifying-users"
+      />
+      <Resource
         title={t('Network Details')}
         subtitle={t('Capture request and response headers or bodies')}
         link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details"

--- a/static/app/components/replays/configureReplayCard.tsx
+++ b/static/app/components/replays/configureReplayCard.tsx
@@ -56,7 +56,7 @@ function ResourceButtons() {
       />
       <Resource
         title={t('Identify Users')}
-        subtitle={t('Identify your users through a specific format, such as email.')}
+        subtitle={t('Identify your users through a specific attribute, such as email.')}
         link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#identifying-users"
       />
       <Resource


### PR DESCRIPTION
<img width="361" alt="SCR-20241212-lxhq" src="https://github.com/user-attachments/assets/52618389-b98f-4652-83db-66c051938f97" />

closes https://github.com/getsentry/sentry/issues/70276