### PR TITLE
fix(widget-builder): Increase responsive slideout size

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -139,6 +139,7 @@ const _SlideOverPanel = styled(motion.div, {
               position: relative;
 
               width: ${PANEL_WIDTH};
+              min-width: 500px;
               height: 100%;
 
               top: 0;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -298,9 +298,16 @@ const SampleWidgetCard = styled(motion.div)`
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     width: 30vw;
-    min-width: 400px;
+    min-width: 300px;
     z-index: ${p => p.theme.zIndex.modal};
     cursor: auto;
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.large}) and (min-width: ${p =>
+      p.theme.breakpoints.medium}) {
+    width: 25vw;
+    min-width: 100px;
+    max-width: 300px;
   }
 `;
 


### PR DESCRIPTION
To make the slideout a little bit bigger I've set a `max-width` of 500px for the slideout and decreased the width of the preview on certain screen sizes.

