### PR TITLE
ref(flags): don't show feature flag section on any issues besides errors

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -197,12 +197,12 @@ export function EventFeatureFlagList({
     }
   }, [hasFlags, hydratedFlags.length, organization]);
 
-  if (showCTA) {
+  if (showCTA && group.issueCategory !== 'cron') {
     return <FeatureFlagInlineCTA projectId={event.projectID} />;
   }
 
   // if contexts.flags is not set, hide the section
-  if (!hasFlagContext) {
+  if (!hasFlagContext || group.issueCategory === 'cron') {
     return null;
   }
 

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -24,7 +24,7 @@ import {featureFlagOnboardingPlatforms} from 'sentry/data/platformCategories';
 import {IconMegaphone, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event, FeatureFlag} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
+import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
@@ -197,12 +197,16 @@ export function EventFeatureFlagList({
     }
   }, [hasFlags, hydratedFlags.length, organization]);
 
-  if (showCTA && group.issueCategory !== 'cron') {
+  if (group.issueCategory !== IssueCategory.ERROR) {
+    return null;
+  }
+
+  if (showCTA) {
     return <FeatureFlagInlineCTA projectId={event.projectID} />;
   }
 
   // if contexts.flags is not set, hide the section
-  if (!hasFlagContext || group.issueCategory === 'cron') {
+  if (!hasFlagContext) {
     return null;
   }
 


### PR DESCRIPTION
the CTA was showing up for a [crons issue](https://sentry.sentry.io/issues/6139435070/events/11af5c3a9188460ab5f2edd5b583a988/?project=1) but we should probably hide it for that category.