### PR TITLE
chore(date-picker): Hide days from previous/next months in date picker

### DIFF
--- a/static/app/components/calendar/dateRangePicker.tsx
+++ b/static/app/components/calendar/dateRangePicker.tsx
@@ -43,15 +43,15 @@ function DateRangePicker({
 
   return (
     <CalendarStylesWrapper>
-      <DateRange {...props} onChange={onChange} ranges={ranges} />
+      <StyledDateRangePicker {...props} onChange={onChange} ranges={ranges} />
     </CalendarStylesWrapper>
   );
 }
 
-const StyledDateRangePicker = styled(DateRangePicker)`
+const StyledDateRangePicker = styled(DateRange)`
   .rdrDayPassive {
     visibility: hidden;
   }
 `;
 
-export default StyledDateRangePicker;
+export default DateRangePicker;

--- a/static/app/components/calendar/dateRangePicker.tsx
+++ b/static/app/components/calendar/dateRangePicker.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo} from 'react';
 import type {DateRangeProps, Range, RangeKeyDict} from 'react-date-range';
 import {DateRange} from 'react-date-range';
+import styled from '@emotion/styled';
 
 import CalendarStylesWrapper from './calendarStylesWrapper';
 
@@ -47,4 +48,10 @@ function DateRangePicker({
   );
 }
 
-export default DateRangePicker;
+const StyledDateRangePicker = styled(DateRangePicker)`
+  .rdrDayPassive {
+    visibility: hidden;
+  }
+`;
+
+export default StyledDateRangePicker;


### PR DESCRIPTION
fixes #59265

hides the passive days in the calendar: 

before: 

![image](https://github.com/user-attachments/assets/347b4994-136b-415c-84b2-04364e423e28)

after:

![image](https://github.com/user-attachments/assets/38fdab86-2e64-4780-be15-18b5fb370e34)
