### PR TITLE
ref(seer grouping): Use frame tallies for excess frame check

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -89,7 +88,7 @@ def _check_for_mismatched_hashes(
 
 
 def get_grouping_info_from_variants(
-    variants: Mapping[str, BaseVariant],
+    variants: dict[str, BaseVariant],
 ) -> dict[str, dict[str, Any]]:
     """
     Given a dictionary of variant objects, create and return a copy of the dictionary in which each

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Mapping
 from dataclasses import asdict
 from typing import Any
 
@@ -33,7 +32,7 @@ from sentry.utils.safe import get_path
 logger = logging.getLogger("sentry.events.grouping")
 
 
-def should_call_seer_for_grouping(event: Event, variants: Mapping[str, BaseVariant]) -> bool:
+def should_call_seer_for_grouping(event: Event, variants: dict[str, BaseVariant]) -> bool:
     """
     Use event content, feature flags, rate limits, killswitches, seer health, etc. to determine
     whether a call to Seer should be made.
@@ -126,7 +125,7 @@ def _project_has_similarity_grouping_enabled(project: Project) -> bool:
 # combined with some other value). To the extent to which we're then using this function to decide
 # whether or not to call Seer, this means that the calculations giving rise to the default part of
 # the value never involve Seer input. In the long run, we probably want to change that.
-def _has_customized_fingerprint(event: Event, variants: Mapping[str, BaseVariant]) -> bool:
+def _has_customized_fingerprint(event: Event, variants: dict[str, BaseVariant]) -> bool:
     fingerprint = event.data.get("fingerprint", [])
 
     if "{{ default }}" in fingerprint:
@@ -200,7 +199,7 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
     return circuit_broken
 
 
-def _has_empty_stacktrace_string(event: Event, variants: Mapping[str, BaseVariant]) -> bool:
+def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant]) -> bool:
     stacktrace_string = get_stacktrace_string_with_metrics(
         get_grouping_info_from_variants(variants), event.platform, ReferrerOptions.INGEST
     )
