### PR TITLE
fix(issues): Show empty key in request body

### DIFF
--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -42,15 +42,15 @@ export function RecursiveStructuredData({
   withOnlyFormattedText = false,
 }: Props) {
   let i = 0;
-
-  const formattedObjectKey = objectKey ? (
-    <Fragment>
-      <ValueObjectKey>
-        {config?.renderObjectKeys?.(objectKey) ?? objectKey}
-      </ValueObjectKey>
-      <span>{': '}</span>
-    </Fragment>
-  ) : null;
+  const formattedObjectKey =
+    objectKey !== undefined ? (
+      <Fragment>
+        <ValueObjectKey>
+          {config?.renderObjectKeys?.(objectKey) ?? objectKey}
+        </ValueObjectKey>
+        <span>{': '}</span>
+      </Fragment>
+    ) : null;
 
   function Wrapper({children}: {children: React.ReactNode}) {
     return (


### PR DESCRIPTION
Show empty keys in issue details request body dictionary

Before:
<img width="333" alt="Screenshot 2024-12-12 at 3 37 26 PM" src="https://github.com/user-attachments/assets/29942099-1cda-4680-87fd-9289ec3cd52e" />

After:
<img width="330" alt="Screenshot 2024-12-12 at 3 36 40 PM" src="https://github.com/user-attachments/assets/39bcc29d-47d0-4cca-bd5a-ddbcaa01ea50" />


fixes https://github.com/getsentry/sentry/issues/75146