### PR TITLE
chore(utils): allow duplicate values in registry by making reverse lookup optional

### DIFF
--- a/src/sentry/utils/registry.py
+++ b/src/sentry/utils/registry.py
@@ -15,6 +15,11 @@ T = TypeVar("T")
 
 
 class Registry(Generic[T]):
+    """
+    A simple generic registry that allows for registering and retrieving items by key. Reverse lookup by value is enabled by default.
+    If you have duplicate values, you may want to disable reverse lookup.
+    """
+
     def __init__(self, enable_reverse_lookup=True):
         self.registrations: dict[str, T] = {}
         self.reverse_lookup: dict[T, str] = {}

--- a/src/sentry/utils/registry.py
+++ b/src/sentry/utils/registry.py
@@ -15,9 +15,10 @@ T = TypeVar("T")
 
 
 class Registry(Generic[T]):
-    def __init__(self):
+    def __init__(self, enable_reverse_lookup=True):
         self.registrations: dict[str, T] = {}
         self.reverse_lookup: dict[T, str] = {}
+        self.enable_reverse_lookup = enable_reverse_lookup
 
     def register(self, key: str):
         def inner(item: T) -> T:
@@ -26,13 +27,14 @@ class Registry(Generic[T]):
                     f"A registration already exists for {key}: {self.registrations[key]}"
                 )
 
-            if item in self.reverse_lookup:
-                raise AlreadyRegisteredError(
-                    f"A registration already exists for {item}: {self.reverse_lookup[item]}"
-                )
+            if self.enable_reverse_lookup:
+                if item in self.reverse_lookup:
+                    raise AlreadyRegisteredError(
+                        f"A registration already exists for {item}: {self.reverse_lookup[item]}"
+                    )
+                self.reverse_lookup[item] = key
 
             self.registrations[key] = item
-            self.reverse_lookup[item] = key
 
             return item
 
@@ -44,6 +46,8 @@ class Registry(Generic[T]):
         return self.registrations[key]
 
     def get_key(self, item: T) -> str:
+        if not self.enable_reverse_lookup:
+            raise NotImplementedError("Reverse lookup is not enabled")
         if item not in self.reverse_lookup:
             raise NoRegistrationExistsError(f"No registration exists for {item}")
         return self.reverse_lookup[item]

--- a/tests/sentry/utils/test_registry.py
+++ b/tests/sentry/utils/test_registry.py
@@ -43,6 +43,7 @@ class RegistryTest(TestCase):
             pass
 
         assert test_registry.get("something") == registered_func
+        assert test_registry.get("something 2") == registered_func
 
         with pytest.raises(NoRegistrationExistsError):
             test_registry.get("something else")

--- a/tests/sentry/utils/test_registry.py
+++ b/tests/sentry/utils/test_registry.py
@@ -33,3 +33,22 @@ class RegistryTest(TestCase):
 
         test_registry.register("something else")(unregistered_func)
         assert test_registry.get("something else") == unregistered_func
+
+    def test_allow_duplicate_values(self):
+        test_registry = Registry[str](enable_reverse_lookup=False)
+
+        @test_registry.register("something")
+        @test_registry.register("something 2")
+        def registered_func():
+            pass
+
+        assert test_registry.get("something") == registered_func
+
+        with pytest.raises(NoRegistrationExistsError):
+            test_registry.get("something else")
+
+        with pytest.raises(NotImplementedError):
+            test_registry.get_key(registered_func)
+
+        test_registry.register("something else")(registered_func)
+        assert test_registry.get("something else") == registered_func


### PR DESCRIPTION
Make reverse lookup optional in `Registry`. Reverse lookup via a dictionary means keys AND values must be unique (because we also have regular lookup via a dictionary), but sometimes different keys have the same value and we want to allow registration if that's the case.