### PR TITLE
chore(issue-details): Don't make issue public immediately

### DIFF
--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -192,11 +192,6 @@ describe('GroupActions', function () {
       features: ['shared-issues'],
     };
 
-    const updateMock = MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/issues/`,
-      method: 'PUT',
-      body: {},
-    });
     render(
       <Fragment>
         <GlobalModal />
@@ -216,7 +211,6 @@ describe('GroupActions', function () {
 
     const modal = screen.getByRole('dialog');
     expect(within(modal).getByText('Share Issue')).toBeInTheDocument();
-    expect(updateMock).toHaveBeenCalled();
   });
 
   describe('delete', function () {

--- a/static/app/views/issueDetails/actions/shareModal.spec.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.spec.tsx
@@ -24,7 +24,7 @@ describe('shareModal', () => {
     jest.clearAllMocks();
   });
 
-  it('should share on open', async () => {
+  it('should share', async () => {
     const group = GroupFixture();
     GroupStore.add([group]);
 
@@ -48,6 +48,7 @@ describe('shareModal', () => {
     );
 
     expect(screen.getByText('Share Issue')).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('Share'));
     expect(await screen.findByRole('button', {name: 'Copy Link'})).toBeInTheDocument();
     expect(issuesApi).toHaveBeenCalledTimes(1);
     expect(onToggle).toHaveBeenCalledTimes(1);

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {bulkUpdate} from 'sentry/actionCreators/group';
@@ -79,18 +79,6 @@ function ShareIssueModal({
     },
     [api, setLoading, onToggle, isShared, organization.slug, projectSlug, groupId]
   );
-
-  /**
-   * Share as soon as modal is opened
-   */
-  useEffect(() => {
-    if (isShared) {
-      return;
-    }
-
-    handleShare(null, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- we only want to run this on open
-  }, []);
 
   const shareUrl = group?.shareId ? getShareUrl(group) : null;
 


### PR DESCRIPTION
this pr updates the behavior of the share modal to not share the issue immediately, but rather open the modal giving the user the option to share the issue