### PR TITLE
feat(alerts): Add schema for MetricAlertFire

### DIFF
--- a/src/sentry/incidents/endpoints/validators.py
+++ b/src/sentry/incidents/endpoints/validators.py
@@ -94,7 +94,6 @@ class MetricAlertComparisonConditionValidator(NumericComparisonConditionValidato
 class MetricAlertsDetectorValidator(BaseGroupTypeDetectorValidator):
     data_source = SnubaQueryDataSourceValidator(required=True)
     data_conditions = MetricAlertComparisonConditionValidator(many=True)
-    config = serializers.JSONField(required=False)
 
     def validate(self, attrs):
         """

--- a/src/sentry/incidents/endpoints/validators.py
+++ b/src/sentry/incidents/endpoints/validators.py
@@ -94,6 +94,7 @@ class MetricAlertComparisonConditionValidator(NumericComparisonConditionValidato
 class MetricAlertsDetectorValidator(BaseGroupTypeDetectorValidator):
     data_source = SnubaQueryDataSourceValidator(required=True)
     data_conditions = MetricAlertComparisonConditionValidator(many=True)
+    config = serializers.JSONField(required=False)
 
     def validate(self, attrs):
         """

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from sentry import features
 from sentry.incidents.endpoints.validators import MetricAlertsDetectorValidator
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -90,7 +91,10 @@ class MetricAlertFire(GroupType):
                 "type": ["integer", "null"],
                 "enum": [None, 300, 900, 6000, 86400, 604800, 2592000],
             },
-            "detection_type": {"type": "string"},
+            "detection_type": {
+                "type": "string",
+                "enum": [detection_type.value for detection_type in AlertRuleDetectionType],
+            },
             "sensitivity": {"type": ["string", "null"]},
             "seasonality": {"type": ["string", "null"]},
         },

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from sentry import features
 from sentry.incidents.endpoints.validators import MetricAlertsDetectorValidator
-from sentry.incidents.models.alert_rule import AlertRuleDetectionType
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -17,6 +17,9 @@ from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey
+
+COMPARISON_DELTA_CHOICES = [choice.value for choice in ComparisonDeltaChoices]
+COMPARISON_DELTA_CHOICES.append(None)
 
 
 class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate]):
@@ -89,7 +92,7 @@ class MetricAlertFire(GroupType):
             "threshold_period": {"type": "integer", "minimum": 1, "maximum": 20},
             "comparison_delta": {
                 "type": ["integer", "null"],
-                "enum": [None, 300, 900, 6000, 86400, 604800, 2592000],
+                "enum": COMPARISON_DELTA_CHOICES,
             },
             "detection_type": {
                 "type": "string",

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -79,7 +79,22 @@ class MetricAlertFire(GroupType):
     enable_escalation_detection = False
     detector_handler = MetricAlertDetectorHandler
     detector_validator = MetricAlertsDetectorValidator
-    detector_config_schema = {}  # TODO(colleen): update this
+    detector_config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "A representation of a metric alert firing",
+        "type": "object",
+        "required": ["threshold_period", "detection_type"],
+        "properties": {
+            "threshold_period": {"type": "integer", "minimum": 1, "maximum": 20},
+            "comparison_delta": {
+                "type": ["integer", "null"],
+                "enum": [None, 300, 900, 6000, 86400, 604800, 2592000],
+            },
+            "detection_type": {"type": "string"},
+            "sensitivity": {"type": ["string", "null"]},
+            "seasonality": {"type": ["string", "null"]},
+        },
+    }
 
     @classmethod
     def allow_post_process_group(cls, organization: Organization) -> bool:

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -18,7 +18,7 @@ from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey
 
-COMPARISON_DELTA_CHOICES = [choice.value for choice in ComparisonDeltaChoices]
+COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
 
 

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -177,6 +177,15 @@ class AlertRuleMonitorTypeInt(IntEnum):
     ACTIVATED = 1
 
 
+class ComparisonDeltaChoices(models.IntegerChoices):
+    FIVE_MINUTES = (300, "5 minutes ago")
+    FIFTEEN_MINUTES = (900, "15 minutes ago")
+    ONE_HOUR = (3600, "1 hour ago")
+    ONE_DAY = (86400, "1 day ago")
+    ONE_WEEK = (604800, "1 week ago")
+    ONE_MONTH = (2592000, "1 month ago")
+
+
 @region_silo_model
 class AlertRule(Model):
     __relocation_scope__ = RelocationScope.Organization
@@ -202,7 +211,7 @@ class AlertRule(Model):
     threshold_period = models.IntegerField()
     # This represents a time delta, in seconds. If not null, this is used to determine which time
     # window to query to compare the result from the current time_window to.
