### PR TITLE
fix(alerts): Updates EAP Alert confidence query to use adjusted 7 day window

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -282,7 +282,7 @@ describe('Incident Rules Create', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           dataset: 'spans',
-          statsPeriod: '7d',
+          statsPeriod: '9998m',
           yAxis: 'count(span.duration)',
         }),
       })

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -665,7 +665,7 @@ class TriggersChart extends PureComponent<Props, State> {
           <EventsRequest
             {...baseProps}
             api={this.confidenceAPI}
-            period="7d"
+            period={TimePeriod.SEVEN_DAYS}
             dataLoadedCallback={onConfidenceDataLoaded}
           >
             {noop}


### PR DESCRIPTION
Updates EAP alerts to use the adjusted seven day period for the confidence query to match the threshold chart window and work around bucket limitation.