### PR TITLE
feat(dashboards): Return `meta` with `useDiscoverSeries` results

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
@@ -196,6 +196,14 @@ describe('useSpanMetricsSeries', () => {
           [1699907700, [{count: 7810.2}]],
           [1699908000, [{count: 1216.8}]],
         ],
+        meta: {
+          fields: {
+            'spm()': 'rate',
+          },
+          units: {
+            'spm()': '1/minute',
+          },
+        },
       },
     });
 
@@ -217,6 +225,14 @@ describe('useSpanMetricsSeries', () => {
           {name: '2023-11-13T20:35:00+00:00', value: 7810.2},
           {name: '2023-11-13T20:40:00+00:00', value: 1216.8},
         ],
+        meta: {
+          fields: {
+            'spm()': 'rate',
+          },
+          units: {
+            'spm()': '1/minute',
+          },
+        },
         seriesName: 'spm()',
       },
     });
@@ -232,12 +248,28 @@ describe('useSpanMetricsSeries', () => {
             [1699907700, [{count: 10.1}]],
             [1699908000, [{count: 11.2}]],
           ],
+          meta: {
+            fields: {
+              'http_response_rate(3)': 'rate',
+            },
+            units: {
+              'http_response_rate(3)': '1/minute',
+            },
+          },
         },
         'http_response_rate(4)': {
           data: [
             [1699907700, [{count: 12.6}]],
             [1699908000, [{count: 13.8}]],
           ],
+          meta: {
+            fields: {
+              'http_response_rate(4)': 'rate',
+            },
+            units: {
+              'http_response_rate(4)': '1/minute',
+            },
+          },
         },
       },
     });
@@ -263,6 +295,14 @@ describe('useSpanMetricsSeries', () => {
           {name: '2023-11-13T20:35:00+00:00', value: 10.1},
           {name: '2023-11-13T20:40:00+00:00', value: 11.2},
         ],
+        meta: {
+          fields: {
+            'http_response_rate(3)': 'rate',
+          },
+          units: {
+            'http_response_rate(3)': '1/minute',
+          },
+        },
         seriesName: 'http_response_rate(3)',
       },
       'http_response_rate(4)': {
@@ -270,6 +310,50 @@ describe('useSpanMetricsSeries', () => {
           {name: '2023-11-13T20:35:00+00:00', value: 12.6},
           {name: '2023-11-13T20:40:00+00:00', value: 13.8},
         ],
+        meta: {
+          fields: {
+            'http_response_rate(4)': 'rate',
+          },
+          units: {
+            'http_response_rate(4)': '1/minute',
+          },
+        },
+        seriesName: 'http_response_rate(4)',
+      },
+    });
+  });
+
+  it('returns a series for all requested yAxis even without data', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result} = renderHook(
+      ({yAxis}) => useSpanMetricsSeries({yAxis}, 'span-metrics-series'),
+      {
+        wrapper: Wrapper,
+        initialProps: {
+          yAxis: [
+            'http_response_rate(3)',
+            'http_response_rate(4)',
+          ] as SpanMetricsProperty[],
+        },
+      }
+    );
+
+    await waitFor(() => expect(result.current.isPending).toEqual(false));
+
+    expect(result.current.data).toEqual({
+      'http_response_rate(3)': {
+        data: [],
+        meta: undefined,
+        seriesName: 'http_response_rate(3)',
+      },
+      'http_response_rate(4)': {
+        data: [],
+        meta: undefined,
         seriesName: 'http_response_rate(4)',
       },
     });

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -1,11 +1,21 @@
-import keyBy from 'lodash/keyBy';
+import moment from 'moment-timezone';
 
 import type {Series} from 'sentry/types/echarts';
