### PR TITLE
chore(similarity): Enable Native platforms

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -19,15 +19,7 @@ FULLY_MINIFIED_STACKTRACE_MAX_FRAME_COUNT = 20
 # this separately from backfill status allows us to backfill projects which have events from
 # multiple platforms, some supported and some not, and not worry about events from the unsupported
 # platforms getting sent to Seer during ingest.
-SEER_INELIGIBLE_EVENT_PLATFORMS = frozenset(
-    [
-        # Native platforms
-        "c",
-        "native",
-        # We don't know what's in the event
-        "other",
-    ]
-)
+SEER_INELIGIBLE_EVENT_PLATFORMS = frozenset(["other"])  # We don't know what's in the event
 # Event platforms corresponding to project platforms which were backfilled before we started
 # blocking events with more than `MAX_FRAME_COUNT` frames from being sent to Seer (which we do to
 # prevent possible over-grouping). Ultimately we want a more unified solution, but for now, we're
@@ -46,11 +38,6 @@ EVENT_PLATFORMS_BYPASSING_FRAME_COUNT_CHECK = frozenset(
 # platforms shouldn't have Seer enabled.
 SEER_INELIGIBLE_PROJECT_PLATFORMS = frozenset(
     [
-        # Native platforms
-        "c",
-        "minidump",
-        "native",
-        "native-qt",
         # We have no clue what's in these projects
         "other",
         "",

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -1818,7 +1818,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         project_same_cohort_not_eligible = self.create_project(
             organization=self.organization, id=self.project.id + thread_number
         )
-        project_same_cohort_not_eligible.platform = "c"  # Not currently eligible
+        project_same_cohort_not_eligible.platform = "other"  # Not currently eligible
         project_same_cohort_not_eligible.save()
         self.create_event(project_same_cohort_not_eligible.id, times_seen=5)
 


### PR DESCRIPTION
We have in place the protection of 30-frames and unsymbolicated stack traces do not have file names or functions to call seer.