### PR TITLE
fix(similarity): Make similar issues endpoint faster

### DIFF
--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -42,7 +42,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
     }
 
     def get_group_id_from_hash(self, hash: str, project_id: int) -> int:
-        group_hash = GroupHash.objects.filter(project_id=project_id, hash=hash)
+        group_hash = GroupHash.objects.get(project_id=project_id, hash=hash)
         return group_hash.group_id
 
     def get_formatted_results(

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -41,24 +41,26 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get_group_hashes_for_group_id(self, group_id: int) -> set[str]:
-        hashes = GroupHash.objects.filter(group_id=group_id)
-        return {hash.hash for hash in hashes}
+    def get_group_id_from_hash(self, hash: str, project_id: int) -> int:
+        group_hash = GroupHash.objects.filter(project_id=project_id, hash=hash)
+        return group_hash.group_id
 
     def get_formatted_results(
         self,
         similar_issues_data: Sequence[SeerSimilarIssueData],
         user: User | AnonymousUser,
-        group_id: int,
+        group: Group,
     ) -> Sequence[tuple[Mapping[str, Any], Mapping[str, Any]] | None]:
         """
         Format the responses using to be used by the frontend by changing the  field names and
         changing the cosine distances into cosine similarities.
         """
-        hashes = self.get_group_hashes_for_group_id(group_id)
         group_data = {}
         for similar_issue_data in similar_issues_data:
-            if similar_issue_data.parent_hash not in hashes:
+            if (
+                self.get_group_id_from_hash(similar_issue_data.parent_hash, group.project.id)
+                != group.id
+            ):
                 formatted_response: FormattedSimilarIssuesEmbeddingsData = {
                     "exception": round(1 - similar_issue_data.stacktrace_distance, 4),
                     "shouldBeGrouped": "Yes" if similar_issue_data.should_group else "No",
@@ -137,6 +139,6 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         if not results:
             return Response([])
-        formatted_results = self.get_formatted_results(results, request.user, group.id)
+        formatted_results = self.get_formatted_results(results, request.user, group)
 
         return Response(formatted_results)

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -41,10 +41,6 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get_group_id_from_hashes(self, hashes: list[str], project_id: int) -> Mapping[str, int]:
-        group_hashes = GroupHash.objects.filter(project_id=project_id, hash__in=hashes)
-        return {group_hash.hash: group_hash.group_id for group_hash in group_hashes}
-
     def get_formatted_results(
         self,
         similar_issues_data: Sequence[SeerSimilarIssueData],
@@ -59,7 +55,10 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         parent_hashes = [
             similar_issue_data.parent_hash for similar_issue_data in similar_issues_data
         ]
-        parent_hashes_group_ids = self.get_group_id_from_hashes(parent_hashes, group.project_id)
+        group_hashes = GroupHash.objects.filter(project_id=group.project_id, hash__in=parent_hashes)
+        parent_hashes_group_ids = {
+            group_hash.hash: group_hash.group_id for group_hash in group_hashes
+        }
         for similar_issue_data in similar_issues_data:
             if parent_hashes_group_ids[similar_issue_data.parent_hash] != group.id:
                 formatted_response: FormattedSimilarIssuesEmbeddingsData = {

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -201,7 +201,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         formatted_results = group_similar_endpoint.get_formatted_results(
             similar_issues_data=[similar_issue_data_1, similar_issue_data_2],
             user=self.user,
-            group_id=self.group.id,
+            group=self.group,
         )
         assert formatted_results == self.get_expected_response(
             [


### PR DESCRIPTION
Similar issues tab loads slowly when a group has a lot of group hashes
Check the similar issue's group id (max 10) instead of the group's hashes (could be 1000s)