### PR TITLE
fix(grouping): Make order of frames in grouping info match main stacktrace

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponent from './groupingComponent';
@@ -20,7 +21,10 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
   const getFrameGroups = () => {
     const frameGroups: FrameGroup[] = [];
 
-    (component.values as EventGroupComponent[])
+    const frames = isStacktraceNewestFirst()
+      ? component.values.reverse()
+      : component.values;
+    (frames as EventGroupComponent[])
       .filter(value => groupingComponentFilter(value, showNonContributing))
       .forEach(value => {
         const key = (value.values as EventGroupComponent[])


### PR DESCRIPTION
In our main stacktrace component on the issue details page, by default we order the frames with the newest ones first, but this is actually controllable via a user preference. In the grouping info UI, we always order the frames with the oldest ones first. Not only is it [confusing](https://github.com/getsentry/sentry/issues/81933) to have the frames in a different oder in each spot, it also means we're not respecting the user preference. 

This fixes that by using the `isStacktraceNewestFirst` utility (which checks the user store) to determine whether the array frames should be reversed before being put through further processing.