### PR TITLE
fix(query-builder): Prevent error when filter sections don't match filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -16,6 +16,7 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import type {RecentSearch, Tag, TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
 import {type FieldDefinition, FieldKind} from 'sentry/utils/fields';
 import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 
@@ -70,9 +71,14 @@ export function createSection(
     key: section.value,
     value: section.value,
     label: section.label,
-    options: section.children.map(key =>
-      createItem(keys[key], getFieldDefinition(key), section)
-    ),
+    options: section.children
+      .map(key => {
+        if (!keys[key]) {
+          return null;
+        }
+        return createItem(keys[key], getFieldDefinition(key), section);
+      })
+      .filter(defined),
     type: 'section',
   };
 }

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -9,6 +9,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import * as pageFilterUtils from 'sentry/components/organizations/pageFilters/persistence';
@@ -90,6 +91,10 @@ describe('Discover > Homepage', () => {
       url: '/organizations/org-slug/measurements-meta/',
       method: 'GET',
       body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
     });
   });
 
@@ -180,9 +185,11 @@ describe('Discover > Homepage', () => {
 
     await userEvent.click(await screen.findByText('Columns'));
 
-    await userEvent.click(screen.getByTestId('label'));
-    await userEvent.click(screen.getByText('event.type'));
-    await userEvent.click(screen.getByText('Apply'));
+    const modal = await screen.findByRole('dialog');
+
+    await userEvent.click(within(modal).getByTestId('label'));
+    await userEvent.click(within(modal).getByText('event.type'));
+    await userEvent.click(within(modal).getByText('Apply'));
 
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Recreating https://github.com/getsentry/sentry/pull/82380 because I was juggling too many changes at once and accidentally included an extra commit I didn't mean to.

Same as before, just needed some changes to a Discover test.