### PR TITLE
ref(toolbar): don't display change text when saving allowed origins

### DIFF
--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -30,6 +30,7 @@ function ProjectToolbarSettings({organization, project, params: {projectId}}: Pr
           type: 'textarea',
           rows: 3,
           autosize: true,
+          // formatMessageValue: false,
 
           // additional data/props that is related to rendering of form field rather than data
           label: t('Allowed Origins'),

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -30,7 +30,7 @@ function ProjectToolbarSettings({organization, project, params: {projectId}}: Pr
           type: 'textarea',
           rows: 3,
           autosize: true,
-          // formatMessageValue: false,
+          formatMessageValue: false,
 
           // additional data/props that is related to rendering of form field rather than data
           label: t('Allowed Origins'),


### PR DESCRIPTION
This pop-up message could get too long/clunky if the user has a long list of origins. Desc for this field [here](https://github.com/getsentry/sentry/blob/39948d2376649b81a87cc86321cd1437bbee6afc/static/app/components/forms/types.tsx#L54-L58)

Before:
![Screenshot 2024-12-16 at 2 47 05 PM](https://github.com/user-attachments/assets/d8ab8707-c0df-4e79-9bba-aa334d7ced01)

After:
![Screenshot 2024-12-16 at 2 42 41 PM](https://github.com/user-attachments/assets/cc03807b-8e06-4be9-9c3d-7cc70d40a19a)
