### PR TITLE
feat(autofix): Iterative version history for changes

### DIFF
--- a/static/app/components/events/autofix/autofixActionSelector.tsx
+++ b/static/app/components/events/autofix/autofixActionSelector.tsx
@@ -83,6 +83,7 @@ function AutofixActionSelector<T extends string>({
 
 const Container = styled('div')`
   min-height: 40px;
+  padding: 0 ${space(1)};
 `;
 
 const ContentWrapper = styled('div')`

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -1,21 +1,27 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
-import type {
-  AutofixChangesStep,
-  AutofixCodebaseChange,
+import {SetupAndCreatePRsButton} from 'sentry/components/events/autofix/autofixPrButton';
+import {AutofixViewPrButton} from 'sentry/components/events/autofix/autofixViewPrButton';
+import {
+  type AutofixChangesStep,
+  type AutofixCodebaseChange,
+  AutofixStatus,
 } from 'sentry/components/events/autofix/types';
 import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
-import {IconFix} from 'sentry/icons';
+import {IconChevron, IconFix} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
 
 type AutofixChangesProps = {
+  changesVersionIndex: number;
   groupId: string;
+  hasMoreThanOneChangesStep: boolean;
+  hasStepBelow: boolean;
   runId: string;
   step: AutofixChangesStep;
 };
@@ -30,12 +36,18 @@ function AutofixRepoChange({
   runId: string;
 }) {
   return (
-    <Content>
+    <RepoChangeContent>
       <RepoChangesHeader>
         <div>
           <Title>{change.title}</Title>
           <PullRequestTitle>{change.repo_name}</PullRequestTitle>
         </div>
+        {change.pull_request && (
+          <AutofixViewPrButton
+            repoName={change.repo_name}
+            prUrl={change.pull_request?.pr_url}
+          />
+        )}
       </RepoChangesHeader>
       <AutofixDiff
         diff={change.diff}
@@ -44,7 +56,7 @@ function AutofixRepoChange({
         repoId={change.repo_external_id}
         editable={!change.pull_request}
       />
-    </Content>
+    </RepoChangeContent>
   );
 }
 
@@ -69,12 +81,20 @@ const cardAnimationProps: AnimationProps = {
   }),
 };
 
-export function AutofixChanges({step, groupId, runId}: AutofixChangesProps) {
+export function AutofixChanges({
+  step,
+  groupId,
+  runId,
+  hasStepBelow,
+  changesVersionIndex,
+  hasMoreThanOneChangesStep,
+}: AutofixChangesProps) {
   const data = useAutofixData({groupId});
+  const [isExpanded, setIsExpanded] = useState(!hasStepBelow);
 
   if (step.status === 'ERROR' || data?.status === 'ERROR') {
     return (
-      <Content>
+      <RepoChangeContent>
         <PreviewContent>
           {data?.error_message ? (
             <Fragment>
@@ -85,38 +105,80 @@ export function AutofixChanges({step, groupId, runId}: AutofixChangesProps) {
             <span>{t('Something went wrong.')}</span>
           )}
         </PreviewContent>
-      </Content>
+      </RepoChangeContent>
     );
   }
 
-  if (!step.changes.length) {
+  if (
+    step.status === AutofixStatus.COMPLETED &&
+    Object.keys(step.codebase_changes).length === 0
+  ) {
     return (
-      <Content>
+      <RepoChangeContent>
         <PreviewContent>
           <span>{t('Could not find a fix.')}</span>
         </PreviewContent>
-      </Content>
+      </RepoChangeContent>
     );
   }
 
-  const allChangesHavePullRequests = step.changes.every(change => change.pull_request);
+  const allChangesHavePullRequests = Object.values(step.codebase_changes).every(
+    change => change.pull_request
+  );
+
+  const changesText = hasMoreThanOneChangesStep
+    ? hasStepBelow
+      ? t('Changes (version %s)', changesVersionIndex + 1)
+      : t('Latest Changes (version %s)', changesVersionIndex + 1)
+    : t('Changes');
 
   return (
     <AnimatePresence initial>
       <AnimationWrapper key="card" {...cardAnimationProps}>
-        <ChangesContainer allChangesHavePullRequests={allChangesHavePullRequests}>
-          <ClippedBox clipHeight={408}>
-            <HeaderText>
-              <IconFix size="sm" />
-              {t('Fixes')}
-            </HeaderText>
-            {step.changes.map((change, i) => (
-              <Fragment key={change.repo_external_id}>
-                {i > 0 && <Separator />}
-                <AutofixRepoChange change={change} groupId={groupId} runId={runId} />
-              </Fragment>
-            ))}
-          </ClippedBox>
+        <ChangesContainer
+          allChangesHavePullRequests={allChangesHavePullRequests}
+          hasStepBelow={hasStepBelow}
+        >
+          <HeaderRow
+            onClick={() => hasStepBelow && setIsExpanded(!isExpanded)}
+            role={hasStepBelow ? 'button' : undefined}
+            aria-expanded={hasStepBelow ? isExpanded : undefined}
+            expandable={hasStepBelow}
+          >
+            <HeaderTextWrapper>
+              <HeaderText isPreviousChanges={hasStepBelow}>
+                <IconFix size="sm" />
+                {changesText}
+              </HeaderText>
+            </HeaderTextWrapper>
+            <HeaderButtonsWrapper>
+              {(!hasStepBelow || isExpanded) && !allChangesHavePullRequests && (
+                <SetupAndCreatePRsButton
+                  changes={Object.values(step.codebase_changes)}
+                  groupId={groupId}
+                  hasStepBelow={hasStepBelow}
+                  changesStepId={step.id}
+                />
+              )}
+              {hasStepBelow && (
+                <CollapseButton
+                  aria-label={isExpanded ? t('Collapse changes') : t('Expand changes')}
+                >
+                  <IconChevron direction={isExpanded ? 'up' : 'down'} size="sm" />
+                </CollapseButton>
+              )}
+            </HeaderButtonsWrapper>
+          </HeaderRow>
+          {(!hasStepBelow || isExpanded) && (
+            <ClippedBox clipHeight={408}>
+              {Object.values(step.codebase_changes).map((change, i) => (
+                <Fragment key={change.repo_external_id}>
+                  {i > 0 && <Separator />}
+                  <AutofixRepoChange change={change} groupId={groupId} runId={runId} />
+                </Fragment>
+              ))}
+            </ClippedBox>
+          )}
         </ChangesContainer>
       </AnimationWrapper>
     </AnimatePresence>
@@ -136,21 +198,24 @@ const AnimationWrapper = styled(motion.div)`
 
 const PrefixText = styled('span')``;
 
-const ChangesContainer = styled('div')<{allChangesHavePullRequests: boolean}>`
-  border: 2px solid
+const ChangesContainer = styled('div')<{
+  allChangesHavePullRequests: boolean;
+  hasStepBelow?: boolean;
+}>`
+  border: ${p => (p.hasStepBelow ? 1 : 2)}px solid
     ${p =>
-      p.allChangesHavePullRequests
-        ? p.theme.alert.success.border
-        : p.theme.alert.info.border};
+      p.hasStepBelow
+        ? p.theme.innerBorder
+        : p.allChangesHavePullRequests
+          ? p.theme.alert.success.border
+          : p.theme.alert.info.border};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowMedium};
-  padding-left: ${space(2)};
-  padding-right: ${space(2)};
-  padding-top: ${space(1)};
+  overflow: hidden;
 `;
 
-const Content = styled('div')`
-  padding: 0 ${space(1)} ${space(1)} ${space(1)};
+const RepoChangeContent = styled('div')`
+  padding: 0 ${space(2)} ${space(2)} ${space(2)};
 `;
 
 const Title = styled('div')`
@@ -164,9 +229,9 @@ const PullRequestTitle = styled('div')`
 
 const RepoChangesHeader = styled('div')`
   padding: ${space(2)} 0;
-  display: grid;
-  align-items: center;
-  grid-template-columns: 1fr auto;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
 `;
 
 const Separator = styled('hr')`
@@ -175,10 +240,53 @@ const Separator = styled('hr')`
   margin: ${space(2)} -${space(2)} 0 -${space(2)};
 `;
 
-const HeaderText = styled('div')`
-  font-weight: bold;
-  font-size: 1.2em;
+const HeaderRow = styled('div')<{expandable?: boolean}>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: space-between;
+  gap: ${space(1)};
+  height: calc((2 * ${space(2)}) + ${p => p.theme.form.sm.height}px);
+  padding: ${space(2)};
+  cursor: ${p => (p.expandable ? 'pointer' : 'default')};
+
+  &:hover {
+    background-color: ${p =>
+      p.expandable ? p.theme.backgroundSecondary : 'transparent'};
+  }
+`;
+
+const HeaderButtonsWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
+`;
+
+const HeaderText = styled('div')<{isPreviousChanges?: boolean}>`
+  font-weight: bold;
+  font-size: ${p => (p.isPreviousChanges ? 1.1 : 1.2)}em;
+  color: ${p => (p.isPreviousChanges ? p.theme.subText : p.theme.textColor)};
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const HeaderTextWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const CollapseButton = styled('button')`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: ${p => p.theme.subText};
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
 `;

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -412,6 +412,39 @@ export function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: 
   });
 }
 
+export function useSendFeedbackOnChanges({
+  groupId,
+  runId,
+}: {
+  groupId: string;
+  runId: string;
+}) {
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {message: string}) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'continue_with_feedback',
+            message: params.message,
+          },
+        },
+      });
+    },
+    onSuccess: _ => {
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+      addSuccessMessage(t('Thanks, rethinking this...'));
+    },
+    onError: () => {
+      addErrorMessage(t('Something went wrong when sending Autofix your message.'));
+    },
+  });
+}
+
 function ChainLink({
   groupId,
   runId,

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -468,7 +468,7 @@ const Placeholder = styled('div')`
 
 const ViewPRButtons = styled(ScrollCarousel)`
   width: 100%;
-  padding: 0 ${space(1)};
+  padding: 0 ${space(1)} ${space(2)} ${space(1)};
 `;
 
 const ScrollIntoViewButtonWrapper = styled('div')`

--- a/static/app/components/events/autofix/autofixPrButton.tsx
+++ b/static/app/components/events/autofix/autofixPrButton.tsx
@@ -1,0 +1,140 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
+import {AutofixSetupWriteAccessModal} from 'sentry/components/events/autofix/autofixSetupWriteAccessModal';
+import type {AutofixCodebaseChange} from 'sentry/components/events/autofix/types';
+import {
+  makeAutofixQueryKey,
+  useAutofixData,
+} from 'sentry/components/events/autofix/useAutofix';
+import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+
+function CreatePRsButton({
+  changes,
+  groupId,
+  changesStepId,
+  isPrimary = true,
+}: {
+  changes: AutofixCodebaseChange[];
+  changesStepId: string;
+  groupId: string;
+  isPrimary?: boolean;
+}) {
+  const autofixData = useAutofixData({groupId});
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const [hasClickedCreatePr, setHasClickedCreatePr] = useState(false);
+
+  const createPRs = () => {
+    setHasClickedCreatePr(true);
+    for (const change of changes) {
+      createPr({change});
+    }
+  };
+
+  const {mutate: createPr} = useMutation({
+    mutationFn: ({change}: {change: AutofixCodebaseChange}) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: autofixData?.run_id,
+          payload: {
+            type: 'create_pr',
+            repo_external_id: change.repo_external_id,
+            changes_step_id: changesStepId,
+          },
+        },
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('Created pull requests.'));
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+    },
+    onError: () => {
+      setHasClickedCreatePr(false);
+      addErrorMessage(t('Failed to create a pull request'));
+    },
+  });
+
+  return (
+    <Button
+      priority={isPrimary ? 'primary' : 'default'}
+      onClick={createPRs}
+      icon={
+        hasClickedCreatePr && <ProcessingStatusIndicator size={14} mini hideMessage />
+      }
+      busy={hasClickedCreatePr}
+      analyticsEventName="Autofix: Create PR Clicked"
+      analyticsEventKey="autofix.create_pr_clicked"
+      analyticsParams={{group_id: groupId}}
+      size="sm"
+    >
+      {changes.length > 1 ? t('Create PRs') : t('Create a PR')}
+    </Button>
+  );
+}
+
+export function SetupAndCreatePRsButton({
+  changes,
+  groupId,
+  changesStepId,
+  hasStepBelow,
+  isPrimary = true,
+}: {
+  changes: AutofixCodebaseChange[];
+  changesStepId: string;
+  groupId: string;
+  hasStepBelow?: boolean;
+  isPrimary?: boolean;
+}) {
+  const {data: setupData} = useAutofixSetup({groupId, checkWriteAccess: true});
+
+  const areAllReposWriteable = changes.every(
+    change =>
+      setupData?.githubWriteIntegration?.repos?.find(
+        repo => `${repo.owner}/${repo.name}` === change.repo_name
+      )?.ok
+  );
+
+  if (!areAllReposWriteable) {
+    return (
+      <Button
+        priority={hasStepBelow ? 'default' : 'primary'}
+        onClick={() => {
+          openModal(deps => <AutofixSetupWriteAccessModal {...deps} groupId={groupId} />);
+        }}
+        analyticsEventName="Autofix: Create PR Setup Clicked"
+        analyticsEventKey="autofix.create_pr_setup_clicked"
+        analyticsParams={{group_id: groupId}}
+        title={t('Enable write access to create pull requests')}
+        size="sm"
+      >
+        {changes.length > 1 ? t('Create PRs') : t('Create a PR')}
+      </Button>
+    );
+  }
+
+  return (
+    <CreatePRsButton
+      changes={changes}
+      groupId={groupId}
+      changesStepId={changesStepId}
+      isPrimary={isPrimary}
+    />
+  );
+}
+
+const ProcessingStatusIndicator = styled(LoadingIndicator)`
+  && {
+    margin: 0;
+    height: 14px;
+    width: 14px;
+  }
+`;

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -306,7 +306,6 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
           <AutofixOutputStream stream={lastStep.output_stream} />
         )}
       </StepsContainer>
-
       <AutofixMessageBox
         displayText={activeLog ?? ''}
         step={lastStep}

--- a/static/app/components/events/autofix/autofixViewPrButton.tsx
+++ b/static/app/components/events/autofix/autofixViewPrButton.tsx
@@ -4,14 +4,16 @@ import {IconOpen} from 'sentry/icons';
 export function AutofixViewPrButton({
   repoName,
   prUrl,
+  isPrimary = true,
 }: {
   prUrl: string;
   repoName: string;
+  isPrimary?: boolean;
 }) {
   return (
     <LinkButton
       size="xs"
-      priority="primary"
+      priority={isPrimary ? 'primary' : 'default'}
       icon={<IconOpen size="xs" />}
       href={prUrl}
       external

--- a/static/app/components/events/autofix/autofixViewPrButton.tsx
+++ b/static/app/components/events/autofix/autofixViewPrButton.tsx
@@ -1,0 +1,22 @@
+import {LinkButton} from 'sentry/components/button';
+import {IconOpen} from 'sentry/icons';
+
+export function AutofixViewPrButton({
+  repoName,
+  prUrl,
+}: {
+  prUrl: string;
+  repoName: string;
+}) {
+  return (
+    <LinkButton
+      size="xs"
+      priority="primary"
+      icon={<IconOpen size="xs" />}
+      href={prUrl}
+      external
+    >
+      View PR in {repoName}
+    </LinkButton>
+  );
+}

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -154,8 +154,8 @@ export type AutofixCodebaseChange = {
   repo_id?: number; // The repo_id is only here for temporary backwards compatibility for LA customers, and we should remove it soon. Use repo_external_id instead.
 };
 
-export interface AutofixChangesStep extends BaseStep {
-  changes: AutofixCodebaseChange[];
+export interface AutofixChangesStep extends Omit<AutofixDefaultStep, 'type'> {
+  codebase_changes: Record<string, AutofixCodebaseChange>;
   type: AutofixStepType.CHANGES;
 }
 


### PR DESCRIPTION
When there is only 1 changes step, it looks normal:

![CleanShot 2024-12-17 at 17 57 54@2x](https://github.com/user-attachments/assets/07fbfe3c-a8b8-4848-8152-d58f8745d3c9)

When there are multiple, the changes are versioned:
![CleanShot 2024-12-17 at 17 56 36@2x](https://github.com/user-attachments/assets/8cc45c28-491a-4544-a9cd-6d7a652892ab)

![CleanShot 2024-12-17 at 17 55 58@2x](https://github.com/user-attachments/assets/60f63046-dee3-4d35-8109-4d675e5c5565)

![CleanShot 2024-12-17 at 18 15 28@2x](https://github.com/user-attachments/assets/de9bad36-1ad5-4697-a292-42e173ddc2dc)


You are also now able to create PRs for a specific previous version of changes as well

