### PR TITLE
fix(web): Add react_config context on auth pages

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -40,6 +40,7 @@ from sentry.utils.auth import (
 from sentry.utils.http import absolute_uri
 from sentry.utils.sdk import capture_exception
 from sentry.utils.urls import add_params_to_url
+from sentry.web.client_config import get_client_config
 from sentry.web.forms.accounts import AuthenticationForm, RegistrationForm
 from sentry.web.frontend.base import BaseView, control_silo_view
 
@@ -531,6 +532,7 @@ class AuthLoginView(BaseView):
             ),  # NOTE: not utilized in basic login page (only org login)
             "register_form": None,
             "CAN_REGISTER": False,
+            "react_config": get_client_config(request, self.active_organization),
             "join_request_link": self.get_join_request_link(
                 organization=organization, request=request
             ),  # NOTE: not utilized in basic login page (only org login)


### PR DESCRIPTION
Follow up to #81654 and should fix getsentry/self-hosted#3473
