### PR TITLE
:wrench: chore: Remove Custom Alert Priorities FF from FE

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -321,9 +321,6 @@ class ActionsPanel extends PureComponent<Props> {
       value: getActionUniqueKey(availableAction),
       label: getFullActionTitle(availableAction),
     }));
-    const hasPriorityFlag = organization.features.includes(
-      'integrations-custom-alert-priorities'
-    );
 
     const levels = [
       {value: 0, label: 'Critical Status'},
@@ -472,8 +469,7 @@ class ActionsPanel extends PureComponent<Props> {
                         'inputChannelId'
                       )}
                     />
-                    {hasPriorityFlag &&
-                    availableAction &&
+                    {availableAction &&
                     (availableAction.type === 'opsgenie' ||
                       availableAction.type === 'pagerduty') ? (
                       <SelectControl


### PR DESCRIPTION
this flag has been GAed for  > 6 months so removing.

removing this flag should make milestone 2 work a tiny bit faster.