### PR TITLE
fix(issues): Always show screenshots filter

### DIFF
--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -81,15 +81,6 @@ describe('GroupEventAttachments', function () {
     );
   });
 
-  it('does not render screenshots tab if not mobile platform', function () {
-    project.platform = 'javascript';
-    render(<GroupEventAttachments project={project} group={group} />, {
-      router: screenshotRouter,
-      organization,
-    });
-    expect(screen.queryByText('Screenshots')).not.toBeInTheDocument();
-  });
-
   it('calls opens modal when clicking on panel body', async function () {
     render(<GroupEventAttachments project={project} group={group} />, {
       router: screenshotRouter,

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -128,10 +128,10 @@ function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
             <IconFilter size="xs" />
             {t('Results are filtered by the selections above.')}
           </FilterMessage>
-          <GroupEventAttachmentsFilter project={project} />
+          <GroupEventAttachmentsFilter />
         </Flex>
       ) : (
-        <GroupEventAttachmentsFilter project={project} />
+        <GroupEventAttachmentsFilter />
       )}
       {activeAttachmentsTab === EventAttachmentFilter.SCREENSHOT
         ? renderScreenshotGallery()

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -2,8 +2,6 @@ import styled from '@emotion/styled';
 
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
-import {isMobilePlatform} from 'sentry/utils/platform';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
@@ -15,12 +13,7 @@ export const enum EventAttachmentFilter {
 
 type AttachmentFilterValue = `${EventAttachmentFilter}`;
 
-type Props = {
-  project: Project;
-};
-
-function GroupEventAttachmentsFilter(props: Props) {
-  const {project} = props;
+function GroupEventAttachmentsFilter() {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -44,21 +37,15 @@ function GroupEventAttachmentsFilter(props: Props) {
           );
         }}
       >
-        {[
-          <SegmentedControl.Item key={EventAttachmentFilter.ALL}>
-            {t('All Attachments')}
-          </SegmentedControl.Item>,
-          ...(isMobilePlatform(project.platform)
-            ? [
-                <SegmentedControl.Item key={EventAttachmentFilter.SCREENSHOT}>
-                  {t('Screenshots')}
-                </SegmentedControl.Item>,
-              ]
-            : []),
-          <SegmentedControl.Item key={EventAttachmentFilter.CRASH_REPORTS}>
-            {t('Only Crash Reports')}
-          </SegmentedControl.Item>,
-        ]}
+        <SegmentedControl.Item key={EventAttachmentFilter.ALL}>
+          {t('All Attachments')}
+        </SegmentedControl.Item>
+        <SegmentedControl.Item key={EventAttachmentFilter.SCREENSHOT}>
+          {t('Screenshots')}
+        </SegmentedControl.Item>
+        <SegmentedControl.Item key={EventAttachmentFilter.CRASH_REPORTS}>
+          {t('Only Crash Reports')}
+        </SegmentedControl.Item>
       </SegmentedControl>
     </FilterWrapper>
   );


### PR DESCRIPTION
Will always show screenshot attachment filter instead of just for mobile. Nintendo and other platforms are not mobile and would like to see these filters
