### PR TITLE
fix: use locks to handle apigrants safely

### DIFF
--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -12,6 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.models.apiapplication import ApiApplicationStatus
 from sentry.models.apiauthorization import ApiAuthorization
+from sentry.models.apigrant import ApiGrant
 from sentry.models.apitoken import ApiToken
 
 
@@ -44,18 +45,33 @@ class ApiAuthorizationsEndpoint(Endpoint):
             return Response({"authorization": ""}, status=400)
 
         try:
-            auth = ApiAuthorization.objects.get(user_id=request.user.id, id=authorization)
+            api_authorization = ApiAuthorization.objects.get(
+                user_id=request.user.id, id=authorization
+            )
         except ApiAuthorization.DoesNotExist:
             return Response(status=404)
 
         with outbox_context(transaction.atomic(using=router.db_for_write(ApiToken)), flush=False):
             for token in ApiToken.objects.filter(
                 user_id=request.user.id,
-                application=auth.application_id,
-                scoping_organization_id=auth.organization_id,
+                application=api_authorization.application_id,
+                scoping_organization_id=api_authorization.organization_id,
             ):
                 token.delete()
 
-            auth.delete()
+        # remove any grants that were created from this authorization
+        # that may not have been exchanged for a token yet
+        with outbox_context(transaction.atomic(using=router.db_for_write(ApiGrant)), flush=False):
+            for grant in ApiGrant.objects.filter(
+                user_id=request.user.id,
+                application=api_authorization.application_id,
+                organization_id=api_authorization.organization_id,
+            ):
+                grant.delete()
+
+        with outbox_context(
+            transaction.atomic(using=router.db_for_write(ApiAuthorization)), flush=False
+        ):
+            api_authorization.delete()
 
         return Response(status=204)

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -15,6 +15,14 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 DEFAULT_EXPIRATION = timedelta(minutes=10)
 
 
+class InvalidGrantError(Exception):
+    pass
+
+
+class ExpiredGrantError(Exception):
+    pass
+
+
 def default_expiration():
     return timezone.now() + DEFAULT_EXPIRATION
 
@@ -96,6 +104,10 @@ class ApiGrant(Model):
 
     def redirect_uri_allowed(self, uri):
         return uri == self.redirect_uri
+
+    @classmethod
+    def get_lock_key(cls, grant_id):
+        return f"api_grant:{grant_id}"
 
     @classmethod
     def sanitize_relocation_json(

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
@@ -14,8 +14,8 @@ from sentry.sentry_apps.api.bases.sentryapps import SentryAppAuthorizationsBaseE
 from sentry.sentry_apps.token_exchange.grant_exchanger import GrantExchanger
 from sentry.sentry_apps.token_exchange.refresher import Refresher
 from sentry.sentry_apps.token_exchange.util import GrantTypes
-from sentry.utils.locking import UnableToAcquireLock
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError
+from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
@@ -14,6 +14,7 @@ from sentry.sentry_apps.api.bases.sentryapps import SentryAppAuthorizationsBaseE
 from sentry.sentry_apps.token_exchange.grant_exchanger import GrantExchanger
 from sentry.sentry_apps.token_exchange.refresher import Refresher
 from sentry.sentry_apps.token_exchange.util import GrantTypes
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError
 
 logger = logging.getLogger(__name__)
@@ -86,6 +87,8 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
                 },
             )
             raise
+        except UnableToAcquireLock:
+            return Response({"error": "invalid_grant"}, status=409)
 
         attrs = {"state": request.data.get("state"), "application": None}
 


### PR DESCRIPTION
- Use locks to ensure an `ApiGrant` cannot be used twice during a race condition that would result in multiple access/refresh token pairs.
- When an `ApiAuthorization` is deleted, remove all `ApiGrant`s as well that may not have been exchanged yet.
- Update the cleanup script to remove `ApiGrant`s that are past their expiration time, 10 minutes, rather than 30 days.
  - Applicable expired `ApiToken`s will still be deleted after 30 days, aligned with the current behavior.