### PR TITLE
fix(grouping): Add frame counts to thread component

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -341,6 +341,17 @@ class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingC
 
 class ThreadsGroupingComponent(BaseGroupingComponent[StacktraceGroupingComponent]):
     id: str = "threads"
+    frame_counts: Counter[str]
+
+    def __init__(
+        self,
+        values: Sequence[StacktraceGroupingComponent] | None = None,
+        hint: str | None = None,
+        contributes: bool | None = None,
+        frame_counts: Counter[str] | None = None,
+    ):
+        super().__init__(hint=hint, contributes=contributes, values=values)
+        self.frame_counts = frame_counts or Counter()
 
 
 class CSPGroupingComponent(

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -825,7 +825,7 @@ def _filtered_threads(
         stacktrace, event=event, **meta
     ).items():
         thread_components_by_variant[variant_name] = ThreadsGroupingComponent(
-            values=[stacktrace_component]
+            values=[stacktrace_component], frame_counts=stacktrace_component.frame_counts
         )
 
     return thread_components_by_variant

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -8,6 +8,7 @@ from sentry.grouping.component import (
     ExceptionGroupingComponent,
     FunctionGroupingComponent,
     StacktraceGroupingComponent,
+    ThreadsGroupingComponent,
 )
 from sentry.testutils.cases import TestCase
 from sentry.utils.types import NonNone
@@ -183,6 +184,36 @@ class ComponentTest(TestCase):
                 in_app_contributing_frames=8,
             )
             assert exception_component.frame_counts == stacktrace_component.frame_counts
+
+    def test_threads_component_uses_stacktrace_frame_counts(self):
+        self.event.data["threads"] = self.event.data.pop("exception")
+        self.event.data["threads"]["values"][0]["stacktrace"] = {
+            "frames": (
+                [self.non_contributing_system_frame] * 20
+                + [self.contributing_system_frame] * 12
+                + [self.non_contributing_in_app_frame] * 20
+                + [self.contributing_in_app_frame] * 13
+            )
+        }
+
+        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            threads_component = variants[variant_name].component.values[0]
+            assert isinstance(threads_component, ThreadsGroupingComponent)
+            stacktrace_component = find_given_child_component(
+                threads_component, StacktraceGroupingComponent
+            )
+            assert stacktrace_component
+
+            assert stacktrace_component.frame_counts == Counter(
+                system_non_contributing_frames=20,
+                system_contributing_frames=12,
+                in_app_non_contributing_frames=20,
+                in_app_contributing_frames=13,
+            )
+            assert threads_component.frame_counts == stacktrace_component.frame_counts
 
     def test_chained_exception_component_sums_stacktrace_frame_counts(self):
         self.event.data["exception"]["values"] = [


### PR DESCRIPTION
When I added frame tallies to `StacktraceGroupingComponent`, `ExceptionGroupingComponent`, and `ChainedExceptionGroupingComponent` in https://github.com/getsentry/sentry/pull/81341, I forgot that threads can have stacktraces, too. This fixes that by giving the same treatment to `ThreadsGroupingComponent`.