### PR TITLE
feat(dynamic-sampling): Rename project table headers

### DIFF
--- a/static/app/views/settings/dynamicSampling/organizationSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/organizationSampling.tsx
@@ -126,6 +126,7 @@ export function OrganizationSampling() {
           <ProjectsPreviewTable
             sampleCounts={sampleCountsQuery.data}
             isLoading={sampleCountsQuery.isPending}
+            period={period}
           />
         )}
         <SubTextParagraph>

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -150,6 +150,7 @@ export function ProjectSampling() {
           <LoadingError onRetry={sampleCountsQuery.refetch} />
         ) : (
           <ProjectsEditTable
+            period={period}
             editMode={editMode}
             onEditModeChange={setEditMode}
             isLoading={sampleRatesQuery.isPending || sampleCountsQuery.isPending}

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -19,12 +19,16 @@ import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatP
 import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {projectSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/projectSamplingForm';
 import {scaleSampleRates} from 'sentry/views/settings/dynamicSampling/utils/scaleSampleRates';
-import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
+import type {
+  ProjectionSamplePeriod,
+  ProjectSampleCount,
+} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 interface Props {
   editMode: 'single' | 'bulk';
   isLoading: boolean;
   onEditModeChange: (mode: 'single' | 'bulk') => void;
+  period: ProjectionSamplePeriod;
   sampleCounts: ProjectSampleCount[];
 }
 
@@ -35,6 +39,7 @@ export function ProjectsEditTable({
   isLoading: isLoadingProp,
   sampleCounts,
   editMode,
+  period,
   onEditModeChange,
 }: Props) {
   const {projects, fetching} = useProjects();
@@ -260,6 +265,7 @@ export function ProjectsEditTable({
         canEdit={!isBulkEditEnabled}
         onChange={handleProjectChange}
         emptyMessage={t('No active projects found in the selected period.')}
+        period={period}
         isLoading={isLoading}
         items={activeItems}
         inactiveItems={inactiveItems}

--- a/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
@@ -13,16 +13,20 @@ import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatP
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
 import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {balanceSampleRate} from 'sentry/views/settings/dynamicSampling/utils/rebalancing';
-import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
+import type {
+  ProjectionSamplePeriod,
+  ProjectSampleCount,
+} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 const {useFormField} = organizationSamplingForm;
 
 interface Props {
   isLoading: boolean;
+  period: ProjectionSamplePeriod;
   sampleCounts: ProjectSampleCount[];
 }
 
-export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
+export function ProjectsPreviewTable({isLoading, period, sampleCounts}: Props) {
   const {value: targetSampleRate, initialValue: initialTargetSampleRate} =
     useFormField('targetSampleRate');
 
@@ -98,6 +102,7 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
         rateHeader={t('Estimated Rate')}
         inputTooltip={t('To edit project sample rates, switch to manual sampling mode.')}
         emptyMessage={t('No active projects found in the selected period.')}
+        period={period}
         isEmpty={!sampleCounts.length}
         isLoading={isLoading}
         items={itemsWithFormattedNumbers}

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -16,6 +16,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
 import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
 import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
+import type {ProjectionSamplePeriod} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 interface ProjectItem {
   count: number;
@@ -29,6 +30,7 @@ interface ProjectItem {
 
 interface Props extends Omit<React.ComponentProps<typeof StyledPanelTable>, 'headers'> {
   items: ProjectItem[];
+  period: ProjectionSamplePeriod;
   rateHeader: React.ReactNode;
   canEdit?: boolean;
   inactiveItems?: ProjectItem[];
@@ -45,6 +47,7 @@ export function ProjectsTable({
   canEdit,
   rateHeader,
   onChange,
+  period,
   ...props
 }: Props) {
   const hasAccess = useHasDynamicSamplingWriteAccess();
@@ -64,12 +67,12 @@ export function ProjectsTable({
       {...props}
       isEmpty={!items.length && !inactiveItems.length}
       headers={[
-        t('Project'),
+        t('Originating Project'),
         <SortableHeader type="button" key="spans" onClick={handleTableSort}>
           {t('Accepted Spans')}
           <IconArrow direction={tableSort === 'desc' ? 'down' : 'up'} size="xs" />
         </SortableHeader>,
-        t('Stored Spans'),
+        period === '24h' ? t('Stored Spans per day') : t('Stored Spans per month'),
         rateHeader,
       ]}
     >


### PR DESCRIPTION
Rename project table headers in dynamic sampling.

`Stored spans per day` switches to `...per month` when selecting `30d`

![Screenshot 2024-12-19 at 09 05 41](https://github.com/user-attachments/assets/9a4f6e5f-fff3-4200-94dc-dff9df7748d9)

Closes https://github.com/getsentry/projects/issues/464
