### PR TITLE
fix(activity): Update activity message for linked issues

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -642,6 +642,7 @@ export interface GroupActivityCreateIssue extends GroupActivityBase {
     location: string;
     provider: string;
     title: string;
+    new?: boolean;
   };
   type: GroupActivityType.CREATE_ISSUE;
 }

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -474,6 +474,13 @@ function GroupActivityItem({
       }
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
+        if (data.new === true) {
+          return tct('[author] linked this issue to [issue] on [provider]', {
+            author,
+            issue: <ExternalLink href={data.location}>{data.title}</ExternalLink>,
+            provider: data.provider,
+          });
+        }
         return tct('[author] created an issue on [provider] titled [title]', {
           author,
           provider: data.provider,

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -493,8 +493,15 @@ export default function getGroupActivityItem(
       }
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
+        let title;
+        if (data.new === true) {
+          title = t('Linked Issue');
+        } else {
+          title = t('Created Issue');
+        }
+
         return {
-          title: t('Created Issue'),
+          title: title,
           message: tct('by [author] on [provider] titled [title]', {
             author,
             provider: data.provider,

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -493,11 +493,9 @@ export default function getGroupActivityItem(
       }
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
-        let title;
+        let title = t('Created Issue');
         if (data.new === true) {
           title = t('Linked Issue');
-        } else {
-          title = t('Created Issue');
         }
 
         return {


### PR DESCRIPTION
Use the `new` field added in https://github.com/getsentry/sentry/pull/73069 to update the message shown for the CREATE_ISSUE activity. This should add the distinction of whether an external issue was linked or created. 

Fixes #77410