### PR TITLE
:sparkles: feat(discord): add button to redirect for user linking

### DIFF
--- a/src/sentry/integrations/discord/views/link_identity.py
+++ b/src/sentry/integrations/discord/views/link_identity.py
@@ -26,6 +26,10 @@ class DiscordLinkIdentityView(DiscordIdentityLinkageView, LinkIdentityView):
     def get_success_template_and_context(
         self, params: Mapping[str, Any], integration: Integration | None
     ) -> tuple[str, dict[str, Any]]:
+        if integration is None:
+            raise ValueError(
+                'integration is required for linking (params must include "integration_id")'
+            )
         return "sentry/integrations/discord/linked.html", {
             "guild_id": integration.external_id,
         }

--- a/src/sentry/integrations/discord/views/link_identity.py
+++ b/src/sentry/integrations/discord/views/link_identity.py
@@ -26,7 +26,9 @@ class DiscordLinkIdentityView(DiscordIdentityLinkageView, LinkIdentityView):
     def get_success_template_and_context(
         self, params: Mapping[str, Any], integration: Integration | None
     ) -> tuple[str, dict[str, Any]]:
-        return "sentry/integrations/discord/linked.html", {}
+        return "sentry/integrations/discord/linked.html", {
+            "guild_id": integration.external_id,
+        }
 
     @property
     def analytics_operation_key(self) -> str | None:

--- a/src/sentry/templates/sentry/integrations/discord/linked.html
+++ b/src/sentry/templates/sentry/integrations/discord/linked.html
@@ -1,14 +1,16 @@
 {% extends "sentry/bases/modal.html" %}
-
 {% load i18n %}
-
 {% block title %}{% trans "Discord Linked" %} | {{ block.super }}{% endblock %}
 {% block wrapperclass %}narrow auth{% endblock %}
-
 {% block main %}
   <div class="align-center">
     <p>
       {% trans "Your Discord account has been associated with your Sentry account. You may now take Sentry actions through Discord." %}
+    </p>
+    <p>
+      <a href="discord://discord.com/channels/{{ guild_id }}" class="btn btn-default btn-login-discord">
+        <span class="provider-logo discord"></span> Go back to Discord
+      </a>
     </p>
   </div>
 {% endblock %}

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -255,7 +255,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
         <LinkButton
           aria-label={t('Open this server in the Discord app')}
           size="sm"
-          href={`discord://discord.com/channels/${integration.externalId}`}
+          href={`https://discord.com/channels/${integration.externalId}`}
         >
           {t('Open in Discord')}
         </LinkButton>


### PR DESCRIPTION
Slack had a button that would redirect you to slack workspace after linking identity.

Did the same for Discord

Closes: https://github.com/getsentry/sentry/issues/58043

https://github.com/user-attachments/assets/6792b8f1-b5e2-4a76-993d-69a83443ad02

