### PR TITLE
:wrench: chore: update the tooltip text

### DIFF
--- a/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
@@ -144,9 +144,7 @@ export function OrganizationAuthTokensAuthTokenRow({
 
       <Actions>
         <Tooltip
-          title={t(
-            'You must be an organization owner, manager or admin to revoke a token.'
-          )}
+          title={t('You must be an organization owner or manager to revoke a token.')}
           disabled={!!revokeToken}
         >
           <Confirm


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/82061

the endpoint to revoke the token requires `org:write` or `org:admin` permissions
https://github.com/getsentry/sentry/blob/faf717417f3ac7d59d55ba2822529ee339e9e9d3/src/sentry/api/bases/organization.py#L220

which admins don't have
https://github.com/getsentry/sentry/blob/faf717417f3ac7d59d55ba2822529ee339e9e9d3/src/sentry/conf/server.py#L2022-L2039

docs also don't mention admin: https://docs.sentry.io/account/auth-tokens/#organization-auth-tokens
