### PR TITLE
feat(docs) Add server metadata to files endpoints

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -15,10 +15,14 @@
   },
   "servers": [
     {
-      "url": "https://us.sentry.io/"
-    },
-    {
-      "url": "https://de.sentry.io/"
+      "url": "https://{region}.sentry.io",
+      "variables": {
+        "region": {
+          "default": "us",
+          "description": "The data-storage-location for an organization",
+          "enum": ["us", "de"]
+        }
+      }
     }
   ],
   "tags": [

--- a/api-docs/paths/projects/dsyms.json
+++ b/api-docs/paths/projects/dsyms.json
@@ -109,6 +109,9 @@
       {
         "auth_token": ["project:write"]
       }
+    ],
+    "servers": [
+      {"url": "https://{region}.sentry.io"}
     ]
   },
   "delete": {

--- a/api-docs/paths/releases/project-release-files.json
+++ b/api-docs/paths/releases/project-release-files.json
@@ -171,6 +171,9 @@
       {
         "auth_token": ["project:releases"]
       }
+    ],
+    "servers": [
+      {"url": "https://{region}.sentry.io"}
     ]
   }
 }

--- a/api-docs/paths/releases/release-files.json
+++ b/api-docs/paths/releases/release-files.json
@@ -135,6 +135,9 @@
       {
         "auth_token": ["project:releases"]
       }
+    ],
+    "servers": [
+      {"url": "https://{region}.sentry.io"}
     ]
   }
 }

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1458,7 +1458,18 @@ if os.environ.get("OPENAPIGENERATE", False):
         "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
         "POSTPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_postprocessing_hook"],
         "PREPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_preprocessing_hook"],
-        "SERVERS": [{"url": "https://us.sentry.io"}, {"url": "https://de.sentry.io"}],
+        "SERVERS": [
+            {
+                "url": "https://{region}.sentry.io",
+                "variables": {
+                    "region": {
+                        "default": "us",
+                        "description": "The data-storage-location for an organization",
+                        "enum": ["us", "de"],
+                    },
+                },
+            },
+        ],
         "SORT_OPERATION_PARAMETERS": custom_parameter_sort,
         "TAGS": OPENAPI_TAGS,
         "TITLE": "API Reference",

--- a/tests/apidocs/endpoints/projects/test_dsyms.py
+++ b/tests/apidocs/endpoints/projects/test_dsyms.py
@@ -50,6 +50,6 @@ class ProjectDsymsDocs(APIDocsTestCase):
             data,
             format="multipart",
         )
-        request = RequestFactory(SERVER_NAME="de.sentry.io", secure=True).post(self.url, data)
+        request = RequestFactory().post(self.url, data, SERVER_NAME="de.sentry.io", secure=True)
 
         self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/projects/test_dsyms.py
+++ b/tests/apidocs/endpoints/projects/test_dsyms.py
@@ -50,6 +50,6 @@ class ProjectDsymsDocs(APIDocsTestCase):
             data,
             format="multipart",
         )
-        request = RequestFactory().post(self.url, data)
+        request = RequestFactory(SERVER_NAME="de.sentry.io", secure=True).post(self.url, data)
 
         self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/releases/test_organization_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_files.py
@@ -49,8 +49,12 @@ class ReleaseFilesListDocsTest(APIDocsTestCase):
             data,
             format="multipart",
         )
-        request = RequestFactory(SERVER_NAME="us.sentry.io", secure=True).post(
-            self.url, data=data, content_type="multipart/form-data"
+        request = RequestFactory().post(
+            self.url,
+            data=data,
+            content_type="multipart/form-data",
+            SERVER_NAME="us.sentry.io",
+            secure=True,
         )
 
         self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/releases/test_organization_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_files.py
@@ -49,6 +49,8 @@ class ReleaseFilesListDocsTest(APIDocsTestCase):
             data,
             format="multipart",
         )
-        request = RequestFactory().post(self.url, data=data, content_type="multipart/form-data")
+        request = RequestFactory(SERVER_NAME="us.sentry.io", secure=True).post(
+            self.url, data=data, content_type="multipart/form-data"
+        )
 
         self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/releases/test_project_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_files.py
@@ -51,6 +51,8 @@ class ProjectReleaseFilesListDocsTest(APIDocsTestCase):
             data,
             format="multipart",
         )
-        request = RequestFactory().post(self.url, data=data, content_type="multipart/form-data")
+        request = RequestFactory(SERVER_NAME="us.sentry.io", secure=True).post(
+            self.url, data=data, content_type="multipart/form-data"
+        )
 
         self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/releases/test_project_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_files.py
@@ -51,8 +51,12 @@ class ProjectReleaseFilesListDocsTest(APIDocsTestCase):
             data,
             format="multipart",
         )
-        request = RequestFactory(SERVER_NAME="us.sentry.io", secure=True).post(
-            self.url, data=data, content_type="multipart/form-data"
+        request = RequestFactory().post(
+            self.url,
+            data=data,
+            content_type="multipart/form-data",
+            SERVER_NAME="us.sentry.io",
+            secure=True,
         )
 
         self.validate_schema(request, response)


### PR DESCRIPTION
Several of our files endpoints require usage of the region domains instead of sentry.io or slug.sentry.io. Having the server context defined in these endpoints will enable us to generate better example code in the docs.

Refs #81232
