### PR TITLE
feat(billing): Allow billing invitations in the new modal

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -104,6 +104,7 @@ function InviteMembersModal({
                 sendingInvites,
                 complete,
                 error,
+                isOverMemberLimit,
               }}
             >
               <Header closeButton>
@@ -139,7 +140,7 @@ function InviteMembersModal({
               invites={invites}
               inviteStatus={inviteStatus}
               isOverMemberLimit={
-                isOverMemberLimit && organization.features?.includes('invite-billing')
+                isOverMemberLimit && organization.features.includes('invite-billing')
               }
               member={memberResult.data}
               pendingInvites={pendingInvites}

--- a/static/app/components/modals/inviteMembersModal/inviteMembersContext.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersContext.tsx
@@ -10,6 +10,7 @@ export type InviteMembersContextValue = {
   complete: boolean;
   inviteStatus: InviteStatus;
   invites: NormalizedInvite[];
+  isOverMemberLimit: boolean;
   pendingInvites: InviteRow;
   reset: () => void;
   sendInvites: () => void;
@@ -26,6 +27,7 @@ export const defaultInviteProps: InviteMembersContextValue = {
   complete: false,
   inviteStatus: {},
   invites: [],
+  isOverMemberLimit: false,
   pendingInvites: {
     emails: new Set<string>(),
     role: '',

--- a/static/app/components/modals/inviteMembersModal/inviteMembersModalview.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersModalview.spec.tsx
@@ -29,28 +29,6 @@ describe('InviteMembersModalView', function () {
     isOverMemberLimit: false,
   };
 
-  const overMemberLimitModalProps: ComponentProps<typeof InviteMembersModalView> = {
-    Footer: styledWrapper(),
-    addInviteRow: () => {},
-    canSend: true,
-    closeModal: () => {},
-    complete: false,
-    headerInfo: null,
-    inviteStatus: {},
-    invites: [],
-    member: undefined,
-    pendingInvites: [],
-    removeInviteRow: () => {},
-    reset: () => {},
-    sendInvites: () => {},
-    sendingInvites: false,
-    setEmails: () => {},
-    setRole: () => {},
-    setTeams: () => {},
-    willInvite: true,
-    isOverMemberLimit: true,
-  };
-
   it('renders', function () {
     render(<InviteMembersModalView {...modalProps} />);
 
@@ -70,6 +48,10 @@ describe('InviteMembersModalView', function () {
   });
 
   it('renders when over member limit', function () {
+    const overMemberLimitModalProps = {
+      ...modalProps,
+      isOverMemberLimit: true,
+    };
     render(<InviteMembersModalView {...overMemberLimitModalProps} />);
 
     expect(screen.getByText('Invite New Members')).toBeInTheDocument();

--- a/static/app/components/modals/inviteMembersModal/inviteRowControlNew.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControlNew.spec.tsx
@@ -26,6 +26,11 @@ describe('InviteRowControlNew', function () {
   ];
   const teams: DetailedTeam[] = teamData.map(data => TeamFixture(data));
 
+  const billingProps = {
+    ...defaultInviteProps,
+    isOverMemberLimit: true,
+  };
+
   const getComponent = (props: InviteMembersContextValue) => (
     <InviteMembersContext.Provider value={props}>
       <InviteRowControlNew
@@ -60,6 +65,17 @@ describe('InviteRowControlNew', function () {
     expect(screen.getByRole('textbox', {name: 'Email Addresses'})).toBeInTheDocument();
     expect(screen.getByRole('textbox', {name: 'Role'})).toBeInTheDocument();
     expect(screen.getByRole('textbox', {name: 'Add to Team'})).toBeInTheDocument();
+  });
+
+  it('renders with invite-billing flag', function () {
+    render(getComponent(billingProps));
+
+    expect(screen.getByRole('textbox', {name: 'Email Addresses'})).toBeInTheDocument();
+    const roleInput = screen.getByRole('textbox', {name: 'Role'});
+    expect(roleInput).toBeInTheDocument();
+    expect(roleInput).toBeDisabled();
+    const teamInput = screen.getByRole('textbox', {name: 'Add to Team'});
+    expect(teamInput).toBeInTheDocument();
   });
 
   describe.each([

--- a/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
@@ -94,7 +94,7 @@ function InviteRowControl({roleDisabledUnallowed, roleOptions}: Props) {
       setRole('billing', 0);
       setTeams([], 0);
     }
-  });
+  }, [isOverMemberLimit, setRole, setTeams]);
 
   return (
     <RowWrapper>

--- a/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import type {MultiValueProps} from 'react-select';
 import type {Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
@@ -29,8 +29,15 @@ function mapToOptions(values: string[]): SelectOption[] {
 }
 
 function InviteRowControl({roleDisabledUnallowed, roleOptions}: Props) {
-  const {inviteStatus, pendingInvites, setEmails, setRole, setTeams, reset} =
-    useInviteMembersContext();
+  const {
+    inviteStatus,
+    isOverMemberLimit,
+    pendingInvites,
+    setEmails,
+    setRole,
+    setTeams,
+    reset,
+  } = useInviteMembersContext();
   const emails = [...(pendingInvites.emails ?? [])];
   const role = pendingInvites.role ?? '';
   const teams = [...(pendingInvites.teams ?? [])];
@@ -82,6 +89,13 @@ function InviteRowControl({roleDisabledUnallowed, roleOptions}: Props) {
     }
   };
 
+  useEffect(() => {
+    if (isOverMemberLimit) {
+      setRole('billing', 0);
+      setTeams([], 0);
+    }
+  });
+
   return (
     <RowWrapper>
       <div>
@@ -119,6 +133,7 @@ function InviteRowControl({roleDisabledUnallowed, roleOptions}: Props) {
           <RoleSelectControl
             id="role"
             aria-label={t('Role')}
+            disabled={isOverMemberLimit}
             value={role}
             roles={roleOptions}
             disableUnallowed={roleDisabledUnallowed}


### PR DESCRIPTION
Updates the new member invitation modal to allow billing member invites when the org is over the member limit. The feature relies on a feature flag to bypass the validation and role restrictions.

**Disables the role field and sets the value to "Billing"**

<img width="897" alt="Screenshot 2024-12-19 at 10 04 30 AM" src="https://github.com/user-attachments/assets/2c13a3c8-874f-429b-8d50-8eacd7acfc66" />

---

**Successfully accepts new billing members, bypassing the standard validation**

<img width="894" alt="Screenshot 2024-12-19 at 10 04 57 AM" src="https://github.com/user-attachments/assets/709f93f1-27e5-4c44-84ae-e0a091a87ba9" />

---

**Invitation appears in the member list as expected**

<img width="1186" alt="Screenshot 2024-12-19 at 10 05 17 AM" src="https://github.com/user-attachments/assets/a0be8eeb-d0ae-45b8-b0a5-606c369f8c58" />
