### PR TITLE
fix(dashboards): Button gap in team plan default overview dashboard

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -164,10 +164,10 @@ function Controls({
 
   return (
     <StyledButtonBar gap={1} key="controls">
+      <FeedbackWidgetButton />
       <DashboardEditFeature>
         {hasFeature => (
           <Fragment>
-            <FeedbackWidgetButton />
             <Feature features="dashboards-import">
               <Button
                 data-test-id="dashboard-export"


### PR DESCRIPTION
The button gap was missing because when a user doesn't have custom dashboards in their plan (e.g. team plan), there's a hover card that displays but that hover card impacts the way we apply the flexbox gap to its children. Move the feedback button out of the edit feature component so it can be styled independently.

To test this, you'll need to go into the `feedbackWidgetButton.tsx` file and comment out the part of the code that returns `null` if the feedback integration isn't present. We just want to see the button on that page.

Closes  JAVASCRIPT-2X5M