### PR TITLE
chore(oauth2): prepare for strict redirect_uri matching

### DIFF
--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -12,12 +12,15 @@ class ApiApplicationTest(TestCase):
 
         assert app.is_valid_redirect_uri("http://example.com/")
         assert app.is_valid_redirect_uri("http://example.com")
+        assert app.is_valid_redirect_uri("http://example.com/.")
+        assert app.is_valid_redirect_uri("http://example.com//")
         assert app.is_valid_redirect_uri("http://example.com/biz/baz")
         assert not app.is_valid_redirect_uri("https://example.com/")
         assert not app.is_valid_redirect_uri("http://foo.com")
         assert not app.is_valid_redirect_uri("http://example.com.foo.com")
 
         assert app.is_valid_redirect_uri("http://sub.example.com/path")
+        assert app.is_valid_redirect_uri("http://sub.example.com/path/")
         assert app.is_valid_redirect_uri("http://sub.example.com/path/bar")
         assert not app.is_valid_redirect_uri("http://sub.example.com")
         assert not app.is_valid_redirect_uri("http://sub.example.com/path/../baz")


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/75591 and preparing for strict string matching according to best practice:
https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-10-4.2.1
https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.1.3