### PR TITLE
feat(explore): Change chart granularity default

### DIFF
--- a/static/app/views/explore/hooks/useChartInterval.spec.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.spec.tsx
@@ -27,7 +27,7 @@ describe('useChartInterval', function () {
       {value: '12h', label: '12 hours'},
       {value: '1d', label: '1 day'},
     ]);
-    expect(chartInterval).toEqual('1h'); // default
+    expect(chartInterval).toEqual('3h'); // default
 
     await act(() => setChartInterval('1d'));
     expect(chartInterval).toEqual('1d');

--- a/static/app/views/explore/hooks/useChartInterval.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.tsx
@@ -58,7 +58,8 @@ function useChartIntervalImpl({
     return decodedInterval &&
       intervalOptions.some(option => option.value === decodedInterval)
       ? decodedInterval
-      : intervalOptions[0].value;
+      : // Default to the second option so we're not defaulting to the smallest option
+        intervalOptions[1].value;
   }, [location.query.interval, intervalOptions]);
 
   const setInterval = useCallback(


### PR DESCRIPTION
- Changes the chart default to the second option so we're not using the narrowest possible granularity everytime