### PR TITLE
feat(quotas): Project abuse limit for attachment items

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1222,6 +1222,12 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "project-abuse-quota.attachment-item-limit",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "project-abuse-quota.session-limit",
     type=Int,
     default=0,

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -458,6 +458,12 @@ class Quota(Service):
                 scope=QuotaScope.PROJECT,
             ),
             AbuseQuota(
+                id="paai",
+                option="project-abuse-quota.attachment-item-limit",
+                categories=[DataCategory.ATTACHMENT_ITEM],
+                scope=QuotaScope.PROJECT,
+            ),
+            AbuseQuota(
                 id="pas",
                 option="project-abuse-quota.session-limit",
                 categories=[DataCategory.SESSION],

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -116,6 +116,7 @@ class RedisQuotaTest(TestCase):
 
         self.organization.update_option("project-abuse-quota.transaction-limit", 600)
         self.organization.update_option("project-abuse-quota.attachment-limit", 601)
+        self.organization.update_option("project-abuse-quota.attachment-item-limit", 6010)
         self.organization.update_option("project-abuse-quota.session-limit", 602)
         self.organization.update_option("organization-abuse-quota.metric-bucket-limit", 603)
         self.organization.update_option("organization-abuse-quota.custom-metric-bucket-limit", 604)
@@ -145,21 +146,29 @@ class RedisQuotaTest(TestCase):
         assert quotas[2].window == 10
         assert quotas[2].reason_code == "project_abuse_limit"
 
-        assert quotas[3].id == "pas"
+        assert quotas[3].id == "paai"
         assert quotas[3].scope == QuotaScope.PROJECT
         assert quotas[3].scope_id is None
-        assert quotas[3].categories == {DataCategory.SESSION}
-        assert quotas[3].limit == 6020
+        assert quotas[3].categories == {DataCategory.ATTACHMENT_ITEM}
+        assert quotas[3].limit == 60100
         assert quotas[3].window == 10
         assert quotas[3].reason_code == "project_abuse_limit"
 
-        assert quotas[4].id == "paspi"
+        assert quotas[4].id == "pas"
         assert quotas[4].scope == QuotaScope.PROJECT
         assert quotas[4].scope_id is None
-        assert quotas[4].categories == {DataCategory.SPAN_INDEXED}
-        assert quotas[4].limit == 6050
+        assert quotas[4].categories == {DataCategory.SESSION}
+        assert quotas[4].limit == 6020
         assert quotas[4].window == 10
         assert quotas[4].reason_code == "project_abuse_limit"
+
+        assert quotas[5].id == "paspi"
+        assert quotas[5].scope == QuotaScope.PROJECT
+        assert quotas[5].scope_id is None
+        assert quotas[5].categories == {DataCategory.SPAN_INDEXED}
+        assert quotas[5].limit == 6050
+        assert quotas[5].window == 10
+        assert quotas[5].reason_code == "project_abuse_limit"
 
         expected_quotas: dict[tuple[QuotaScope, UseCaseID | None], str] = dict()
         for scope, prefix in [


### PR DESCRIPTION
Attachment quotas and rate limits are currently defined in bytes, so we have no way to prevent an abusively high number of very small attachments.

No abuse limit will be set by default.

ref: https://github.com/getsentry/relay/issues/4175