### PR TITLE
fix(toolbar): Strip the protocol from regionUrl to set cookies

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -102,7 +102,7 @@ Required context variables:
           'did-login': ({ cookie, token }) => {
             if (cookie) {
               document.cookie = getCookieValue(cookie, window.location.hostname);
-              document.cookie = getCookieValue(cookie, regionUrl);
+              document.cookie = getCookieValue(cookie, new URL(regionUrl).hostname);
               log('Saved a cookie', document.cookie.indexOf(cookie) >= 0);
             }
             if (token) {


### PR DESCRIPTION
Setting something like `https://us.sentry.io` as the cookie domain isn't right, it should be `us.sentry.io` only.