### PR TITLE
feat(tempest): Endpoint for fetching tempest credentials

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -632,3 +632,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 # Taskworkers
 /src/sentry/taskworker/                                       @getsentry/taskworker
 /tests/sentry/taskworker/                                     @getsentry/taskworker
+
+# Tempest
+/src/sentry/tempest/                                       @getsentry/gdx
+/tests/sentry/tempest/                                     @getsentry/gdx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -632,3 +632,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 # Taskworkers
 /src/sentry/taskworker/                                       @getsentry/taskworker
 /tests/sentry/taskworker/                                     @getsentry/taskworker
+
+# Tempest
+/src/sentry/tempest/                                       @getsentry/team-gdx
+/tests/sentry/tempest/                                     @getsentry/team-gdx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -632,7 +632,3 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 # Taskworkers
 /src/sentry/taskworker/                                       @getsentry/taskworker
 /tests/sentry/taskworker/                                     @getsentry/taskworker
-
-# Tempest
-/src/sentry/tempest/                                       @getsentry/team-gdx
-/tests/sentry/tempest/                                     @getsentry/team-gdx

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -28,3 +28,4 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
+    GDX = "gdx"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -28,4 +28,3 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
-    TEAM_GDX = "team-gdx"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -28,4 +28,4 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
-    TEAM_GDX = "team-game-dev-experience"
+    TEAM_GDX = "team-gdx"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -28,3 +28,4 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
+    TEAM_GDX = "team-game-dev-experience"

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2788,6 +2788,12 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         ProjectUptimeAlertIndexEndpoint.as_view(),
         name="sentry-api-0-project-uptime-alert-index",
     ),
+    # Tempest
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/tempest-credentials/$",
+        TempestCredentialsEndpoint.as_view(),
+        name="sentry-api-0-project-tempest-credentials",
+    ),
     *workflow_urls.urlpatterns,
 ]
 
