### PR TITLE
fix(grouping): Fix bug with order of hashes

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -336,14 +336,23 @@ class BaseEvent(metaclass=abc.ABCMeta):
         """
 
         variants = self.get_grouping_variants(config)
+        hashes_by_variant = {
+            variant_name: variant.get_hash() for variant_name, variant in variants.items()
+        }
+
         # Sort the variants so that the system variant (if any) is always last, in order to resolve
         # ambiguities when choosing primary_hash for Snuba
-        sorted_variants = sorted(
-            variants.items(),
-            key=lambda name_and_variant: 1 if name_and_variant[0] == "system" else 0,
+        sorted_variant_names = sorted(
+            variants,
+            key=lambda variant_name: 1 if variant_name == "system" else 0,
         )
+
         # Get each variant's hash value, filtering out Nones
-        hashes = list({variant.get_hash() for _, variant in sorted_variants} - {None})
+        hashes = [
+            hashes_by_variant[variant_name]
+            for variant_name in sorted_variant_names
+            if hashes_by_variant[variant_name] is not None
+        ]
 
         # Write to event before returning
         self.data["hashes"] = hashes


### PR DESCRIPTION
A while back, I refactored `Event.get_hashes_and_variants` to use a set and set subtraction to filter out duplicate hashes and hashes which are `None`. Unfortunately, I didn't think of the fact that using a set totally undoes the sorting that we make a point to do immediately beforehand, with the result that in cases where there are two hashes, they come back as `[A, B]` sometimes and as `[B, A]` other times. 

The first hash is stored as the "primary hash" in snuba, and this bug means two events which hashed identically could be stored with different primary hashes. The main place this shows up is in the Merged Issues tab, which displays a list of the distinct primary hashes of events in the group. For issues where this has happened, it ends up looking like two issues have been merged, when in reality there are two entries only because the tab is showing both `A` and `B`.

This will hopefully soon be a moot point, as we are aiming to fix it so that we only ever return a single hash, but given that that work is temporarily on hold, it seemed worthwhile to fix the bug directly in the meantime.