### PR TITLE
feat(uptime): Add region configuration and basic functions to interact with regions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -21,12 +21,13 @@ from sentry.conf.api_pagination_allowlist_do_not_modify import (
     SENTRY_API_PAGINATION_ALLOWLIST_DO_NOT_MODIFY,
 )
 from sentry.conf.types.celery import SplitQueueSize, SplitQueueTaskRoute
-from sentry.conf.types.kafka_definition import ConsumerDefinition
+from sentry.conf.types.kafka_definition import ConsumerDefinition, Topic
 from sentry.conf.types.logging_config import LoggingConfig
 from sentry.conf.types.role_dict import RoleDict
 from sentry.conf.types.sdk_config import ServerSdkConfig
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.conf.types.service_options import ServiceOptions
+from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.utils import json  # NOQA (used in getsentry config)
 from sentry.utils.celery import crontab_with_minute_jitter, make_split_task_queues
 from sentry.utils.types import Type, type_from_value
@@ -3438,6 +3439,16 @@ SEER_ANOMALY_DETECTION_VERSION = "v1"
 SEER_ANOMALY_DETECTION_STORE_DATA_URL = f"/{SEER_ANOMALY_DETECTION_VERSION}/anomaly-detection/store"
 
 SIMILARITY_BACKFILL_COHORT_MAP: dict[str, list[int]] = {}
+
+UPTIME_REGIONS = [
+    UptimeRegionConfig(
+        slug="default",
+        name="Default Region",
+        config_topic=Topic.UPTIME_CONFIGS,
+        enabled=True,
+    ),
+]
+
 
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")

--- a/src/sentry/conf/types/uptime.py
+++ b/src/sentry/conf/types/uptime.py
@@ -1,0 +1,11 @@
+import dataclasses
+
+from sentry.conf.types.kafka_definition import Topic
+
+
+@dataclasses.dataclass
+class UptimeRegionConfig:
+    slug: str
+    name: str
+    config_topic: Topic
+    enabled: bool

--- a/src/sentry/conf/types/uptime.py
+++ b/src/sentry/conf/types/uptime.py
@@ -6,8 +6,9 @@ from sentry.conf.types.kafka_definition import Topic
 @dataclasses.dataclass
 class UptimeRegionConfig:
     """
-    Defines an available region which an uptime-checker is run in.
+    Defines a region which uptime checks can be run in.
     """
+
     slug: str
     name: str
     config_topic: Topic

--- a/src/sentry/conf/types/uptime.py
+++ b/src/sentry/conf/types/uptime.py
@@ -5,6 +5,9 @@ from sentry.conf.types.kafka_definition import Topic
 
 @dataclasses.dataclass
 class UptimeRegionConfig:
+    """
+    Defines an available region which an uptime-checker is run in.
+    """
     slug: str
     name: str
     config_topic: Topic

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+
+from sentry.conf.types.uptime import UptimeRegionConfig
+
+region_lookup = None
+
+
+def get_active_region_configs() -> list[UptimeRegionConfig]:
+    return [v for v in settings.UPTIME_REGIONS if v.enabled]
+
+
+def get_region_config(region: str) -> UptimeRegionConfig | None:
+    region = get_region_lookup().get(region)
+    if region is None:
+        # XXX: Temporary hack to guarantee we get a config
+        region = get_active_region_configs()[0]
+    return region
+
+
+def get_region_lookup() -> UptimeRegionConfig | None:
+    global region_lookup
+    if region_lookup is None:
+        region_lookup = {r.slug: r for r in settings.UPTIME_REGIONS}
+    return region_lookup

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -9,15 +9,15 @@ def get_active_region_configs() -> list[UptimeRegionConfig]:
     return [v for v in settings.UPTIME_REGIONS if v.enabled]
 
 
-def get_region_config(region: str) -> UptimeRegionConfig | None:
-    region = get_region_lookup().get(region)
+def get_region_config(region_slug: str) -> UptimeRegionConfig | None:
+    region = get_region_lookup().get(region_slug)
     if region is None:
         # XXX: Temporary hack to guarantee we get a config
         region = get_active_region_configs()[0]
     return region
 
 
