### PR TITLE
fix(issues): Adjust tag count tooltip

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Color from 'color';
 
 import {DeviceName} from 'sentry/components/deviceName';
 import Link from 'sentry/components/links/link';
@@ -138,7 +139,7 @@ const TagBarContainer = styled('div')`
     inset: 0;
     content: '';
     border-radius: 3px;
-    background: ${p => p.theme.border};
+    background: ${p => Color(p.theme.gray300).alpha(0.5).toString()};
     border: 1px solid ${p => p.theme.translucentBorder};
     width: 100%;
   }

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -49,9 +49,11 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
                   })}
                   skipWrapper
                 >
-                  <TagBarValue>{displayPercentage}</TagBarValue>
+                  <TooltipContainer>
+                    <TagBarValue>{displayPercentage}</TagBarValue>
+                    <TagBar percentage={percentage} />
+                  </TooltipContainer>
                 </Tooltip>
-                <TagBar percentage={percentage} />
               </TagValueRow>
             );
           })}
@@ -135,7 +137,7 @@ const TagBarContainer = styled('div')`
     position: absolute;
     inset: 0;
     content: '';
-    border-radius: 1000px;
+    border-radius: 3px;
     background: ${p => p.theme.border};
     border: 1px solid ${p => p.theme.translucentBorder};
     width: 100%;
@@ -144,4 +146,11 @@ const TagBarContainer = styled('div')`
 
 const TagBarValue = styled('div')`
   text-align: right;
+`;
+
+const TooltipContainer = styled('div')`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 2 / -1;
+  align-items: center;
 `;


### PR DESCRIPTION
Shows the tooltip over both the progress bar and the percentage

makes the progress bars less round
![image](https://github.com/user-attachments/assets/57e76e6d-d40f-4816-a87d-18762c0d1241)
