### PR TITLE
feat(tempest): Include user email in endpoint response

### DIFF
--- a/src/sentry/tempest/serializers.py
+++ b/src/sentry/tempest/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from sentry.api.serializers.base import Serializer, register
 from sentry.tempest.models import TempestCredentials
+from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
 
 
@@ -27,15 +28,14 @@ class TempestCredentialsSerializer(Serializer):
 
     def get_attrs(
         self,
-        item_list: serializers.Sequence[serializers.Any],
-        user: serializers.Any,
-        **kwargs: serializers.Any,
-    ) -> serializers.MutableMapping[serializers.Any, serializers.Any]:
+        item_list: list[TempestCredentials],
+        user: RpcUser,
+    ) -> dict[int, RpcUser]:
         attrs = {}
         user_ids = {item.created_by_id for item in item_list}
         users = user_service.get_many_by_id(user_ids)
-        for user in users:
-            attrs[user.id] = user
+        for rpc_user in users:
+            attrs[rpc_user.id] = rpc_user
         return attrs
 
 

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials.py
@@ -126,6 +126,6 @@ class TestTempestCredentials(APITestCase):
     def test_user_email_in_response(self):
         with Feature({"organizations:tempest-access": True}):
             self.login_as(self.user)
-            self.create_tempest_credentials(self.project, created_by_id=self.user.id)
+            self.create_tempest_credentials(self.project, created_by=self.user)
             response = self.get_success_response(self.project.organization.slug, self.project.slug)
             assert response.data[0]["createdByEmail"] == self.user.email

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials.py
@@ -122,3 +122,10 @@ class TestTempestCredentials(APITestCase):
             # database constraint violation
             assert response.status_code == 400
             assert response.data["detail"] == "A credential with this client ID already exists."
+
+    def test_user_email_in_response(self):
+        with Feature({"organizations:tempest-access": True}):
+            self.login_as(self.user)
+            self.create_tempest_credentials(self.project, created_by_id=self.user.id)
+            response = self.get_success_response(self.project.organization.slug, self.project.slug)
+            assert response.data[0]["createdByEmail"] == self.user.email


### PR DESCRIPTION
Adds user's email when it is known to the response of the endpoint