### PR TITLE
ref: report coverage on all python files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -53,7 +53,7 @@ flags:
     after_n_builds: 4
   backend:
     paths:
-      - 'src/sentry/**/*.py'
+      - '**/*.py'
     carryforward: true
     # Do not send any status checks until n coverage reports are uploaded.
     # NOTE: If you change this, make sure to change `comment.after_n_builds` below as well.

--- a/tests/sentry/organizations/test_absolute_url.py
+++ b/tests/sentry/organizations/test_absolute_url.py
@@ -18,7 +18,7 @@ from sentry.organizations.absolute_url import customer_domain_path
             "/settings/acme/developer-settings/release-bot/",
             "/settings/developer-settings/release-bot/",
         ),
-        # Settings views for orgs with acccount/billing in their slugs.
+        # Settings views for orgs with account/billing in their slugs.
         ("/settings/account-on/", "/settings/organization/"),
         ("/settings/billing-co/", "/settings/organization/"),
         ("/settings/account-on/integrations/", "/settings/integrations/"),


### PR DESCRIPTION
would like to be able to use codecov to look at coverage in tests as well (where it should be 100%)

<!-- Describe your PR here. -->