### PR TITLE
fix(flags): only record suspect flag analytic if a flag was recorded

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useSuspectFlags.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useSuspectFlags.tsx
@@ -35,8 +35,13 @@ export default function useSuspectFlags({
   );
 
   // no flags in common between event evaluations and audit log
+  // only track this analytic if there is at least 1 flag recorded
+  // in either the audit log or the event context
   useEffect(() => {
-    if (!intersectionFlags.length) {
+    if (
+      !intersectionFlags.length &&
+      (hydratedFlagData.length || evaluatedFlagNames?.length)
+    ) {
       trackAnalytics('flags.event_and_suspect_flags_found', {
         numTotalFlags: hydratedFlagData.length,
         numEventFlags: 0,
@@ -44,7 +49,12 @@ export default function useSuspectFlags({
         organization,
       });
     }
-  }, [hydratedFlagData.length, intersectionFlags.length, organization]);
+  }, [
+    hydratedFlagData.length,
+    intersectionFlags.length,
+    organization,
+    evaluatedFlagNames?.length,
+  ]);
 
   // get all the audit log flag changes which happened prior to the first seen date
   const start = moment(firstSeen).subtract(1, 'year').format('YYYY-MM-DD HH:mm:ss');


### PR DESCRIPTION
<img width="734" alt="SCR-20241218-lfjf" src="https://github.com/user-attachments/assets/fbd1e4e8-54cc-40ec-a101-8ce16d4a9d4f" />

we only want to track this analytic going forward if the user has set up feature flags