### PR TITLE
feat(aci milestone 3): ACI dual delete helper

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1047,10 +1047,10 @@ def delete_alert_rule(
             )
         else:
             RegionScheduledDeletion.schedule(instance=alert_rule, days=0, actor=user)
-            # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:
-            # the user could be removed from the dual write flag for whatever reason, and we need to make sure
-            # that the extra table data is deleted. If the rows don't exist, we'll exit early.
-            dual_delete_migrated_alert_rule(alert_rule=alert_rule, user=user)
+        # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:
+        # the user could be removed from the dual write flag for whatever reason, and we need to make sure
+        # that the extra table data is deleted. If the rows don't exist, we'll exit early.
+        dual_delete_migrated_alert_rule(alert_rule=alert_rule, user=user)
 
         bulk_delete_snuba_subscriptions(subscriptions)
         schedule_update_project_config(alert_rule, [sub.project for sub in subscriptions])

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -103,8 +103,6 @@ from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.snuba import is_measurement
 
-# from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
-
 if TYPE_CHECKING:
     from sentry.incidents.utils.types import AlertRuleActivationConditionType
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -102,7 +102,8 @@ from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.snuba import is_measurement
-from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
+
+# from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
 
 if TYPE_CHECKING:
     from sentry.incidents.utils.types import AlertRuleActivationConditionType
@@ -1054,10 +1055,10 @@ def delete_alert_rule(
             )
         else:
             RegionScheduledDeletion.schedule(instance=alert_rule, days=0, actor=user)
