### PR TITLE
feat(new-trace): Correctly rendering resource.img spans with relative URLs

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -212,6 +212,22 @@ export function SpanDescription({
   );
 }
 
+function getImageSrc(span: TraceTree.Span) {
+  let src = span.description ?? '';
+
+  // Account for relative URLs
+  if (src.startsWith('/')) {
+    const urlScheme = span.data?.['url.scheme'];
+    const serverAddress = span.data?.['server.address'];
+
+    if (urlScheme && serverAddress) {
+      src = `${urlScheme}://${serverAddress}${src}`;
+    }
+  }
+
+  return src;
+}
+
 function ResourceImageDescription({
   formattedDescription,
   node,
@@ -243,7 +259,7 @@ function ResourceImageDescription({
           fileName={formattedDescription}
           showImage={!showLinks}
           size={size}
-          src={span.description ?? ''}
+          src={getImageSrc(span)}
         />
       )}
     </StyledDescriptionWrapper>
@@ -259,7 +275,6 @@ function ResourceImage(props: {
   const [hasError, setHasError] = useState(false);
 
   const {fileName, size, src, showImage = true} = props;
-  const isRelativeUrl = src.startsWith('/');
 
   return (
     <ImageContainer>
@@ -275,7 +290,7 @@ function ResourceImage(props: {
           title={t('Copy file name')}
         />
       </FilenameContainer>
-      {showImage && !isRelativeUrl && !hasError ? (
+      {showImage && !hasError ? (
         <ImageWrapper>
           <img
             data-test-id="sample-image"


### PR DESCRIPTION
Before:
<img width="1275" alt="Screenshot 2024-12-18 at 10 42 04 PM" src="https://github.com/user-attachments/assets/fd56d0cc-16e2-4af1-920b-3aadc6604d96" />
-----------------------------
After:
<img width="1282" alt="Screenshot 2024-12-18 at 10 36 24 PM" src="https://github.com/user-attachments/assets/13a994b2-096d-48a3-9590-5483370468d3" />
 