### PR TITLE
ref(uptime): Switch fixture to use petnames

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1982,7 +1982,7 @@ class Factories:
         type: str,
         subscription_id: str | None,
         status: UptimeSubscription.Status,
-        url: str,
+        url: str | None,
         url_domain: str,
         url_domain_suffix: str,
         host_provider_id: str,
@@ -1994,6 +1994,10 @@ class Factories:
         date_updated: datetime,
         trace_sampling: bool = False,
     ):
+        if url is None:
+            url = petname.generate().title()
+            url = f"http://{url}.com"
+
         return UptimeSubscription.objects.create(
             type=type,
             subscription_id=subscription_id,
@@ -2017,10 +2021,12 @@ class Factories:
         env: Environment | None,
         uptime_subscription: UptimeSubscription,
         mode: ProjectUptimeSubscriptionMode,
-        name: str,
+        name: str | None,
         owner: Actor | None,
         uptime_status: UptimeStatus,
     ):
+        if name is None:
+            name = petname.generate().title()
         owner_team_id = None
         owner_user_id = None
         if owner:

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -677,7 +677,7 @@ class Fixtures:
         type: str = "test",
         subscription_id: str | None = None,
         status: UptimeSubscription.Status = UptimeSubscription.Status.ACTIVE,
-        url="http://sentry.io/",
+        url: str | None = None,
         host_provider_id="TEST",
         url_domain="sentry",
         url_domain_suffix="io",
@@ -717,7 +717,7 @@ class Fixtures:
         env: Environment | None = None,
         uptime_subscription: UptimeSubscription | None = None,
         mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        name="Test Name",
+        name: str | None = None,
         owner: User | Team | None = None,
         uptime_status=UptimeStatus.OK,
     ) -> ProjectUptimeSubscription:

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -435,10 +435,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             organization=self.org, projects=[self.project2]
         )
         proj_uptime_monitor = self.create_project_uptime_subscription(project=self.project)
-        proj2_uptime_monitor = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(url="http://santry.io"),
-            project=self.project2,
-        )
+        proj2_uptime_monitor = self.create_project_uptime_subscription(project=self.project2)
 
         with self.feature(
             [
@@ -631,7 +628,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         unowned_uptime_monitor = self.create_project_uptime_subscription(
             name="Uptime unowned",
-            uptime_subscription=self.create_uptime_subscription(url="http://santry.io"),
         )
 
         with self.feature(
@@ -773,7 +769,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.setup_project_and_rules()
         uptime_monitor = self.create_project_uptime_subscription(name="Uptime")
         another_uptime_monitor = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(url="https://santry.io"),
             name="yet another Uptime",
         )
         with self.feature(
@@ -946,7 +941,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         uptime_monitor = self.create_project_uptime_subscription()
         failed_uptime_monitor = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(url="https://santry.io"),
             uptime_status=UptimeStatus.FAILED,
         )
         with self.feature(
@@ -1033,12 +1027,10 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         uptime_monitor = self.create_project_uptime_subscription(name="Uptime Monitor")
         other_uptime_monitor = self.create_project_uptime_subscription(
             name="Other Uptime Monitor",
-            uptime_subscription=self.create_uptime_subscription(url="https://santry.io"),
         )
         self.create_project_uptime_subscription(
             name="Onboarding Uptime monitor",
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
-            uptime_subscription=self.create_uptime_subscription(url="https://santry-iz-kool.io"),
         )
 
         request_data = {"name": "Uptime", "project": [self.project.id]}
@@ -1057,12 +1049,10 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.create_project_uptime_subscription(name="Uptime Monitor")
         self.create_project_uptime_subscription(
             name="Other Uptime Monitor",
-            uptime_subscription=self.create_uptime_subscription(url="https://santry.io"),
         )
         self.create_project_uptime_subscription(
             name="Onboarding Uptime monitor",
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
-            uptime_subscription=self.create_uptime_subscription(url="https://santry-iz-kool.io"),
         )
 
         request_data = {"project": [self.project.id], "sort": "name"}

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -563,8 +563,7 @@ class IsUrlMonitoredForProjectTest(UptimeTestCase):
     def test_not_monitored(self):
         assert not is_url_auto_monitored_for_project(self.project, "https://sentry.io")
         subscription = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(),
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=ProjectUptimeSubscriptionMode.MANUAL
         )
         assert not is_url_auto_monitored_for_project(
             self.project, subscription.uptime_subscription.url
@@ -572,15 +571,13 @@ class IsUrlMonitoredForProjectTest(UptimeTestCase):
 
     def test_monitored(self):
         subscription = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(),
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
         )
         assert is_url_auto_monitored_for_project(self.project, subscription.uptime_subscription.url)
 
     def test_monitored_other_project(self):
         other_project = self.create_project()
         subscription = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(),
             project=self.project,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
         )
@@ -596,18 +593,13 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
 
     def test(self):
         subscription = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(),
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
         )
         assert get_auto_monitored_subscriptions_for_project(self.project) == [subscription]
         other_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(url="https://santry.io"),
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
         )
-        self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(url="https://sintry.io"),
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )
+        self.create_project_uptime_subscription(mode=ProjectUptimeSubscriptionMode.MANUAL)
         assert set(get_auto_monitored_subscriptions_for_project(self.project)) == {
             subscription,
             other_subscription,
@@ -616,7 +608,6 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
     def test_other_project(self):
         other_project = self.create_project()
         self.create_project_uptime_subscription(
-            uptime_subscription=self.create_uptime_subscription(),
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
         )
         assert get_auto_monitored_subscriptions_for_project(other_project) == []


### PR DESCRIPTION
This makes testing a little easier since we don't have to pass through
the uptime_subscription when using create_project_uptime_subscription
each time for a new one.