### PR TITLE
feat(alerts): Removes the disable state from the Alert Rule Edit Display chart

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -448,7 +448,6 @@ class TriggersChart extends PureComponent<Props, State> {
                 borderless: true,
                 prefix: t('Display'),
               }}
-              disabled={isLoading || isReloading}
             />
           </InlineContainer>
         </ChartControls>


### PR DESCRIPTION
Removes the disable state from the Alert Rule Edit page Display chart. This prevented users from updating the time window which was especially annoying on long running queries. Also fixes an issue with failed queries permanently blocking the time window dropdown entirely.

Should be safe to remove this disabled state, especially since running queries get cancelled. I don't think there are any specific reasons why we have this disabled state.