### PR TITLE
fix(js): Correct moduleUrlToModule in routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1504,21 +1504,9 @@ function buildRoutes() {
     />
   );
 
-  const moduleUrlToModule: Record<keyof typeof MODULE_BASE_URLS, ModuleName> = {
-    'mobile-screens': ModuleName.MOBILE_SCREENS,
-    'mobile-ui': ModuleName.MOBILE_UI,
-    'screen-rendering': ModuleName.SCREEN_RENDERING,
-    ai: ModuleName.AI,
-    app_start: ModuleName.APP_START,
-    cache: ModuleName.CACHE,
-    db: ModuleName.DB,
-    http: ModuleName.HTTP,
-    queue: ModuleName.QUEUE,
-    resource: ModuleName.RESOURCE,
-    screen_load: ModuleName.SCREEN_LOAD,
-    other: ModuleName.OTHER,
-    vital: ModuleName.VITAL,
-  };
+  const moduleUrlToModule: Record<string, ModuleName> = Object.fromEntries(
+    Object.values(ModuleName).map(name => [MODULE_BASE_URLS[name], name])
+  );
 
   const insightsRedirects = Object.values(MODULE_BASE_URLS)
     .map(


### PR DESCRIPTION
This just happened to work before because the module name and the URL are all the same. If you look closely, this was just mapping module name to module name, since they key of the MODULE_BASE_URLS was the module name.

I've fixed this so it now is correctly mapping the module URL to the module name.