### PR TITLE
feat(insights): remove new badge on region selector

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -1,7 +1,6 @@
 import {type ComponentProps, Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {
   CompactSelect,
   type SelectOption,
@@ -63,14 +62,6 @@ export default function SubregionSelector({size}: Props) {
     <CompactSelect
       size={size}
       searchable
-      triggerProps={{
-        prefix: (
-          <Fragment>
-            <StyledFeatureBadge type="new" />
-            {t('Geo region')}
-          </Fragment>
-        ),
-      }}
       multiple
       loading={isPending}
       clearable
@@ -102,10 +93,6 @@ export default function SubregionSelector({size}: Props) {
     />
   );
 }
-
-const StyledFeatureBadge = styled(FeatureBadge)`
-  margin-right: ${space(1)};
-`;
 
 const MenuTitleContainer = styled('div')`
   display: flex;

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -62,6 +62,9 @@ export default function SubregionSelector({size}: Props) {
     <CompactSelect
       size={size}
       searchable
+      triggerProps={{
+        prefix: <Fragment>{t('Geo region')}</Fragment>,
+      }}
       multiple
       loading={isPending}
       clearable

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -63,7 +63,7 @@ export default function SubregionSelector({size}: Props) {
       size={size}
       searchable
       triggerProps={{
-        prefix: <Fragment>{t('Geo region')}</Fragment>,
+        prefix: t('Geo region'),
       }}
       multiple
       loading={isPending}


### PR DESCRIPTION
The region selector has been release for a few weeks, so we can remove the new badge.