### PR TITLE
feat(widget-builder): Push default state when adding widget

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -58,7 +58,10 @@ import {
 } from 'sentry/views/dashboards/utils';
 import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
-import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {
+  convertWidgetToBuilderStateParams,
+  DEFAULT_WIDGET,
+} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import {MetricsDataSwitcherAlert} from 'sentry/views/performance/landing/metricsDataSwitcherAlert';
 
@@ -698,7 +701,7 @@ class DashboardDetail extends Component<Props, State> {
               pathname,
               query: {
                 ...location.query,
-                dataset,
+                ...convertWidgetToBuilderStateParams(DEFAULT_WIDGET),
               },
             })
           );

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -58,10 +58,9 @@ import {
 } from 'sentry/views/dashboards/utils';
 import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
-import {
-  convertWidgetToBuilderStateParams,
-  DEFAULT_WIDGET,
-} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getDefaultWidget';
+import {DATA_SET_TO_WIDGET_TYPE} from 'sentry/views/dashboards/widgetBuilder/widgetBuilder';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import {MetricsDataSwitcherAlert} from 'sentry/views/performance/landing/metricsDataSwitcherAlert';
 
@@ -701,7 +700,9 @@ class DashboardDetail extends Component<Props, State> {
               pathname,
               query: {
                 ...location.query,
-                ...convertWidgetToBuilderStateParams(DEFAULT_WIDGET),
+                ...convertWidgetToBuilderStateParams(
+                  getDefaultWidget(DATA_SET_TO_WIDGET_TYPE[dataset ?? DataSet.ERRORS])
+                ),
               },
             })
           );

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -1,21 +1,10 @@
-import {DisplayType} from 'sentry/views/dashboards/types';
-import {
-  convertWidgetToBuilderStateParams,
-  DEFAULT_WIDGET,
-} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getDefaultWidget';
 
 describe('convertWidgetToBuilderStateParams', () => {
   it('should not pass along yAxis when converting a table to builder params', () => {
-    const widget = {
-      ...DEFAULT_WIDGET,
-      displayType: DisplayType.TABLE,
-      queries: [
-        {
-          ...DEFAULT_WIDGET.queries[0],
-          aggregates: ['count()'],
-        },
-      ],
-    };
+    const widget = {...getDefaultWidget(WidgetType.ERRORS), aggregates: ['count()']};
     const params = convertWidgetToBuilderStateParams(widget);
     expect(params.yAxis).toEqual([]);
   });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -1,0 +1,22 @@
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {
+  convertWidgetToBuilderStateParams,
+  DEFAULT_WIDGET,
+} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+
+describe('convertWidgetToBuilderStateParams', () => {
+  it('should not pass along yAxis when converting a table to builder params', () => {
+    const widget = {
+      ...DEFAULT_WIDGET,
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          ...DEFAULT_WIDGET.queries[0],
+          aggregates: ['count()'],
+        },
+      ],
+    };
+    const params = convertWidgetToBuilderStateParams(widget);
+    expect(params.yAxis).toEqual([]);
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -1,14 +1,5 @@
-import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
 import {DisplayType, type Widget, WidgetType} from 'sentry/views/dashboards/types';
 import type {WidgetBuilderStateQueryParams} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-
-export const DEFAULT_WIDGET: Widget = {
-  displayType: DisplayType.TABLE,
-  interval: '',
-  queries: [ErrorsConfig.defaultWidgetQuery],
-  title: '',
-  widgetType: WidgetType.ERRORS,
-};
 
 /**
  * Converts a widget to a set of query params that can be used to

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -1,5 +1,14 @@
+import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
 import {DisplayType, type Widget, WidgetType} from 'sentry/views/dashboards/types';
 import type {WidgetBuilderStateQueryParams} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+export const DEFAULT_WIDGET: Widget = {
+  displayType: DisplayType.TABLE,
+  interval: '',
+  queries: [ErrorsConfig.defaultWidgetQuery],
+  title: '',
+  widgetType: WidgetType.ERRORS,
+};
 
 /**
  * Converts a widget to a set of query params that can be used to
@@ -8,7 +17,7 @@ import type {WidgetBuilderStateQueryParams} from 'sentry/views/dashboards/widget
 export function convertWidgetToBuilderStateParams(
   widget: Widget
 ): WidgetBuilderStateQueryParams {
-  const yAxis = widget.queries.flatMap(q => q.aggregates);
+  let yAxis = widget.queries.flatMap(q => q.aggregates);
   const query = widget.queries.flatMap(q => q.conditions);
   const sort = widget.queries.flatMap(q => q.orderby);
 
@@ -18,6 +27,7 @@ export function convertWidgetToBuilderStateParams(
     widget.displayType === DisplayType.BIG_NUMBER
   ) {
     field = widget.queries.flatMap(q => q.fields ?? []);
+    yAxis = [];
   } else {
     field = widget.queries.flatMap(q => q.columns);
   }

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
@@ -1,0 +1,89 @@
+import {SessionField} from 'sentry/types/sessions';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getDefaultWidget';
+
+describe('getDefaultWidget', () => {
+  it('should return a default widget for errors', () => {
+    const widget = getDefaultWidget(WidgetType.ERRORS);
+    expect(widget).toEqual({
+      displayType: DisplayType.TABLE,
+      interval: '',
+      title: '',
+      widgetType: WidgetType.ERRORS,
+      queries: [
+        {
+          fields: ['count()'],
+          conditions: '',
+          aggregates: ['count()'],
+          columns: [],
+          orderby: '-count()',
+          fieldAliases: [],
+          name: '',
+        },
+      ],
+    });
+  });
+
+  it('should return a default widget for spans', () => {
+    const widget = getDefaultWidget(WidgetType.SPANS);
+    expect(widget).toEqual({
+      displayType: DisplayType.TABLE,
+      interval: '',
+      title: '',
+      widgetType: WidgetType.SPANS,
+      queries: [
+        {
+          fields: ['count(span.duration)'],
+          conditions: '',
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: '',
+          fieldAliases: [],
+          name: '',
+        },
+      ],
+    });
+  });
+
+  it('should return a default widget for issues', () => {
+    const widget = getDefaultWidget(WidgetType.ISSUE);
+    expect(widget).toEqual({
+      displayType: DisplayType.TABLE,
+      interval: '',
+      title: '',
+      widgetType: WidgetType.ISSUE,
+      queries: [
+        {
+          fields: ['issue', 'assignee', 'title'] as string[],
+          columns: ['issue', 'assignee', 'title'],
+          conditions: '',
+          aggregates: [],
+          orderby: 'date',
+          fieldAliases: [],
+          name: '',
+        },
+      ],
+    });
+  });
+
+  it('should return a default widget for releases', () => {
+    const widget = getDefaultWidget(WidgetType.RELEASE);
+    expect(widget).toEqual({
+      displayType: DisplayType.TABLE,
+      interval: '',
+      title: '',
+      widgetType: WidgetType.RELEASE,
+      queries: [
+        {
+          fields: [`crash_free_rate(${SessionField.SESSION})`],
+          columns: [],
+          fieldAliases: [],
+          aggregates: [`crash_free_rate(${SessionField.SESSION})`],
+          conditions: '',
+          orderby: `-crash_free_rate(${SessionField.SESSION})`,
+          name: '',
+        },
+      ],
+    });
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
@@ -1,0 +1,13 @@
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
+import {DisplayType, type Widget, type WidgetType} from 'sentry/views/dashboards/types';
+
+export function getDefaultWidget(widgetType: WidgetType): Widget {
+  const config = getDatasetConfig(widgetType);
+  return {
+    displayType: DisplayType.TABLE,
+    interval: '',
+    title: '',
+    widgetType,
+    queries: [config.defaultWidgetQuery],
+  };
+}


### PR DESCRIPTION
Pushes the default widget state to the URL params when adding a widget. If no dataset is supplied when the add widget button is called, then default to the errors widget.