### PR TITLE
feat: sync now ensures kafka topics are created

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -289,6 +289,7 @@ Then, use it to run sync this one time.
                 "up",
                 "redis",
                 "postgres",
+                "kafka",
             ),
             pathprepend=f"{reporoot}/.devenv/bin",
             exit=True,

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -27,7 +27,9 @@ x-sentry-service-config:
         repo_link: https://github.com/getsentry/sentry-shared-redis.git
   modes:
     default: [snuba, postgres, relay]
-    migrations: [postgres, redis]
+    # make apply-migrations now require kafka (we'll just up snuba as well) since
+    # we want to ensure kafka topics are created
+    migrations: [postgres, redis, snuba]
 
 services:
   postgres:

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -104,8 +104,8 @@ create-db() {
 
 apply-migrations() {
     create-db
-    echo "--> Applying migrations"
-    sentry upgrade --noinput
+    echo "--> Applying migrations and creating kafka topics"
+    sentry upgrade --noinput --create-kafka-topics
 }
 
 create-superuser() {


### PR DESCRIPTION
sync (which calls make apply-migrations) now ensures kafka topics are created, which means kafka must be brought up as well (not really that big of a deal anymore ever since i removed zookeeper and now we have faster new devservices)

tested with both old and new devservices, verified with `docker exec (kafka container) kafka-topics --bootstrap-server 127.0.0.1:9092 --list`