### PR TITLE
ref(replay): rm value from CouldNotParseValue error msgs

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_clicks_index.py
+++ b/src/sentry/replays/endpoints/project_replay_clicks_index.py
@@ -213,9 +213,7 @@ def handle_search_filters(
             except OperatorNotSupported:
                 raise ParseError(f"Invalid operator specified for `{search_filter.key.name}`")
             except CouldNotParseValue:
-                raise ParseError(
-                    f"Could not parse value '{search_filter.value.value}' for `{search_filter.key.name}`"
-                )
+                raise ParseError(f"Could not parse value for `{search_filter.key.name}`")
 
             if look_back == "AND":
                 look_back = None

--- a/src/sentry/replays/lib/new_query/parsers.py
+++ b/src/sentry/replays/lib/new_query/parsers.py
@@ -19,7 +19,10 @@ def parse_float(value: str) -> float:
 
 def parse_int(value: str) -> int:
     """Coerce to int or fail."""
-    return int(parse_float(value))
+    try:
+        return int(parse_float(value))
+    except (ValueError, CouldNotParseValue):
+        raise CouldNotParseValue("Failed to parse int.")
 
 
 def parse_duration(value: str) -> int:

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -71,9 +71,7 @@ def handle_viewed_by_me_filters(
 
         value = search_filter.value.value
         if not isinstance(value, str) or value.lower() not in ["true", "false"]:
-            raise ParseError(
-                f"Could not parse value '{search_filter.value.value}' for `{search_filter.key.name}`"
-            )
+            raise ParseError(f"Could not parse value for `{search_filter.key.name}`")
         value = value.lower() == "true"
 
         if request_user_id is None:
@@ -113,11 +111,10 @@ def handle_search_filters(
             except OperatorNotSupported:
                 raise ParseError(f"Invalid operator specified for `{search_filter.key.name}`")
             except CouldNotParseValue as e:
-                err_msg = f"Could not parse value '{search_filter.value.value}' for `{search_filter.key.name}`."
-                if e.args:
-                    err_msg += (
-                        f" {e.args[0]}"  # avoid using str(e) as it may expose stack trace info
-                    )
+                err_msg = f"Could not parse value for `{search_filter.key.name}`."
+                if e.args and e.args[0]:
+                    # avoid using str(e) as it may expose stack trace info
+                    err_msg += f" Detail: {e.args[0]}"
                 raise ParseError(err_msg)
 
             if look_back == "AND":


### PR DESCRIPTION
The parser reformats the searchbar input, switches/strips units, etc, so the value of search_filter.value.value could be confusing to the user. IMO we don't need to include the value, just the key. Ex:
![Screenshot 2024-12-16 at 12 45 13 PM](https://github.com/user-attachments/assets/d8b2e959-bdbf-4531-b5a3-008bca9e4118)


Also adds a "Detail: " prefix and a handler for `parse_int`

