### PR TITLE
lint: Remove unused suppression comments

### DIFF
--- a/static/app/utils/profiling/renderers/flamegraphRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererWebGL.tsx
@@ -259,7 +259,6 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
     });
 
     // Use shader program
-    // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
     this.ctx.useProgram(this.program);
 
     // Check if we should draw border - order matters here

--- a/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
@@ -225,7 +225,6 @@ class UIFramesRendererWebGL extends UIFramesRenderer {
     });
 
     // Use shader program
-    // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
     this.ctx.useProgram(this.program);
   }
 
@@ -252,7 +251,6 @@ class UIFramesRendererWebGL extends UIFramesRenderer {
       return;
     }
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
     this.ctx.useProgram(this.program);
 
     const projectionMatrix = makeProjectionMatrix(

--- a/static/app/utils/useLocalStorageState.spec.tsx
+++ b/static/app/utils/useLocalStorageState.spec.tsx
@@ -18,7 +18,6 @@ describe('useLocalStorageState', () => {
     renderHook(() => {
       try {
         // @ts-expect-error force incorrect usage
-        // biome-ignore lint/correctness/useHookAtTopLevel: <explanation>
         useLocalStorageState({}, 'default value');
       } catch (err) {
         errorResult = err;


### PR DESCRIPTION
I was running biome and noticed it's emitting some warnings related to unused suppression comments. So we can just remove these comments.