### PR TITLE
feat(dashboards): enable sorting by column in table view

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -60,6 +60,7 @@ import TemplateCard from './templateCard';
 const SORT_OPTIONS: SelectValue<string>[] = [
   {label: t('My Dashboards'), value: 'mydashboards'},
   {label: t('Dashboard Name (A-Z)'), value: 'title'},
+  {label: t('Dashboard Name (Z-A)'), value: '-title'},
   {label: t('Date Created (Newest)'), value: '-dateCreated'},
   {label: t('Date Created (Oldest)'), value: 'dateCreated'},
   {label: t('Most Popular'), value: 'mostPopular'},


### PR DESCRIPTION
Enable sorting by column in dashboards table view.

- This PR adds sorting by `name`, `date created`, and `owner`
- Added sort by `Name (Z-A)` to dropdown to maintain consistency b/w grid and table view
- Sorting by `owner` column makes your dashboards show up on top (i.e. `myDashboards` in the sort dropdown)
- The plan is to remove the sort dropdown for the table view in the future

<img width="800" alt="Screenshot 2024-12-17 at 1 03 30 PM" src="https://github.com/user-attachments/assets/6393a5ec-2b3c-43e8-8dca-2731060c6add" />
