### PR TITLE
feat(new-trace): Aligning trace flyout with issues flyout panel

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.tsx
@@ -36,7 +36,7 @@ export function AutogroupNodeDetails(
   }
 
   return (
-    <TraceDrawerComponents.DetailContainer hasNewTraceUi={hasTraceNewUi}>
+    <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.HeaderContainer>
         <TraceDrawerComponents.Title>
           <TraceDrawerComponents.LegacyTitleText>
@@ -54,20 +54,22 @@ export function AutogroupNodeDetails(
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceDrawerComponents.HeaderContainer>
-      <TextBlock>
-        {t(
-          'This block represents autogrouped spans. We do this to reduce noise whenever it fits one of the following criteria:'
-        )}
-      </TextBlock>
-      <BulletList>
-        <li>{t('5 or more siblings with the same operation and description')}</li>
-        <li>{t('2 or more descendants with the same operation')}</li>
-      </BulletList>
-      <TextBlock>
-        {t(
-          'You can either open this autogroup using the chevron on the span or turn this functionality off using the settings dropdown above.'
-        )}
-      </TextBlock>
+      <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasTraceNewUi}>
+        <TextBlock>
+          {t(
+            'This block represents autogrouped spans. We do this to reduce noise whenever it fits one of the following criteria:'
+          )}
+        </TextBlock>
+        <BulletList>
+          <li>{t('5 or more siblings with the same operation and description')}</li>
+          <li>{t('2 or more descendants with the same operation')}</li>
+        </BulletList>
+        <TextBlock>
+          {t(
+            'You can either open this autogroup using the chevron on the span or turn this functionality off using the settings dropdown above.'
+          )}
+        </TextBlock>
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/parentAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/parentAutogroup.tsx
@@ -76,10 +76,11 @@ export function ParentAutogroupNodeDetails({
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceDrawerComponents.LegacyHeaderContainer>
+      <TraceDrawerComponents.BodyContainer>
+        <IssueList issues={issues} node={node} organization={organization} />
 
-      <IssueList issues={issues} node={node} organization={organization} />
-
-      <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
+        <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/siblingAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/siblingAutogroup.tsx
@@ -77,10 +77,11 @@ export function SiblingAutogroupNodeDetails({
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceDrawerComponents.LegacyHeaderContainer>
+      <TraceDrawerComponents.BodyContainer>
+        <IssueList issues={issues} node={node} organization={organization} />
 
-      <IssueList issues={issues} node={node} organization={organization} />
-
-      <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
+        <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -39,7 +39,7 @@ export function ErrorNodeDetails(
   }
 
   return (
-    <TraceDrawerComponents.DetailContainer hasNewTraceUi={hasTraceNewUi}>
+    <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.HeaderContainer>
         <TraceDrawerComponents.Title>
           <TraceDrawerComponents.LegacyTitleText>
@@ -57,12 +57,14 @@ export function ErrorNodeDetails(
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceDrawerComponents.HeaderContainer>
-      <Description>
-        {t(
-          'This error is related to an ongoing issue. For details about how many users this affects and more, go to the issue below.'
-        )}
-      </Description>
-      <IssueList issues={issues} node={node} organization={organization} />
+      <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasTraceNewUi}>
+        <Description>
+          {t(
+            'This error is related to an ongoing issue. For details about how many users this affects and more, go to the issue below.'
+          )}
+        </Description>
+        <IssueList issues={issues} node={node} organization={organization} />
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }
@@ -153,34 +155,35 @@ function LegacyErrorNodeDetails({
           </LinkButton>
         </TraceDrawerComponents.Actions>
       </TraceDrawerComponents.LegacyHeaderContainer>
+      <TraceDrawerComponents.BodyContainer>
+        <IssueList issues={issues} node={node} organization={organization} />
 
-      <IssueList issues={issues} node={node} organization={organization} />
+        <TraceDrawerComponents.SectionCard
+          items={[
+            {
+              key: 'stack_trace',
+              subject: t('Stack Trace'),
+              subjectNode: null,
+              value:
+                stackTrace && data ? (
+                  <StackTraceWrapper>
+                    <StackTracePreviewContent event={data} stacktrace={stackTrace} />
+                  </StackTraceWrapper>
+                ) : (
+                  t('No stack trace has been reported with this error')
+                ),
+            },
+          ]}
+          title={t('Stack Trace')}
+        />
 
-      <TraceDrawerComponents.SectionCard
-        items={[
-          {
-            key: 'stack_trace',
-            subject: t('Stack Trace'),
-            subjectNode: null,
-            value:
-              stackTrace && data ? (
-                <StackTraceWrapper>
-                  <StackTracePreviewContent event={data} stacktrace={stackTrace} />
-                </StackTraceWrapper>
-              ) : (
-                t('No stack trace has been reported with this error')
-              ),
-          },
-        ]}
-        title={t('Stack Trace')}
-      />
+        <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
 
-      <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
-
-      <TraceDrawerComponents.EventTags
-        projectSlug={node.value.project_slug}
-        event={data}
-      />
+        <TraceDrawerComponents.EventTags
+          projectSlug={node.value.project_slug}
+          event={data}
+        />
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   ) : null;
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -630,7 +630,8 @@ const IssuesWrapper = styled('div')`
   flex-direction: column;
   gap: ${space(0.75)};
   justify-content: left;
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(1.5)};
+  margin-top: ${space(2)};
 
   ${StyledPanel} {
     margin-bottom: 0;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
@@ -38,7 +38,7 @@ export function MissingInstrumentationNodeDetails(
   const profileId = event?.contexts?.profile?.profile_id ?? null;
 
   return (
-    <TraceDrawerComponents.DetailContainer hasNewTraceUi={hasTraceNewUi}>
+    <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.HeaderContainer>
         <TraceDrawerComponents.Title>
           <TraceDrawerComponents.LegacyTitleText>
@@ -57,43 +57,44 @@ export function MissingInstrumentationNodeDetails(
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceDrawerComponents.HeaderContainer>
+      <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasTraceNewUi}>
+        <TextBlock>
+          {tct(
+            'It looks like there’s more than 100ms unaccounted for. This might be a missing service or just idle time. If you know there’s something going on, you can [customInstrumentationLink: add more spans using custom instrumentation].',
+            {
+              customInstrumentationLink: (
+                <ExternalLink href={getCustomInstrumentationLink(project)} />
+              ),
+            }
+          )}
+        </TextBlock>
 
-      <TextBlock>
-        {tct(
-          'It looks like there’s more than 100ms unaccounted for. This might be a missing service or just idle time. If you know there’s something going on, you can [customInstrumentationLink: add more spans using custom instrumentation].',
-          {
-            customInstrumentationLink: (
-              <ExternalLink href={getCustomInstrumentationLink(project)} />
-            ),
-          }
-        )}
-      </TextBlock>
+        {event?.projectSlug ? (
+          <ProfilesProvider
+            orgSlug={organization.slug}
+            projectSlug={event?.projectSlug ?? ''}
+            profileId={profileId || ''}
+          >
+            <ProfileContext.Consumer>
+              {profiles => (
+                <ProfileGroupProvider
+                  type="flamechart"
+                  input={profiles?.type === 'resolved' ? profiles.data : null}
+                  traceID={profileId || ''}
+                >
+                  <ProfilePreview event={event!} node={node} />
+                </ProfileGroupProvider>
+              )}
+            </ProfileContext.Consumer>
+          </ProfilesProvider>
+        ) : null}
 
-      {event?.projectSlug ? (
-        <ProfilesProvider
-          orgSlug={organization.slug}
-          projectSlug={event?.projectSlug ?? ''}
-          profileId={profileId || ''}
-        >
-          <ProfileContext.Consumer>
-            {profiles => (
-              <ProfileGroupProvider
-                type="flamechart"
-                input={profiles?.type === 'resolved' ? profiles.data : null}
-                traceID={profileId || ''}
-              >
-                <ProfilePreview event={event!} node={node} />
-              </ProfileGroupProvider>
-            )}
-          </ProfileContext.Consumer>
-        </ProfilesProvider>
-      ) : null}
-
-      <TextBlock>
-        {t(
-          "You can turn off the 'No Instrumentation' feature using the settings dropdown above."
-        )}
-      </TextBlock>
+        <TextBlock>
+          {t(
+            "You can turn off the 'No Instrumentation' feature using the settings dropdown above."
+          )}
+        </TextBlock>
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }
@@ -185,28 +186,29 @@ function LegacyMissingInstrumentationNodeDetails({
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceDrawerComponents.LegacyHeaderContainer>
+      <TraceDrawerComponents.BodyContainer>
+        {node.event?.projectSlug ? (
+          <ProfilesProvider
+            orgSlug={organization.slug}
+            projectSlug={node.event?.projectSlug ?? ''}
+            profileId={profileId || ''}
+          >
+            <ProfileContext.Consumer>
+              {profiles => (
+                <ProfileGroupProvider
+                  type="flamechart"
+                  input={profiles?.type === 'resolved' ? profiles.data : null}
+                  traceID={profileId || ''}
+                >
+                  <ProfilePreview event={node.event!} node={node} />
+                </ProfileGroupProvider>
+              )}
+            </ProfileContext.Consumer>
+          </ProfilesProvider>
+        ) : null}
 
-      {node.event?.projectSlug ? (
-        <ProfilesProvider
-          orgSlug={organization.slug}
-          projectSlug={node.event?.projectSlug ?? ''}
-          profileId={profileId || ''}
-        >
-          <ProfileContext.Consumer>
-            {profiles => (
-              <ProfileGroupProvider
-                type="flamechart"
-                input={profiles?.type === 'resolved' ? profiles.data : null}
-                traceID={profileId || ''}
-              >
-                <ProfilePreview event={node.event!} node={node} />
-              </ProfileGroupProvider>
-            )}
-          </ProfileContext.Consumer>
-        </ProfilesProvider>
-      ) : null}
-
-      <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
+        <TraceDrawerComponents.SectionCard items={items} title={t('General')} />
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -274,51 +274,53 @@ export function SpanNodeDetails({
   const profileId = node.event?.contexts?.profile?.profile_id ?? null;
 
   return (
-    <TraceDrawerComponents.DetailContainer hasNewTraceUi={hasNewTraceUi}>
+    <TraceDrawerComponents.DetailContainer>
       <SpanNodeDetailHeader
         node={node}
         organization={organization}
         project={project}
         onTabScrollToNode={onTabScrollToNode}
       />
-      {node.event?.projectSlug ? (
-        <ProfilesProvider
-          orgSlug={organization.slug}
-          projectSlug={node.event?.projectSlug}
-          profileId={profileId || ''}
-        >
-          <ProfileContext.Consumer>
-            {profiles => (
-              <ProfileGroupProvider
-                type="flamechart"
-                input={profiles?.type === 'resolved' ? profiles.data : null}
-                traceID={profileId || ''}
-              >
-                <Alerts node={node} />
-                {issues.length > 0 ? (
-                  <IssueList organization={organization} issues={issues} node={node} />
-                ) : null}
-                <SpanDescription
-                  node={node}
-                  project={project}
-                  organization={organization}
-                  location={location}
-                />
-                <SpanSections
-                  node={node}
-                  project={project}
-                  organization={organization}
-                  location={location}
-                  onParentClick={onParentClick}
-                />
-                {organization.features.includes('profiling') ? (
-                  <ProfileDetails event={node.event!} span={node.value} />
-                ) : null}
-              </ProfileGroupProvider>
-            )}
-          </ProfileContext.Consumer>
-        </ProfilesProvider>
-      ) : null}
+      <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasNewTraceUi}>
+        {node.event?.projectSlug ? (
+          <ProfilesProvider
+            orgSlug={organization.slug}
+            projectSlug={node.event?.projectSlug}
+            profileId={profileId || ''}
+          >
+            <ProfileContext.Consumer>
+              {profiles => (
+                <ProfileGroupProvider
+                  type="flamechart"
+                  input={profiles?.type === 'resolved' ? profiles.data : null}
+                  traceID={profileId || ''}
+                >
+                  <Alerts node={node} />
+                  {issues.length > 0 ? (
+                    <IssueList organization={organization} issues={issues} node={node} />
+                  ) : null}
+                  <SpanDescription
+                    node={node}
+                    project={project}
+                    organization={organization}
+                    location={location}
+                  />
+                  <SpanSections
+                    node={node}
+                    project={project}
+                    organization={organization}
+                    location={location}
+                    onParentClick={onParentClick}
+                  />
+                  {organization.features.includes('profiling') ? (
+                    <ProfileDetails event={node.event!} span={node.value} />
+                  ) : null}
+                </ProfileGroupProvider>
+              )}
+            </ProfileContext.Consumer>
+          </ProfilesProvider>
+        ) : null}
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -69,15 +69,23 @@ import type {TraceTreeNode} from '../../traceModels/traceTreeNode';
 import {useTraceState, useTraceStateDispatch} from '../../traceState/traceStateProvider';
 import {useHasTraceNewUi} from '../../useHasTraceNewUi';
 
-const DetailContainer = styled('div')<{hasNewTraceUi?: boolean}>`
+const BodyContainer = styled('div')<{hasNewTraceUi?: boolean}>`
   display: flex;
   flex-direction: column;
   gap: ${p => (p.hasNewTraceUi ? 0 : space(2))};
   padding: ${p => (p.hasNewTraceUi ? `${space(0.5)} ${space(2)}` : space(1))};
+  height: 100%;
+  overflow: auto;
 
   ${DataSection} {
     padding: 0;
   }
+`;
+
+const DetailContainer = styled('div')`
+  height: 100%;
+  overflow: hidden;
+  padding-bottom: ${space(1)};
 `;
 
 const FlexBox = styled('div')`
@@ -210,6 +218,7 @@ const IconBorder = styled('div')<{backgroundColor: string; errored?: boolean}>`
 `;
 
 const LegacyHeaderContainer = styled(FlexBox)`
+  margin: ${space(1)};
   justify-content: space-between;
   gap: ${space(3)};
   container-type: inline-size;
@@ -231,15 +240,11 @@ const LegacyHeaderContainer = styled(FlexBox)`
 `;
 
 const HeaderContainer = styled(FlexBox)`
-  z-index: 1;
   align-items: baseline;
   justify-content: space-between;
   gap: ${space(3)};
-  position: sticky;
-  top: 0;
-  margin-bottom: ${space(1.5)};
   padding: ${space(0.25)} 0 ${space(0.5)} 0;
-  background-color: ${p => p.theme.background};
+  margin: 0 ${space(2)} 0 ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 
@@ -582,7 +587,6 @@ const HighlightsWrapper = styled('div')`
   align-items: stretch;
   gap: ${space(1)};
   width: 100%;
-  overflow: hidden;
   margin: ${space(1)} 0;
 `;
 
@@ -1179,6 +1183,7 @@ export const CardContentSubject = styled('div')`
 
 const TraceDrawerComponents = {
   DetailContainer,
+  BodyContainer,
   FlexBox,
   Title: TitleWithTestId,
   Type,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -73,7 +73,7 @@ const DetailContainer = styled('div')<{hasNewTraceUi?: boolean}>`
   display: flex;
   flex-direction: column;
   gap: ${p => (p.hasNewTraceUi ? 0 : space(2))};
-  padding: ${p => (p.hasNewTraceUi ? `${space(1)} ${space(2)}` : space(1))};
+  padding: ${p => (p.hasNewTraceUi ? `${space(0.5)} ${space(2)}` : space(1))};
 
   ${DataSection} {
     padding: 0;
@@ -231,10 +231,16 @@ const LegacyHeaderContainer = styled(FlexBox)`
 `;
 
 const HeaderContainer = styled(FlexBox)`
+  z-index: 1;
   align-items: baseline;
   justify-content: space-between;
   gap: ${space(3)};
+  position: sticky;
+  top: 0;
   margin-bottom: ${space(1.5)};
+  padding: ${space(0.25)} 0 ${space(0.5)} 0;
+  background-color: ${p => p.theme.background};
+  border-bottom: 1px solid ${p => p.theme.border};
 `;
 
 const DURATION_COMPARISON_STATUS_COLORS: {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -244,7 +244,7 @@ const HeaderContainer = styled(FlexBox)`
   justify-content: space-between;
   gap: ${space(3)};
   padding: ${space(0.25)} 0 ${space(0.5)} 0;
-  margin: 0 ${space(2)} 0 ${space(2)};
+  margin: 0 ${space(2)} ${space(1)} ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -185,25 +185,7 @@ export function TransactionNodeDetails({
   const project = projects.find(proj => proj.slug === event?.projectSlug);
 
   return (
-    <TraceDrawerComponents.DetailContainer hasNewTraceUi={hasNewTraceUi}>
-      {!node.canFetch ? (
-        <StyledAlert type="info" showIcon>
-          {tct(
-            'This transaction does not have any child spans. You can add more child spans via [customInstrumentationLink:custom instrumentation].',
-            {
-              customInstrumentationLink: (
-                <ExternalLink
-                  onClick={() => {
-                    traceAnalytics.trackMissingSpansDocLinkClicked(organization);
-                  }}
-                  href={getCustomInstrumentationLink(project)}
-                />
-              ),
-            }
-          )}
-        </StyledAlert>
-      ) : null}
-
+    <TraceDrawerComponents.DetailContainer>
       <TransactionNodeDetailHeader
         node={node}
         organization={organization}
@@ -211,61 +193,80 @@ export function TransactionNodeDetails({
         event={event}
         onTabScrollToNode={onTabScrollToNode}
       />
+      <TraceDrawerComponents.BodyContainer hasNewTraceUi={hasNewTraceUi}>
+        {!node.canFetch ? (
+          <StyledAlert type="info" showIcon>
+            {tct(
+              'This transaction does not have any child spans. You can add more child spans via [customInstrumentationLink:custom instrumentation].',
+              {
+                customInstrumentationLink: (
+                  <ExternalLink
+                    onClick={() => {
+                      traceAnalytics.trackMissingSpansDocLinkClicked(organization);
+                    }}
+                    href={getCustomInstrumentationLink(project)}
+                  />
+                ),
+              }
+            )}
+          </StyledAlert>
+        ) : null}
 
-      <IssueList node={node} organization={organization} issues={issues} />
+        <IssueList node={node} organization={organization} issues={issues} />
 
-      {hasNewTraceUi ? (
-        <TransactionHighlights
+        {hasNewTraceUi ? (
+          <TransactionHighlights
+            event={event}
+            node={node}
+            project={project}
+            organization={organization}
+          />
+        ) : null}
+
+        <TransactionSpecificSections
           event={event}
           node={node}
-          project={project}
+          onParentClick={onParentClick}
           organization={organization}
+          cacheMetrics={cacheMetrics}
         />
-      ) : null}
 
-      <TransactionSpecificSections
-        event={event}
-        node={node}
-        onParentClick={onParentClick}
-        organization={organization}
-        cacheMetrics={cacheMetrics}
-      />
+        {event.projectSlug ? (
+          <Entries
+            definedEvent={event}
+            projectSlug={event.projectSlug}
+            group={undefined}
+            organization={organization}
+          />
+        ) : null}
 
-      {event.projectSlug ? (
-        <Entries
-          definedEvent={event}
-          projectSlug={event.projectSlug}
-          group={undefined}
-          organization={organization}
-        />
-      ) : null}
-
-      <TraceDrawerComponents.EventTags
-        projectSlug={node.value.project_slug}
-        event={event}
-      />
-
-      <EventContexts event={event} />
-
-      {project ? <EventEvidence event={event} project={project} /> : null}
-
-      {replay ? null : <ReplayPreview event={event} organization={organization} />}
-
-      <BreadCrumbs event={event} organization={organization} />
-
-      {project ? (
-        <EventAttachments event={event} project={project} group={undefined} />
-      ) : null}
-
-      {project ? <EventViewHierarchy event={event} project={project} /> : null}
-
-      {event.projectSlug ? (
-        <EventRRWebIntegration
+        <TraceDrawerComponents.EventTags
+          projectSlug={node.value.project_slug}
           event={event}
-          orgId={organization.slug}
-          projectSlug={event.projectSlug}
         />
-      ) : null}
+
+        <EventContexts event={event} />
+
+        {project ? <EventEvidence event={event} project={project} /> : null}
+
+        {replay ? null : <ReplayPreview event={event} organization={organization} />}
+
+        <BreadCrumbs event={event} organization={organization} />
+
+        {project ? (
+          <EventAttachments event={event} project={project} group={undefined} />
+        ) : null}
+
+        {project ? <EventViewHierarchy event={event} project={project} /> : null}
+
+        {event.projectSlug ? (
+          <EventRRWebIntegration
+            event={event}
+            orgId={organization.slug}
+            projectSlug={event.projectSlug}
+          />
+        ) : null}
+      </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );
 }
@@ -371,5 +372,6 @@ function LegacyTransactionSpecificSections({
 }
 
 const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(2)};
+  margin-top: ${space(2)};
+  margin-bottom: 0;
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
@@ -26,7 +26,7 @@ export function TraceVitals(props: TraceVitalsProps) {
   const measurements = Array.from(props.trace.vitals.entries());
 
   return (
-    <TraceDrawerComponents.DetailContainer>
+    <TraceDrawerComponents.BodyContainer>
       {measurements.map(([node, vital]) => {
         const op = isTransactionNode(node) ? node.value['transaction.op'] : '';
         const transaction = isTransactionNode(node) ? node.value.transaction : '';
@@ -66,7 +66,7 @@ export function TraceVitals(props: TraceVitalsProps) {
           </div>
         );
       })}
-    </TraceDrawerComponents.DetailContainer>
+    </TraceDrawerComponents.BodyContainer>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -754,7 +754,6 @@ const TabsContainer = styled('ul')`
   gap: ${space(0.5)};
   padding-left: 0;
   margin-bottom: 0;
-  margin-left: ${space(0.5)};
 `;
 
 const TabActions = styled('ul')`
@@ -766,7 +765,7 @@ const TabActions = styled('ul')`
   flex: none;
 
   button {
-    padding: 0 ${space(0.5)};
+    padding: 0 ${space(0.25)};
   }
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
@@ -8,6 +8,8 @@ import {
   useDispatchingReducer,
 } from 'sentry/utils/useDispatchingReducer';
 
+import {useHasTraceNewUi} from '../useHasTraceNewUi';
+
 import {TraceReducer, type TraceReducerAction, type TraceReducerState} from './index';
 import {storeTraceViewPreferences, type TracePreferencesState} from './tracePreferences';
 
@@ -63,6 +65,7 @@ interface TraceStateProviderProps {
 }
 
 export function TraceStateProvider(props: TraceStateProviderProps): React.ReactNode {
+  const hasTraceNewUi = useHasTraceNewUi();
   const initialQuery = useMemo((): string | undefined => {
     const query = qs.parse(location.search);
 
@@ -93,8 +96,8 @@ export function TraceStateProvider(props: TraceStateProviderProps): React.ReactN
       },
       preferences: props.initialPreferences,
       tabs: {
-        tabs: STATIC_DRAWER_TABS,
-        current_tab: STATIC_DRAWER_TABS[0] ?? null,
+        tabs: hasTraceNewUi ? [] : STATIC_DRAWER_TABS,
+        current_tab: hasTraceNewUi ? null : STATIC_DRAWER_TABS[0] ?? null,
         last_clicked_tab: null,
       },
     }

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -321,9 +321,16 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     ) => {
       // sync query string with the clicked node
       if (node) {
+        // The new ui has the trace info and web vitals in the bottom drawer and
+        // we don't treat the trace node as a clickable node
+        if (isTraceNode(node) && hasTraceNewUi) {
+          return;
+        }
+
         if (queryStringAnimationTimeoutRef.current) {
           cancelAnimationTimeout(queryStringAnimationTimeoutRef.current);
         }
+
         queryStringAnimationTimeoutRef.current = requestAnimationTimeout(() => {
           const currentQueryStringPath = qs.parse(location.search).node;
           const nextNodePath = TraceTree.PathToNode(node);
@@ -363,7 +370,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         });
       }
     },
-    [traceDispatch]
+    [traceDispatch, hasTraceNewUi]
   );
 
   const onRowClick = useCallback(

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -379,6 +379,18 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       event: React.MouseEvent<HTMLElement>,
       index: number
     ) => {
+      // The new ui has the trace info and web vitals in the bottom drawer and
+      // we don't treat the trace node as a clickable node
+      if (isTraceNode(node) && hasTraceNewUi) {
+        traceDispatch({
+          type: 'set roving index',
+          action_source: 'click',
+          index,
+          node,
+        });
+        return;
+      }
+
       trackAnalytics('trace.trace_layout.span_row_click', {
         organization,
         num_children: node.children.length,
@@ -411,7 +423,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         node,
       });
     },
-    [setRowAsFocused, traceDispatch, organization, projects]
+    [setRowAsFocused, traceDispatch, organization, projects, hasTraceNewUi]
   );
 
   const scrollRowIntoView = useCallback(


### PR DESCRIPTION
- Updated trace drawer opened-closed state:
- - No longer loading trace details inside drawer
- - Added close button and clicking on row reopens drawer
- Made drawer header position fixed during scroll 
-----------------
<img width="1281" alt="Screenshot 2024-12-18 at 5 06 42 PM" src="https://github.com/user-attachments/assets/6b3256d8-9f2c-43c5-855b-40a4d45e2d24" />

