### PR TITLE
ref: remove requires_not_arm64

### DIFF
--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -12,15 +12,6 @@ from django.conf import settings
 T = TypeVar("T", bound=Callable[..., Any])
 
 
-def is_arm64() -> bool:
-    return os.uname().machine == "arm64"
-
-
-requires_not_arm64 = pytest.mark.skipif(
-    is_arm64(), reason="this test fails in our arm64 testing env"
-)
-
-
 def xfail_if_not_postgres(reason: str) -> Callable[[T], T]:
     def decorator(function: T) -> T:
         return pytest.mark.xfail(os.environ.get("TEST_SUITE") != "postgres", reason=reason)(

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -38,7 +38,6 @@ from sentry.testutils.cases import (
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.discover import user_misery_formula
-from sentry.testutils.skips import requires_not_arm64
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
 from sentry.utils.samples import load_data
@@ -3373,7 +3372,6 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert data[0]["linear_regression(transaction.duration, transaction.duration)"] == [0, 0]
         assert data[0]["sum(transaction.duration)"] == 10000
 
-    @requires_not_arm64
     def test_null_user_misery_returns_zero(self):
         self.transaction_data["user"] = None
         self.transaction_data["transaction"] = "/no_users/1"
@@ -3393,7 +3391,6 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
             data = response.data["data"]
             assert data[0]["user_misery(300)"] == 0
 
-    @requires_not_arm64
     def test_null_user_misery_new_returns_zero(self):
         self.transaction_data["user"] = None
         self.transaction_data["transaction"] = "/no_users/1"


### PR DESCRIPTION
these tests pass now on arm64 -- presumably because we no longer have version drift for clickhouse

<!-- Describe your PR here. -->