### PR TITLE
fix(stats): Show decimals for K values

### DIFF
--- a/static/app/views/organizationStats/utils.spec.tsx
+++ b/static/app/views/organizationStats/utils.spec.tsx
@@ -116,7 +116,7 @@ describe('formatUsageWithUnits', function () {
       formatUsageWithUnits(1234 * BILLION, DATA_CATEGORY_INFO.attachment.plural, {
         isAbbreviated: true,
       })
-    ).toBe('1K GB');
+    ).toBe('1.2K GB');
 
     expect(
       formatUsageWithUnits(0, DATA_CATEGORY_INFO.attachment.plural, {

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -90,7 +90,7 @@ export function abbreviateUsageNumber(n: number) {
   }
 
   if (n >= 1000) {
-    return (n / 1000).toFixed().toLocaleString() + 'K';
+    return (n / 1000).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'K';
   }
 
   // Do not show decimals


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/81482

**Before**
![image](https://github.com/user-attachments/assets/5486a076-82c8-4fc6-be16-8b399a8adf45)



**After**

![image](https://github.com/user-attachments/assets/f2beb1f0-a48a-443f-9548-e7d27dcee376)


**Note**

In my opinion, if the chart shows decimal numbers, we should use decimals consistently for all K values on the page.