@@ -3265,12 +3271,6 @@ urlpatterns = [
         r"^secret-scanning/github/$",
         SecretScanningGitHubEndpoint.as_view(),
         name="sentry-api-0-secret-scanning-github",
-    ),
-    # Tempest
-    re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/tempest-credentials/$",
-        TempestCredentialsEndpoint.as_view(),
-        name="sentry-api-0-project-tempest-credentials",
     ),
     # Catch all
     re_path(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -313,6 +313,7 @@ from sentry.sentry_apps.api.endpoints.sentry_internal_app_token_details import (
 from sentry.sentry_apps.api.endpoints.sentry_internal_app_tokens import (
     SentryInternalAppTokensEndpoint,
 )
+from sentry.tempest.endpoints.tempest_credentials import TempestCredentialsEndpoint
 from sentry.uptime.endpoints.project_uptime_alert_details import ProjectUptimeAlertDetailsEndpoint
 from sentry.uptime.endpoints.project_uptime_alert_index import ProjectUptimeAlertIndexEndpoint
 from sentry.users.api.endpoints.authenticator_index import AuthenticatorIndexEndpoint
@@ -3264,6 +3265,12 @@ urlpatterns = [
         r"^secret-scanning/github/$",
         SecretScanningGitHubEndpoint.as_view(),
         name="sentry-api-0-secret-scanning-github",
+    ),
+    # Tempest
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/tempest-credentials/$",
+        TempestCredentialsEndpoint.as_view(),
+        name="sentry-api-0-project-tempest-credentials",
     ),
     # Catch all
     re_path(

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -19,7 +19,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.UNOWNED  # TODO (vgrozdanic): add team gdx to CODEOWNERS
+    owner = ApiOwner.TELEMETRY_EXPERIENCE  # TODO (vgrozdanic): add team gdx to CODEOWNERS
 
     permission_classes = (TempestCredentialsPermission,)
 

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -19,7 +19,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE  # TODO (vgrozdanic): add team gdx to CODEOWNERS
+    owner = ApiOwner.GDX
 
     permission_classes = (TempestCredentialsPermission,)
 

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -19,7 +19,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TEAM_GDX
+    owner = ApiOwner.UNOWNED  # TODO (vgrozdanic): add team gdx to CODEOWNERS
 
     permission_classes = (TempestCredentialsPermission,)
 

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 
 from sentry import features
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectEndpoint
@@ -18,6 +19,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+    owner = ApiOwner.TEAM_GDX
 
     permission_classes = (TempestCredentialsPermission,)
 

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -1,5 +1,6 @@
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -28,7 +29,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
             "organizations:tempest-access", project.organization, actor=request.user
         )
 
-    def get(self, request, project):
+    def get(self, request: Request, project: Project) -> Response:
         if not self.has_feature(request, project):
             raise NotFound
 

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -1,0 +1,39 @@
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+
+from sentry import features
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import ProjectEndpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers.base import serialize
+from sentry.models.project import Project
+from sentry.tempest.models import TempestCredentials
+from sentry.tempest.permissions import TempestCredentialsPermission
+from sentry.tempest.serializers import TempestCredentialsSerializer
+
+
+@region_silo_endpoint
+class TempestCredentialsEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    permission_classes = (TempestCredentialsPermission,)
+
+    def has_feature(self, request: Request, project: Project) -> bool:
+        return features.has(
+            "organizations:tempest-access", project.organization, actor=request.user
+        )
+
+    def get(self, request, project):
+        if not self.has_feature(request, project):
+            raise NotFound
+
+        tempest_credentials_qs = TempestCredentials.objects.filter(project=project)
+        return self.paginate(
+            request=request,
+            queryset=tempest_credentials_qs,
+            on_results=lambda x: serialize(x, request.user, TempestCredentialsSerializer()),
+            paginator_cls=OffsetPaginator,
+        )

--- a/src/sentry/tempest/permissions.py
+++ b/src/sentry/tempest/permissions.py
@@ -1,0 +1,16 @@
+from sentry.api.bases.project import ProjectPermission
+
+
+class TempestCredentialsPermission(ProjectPermission):
+    scope_map = {
+        "GET": [
+            "project:read",
+            "project:write",
+            "project:admin",
+            "org:read",
+            "org:write",
+            "org:admin",
+        ],
+        "POST": ["org:admin"],
+        "DELETE": ["org:admin"],
+    }

--- a/src/sentry/tempest/serializers.py
+++ b/src/sentry/tempest/serializers.py
@@ -1,6 +1,8 @@
-from sentry.api.serializers.base import Serializer
+from sentry.api.serializers.base import Serializer, register
+from sentry.tempest.models import TempestCredentials
 
 
+@register(TempestCredentials)
 class TempestCredentialsSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         return {

--- a/src/sentry/tempest/serializers.py
+++ b/src/sentry/tempest/serializers.py
@@ -4,11 +4,14 @@ from sentry.tempest.models import TempestCredentials
 
 @register(TempestCredentials)
 class TempestCredentialsSerializer(Serializer):
+    def _obfuscate_client_secret(self, client_secret: str) -> str:
+        return "*" * len(client_secret)
+
     def serialize(self, obj, attrs, user, **kwargs):
         return {
             "id": obj.id,
             "clientId": obj.client_id,
-            "clientSecret": obj.client_secret,
+            "clientSecret": self._obfuscate_client_secret(obj.client_secret),
             "message": obj.message,
             "messageType": obj.message_type,
             "latestFetchedItemId": obj.latest_fetched_item_id,

--- a/src/sentry/tempest/serializers.py
+++ b/src/sentry/tempest/serializers.py
@@ -1,0 +1,14 @@
+from sentry.api.serializers.base import Serializer
+
+
+class TempestCredentialsSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs):
+        return {
+            "id": obj.id,
+            "clientId": obj.client_id,
+            "clientSecret": obj.client_secret,
+            "message": obj.message,
+            "messageType": obj.message_type,
+            "latestFetchedItemId": obj.latest_fetched_item_id,
+            "createdById": obj.created_by_id,
+        }

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -146,6 +146,8 @@ from sentry.signals import project_created
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, QuerySubscriptionDataSourceHandler
+from sentry.tempest.models import MessageType as TempestMessageType
+from sentry.tempest.models import TempestCredentials
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -603,6 +605,34 @@ class Factories:
     @assume_test_silo_mode(SiloMode.REGION)
     def create_project_key(project):
         return project.key_set.get_or_create()[0]
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_tempest_credentials(
+        project: Project,
+        created_by: User | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        message: str = "",
+        message_type: str | None = None,
+        latest_fetched_item_id: str | None = None,
+    ):
+        if client_id is None:
+            client_id = str(uuid4())
+        if client_secret is None:
+            client_secret = str(uuid4())
+        if message_type is None:
+            message_type = TempestMessageType.ERROR
+
+        return TempestCredentials.objects.create(
+            project=project,
+            created_by_id=created_by.id if created_by else None,
+            client_id=client_id,
+            client_secret=client_secret,
+            message=message,
+            message_type=message_type,
+            latest_fetched_item_id=latest_fetched_item_id,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -27,6 +27,7 @@ from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.silo.base import SiloMode
 from sentry.snuba.models import QuerySubscription
+from sentry.tempest.models import TempestCredentials
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode
@@ -279,6 +280,9 @@ class Fixtures:
 
     def store_event(self, *args, **kwargs) -> Event:
         return Factories.store_event(*args, **kwargs)
+
+    def create_tempest_credentials(self, project: Project, *args, **kwargs) -> TempestCredentials:
+        return Factories.create_tempest_credentials(project, *args, **kwargs)
 
     def create_group(self, project=None, *args, **kwargs):
         if project is None:

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials.py
@@ -11,7 +11,8 @@ class TestTempestCredentials(APITestCase):
 
             other_project = self.create_project(organization=self.organization)
             # credentials connected to other project which should not be included in the response
-            [self.create_tempest_credentials(other_project) for _ in range(5)]
+            for _ in range(5):
+                self.create_tempest_credentials(other_project)
 
             self.login_as(self.user)
             response = self.get_success_response(self.project.organization.slug, self.project.slug)
@@ -23,6 +24,13 @@ class TestTempestCredentials(APITestCase):
         self.login_as(self.user)
         response = self.get_response(self.project.organization.slug, self.project.slug)
         assert response.status_code == 404
+
+    def test_client_secret_is_obfuscated(self):
+        with Feature({"organizations:tempest-access": True}):
+            credentials = self.create_tempest_credentials(self.project)
+            self.login_as(self.user)
+            response = self.get_success_response(self.project.organization.slug, self.project.slug)
+            assert response.data[0]["clientSecret"] == "*" * len(credentials.client_secret)
 
     def test_unauthenticated_user_cant_access_endpoint(self):
         self.get_error_response(self.project.organization.slug, self.project.slug)

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials.py
@@ -1,0 +1,28 @@
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import Feature
+
+
+class TestTempestCredentials(APITestCase):
+    endpoint = "sentry-api-0-project-tempest-credentials"
+
+    def test_create_tempest_credentials(self):
+        with Feature({"organizations:tempest-access": True}):
+            credentials = [self.create_tempest_credentials(self.project) for _ in range(5)]
+
+            other_project = self.create_project(organization=self.organization)
+            # credentials connected to other project which should not be included in the response
+            [self.create_tempest_credentials(other_project) for _ in range(5)]
+
+            self.login_as(self.user)
+            response = self.get_success_response(self.project.organization.slug, self.project.slug)
+
+            assert len(response.data) == 5
+            assert {cred.id for cred in credentials} == {item["id"] for item in response.data}
+
+    def test_endpoint_returns_404_if_feature_flag_is_disabled(self):
+        self.login_as(self.user)
+        response = self.get_response(self.project.organization.slug, self.project.slug)
+        assert response.status_code == 404
+
+    def test_unauthenticated_user_cant_access_endpoint(self):
+        self.get_error_response(self.project.organization.slug, self.project.slug)


### PR DESCRIPTION
Endpoint only for GET request. Responsible for fetching all tempest credentials for a given project.

Part of https://github.com/getsentry/team-gdx/issues/52

2 more endpoints will be done as a part of separate PRs to reduce the scope of the PR:
- POST - creation of new credentials record
- DELETE - deletion of the existing credentials record 