### PR TITLE
feat(explore): Add suggested queries

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -24,6 +24,7 @@ import {
   getSortBysFromLocation,
   updateLocationWithSortBys,
 } from './sortBys';
+import {defaultTitle, getTitleFromLocation, updateLocationWithTitle} from './title';
 import {
   defaultVisualizes,
   getVisualizesFromLocation,
@@ -39,6 +40,7 @@ interface ReadablePageParams {
   query: string;
   sortBys: Sort[];
   visualizes: Visualize[];
+  title?: string;
 }
 
 interface WritablePageParams {
@@ -48,7 +50,18 @@ interface WritablePageParams {
   mode?: Mode | null;
   query?: string | null;
   sortBys?: Sort[] | null;
+  title?: string | null;
   visualizes?: Omit<Visualize, 'label'>[] | null;
+}
+
+export interface SuggestedQuery {
+  fields: string[];
+  groupBys: string[];
+  mode: Mode;
+  query: string;
+  sortBys: Sort[];
+  title: string;
+  visualizes: Omit<Visualize, 'label'>[];
 }
 
 function defaultPageParams(): ReadablePageParams {
@@ -58,6 +71,7 @@ function defaultPageParams(): ReadablePageParams {
   const mode = defaultMode();
   const query = defaultQuery();
   const visualizes = defaultVisualizes();
+  const title = defaultTitle();
   const sortBys = defaultSortBys(mode, fields, visualizes);
 
   return {
@@ -67,6 +81,7 @@ function defaultPageParams(): ReadablePageParams {
     mode,
     query,
     sortBys,
+    title,
     visualizes,
   };
 }
@@ -88,6 +103,7 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
     const query = getQueryFromLocation(location);
     const visualizes = getVisualizesFromLocation(location);
     const sortBys = getSortBysFromLocation(location, mode, fields, groupBys, visualizes);
+    const title = getTitleFromLocation(location);
 
     return {
       dataset,
@@ -96,6 +112,7 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
       mode,
       query,
       sortBys,
+      title,
       visualizes,
     };
   }, [location]);
@@ -139,6 +156,11 @@ export function useExploreSortBys(): Sort[] {
   return pageParams.sortBys;
 }
 
+export function useExploreTitle(): string | undefined {
+  const pageParams = useExplorePageParams();
+  return pageParams.title;
+}
+
 export function useExploreVisualizes(): Visualize[] {
   const pageParams = useExplorePageParams();
   return pageParams.visualizes;
@@ -158,6 +180,7 @@ export function useSetExplorePageParams() {
       updateLocationWithQuery(target, pageParams.query);
       updateLocationWithSortBys(target, pageParams.sortBys);
       updateLocationWithVisualizes(target, pageParams.visualizes);
+      updateLocationWithTitle(target, pageParams.title);
       navigate(target);
     },
     [location, navigate]
@@ -248,6 +271,24 @@ export function useSetExploreVisualizes() {
   return useCallback(
     (visualizes: Omit<Visualize, 'label'>[]) => {
       setPageParams({visualizes});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreSuggestedQuery() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (query: SuggestedQuery) => {
+      setPageParams({
+        fields: query.fields,
+        groupBys: query.groupBys,
+        mode: query.mode,
+        query: query.query,
+        sortBys: query.sortBys,
+        visualizes: query.visualizes,
+        title: query.title,
+      });
     },
     [setPageParams]
   );

--- a/static/app/views/explore/contexts/pageParamsContext/title.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/title.tsx
@@ -1,0 +1,23 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export function defaultTitle(): string | undefined {
+  return undefined;
+}
+
+export function getTitleFromLocation(location: Location) {
+  return decodeScalar(location.query.title);
+}
+
+export function updateLocationWithTitle(
+  location: Location,
+  title: string | null | undefined
+) {
+  if (defined(title)) {
+    location.query.title = title;
+  } else if (title === null) {
+    delete location.query.title;
+  }
+}

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -19,6 +19,7 @@ export function useAnalytics({
   columns,
   userQuery,
   confidence,
+  title,
 }: {
   columns: string[];
   confidence: Confidence;
@@ -30,6 +31,7 @@ export function useAnalytics({
   userQuery: string;
   visualizes: Visualize[];
   resultMissingRoot?: number;
+  title?: string;
 }) {
   useEffect(() => {
     if (resultStatus === 'pending') {
@@ -51,6 +53,7 @@ export function useAnalytics({
       user_queries_count: search.tokens.length,
       visualizes,
       visualizes_count: visualizes.length,
+      title,
     };
 
     trackAnalytics('trace.explorer.metadata', params);
@@ -65,5 +68,6 @@ export function useAnalytics({
     userQuery,
     confidence,
     dataset,
+    title,
   ]);
 }

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -37,6 +37,7 @@ import {
   useExploreGroupBys,
   useExploreQuery,
   useExploreSortBys,
+  useExploreTitle,
   useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -57,6 +58,7 @@ export function AggregatesTable({confidence, setError}: AggregatesTableProps) {
   const {selection} = usePageFilters();
   const topEvents = useTopEvents();
   const organization = useOrganization();
+  const title = useExploreTitle();
   const dataset = useExploreDataset();
   const groupBys = useExploreGroupBys();
   const visualizes = useExploreVisualizes();
@@ -132,6 +134,7 @@ export function AggregatesTable({confidence, setError}: AggregatesTableProps) {
     columns: groupBys,
     userQuery: query,
     confidence,
+    title,
   });
 
   const tableRef = useRef<HTMLTableElement>(null);

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -31,6 +31,7 @@ import {
   useExploreFields,
   useExploreQuery,
   useExploreSortBys,
+  useExploreTitle,
   useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -49,6 +50,7 @@ export function SpansTable({confidence, setError}: SpansTableProps) {
   const {selection} = usePageFilters();
 
   const dataset = useExploreDataset();
+  const title = useExploreTitle();
   const fields = useExploreFields();
   const sortBys = useExploreSortBys();
   const setSortBys = useSetExploreSortBys();
@@ -114,6 +116,7 @@ export function SpansTable({confidence, setError}: SpansTableProps) {
     columns: fields,
     userQuery: query,
     confidence,
+    title,
   });
 
   const tableRef = useRef<HTMLTableElement>(null);

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -27,6 +27,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {
   useExploreDataset,
   useExploreQuery,
+  useExploreTitle,
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
@@ -57,6 +58,7 @@ interface TracesTableProps {
 }
 
 export function TracesTable({confidence, setError}: TracesTableProps) {
+  const title = useExploreTitle();
   const dataset = useExploreDataset();
   const query = useExploreQuery();
   const visualizes = useExploreVisualizes();
@@ -95,6 +97,7 @@ export function TracesTable({confidence, setError}: TracesTableProps) {
     ],
     userQuery: query,
     confidence,
+    title,
   });
 
   const {data, isPending, isError, getResponseHeader} = result;

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -14,6 +14,7 @@ import {ToolbarDataset} from 'sentry/views/explore/toolbar/toolbarDataset';
 import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
 import {ToolbarMode} from 'sentry/views/explore/toolbar/toolbarMode';
 import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
+import {ToolbarSuggestedQueries} from 'sentry/views/explore/toolbar/toolbarSuggestedQueries';
 import {ToolbarVisualize} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 type Extras = 'dataset toggle';
@@ -48,6 +49,7 @@ export function ExploreToolbar({extras}: ExploreToolbarProps) {
         sorts={sortBys}
         setSorts={setSortBys}
       />
+      <ToolbarSuggestedQueries />
     </div>
   );
 }

--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 
 export const ToolbarSection = styled('div')`
   margin-bottom: ${space(2)};
@@ -15,14 +16,16 @@ export const ToolbarHeader = styled('div')`
   margin-bottom: ${space(0.5)};
 `;
 
-export const ToolbarLabel = styled('h6')<{disabled?: boolean}>`
+export const ToolbarLabel = styled('h6')<{disabled?: boolean; underlined?: boolean}>`
   color: ${p => (p.disabled ? p.theme.gray300 : p.theme.gray500)};
   height: ${p => p.theme.form.md.height};
   min-height: ${p => p.theme.form.md.minHeight};
   font-size: ${p => p.theme.form.md.fontSize};
-  text-decoration: underline dotted
-    ${p => (p.disabled ? p.theme.gray300 : p.theme.gray300)};
   margin: 0;
+  ${p =>
+    !defined(p.underlined) || p.underlined
+      ? `text-decoration: underline dotted ${p.disabled ? p.theme.gray300 : p.theme.gray300}`
+      : ''};
 `;
 
 export const ToolbarHeaderButton = styled(Button)<{disabled?: boolean}>`

--- a/static/app/views/explore/toolbar/toolbarSuggestedQueries.tsx
+++ b/static/app/views/explore/toolbar/toolbarSuggestedQueries.tsx
@@ -1,0 +1,333 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import Panel from 'sentry/components/panels/panel';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import {
+  backend,
+  frontend,
+  mobile,
+  PlatformCategory,
+  serverless,
+} from 'sentry/data/platformCategories';
+import {IconClose} from 'sentry/icons/iconClose';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {PageFilters} from 'sentry/types/core';
+import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {
+  type SuggestedQuery,
+  useSetExploreSuggestedQuery,
+} from 'sentry/views/explore/contexts/pageParamsContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+import {ToolbarHeader, ToolbarHeaderButton, ToolbarLabel, ToolbarSection} from './styles';
+
+interface ToolbarSuggestedQueriesProps {}
+
+export function ToolbarSuggestedQueries(props: ToolbarSuggestedQueriesProps) {
+  const organization = useOrganization();
+
+  const {dismiss, isDismissed} = useDismissAlert({
+    key: `${organization.id}:metrics-empty-state-dismissed`,
+    expirationDays: 30,
+  });
+
+  if (isDismissed) {
+    return null;
+  }
+
+  return <ToolbarSuggestedQueriesInner {...props} dismiss={dismiss} />;
+}
+
+interface ToolbarSuggestedQueriesInnerProps extends ToolbarSuggestedQueriesProps {
+  dismiss: () => void;
+}
+
+function ToolbarSuggestedQueriesInner({dismiss}: ToolbarSuggestedQueriesInnerProps) {
+  const {selection} = usePageFilters();
+  const {projects} = useProjects();
+
+  const setExploreSuggestedQuery = useSetExploreSuggestedQuery();
+
+  const suggestedQueries: SuggestedQuery[] = useMemo(() => {
+    const counters = {
+      [PlatformCategory.FRONTEND]: 0,
+      [PlatformCategory.MOBILE]: 0,
+      [PlatformCategory.BACKEND]: 0,
+    };
+
+    for (const project of getSelectedProjectsList(selection.projects, projects)) {
+      if (!defined(project.platform)) {
+        continue;
+      }
+      if (frontend.includes(project.platform)) {
+        counters[PlatformCategory.FRONTEND] += 1;
+      } else if (mobile.includes(project.platform)) {
+        counters[PlatformCategory.MOBILE] += 1;
+      } else if (backend.includes(project.platform)) {
+        counters[PlatformCategory.BACKEND] += 1;
+      } else if (serverless.includes(project.platform)) {
+        // consider serverless as a type of backend platform
+        counters[PlatformCategory.BACKEND] += 1;
+      }
+    }
+
+    const platforms = [
+      PlatformCategory.FRONTEND,
+      PlatformCategory.MOBILE,
+      PlatformCategory.BACKEND,
+    ]
+      .filter(k => counters[k] > 0)
+      .sort((a, b) => counters[b] - counters[a]);
+
+    return getSuggestedQueries(platforms);
+  }, [selection, projects]);
+
+  return (
+    <ToolbarSection data-test-id="section-suggested-queries">
+      <StyledPanel>
+        <ToolbarHeader>
+          <ToolbarLabel underlined={false}>{t('Suggested Queries')}</ToolbarLabel>
+          <ToolbarHeaderButton
+            size="zero"
+            onClick={dismiss}
+            borderless
+            aria-label={t('Dismiss Suggested Queries')}
+            icon={<IconClose />}
+          />
+        </ToolbarHeader>
+        <div>
+          {t("Feeling like a newb? Been there, done that. Here's a few to get you goin.")}
+        </div>
+        <SuggestedQueriesContainer>
+          {suggestedQueries.map(suggestedQuery => {
+            return (
+              <Tag
+                key={suggestedQuery.title}
+                onClick={() => setExploreSuggestedQuery(suggestedQuery)}
+              >
+                {suggestedQuery.title}
+              </Tag>
+            );
+          })}
+        </SuggestedQueriesContainer>
+      </StyledPanel>
+    </ToolbarSection>
+  );
+}
+
+function getSelectedProjectsList(
+  selectedProjects: PageFilters['projects'],
+  projects: Project[]
+): Project[] {
+  if (
+    selectedProjects[0] === ALL_ACCESS_PROJECTS || // all projects
+    selectedProjects.length === 0 // my projects
+  ) {
+    return projects;
+  }
+
+  const projectIds = new Set(selectedProjects.map(String));
+
+  return projects.filter(project => projectIds.has(project.id));
+}
+
+function getSuggestedQueries(platforms: PlatformCategory[], maxQueries = 5) {
+  const frontendQueries: SuggestedQuery[] = [
+    {
+      title: t('Worst LCPs'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'measurements.lcp',
+      ],
+      groupBys: ['span.description'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:[pageload,navigation]',
+      sortBys: [{field: 'avg(measurements.lcp)', kind: 'desc'}],
+      visualizes: [
+        {chartType: ChartType.LINE, yAxes: ['p50(measurements.lcp)']},
+        {chartType: ChartType.LINE, yAxes: ['avg(measurements.lcp)']},
+      ],
+    },
+    {
+      title: t('Biggest Assets'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'http.response_transfer_size',
+        'timestamp',
+      ],
+      groupBys: ['span.description'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:[resource.css,resource.img,resource.script]',
+      sortBys: [{field: 'p75(http.response_transfer_size)', kind: 'desc'}],
+      visualizes: [
+        {chartType: ChartType.LINE, yAxes: ['p75(http.response_transfer_size)']},
+        {chartType: ChartType.LINE, yAxes: ['p90(http.response_transfer_size)']},
+      ],
+    },
+    {
+      title: t('Top Pageloads'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'timestamp',
+      ],
+      groupBys: ['span.description'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:[pageload,navigation]',
+      sortBys: [{field: 'avg(span.duration)', kind: 'desc'}],
+      visualizes: [
+        {chartType: ChartType.LINE, yAxes: ['avg(span.duration)']},
+        {chartType: ChartType.LINE, yAxes: ['p50(span.duration)']},
+      ],
+    },
+  ];
+
+  const backendQueries: SuggestedQuery[] = [
+    {
+      title: t('Slowest Server Calls'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'timestamp',
+      ],
+      groupBys: ['span.description'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:http.server',
+      sortBys: [{field: 'p75(span.duration)', kind: 'desc'}],
+      visualizes: [
+        {chartType: ChartType.LINE, yAxes: ['p75(span.duration)']},
+        {chartType: ChartType.LINE, yAxes: ['p90(span.duration)']},
+      ],
+    },
+  ];
+
+  const mobileQueries: SuggestedQuery[] = [
+    {
+      title: t('Top Screenloads'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'timestamp',
+      ],
+      groupBys: ['span.description'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:ui.load',
+      sortBys: [{field: 'count(span.duration)', kind: 'desc'}],
+      visualizes: [{chartType: ChartType.LINE, yAxes: ['count(span.duration)']}],
+    },
+  ];
+
+  const allQueries: Partial<Record<PlatformCategory, SuggestedQuery[]>> = {
+    [PlatformCategory.FRONTEND]: frontendQueries,
+    [PlatformCategory.BACKEND]: backendQueries,
+    [PlatformCategory.MOBILE]: mobileQueries,
+  };
+
+  const genericQueries: SuggestedQuery[] = [
+    {
+      title: t('Slowest Ops'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'timestamp',
+      ],
+      groupBys: ['span.op'],
+      mode: Mode.AGGREGATE,
+      query: '',
+      sortBys: [{field: 'avg(span.duration)', kind: 'desc'}],
+      visualizes: [
+        {chartType: ChartType.LINE, yAxes: ['avg(span.duration)']},
+        {chartType: ChartType.LINE, yAxes: ['p50(span.duration)']},
+      ],
+    },
+    {
+      title: t('Database Latency'),
+      fields: [
+        'id',
+        'project',
+        'span.op',
+        'span.description',
+        'span.duration',
+        'db.system',
+      ],
+      groupBys: ['span.op', 'db.system'],
+      mode: Mode.AGGREGATE,
+      query: 'span.op:db',
+      sortBys: [{field: 'avg(span.duration)', kind: 'desc'}],
+      visualizes: [
+        {chartType: ChartType.LINE, yAxes: ['avg(span.duration)']},
+        {chartType: ChartType.LINE, yAxes: ['p50(span.duration)']},
+      ],
+    },
+  ];
+
+  const queries: SuggestedQuery[] = [];
+
+  for (const platform of platforms) {
+    for (const query of allQueries[platform] || []) {
+      queries.push(query);
+      if (queries.length >= maxQueries) {
+        return queries;
+      }
+    }
+  }
+
+  for (const query of genericQueries) {
+    queries.push(query);
+    if (queries.length >= maxQueries) {
+      return queries;
+    }
+  }
+
+  return queries;
+}
+
+const StyledPanel = styled(Panel)`
+  padding: ${space(2)};
+`;
+
+const SuggestedQueriesContainer = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+  margin-top: ${space(2)};
+`;
+
+const Tag = styled('div')`
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0px ${space(1)};
+  border-radius: 20px;
+  background-color: ${p => p.theme.background};
+  border: solid 1px ${p => p.theme.border};
+  cursor: pointer;
+`;


### PR DESCRIPTION
This adds some suggested queries for explore. There are suggested queries for general, frontend, backend, and mobile views, and we try to pick up to 5 possibly useful ones based on the platforms of the selected projects.