### PR TITLE
fix(query-builder): Move focus correctly when text gets converted into tokens

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -856,6 +856,29 @@ describe('SearchQueryBuilder', function () {
 
       expect(getLastInput()).toHaveFocus();
     });
+
+    it('focuses the correct text input after typing boolean operators', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+
+      await userEvent.click(getLastInput());
+
+      // XXX(malwilley): SearchQueryBuilderInput updates state in the render
+      // function which causes an act warning despite using userEvent.click.
+      // Cannot find a way to avoid this warning.
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
+      await userEvent.keyboard('a or b{enter}');
+      jest.restoreAllMocks();
+
+      const lastInput = (await screen.findAllByTestId('query-builder-input')).at(-1);
+      expect(lastInput).toHaveFocus();
+
+      await userEvent.click(getLastInput());
+
+      // Should have three tokens: a, or, b
+      await screen.findByRole('row', {name: /a/});
+      await screen.findByRole('row', {name: /or/});
+      await screen.findByRole('row', {name: /b/});
+    });
   });
 
   describe('filter key suggestions', function () {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -21,7 +21,11 @@ import type {
   FieldDefinitionGetter,
   FocusOverride,
 } from 'sentry/components/searchQueryBuilder/types';
-import {recentSearchTypeToLabel} from 'sentry/components/searchQueryBuilder/utils';
+import {
+  collapseTextTokens,
+  parseTokenKey,
+  recentSearchTypeToLabel,
+} from 'sentry/components/searchQueryBuilder/utils';
 import {
   InvalidReason,
   type ParseResultToken,
@@ -131,12 +135,37 @@ function calculateNextFocusForFilter(state: ListState<ParseResultToken>): FocusO
 }
 
 function calculateNextFocusForInsertedToken(item: Node<ParseResultToken>): FocusOverride {
-  const [, tokenTypeIndexStr] = item.key.toString().split(':');
-
-  const tokenTypeIndex = parseInt(tokenTypeIndexStr, 10);
+  const {index} = parseTokenKey(item.key.toString());
 
   return {
-    itemKey: `${Token.FREE_TEXT}:${tokenTypeIndex + 1}`,
+    itemKey: `${Token.FREE_TEXT}:${index + 1}`,
+  };
+}
+
+function calculateNextFocusForCommittedCustomValue({
+  value,
+  currentFocusedKey,
+}: {
+  currentFocusedKey: string;
+  value: string;
+}): FocusOverride | undefined {
+  const {tokenType, index} = parseTokenKey(currentFocusedKey.toString());
+
+  const parsedText = collapseTextTokens(parseSearch(value));
+  const numFreeTextTokens = Math.max(
+    parsedText?.filter(token => token.type === Token.FREE_TEXT).length ?? 0
+  );
+
+  // We always expect there to be at least one free text token, so we subtract one
+  // to get the index of the next token to focus.
+  const diff = Math.max(0, numFreeTextTokens - 1);
+
+  if (diff <= 0) {
+    return undefined;
+  }
+
+  return {
+    itemKey: `${tokenType}:${index + diff}`,
   };
 }
 
@@ -409,11 +438,27 @@ function SearchQueryBuilderInputInternal({
           });
         }}
         onCustomValueBlurred={value => {
-          dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: value});
+          dispatch({
+            type: 'UPDATE_FREE_TEXT',
+            tokens: [token],
+            text: value,
+            focusOverride: calculateNextFocusForCommittedCustomValue({
+              currentFocusedKey: item.key.toString(),
+              value,
+            }),
+          });
           resetInputValue();
         }}
         onCustomValueCommitted={value => {
-          dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: value});
+          dispatch({
+            type: 'UPDATE_FREE_TEXT',
+            tokens: [token],
+            text: value,
+            focusOverride: calculateNextFocusForCommittedCustomValue({
+              currentFocusedKey: item.key.toString(),
+              value,
+            }),
+          });
           resetInputValue();
 
           // Because the query does not change until a subsequent render,

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -111,6 +111,12 @@ export function makeTokenKey(token: ParseResultToken, allTokens: ParseResult | n
   return `${token.type}:${tokenTypeIndex}`;
 }
 
+export function parseTokenKey(key: string) {
+  const [tokenType, indexStr] = key.split(':');
+  const index = parseInt(indexStr, 10);
+  return {tokenType, index};
+}
+
 const isSimpleTextToken = (
   token: ParseResultToken
 ): token is TokenResult<Token.FREE_TEXT> | TokenResult<Token.SPACES> => {
@@ -121,7 +127,7 @@ const isSimpleTextToken = (
  * Collapse adjacent FREE_TEXT and SPACES tokens into a single token.
  * This is useful for rendering the minimum number of inputs in the UI.
  */
-function collapseTextTokens(tokens: ParseResult | null) {
+export function collapseTextTokens(tokens: ParseResult | null) {
   if (!tokens) {
     return null;
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/79078

In the case where free text would get converted to tokens, the focus would stay in the first input rather than being moved to the appropriate end input. This required me to send the new focus position in the `UPDATE_FREE_TEXT` action.

Before:

https://github.com/user-attachments/assets/2513ea65-4cde-4940-adb1-77eaa977aab6

After:


https://github.com/user-attachments/assets/51c7d2b1-7f75-4e9b-a342-091acc027079

