### PR TITLE
feat(explore): Update insufficient samples warning

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -10,7 +10,7 @@ import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconClock, IconGraph} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {NewQuery} from 'sentry/types/organization';
+import type {Confidence, NewQuery} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import EventView from 'sentry/utils/discover/eventView';
@@ -49,6 +49,7 @@ import {TOP_EVENTS_LIMIT, useTopEvents} from '../hooks/useTopEvents';
 
 interface ExploreChartsProps {
   query: string;
+  setConfidence: Dispatch<SetStateAction<Confidence>>;
   setError: Dispatch<SetStateAction<string>>;
 }
 
@@ -69,7 +70,7 @@ const exploreChartTypeOptions = [
 
 export const EXPLORE_CHART_GROUP = 'explore-charts_group';
 
-export function ExploreCharts({query, setError}: ExploreChartsProps) {
+export function ExploreCharts({query, setConfidence, setError}: ExploreChartsProps) {
   const dataset = useExploreDataset();
   const visualizes = useExploreVisualizes();
   const setVisualizes = useSetExploreVisualizes();
@@ -189,6 +190,13 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
 
     return 'high';
   }, [dataset, timeSeriesResult.data]);
+
+  useEffect(() => {
+    // only update the confidence once the result has loaded
+    if (!timeSeriesResult.isPending) {
+      setConfidence(resultConfidence);
+    }
+  }, [setConfidence, resultConfidence, timeSeriesResult.isPending]);
 
   useEffect(() => {
     setError(timeSeriesResult.error?.message ?? '');

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -21,6 +21,7 @@ import {
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Confidence} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   type AggregationKey,
@@ -78,6 +79,7 @@ function ExploreContentImpl({}: ExploreContentProps) {
     });
   }, [location, navigate]);
 
+  const [confidence, setConfidence] = useState<Confidence>(null);
   const [chartError, setChartError] = useState<string>('');
   const [tableError, setTableError] = useState<string>('');
 
@@ -169,8 +171,12 @@ function ExploreContentImpl({}: ExploreContentProps) {
                   {tableError || chartError}
                 </Alert>
               )}
-              <ExploreCharts query={query} setError={setChartError} />
-              <ExploreTables setError={setTableError} />
+              <ExploreCharts
+                query={query}
+                setConfidence={setConfidence}
+                setError={setChartError}
+              />
+              <ExploreTables confidence={confidence} setError={setTableError} />
             </MainSection>
           </Body>
         </Layout.Page>

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -21,7 +21,6 @@ import {
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Confidence} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   type AggregationKey,
@@ -79,7 +78,6 @@ function ExploreContentImpl({}: ExploreContentProps) {
     });
   }, [location, navigate]);
 
-  const [confidence, setConfidence] = useState<Confidence>(null);
   const [chartError, setChartError] = useState<string>('');
   const [tableError, setTableError] = useState<string>('');
 
@@ -114,13 +112,6 @@ function ExploreContentImpl({}: ExploreContentProps) {
             </Layout.HeaderActions>
           </Layout.Header>
           <Body>
-            {confidence === 'low' && (
-              <ConfidenceAlert type="warning" showIcon>
-                {t(
-                  'Your low sample count may impact the accuracy of this extrapolation. Edit your query or increase your sample rate.'
-                )}
-              </ConfidenceAlert>
-            )}
             <TopSection>
               <StyledPageFilterBar condensed>
                 <ProjectPageFilter />
@@ -178,12 +169,8 @@ function ExploreContentImpl({}: ExploreContentProps) {
                   {tableError || chartError}
                 </Alert>
               )}
-              <ExploreCharts
-                query={query}
-                setConfidence={setConfidence}
-                setError={setChartError}
-              />
-              <ExploreTables confidence={confidence} setError={setTableError} />
+              <ExploreCharts query={query} setError={setChartError} />
+              <ExploreTables setError={setTableError} />
             </MainSection>
           </Body>
         </Layout.Page>
@@ -223,11 +210,6 @@ const Body = styled(Layout.Body)`
   @media (min-width: ${p => p.theme.breakpoints.xxlarge}) {
     grid-template-columns: 400px minmax(100px, auto);
   }
-`;
-
-const ConfidenceAlert = styled(Alert)`
-  grid-column: 1/3;
-  margin: 0;
 `;
 
 const TopSection = styled('div')`

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -8,7 +8,6 @@ import {TabList, Tabs} from 'sentry/components/tabs';
 import {IconTable} from 'sentry/icons/iconTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Confidence} from 'sentry/types/organization';
 import {
   useExploreFields,
   useExploreMode,
@@ -23,7 +22,6 @@ import {SpansTable} from 'sentry/views/explore/tables/spansTable';
 import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
 interface ExploreTablesProps {
-  confidence: Confidence;
   setError: Dispatch<SetStateAction<string>>;
 }
 

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -8,6 +8,7 @@ import {TabList, Tabs} from 'sentry/components/tabs';
 import {IconTable} from 'sentry/icons/iconTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Confidence} from 'sentry/types/organization';
 import {
   useExploreFields,
   useExploreMode,
@@ -22,6 +23,7 @@ import {SpansTable} from 'sentry/views/explore/tables/spansTable';
 import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
 interface ExploreTablesProps {
+  confidence: Confidence;
   setError: Dispatch<SetStateAction<string>>;
 }
 


### PR DESCRIPTION
Simplify the designs a little by using the chart footer only instead of an alert on the top of the page.