### PR TITLE
feat(widget-builder): Add default state on dataset change

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -46,7 +46,7 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   fieldAliases: [],
   aggregates: ['count(span.duration)'],
   conditions: '',
-  orderby: '',
+  orderby: '-count(span.duration)',
 };
 
 const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggregate) => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -503,6 +503,30 @@ describe('Visualize', () => {
     expect(screen.getByDisplayValue('300')).toBeInTheDocument();
   });
 
+  it('disables the aggregate selection when there is only one aggregate option', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.ISSUE,
+              field: ['issue.id'],
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toBeDisabled();
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -193,10 +193,13 @@ function Visualize() {
                 ) : null,
             }));
 
-          const aggregateOptions = aggregates.map(option => ({
+          let aggregateOptions = aggregates.map(option => ({
             value: option.value.meta.name,
             label: option.value.meta.name,
           }));
+          aggregateOptions = isChartWidget
+            ? aggregateOptions
+            : [NONE_AGGREGATE, ...aggregateOptions];
 
           let matchingAggregate;
           if (
@@ -276,11 +279,8 @@ function Visualize() {
                         }
                       />
                       <AggregateCompactSelect
-                        options={
-                          isChartWidget
-                            ? aggregateOptions
-                            : [NONE_AGGREGATE, ...aggregateOptions]
-                        }
+                        disabled={aggregateOptions.length <= 1}
+                        options={aggregateOptions}
                         value={parseFunction(stringFields?.[index] ?? '')?.name ?? ''}
                         onChange={aggregateSelection => {
                           const isNone = aggregateSelection.value === NONE;

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -177,6 +177,74 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.dataset).toBe(WidgetType.ERRORS);
     });
+
+    it('resets the display type to table when the dataset is switched to issues', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {dataset: WidgetType.TRANSACTIONS, displayType: DisplayType.LINE},
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.displayType).toBe(DisplayType.LINE);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.ISSUE,
+        });
+      });
+
+      expect(result.current.state.displayType).toBe(DisplayType.TABLE);
+    });
+
+    it('resets the fields, yAxis, query, and sort when the dataset is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            title: 'This title should persist',
+            description: 'This description should persist',
+            dataset: WidgetType.TRANSACTIONS,
+            field: ['event.type', 'potato', 'count()'],
+            yAxis: ['count()', 'count_unique(user)'],
+            query: ['event.type = "test"'],
+            sort: ['-testField'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.SPANS,
+        });
+      });
+
+      expect(result.current.state.title).toBe('This title should persist');
+      expect(result.current.state.description).toBe('This description should persist');
+      expect(result.current.state.fields).toEqual([
+        {
+          function: ['count', 'span.duration', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+      expect(result.current.state.yAxis).toEqual([]);
+      expect(result.current.state.query).toEqual(['']);
+      expect(result.current.state.sort).toEqual([
+        {
+          field: 'count(span.duration)',
+          kind: 'desc',
+        },
+      ]);
+    });
   });
 
   describe('fields', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -130,16 +130,18 @@ function useWidgetBuilderState(): {
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);
 
+          let newDisplayType;
           if (action.payload === WidgetType.ISSUE) {
             // Issues only support table display type
             setDisplayType(DisplayType.TABLE);
+            newDisplayType = DisplayType.TABLE;
           }
 
           const config = getDatasetConfig(action.payload);
           setFields(
             config.defaultWidgetQuery.fields?.map(field => explodeField({field}))
           );
-          if (displayType === DisplayType.TABLE) {
+          if (newDisplayType === DisplayType.TABLE) {
             setYAxis([]);
           } else {
             setYAxis(
@@ -180,7 +182,6 @@ function useWidgetBuilderState(): {
       setQuery,
       setSort,
       setLimit,
-      displayType,
     ]
   );
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -12,6 +12,7 @@ import {
   decodeScalar,
   decodeSorts,
 } from 'sentry/utils/queryString';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {useQueryParamState} from 'sentry/views/dashboards/widgetBuilder/hooks/useQueryParamState';
 import {DEFAULT_RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
@@ -128,6 +129,27 @@ function useWidgetBuilderState(): {
           break;
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);
+
+          if (action.payload === WidgetType.ISSUE) {
+            // Issues only support table display type
+            setDisplayType(DisplayType.TABLE);
+          }
+
+          const config = getDatasetConfig(action.payload);
+          setFields(
+            config.defaultWidgetQuery.fields?.map(field => explodeField({field}))
+          );
+          if (displayType === DisplayType.TABLE) {
+            setYAxis([]);
+          } else {
+            setYAxis(
+              config.defaultWidgetQuery.aggregates?.map(aggregate =>
+                explodeField({field: aggregate})
+              )
+            );
+          }
+          setQuery([config.defaultWidgetQuery.conditions]);
+          setSort(decodeSorts(config.defaultWidgetQuery.orderby));
           break;
         case BuilderStateAction.SET_FIELDS:
           setFields(action.payload);
@@ -158,6 +180,7 @@ function useWidgetBuilderState(): {
       setQuery,
       setSort,
       setLimit,
+      displayType,
     ]
   );
 

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
@@ -37,7 +37,7 @@ describe('getDefaultWidget', () => {
           conditions: '',
           aggregates: ['count(span.duration)'],
           columns: [],
-          orderby: '',
+          orderby: '-count(span.duration)',
           fieldAliases: [],
           name: '',
         },


### PR DESCRIPTION
When the datasets are changed, we should clear the state and replace it with the default query

Also snuck in a change to fix a missing sort for the spans dataset, and disable the aggregate selector if there aren't any aggregates (e.g. issues can only do samples)