### PR TITLE
chore(similarity): Return empty stacktrace for events with little info

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -283,15 +283,12 @@ def generate_stacktrace_string(
         },
     )
 
-    # Metric for errors with no header, only one frame and no filename
-    # TODO: Determine how often this occurs and if we should send to seer, then remove metric
+    # Return empty stacktrace for events with no header, only one frame and no filename
+    # since this is too little info to group on
     if frame_metrics["has_no_filename"] and len(result_parts) == 1:
         header, frames = result_parts[0][0], result_parts[0][1]
         if header == "" and len(frames) == 1:
-            metrics.incr(
-                "seer.grouping.no_header_one_frame_no_filename",
-                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            )
+            stacktrace_str = ""
 
     return stacktrace_str.strip()
 

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -6,7 +6,6 @@ from uuid import uuid1
 
 import pytest
 
-from sentry import options
 from sentry.eventstore.models import Event
 from sentry.seer.similarity.utils import (
     BASE64_ENCODED_PREFIXES,
@@ -873,11 +872,7 @@ class GetStacktraceStringTest(TestCase):
         exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][1][
             "values"
         ] = []
-        get_stacktrace_string(exception)
-        sample_rate = options.get("seer.similarity.metrics_sample_rate")
-        mock_metrics.incr.assert_called_with(
-            "seer.grouping.no_header_one_frame_no_filename", sample_rate=sample_rate
-        )
+        assert get_stacktrace_string(exception) == ""
 
 
 class EventContentIsSeerEligibleTest(TestCase):


### PR DESCRIPTION
Return empty stacktrace for events with no head, filename, and only one frame
This will prevent us from sending these events to seer
Since they have so little information about them, seer cannot make a good decision with them

Note:
this happens quite infrequently on average, based on [metrics](https://app.datadoghq.com/dashboard/z26-zps-5bs/seer-grouping?fromUser=true&fullscreen_end_ts=1734368878653&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1733159278653&fullscreen_widget=6504195226755924&refresh_mode=sliding&from_ts=1733159256457&to_ts=1734368856457&live=true), it looks like seer currently see this type of event 5 times/4 hours, with a max of 62 times/4 hours