### PR TITLE
feat(issue-details): Add current event to the graph on streamline UI

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -26,6 +26,7 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getBucketSize} from 'sentry/views/dashboards/widgetCard/utils';
+import {useCurrentEventMarklineSeries} from 'sentry/views/issueDetails/streamline/hooks/useEventMarkLineSeries';
 import useFlagSeries from 'sentry/views/issueDetails/streamline/hooks/useFlagSeries';
 import {
   useIssueDetailsDiscoverQuery,
@@ -72,7 +73,6 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     EventGraphSeries.EVENT
   );
   const eventView = useIssueDetailsEventView({group});
-
   const config = getConfigForIssueType(group, group.project);
 
   const {
@@ -161,6 +161,10 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     saveOnZoom: true,
   });
 
+  const currentEventSeries = useCurrentEventMarklineSeries({
+    event,
+    group,
+  });
   const releaseSeries = useReleaseMarkLineSeries({group});
   const flagSeries = useFlagSeries({
     query: {
@@ -228,6 +232,10 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
       });
     }
 
+    if (currentEventSeries.markLine) {
+      seriesData.push(currentEventSeries as BarChartSeries);
+    }
+
     if (releaseSeries.markLine) {
       seriesData.push(releaseSeries as BarChartSeries);
     }
@@ -241,6 +249,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     visibleSeries,
     userSeries,
     eventSeries,
+    currentEventSeries,
     releaseSeries,
     flagSeries,
     theme,

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -1,0 +1,119 @@
+import {useTheme} from '@emotion/react';
+import type {LineSeriesOption} from 'echarts';
+
+import MarkLine from 'sentry/components/charts/components/markLine';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {getFormattedDate} from 'sentry/utils/dates';
+import {getShortEventId} from 'sentry/utils/events';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
+
+export function useEventMarklineSeries({
+  events,
+  group,
+  markLineProps = {},
+}: {
+  events: Event[];
+  group: Group;
+  markLineProps?: Partial<LineSeriesOption['markLine']>;
+}) {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const eventView = useIssueDetailsEventView({group});
+  const baseEventsPath = `/organizations/${organization.slug}/issues/${group.id}/events/`;
+
+  const markLine = events.length
+    ? MarkLine({
+        animation: false,
+        lineStyle: {
+          color: theme.pink200,
+          type: 'solid',
+        },
+        label: {
+          show: false,
+        },
+        data: events.map(event => ({
+          xAxis: +new Date(event.dateCreated ?? event.dateReceived),
+          name: getShortEventId(event.id),
+          value: getShortEventId(event.id),
+          onClick: () => {
+            navigate({
+              pathname: `${baseEventsPath}${event.id}/`,
+            });
+          },
+          label: {
+            formatter: () => getShortEventId(event.id),
+          },
+        })),
+        tooltip: {
+          trigger: 'item',
+          formatter: ({data}: any) => {
+            const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
+              local: !eventView.utc,
+            });
+            return [
+              '<div class="tooltip-series">',
+              `<div><span class="tooltip-label"><strong>${data.name}</strong></span></div>`,
+              '</div>',
+              `<div class="tooltip-footer">${time}</div>`,
+              '<div class="tooltip-arrow"></div>',
+            ].join('');
+          },
+        },
+        ...markLineProps,
+      })
+    : undefined;
+
+  return {
+    seriesName: t('Specific Events'),
+    data: [],
+    markLine,
+    color: theme.pink200,
+    type: 'line',
+  };
+}
+
+export function useCurrentEventMarklineSeries({
+  event,
+  group,
+  markLineProps = {},
+}: {
+  group: Group;
+  event?: Event;
+  markLineProps?: Partial<LineSeriesOption['markLine']>;
+}) {
+  const eventView = useIssueDetailsEventView({group});
+
+  const result = useEventMarklineSeries({
+    events: event ? [event] : [],
+    group,
+    markLineProps: {
+      tooltip: {
+        trigger: 'item',
+        formatter: ({data}: any) => {
+          const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
+            local: !eventView.utc,
+          });
+          return [
+            '<div class="tooltip-series">',
+            `<div><span class="tooltip-label"><strong>${t(
+              'Current Event'
+            )}</strong></span></div>`,
+            '</div>',
+            `<div class="tooltip-footer">${time}</div>`,
+            '<div class="tooltip-arrow"></div>',
+          ].join('');
+        },
+      },
+      ...markLineProps,
+    },
+  });
+  return {
+    ...result,
+    seriesName: t('Current Event'),
+  };
+}


### PR DESCRIPTION
Adding a series to the streamline graph for the current event. I made the hook a bit more reusable than necessary in case we ever want to show a subset of events labeled on the graphs for whatever reason.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/520773d9-495f-45de-973b-a76874e4e6e0" />

<img width="195" alt="image" src="https://github.com/user-attachments/assets/08722e8a-b1ee-4546-ad68-2fc781b7546c" />
