### PR TITLE
ref(workflow_engine): Remove DetectorType

### DIFF
--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import IntEnum, StrEnum
+from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from sentry.types.group import PriorityLevel
@@ -44,8 +44,3 @@ class DataConditionHandler(Generic[T]):
     @staticmethod
     def evaluate_value(value: T, comparison: Any, condition: str) -> DataConditionResult:
         raise NotImplementedError
-
-
-class DetectorType(StrEnum):
-    ERROR = "ErrorDetector"
-    METRIC_ALERT_FIRE = "metric_alert_fire"


### PR DESCRIPTION
## Description
Removes the `DetectorType` from the `workflow_engine.type` and adds comments to clarify how this type is defined and used.