### PR TITLE
perf(organization-teams): fix n+1 org query

### DIFF
--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -19,8 +19,7 @@ class ProjectTeamManager(BaseManager["ProjectTeam"]):
         return (
             self.filter(team__in=teams, project__status=ObjectStatus.ACTIVE)
             .order_by("project__name", "project__slug")
-            .select_related("project")
-            .prefetch_related("project__organization")
+            .select_related("project", "project__organization")
         )
 
 

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -21,9 +21,11 @@ class ProjectTeamManager(BaseManager["ProjectTeam"]):
             .order_by("project__name", "project__slug")
             .select_related("project")
         )
-
         # TODO(dcramer): we should query in bulk for ones we're missing here
-        orgs = {i.organization_id: i.organization for i in teams}
+        orgs = {}
+        for team in teams:
+            if team.organization_id not in orgs:
+                orgs[team.organization_id] = team.organization
 
         for project_team in project_teams:
             if project_team.project.organization_id in orgs:

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -22,13 +22,6 @@ class ProjectTeamManager(BaseManager["ProjectTeam"]):
             .select_related("project")
         )
         prefetch_related_objects(project_teams, "project__organization")
-        orgs = {pt.project.organization_id: pt.project.organization for pt in project_teams}
-
-        for project_team in project_teams:
-            if project_team.project.organization_id in orgs:
-                project_team.project.set_cached_field_value(
-                    "organization", orgs[project_team.project.organization_id]
-                )
 
         return project_teams
 

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar
 
 from django.db import router, transaction
-from django.db.models import QuerySet, prefetch_related_objects
+from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save
 
 from sentry.backup.scopes import RelocationScope
@@ -16,14 +16,12 @@ if TYPE_CHECKING:
 
 class ProjectTeamManager(BaseManager["ProjectTeam"]):
     def get_for_teams_with_org_cache(self, teams: Sequence["Team"]) -> QuerySet["ProjectTeam"]:
-        project_teams = (
+        return (
             self.filter(team__in=teams, project__status=ObjectStatus.ACTIVE)
             .order_by("project__name", "project__slug")
             .select_related("project")
+            .prefetch_related("project__organization")
         )
-        prefetch_related_objects(project_teams, "project__organization")
-
-        return project_teams
 
 
 @region_silo_model


### PR DESCRIPTION
the way this is currently written it will make the same sql query over and over again 🤦🏼 

this fixes it so we simply do once for each org_id. (there should never be more than one org_id in a set of teams being queried, but will leave that for future refactors.