### PR TITLE
feat(insights): Ability to hide module tabs via feature flags

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -1,12 +1,12 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import type {LocationDescriptor} from 'history';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList, Tabs} from 'sentry/components/tabs';
+import type {TabListItemProps} from 'sentry/components/tabs/item';
 import {IconBusiness} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -19,7 +19,7 @@ import {
   DOMAIN_VIEW_BASE_TITLE,
   OVERVIEW_PAGE_TITLE,
 } from 'sentry/views/insights/pages/settings';
-import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
+import {isModuleEnabled, isModuleHidden} from 'sentry/views/insights/pages/utils';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 export type Props = {
@@ -32,12 +32,6 @@ export type Props = {
   additonalHeaderActions?: React.ReactNode;
   hideDefaultTabs?: boolean;
   tabs?: {onTabChange: (key: string) => void; tabList: React.ReactNode; value: string};
-};
-
-type Tab = {
-  key: string;
-  label: React.ReactNode;
-  to: LocationDescriptor;
 };
 
 export function DomainViewHeader({
@@ -81,21 +75,25 @@ export function DomainViewHeader({
   const tabValue =
     hideDefaultTabs && tabs?.value ? tabs.value : selectedModule ?? OVERVIEW_PAGE_TITLE;
 
-  const tabList: Tab[] = [
+  const tabList: TabListItemProps[] = [
     {
       key: OVERVIEW_PAGE_TITLE,
-      label: OVERVIEW_PAGE_TITLE,
+      children: OVERVIEW_PAGE_TITLE,
       to: domainBaseUrl,
     },
   ];
 
   if (showModuleTabs) {
     tabList.push(
-      ...modules.map(moduleName => ({
-        key: moduleName,
-        label: <TabLabel moduleName={moduleName} />,
-        to: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
-      }))
+      ...modules.map(
+        moduleName =>
+          ({
+            key: moduleName,
+            children: <TabLabel moduleName={moduleName} />,
+            to: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
+            hidden: isModuleHidden(moduleName, organization),
+          }) satisfies TabListItemProps
+      )
     );
   }
 
@@ -117,9 +115,7 @@ export function DomainViewHeader({
           {!hideDefaultTabs && (
             <TabList hideBorder>
               {tabList.map(tab => (
-                <TabList.Item key={tab.key} to={tab.to}>
-                  {tab.label}
-                </TabList.Item>
+                <TabList.Item {...tab} key={tab.key} />
               ))}
             </TabList>
           )}

--- a/static/app/views/insights/pages/utils.ts
+++ b/static/app/views/insights/pages/utils.ts
@@ -1,7 +1,10 @@
 import type {Organization} from 'sentry/types/organization';
 import {DOMAIN_VIEW_MODULES} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
-import {MODULE_FEATURE_MAP} from 'sentry/views/insights/settings';
+import {
+  MODULE_FEATURE_MAP,
+  MODULE_HIDDEN_WHEN_FEAUTRE_DISABLED,
+} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 export const isModuleEnabled = (module: ModuleName, organization: Organization) => {
@@ -11,6 +14,10 @@ export const isModuleEnabled = (module: ModuleName, organization: Organization) 
   }
   return moduleFeatures.every(feature => organization.features.includes(feature));
 };
+
+export const isModuleHidden = (module: ModuleName, organization: Organization) =>
+  MODULE_HIDDEN_WHEN_FEAUTRE_DISABLED.includes(module) &&
+  !isModuleEnabled(module, organization);
 
 export const getModuleView = (module: ModuleName): DomainView => {
   if (DOMAIN_VIEW_MODULES.backend.includes(module)) {

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -169,3 +169,8 @@ export const MODULE_FEATURE_MAP: Record<ModuleName, string[]> = {
   [ModuleName.SCREEN_RENDERING]: SCREEN_RENDERING_MODULE_FEATURES,
   [ModuleName.OTHER]: [],
 };
+
+/**
+ * Modules that will not display tabs when the feature is not enabled
+ */
+export const MODULE_HIDDEN_WHEN_FEAUTRE_DISABLED: ModuleName[] = [];


### PR DESCRIPTION
Previously modules behind flags would be displayed with a business icon
indicating you needed to upgrade your plan. For the upcoming move of
crons (and the creation of uptime) as backend insight tabs, we need a
way to hide the tabs, not just indicate them as business features.