### PR TITLE
fix: soft delete ips from user field on sentry tags

### DIFF
--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -143,6 +143,10 @@ class EventJsonEndpoint(ProjectEndpoint):
                             continue
                         if "user.ip" in span["sentry_tags"]:
                             del span["sentry_tags"]["user.ip"]
+                        if "user" in span["sentry_tags"] and span["sentry_tags"]["user"].startswith(
+                            "ip:"
+                        ):
+                            span["sentry_tags"]["user"] = "ip:[ip]"
         except Exception as e:
             sentry_sdk.capture_exception(e)
 

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -394,38 +394,59 @@ class ProjectEventDetailsTransactionTestScrubbed(APITestCase, SnubaTestCase):
         data = load_data("transaction")
         for span in data["spans"]:
             span["sentry_tags"]["user.ip"] = "127.0.0.1"
+            span["sentry_tags"]["user"] = "ip:127.0.0.1"
         self.event = self.store_event(data=data, project_id=self.project.id)
 
-        self.url = reverse(
+    def url(self, event):
+        return reverse(
             "sentry-api-0-event-json",
             kwargs={
                 "organization_id_or_slug": self.organization.slug,
                 "project_id_or_slug": self.project.slug,
-                "event_id": self.event.event_id,
+                "event_id": event.event_id,
             },
         )
 
     def test_no_scrubbed(self):
-        response = self.client.get(self.url, format="json")
+        response = self.client.get(self.url(self.event), format="json")
         assert response.status_code == 200, response.content
         assert len(response.data["spans"]) > 0
         for span in response.data["spans"]:
             assert "user.ip" in span["sentry_tags"]
+            assert span["sentry_tags"]["user"] == "ip:127.0.0.1"
 
     def test_scrubbed_project(self):
         self.project.update_option("sentry:scrub_ip_address", True)
 
-        response = self.client.get(self.url, format="json")
+        response = self.client.get(self.url(self.event), format="json")
         assert response.status_code == 200, response.content
         assert len(response.data["spans"]) > 0
         for span in response.data["spans"]:
             assert "user.ip" not in span["sentry_tags"]
+            assert span["sentry_tags"]["user"] == "ip:[ip]"
 
     def test_scrubbed_organization(self):
         self.organization.update_option("sentry:require_scrub_ip_address", True)
 
-        response = self.client.get(self.url, format="json")
+        response = self.client.get(self.url(self.event), format="json")
         assert response.status_code == 200, response.content
         assert len(response.data["spans"]) > 0
         for span in response.data["spans"]:
             assert "user.ip" not in span["sentry_tags"]
+            assert span["sentry_tags"]["user"] == "ip:[ip]"
+
+    def test_scrubbed_organization_does_not_scrub_other_user_fields(self):
+        self.organization.update_option("sentry:require_scrub_ip_address", True)
+
+        data = load_data("transaction")
+        for span in data["spans"]:
+            span["sentry_tags"]["user.ip"] = "127.0.0.1"
+            span["sentry_tags"]["user"] = "username:foo"
+        event = self.store_event(data=data, project_id=self.project.id)
+
+        response = self.client.get(self.url(event), format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data["spans"]) > 0
+        for span in response.data["spans"]:
+            assert "user.ip" not in span["sentry_tags"]
+            assert span["sentry_tags"]["user"] == "username:foo"


### PR DESCRIPTION
This scrubs the user field on sentry_tags if it contains IPs