### PR TITLE
fix(query-builder): Prevent error when filter sections don't match filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -520,6 +520,35 @@ describe('SearchQueryBuilder', function () {
         ).toBeInTheDocument();
       });
 
+      it('switches to keys menu when recent searches no longer exist', async function () {
+        const {rerender} = render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            recentSearches={SavedSearchType.ISSUE}
+            initialQuery=""
+          />
+        );
+
+        await userEvent.click(getLastInput());
+
+        // Recent should be selected
+        expect(screen.getByRole('button', {name: 'Recent'})).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+
+        // Rerender without recent searches
+        rerender(<SearchQueryBuilder {...defaultProps} />);
+
+        // Recent should not exist anymore
+        expect(screen.queryByRole('button', {name: 'Recent'})).not.toBeInTheDocument();
+        // All should be selected
+        expect(screen.getByRole('button', {name: 'All'})).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+
       it('when selecting a recent search, should reset query and call onSearch', async function () {
         const mockOnSearch = jest.fn();
         const mockCreateRecentSearch = MockApiClient.addMockResponse({

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -178,6 +178,28 @@ function useHighlightFirstOptionOnSectionChange({
   ]);
 }
 
+// If the selected section no longer exists, switch to the first valid section
+function useSwitchToValidSection({
+  sections,
+  selectedSection,
+  setSelectedSection,
+}: {
+  sections: Section[];
+  selectedSection: Key | null;
+  setSelectedSection: (section: string) => void;
+}) {
+  useEffect(() => {
+    if (!selectedSection || !sections.length) {
+      return;
+    }
+
+    const section = sections.find(s => s.value === selectedSection);
+    if (!section) {
+      setSelectedSection(sections[0].value);
+    }
+  }, [sections, selectedSection, setSelectedSection]);
+}
+
 function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
   recentFilters,
   selectedSection,
@@ -286,6 +308,8 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
     sections,
     isOpen,
   });
+
+  useSwitchToValidSection({sections, selectedSection, setSelectedSection});
 
   const fullWidth = !query;
   const showDetailsPane = fullWidth && selectedSection !== RECENT_SEARCH_CATEGORY_VALUE;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -16,6 +16,7 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import type {RecentSearch, Tag, TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
 import {type FieldDefinition, FieldKind} from 'sentry/utils/fields';
 import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 
@@ -70,9 +71,14 @@ export function createSection(
     key: section.value,
     value: section.value,
     label: section.label,
-    options: section.children.map(key =>
-      createItem(keys[key], getFieldDefinition(key), section)
-    ),
+    options: section.children
+      .map(key => {
+        if (!keys[key]) {
+          return null;
+        }
+        return createItem(keys[key], getFieldDefinition(key), section);
+      })
+      .filter(defined),
     type: 'section',
   };
 }

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -9,6 +9,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import * as pageFilterUtils from 'sentry/components/organizations/pageFilters/persistence';
@@ -91,6 +92,10 @@ describe('Discover > Homepage', () => {
       method: 'GET',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
   });
 
   it('renders the Discover banner', async () => {
@@ -129,7 +134,7 @@ describe('Discover > Homepage', () => {
     // Only the environment field
     expect(screen.getAllByTestId('grid-head-cell').length).toEqual(1);
     screen.getByText('Previous Period');
-    screen.getByText('event.type:error');
+    screen.getByRole('row', {name: 'event.type:error'});
     expect(screen.queryByText('Dataset')).not.toBeInTheDocument();
   });
 
@@ -180,9 +185,11 @@ describe('Discover > Homepage', () => {
 
     await userEvent.click(await screen.findByText('Columns'));
 
-    await userEvent.click(screen.getByTestId('label'));
-    await userEvent.click(screen.getByText('event.type'));
-    await userEvent.click(screen.getByText('Apply'));
+    const modal = await screen.findByRole('dialog');
+
+    await userEvent.click(within(modal).getByTestId('label'));
+    await userEvent.click(within(modal).getByText('event.type'));
+    await userEvent.click(within(modal).getByText('Apply'));
 
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -579,7 +586,7 @@ describe('Discover > Homepage', () => {
     await screen.findByText('environment');
 
     expect(screen.getAllByTestId('grid-head-cell').length).toEqual(1);
-    screen.getByText('event.type:error');
+    screen.getByRole('row', {name: 'event.type:error'});
     expect(screen.getByRole('tab', {name: 'Errors'})).toHaveAttribute(
       'aria-selected',
       'true'

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1836,7 +1836,9 @@ describe('Results', function () {
       await userEvent.click(
         screen.getByPlaceholderText('Search for events, users, tags, and more')
       );
-      expect(screen.getByTestId('filter-token')).toHaveTextContent('event.type:error');
+      expect(
+        await screen.findByRole('option', {name: 'event.type:error'})
+      ).toBeInTheDocument();
     });
 
     it('shows the search history for the transaction dataset', async function () {
@@ -1954,9 +1956,10 @@ describe('Results', function () {
       await userEvent.click(
         screen.getByPlaceholderText('Search for events, users, tags, and more')
       );
-      expect(screen.getByTestId('filter-token')).toHaveTextContent(
-        'transaction.status:ok'
-      );
+
+      expect(
+        await screen.findByRole('option', {name: 'transaction.status:ok'})
+      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -14,7 +14,6 @@ import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
-import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -29,7 +28,6 @@ import {
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import type {CursorHandler} from 'sentry/components/pagination';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -723,22 +721,6 @@ export class Results extends Component<Props, State> {
       ? generateAggregateFields(organization, eventView.fields)
       : eventView.fields;
 
-    if (organization.features.includes('search-query-builder-discover')) {
-      return (
-        <Wrapper>
-          <ResultsSearchQueryBuilder
-            projectIds={eventView.project}
-            query={eventView.query}
-            fields={fields}
-            onSearch={this.handleSearch}
-            customMeasurements={customMeasurements}
-            dataset={eventView.dataset}
-            includeTransactions
-          />
-        </Wrapper>
-      );
-    }
-
     let savedSearchType: SavedSearchType | undefined = SavedSearchType.EVENT;
     if (hasDatasetSelector(organization)) {
       savedSearchType =
@@ -748,19 +730,18 @@ export class Results extends Component<Props, State> {
     }
 
     return (
-      <StyledSearchBar
-        searchSource="eventsv2"
-        organization={organization}
-        projectIds={eventView.project}
-        query={eventView.query}
-        fields={fields}
-        onSearch={this.handleSearch}
-        maxQueryLength={MAX_QUERY_LENGTH}
-        customMeasurements={customMeasurements}
-        dataset={eventView.dataset}
-        includeTransactions
-        savedSearchType={savedSearchType}
-      />
+      <Wrapper>
+        <ResultsSearchQueryBuilder
+          projectIds={eventView.project}
+          query={eventView.query}
+          fields={fields}
+          onSearch={this.handleSearch}
+          customMeasurements={customMeasurements}
+          dataset={eventView.dataset}
+          includeTransactions
+          recentSearches={savedSearchType}
+        />
+      </Wrapper>
     );
   }
 
@@ -913,10 +894,6 @@ const Wrapper = styled('div')`
     display: grid;
     grid-auto-flow: row;
   }
-`;
-
-const StyledSearchBar = styled(SearchBar)`
-  margin-bottom: ${space(2)};
 `;
 
 const Top = styled(Layout.Main)`

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -124,6 +124,7 @@ type Props = {
   placeholder?: string;
   projectIds?: number[] | Readonly<number[]>;
   query?: string;
+  recentSearches?: SavedSearchType;
   searchSource?: string;
   supportedTags?: TagCollection | undefined;
 };
@@ -289,7 +290,7 @@ function ResultsSearchQueryBuilder(props: Props) {
       searchSource={props.searchSource || 'eventsv2'}
       filterKeySections={filterKeySections}
       getTagValues={getEventFieldValues}
-      recentSearches={SavedSearchType.EVENT}
+      recentSearches={props.recentSearches ?? SavedSearchType.EVENT}
       showUnsubmittedIndicator
     />
   );


### PR DESCRIPTION
When you have items in `filterKeySections` that don't exist in `filterKeys`, it will break. This just makes things a bit safer to avoid that.