### PR TITLE
chore(onboarding): update logging for messaging integration onboarding

### DIFF
--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -1,10 +1,12 @@
 import type {IntegrationType, SentryAppStatus} from 'sentry/types/integrations';
+import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 import type {PlatformEventParameters} from './platformAnalyticsEvents';
 import {platformEventMap} from './platformAnalyticsEvents';
 
 export type IntegrationView = {
   view?:
+    | MessagingIntegrationAnalyticsView
     | 'external_install'
     | 'legacy_integrations'
     | 'plugin_details'
@@ -13,7 +15,6 @@ export type IntegrationView = {
     | 'stacktrace_link'
     | 'stacktrace_issue_details'
     | 'integration_configuration_detail'
-    | 'messaging_integration_onboarding'
     | 'onboarding'
     | 'project_creation'
     | 'developer_settings'

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -28,10 +28,6 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
-  'onboarding.messaging_integration_external_install_clicked': {
-    provider_key: string;
-  };
-  'onboarding.messaging_integration_modal_rendered': {};
   'onboarding.next_step_clicked': {
     newOrg: boolean;
     platform: string;
@@ -99,10 +95,6 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.source_maps_wizard_selected_and_copied':
     'Onboarding: Source Maps Wizard Selected and Copied',
   'onboarding.nextjs-dsn-copied': 'Onboarding: NextJS DSN Copied',
-  'onboarding.messaging_integration_modal_rendered':
-    'Onboarding: Messaging Integration Modal Rendered',
-  'onboarding.messaging_integration_external_install_clicked':
-    'Onboarding: Messaging Integration External Install Clicked',
   'onboarding.take_me_to_issues_clicked': 'Onboarding: Take Me to Issues Clicked',
   'onboarding.slack_setup_clicked': 'Onboarding: Slack Setup Clicked',
   'onboarding.next_step_clicked': 'Onboarding: Next Step Clicked',

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -6,7 +6,6 @@ import {LinkButton} from 'sentry/components/button';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
@@ -25,13 +24,6 @@ function AddIntegrationRow({onClick}: Props) {
   const provider = integration.provider;
   const onAddIntegration = () => {
     integration.onAddIntegration?.();
-    onClick();
-  };
-  const onExternalClick = () => {
-    trackAnalytics('onboarding.messaging_integration_external_install_clicked', {
-      provider_key: provider.key,
-      organization,
-    });
     onClick();
   };
 
@@ -61,7 +53,7 @@ function AddIntegrationRow({onClick}: Props) {
             <StyledButton
               userHasAccess={hasAccess}
               onAddIntegration={onAddIntegration}
-              onExternalClick={onExternalClick}
+              onExternalClick={onClick}
               externalInstallText={`Add ${provider.metadata.noun}`}
               buttonProps={buttonProps}
             />

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1239,9 +1239,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
               <SetupMessagingIntegrationButton
                 projectId={project.id}
                 refetchConfigs={this.refetchConfigs}
-                analyticsParams={{
-                  view: MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION,
-                }}
+                analyticsView={MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION}
               />
             </SetConditionsListItem>
             <ContentIndent>

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry/components/globalModal/components';
 import {t} from 'sentry/locale';
 import MessagingIntegrationModal from 'sentry/views/alerts/rules/issue/messagingIntegrationModal';
+import {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 jest.mock('sentry/actionCreators/modal');
 
@@ -31,6 +32,7 @@ describe('MessagingIntegrationModal', function () {
       providers={providers}
       CloseButton={makeCloseButton(() => {})}
       Footer={ModalFooter}
+      analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
       {...props}
     />
   );

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
@@ -5,9 +5,11 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {space} from 'sentry/styles/space';
 import type {IntegrationProvider} from 'sentry/types/integrations';
 import AddIntegrationRow from 'sentry/views/alerts/rules/issue/addIntegrationRow';
+import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 type Props = ModalRenderProps & {
+  analyticsView: MessagingIntegrationAnalyticsView;
   headerContent: React.ReactNode;
   providers: IntegrationProvider[];
   bodyContent?: React.ReactNode;
@@ -24,6 +26,7 @@ function MessagingIntegrationModal({
   providers,
   modalParams,
   onAddIntegration,
+  analyticsView,
 }: Props) {
   return (
     <Fragment>
@@ -43,7 +46,7 @@ function MessagingIntegrationModal({
                   installStatus: 'Not Installed',
                   analyticsParams: {
                     already_installed: false,
-                    view: 'messaging_integration_onboarding',
+                    view: analyticsView,
                   },
                   onAddIntegration: onAddIntegration,
                   ...(modalParams && {modalParams}),

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -25,7 +25,7 @@ describe('SetupAlertIntegrationButton', function () {
     <SetupMessagingIntegrationButton
       projectId={project.id}
       refetchConfigs={jest.fn()}
-      analyticsParams={{view: MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION}}
+      analyticsView={MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION}
     />
   );
 

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -17,7 +17,6 @@ import MessagingIntegrationModal from 'sentry/views/alerts/rules/issue/messaging
 export enum MessagingIntegrationAnalyticsView {
   ALERT_RULE_CREATION = 'alert_rule_creation_messaging_integration_onboarding',
   PROJECT_CREATION = 'project_creation_messaging_integration_onboarding',
-  DEFAULT = 'messaging_integration_onboarding',
 }
 
 type Props = {

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -21,16 +21,14 @@ export enum MessagingIntegrationAnalyticsView {
 }
 
 type Props = {
-  analyticsParams?: {
-    view: MessagingIntegrationAnalyticsView;
-  };
+  analyticsView: MessagingIntegrationAnalyticsView;
   projectId?: string;
   refetchConfigs?: () => void;
 };
 
 function SetupMessagingIntegrationButton({
   refetchConfigs,
-  analyticsParams,
+  analyticsView,
   projectId,
 }: Props) {
   const providerKeys = ['slack', 'discord', 'msteams'];
@@ -112,9 +110,7 @@ function SetupMessagingIntegrationButton({
                       )}
                     onAddIntegration={onAddIntegration}
                     {...(projectId && {modalParams: {projectId: projectId}})}
-                    analyticsView={
-                      analyticsParams?.view ?? MessagingIntegrationAnalyticsView.DEFAULT
-                    }
+                    analyticsView={analyticsView}
                   />
                 ),
                 {

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -9,15 +9,15 @@ import type {
   IntegrationProvider,
   OrganizationIntegration,
 } from 'sentry/types/integrations';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {getIntegrationFeatureGate} from 'sentry/utils/integrationUtil';
 import {useApiQueries, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import MessagingIntegrationModal from 'sentry/views/alerts/rules/issue/messagingIntegrationModal';
 
 export enum MessagingIntegrationAnalyticsView {
-  ALERT_RULE_CREATION = 'alert_rule_creation',
-  PROJECT_CREATION = 'project_creation',
+  ALERT_RULE_CREATION = 'alert_rule_creation_messaging_integration_onboarding',
+  PROJECT_CREATION = 'project_creation_messaging_integration_onboarding',
+  DEFAULT = 'messaging_integration_onboarding',
 }
 
 type Props = {
@@ -112,16 +112,15 @@ function SetupMessagingIntegrationButton({
                       )}
                     onAddIntegration={onAddIntegration}
                     {...(projectId && {modalParams: {projectId: projectId}})}
+                    analyticsView={
+                      analyticsParams?.view ?? MessagingIntegrationAnalyticsView.DEFAULT
+                    }
                   />
                 ),
                 {
                   closeEvents: 'escape-key',
                 }
               );
-              trackAnalytics('onboarding.messaging_integration_modal_rendered', {
-                organization,
-                ...analyticsParams,
-              });
             }}
           >
             {t('Connect to messaging')}

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -248,9 +248,7 @@ export default function IssueAlertNotificationOptions(
       </MultipleCheckbox>
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
-          analyticsParams={{
-            view: MessagingIntegrationAnalyticsView.PROJECT_CREATION,
-          }}
+          analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
         />
       )}
     </Fragment>

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -7,6 +7,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
+import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 type Props = {
   children: (
@@ -19,9 +20,9 @@ type Props = {
   analyticsParams?: {
     already_installed: boolean;
     view:
+      | MessagingIntegrationAnalyticsView
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
-      | 'messaging_integration_onboarding'
       | 'onboarding'
       | 'project_creation';
   };

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -1,14 +1,15 @@
 import {createContext} from 'react';
 
 import type {IntegrationProvider, IntegrationType} from 'sentry/types/integrations';
+import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 export type IntegrationContextProps = {
   analyticsParams: {
     already_installed: boolean;
     view:
+      | MessagingIntegrationAnalyticsView
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
-      | 'messaging_integration_onboarding'
       | 'onboarding'
       | 'project_creation';
     referrer?: string;


### PR DESCRIPTION
biggest change is updating the `view` prop of `analyticsParam` to be the page that the user came from (alert creation or project creation) instead of a generic `messaging_integration_onboarding` view

also removed unnecessary analytics that we won't be tracking anymore (ex. modal rendered)