### PR TITLE
ref(workflow_engine): Add pre save signal to DataSource to enforce type

### DIFF
--- a/src/sentry/workflow_engine/models/data_source.py
+++ b/src/sentry/workflow_engine/models/data_source.py
@@ -3,6 +3,8 @@ import dataclasses
 from typing import Generic, TypeVar
 
 from django.db import models
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
@@ -11,6 +13,7 @@ from sentry.db.models import (
     FlexibleForeignKey,
     region_silo_model,
 )
+from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.data_source_detector import DataSourceDetector
 from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DataSourceTypeHandler
@@ -30,6 +33,8 @@ class DataSource(DefaultFieldsModel):
 
     organization = FlexibleForeignKey("sentry.Organization")
     query_id = BoundedBigIntegerField()
+
+    # This is a dynamic field, depending on the type in the data_source_type_registry
     type = models.TextField()
 
     detectors = models.ManyToManyField("workflow_engine.Detector", through=DataSourceDetector)
@@ -45,3 +50,19 @@ class DataSource(DefaultFieldsModel):
         if not handler:
             raise ValueError(f"Unknown data source type: {self.type}")
         return handler
+
+
+@receiver(pre_save, sender=DataSource)
+def ensure_valid_type(sender, instance: DataSource, **kwargs):
+    """
+    Ensure that the type of the data source is valid and registered in the data_source_type_registry
+    """
+    data_source_type = instance.type
+
+    if not data_source_type:
+        raise ValueError(f"No group type found with type {instance.type}")
+
+    try:
+        data_source_type_registry.get(data_source_type)
+    except NoRegistrationExistsError:
+        raise ValueError(f"No data source type found with type {data_source_type}")


### PR DESCRIPTION
## Description
Adds constraints to data_source.type, but allows other modules to define the types.

This allows modules outside of `workflow_engine` to define their type / support, while having a bit of safety. We can't use these as direct types because they're registry keys, and are only available at runtime.