### PR TITLE
fix(issues): Prevent stack trace from shrinking

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -1,4 +1,5 @@
 import {Fragment, lazy, useMemo, useRef} from 'react';
+import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {usePrompt} from 'sentry/actionCreators/prompts';
@@ -228,51 +229,58 @@ export function EventDetailsContent({
         </EntryErrorBoundary>
       )}
       {/* Wrapping all stacktrace components since multiple could appear */}
-      <GuideAnchor
-        target="stacktrace"
-        position="top"
-        disabled={
-          !(
-            defined(eventEntries[EntryType.EXCEPTION]) ||
-            defined(eventEntries[EntryType.STACKTRACE]) ||
-            defined(eventEntries[EntryType.THREADS])
-          )
-        }
-      >
-        {defined(eventEntries[EntryType.EXCEPTION]) && (
-          <EntryErrorBoundary type={EntryType.EXCEPTION}>
-            <Exception
-              event={event}
-              data={eventEntries[EntryType.EXCEPTION].data}
-              projectSlug={project.slug}
-              group={group}
-              groupingCurrentLevel={groupingCurrentLevel}
-            />
-          </EntryErrorBoundary>
+      <ClassNames>
+        {({css}) => (
+          <GuideAnchor
+            target="stacktrace"
+            position="top"
+            disabled={
+              !(
+                defined(eventEntries[EntryType.EXCEPTION]) ||
+                defined(eventEntries[EntryType.STACKTRACE]) ||
+                defined(eventEntries[EntryType.THREADS])
+              )
+            }
+            containerClassName={css`
+              display: block !important;
+            `}
+          >
+            {defined(eventEntries[EntryType.EXCEPTION]) && (
+              <EntryErrorBoundary type={EntryType.EXCEPTION}>
+                <Exception
+                  event={event}
+                  data={eventEntries[EntryType.EXCEPTION].data}
+                  projectSlug={project.slug}
+                  group={group}
+                  groupingCurrentLevel={groupingCurrentLevel}
+                />
+              </EntryErrorBoundary>
+            )}
+            {issueTypeConfig.stacktrace.enabled &&
+              defined(eventEntries[EntryType.STACKTRACE]) && (
+                <EntryErrorBoundary type={EntryType.STACKTRACE}>
+                  <StackTrace
+                    event={event}
+                    data={eventEntries[EntryType.STACKTRACE].data}
+                    projectSlug={projectSlug}
+                    groupingCurrentLevel={groupingCurrentLevel}
+                  />
+                </EntryErrorBoundary>
+              )}
+            {defined(eventEntries[EntryType.THREADS]) && (
+              <EntryErrorBoundary type={EntryType.THREADS}>
+                <Threads
+                  event={event}
+                  data={eventEntries[EntryType.THREADS].data}
+                  projectSlug={project.slug}
+                  groupingCurrentLevel={groupingCurrentLevel}
+                  group={group}
+                />
+              </EntryErrorBoundary>
+            )}
+          </GuideAnchor>
         )}
-        {issueTypeConfig.stacktrace.enabled &&
-          defined(eventEntries[EntryType.STACKTRACE]) && (
-            <EntryErrorBoundary type={EntryType.STACKTRACE}>
-              <StackTrace
-                event={event}
-                data={eventEntries[EntryType.STACKTRACE].data}
-                projectSlug={projectSlug}
-                groupingCurrentLevel={groupingCurrentLevel}
-              />
-            </EntryErrorBoundary>
-          )}
-        {defined(eventEntries[EntryType.THREADS]) && (
-          <EntryErrorBoundary type={EntryType.THREADS}>
-            <Threads
-              event={event}
-              data={eventEntries[EntryType.THREADS].data}
-              projectSlug={project.slug}
-              groupingCurrentLevel={groupingCurrentLevel}
-              group={group}
-            />
-          </EntryErrorBoundary>
-        )}
-      </GuideAnchor>
+      </ClassNames>
       {defined(eventEntries[EntryType.DEBUGMETA]) && (
         <EntryErrorBoundary type={EntryType.DEBUGMETA}>
           <DebugMeta

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -241,6 +241,7 @@ export function EventDetailsContent({
                 defined(eventEntries[EntryType.THREADS])
               )
             }
+            // Prevent the container span from shrinking the content
             containerClassName={css`
               display: block !important;
             `}


### PR DESCRIPTION
Prevents the stack trace from shrinking when the guide is shown

![image](https://github.com/user-attachments/assets/1cd396bc-ec17-4bb7-9e1e-94738ccc1195)

