### PR TITLE
fix(docs) Add notes about region domains to symbol endpoints 

### DIFF
--- a/api-docs/paths/projects/dsyms.json
+++ b/api-docs/paths/projects/dsyms.json
@@ -45,7 +45,7 @@
   },
   "post": {
     "tags": ["Projects"],
-    "description": "Upload a new debug information file for the given release.\n\nUnlike other API requests, files must be uploaded using the\ntraditional multipart/form-data content-type.\n\nThe file uploaded is a zip archive of an Apple .dSYM folder which\ncontains the individual debug images.  Uploading through this endpoint\nwill create different files for the contained images.",
+    "description": "Upload a new debug information file for the given release.\n\nUnlike other API requests, files must be uploaded using the\ntraditional multipart/form-data content-type.\n\nRequests to this endpoint should use the region-specific domain eg. `us.sentry.io` or `de.sentry.io`.\n\nThe file uploaded is a zip archive of an Apple .dSYM folder which\ncontains the individual debug images.  Uploading through this endpoint\nwill create different files for the contained images.",
     "operationId": "Upload a New File",
     "parameters": [
       {

--- a/api-docs/paths/releases/project-release-files.json
+++ b/api-docs/paths/releases/project-release-files.json
@@ -74,7 +74,6 @@
   },
   "post": {
     "tags": ["Releases"],
-    "description": "Upload a new project release file.",
     "description": "Upload a new file for the given release.\n\nUnlike other API requests, files must be uploaded using the traditional multipart/form-data content-type.\n\nRequests to this endpoint should use the region-specific domain eg. `us.sentry.io` or `de.sentry.io`\n\nThe optional 'name' attribute should reflect the absolute path that this file will be referenced as. For example, in the case of JavaScript you might specify the full web URI.",
     "operationId": "Upload a New Project Release File",
     "parameters": [

--- a/api-docs/paths/releases/project-release-files.json
+++ b/api-docs/paths/releases/project-release-files.json
@@ -75,6 +75,7 @@
   "post": {
     "tags": ["Releases"],
     "description": "Upload a new project release file.",
+    "description": "Upload a new file for the given release.\n\nUnlike other API requests, files must be uploaded using the traditional multipart/form-data content-type.\n\nRequests to this endpoint should use the region-specific domain eg. `us.sentry.io` or `de.sentry.io`\n\nThe optional 'name' attribute should reflect the absolute path that this file will be referenced as. For example, in the case of JavaScript you might specify the full web URI.",
     "operationId": "Upload a New Project Release File",
     "parameters": [
       {

--- a/api-docs/paths/releases/release-files.json
+++ b/api-docs/paths/releases/release-files.json
@@ -65,7 +65,7 @@
   },
   "post": {
     "tags": ["Releases"],
-    "description": "Upload a new organization release file.",
+    "description": "Upload a new file for the given release.\n\nUnlike other API requests, files must be uploaded using the traditional multipart/form-data content-type.\n\nRequests to this endpoint should use the region-specific domain eg. `us.sentry.io` or `de.sentry.io`.\n\nThe optional 'name' attribute should reflect the absolute path that this file will be referenced as. For example, in the case of JavaScript you might specify the full web URI.",
     "operationId": "Upload a New Organization Release File",
     "parameters": [
       {

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -122,6 +122,10 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         """
         Upload chunks and store them as FileBlobs
         `````````````````````````````````````````
+
+        Requests to this endpoint should use the region-specific domain
+        eg. `us.sentry.io` or `de.sentry.io`
+
         :pparam file file: The filename should be sha1 hash of the content.
                             Also not you can add up to MAX_CHUNKS_PER_REQUEST files
                             in this request.

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -321,6 +321,9 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
         Delete a debug information file for a given project.
 
+        Requests to this endpoint should use the region-specific domain
+        eg. `us.sentry.io` or `de.sentry.io`
+
         :pparam string organization_id_or_slug: the id or slug of the organization the
                                           file belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the
@@ -350,6 +353,9 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
         Unlike other API requests, files must be uploaded using the
         traditional multipart/form-data content-type.
+
+        Requests to this endpoint should use the region-specific domain
+        eg. `us.sentry.io` or `de.sentry.io`
 
         The file uploaded is a zip archive of a Apple .dSYM folder which
         contains the individual debug images.  Uploading through this endpoint

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -321,9 +321,6 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
         Delete a debug information file for a given project.
 
-        Requests to this endpoint should use the region-specific domain
-        eg. `us.sentry.io` or `de.sentry.io`
-
         :pparam string organization_id_or_slug: the id or slug of the organization the
                                           file belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to delete the

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -52,6 +52,9 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
         Unlike other API requests, files must be uploaded using the
         traditional multipart/form-data content-type.
 
+        Requests to this endpoint should use the region-specific domain
+        eg. `us.sentry.io` or `de.sentry.io`
+
         The optional 'name' attribute should reflect the absolute path
         that this file will be referenced as. For example, in the case of
         JavaScript you might specify the full web URI.

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -272,6 +272,9 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
         Unlike other API requests, files must be uploaded using the
         traditional multipart/form-data content-type.
 
+        Requests to this endpoint should use the region-specific domain
+        eg. `us.sentry.io` or `de.sentry.io`
+
         The optional 'name' attribute should reflect the absolute path
         that this file will be referenced as. For example, in the case of
         JavaScript you might specify the full web URI.


### PR DESCRIPTION
The file upload endpoints have special cased behavior for backwards compatibility reasons that result in slug.sentry.io being pinned to the US region. This can create confusing scenarios for customers in other regions.

Refs https://github.com/getsentry/sentry/issues/81232