### PR TITLE
fix(admin): extract correct parameter from invalidate project config call

### DIFF
--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -52,8 +52,7 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
 
     def post(self, request: Request) -> Response:
         """Regenerate the project config"""
-        project_id = request.GET.get("projectId")
-
+        project_id = request.data.get("projectId")
         if project_id is not None:
             try:
                 schedule_invalidate_project_config(

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -53,13 +53,16 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
     def post(self, request: Request) -> Response:
         """Regenerate the project config"""
         project_id = request.data.get("projectId")
-        if project_id is not None:
-            try:
-                schedule_invalidate_project_config(
-                    project_id=project_id, trigger="_admin_trigger_invalidate_project_config"
-                )
 
-            except Exception:
-                raise Http404
+        if not project_id:
+            return Response({"error": "Missing project id"}, status=400)
+
+        try:
+            schedule_invalidate_project_config(
+                project_id=project_id, trigger="_admin_trigger_invalidate_project_config"
+            )
+
+        except Exception:
+            raise Http404
 
         return Response(status=204)

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -141,10 +141,18 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         assert actual == expected
 
     def test_invalidate_project_config(self):
-        response = self.get_response(method="post", project_id=self.project.id)
+        data = {"projectId": self.project.id}
+        response = self.get_response(method="post", **data)
         assert response.status_code == 401
+
+        self.login_as(self.user, superuser=False)
+        response = self.get_response(method="post", **data)
+        assert response.status_code == 403
 
         self.login_as(self.superuser, superuser=True)
 
-        response = self.get_response(method="post", project_id=self.project.id)
+        response = self.get_response(method="post")
+        assert response.status_code == 400
+
+        response = self.get_response(method="post", **data)
         assert response.status_code == 204


### PR DESCRIPTION
- Fix that the post endpoint was expecting data in the query parameters
- Add additional tests
- Add correct response types based on type of wrong input

Contributes to https://github.com/getsentry/getsentry/issues/15912