### PR TITLE
ref(grouping): Refactor `get_grouping_variants_for_event`

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -355,9 +355,7 @@ def get_grouping_variants_for_event(
     fingerprint_info = event.data.get("_fingerprint_info", {})
     defaults_referenced = sum(1 if is_default_fingerprint_var(d) else 0 for d in fingerprint)
 
-    if config is None:
-        config = load_default_grouping_config()
-    context = GroupingContext(config)
+    context = GroupingContext(config or load_default_grouping_config())
     component_trees_by_variant = _get_component_trees_for_variants(event, context)
     variants: dict[str, BaseVariant] = {}
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -296,8 +296,8 @@ def _get_component_trees_for_variants(
         for variant_name, component in current_strategy_components_by_variant.items():
             all_strategies_components_by_variant.setdefault(variant_name, []).append(component)
 
-            if winning_strategy is None:
-                if component.contributes:
+            if component.contributes:
+                if winning_strategy is None:
                     winning_strategy = strategy.name
                     variant_descriptor = "/".join(
                         sorted(
@@ -314,8 +314,8 @@ def _get_component_trees_for_variants(
                         ),
                         "" if strategy.name.endswith("s") else "s",
                     )
-            elif component.contributes and winning_strategy != strategy.name:
-                component.update(contributes=False, hint=precedence_hint)
+                elif strategy.name != winning_strategy:
+                    component.update(contributes=False, hint=precedence_hint)
 
     component_trees_by_variant = {}
     for variant_name, components in all_strategies_components_by_variant.items():

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Iterable, Mapping
 from hashlib import md5
 from re import Match
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from django.utils.encoding import force_bytes
@@ -41,6 +41,18 @@ def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingCompon
     for value in values:
         result.update(force_bytes(value, errors="replace"))
     return result.hexdigest()
+
+
+def get_fingerprint_type(fingerprint: list[str]) -> Literal["default", "hybrid", "custom"]:
+    return (
+        "default"
+        if len(fingerprint) == 1 and is_default_fingerprint_var(fingerprint[0])
+        else (
+            "hybrid"
+            if any(is_default_fingerprint_var(entry) for entry in fingerprint)
+            else "custom"
+        )
+    )
 
 
 def bool_from_string(value: str) -> bool | None:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict
 
 from sentry.grouping.component import (
     AppGroupingComponent,
@@ -216,6 +216,20 @@ class SaltedComponentVariant(ComponentVariant):
     """A salted version of a component."""
 
     type = "salted_component"
+
+    @classmethod
+    def from_component_variant(
+        cls,
+        component_variant: ComponentVariant,
+        fingerprint: list[str],
+        fingerprint_info: FingerprintInfo,
+    ) -> Self:
+        return cls(
+            fingerprint=fingerprint,
+            component=component_variant.component,
+            strategy_config=component_variant.config,
+            fingerprint_info=fingerprint_info,
+        )
 
     def __init__(
         self,


### PR DESCRIPTION
This is a small(ish) refactor of the code which produces the grouping variant objects which are both serialized for use in grouping info and passed through the ingestion pipeline as a record of what happened during the grouping calculation. (Specifically, the refactor affects `get_grouping_variants_for_event` and its helper, `_get_component_trees_for_variants`.)

Though it won't happen until a follow-up PR, the ultimate goal of this refactor is to allow instances of `ComponentVariant` to track which node in their grouping component tree corresponds to the chosen grouping method, so that we don't have to go searching for it in multiple places in the code. It's also a good excuse to clean up that bit of the grouping code to hopefully make it easier to understand.

Key changes:

- Instead of resolving the fingerprint values in multiple places in the code, do it once, right after we pull the fingerprint from the event.

- Instead of creating component variants in multiple places in the code, do it once, in the helper that's currently computing component trees (which has now been renamed from `_get_component_trees_for_variants` to `_get_variants_from_strategies`). In addition to being dryer, this also allowed for the removal of the default fingerprint branch entirely. (The one measure of complexity it did add was the need to convert the `ComponentVariant` instances to `SaltedComponentVariant` instances, hence the new `SaltedComponentVariant.from_component_variant` helper.)

- Base the conditional in `get_grouping_variants_for_event` on named fingerprint types rather than the less obvious `defaults_referenced`.