### PR TITLE
ref(workflow_engine): Add constraint to `DataSource.type` on pre_save signal

### DIFF
--- a/src/sentry/workflow_engine/models/data_source.py
+++ b/src/sentry/workflow_engine/models/data_source.py
@@ -3,6 +3,8 @@ import dataclasses
 from typing import Generic, TypeVar
 
 from django.db import models
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
@@ -11,6 +13,7 @@ from sentry.db.models import (
     FlexibleForeignKey,
     region_silo_model,
 )
+from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models.data_source_detector import DataSourceDetector
 from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DataSourceTypeHandler
@@ -33,7 +36,7 @@ class DataSource(DefaultFieldsModel):
     # Should this be a string so we can support UUID / ints?
     query_id = BoundedBigIntegerField()
 
-    # TODO - Add a type here
+    # This is a dynamic field, depending on the type in the data_source_type_registry
     type = models.TextField()
 
     detectors = models.ManyToManyField("workflow_engine.Detector", through=DataSourceDetector)
@@ -49,3 +52,19 @@ class DataSource(DefaultFieldsModel):
         if not handler:
             raise ValueError(f"Unknown data source type: {self.type}")
         return handler
+
+
+@receiver(pre_save, sender=DataSource)
+def ensure_valid_type(sender, instance: DataSource, **kwargs):
+    """
+    Ensure that the type of the data source is valid and registered in the data_source_type_registry
+    """
+    data_source_type = instance.type
+
+    if not data_source_type:
+        raise ValueError(f"No group type found with type {instance.type}")
+
+    try:
+        data_source_type_registry.get(data_source_type)
+    except NoRegistrationExistsError:
+        raise ValueError(f"No data source type found with type {data_source_type}")

--- a/src/sentry/workflow_engine/models/data_source.py
+++ b/src/sentry/workflow_engine/models/data_source.py
@@ -55,7 +55,7 @@ class DataSource(DefaultFieldsModel):
 
 
 @receiver(pre_save, sender=DataSource)
-def ensure_valid_type(sender, instance: DataSource, **kwargs):
+def ensure_type_handler_registered(sender, instance: DataSource, **kwargs):
     """
     Ensure that the type of the data source is valid and registered in the data_source_type_registry
     """

--- a/tests/sentry/workflow_engine/models/test_data_source.py
+++ b/tests/sentry/workflow_engine/models/test_data_source.py
@@ -12,9 +12,8 @@ class DataSourceTest(BaseWorkflowTest):
             self.create_data_source(type="invalid_type")
 
     def test_data_source_valid_type(self):
-        type_mock = mock.Mock()
-        data_source_type_registry.register("test")(type_mock)
-        assert data_source_type_registry.get("test") == type_mock
+        # Make sure the mock was registered in test_base
+        assert isinstance(data_source_type_registry.get("test"), mock.Mock)
 
         data_source = self.create_data_source(type="test")
         assert data_source is not None

--- a/tests/sentry/workflow_engine/models/test_data_source.py
+++ b/tests/sentry/workflow_engine/models/test_data_source.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import pytest
+
+from sentry.workflow_engine.registry import data_source_type_registry
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class DataSourceTest(BaseWorkflowTest):
+    def test_inavlid_data_source_type(self):
+        with pytest.raises(ValueError):
+            self.create_data_source(type="invalid_type")
+
+    def test_data_source_valid_type(self):
+        test_type = "test"
+        type_mock = mock.Mock()
+
+        data_source_type_registry.register(test_type)(type_mock)
+        assert data_source_type_registry.get(test_type) == type_mock
+
+        data_source = self.create_data_source(type=test_type)
+
+        assert data_source is not None

--- a/tests/sentry/workflow_engine/models/test_data_source.py
+++ b/tests/sentry/workflow_engine/models/test_data_source.py
@@ -7,7 +7,7 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 class DataSourceTest(BaseWorkflowTest):
-    def test_inavlid_data_source_type(self):
+    def test_invalid_data_source_type(self):
         with pytest.raises(ValueError):
             self.create_data_source(type="invalid_type")
 

--- a/tests/sentry/workflow_engine/models/test_data_source.py
+++ b/tests/sentry/workflow_engine/models/test_data_source.py
@@ -12,12 +12,10 @@ class DataSourceTest(BaseWorkflowTest):
             self.create_data_source(type="invalid_type")
 
     def test_data_source_valid_type(self):
-        test_type = "test"
         type_mock = mock.Mock()
+        data_source_type_registry.register("test")(type_mock)
+        assert data_source_type_registry.get("test") == type_mock
 
-        data_source_type_registry.register(test_type)(type_mock)
-        assert data_source_type_registry.get(test_type) == type_mock
-
-        data_source = self.create_data_source(type=test_type)
-
+        data_source = self.create_data_source(type="test")
         assert data_source is not None
+        assert data_source.type == "test"

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -6,9 +6,6 @@ from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.processors import process_data_sources
 from sentry.workflow_engine.registry import data_source_type_registry
 
-# Setup a mock data source for the tests
-data_source_type_registry.register("test")(mock.Mock)
-
 
 class TestProcessDataSources(TestCase):
     def create_snuba_query(self, **kwargs):
@@ -22,6 +19,9 @@ class TestProcessDataSources(TestCase):
         )
 
     def setUp(self):
+        # check that test_base registers the data_source_type_registry
+        assert isinstance(data_source_type_registry.get("test"), mock.Mock)
+
         self.query = self.create_snuba_query()
         self.query_two = self.create_snuba_query()
 

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -1,7 +1,13 @@
+from unittest import mock
+
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.processors import process_data_sources
+from sentry.workflow_engine.registry import data_source_type_registry
+
+# Setup a mock data source for the tests
+data_source_type_registry.register("test")(mock.Mock)
 
 
 class TestProcessDataSources(TestCase):

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from unittest import mock
 from uuid import uuid4
 
 from sentry.eventstore.models import Event, GroupEvent
@@ -8,6 +9,7 @@ from sentry.models.group import Group
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import EventType
+from sentry.utils.registry import AlreadyRegisteredError
 from sentry.workflow_engine.models import (
     Action,
     DataConditionGroup,
@@ -18,8 +20,16 @@ from sentry.workflow_engine.models import (
     Workflow,
 )
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
+
+try:
+    type_mock = mock.Mock()
+    data_source_type_registry.register("test")(type_mock)
+except AlreadyRegisteredError:
+    # Ensure "test" is mocked for tests, but don't fail if already registered here.
+    pass
 
 
 class BaseWorkflowTest(TestCase, OccurrenceTestMixin):


### PR DESCRIPTION
## Description
Adds constraints to data_source.type, but allows other modules to define the types.

This allows modules outside of workflow_engine to define their type / support, while having a bit of safety. We can't use these as direct types because they're registry keys, and are only available at runtime.