### PR TITLE
fix(issues): Hide "view all issue tags" from performance

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -56,9 +56,12 @@ export const EventTagsDataSection = forwardRef<HTMLElement, Props>(
       });
     }, [event.tags]);
 
+    // Prevent drawer button from appearing on performance pages
+    const isOnIssueDetails = location.pathname.includes('/issues/');
+
     const actions = (
       <ButtonBar gap={1}>
-        {hasStreamlinedUI && event.groupID && (
+        {hasStreamlinedUI && event.groupID && isOnIssueDetails && (
           <LinkButton
             to={{
               pathname: `${location.pathname}${TabPaths[Tab.TAGS]}`,


### PR DESCRIPTION
Component is shared between issue details and the trace sidebar. Link currently leads to a bad route