### PR TITLE
feat(chunks): Declare Proguard chunk upload support

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -36,6 +36,7 @@ CHUNK_UPLOAD_ACCEPT = (
     "portablepdbs",  # Portable PDB debug file
     "artifact_bundles",  # Artifact Bundles for JavaScript Source Maps
     "artifact_bundles_v2",  # The `assemble` endpoint will check for missing chunks
+    "proguard",  # Chunk-uploaded proguard mappings
 )
 
 


### PR DESCRIPTION
Update the `accept` field of the payload returned by the chunk upload endpoint to indicate that the Sentry server supports receiving chunk-uploaded Proguard mappings.

Support for receiving chunk-uploaded Proguard mappings was added in https://github.com/getsentry/sentry/pull/81131.