### PR TITLE
ref(feedback): remove spam detection logs - replaced by redash

### DIFF
--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -34,8 +34,8 @@ def make_input_prompt(message: str):
 
 @metrics.wraps("feedback.spam_detection", sample_rate=1.0)
 def is_spam(message: str):
-    is_spam = False
-    trimmed_response = ""
+    labeled_spam = False
+    _trimmed_response = ""
     response = complete_prompt(
         usecase=LLMUseCase.SPAM_DETECTION,
         message=make_input_prompt(message),
@@ -43,18 +43,9 @@ def is_spam(message: str):
         max_output_tokens=20,
     )
     if response:
-        is_spam, trimmed_response = trim_response(response)
+        labeled_spam, _trimmed_response = trim_response(response)
 
-    logger.info(
-        "Spam detection",
-        extra={
-            "feedback_message": message,
-            "is_spam": is_spam,
-            "response": response,
-            "trimmed_response": trimmed_response,
-        },
-    )
-    return is_spam
+    return labeled_spam
 
 
 def trim_response(text):


### PR DESCRIPTION
We're logging this on every feedback, from projects with spam detection enabled (enabled by default). Table at the bottom of https://redash.getsentry.net/dashboards/301-user-feedback-spam-activity?p_interval=2%20weeks can be used in place of this