### PR TITLE
fix(toolbar): Include credentials with fetch requests

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -161,7 +161,7 @@ Required context variables:
             const initWithCreds = {
               ...init,
               headers: { ...init.headers, ...bearer },
-              credentials: 'same-origin',
+              credentials: 'include',
             };
             const response = await fetch(url, initWithCreds);
             return {


### PR DESCRIPTION
Our fetch requests are cross-domain by design, we're making requests from a customer domain like `acme.sentry.io` into a an region like `us.sentry.io`. Therefore we need to include credentials. This is also how the website is configured: https://github.com/getsentry/sentry/blob/aa22f5d2373fc19e224bc9cc1fb30c405f05d782/static/app/api.tsx#L338

More docs: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials

Previously we had `same-origin` which worked because we weren't using the regionUrl. We were instead sending api requests to the customer domain at `acme.sentry.io`. This meant that api requests were slower than using the regionUrl, but and also we were unable to make requests for api endpoints that don't include an `/:organization/` segment. 

So using the regionUrl is an improvement, and this PR updates the credentials field to match.

Another thing to consider is that before we were using `window.location.origin` to make requests. That has since been replaced by https://github.com/getsentry/sentry/blob/aa22f5d2373fc19e224bc9cc1fb30c405f05d782/src/sentry/templates/sentry/toolbar/iframe.html#L31 so we can trust that we're always sending these credentials off to a domain that the server trusts and told us about.

Related to https://github.com/getsentry/sentry/pull/81942