### PR TITLE
fix: Toolbar should make all api requests against the organiztionUrl, skipping controlSilo for now

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -98,6 +98,28 @@ Required context variables:
           return `${cookie}; domain=${domain}; path=/; max-age=31536000; SameSite=none; partitioned; secure`;
         }
 
+        const controlSiloPathPatterns = [
+          /^\/auth\/.*/,
+          /^\/account\/.*/,
+          /^\/api\/0\/users\/.*/,
+          /^\/api\/0\/api-tokens\/.*/,
+          /^\/api\/0\/sentry-apps\/.*/,
+          /^\/api\/0\/organizations\/[^/]+\/audit-logs\/.*/,
+          /^\/api\/0\/organizations\/[^/]+\/broadcasts\/.*/,
+          /^\/api\/0\/organizations\/[^/]+\/integrations\/.*/,
+          /^\/api\/0\/organizations\/[^/]+\/config\/integrations\/.*/,
+          /^\/api\/0\/organizations\/[^/]+\/sentry-apps\/.*/,
+          /^\/api\/0\/organizations\/[^/]+\/sentry-app-installations\/.*/,
+          /^\/api\/0\/api-authorizations\/.*/,
+          /^\/api\/0\/api-applications\/.*/,
+          /^\/api\/0\/doc-integrations\/.*/,
+          /^\/api\/0\/assistant\/.*/,
+        ];
+
+        function isControlSiloPath(path) {
+          return controlSiloPathPatterns.some(pattern => pattern.test(path));
+        }
+
         const loginWindowMessageDispatch = {
           'did-login': ({ cookie, token }) => {
             if (cookie) {
@@ -157,7 +179,10 @@ Required context variables:
             // tokens be destroyed and reload the iframe in an unauth state.
             log('Has access info', { cookie: Boolean(document.cookie), accessToken: Boolean(accessToken) });
 
-            const url = new URL('/api/0' + path, regionUrl);
+            const domain = isControlSiloPath('/api/0' + path)
+              ? organizationUrl
+              : regionUrl;
+            const url = new URL('/api/0' + path, domain);
             const initWithCreds = {
               ...init,
               headers: { ...init.headers, ...bearer },

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -26,7 +26,6 @@ Required context variables:
         const logging = '{{ logging|escapejs }}';
         const organizationSlug = '{{ organization_slug|escapejs }}';
         const projectIdOrSlug = '{{ project_id_or_slug|escapejs }}';
-
         const organizationUrl = '{{ organization_url|escapejs }}';
         const regionUrl = '{{ region_url|escapejs }}';
 
@@ -98,33 +97,10 @@ Required context variables:
           return `${cookie}; domain=${domain}; path=/; max-age=31536000; SameSite=none; partitioned; secure`;
         }
 
-        const controlSiloPathPatterns = [
-          /^\/auth\/.*/,
-          /^\/account\/.*/,
-          /^\/api\/0\/users\/.*/,
-          /^\/api\/0\/api-tokens\/.*/,
-          /^\/api\/0\/sentry-apps\/.*/,
-          /^\/api\/0\/organizations\/[^/]+\/audit-logs\/.*/,
-          /^\/api\/0\/organizations\/[^/]+\/broadcasts\/.*/,
-          /^\/api\/0\/organizations\/[^/]+\/integrations\/.*/,
-          /^\/api\/0\/organizations\/[^/]+\/config\/integrations\/.*/,
-          /^\/api\/0\/organizations\/[^/]+\/sentry-apps\/.*/,
-          /^\/api\/0\/organizations\/[^/]+\/sentry-app-installations\/.*/,
-          /^\/api\/0\/api-authorizations\/.*/,
-          /^\/api\/0\/api-applications\/.*/,
-          /^\/api\/0\/doc-integrations\/.*/,
-          /^\/api\/0\/assistant\/.*/,
-        ];
-
-        function isControlSiloPath(path) {
-          return controlSiloPathPatterns.some(pattern => pattern.test(path));
-        }
-
         const loginWindowMessageDispatch = {
           'did-login': ({ cookie, token }) => {
             if (cookie) {
               document.cookie = getCookieValue(cookie, window.location.hostname);
-              document.cookie = getCookieValue(cookie, new URL(regionUrl).hostname);
               log('Saved a cookie', document.cookie.indexOf(cookie) >= 0);
             }
             if (token) {
@@ -179,10 +155,7 @@ Required context variables:
             // tokens be destroyed and reload the iframe in an unauth state.
             log('Has access info', { cookie: Boolean(document.cookie), accessToken: Boolean(accessToken) });
 
-            const domain = isControlSiloPath('/api/0' + path)
-              ? organizationUrl
-              : regionUrl;
-            const url = new URL('/api/0' + path, domain);
+            const url = new URL('/api/0' + path, organizationUrl);
             const initWithCreds = {
               ...init,
               headers: { ...init.headers, ...bearer },


### PR DESCRIPTION
API requests can be split between the region silos and control silo. Using the region silo when possible is faster because requests are directed to the same servers that hold the data for the org.

We cannot do that right now though because cookies are not being set properly against the regionUrl.