### PR TITLE
fix(integrations): check scope at finish_pipeline, part 2

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -104,16 +104,19 @@ class IntegrationPipeline(Pipeline):
             and org_context.member
             and "org:integrations" not in org_context.member.scopes
         ):
+            error_message = (
+                "You must be an organization owner, manager or admin to install this integration."
+            )
             logger.info(
                 "build-integration.permission_error",
                 extra={
-                    "error_message": "User has no 'org:integrations' scope.",
+                    "error_message": error_message,
                     "organization_id": self.organization.id,
                     "user_id": self.request.user.id,
                     "provider_key": self.provider.key,
                 },
             )
-            return self.error("User has no 'org:integrations' scope.")
+            return self.error(error_message)
 
         try:
             data = self.provider.build_integration(self.state.data)

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -113,6 +113,7 @@ class IntegrationPipeline(Pipeline):
                     "provider_key": self.provider.key,
                 },
             )
+            return self.error("User has no 'org:integrations' scope.")
 
         try:
             data = self.provider.build_integration(self.state.data)

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -479,10 +479,13 @@ class FinishPipelineTestCase(IntegrationTestCase):
 
         # attempt to finish pipeline with no 'org:integrations' scope
         resp = self.pipeline.finish_pipeline()
-        assert "User has no &#x27;org:integrations&#x27; scope." in resp.content.decode()
+        assert (
+            "You must be an organization owner, manager or admin to install this integration."
+            in resp.content.decode()
+        )
 
         extra = {
-            "error_message": "User has no 'org:integrations' scope.",
+            "error_message": "You must be an organization owner, manager or admin to install this integration.",
             "organization_id": self.organization.id,
             "user_id": member_user.id,
             "provider_key": "example",

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -478,7 +478,8 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.state.data = data
 
         # attempt to finish pipeline with no 'org:integrations' scope
-        self.pipeline.finish_pipeline()
+        resp = self.pipeline.finish_pipeline()
+        assert "User has no &#x27;org:integrations&#x27; scope." in resp.content.decode()
 
         extra = {
             "error_message": "User has no 'org:integrations' scope.",


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/82137
Now, if the user happens to be at the end of the integration pipeline but with no `org:integrations`, this error is being shown:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/01fb794b-0315-480d-8019-1727d0740880" />
