### PR TITLE
fix(trace-view): Guard against `undefined` trace context height

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextPanel.tsx
@@ -42,7 +42,7 @@ export function TraceContextPanel({tree, rootEvent}: Props) {
   useEffect(() => {
     const loadedHeight = preferences.drawer.sizes['trace context height'];
 
-    if (containerRef.current) {
+    if (containerRef.current && loadedHeight !== undefined) {
       setHeight(loadedHeight);
       containerRef.current.style.setProperty('--panel-height', `${loadedHeight}px`);
     }


### PR DESCRIPTION
In some cases, the loaded trace context height could be `undefined`, which would result in the drawer getting stuck because the computations rely on an integer value to calculate the new positions when dragging.