### PR TITLE
ref(grouping): Store variant name on variant

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -260,7 +260,7 @@ def _get_stacktrace_hashing_metadata(
     ),
 ) -> StacktraceHashingMetadata:
     return {
-        "stacktrace_type": "in_app" if "in-app" in contributing_variant.description else "system",
+        "stacktrace_type": "in_app" if contributing_variant.variant_name == "app" else "system",
         "stacktrace_location": (
             "exception"
             if "exception" in contributing_variant.description

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -26,6 +26,8 @@ class FingerprintVariantMetadata(TypedDict):
 
 
 class BaseVariant(ABC):
+    variant_name: str | None = None
+
     @property
     def contributes(self) -> bool:
         return True
@@ -146,6 +148,7 @@ class ComponentVariant(BaseVariant):
         self.component = component
         self.config = strategy_config
         self.contributing_component = contributing_component
+        self.variant_name = self.component.id  # "app", "system", or "default"
 
     @property
     def description(self) -> str:

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -214,7 +214,7 @@ def dump_variant(
     # Note that this prints `__dict__`, not `as_dict()`, so if something seems missing, that's
     # probably why
     for key, value in sorted(variant.__dict__.items()):
-        if key in ["config", "hash", "contributing_component"]:
+        if key in ["config", "hash", "contributing_component", "variant_name"]:
             # We do not want to dump the config, and we've already dumped the hash and the
             # contributing component
             continue


### PR DESCRIPTION
In many places in the code, variants are passed around in a dictionary, keyed by variant name or type. In other places, though, we only have a variant object, and don't know what its key in the dictionary was. For many types of variants (checksum, fingerprint, fallback) that's not an issue, because they only come in one flavor. But component and salted component variants come in `app`, `system`, and `default` flavors,* and it would be convenient for these variants to know their flavor. This therefore adds a `variant_name` property to the `ComponentVariant` class (and a dummy one to the `BaseVariant` class, so that we can always safely check `variant.variant_name`).

The line in the grouphash metadata module which is also changed in this PR is a good example of why this is useful. Right now, we're distinguishing app from system by checking the variant's description, but `description` is in fact a computed property, obtained by walking the full component tree. Being able to check `variant_name` directly saves us that computation.

*Just to make things extra exciting/confusing, in the code we say the component variants come in three different... variants. Here I'll stick to using "flavors," though, to try to make things a little clearer.