### PR TITLE
feat(admin): compute project configs on demand / sync for admin

### DIFF
--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -100,7 +100,7 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
 
         if project is not None:
             for project_key2 in project.key_set.all():
-                project_keys.append(project_key)
+                project_keys.append(project_key2)
 
         return project_keys
 

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -35,16 +35,6 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
         If the project config is currently in cache, will return the cache entry.
         If the project config is not in cache, the project config for that key will be null.
         """
-
-        # algorithm
-        # - if a correct project ID is provided, return all project configs for all project keys
-        # - if a wrong / non-existent project ID is provided, it's an error
-        # - if no project ID is provided, fall back to project keys
-        #
-        # - if a correct project key is provided, return the project config along with the other project configs
-        # - if a wrong project key is provided -> HTTP400
-        #  - if no project key is provided, use
-
         project_id = request.GET.get("projectId")
         project_key_param = request.GET.get("projectKey")
 

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -227,3 +227,5 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         assert second_key.public_key in configs
         assert configs[first_key.public_key] != {"test_proj": "config1"}
         assert configs[second_key.public_key] != {"test_proj": "config2"}
+        assert projectconfig_cache.backend.get(first_key.public_key) != {"test_proj": "config1"}
+        assert projectconfig_cache.backend.get(second_key.public_key) != {"test_proj": "config2"}

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -154,5 +154,13 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         response = self.get_response(method="post")
         assert response.status_code == 400
 
+        # Test project config that is not currently cached
         response = self.get_response(method="post", **data)
-        assert response.status_code == 204
+        assert response.status_code == 200
+        data = response.data["configs"]
+        assert len(data) == 1
+
+        # Test project config that is currently cached
+        response = self.get_response(method="post", **data)
+        assert response.status_code == 200
+        assert len(data) == 1


### PR DESCRIPTION
Closes https://github.com/getsentry/getsentry/issues/15912
- Generate project config sync when the GET method is called on the endpoint if the config is not cached, set cache entries and return 200 with the configs
- Generate project config sync when the POST method is called on the endpoint (instead of only scheduling async computation), set cache entries and return 201
- Added docstrings to the methods explaining behaviour