-    comparison_delta = models.IntegerField(null=True)
+    comparison_delta = models.IntegerField(choices=ComparisonDeltaChoices.choices, null=True)
     date_modified = models.DateTimeField(default=timezone.now)
     date_added = models.DateTimeField(default=timezone.now)
     monitor_type = models.IntegerField(default=AlertRuleMonitorTypeInt.CONTINUOUS)

--- a/src/sentry/workflow_engine/endpoints/validators/base.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base.py
@@ -164,6 +164,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
                 name=validated_data["name"],
                 workflow_condition_group=condition_group,
                 type=validated_data["group_type"].slug,
+                config=validated_data.get("config", {}),
             )
             DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -314,11 +314,12 @@ def create_detector(
         description=alert_rule.description,
         owner_user_id=alert_rule.user_id,
         owner_team=alert_rule.team,
-        config={  # TODO create a schema
+        config={
             "threshold_period": alert_rule.threshold_period,
             "sensitivity": alert_rule.sensitivity,
             "seasonality": alert_rule.seasonality,
             "comparison_delta": alert_rule.comparison_delta,
+            "detection_type": alert_rule.detection_type,
         },
     )
 

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -124,9 +124,9 @@ def enforce_config_schema(sender, instance: Detector, **kwargs):
     This needs to be a signal because the grouptype registry's entries are not available at import time.
     """
     group_type = instance.group_type
-
     if not group_type:
         raise ValueError(f"No group type found with type {instance.type}")
 
     config_schema = group_type.detector_config_schema
-    instance.validate_config(config_schema)
+    if instance.config:
+        instance.validate_config(config_schema)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -129,8 +129,6 @@ def enforce_config_schema(sender, instance: Detector, **kwargs):
         raise ValueError(f"No group type found with type {instance.type}")
 
     if not isinstance(instance.config, dict):
-        # if config isn't passed it gets set as a DatabaseDefault object
-        # the schema can't process anything but a non-empty dict
         raise ValidationError("Detector config must be a dictionary")
 
     config_schema = group_type.detector_config_schema

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricAlertFire
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import (
@@ -75,6 +76,10 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
                     "result": DetectorPriorityLevel.HIGH,
                 }
             ],
+            "config": {
+                "threshold_period": 1,
+                "detection_type": AlertRuleDetectionType.STATIC.value,
+            },
         }
 
     def test_missing_group_type(self):

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -32,15 +32,11 @@ class ProjectDetectorIndexBaseTest(APITestCase):
 @region_silo_test
 class ProjectDetectorIndexGetTest(ProjectDetectorIndexBaseTest):
     def test_simple(self):
-        detector = Detector.objects.create(
-            organization_id=self.organization.id,
-            name="Test Detector",
-            type=MetricAlertFire.slug,
+        detector = self.create_detector(
+            organization_id=self.organization.id, name="Test Detector", type=MetricAlertFire.slug
         )
-        detector_2 = Detector.objects.create(
-            organization_id=self.organization.id,
-            name="Test Detector 2",
-            type=MetricAlertFire.slug,
+        detector_2 = self.create_detector(
+            organization_id=self.organization.id, name="Test Detector 2", type=MetricAlertFire.slug
         )
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert response.data == serialize([detector, detector_2])

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from sentry.api.serializers import serialize
 from sentry.incidents.grouptype import MetricAlertFire
-from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import (
@@ -76,10 +75,6 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
                     "result": DetectorPriorityLevel.HIGH,
                 }
             ],
-            "config": {
-                "threshold_period": 1,
-                "detection_type": AlertRuleDetectionType.STATIC.value,
-            },
         }
 
     def test_missing_group_type(self):

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -11,14 +11,7 @@ from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.workflow_engine.models import (
-    Action,
-    DataCondition,
-    DataConditionGroup,
-    DataSource,
-    Detector,
-    Workflow,
-)
+from sentry.workflow_engine.models import Action, DataCondition, DataConditionGroup, DataSource, Workflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.data_condition_group_action import DataConditionGroupAction
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
@@ -28,12 +21,9 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 
 class TestDetectorSerializer(TestCase):
     def test_serialize_simple(self):
-        detector = Detector.objects.create(
-            organization_id=self.organization.id,
-            name="Test Detector",
-            type=MetricAlertFire.slug,
+        detector = self.create_detector(
+            organization_id=self.organization.id, name="Test Detector", type=MetricAlertFire.slug
         )
-
         result = serialize(detector)
 
         assert result == {
@@ -59,12 +49,9 @@ class TestDetectorSerializer(TestCase):
             comparison=100,
             condition_result=DetectorPriorityLevel.HIGH,
         )
-
         action = Action.objects.create(type=Action.Type.EMAIL, data={"foo": "bar"})
-
         DataConditionGroupAction.objects.create(condition_group=condition_group, action=action)
-
-        detector = Detector.objects.create(
+        detector = self.create_detector(
             organization_id=self.organization.id,
             name="Test Detector",
             type=MetricAlertFire.slug,
@@ -145,7 +132,7 @@ class TestDetectorSerializer(TestCase):
 
     def test_serialize_bulk(self):
         detectors = [
-            Detector.objects.create(
+            self.create_detector(
                 organization_id=self.organization.id,
                 name=f"Test Detector {i}",
                 type=MetricAlertFire.slug,

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -11,7 +11,13 @@ from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.workflow_engine.models import Action, DataCondition, DataConditionGroup, DataSource, Workflow
+from sentry.workflow_engine.models import (
+    Action,
+    DataCondition,
+    DataConditionGroup,
+    DataSource,
+    Workflow,
+)
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.data_condition_group_action import DataConditionGroupAction
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -11,6 +11,7 @@ from sentry.incidents.endpoints.validators import (
     MetricAlertComparisonConditionValidator,
     MetricAlertsDetectorValidator,
 )
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupCategory, GroupType
@@ -193,6 +194,10 @@ class DetectorValidatorTest(TestCase):
                     "result": DetectorPriorityLevel.HIGH,
                 }
             ],
+            "config": {
+                "threshold_period": 1,
+                "detection_type": AlertRuleDetectionType.STATIC.value,
+            },
         }
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.create_audit_entry")

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -2,7 +2,11 @@ from unittest import mock
 
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.grouptype import MetricAlertFire
-from sentry.incidents.models.alert_rule import AlertRuleThresholdType, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import (
+    AlertRuleDetectionType,
+    AlertRuleThresholdType,
+    AlertRuleTriggerAction,
+)
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.snuba.models import QuerySubscription
@@ -118,6 +122,7 @@ class AlertRuleMigrationHelpersTest(APITestCase):
             "sensitivity": None,
             "seasonality": None,
             "comparison_delta": None,
+            "detection_type": AlertRuleDetectionType.STATIC,
         }
 
         detector_workflow = DetectorWorkflow.objects.get(detector=detector)

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 import pytest
 from jsonschema import ValidationError
 
+from sentry.incidents.grouptype import MetricAlertFire
 from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.testutils.cases import APITestCase
 from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 
 
@@ -81,4 +83,72 @@ class TestWorkflowConfig(TestJsonConfigBase):
         self.create_workflow(organization=self.organization, name="test_workflow", config={})
         self.create_workflow(
             organization=self.organization, name="test_workflow2", config={"frequency": 30}
+        )
+
+
+class TestMetricAlertFireDetectorConfig(TestJsonConfigBase, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.metric_alert = self.create_alert_rule(threshold_period=1)
+        self.config = (
+            {
+                "threshold_period": self.metric_alert.threshold_period,
+                "sensitivity": self.metric_alert.sensitivity,
+                "seasonality": self.metric_alert.seasonality,
+                "comparison_delta": self.metric_alert.comparison_delta,
+            },
+        )
+
+        @dataclass(frozen=True)
+        class TestGroupType(GroupType):
+            type_id = 2
+            slug = "test_metric_alert_fire"
+            description = "Metric alert fired"
+            category = GroupCategory.METRIC_ALERT.value
+            detector_config_schema = MetricAlertFire.detector_config_schema
+
+    def test_mismatched_schema(self):
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.metric_alert.name,
+                project_id=self.project.id,
+                type="test_metric_alert_fire",
+                owner_user_id=self.metric_alert.user_id,
+                config={
+                    "threshold_period": self.metric_alert.threshold_period,
+                    "comparison_delta": self.metric_alert.comparison_delta,
+                    "detection_type": self.metric_alert.detection_type,
+                    "sensitivity": self.metric_alert.sensitivity,
+                    "seasonality": 42,
+                },
+            )
+
+    def test_missing_required(self):
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.metric_alert.name,
+                project_id=self.project.id,
+                type="test_metric_alert_fire",
+                owner_user_id=self.metric_alert.user_id,
+                config={
+                    "threshold_period": self.metric_alert.threshold_period,
+                    "comparison_delta": self.metric_alert.comparison_delta,
+                    "sensitivity": self.metric_alert.sensitivity,
+                    "seasonality": 42,
+                },
+            )
+
+    def test_detector_correct_schema(self):
+        self.create_detector(
+            name=self.metric_alert.name,
+            project_id=self.project.id,
+            type="test_metric_alert_fire",
+            owner_user_id=self.metric_alert.user_id,
+            config={
+                "threshold_period": self.metric_alert.threshold_period,
+                "comparison_delta": self.metric_alert.comparison_delta,
+                "detection_type": self.metric_alert.detection_type,
+                "sensitivity": self.metric_alert.sensitivity,
+                "seasonality": self.metric_alert.seasonality,
+            },
         )

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -101,7 +101,7 @@ class TestMetricAlertFireDetectorConfig(TestJsonConfigBase, APITestCase):
 
         @dataclass(frozen=True)
         class TestGroupType(GroupType):
-            type_id = 2
+            type_id = 3
             slug = "test_metric_alert_fire"
             description = "Metric alert fired"
             category = GroupCategory.METRIC_ALERT.value

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -90,14 +90,6 @@ class TestMetricAlertFireDetectorConfig(TestJsonConfigBase, APITestCase):
     def setUp(self):
         super().setUp()
         self.metric_alert = self.create_alert_rule(threshold_period=1)
-        self.config = (
-            {
-                "threshold_period": self.metric_alert.threshold_period,
-                "sensitivity": self.metric_alert.sensitivity,
-                "seasonality": self.metric_alert.seasonality,
-                "comparison_delta": self.metric_alert.comparison_delta,
-            },
-        )
 
         @dataclass(frozen=True)
         class TestGroupType(GroupType):
@@ -106,6 +98,48 @@ class TestMetricAlertFireDetectorConfig(TestJsonConfigBase, APITestCase):
             description = "Metric alert fired"
             category = GroupCategory.METRIC_ALERT.value
             detector_config_schema = MetricAlertFire.detector_config_schema
+
+    def test_detector_correct_schema(self):
+        self.create_detector(
+            name=self.metric_alert.name,
+            project_id=self.project.id,
+            type="test_metric_alert_fire",
+            owner_user_id=self.metric_alert.user_id,
+            config={
+                "threshold_period": self.metric_alert.threshold_period,
+                "comparison_delta": self.metric_alert.comparison_delta,
+                "detection_type": self.metric_alert.detection_type,
+                "sensitivity": self.metric_alert.sensitivity,
+                "seasonality": self.metric_alert.seasonality,
+            },
+        )
+
+    def test_empty_config(self):
+        self.create_detector(
+            name=self.metric_alert.name,
+            project_id=self.project.id,
+            type="test_metric_alert_fire",
+            owner_user_id=self.metric_alert.user_id,
+            config={},
+        )
+
+    def test_no_config(self):
+        self.create_detector(
+            name=self.metric_alert.name,
+            project_id=self.project.id,
+            type="test_metric_alert_fire",
+            owner_user_id=self.metric_alert.user_id,
+        )
+
+    def test_incorrect_config(self):
+        with pytest.raises(ValidationError):
+            self.create_detector(
+                name=self.metric_alert.name,
+                project_id=self.project.id,
+                type="test_metric_alert_fire",
+                owner_user_id=self.metric_alert.user_id,
+                config=["some", "stuff"],
+            )
 
     def test_mismatched_schema(self):
         with pytest.raises(ValidationError):
@@ -137,18 +171,3 @@ class TestMetricAlertFireDetectorConfig(TestJsonConfigBase, APITestCase):
                     "seasonality": self.metric_alert.seasonality,
                 },
             )
-
-    def test_detector_correct_schema(self):
-        self.create_detector(
-            name=self.metric_alert.name,
-            project_id=self.project.id,
-            type="test_metric_alert_fire",
-            owner_user_id=self.metric_alert.user_id,
-            config={
-                "threshold_period": self.metric_alert.threshold_period,
-                "comparison_delta": self.metric_alert.comparison_delta,
-                "detection_type": self.metric_alert.detection_type,
-                "sensitivity": self.metric_alert.sensitivity,
-                "seasonality": self.metric_alert.seasonality,
-            },
-        )

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -134,7 +134,7 @@ class TestMetricAlertFireDetectorConfig(TestJsonConfigBase, APITestCase):
                     "threshold_period": self.metric_alert.threshold_period,
                     "comparison_delta": self.metric_alert.comparison_delta,
                     "sensitivity": self.metric_alert.sensitivity,
-                    "seasonality": 42,
+                    "seasonality": self.metric_alert.seasonality,
                 },
             )
 


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry/pull/81979/ define a schema for `MetricRuleFire` group type. 