### PR TITLE
ref(update_groups): Simplify signature

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -243,17 +243,17 @@ def update_groups(
     )
 
 
+# XXX: The callers can probably call two different functions depending if the UI calls
+# with group IDs or not
 def update_groups_with_search_fn(
     request: Request,
     group_ids: Sequence[int | str] | None,
     projects: Sequence[Project],
     organization_id: int,
-    search_fn: SearchFunction | None,
-    user: RpcUser | User | AnonymousUser | None = None,
-    data: Mapping[str, Any] | None = None,
+    search_fn: SearchFunction,
 ) -> Response:
     group_ids, group_list = get_group_ids_and_group_list(organization_id, projects, group_ids)
-    if search_fn and not group_ids:
+    if not group_ids:
         try:
             # It can raise ValidationError
             cursor_result, _ = search_fn(
@@ -273,7 +273,7 @@ def update_groups_with_search_fn(
     if not group_ids or not group_list:
         return Response({"detail": "No groups found"}, status=204)
 
-    return update_groups(request, group_list, user, data)
+    return update_groups(request, group_list)
 
 
 def validate_request(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -247,8 +247,6 @@ def update_groups(
     )
 
 
-# XXX: The callers can probably call two different functions depending if the UI calls
-# with group IDs or not
 def update_groups_with_search_fn(
     request: Request,
     group_ids: Sequence[int | str] | None,

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -174,10 +174,14 @@ def update_groups(
     user = user or request.user
     acting_user = user if user and user.is_authenticated else None
     data = data or request.data
-    # XXX: Validate that all groups belong to the same organization and project
+
     # so we won't have to requery for each group
     project_lookup = {g.project_id: g.project for g in groups}
     projects = list(project_lookup.values())
+
+    # Assert all projects belong to the same organization
+    if len({p.organization_id for p in projects}) > 1:
+        return Response({"detail": "All groups must belong to same organization."}, status=400)
 
     if not groups:
         return Response({"detail": "No groups found"}, status=204)

--- a/src/sentry/integrations/discord/webhooks/message_component.py
+++ b/src/sentry/integrations/discord/webhooks/message_component.py
@@ -247,12 +247,7 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
                 status=data,
             )
             update_groups(
-                request=self.request.request,
-                group_ids=[self.group.id],
-                projects=[self.group.project],
-                organization_id=self.group.organization.id,
-                user=self.user,
-                data=data,
+                request=self.request.request, groups=[self.group], user=self.user, data=data
             )
 
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -118,14 +118,7 @@ def update_group(
             status_code=403, body="The user does not have access to the organization."
         )
 
-    return update_groups(
-        request=request,
-        group_ids=[group.id],
-        projects=[group.project],
-        organization_id=group.organization.id,
-        user=user,
-        data=data,
-    )
+    return update_groups(request=request, groups=[group], user=user, data=data)
 
 
 def get_rule(slack_request: SlackActionRequest) -> Rule | None:

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -8,6 +8,7 @@ from django.http import QueryDict
 from sentry.api.helpers.group_index import update_groups, validate_search_filter_permissions
 from sentry.api.helpers.group_index.delete import delete_groups
 from sentry.api.helpers.group_index.update import (
+    get_group_ids_and_group_list,
     handle_assigned_to,
     handle_has_seen,
     handle_is_bookmarked,
@@ -106,7 +107,10 @@ class UpdateGroupsTest(TestCase):
         request.data = {"status": "unresolved", "substatus": "ongoing"}
         request.GET = QueryDict(query_string=f"id={resolved_group.id}")
 
-        update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(
+            self.organization.id, [self.project], request.GET.getlist("id")
+        )
+        update_groups(request, group_list)
 
         resolved_group.refresh_from_db()
 
@@ -126,7 +130,10 @@ class UpdateGroupsTest(TestCase):
         request.data = {"status": "resolved", "substatus": None}
         request.GET = QueryDict(query_string=f"id={unresolved_group.id}")
 
-        update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(
+            self.organization.id, [self.project], request.GET.getlist("id")
+        )
+        update_groups(request, group_list)
 
         unresolved_group.refresh_from_db()
 
@@ -145,7 +152,10 @@ class UpdateGroupsTest(TestCase):
         request.data = {"status": "ignored", "substatus": "archived_forever"}
         request.GET = QueryDict(query_string=f"id={group.id}")
 
-        update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(
+            self.organization.id, [self.project], request.GET.getlist("id")
+        )
+        update_groups(request, group_list)
 
         group.refresh_from_db()
 
@@ -174,7 +184,10 @@ class UpdateGroupsTest(TestCase):
         }
         request.GET = QueryDict(query_string=f"id={group.id}")
 
-        update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(
+            self.organization.id, [self.project], request.GET.getlist("id")
+        )
+        update_groups(request, group_list)
 
         group.refresh_from_db()
 
@@ -215,7 +228,10 @@ class UpdateGroupsTest(TestCase):
             request.data = data["request_data"]
             request.GET = QueryDict(query_string=f"id={group.id}")
 
-            update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+            _, group_list = get_group_ids_and_group_list(
+                self.organization.id, [self.project], request.GET.getlist("id")
+            )
+            update_groups(request, group_list)
 
             group.refresh_from_db()
 
@@ -233,7 +249,10 @@ class UpdateGroupsTest(TestCase):
         request.data = {"inbox": False}
         request.GET = QueryDict(query_string=f"id={group.id}")
 
-        update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(
+            self.organization.id, [self.project], request.GET.getlist("id")
+        )
+        update_groups(request, group_list)
 
         group.refresh_from_db()
 
@@ -250,7 +269,10 @@ class UpdateGroupsTest(TestCase):
         request.data = {"status": "ignored", "substatus": "archived_until_escalating"}
         request.GET = QueryDict(query_string=f"id={group.id}")
 
-        update_groups(request, request.GET.getlist("id"), [self.project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(
+            self.organization.id, [self.project], request.GET.getlist("id")
+        )
+        update_groups(request, group_list)
 
         group.refresh_from_db()
 
@@ -271,7 +293,8 @@ class MergeGroupsTest(TestCase):
         request.data = {"merge": 1}
         request.GET = {"id": group_ids, "project": [project.id]}
 
-        update_groups(request, group_ids, [project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(self.organization.id, [project], group_ids)
+        update_groups(request, group_list)
 
         call_args = mock_handle_merge.call_args.args
 
@@ -298,7 +321,8 @@ class MergeGroupsTest(TestCase):
         request.data = {"merge": 1}
         request.GET = {"id": group_ids, "project": project_ids}
 
-        response = update_groups(request, group_ids, projects, self.organization.id)
+        _, group_list = get_group_ids_and_group_list(self.organization.id, projects, group_ids)
+        response = update_groups(request, group_list)
 
         assert response.data == {"detail": "Merging across multiple projects is not supported"}
         assert response.status_code == 400
@@ -320,7 +344,8 @@ class MergeGroupsTest(TestCase):
         # we're passing multiple project ids
         request.GET = {"id": group_ids, "project": project_ids}
 
-        update_groups(request, group_ids, projects, self.organization.id)
+        _, group_list = get_group_ids_and_group_list(self.organization.id, projects, group_ids)
+        update_groups(request, group_list)
 
         call_args = mock_handle_merge.call_args.args
 
@@ -342,7 +367,8 @@ class MergeGroupsTest(TestCase):
         request.data = {"merge": 1}
         request.GET = {"id": group_ids}
 
-        update_groups(request, group_ids, [project], self.organization.id)
+        _, group_list = get_group_ids_and_group_list(self.organization.id, [project], group_ids)
+        update_groups(request, group_list)
 
         call_args = mock_handle_merge.call_args.args
 
@@ -393,7 +419,10 @@ class MergeGroupsTest(TestCase):
             request.META = {"HTTP_REFERER": referer}
 
             with patch("sentry.api.helpers.group_index.update.metrics.incr") as mock_metrics_incr:
-                update_groups(request, group_ids, [project], self.organization.id)
+                _, group_list = get_group_ids_and_group_list(
+                    self.organization.id, [project], group_ids
+                )
+                update_groups(request, group_list)
 
                 mock_metrics_incr.assert_any_call(
                     "grouping.merge_issues",


### PR DESCRIPTION
`update_groups` will now require a sequence of groups rather than group IDs, project and an org id.