### PR TITLE
feat(uptime): Start sending regions and schedule mode to uptime checkers

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.19.7
-sentry-kafka-schemas>=0.1.123
+sentry-kafka-schemas>=0.1.124
 sentry-ophio==1.0.0
 sentry-protos>=0.1.37
 sentry-redis-tools>=0.1.7

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sentry-covdefaults-disable-branch-coverage==1.0.2
 sentry-devenv==1.14.2
 sentry-forked-django-stubs==5.1.1.post1
 sentry-forked-djangorestframework-stubs==3.15.2.post1
-sentry-kafka-schemas==0.1.123
+sentry-kafka-schemas==0.1.124
 sentry-ophio==1.0.0
 sentry-protos==0.1.39
 sentry-redis-tools==0.1.7

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -126,7 +126,7 @@ rpds-py==0.20.0
 rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.19.7
-sentry-kafka-schemas==0.1.123
+sentry-kafka-schemas==0.1.124
 sentry-ophio==1.0.0
 sentry-protos==0.1.39
 sentry-redis-tools==0.1.7

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -154,6 +154,7 @@ from sentry.types.activity import ActivityType
 from sentry.types.actor import Actor
 from sentry.types.region import Region, get_local_region, get_region_by_name
 from sentry.types.token import AuthTokenType
+from sentry.uptime import models as uptime_models
 from sentry.uptime.models import (
     IntervalSecondsLiteral,
     ProjectUptimeSubscription,
@@ -2038,6 +2039,21 @@ class Factories:
             owner_team_id=owner_team_id,
             owner_user_id=owner_user_id,
             uptime_status=uptime_status,
+        )
+
+    @staticmethod
+    def create_uptime_region(
+        slug: str,
+        name: str,
+    ):
+        return uptime_models.Region.objects.get_or_create(slug=slug, name=name)[0]
+
+    @staticmethod
+    def create_uptime_subscription_region(
+        subscription: UptimeSubscription, region: uptime_models.Region
+    ):
+        return uptime_models.UptimeSubscriptionRegion.objects.create(
+            uptime_subscription=subscription, region=region
         )
 
     @staticmethod

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -154,13 +154,13 @@ from sentry.types.activity import ActivityType
 from sentry.types.actor import Actor
 from sentry.types.region import Region, get_local_region, get_region_by_name
 from sentry.types.token import AuthTokenType
-from sentry.uptime import models as uptime_models
 from sentry.uptime.models import (
     IntervalSecondsLiteral,
     ProjectUptimeSubscription,
     ProjectUptimeSubscriptionMode,
     UptimeStatus,
     UptimeSubscription,
+    UptimeSubscriptionRegion,
 )
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.users.models.user import User
@@ -2042,18 +2042,11 @@ class Factories:
         )
 
     @staticmethod
-    def create_uptime_region(
-        slug: str,
-        name: str,
-    ):
-        return uptime_models.Region.objects.get_or_create(slug=slug, name=name)[0]
-
-    @staticmethod
     def create_uptime_subscription_region(
-        subscription: UptimeSubscription, region: uptime_models.Region
-    ):
-        return uptime_models.UptimeSubscriptionRegion.objects.create(
-            uptime_subscription=subscription, region=region
+        subscription: UptimeSubscription, region_slug: str
+    ) -> UptimeSubscriptionRegion:
+        return UptimeSubscriptionRegion.objects.create(
+            uptime_subscription=subscription, region_slug=region_slug
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -688,13 +688,16 @@ class Fixtures:
         body=None,
         date_updated: None | datetime = None,
         trace_sampling: bool = False,
+        region_slugs: list[str] | None = None,
     ) -> UptimeSubscription:
         if date_updated is None:
             date_updated = timezone.now()
         if headers is None:
             headers = []
+        if region_slugs is None:
+            region_slugs = []
 
