### PR TITLE
style(feedback): fix header action alignment

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -35,7 +35,7 @@ export default function FeedbackActions({
   }
 
   return (
-    <Flex gap={space(1)} align="center" className={className} style={style}>
+    <Flex gap={space(1)} align="flex-end" className={className} style={style}>
       <ErrorBoundary mini>
         <FeedbackAssignedTo
           feedbackIssue={feedbackItem as any as Group}

--- a/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
@@ -49,6 +49,7 @@ export default function FeedbackItemHeader({eventData, feedbackItem}: Props) {
           eventData={eventData}
           feedbackItem={feedbackItem}
           size={dimensionsToSize(dimensions)}
+          style={{lineHeight: 1}}
         />
       </Flex>
 


### PR DESCRIPTION
slightly better

before:
<img width="206" alt="SCR-20241216-nkbg" src="https://github.com/user-attachments/assets/7373b611-ff45-41b3-84b2-7c4485bd9555" />
<img width="901" alt="SCR-20241216-njzk" src="https://github.com/user-attachments/assets/8be42650-97ba-4eb5-940a-8e1b622824fa" />



after:

<img width="234" alt="SCR-20241216-njlv" src="https://github.com/user-attachments/assets/82a961c7-2b60-406f-8a87-b6aaf0165fc7" />
<img width="911" alt="SCR-20241216-njkd" src="https://github.com/user-attachments/assets/5ec15298-7528-4b0f-86e4-5882baa6dfdb" />
