### PR TITLE
fix(seer grouping): Clean up seer request metrics

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -48,7 +48,7 @@ def should_call_seer_for_grouping(event: Event, variants: Mapping[str, BaseVaria
 
     if (
         _has_customized_fingerprint(event, variants)
-        or killswitch_enabled(project.id, event)
+        or killswitch_enabled(project.id, ReferrerOptions.INGEST, event)
         or _circuit_breaker_broken(event, project)
         # The rate limit check has to be last (see below) but rate-limiting aside, call this after other checks
         # because it calculates the stacktrace string, which we only want to spend the time to do if we already

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -18,6 +18,7 @@ from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsRequest
 from sentry.seer.similarity.utils import (
+    ReferrerOptions,
     TooManyOnlySystemFramesException,
     event_content_has_stacktrace,
     get_stacktrace_string,
@@ -75,7 +76,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         return [(serialized_groups[group_id], group_data[group_id]) for group_id in group_data]
 
     def get(self, request: Request, group: Group) -> Response:
-        if killswitch_enabled(group.project.id):
+        if killswitch_enabled(group.project.id, ReferrerOptions.SIMILAR_ISSUES_TAB):
             return Response([])
 
         latest_event = group.get_latest_event()

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -291,7 +291,6 @@ def get_stacktrace_string_with_metrics(
     data: dict[str, Any], platform: str | None, referrer: ReferrerOptions
 ) -> str | None:
     stacktrace_string = None
-    key = "grouping.similarity.did_call_seer"
     sample_rate = options.get("seer.similarity.metrics_sample_rate")
     try:
         stacktrace_string = get_stacktrace_string(data, platform)
@@ -303,11 +302,7 @@ def get_stacktrace_string_with_metrics(
             tags={"platform": platform, "referrer": referrer},
         )
         if referrer == ReferrerOptions.INGEST:
-            metrics.incr(
-                key,
-                sample_rate=sample_rate,
-                tags={"call_made": False, "blocker": "over-threshold-frames"},
-            )
+            record_did_call_seer_metric(call_made=False, blocker="over-threshold-frames")
     except Exception:
         logger.exception("Unexpected exception in stacktrace string formatting")
 
@@ -376,11 +371,8 @@ def killswitch_enabled(
             "should_call_seer_for_grouping.seer_global_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr(
-            "grouping.similarity.did_call_seer",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"call_made": False, "blocker": "global-killswitch"},
-        )
+        record_did_call_seer_metric(call_made=False, blocker="global-killswitch")
+
         return True
 
     if options.get("seer.similarity-killswitch.enabled"):
@@ -388,11 +380,8 @@ def killswitch_enabled(
             "should_call_seer_for_grouping.seer_similarity_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr(
-            "grouping.similarity.did_call_seer",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"call_made": False, "blocker": "similarity-killswitch"},
-        )
+        record_did_call_seer_metric(call_made=False, blocker="similarity-killswitch")
+
         return True
 
     if killswitch_matches_context(
@@ -402,11 +391,8 @@ def killswitch_enabled(
             "should_call_seer_for_grouping.seer_similarity_project_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr(
-            "grouping.similarity.did_call_seer",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"call_made": False, "blocker": "project-killswitch"},
-        )
+        record_did_call_seer_metric(call_made=False, blocker="project-killswitch")
+
         return True
 
     return False

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -319,35 +319,6 @@ def event_content_has_stacktrace(event: GroupEvent | Event) -> bool:
     return exception_stacktrace or threads_stacktrace or only_stacktrace
 
 
-def event_content_is_seer_eligible(event: GroupEvent | Event) -> bool:
-    """
-    Determine if an event's contents makes it fit for using with Seer's similar issues model.
-    """
-    # TODO: Determine if we want to filter out non-sourcemapped events
-    if not event_content_has_stacktrace(event):
-        metrics.incr(
-            "grouping.similarity.event_content_seer_eligible",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"eligible": False, "blocker": "no-stacktrace"},
-        )
-        return False
-
-    if event.platform in SEER_INELIGIBLE_EVENT_PLATFORMS:
-        metrics.incr(
-            "grouping.similarity.event_content_seer_eligible",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"eligible": False, "blocker": "unsupported-platform"},
-        )
-        return False
-
-    metrics.incr(
-        "grouping.similarity.event_content_seer_eligible",
-        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-        tags={"eligible": True, "blocker": "none"},
-    )
-    return True
-
-
 def record_did_call_seer_metric(*, call_made: bool, blocker: str) -> None:
     metrics.incr(
         "grouping.similarity.did_call_seer",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -353,6 +353,14 @@ def event_content_is_seer_eligible(event: GroupEvent | Event) -> bool:
     return True
 
 
+def record_did_call_seer_metric(*, call_made: bool, blocker: str) -> None:
+    metrics.incr(
+        "grouping.similarity.did_call_seer",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={"call_made": call_made, "blocker": blocker},
+    )
+
+
 def killswitch_enabled(
     project_id: int | None,
     event: GroupEvent | Event | None = None,

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -8,7 +8,7 @@ from sentry.seer.similarity.grouping_records import (
     delete_grouping_records_by_hash,
     delete_project_grouping_records,
 )
-from sentry.seer.similarity.utils import killswitch_enabled
+from sentry.seer.similarity.utils import ReferrerOptions, killswitch_enabled
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
@@ -34,7 +34,7 @@ def delete_seer_grouping_records_by_hash(
     Task to delete seer grouping records by hash list.
     Calls the seer delete by hash endpoint with batches of hashes of size `BATCH_SIZE`.
     """
-    if killswitch_enabled(project_id) or options.get(
+    if killswitch_enabled(project_id, ReferrerOptions.DELETION) or options.get(
         "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
     ):
         return
@@ -57,7 +57,7 @@ def call_delete_seer_grouping_records_by_hash(
     if (
         project
         and project.get_option("sentry:similarity_backfill_completed")
-        and not killswitch_enabled(project.id)
+        and not killswitch_enabled(project.id, ReferrerOptions.DELETION)
         and not options.get("seer.similarity-embeddings-delete-by-hash-killswitch.enabled")
     ):
         # TODO (jangjodi): once we store seer grouping info in GroupHash, we should filter by that here
@@ -86,7 +86,7 @@ def call_seer_delete_project_grouping_records(
     *args: Any,
     **kwargs: Any,
 ) -> None:
-    if killswitch_enabled(project_id) or options.get(
+    if killswitch_enabled(project_id, ReferrerOptions.DELETION) or options.get(
         "seer.similarity-embeddings-delete-by-hash-killswitch.enabled"
     ):
         return

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -9,7 +9,11 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.api import GroupingConfigNotFound
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.models.project import Project
-from sentry.seer.similarity.utils import killswitch_enabled, project_is_seer_eligible
+from sentry.seer.similarity.utils import (
+    ReferrerOptions,
+    killswitch_enabled,
+    project_is_seer_eligible,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.embeddings_grouping.utils import (
@@ -80,7 +84,7 @@ def backfill_seer_grouping_records_for_project(
     assert current_project_id is not None
 
     if options.get("seer.similarity-backfill-killswitch.enabled") or killswitch_enabled(
-        current_project_id
+        current_project_id, ReferrerOptions.BACKFILL
     ):
         logger.info("backfill_seer_grouping_records.killswitch_enabled")
         return

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -67,7 +67,7 @@ class SeerEventManagerGroupingTest(TestCase):
                 return_value=[seer_result_data],
             ),
             patch(
-                "sentry.grouping.ingest.seer.event_content_is_seer_eligible",
+                "sentry.grouping.ingest.seer._event_content_is_seer_eligible",
                 return_value=True,
             ),
         ):


### PR DESCRIPTION
In trying to make a change to our checks for what gets sent to Seer, and the metrics we record as part of those checks, I was going a little crazy trying to keep straight what metrics applied to what processes (the four options being ingest, backfill, deletion, and the similar issues tab), so I did a little clean up in that area. 

Goals/principles I was going for (some of which are not currently the case):

- The `did_call_seer` metric should only fire during ingest.
- We want to check platform during ingest, but we actively don't want to check it during backfill or when using the similar issues tab, since we want to be able to investigate platforms we're not yet supporting. Platform is a moot point when it comes to deletion.
- When we check killswitches, we want to log no matter what the process, and it would be nice to know which process is getting blocked.


Key changes:

- Add deletion and the similar issues tab to the referrer enum.
- Just to make things less verbose, pull all the many calls to record the `did_call_seer` metric into a helper, `record_did_call_seer_metric`.
- Add a `referrer` parameter to `killswitch_enabled`, and only record the `did_call_seer` metrics if the referrer is ingest. Also, change the event name in the log from `should_call_seer_for_grouping.xxx_killswitch_enabled` (which is ingest-specific) to `ingest.xxx_killswitch_enabled`, `backfill.xxx_killswitch_enabled`, etc.
- Move `event_content_is_seer_eligible` from the general similarity utils module into the ingest-specific seer module. It contains the aforementioned platform check we only want in ingest, and for metrics purposes we need the platform check to stay wrapped up with the no stacktrace check so we can record a "neither of the above, meaning it's eligible" metric.