+import {encodeSort, type EventsMetaType} from 'sentry/utils/discover/eventView';
+import {
+  type DiscoverQueryProps,
+  useGenericDiscoverQuery,
+} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSeriesEventView} from 'sentry/views/insights/common/queries/getSeriesEventView';
-import {useWrappedDiscoverTimeseriesQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {
+  getRetryDelay,
+  shouldRetryHandler,
+} from 'sentry/views/insights/common/utils/retryHandlers';
 import type {
   MetricsProperty,
   SpanFunctions,
@@ -13,10 +23,16 @@ import type {
   SpanMetricsProperty,
 } from 'sentry/views/insights/types';
 
+import {DATE_FORMAT} from './useSpansQuery';
+
 export interface MetricTimeseriesRow {
   [key: string]: number;
   interval: number;
 }
+
+type DiscoverSeries = Series & {
+  meta?: EventsMetaType;
+};
 
 interface UseMetricsSeriesOptions<Fields> {
   enabled?: boolean;
@@ -66,6 +82,8 @@ const useDiscoverSeries = <T extends string[]>(
   const {search = undefined, yAxis = [], interval = undefined} = options;
 
   const pageFilters = usePageFilters();
+  const location = useLocation();
+  const organization = useOrganization();
 
   const eventView = getSeriesEventView(
     search,
@@ -80,28 +98,57 @@ const useDiscoverSeries = <T extends string[]>(
     eventView.interval = interval;
   }
 
-  const result = useWrappedDiscoverTimeseriesQuery<MetricTimeseriesRow[]>({
+  const result = useGenericDiscoverQuery<
+    {
+      data: any[];
+      meta: EventsMetaType;
+    },
+    DiscoverQueryProps
+  >({
+    route: 'events-stats',
     eventView,
-    initialData: [],
+    location,
+    orgSlug: organization.slug,
+    getRequestPayload: () => ({
+      ...eventView.getEventsAPIPayload(location),
+      yAxis: eventView.yAxis,
+      topEvents: eventView.topEvents,
+      excludeOther: 0,
+      partial: 1,
+      orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
+      interval: eventView.interval,
+    }),
+    options: {
+      enabled: options.enabled && pageFilters.isReady,
+      refetchOnWindowFocus: false,
+      retry: shouldRetryHandler,
+      retryDelay: getRetryDelay,
+      staleTime: Infinity,
+    },
     referrer,
-    enabled: options.enabled,
-    overriddenRoute: options.overriddenRoute,
   });
 
-  const parsedData = keyBy(
-    yAxis.map(seriesName => {
-      const series: Series = {
-        seriesName,
-        data: (result?.data ?? []).map(datum => ({
-          value: datum[seriesName],
-          name: datum?.interval,
-        })),
-      };
+  const parsedData: Record<string, DiscoverSeries> = {};
 
-      return series;
-    }),
-    'seriesName'
-  ) as Record<T[number], Series>;
+  yAxis.forEach(seriesName => {
+    const dataSeries = result.data?.[seriesName] ?? result?.data ?? {};
+    const convertedSeries: DiscoverSeries = {
+      seriesName,
+      data: convertDiscoverTimeseriesResponse(dataSeries?.data ?? []),
+      meta: dataSeries?.meta,
+    };
 
-  return {...result, data: parsedData};
+    parsedData[seriesName] = convertedSeries;
+  });
+
+  return {...result, data: parsedData as Record<T[number], DiscoverSeries>};
 };
+
+function convertDiscoverTimeseriesResponse(data: any[]): DiscoverSeries['data'] {
+  return data.map(([timestamp, [{count: value}]]) => {
+    return {
+      name: moment(parseInt(timestamp, 10) * 1000).format(DATE_FORMAT),
+      value,
+    };
+  });
+}


### PR DESCRIPTION
Right now, if you use `useDiscoverSeries` but you request multiple series (e.g., a Top N query, or multiple YAxis) you cannot get the series meta back, there's simply nowhere for it to go!

The reason is that `useWrappedDiscoverTimeseriesQuery` drops the meta, and returns just the actual data. After looking at it for a while, I decided to skip `useWrappedDiscoverTimeseriesQuery` and use `useGenericDiscoverQuery` instead.

This approach skips all the wacky processing that's leftover from the Starfish days, and cleanly re-formats and returns the data! As a benefit, this also preserves the `meta` so that it can be passed to generic Dashboard widgets for rendering.
