### PR TITLE
feat(insights): louder warning about performance going away

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -92,7 +92,7 @@ export function PerformanceLanding(props: Props) {
     handleTrendsClick,
     onboardingProject,
   } = props;
-  const {setPageInfo, pageAlert} = usePageAlert();
+  const {setPageWarning, pageAlert} = usePageAlert();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
   const {slug} = organization;
 
@@ -118,7 +118,9 @@ export function PerformanceLanding(props: Props) {
         </Link>
         {t(', and ')}
         <Link to={`${getPerformanceBaseUrl(slug, 'ai')}/`}>{AI_SIDEBAR_LABEL}</Link>
-        {t(' performance pages. They can all be found in the Insights tab.')}
+        {t(
+          ' performance pages. They can all be found in the Insights tab. The Performance landing page will be retired February 2025.'
+        )}
       </Fragment>
     );
   }, [slug]);
@@ -134,9 +136,9 @@ export function PerformanceLanding(props: Props) {
 
   useEffect(() => {
     if (performanceMovingAlert && pageAlert?.message !== performanceMovingAlert) {
-      setPageInfo(performanceMovingAlert);
+      setPageWarning(performanceMovingAlert);
     }
-  }, [pageAlert?.message, performanceMovingAlert, setPageInfo]);
+  }, [pageAlert?.message, performanceMovingAlert, setPageWarning]);
 
   useEffect(() => {
     if (hasMounted.current) {


### PR DESCRIPTION
Provide a louder warning message that the performance landing page is going away in favour of the new frontend / backend / mobile landing pages.


This:

<img width="1082" alt="Screenshot 2024-12-19 at 4 40 19 PM" src="https://github.com/user-attachments/assets/b4bc3e65-9883-46ec-9e3f-925779a03282" />

vs.,

<img width="1114" alt="Screenshot 2024-12-19 at 4 41 34 PM" src="https://github.com/user-attachments/assets/3ba8d705-7eec-4ed1-87ec-e841c8062972" />