-def get_region_lookup() -> UptimeRegionConfig | None:
+def get_region_lookup() -> dict[str, UptimeRegionConfig]:
     global region_lookup
     if region_lookup is None:
         region_lookup = {r.slug: r for r in settings.UPTIME_REGIONS}

--- a/tests/sentry/conf/types/test_imports.py
+++ b/tests/sentry/conf/types/test_imports.py
@@ -13,6 +13,7 @@ ALLOWLIST = frozenset(
     (
         "sentry.conf",
         "sentry.conf.types",
+        "sentry.conf.types.kafka_definition",
         # these come from sentry.__init__ -- please don't make this longer!
         "sentry._importchecker",
         "sentry.monkey",

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -1,0 +1,79 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.uptime.subscriptions.regions import (
+    get_active_region_configs,
+    get_region_config,
+    get_region_lookup,
+)
+
+
+class TestBase(TestCase):
+    def setUp(self):
+        self.test_regions = [
+            UptimeRegionConfig(
+                slug="us",
+                name="United States",
+                config_topic=Topic("uptime-config-us"),
+                enabled=True,
+            ),
+            UptimeRegionConfig(
+                slug="eu",
+                name="Europe",
+                config_topic=Topic("uptime-config-eu"),
+                enabled=False,
+            ),
+            UptimeRegionConfig(
+                slug="ap",
+                name="Asia Pacific",
+                config_topic=Topic("uptime-config-ap"),
+                enabled=True,
+            ),
+        ]
+
+    def tearDown(self):
+        # Reset the global region_lookup between tests
+        from sentry.uptime.subscriptions import regions
+
+        regions.region_lookup = None
+
+
+class GetActiveRegionConfigsTest(TestBase):
+    def test_returns_only_enabled_regions(self):
+        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+            active_regions = get_active_region_configs()
+            assert len(active_regions) == 2
+            assert all(region.enabled for region in active_regions)
+            assert {region.slug for region in active_regions} == {"us", "ap"}
+
+
+class GetRegionConfigTest(TestBase):
+    def test_returns_existing_region(self):
+        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+            region = get_region_config("us")
+            assert region is not None
+            assert region.slug == "us"
+            assert region.name == "United States"
+
+    def test_returns_first_active_region_for_invalid_slug(self):
+        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+            region = get_region_config("invalid")
+            assert region is not None
+            assert region.slug == "us"  # First active region
+
+
+class GetRegionLookupTest(TestBase):
+    def test_creates_lookup_dictionary(self):
+        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+            lookup = get_region_lookup()
+            assert len(lookup) == 3
+            assert set(lookup.keys()) == {"us", "eu", "ap"}
+
+    def test_caches_lookup_dictionary(self):
+        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+            lookup1 = get_region_lookup()
+            lookup2 = get_region_lookup()
+            assert lookup1 is lookup2

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -17,19 +17,19 @@ class TestBase(TestCase):
             UptimeRegionConfig(
                 slug="us",
                 name="United States",
-                config_topic=Topic("uptime-config-us"),
+                config_topic=Topic("uptime-results"),
                 enabled=True,
             ),
             UptimeRegionConfig(
                 slug="eu",
                 name="Europe",
-                config_topic=Topic("uptime-config-eu"),
+                config_topic=Topic("uptime-configs"),
                 enabled=False,
             ),
             UptimeRegionConfig(
                 slug="ap",
                 name="Asia Pacific",
-                config_topic=Topic("uptime-config-ap"),
+                config_topic=Topic("monitors-clock-tasks"),
                 enabled=True,
             ),
         ]


### PR DESCRIPTION
This adds types and configs for interacting with regions. The idea is that when regions are configured, uptime monitors will look at the regions they currently have configured and then automatically add them in - that will come in a follow up pr.

<!-- Describe your PR here. -->