### PR TITLE
feat(widget-builder): Support aggregates with multiple args

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -367,6 +367,44 @@ describe('Visualize', () => {
       'spans.db'
     );
   });
+
+  it('properly transitions between aggregates of higher to no parameter count', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['count_if(transaction.duration,equals,testValue)'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'count'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'None'
+    );
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'count'
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          field: ['count()'],
+        }),
+      })
+    );
+  });
+
   it('properly transitions between aggregates of higher to lower parameter count', async () => {
     render(
       <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -6,6 +6,7 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 
 import type {TagCollection} from 'sentry/types/group';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import Visualize from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
@@ -13,9 +14,11 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
+jest.mock('sentry/utils/useNavigate');
 
 describe('Visualize', () => {
   let organization;
+  let mockNavigate;
 
   beforeEach(() => {
     organization = OrganizationFixture({
@@ -27,6 +30,9 @@ describe('Visualize', () => {
     });
 
     jest.mocked(useSpanTags).mockReturnValue({});
+
+    mockNavigate = jest.fn();
+    jest.mocked(useNavigate).mockReturnValue(mockNavigate);
   });
 
   it('renders basic aggregates correctly from the URL params', async () => {
@@ -306,6 +312,157 @@ describe('Visualize', () => {
     await userEvent.type(screen.getByLabelText('Equation'), '* 2');
 
     expect(screen.getByLabelText('Equation')).toHaveValue('count() * 2');
+  });
+
+  it('maintains the selected column when switching from field to aggregate', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              yAxis: ['transaction.duration'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'p95'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'transaction.duration'
+    );
+  });
+
+  it('maintains the selected column when switching from aggregate to aggregate', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['max(spans.db)'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'p95'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'spans.db'
+    );
+  });
+  it('properly transitions between aggregates of higher to lower parameter count', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['count_if(transaction.duration,equals,testValue)'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'count_miserable'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'transaction.duration'
+    );
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'count_miserable'
+    );
+    expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          field: ['count_miserable(transaction.duration,300)'],
+        }),
+      })
+    );
+  });
+
+  it('adds the default value for an aggregate with 2 parameters', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['transaction.duration'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'count_miserable'}));
+
+    // TODO: This is supposed to only allow the user field
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'transaction.duration'
+    );
+  });
+
+  it('adds the default values for an aggregate with 3 parameters', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['transaction'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'count_if'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'transaction'
+    );
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'count_if'
+    );
+    expect(screen.getByText('is equal to')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('300')).toBeInTheDocument();
   });
 
   describe('spans', () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -4,6 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import SelectControl from 'sentry/components/forms/controls/selectControl';
 import Input from 'sentry/components/input';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -14,6 +15,7 @@ import {
   generateFieldAsString,
   parseFunction,
   prettifyTagKey,
+  type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -24,9 +26,21 @@ import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/co
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
+import {
+  BufferedInput,
+  type ParameterDescription,
+} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
+type AggregateFunction = [
+  AggregationKeyWithAlias,
+  string,
+  AggregationRefinement,
+  AggregationRefinement,
+];
+
+const MAX_FUNCTION_PARAMETERS = 4;
 const NONE = 'none';
 
 const NONE_AGGREGATE = {
@@ -125,6 +139,11 @@ function Visualize() {
             );
           }
 
+          const parameterRefinements =
+            matchingAggregate?.value.meta.parameters.length > 1
+              ? matchingAggregate?.value.meta.parameters.slice(1)
+              : [];
+
           return (
             <FieldRow key={index}>
               <FieldBar data-testid={'field-bar'}>
@@ -149,119 +168,183 @@ function Visualize() {
                   />
                 ) : (
                   <Fragment>
-                    <ColumnCompactSelect
-                      searchable
-                      options={columnOptions}
-                      value={
-                        field.kind === FieldValueKind.FUNCTION
-                          ? parseFunction(stringFields?.[index] ?? '')?.arguments[0] ?? ''
-                          : field.field
-                      }
-                      onChange={newField => {
-                        // Update the current field's aggregate with the new aggregate
-                        if (field.kind === FieldValueKind.FUNCTION) {
-                          field.function[1] = newField.value as string;
+                    <PrimarySelectRow>
+                      <ColumnCompactSelect
+                        searchable
+                        options={columnOptions}
+                        value={
+                          field.kind === FieldValueKind.FUNCTION
+                            ? parseFunction(stringFields?.[index] ?? '')?.arguments[0] ??
+                              ''
+                            : field.field
                         }
-                        if (field.kind === FieldValueKind.FIELD) {
-                          field.field = newField.value as string;
+                        onChange={newField => {
+                          // Update the current field's aggregate with the new aggregate
+                          if (field.kind === FieldValueKind.FUNCTION) {
+                            field.function[1] = newField.value as string;
+                          }
+                          if (field.kind === FieldValueKind.FIELD) {
+                            field.field = newField.value as string;
+                          }
+                          dispatch({
+                            type: updateAction,
+                            payload: fields,
+                          });
+                        }}
+                        triggerProps={{
+                          'aria-label': t('Column Selection'),
+                        }}
+                        disabled={
+                          fields[index].kind === FieldValueKind.FUNCTION &&
+                          matchingAggregate?.value.meta.parameters.length === 0
                         }
-                        dispatch({
-                          type: updateAction,
-                          payload: fields,
-                        });
-                      }}
-                      triggerProps={{
-                        'aria-label': t('Column Selection'),
-                      }}
-                      disabled={
-                        fields[index].kind === FieldValueKind.FUNCTION &&
-                        matchingAggregate?.value.meta.parameters.length === 0
-                      }
-                    />
-                    {/* TODO: Handle aggregates with multiple parameters */}
-                    <AggregateCompactSelect
-                      options={
-                        isChartWidget
-                          ? aggregateOptions
-                          : [NONE_AGGREGATE, ...aggregateOptions]
-                      }
-                      value={parseFunction(stringFields?.[index] ?? '')?.name ?? ''}
-                      onChange={aggregateSelection => {
-                        const isNone = aggregateSelection.value === NONE;
-                        const newFields = cloneDeep(fields);
-                        const currentField = newFields[index];
-                        // Update the current field's aggregate with the new aggregate
-                        if (!isNone) {
+                      />
+                      <AggregateCompactSelect
+                        options={
+                          isChartWidget
+                            ? aggregateOptions
+                            : [NONE_AGGREGATE, ...aggregateOptions]
+                        }
+                        value={parseFunction(stringFields?.[index] ?? '')?.name ?? ''}
+                        onChange={aggregateSelection => {
+                          const isNone = aggregateSelection.value === NONE;
+                          const newFields = cloneDeep(fields);
+                          const currentField = newFields[index];
                           const newAggregate = aggregates.find(
                             option => option.value.meta.name === aggregateSelection.value
                           );
-                          if (currentField.kind === FieldValueKind.FUNCTION) {
-                            // Handle setting an aggregate from an aggregate
-                            currentField.function[0] =
-                              aggregateSelection.value as AggregationKeyWithAlias;
-                            if (
-                              newAggregate?.value.meta &&
-                              'parameters' in newAggregate.value.meta
-                            ) {
-                              // There are aggregates that have no parameters, so wipe out the argument
-                              // if it's supposed to be empty
-                              if (newAggregate.value.meta.parameters.length === 0) {
-                                currentField.function[1] = '';
-                              } else {
-                                currentField.function[1] =
-                                  (currentField.function[1] ||
-                                    newAggregate.value.meta.parameters[0].defaultValue) ??
-                                  '';
+                          // Update the current field's aggregate with the new aggregate
+                          if (!isNone) {
+                            if (currentField.kind === FieldValueKind.FUNCTION) {
+                              // Handle setting an aggregate from an aggregate
+                              currentField.function[0] =
+                                aggregateSelection.value as AggregationKeyWithAlias;
+                              if (
+                                newAggregate?.value.meta &&
+                                'parameters' in newAggregate.value.meta
+                              ) {
+                                // There are aggregates that have no parameters, so wipe out the argument
+                                // if it's supposed to be empty
+                                if (newAggregate.value.meta.parameters.length === 0) {
+                                  currentField.function[1] = '';
+                                } else {
+                                  currentField.function[1] =
+                                    (currentField.function[1] ||
+                                      newAggregate.value.meta.parameters[0]
+                                        .defaultValue) ??
+                                    '';
+                                  // Set the remaining parameters for the new aggregate
+                                  for (
+                                    let i = 1; // The first parameter is the column selection
+                                    i < newAggregate.value.meta.parameters.length;
+                                    i++
+                                  ) {
+                                    // Increment by 1 to skip past the aggregate name
+                                    currentField.function[i + 1] =
+                                      newAggregate.value.meta.parameters[i].defaultValue;
+                                  }
+
+                                  // Wipe out the remaining parameters that are unnecessary
+                                  // This is necessary for transitioning between aggregates that have
+                                  // more parameters to ones of fewer parameters
+                                  for (
+                                    let i = newAggregate.value.meta.parameters.length;
+                                    i < MAX_FUNCTION_PARAMETERS;
+                                    i++
+                                  ) {
+                                    currentField.function[i + 1] = undefined;
+                                  }
+                                }
                               }
+                            } else {
+                              if (
+                                !newAggregate ||
+                                !('parameters' in newAggregate.value.meta)
+                              ) {
+                                return;
+                              }
+
+                              // Handle setting an aggregate from a field
+                              const newFunction: AggregateFunction = [
+                                aggregateSelection.value as AggregationKeyWithAlias,
+                                (currentField.field ||
+                                  newAggregate?.value.meta?.parameters?.[0]
+                                    ?.defaultValue) ??
+                                  '',
+                                newAggregate?.value.meta?.parameters?.[1]?.defaultValue ??
+                                  undefined,
+                                newAggregate?.value.meta?.parameters?.[2]?.defaultValue ??
+                                  undefined,
+                              ];
+                              if (
+                                newAggregate?.value.meta &&
+                                'parameters' in newAggregate.value.meta
+                              ) {
+                                newAggregate?.value.meta.parameters.forEach(
+                                  (parameter, parameterIndex) => {
+                                    // Increment by 1 to skip past the aggregate name
+                                    newFunction[parameterIndex + 1] =
+                                      newFunction[parameterIndex + 1] ??
+                                      parameter.defaultValue;
+                                  }
+                                );
+                              }
+                              newFields[index] = {
+                                kind: FieldValueKind.FUNCTION,
+                                function: newFunction,
+                              };
                             }
                           } else {
-                            // Handle setting a field from an aggregate
-                            const newFunction: [
-                              AggregationKeyWithAlias,
-                              string,
-                              AggregationRefinement,
-                              AggregationRefinement,
-                            ] = ['', '', undefined, undefined];
-                            newFunction[0] =
-                              aggregateSelection.value as AggregationKeyWithAlias;
-                            if (
-                              newAggregate?.value.meta &&
-                              'parameters' in newAggregate.value.meta
-                            ) {
-                              newAggregate?.value.meta.parameters.forEach(
-                                (parameter, parameterIndex) => {
-                                  // Increment by 1 to skip past the aggregate name
-                                  newFunction[parameterIndex + 1] =
-                                    parameter.defaultValue;
-                                }
-                              );
-                            }
+                            // Handle selecting None so we can select just a field, e.g. for samples
+                            // If none is selected, set the field to a field value
                             newFields[index] = {
-                              kind: FieldValueKind.FUNCTION,
-                              function: newFunction,
+                              kind: FieldValueKind.FIELD,
+                              field:
+                                'function' in currentField
+                                  ? (currentField.function[1] as string) ??
+                                    columnOptions[0].value
+                                  : '',
                             };
                           }
-                        }
-                        if (isNone) {
-                          // Handle selecting None so we can select just a field, e.g. for samples
-                          // If none is selected, set the field to a field value
-                          newFields[index] = {
-                            kind: FieldValueKind.FIELD,
-                            field:
-                              'function' in currentField
-                                ? currentField?.function[1] ?? columnOptions[0].value
-                                : '',
-                          };
-                        }
-                        dispatch({
-                          type: updateAction,
-                          payload: newFields,
-                        });
-                      }}
-                      triggerProps={{
-                        'aria-label': t('Aggregate Selection'),
-                      }}
-                    />
+                          dispatch({
+                            type: updateAction,
+                            payload: newFields,
+                          });
+                        }}
+                        triggerProps={{
+                          'aria-label': t('Aggregate Selection'),
+                        }}
+                      />
+                    </PrimarySelectRow>
+                    {parameterRefinements.length > 0 && (
+                      <AggregateRefinements>
+                        {parameterRefinements.map((parameter, parameterIndex) => (
+                          <AggregateParameter
+                            key={`${parameter.name}-${parameterIndex}`} // TODO: This shouldn't use index
+                            parameter={parameter}
+                            fieldValue={field}
+                            // The current value is displaced by 2 because the first two parameters
+                            // are the aggregate name and the column selection
+                            currentValue={
+                              ('function' in field &&
+                                field.function[parameterIndex + 2]) ||
+                              ''
+                            }
+                            onChange={value => {
+                              const newFields = cloneDeep(fields);
+                              if (newFields[index].kind !== FieldValueKind.FUNCTION) {
+                                return;
+                              }
+                              newFields[index].function[parameterIndex + 2] = value;
+                              dispatch({
+                                type: updateAction,
+                                payload: newFields,
+                              });
+                            }}
+                          />
+                        ))}
+                      </AggregateRefinements>
+                    )}
                   </Fragment>
                 )}
               </FieldBar>
@@ -332,6 +415,80 @@ function Visualize() {
 
 export default Visualize;
 
+function AggregateParameter({
+  parameter,
+  fieldValue,
+  onChange,
+  currentValue,
+}: {
+  currentValue: string;
+  fieldValue: QueryFieldValue;
+  onChange: (value: string) => void;
+  parameter: ParameterDescription;
+}) {
+  if (parameter.kind === 'value') {
+    const inputProps = {
+      required: parameter.required,
+      value:
+        parameter.value ?? ('defaultValue' in parameter && parameter?.defaultValue) ?? '',
+      onUpdate: value => {
+        onChange(value);
+      },
+      placeholder: parameter.placeholder,
+    };
+    switch (parameter.dataType) {
+      case 'number':
+        return (
+          <BufferedInput
+            name="refinement"
+            key="parameter:number"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*(\.[0-9]*)?"
+            {...inputProps}
+          />
+        );
+      case 'integer':
+        return (
+          <BufferedInput
+            name="refinement"
+            key="parameter:integer"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            {...inputProps}
+          />
+        );
+      default:
+        return (
+          <BufferedInput
+            name="refinement"
+            key="parameter:text"
+            type="text"
+            {...inputProps}
+          />
+        );
+    }
+  }
+  if (parameter.kind === 'dropdown') {
+    return (
+      <SelectControl
+        key="dropdown"
+        name="dropdown"
+        menuPlacement="auto"
+        placeholder={t('Select value')}
+        options={parameter.options}
+        value={currentValue}
+        required={parameter.required}
+        onChange={({value}) => {
+          onChange(value);
+        }}
+      />
+    );
+  }
+  throw new Error(`Unknown parameter type encountered for ${fieldValue}`);
+}
+
 const ColumnCompactSelect = styled(CompactSelect)`
   flex: 1 1 auto;
   min-width: 0;
@@ -353,8 +510,26 @@ const AggregateCompactSelect = styled(CompactSelect)`
 
 const LegendAliasInput = styled(Input)``;
 
-const FieldBar = styled('div')`
+const AggregateRefinements = styled('div')`
   display: flex;
+  flex-direction: row;
+  gap: ${space(1)};
+
+  > * {
+    flex: 1;
+  }
+`;
+
+const FieldBar = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: ${space(1)};
+  flex: 3;
+`;
+
+const PrimarySelectRow = styled('div')`
+  display: flex;
+  width: 100%;
   flex: 3;
 
   & > ${ColumnCompactSelect} > button {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -316,35 +316,36 @@ function Visualize() {
                         }}
                       />
                     </PrimarySelectRow>
-                    {parameterRefinements.length > 0 && (
-                      <AggregateRefinements>
-                        {parameterRefinements.map((parameter, parameterIndex) => (
-                          <AggregateParameter
-                            key={`${parameter.name}-${parameterIndex}`} // TODO: This shouldn't use index
-                            parameter={parameter}
-                            fieldValue={field}
+                    {field.kind === FieldValueKind.FUNCTION &&
+                      parameterRefinements.length > 0 && (
+                        <ParameterRefinements>
+                          {parameterRefinements.map((parameter, parameterIndex) => {
                             // The current value is displaced by 2 because the first two parameters
                             // are the aggregate name and the column selection
-                            currentValue={
-                              ('function' in field &&
-                                field.function[parameterIndex + 2]) ||
-                              ''
-                            }
-                            onChange={value => {
-                              const newFields = cloneDeep(fields);
-                              if (newFields[index].kind !== FieldValueKind.FUNCTION) {
-                                return;
-                              }
-                              newFields[index].function[parameterIndex + 2] = value;
-                              dispatch({
-                                type: updateAction,
-                                payload: newFields,
-                              });
-                            }}
-                          />
-                        ))}
-                      </AggregateRefinements>
-                    )}
+                            const currentValue = field.function[parameterIndex + 2] || '';
+                            const key = `${field.function.join('_')}-${parameterIndex}`;
+                            return (
+                              <AggregateParameter
+                                key={key}
+                                parameter={parameter}
+                                fieldValue={field}
+                                currentValue={currentValue}
+                                onChange={value => {
+                                  const newFields = cloneDeep(fields);
+                                  if (newFields[index].kind !== FieldValueKind.FUNCTION) {
+                                    return;
+                                  }
+                                  newFields[index].function[parameterIndex + 2] = value;
+                                  dispatch({
+                                    type: updateAction,
+                                    payload: newFields,
+                                  });
+                                }}
+                              />
+                            );
+                          })}
+                        </ParameterRefinements>
+                      )}
                   </Fragment>
                 )}
               </FieldBar>
@@ -510,7 +511,7 @@ const AggregateCompactSelect = styled(CompactSelect)`
 
 const LegendAliasInput = styled(Input)``;
 
-const AggregateRefinements = styled('div')`
+const ParameterRefinements = styled('div')`
   display: flex;
   flex-direction: row;
   gap: ${space(1)};

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -243,17 +243,17 @@ function Visualize() {
                                     currentField.function[i + 1] =
                                       newAggregate.value.meta.parameters[i].defaultValue;
                                   }
+                                }
 
-                                  // Wipe out the remaining parameters that are unnecessary
-                                  // This is necessary for transitioning between aggregates that have
-                                  // more parameters to ones of fewer parameters
-                                  for (
-                                    let i = newAggregate.value.meta.parameters.length;
-                                    i < MAX_FUNCTION_PARAMETERS;
-                                    i++
-                                  ) {
-                                    currentField.function[i + 1] = undefined;
-                                  }
+                                // Wipe out the remaining parameters that are unnecessary
+                                // This is necessary for transitioning between aggregates that have
+                                // more parameters to ones of fewer parameters
+                                for (
+                                  let i = newAggregate.value.meta.parameters.length;
+                                  i < MAX_FUNCTION_PARAMETERS;
+                                  i++
+                                ) {
+                                  currentField.function[i + 1] = undefined;
                                 }
                               }
                             } else {

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -36,7 +36,7 @@ type FieldOptions = Record<string, FieldValueOption>;
 
 // Intermediate type that combines the current column
 // data with the AggregateParameter type.
-type ParameterDescription =
+export type ParameterDescription =
   | {
       dataType: ColumnType;
       kind: 'value';
@@ -739,7 +739,7 @@ type InputState = {value: string};
  * Using a buffered input lets us throttle rendering and enforce data
  * constraints better.
  */
-class BufferedInput extends Component<BufferedInputProps, InputState> {
+export class BufferedInput extends Component<BufferedInputProps, InputState> {
   constructor(props: BufferedInputProps) {
     super(props);
     this.input = createRef();


### PR DESCRIPTION
This looks like a lot of changes, but it's some copy + paste and some whitespace changes due to new styling so I suggest turning off whitespace when viewing the diff.

Adds support for aggregates with more arguments than just the column. e.g. count_miserable takes a column and a text value that represents a threshold, or count_if takes a column (from the column selector), an operation (equal, greater than, etc) and a text value for that condition.

This adds support for those fields and the extra field always renders below the main column and aggregate selector. This accounts for updates where you go from field -> aggregate with any # of parameters, and between aggregates of different #s of parameters (e.g. count_if to count_miserable goes from 3 to 2, the other way goes from 2 to 3 and should get the proper defaults in both cases)