### PR TITLE
chore(aci milestone 3): move aggregation value helpers to incidents directory

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -43,6 +43,10 @@ from sentry.incidents.models.incident import (
 )
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.incidents.utils.metric_issue_poc import create_or_update_metric_issue
+from sentry.incidents.utils.process_update_helpers import (
+    get_aggregation_value_helper,
+    get_crash_rate_alert_metrics_aggregation_value_helper,
+)
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.models.project import Project
 from sentry.search.eap.utils import add_start_end_conditions
@@ -58,10 +62,6 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.snuba.subscriptions import delete_snuba_subscription
 from sentry.utils import metrics, redis, snuba_rpc
 from sentry.utils.dates import to_datetime
-from sentry.workflow_engine.process_update_helpers import (
-    get_aggregation_value_helper,
-    get_crash_rate_alert_metrics_aggregation_value_helper,
-)
 
 logger = logging.getLogger(__name__)
 REDIS_TTL = int(timedelta(days=7).total_seconds())

--- a/src/sentry/incidents/utils/process_update_helpers.py
+++ b/src/sentry/incidents/utils/process_update_helpers.py
@@ -1,6 +1,11 @@
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.utils import metrics
 
+"""
+We pull these methods out of the subscription processor to be used by the
+workflow engine data condition handlers.
+"""
+
 # NOTE (mifu67): this is set to None in the subscription processor code and doesn't
 # seem to be used. Maybe we don't need the logic gated by it?
 CRASH_RATE_ALERT_MINIMUM_THRESHOLD: int | None = None

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -3418,7 +3418,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         )
         self.assert_active_incident(rule)
 
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_crash_rate_alert_for_sessions_with_no_sessions_data(self, helper_metrics):
         """
         Test that ensures we skip the Crash Rate Alert processing if we have no sessions data
@@ -3441,8 +3441,8 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
             ]
         )
 
-    @patch("sentry.workflow_engine.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_crash_rate_alert_when_session_count_is_lower_than_minimum_threshold(
         self, helper_metrics
     ):
@@ -3470,7 +3470,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
             ]
         )
 
-    @patch("sentry.workflow_engine.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
     def test_crash_rate_alert_when_session_count_is_higher_than_minimum_threshold(self):
         rule = self.crash_rate_alert_rule
         trigger = self.crash_rate_alert_critical_trigger
@@ -3489,7 +3489,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         self.assert_actions_fired_for_incident(incident, [action_critical], None)
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
 
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_multiple_threshold_trigger_is_reset_when_no_sessions_data(self, helper_metrics):
         rule = self.crash_rate_alert_rule
         rule.update(threshold_period=2)
@@ -3528,8 +3528,8 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         )
         self.assert_trigger_counts(processor, trigger, 0, 0)
 
-    @patch("sentry.workflow_engine.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_multiple_threshold_trigger_is_reset_when_count_is_lower_than_min_threshold(
         self, helper_metrics
     ):
@@ -3571,7 +3571,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         )
         self.assert_trigger_counts(processor, trigger, 0, 0)
 
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_multiple_threshold_resolve_is_reset_when_no_sessions_data(self, helper_metrics):
         rule = self.crash_rate_alert_rule
         trigger = self.crash_rate_alert_critical_trigger
@@ -3630,8 +3630,8 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
         self.assert_action_handler_called_with_actions(incident, [])
 
-    @patch("sentry.workflow_engine.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_multiple_threshold_resolve_is_reset_when_count_is_lower_than_min_threshold(
         self, helper_metrics
     ):
@@ -3690,7 +3690,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
         self.assert_action_handler_called_with_actions(incident, [])
 
-    @patch("sentry.workflow_engine.process_update_helpers.metrics")
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_ensure_case_when_no_metrics_index_not_found_is_handled_gracefully(
         self, helper_metrics
     ):


### PR DESCRIPTION
Move the helper methods out of the workflow engine directory so that we can keep everything clean.