@@ -216,7 +215,7 @@ def _has_empty_stacktrace_string(event: Event, variants: Mapping[str, BaseVarian
 
 def get_seer_similar_issues(
     event: Event,
-    variants: Mapping[str, BaseVariant],
+    variants: dict[str, BaseVariant],
     num_neighbors: int = 1,
 ) -> tuple[dict[str, Any], GroupHash | None]:
     """
@@ -292,7 +291,7 @@ def get_seer_similar_issues(
 
 
 def maybe_check_seer_for_matching_grouphash(
-    event: Event, variants: Mapping[str, BaseVariant], all_grouphashes: list[GroupHash]
+    event: Event, variants: dict[str, BaseVariant], all_grouphashes: list[GroupHash]
 ) -> GroupHash | None:
     seer_matched_grouphash = None
 

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -12,7 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
-from sentry.grouping.grouping_info import get_grouping_info
+from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
@@ -22,6 +22,7 @@ from sentry.seer.similarity.utils import (
     TooManyOnlySystemFramesException,
     event_content_has_stacktrace,
     get_stacktrace_string,
+    has_too_many_contributing_frames,
     killswitch_enabled,
 )
 from sentry.users.models.user import User
@@ -81,16 +82,22 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         latest_event = group.get_latest_event()
         stacktrace_string = ""
+
         if latest_event and event_content_has_stacktrace(latest_event):
-            grouping_info = get_grouping_info(None, project=group.project, event=latest_event)
-            try:
-                stacktrace_string = get_stacktrace_string(
-                    grouping_info, platform=latest_event.platform
-                )
-            except TooManyOnlySystemFramesException:
-                pass
-            except Exception:
-                logger.exception("Unexpected exception in stacktrace string formatting")
+            variants = latest_event.get_grouping_variants(normalize_stacktraces=True)
+
+            if not has_too_many_contributing_frames(
+                latest_event, variants, ReferrerOptions.SIMILAR_ISSUES_TAB
+            ):
+                grouping_info = get_grouping_info_from_variants(variants)
+                try:
+                    stacktrace_string = get_stacktrace_string(
+                        grouping_info, platform=latest_event.platform
+                    )
+                except TooManyOnlySystemFramesException:
+                    pass
+                except Exception:
+                    logger.exception("Unexpected exception in stacktrace string formatting")
 
         if not stacktrace_string or not latest_event:
             return Response([])  # No exception, stacktrace or in-app frames, or event

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -5,6 +5,8 @@ from typing import Any, TypedDict, TypeVar
 
 from sentry import options
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.grouping.api import get_contributing_variant_and_component
+from sentry.grouping.variants import BaseVariant, ComponentVariant
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
 from sentry.utils import metrics
@@ -327,6 +329,64 @@ def record_did_call_seer_metric(*, call_made: bool, blocker: str) -> None:
         sample_rate=options.get("seer.similarity.metrics_sample_rate"),
         tags={"call_made": call_made, "blocker": blocker},
     )
+
+
+def has_too_many_contributing_frames(
+    event: Event | GroupEvent,
+    variants: dict[str, BaseVariant],
+    referrer: ReferrerOptions,
+) -> bool:
+    platform = event.platform
+    shared_tags = {"referrer": referrer.value, "platform": platform}
+
+    contributing_variant, contributing_component = get_contributing_variant_and_component(variants)
+
+    # Ideally we're calling this function after we already know the event both has a stacktrace and
+    # is using it for grouping (in which case none of the below conditions should apply), but still
+    # worth checking that we have enough information to answer the question just in case
+    if (
+        # Fingerprint, checksum, fallback variants
+        not isinstance(contributing_variant, ComponentVariant)
+        # Security violations, log-message-based grouping
+        or contributing_variant.variant_name == "default"
+        # Any ComponentVariant will have this, but this reassures mypy
+        or not contributing_component
+        # Exception-message-based grouping
+        or not hasattr(contributing_component, "frame_counts")
+    ):
+        # We don't bother to collect a metric on this outcome, because we shouldn't have called the
+        # function in the first place
+        return False
+
+    # Certain platforms were backfilled before we added this filter, so to keep new events matching
+    # with the existing data, we turn off the filter for them (instead their stacktraces will be
+    # truncated)
+    if platform in EVENT_PLATFORMS_BYPASSING_FRAME_COUNT_CHECK:
+        metrics.incr(
+            "grouping.similarity.frame_count_filter",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={**shared_tags, "outcome": "bypass"},
+        )
+        return False
+
+    stacktrace_type = "in_app" if contributing_variant.variant_name == "app" else "system"
+    key = f"{stacktrace_type}_contributing_frames"
+    shared_tags["stacktrace_type"] = stacktrace_type
+
+    if contributing_component.frame_counts[key] > MAX_FRAME_COUNT:
+        metrics.incr(
+            "grouping.similarity.frame_count_filter",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={**shared_tags, "outcome": "block"},
+        )
+        return True
+
+    metrics.incr(
+        "grouping.similarity.frame_count_filter",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={**shared_tags, "outcome": "pass"},
+    )
+    return False
 
 
 def killswitch_enabled(

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -13,7 +13,7 @@ from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request
 from sentry import nodestore, options
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
-from sentry.grouping.grouping_info import get_grouping_info
+from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.issues.grouptype import ErrorGroupType
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
@@ -35,6 +35,7 @@ from sentry.seer.similarity.utils import (
     event_content_has_stacktrace,
     filter_null_from_string,
     get_stacktrace_string_with_metrics,
+    has_too_many_contributing_frames,
 )
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -356,11 +357,17 @@ def get_events_from_nodestore(
     bulk_event_ids = set()
     for group_id, event in nodestore_events.items():
         event._project_cache = project
-        if event and event.data and event_content_has_stacktrace(event):
-            grouping_info = get_grouping_info(None, project=project, event=event)
-            stacktrace_string = get_stacktrace_string_with_metrics(
-                grouping_info, event.platform, ReferrerOptions.BACKFILL
-            )
+        stacktrace_string = None
+
+        if event and event_content_has_stacktrace(event):
+            variants = event.get_grouping_variants(normalize_stacktraces=True)
+
+            if not has_too_many_contributing_frames(event, variants, ReferrerOptions.BACKFILL):
+                grouping_info = get_grouping_info_from_variants(variants)
+                stacktrace_string = get_stacktrace_string_with_metrics(
+                    grouping_info, event.platform, ReferrerOptions.BACKFILL
+                )
+
             if not stacktrace_string:
                 invalid_event_group_ids.append(group_id)
                 continue

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -536,7 +536,7 @@ class GetStacktraceStringTest(TestCase):
         )
         assert stacktrace_str == expected_stacktrace_str
 
-    def test_chained_too_many_frames(self):
+    def test_chained_stacktrace_truncation(self):
         data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
         data_chained_exception["app"]["component"]["values"][0]["values"] = [
             self.create_exception(
@@ -582,7 +582,7 @@ class GetStacktraceStringTest(TestCase):
         )
         assert stacktrace_str == expected
 
-    def test_chained_too_many_frames_all_minified_js(self):
+    def test_chained_stacktrace_truncation_all_minified_js(self):
         data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
         data_chained_exception["app"]["component"]["values"][0]["values"] = [
             self.create_exception(
@@ -634,7 +634,7 @@ class GetStacktraceStringTest(TestCase):
         )
         assert stacktrace_str == expected
 
-    def test_chained_too_many_frames_minified_js_frame_limit(self):
+    def test_chained_stacktrace_truncation_minified_js_frame_limit_is_lower(self):
         """Test that we restrict fully-minified stacktraces to 20 frames, and all other stacktraces to 30 frames."""
         for minified_frames, expected_frame_count in [("all", 20), ("some", 30), ("none", 30)]:
             data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
@@ -676,7 +676,7 @@ class GetStacktraceStringTest(TestCase):
                 == expected_frame_count
             )
 
-    def test_chained_too_many_exceptions(self):
+    def test_chained_exception_limit(self):
         """Test that we restrict number of chained exceptions to MAX_FRAME_COUNT."""
         data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
         data_chained_exception["app"]["component"]["values"][0]["values"] = [
@@ -717,7 +717,7 @@ class GetStacktraceStringTest(TestCase):
         stacktrace_str = get_stacktrace_string(data)
         assert stacktrace_str == ""
 
-    def test_too_many_system_frames_single_exception(self):
+    def test_stacktrace_length_filter_single_exception(self):
         data_system = copy.deepcopy(self.BASE_APP_DATA)
         data_system["system"] = data_system.pop("app")
         data_system["system"]["component"]["values"][0]["values"][0][
@@ -727,7 +727,7 @@ class GetStacktraceStringTest(TestCase):
         with pytest.raises(TooManyOnlySystemFramesException):
             get_stacktrace_string(data_system, platform="java")
 
-    def test_too_many_system_frames_single_exception_invalid_platform(self):
+    def test_stacktrace_length_filter_single_exception_invalid_platform(self):
         data_system = copy.deepcopy(self.BASE_APP_DATA)
         data_system["system"] = data_system.pop("app")
         data_system["system"]["component"]["values"][0]["values"][0][
@@ -737,7 +737,7 @@ class GetStacktraceStringTest(TestCase):
         stacktrace_string = get_stacktrace_string(data_system, "python")
         assert stacktrace_string is not None and stacktrace_string != ""
 
-    def test_too_many_system_frames_chained_exception(self):
+    def test_stacktrace_length_filter_chained_exception(self):
         data_system = copy.deepcopy(self.CHAINED_APP_DATA)
         data_system["system"] = data_system.pop("app")
         # Split MAX_FRAME_COUNT across the two exceptions
@@ -751,7 +751,7 @@ class GetStacktraceStringTest(TestCase):
         with pytest.raises(TooManyOnlySystemFramesException):
             get_stacktrace_string(data_system, platform="java")
 
-    def test_too_many_system_frames_chained_exception_invalid_platform(self):
+    def test_stacktrace_length_filter_chained_exception_invalid_platform(self):
         data_system = copy.deepcopy(self.CHAINED_APP_DATA)
         data_system["system"] = data_system.pop("app")
         # Split MAX_FRAME_COUNT across the two exceptions
@@ -765,7 +765,7 @@ class GetStacktraceStringTest(TestCase):
         stacktrace_string = get_stacktrace_string(data_system, "python")
         assert stacktrace_string is not None and stacktrace_string != ""
 
-    def test_too_many_in_app_contributing_frames(self):
+    def test_stacktrace_truncation_uses_in_app_contributing_frames(self):
         """
         Check that when there are over MAX_FRAME_COUNT contributing frames, the last MAX_FRAME_COUNT
         is included.
@@ -798,7 +798,7 @@ class GetStacktraceStringTest(TestCase):
             assert ("test = " + str(i) + "!") in stacktrace_str
         assert num_frames == MAX_FRAME_COUNT
 
-    def test_too_many_frames_minified_js_frame_limit(self):
+    def test_stacktrace_truncation_minified_js_frame_limit_is_lower(self):
         """Test that we restrict fully-minified stacktraces to 20 frames, and all other stacktraces to 30 frames."""
         for minified_frames, expected_frame_count in [("all", 20), ("some", 30), ("none", 30)]:
             data_frames = copy.deepcopy(self.BASE_APP_DATA)

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -359,7 +359,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
     @patch("sentry.seer.similarity.utils.metrics")
     def test_lookup_group_data_stacktrace_bulk_invalid_stacktrace_exception(self, mock_metrics):
         """
-        Test that if a group has over MAX_FRAME_COUNT only system frames, its data is not included in
+        Test that if a group has over MAX_FRAME_COUNT frames, its data is not included in
         the bulk lookup result
         """
         # Use 2 events
@@ -367,7 +367,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         group_ids = [row["group_id"] for row in rows]
         for group_id in group_ids:
             hashes.update({group_id: self.group_hashes[group_id]})
-        # Create one event where the stacktrace has over MAX_FRAME_COUNT system only frames
+        # Create one event where the stacktrace has over MAX_FRAME_COUNT frames
         exception = copy.deepcopy(EXCEPTION)
         exception["values"][0]["stacktrace"]["frames"] = [
             {
@@ -414,9 +414,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
         sample_rate = options.get("seer.similarity.metrics_sample_rate")
         mock_metrics.incr.assert_called_with(
-            "grouping.similarity.over_threshold_only_system_frames",
+            "grouping.similarity.frame_count_filter",
             sample_rate=sample_rate,
-            tags={"platform": "java", "referrer": "backfill"},
+            tags={
+                "platform": "java",
+                "referrer": "backfill",
+                "stacktrace_type": "system",
+                "outcome": "block",
+            },
         )
 
     def test_lookup_group_data_stacktrace_bulk_with_fallback_success(self):


### PR DESCRIPTION
This is the first step in simplifying the way we apply the stacktrace length filter to events sent to Seer. It puts in place the new machinery, but does not yet remove the old machinery, which will happen in a follow-up PR. 

In the meantime, though, even though the old code is still there, the new code should supplant it, since its check comes before the existing one - meaning anything which should get filtered should be flagged by the new check and shouldn't make it through to the existing check. I used different names for the metrics so that we can make sure that's the case before we remove the existing code.

Key changes:

- A new `has_too_many_contributing_frames` to be used in all the places we send events to Seer (ingest, backfill, similar issues tab), which collects a `grouping.similarity.frame_count_filter` metric, regardless of (and tagged with) the referrer.
- A new ingest-specific `_has_too_many_contributing_frames` wrapper for the above, which also records a `did_call_seer` metric.
- In both the backfill and similar issues tab endpoint code, getting `grouping_info` is now split into two steps, first getting the variants and then getting grouping info from the variants, so that the variants can be fed to `has_too_many_contributing_frames`.
- All `get_stacktrace_string` tests whose names included some variation of "too many fames" have been renamed, so as not to confuse them with the tests of the new helper, which are added in a separate class at the bottom of the module.

Note that one of the tests is marked as a skip, because in the process of doing this I found what might be a bug in our grouping logic. (TL;DR, frames which are marked `-app +group` by a stacktrace rule might not be behaving as expected... depending on what you think is expected.) In any case, for now the test is skipped, and once we resolve the stacktrace rule question, we can ether turn it back on or change it.