-            if features.has(
-                "organizations:workflow-engine-metric-alert-dual-write", alert_rule.organization
-            ):
-                dual_delete_migrated_alert_rule(alert_rule=alert_rule, user=user)
+            # if features.has(
+            #     "organizations:workflow-engine-metric-alert-dual-write", alert_rule.organization
+            # ):
+            #     dual_delete_migrated_alert_rule(alert_rule=alert_rule, user=user)
         alert_rule.update(status=AlertRuleStatus.SNAPSHOT.value)
 
     if alert_rule.id:

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -147,7 +147,6 @@ def migrate_alert_rule(
 
 
 def get_data_source(alert_rule: AlertRule) -> DataSource | None:
-    # TODO: if dual deleting, then we should delete the subscriptions here and not in logic.py
     snuba_query = alert_rule.snuba_query
     organization = alert_rule.organization
     if not snuba_query or not organization:
@@ -192,9 +191,10 @@ def dual_delete_migrated_alert_rule(
     RegionScheduledDeletion.schedule(instance=alert_rule_workflow, days=0, actor=user)
     # also deletes alert_rule_detector, detector_workflow, detector_state
     RegionScheduledDeletion.schedule(instance=detector, days=0, actor=user)
-    # also deletes workflow_data_condition_group
     if data_condition_group:
         RegionScheduledDeletion.schedule(instance=data_condition_group, days=0, actor=user)
     RegionScheduledDeletion.schedule(instance=data_source, days=0, actor=user)
+
+    # NOTE: we do not delete the workflow or workflow_data_condition_group
 
     return

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -198,11 +198,10 @@ def dual_delete_migrated_alert_rule(
 
     data_source = get_data_source(alert_rule=alert_rule)
     if data_source is None:
-        logger.error(
+        logger.info(
             "DataSource does not exist",
             extra={"alert_rule_id": AlertRule.id},
         )
-        return
     # NOTE: for migrated alert rules, each workflow is associated with a single detector
     # make sure there are no other detectors associated with the workflow, then delete it if so
     if DetectorWorkflow.objects.filter(workflow=workflow).count() == 1:
@@ -212,6 +211,7 @@ def dual_delete_migrated_alert_rule(
     RegionScheduledDeletion.schedule(instance=detector, days=0, actor=user)
     if data_condition_group:
         RegionScheduledDeletion.schedule(instance=data_condition_group, days=0, actor=user)
-    RegionScheduledDeletion.schedule(instance=data_source, days=0, actor=user)
+    if data_source:
+        RegionScheduledDeletion.schedule(instance=data_source, days=0, actor=user)
 
     return

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -178,12 +178,15 @@ def dual_delete_migrated_alert_rule(
         alert_rule_detector = AlertRuleDetector.objects.get(alert_rule=alert_rule)
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=alert_rule)
     except AlertRuleDetector.DoesNotExist:
-        logger.exception(
+        # NOTE: making this an info log because we run the dual delete even if the user
+        # isn't flagged into dual write
+        logger.info(
             "AlertRuleDetector does not exist",
             extra={"alert_rule_id": AlertRule.id},
         )
+        return
     except AlertRuleWorkflow.DoesNotExist:
-        logger.exception(
+        logger.info(
             "AlertRuleWorkflow does not exist",
             extra={"alert_rule_id": AlertRule.id},
         )

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -5,7 +5,6 @@ from sentry.incidents.grouptype import MetricAlertFire
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.snuba.models import QuerySubscription, SnubaQuery
-from sentry.snuba.subscriptions import bulk_delete_snuba_subscriptions
 from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.models import (
     AlertRuleDetector,
@@ -201,10 +200,6 @@ def dual_delete_migrated_alert_rule(
             extra={"alert_rule_id": AlertRule.id},
         )
         return
-    # we know this exists because the data_source exists
-    assert alert_rule.snuba_query is not None
-    query_subscription = QuerySubscription.objects.get(snuba_query=alert_rule.snuba_query.id)
-    bulk_delete_snuba_subscriptions([query_subscription])
     # NOTE: for migrated alert rules, each workflow is associated with a single detector
     # make sure there are no other detectors associated with the workflow, then delete it if so
     if DetectorWorkflow.objects.filter(workflow=workflow).count() == 1:

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -1,6 +1,9 @@
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents.grouptype import MetricAlertFire
 from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.subscriptions import bulk_delete_snuba_subscriptions
 from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.models import (
     AlertRuleDetector,
@@ -35,12 +38,10 @@ def create_data_source(
 ) -> DataSource | None:
     if not snuba_query:
         return None
-
     try:
         query_subscription = QuerySubscription.objects.get(snuba_query=snuba_query.id)
     except QuerySubscription.DoesNotExist:
         return None
-
     return DataSource.objects.create(
         organization_id=organization_id,
         query_id=query_subscription.id,
@@ -143,3 +144,55 @@ def migrate_alert_rule(
         alert_rule_workflow,
         detector_workflow,
     )
+
+
+def get_data_source(alert_rule: AlertRule) -> DataSource | None:
+    # TODO: if dual deleting, then we should delete the subscriptions here and not in logic.py
+    snuba_query = alert_rule.snuba_query
+    organization = alert_rule.organization
+    if not snuba_query or not organization:
+        # This shouldn't be possible, but just in case.
+        return None
+    try:
+        query_subscription = QuerySubscription.objects.get(snuba_query=snuba_query.id)
+    except QuerySubscription.DoesNotExist:
+        return None
+    try:
+        data_source = DataSource.objects.get(
+            organization=organization,
+            query_id=query_subscription.id,
+            type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+        )
+    except DataSource.DoesNotExist:
+        return None
+    bulk_delete_snuba_subscriptions([QuerySubscription])
+    return data_source
+
+
+def dual_delete_migrated_alert_rule(
+    alert_rule: AlertRule,
+    user: RpcUser | None = None,
+) -> None:
+    try:
+        alert_rule_detector = AlertRuleDetector.objects.get(alert_rule=alert_rule)
+    except AlertRuleDetector.DoesNotExist:
+        # TODO: log failure
+        return
+
+    detector: Detector = alert_rule_detector.detector
+    data_condition_group: DataConditionGroup | None = detector.workflow_condition_group
+
+    data_source = get_data_source(alert_rule=alert_rule)
+    if data_source is None:
+        # TODO: log failure
+        return
+
+    # deleting the alert_rule also deletes alert_rule_workflow (in main delete logic)
+    # also deletes alert_rule_detector, detector_workflow, detector_state
+    RegionScheduledDeletion.schedule(instance=detector, days=0, actor=user)
+    # also deletes workflow_data_condition_group
+    if data_condition_group:
+        RegionScheduledDeletion.schedule(instance=data_condition_group, days=0, actor=user)
+    RegionScheduledDeletion.schedule(instance=data_source, days=0, actor=user)
+
+    return

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -109,7 +109,8 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         with self.tasks():
             run_scheduled_deletions()
 
-        # check alert_rule_workflow
+        # check workflow-related tables
+        assert not Workflow.objects.filter(id=workflow.id).exists()
         assert not AlertRuleWorkflow.objects.filter(id=alert_rule_workflow.id).exists()
 
         # check detector-related tables
@@ -128,7 +129,3 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         assert not DataSource.objects.filter(id=data_source.id).exists()
         query_subscription.refresh_from_db()
         assert query_subscription.status == QuerySubscription.Status.DELETING.value
-
-        # don't delete the associated workflow
-        # uncomment this when things change in the dual write
-        # assert Workflow.objects.filter(id=workflow.id).exists()

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -1,11 +1,16 @@
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.grouptype import MetricAlertFire
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import APITestCase
 from sentry.users.services.user.service import user_service
-from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    dual_delete_migrated_alert_rule,
+    migrate_alert_rule,
+)
 from sentry.workflow_engine.models import (
     AlertRuleDetector,
     AlertRuleWorkflow,
+    DataConditionGroup,
     DataSource,
     DataSourceDetector,
     Detector,
@@ -79,3 +84,48 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         assert len(DataSource.objects.all()) == 0
         assert not AlertRuleWorkflow.objects.filter(alert_rule=self.metric_alert).exists()
         assert not AlertRuleDetector.objects.filter(alert_rule=self.metric_alert).exists()
+
+    def test_delete_metric_alert(self):
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
+        alert_rule_detector = AlertRuleDetector.objects.get(alert_rule=self.metric_alert)
+        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+        detector = Detector.objects.get(id=alert_rule_detector.detector.id)
+        detector_workflow = DetectorWorkflow.objects.get(detector=detector)
+        workflow_data_condition_group = WorkflowDataConditionGroup.objects.get(workflow=workflow)
+        data_condition_group = detector.workflow_condition_group
+        assert data_condition_group is not None
+        assert self.metric_alert.snuba_query
+        query_subscription = QuerySubscription.objects.get(
+            snuba_query=self.metric_alert.snuba_query.id
+        )
+        data_source = DataSource.objects.get(
+            organization_id=self.metric_alert.organization_id, query_id=query_subscription.id
+        )
+        detector_state = DetectorState.objects.get(detector=detector)
+        data_source_detector = DataSourceDetector.objects.get(data_source=data_source)
+
+        dual_delete_migrated_alert_rule(self.metric_alert)
+        with self.tasks():
+            run_scheduled_deletions()
+
+        # check alert_rule_workflow
+        assert not AlertRuleWorkflow.objects.filter(id=alert_rule_workflow.id).exists()
+
+        # check detector-related tables
+        assert not Detector.objects.filter(id=detector.id).exists()
+        assert not DetectorWorkflow.objects.filter(id=detector_workflow.id).exists()
+        assert not DetectorState.objects.filter(id=detector_state.id).exists()
+        assert not DataSourceDetector.objects.filter(id=data_source_detector.id).exists()
+
+        # check data condition group-related tables
+        assert not DataConditionGroup.objects.filter(id=data_condition_group.id).exists()
+        assert not WorkflowDataConditionGroup.objects.filter(
+            id=workflow_data_condition_group.id
+        ).exists()
+        assert not Workflow.objects.filter(id=workflow.id).exists()
+
+        # check data source
+        assert not DataSource.objects.filter(id=data_source.id).exists()
+        query_subscription.refresh_from_db()
+        assert query_subscription.status == QuerySubscription.Status.DELETING.value

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -123,9 +123,12 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         assert not WorkflowDataConditionGroup.objects.filter(
             id=workflow_data_condition_group.id
         ).exists()
-        assert not Workflow.objects.filter(id=workflow.id).exists()
 
         # check data source
         assert not DataSource.objects.filter(id=data_source.id).exists()
         query_subscription.refresh_from_db()
         assert query_subscription.status == QuerySubscription.Status.DELETING.value
+
+        # don't delete the associated workflow
+        # uncomment this when things change in the dual write
+        # assert Workflow.objects.filter(id=workflow.id).exists()

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -17,6 +17,7 @@ from sentry.workflow_engine.models import (
     DetectorState,
     DetectorWorkflow,
     Workflow,
+    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.types import DetectorPriorityLevel
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -127,5 +127,3 @@ class AlertRuleMigrationHelpersTest(APITestCase):
 
         # check data source
         assert not DataSource.objects.filter(id=data_source.id).exists()
-        query_subscription.refresh_from_db()
-        assert query_subscription.status == QuerySubscription.Status.DELETING.value

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -17,7 +17,6 @@ from sentry.workflow_engine.models import (
     DetectorState,
     DetectorWorkflow,
     Workflow,
-    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -93,7 +92,6 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
         detector = Detector.objects.get(id=alert_rule_detector.detector.id)
         detector_workflow = DetectorWorkflow.objects.get(detector=detector)
-        workflow_data_condition_group = WorkflowDataConditionGroup.objects.get(workflow=workflow)
         data_condition_group = detector.workflow_condition_group
         assert data_condition_group is not None
         assert self.metric_alert.snuba_query
@@ -120,11 +118,8 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         assert not DetectorState.objects.filter(id=detector_state.id).exists()
         assert not DataSourceDetector.objects.filter(id=data_source_detector.id).exists()
 
-        # check data condition group-related tables
+        # check data condition group
         assert not DataConditionGroup.objects.filter(id=data_condition_group.id).exists()
-        assert not WorkflowDataConditionGroup.objects.filter(
-            id=workflow_data_condition_group.id
-        ).exists()
 
         # check data source
         assert not DataSource.objects.filter(id=data_source.id).exists()


### PR DESCRIPTION
Add helper method to delete the corresponding rows in the ACI tables after deleting an `AlertRule`.