### PR TITLE
chore(autofix): Unmerge button bar in autofix message box

### DIFF
--- a/static/app/components/events/autofix/autofixActionSelector.tsx
+++ b/static/app/components/events/autofix/autofixActionSelector.tsx
@@ -45,7 +45,7 @@ function AutofixActionSelector<T extends string>({
             }}
             transition={testableTransition({duration: 0.1})}
           >
-            <ButtonBar merged>
+            <ButtonBar gap={1}>
               {options.map(option => (
                 <Button
                   key={option.key}


### PR DESCRIPTION
Make action buttons look separated for readability.

<img width="676" alt="Screenshot 2024-12-17 at 1 32 17 PM" src="https://github.com/user-attachments/assets/c2fbb633-95c3-4046-9ae5-3b381b66480d" />

<img width="672" alt="Screenshot 2024-12-17 at 1 31 26 PM" src="https://github.com/user-attachments/assets/9f0b8b4b-ebcb-4df7-828c-49c39aa04759" />
