### PR TITLE
feat(widget-builder): Add default fields

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -45,10 +45,17 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
    */
   SearchBar: (props: WidgetBuilderSearchBarProps) => JSX.Element;
   /**
+   * Default field to add to the widget query when adding a new field.
+   */
+  defaultField: QueryFieldValue;
+  /**
    * Default query to display when dataset is selected in the
    * Widget Builder.
    */
   defaultWidgetQuery: WidgetQuery;
+  /**
+   * Whether or not the current dataset supports adding equations.
+   */
   enableEquations: boolean;
   /**
    * Field options to display in the Column selectors for

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -16,6 +16,7 @@ import {
   ERROR_FIELDS,
   ERRORS_AGGREGATION_FUNCTIONS,
   getAggregations,
+  type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -25,6 +26,7 @@ import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSe
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 import type {Widget, WidgetQuery} from '../types';
@@ -55,12 +57,18 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: '-count()',
 };
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: ['count', '', undefined, undefined],
+  kind: FieldValueKind.FUNCTION,
+};
+
 export type SeriesWithOrdering = [order: number, series: Series];
 
 export const ErrorsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData
 > = {
+  defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -89,12 +89,18 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: '-count()',
 };
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: ['count', '', undefined, undefined],
+  kind: FieldValueKind.FUNCTION,
+};
+
 export type SeriesWithOrdering = [order: number, series: Series];
 
 export const ErrorsAndTransactionsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData
 > = {
+  defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -8,7 +8,9 @@ import type {Organization} from 'sentry/types/organization';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {
   DISCOVER_EXCLUSION_FIELDS,
   getSortLabel,
@@ -36,6 +38,11 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
 const DEFAULT_SORT = IssueSortOptions.DATE;
 const DEFAULT_EXPAND = ['owners'];
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  field: 'issue',
+  kind: FieldValueKind.FIELD,
+};
+
 type EndpointParams = Partial<PageFilters['datetime']> & {
   environment: string[];
   project: number[];
@@ -51,6 +58,7 @@ type EndpointParams = Partial<PageFilters['datetime']> & {
 };
 
 export const IssuesConfig: DatasetConfig<never, Group[]> = {
+  defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false,
   disableSortOptions,

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -14,7 +14,10 @@ import {SessionField} from 'sentry/types/sessions';
 import {defined} from 'sentry/utils';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import type {QueryFieldValue} from 'sentry/utils/discover/fields';
+import type {
+  AggregationKeyWithAlias,
+  QueryFieldValue,
+} from 'sentry/utils/discover/fields';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
@@ -60,12 +63,23 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: `-crash_free_rate(${SessionField.SESSION})`,
 };
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: [
+    'crash_free_rate' as AggregationKeyWithAlias,
+    SessionField.SESSION,
+    undefined,
+    undefined,
+  ],
+  kind: FieldValueKind.FUNCTION,
+};
+
 const METRICS_BACKED_SESSIONS_START_DATE = new Date('2022-07-12');
 
 export const ReleasesConfig: DatasetConfig<
   SessionApiResponse | MetricsApiResponse,
   SessionApiResponse | MetricsApiResponse
 > = {
+  defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false,
   disableSortOptions,

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -13,6 +13,7 @@ import toArray from 'sentry/utils/array/toArray';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {
   type DiscoverQueryExtras,
   type DiscoverQueryRequestParams,
@@ -49,6 +50,11 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: '-count(span.duration)',
 };
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: ['count', 'span.duration', undefined, undefined],
+  kind: FieldValueKind.FUNCTION,
+};
+
 const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggregate) => {
   acc[aggregate] = {
     isSortable: true,
@@ -72,6 +78,7 @@ export const SpansConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData
 > = {
+  defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false,
   SearchBar: SpansSearchBar,

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -11,7 +11,11 @@ import type {
 import {defined} from 'sentry/utils';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
-import {SPAN_OP_BREAKDOWN_FIELDS, TRANSACTION_FIELDS} from 'sentry/utils/discover/fields';
+import {
+  type QueryFieldValue,
+  SPAN_OP_BREAKDOWN_FIELDS,
+  TRANSACTION_FIELDS,
+} from 'sentry/utils/discover/fields';
 import type {
   DiscoverQueryExtras,
   DiscoverQueryRequestParams,
@@ -25,6 +29,7 @@ import {
   shouldUseOnDemandMetrics,
 } from 'sentry/utils/performance/contexts/onDemandControl';
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 import type {Widget, WidgetQuery} from '../types';
@@ -56,12 +61,18 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: '-count()',
 };
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: ['count', '', undefined, undefined],
+  kind: FieldValueKind.FUNCTION,
+};
+
 export type SeriesWithOrdering = [order: number, series: Series];
 
 export const TransactionsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData
 > = {
+  defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -458,18 +458,11 @@ function Visualize() {
           onClick={() =>
             dispatch({
               type: updateAction,
-              payload: [
-                ...(fields ?? []),
-                // TODO: Define a default aggregate/field for the datasets?
-                {
-                  function: ['count', '', undefined, undefined],
-                  kind: FieldValueKind.FUNCTION,
-                },
-              ],
+              payload: [...(fields ?? []), datasetConfig.defaultField],
             })
           }
         >
-          {t('+ Add Series')}
+          {isChartWidget ? t('+ Add Series') : t('+ Add Field')}
         </AddButton>
         {datasetConfig.enableEquations && (
           <AddButton


### PR DESCRIPTION
Define a `defaultField` in the config and use that when adding a new series or field in visualize.

Closes [#82367](https://github.com/getsentry/sentry/issues/82367)