### PR TITLE
test(chunks): Ensure `"chunkSize"` is a power of two

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -104,6 +104,11 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
 
         accept = CHUNK_UPLOAD_ACCEPT
 
+        # Sentry CLI versions ≤2.39.1 require "chunkSize" to be a power of two, and will error otherwise,
+        # with no way for the user to work around the error. This restriction has been removed from
+        # newer Sentry CLI versions.
+        # Be aware that changing "chunkSize" to something that is not a power of two will break
+        # Sentry CLI ≤2.39.1.
         return Response(
             {
                 "url": url,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2220,6 +2220,11 @@ SENTRY_ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 # The chunk size for files in the chunk upload. This is used for native debug
 # files and source maps, and directly translates to the chunk size in blob
 # store. MUST be a power of two.
+#
+# Note: Even if the power of two restriction is lifted in Sentry, Sentry CLI
+# versions ≤2.39.1 will error if the chunkSize returned by the server is
+# not a power of two. Changing this value to a non-power-of-two is therefore
+# a breaking API change.
 SENTRY_CHUNK_UPLOAD_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 
 # This flag tell DEVSERVICES to start the ingest-metrics-consumer in order to work on

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -1,3 +1,5 @@
+import math
+
 from hashlib import sha1
 
 import pytest
@@ -56,6 +58,13 @@ class ChunkUploadTest(APITestCase):
             )
 
             assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
+
+        assert math.log2(response.data["chunkSize"]) % 1 == 0, (
+            "chunkSize is not a power of two. This change will break Sentry CLI versions ≤2.39.1, "
+            "since these versions only support chunk sizes which are a power of two. Chunk uploads "
+            "will error in these versions when the CLI receives a chunk size which is not a power "
+            "of two from the server, and there is no way for users to work around the error."
+        )
 
     def test_relative_url_support(self):
         # Starting `sentry-cli@1.70.1` we added a support for relative chunk-uploads urls

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -1,5 +1,4 @@
 import math
-
 from hashlib import sha1
 
 import pytest


### PR DESCRIPTION
This is required by Sentry CLI versions ≤2.39.1. The restriction (for now, based on existing code comments) appears to also be needed for our blob storage in Sentry. However, if we ever remove the restriction for the blob storage, my the test I added here (plus the code comments) will make it clear that changing the chunk size would break Sentry CLI versions below and including 2.39.1.