-        return Factories.create_uptime_subscription(
+        subscription = Factories.create_uptime_subscription(
             type=type,
             subscription_id=subscription_id,
             status=status,
@@ -710,6 +713,11 @@ class Fixtures:
             body=body,
             trace_sampling=trace_sampling,
         )
+        for region_slug in region_slugs:
+            region = Factories.create_uptime_region(region_slug, region_slug)
+            Factories.create_uptime_subscription_region(subscription, region)
+
+        return subscription
 
     def create_project_uptime_subscription(
         self,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -714,8 +714,7 @@ class Fixtures:
             trace_sampling=trace_sampling,
         )
         for region_slug in region_slugs:
-            region = Factories.create_uptime_region(region_slug, region_slug)
-            Factories.create_uptime_subscription_region(subscription, region)
+            Factories.create_uptime_subscription_region(subscription, region_slug)
 
         return subscription
 

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.models import Q
 from django.db.models.expressions import Value
 from django.db.models.functions import MD5, Coalesce
+from sentry_kafka_schemas.schema_types.uptime_configs_v1 import REGIONSCHEDULEMODE_ROUND_ROBIN
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
@@ -226,3 +227,7 @@ def get_active_auto_monitor_count_for_org(organization: Organization) -> int:
             ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
         ],
     ).count()
+
+
+class UptimeRegionScheduleMode(enum.StrEnum):
+    ROUND_ROBIN = REGIONSCHEDULEMODE_ROUND_ROBIN

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -5,15 +5,12 @@ from datetime import timedelta
 from uuid import uuid4
 
 from django.utils import timezone
-from sentry_kafka_schemas.schema_types.uptime_configs_v1 import (
-    _CHECKCONFIGREGIONSCHEDULEMODE_ROUND_ROBIN,
-    CheckConfig,
-)
+from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 
 from sentry.snuba.models import QuerySubscription
 from sentry.tasks.base import instrumented_task
 from sentry.uptime.config_producer import produce_config, produce_config_removal
-from sentry.uptime.models import UptimeSubscription
+from sentry.uptime.models import UptimeRegionScheduleMode, UptimeSubscription
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -100,7 +97,7 @@ def uptime_subscription_to_check_config(
         "request_headers": headers,
         "trace_sampling": subscription.trace_sampling,
         "active_regions": [r.region_slug for r in subscription.regions.all()],
-        "region_schedule_mode": _CHECKCONFIGREGIONSCHEDULEMODE_ROUND_ROBIN,
+        "region_schedule_mode": UptimeRegionScheduleMode.ROUND_ROBIN.value,
     }
     if subscription.body is not None:
         config["request_body"] = subscription.body

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -5,7 +5,10 @@ from datetime import timedelta
 from uuid import uuid4
 
 from django.utils import timezone
-from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
+from sentry_kafka_schemas.schema_types.uptime_configs_v1 import (
+    _CHECKCONFIGREGIONSCHEDULEMODE_ROUND_ROBIN,
+    CheckConfig,
+)
 
 from sentry.snuba.models import QuerySubscription
 from sentry.tasks.base import instrumented_task
@@ -96,8 +99,8 @@ def uptime_subscription_to_check_config(
         "request_method": subscription.method,
         "request_headers": headers,
         "trace_sampling": subscription.trace_sampling,
-        "active_regions": [r.slug for r in subscription.regions.all()],
-        "region_schedule_mode": "round_robin",
+        "active_regions": [r.region_slug for r in subscription.regions.all()],
+        "region_schedule_mode": _CHECKCONFIGREGIONSCHEDULEMODE_ROUND_ROBIN,
     }
     if subscription.body is not None:
         config["request_body"] = subscription.body

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -96,6 +96,8 @@ def uptime_subscription_to_check_config(
         "request_method": subscription.method,
         "request_headers": headers,
         "trace_sampling": subscription.trace_sampling,
+        "active_regions": [r.slug for r in subscription.regions.all()],
+        "region_schedule_mode": "round_robin",
     }
     if subscription.body is not None:
         config["request_body"] = subscription.body


### PR DESCRIPTION
This starts passing the new region and schedule modes to the uptime checkers, and bumps the schema to support sending them.

<!-- Describe your PR here. -->