### PR TITLE
spike(slack): refactor slack threads logic

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -137,6 +137,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:failure-rate-metric-alert-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GenAI features such as Autofix and Issue Summary
     manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable generic notification message repository
+    manager.add("organizations:generic-notification-message-repository", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Allow creating `GroupHashMetadata` records

--- a/src/sentry/integrations/repository/__init__.py
+++ b/src/sentry/integrations/repository/__init__.py
@@ -10,11 +10,13 @@ What we query from an interface level won't change, simply how we query will cha
 only thing that need to change after we make the migration.
 """
 
+from sentry.integrations.repository.generic import GenericNotificationMessageRepository
 from sentry.integrations.repository.issue_alert import IssueAlertNotificationMessageRepository
 from sentry.integrations.repository.metric_alert import MetricAlertNotificationMessageRepository
 
 _default_metric_alert_repository = None
 _default_issue_alert_repository = None
+_default_generic_repository = None
 
 
 def get_default_metric_alert_repository() -> MetricAlertNotificationMessageRepository:
@@ -31,3 +33,11 @@ def get_default_issue_alert_repository() -> IssueAlertNotificationMessageReposit
         _default_issue_alert_repository = IssueAlertNotificationMessageRepository.default()
 
     return _default_issue_alert_repository
+
+
+def get_default_generic_repository() -> GenericNotificationMessageRepository:
+    global _default_generic_repository
+    if _default_generic_repository is None:
+        _default_generic_repository = GenericNotificationMessageRepository.default()
+
+    return _default_generic_repository

--- a/src/sentry/integrations/repository/generic.py
+++ b/src/sentry/integrations/repository/generic.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from logging import Logger, getLogger
+
+from django.db.models import Q
+
+from sentry.integrations.repository.base import (
+    BaseNewNotificationMessage,
+    BaseNotificationMessage,
+    NotificationMessageValidationError,
+)
+from sentry.notifications.models.notificationmessage import NotificationMessage
+
+_default_logger: Logger = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GenericNotificationMessage(BaseNotificationMessage):
+    composite_key: str | None = None
+    group_id: int | None = None
+
+    @classmethod
+    def from_model(cls, instance: NotificationMessage) -> GenericNotificationMessage:
+        return GenericNotificationMessage(
+            id=instance.id,
+            error_code=instance.error_code,
+            error_details=instance.error_details,
+            message_identifier=instance.message_identifier,
+            parent_notification_message_id=(
+                instance.parent_notification_message.id
+                if instance.parent_notification_message
+                else None
+            ),
+            composite_key=instance.composite_key,
+            group_id=instance.group_id,
+            date_added=instance.date_added,
+        )
+
+
+class GenericNotificationMessageValidationError(NotificationMessageValidationError):
+    pass
+
+
+class CompositeKeyValidationError(GenericNotificationMessageValidationError):
+    message = "composite key is required and cannot set other FK fields"
+
+
+@dataclass
+class NewGenericNotificationMessage(BaseNewNotificationMessage):
+    composite_key: str | None = None
+    group_id: int | None = None
+
+    def get_validation_error(self) -> Exception | None:
+        error = super().get_validation_error()
+        if error is not None:
+            return error
+
+        # If a message_identifier exists, that means a successful notification happened for a rule action and fire
+        # This means that composite key must exist
+        if self.message_identifier is None:
+            if self.composite_key is None:
+                return CompositeKeyValidationError()
+
+        # Group ID cannot exist without a composite key
+        if self.group_id is not None and self.composite_key is None:
+            return CompositeKeyValidationError()
+
+
+class GenericNotificationMessageRepository:
+    """Generic repository class for notification message operations."""
+
+    _model = NotificationMessage
+
+    def __init__(self, logger: Logger) -> None:
+        self._logger: Logger = logger
+
+    @classmethod
+    def default(cls) -> GenericNotificationMessageRepository:
+        return cls(logger=_default_logger)
+
+    @classmethod
+    def _parent_notification_message_base_filter(cls) -> Q:
+        """
+        Returns the query used to filter the notification messages for parent notification messages.
+        Parent notification messages are notification message instances without a parent notification message itself,
+        and where the error code is null.
+        """
+        return Q(parent_notification_message__isnull=True, error_code__isnull=True)
+
+    def get_parent_notification_message(
+        self, composite_key: str
+    ) -> GenericNotificationMessage | None:
+        """
+        Returns the parent notification message for a given composite key if it exists, otherwise returns None.
+        Will raise an exception if the query fails and logs the error with associated data.
+        """
+        try:
+            base_filter = self._parent_notification_message_base_filter()
+            instance = (
+                self._model.objects.filter(base_filter)
+                .filter(composite_key=composite_key)
+                .latest("date_added")
+            )
+            return GenericNotificationMessage.from_model(instance=instance)
+        except NotificationMessage.DoesNotExist:
+            return None
+        except Exception as e:
+            self._logger.exception(
+                "Failed to get parent notification by composite key",
+                exc_info=e,
+                extra={"composite_key": composite_key},
+            )
+            raise
+
+    def create_notification_message(
+        self, data: NewGenericNotificationMessage
+    ) -> GenericNotificationMessage:
+        if (error := data.get_validation_error()) is not None:
+            raise error
+
+        try:
+            new_instance = self._model.objects.create(
+                error_details=data.error_details,
+                error_code=data.error_code,
+                message_identifier=data.message_identifier,
+                parent_notification_message_id=data.parent_notification_message_id,
+                composite_key=data.composite_key,
+                group_id=data.group_id,
+            )
+            return GenericNotificationMessage.from_model(instance=new_instance)
+        except Exception as e:
+            self._logger.exception(
+                "failed to create new generic notification alert",
+                exc_info=e,
+                extra=data.__dict__,
+            )
+            raise
+
+    def get_all_parent_notification_messages_by_filters(
+        self, group_ids: list[int] | None = None
+    ) -> Generator[GenericNotificationMessage]:
+        """
+        If no filters are passed, then all parent notification objects are returned.
+
+        Because an unbounded amount of parent notification objects can be returned, this method leverages generator to
+        control the usage of memory in the application.
+        It is up to the caller to iterate over all the data, or store in memory if they need all objects concurrently.
+        """
+        group_id_filter = Q(group_id__in=group_ids) if group_ids else Q()
+
+        query = self._model.objects.filter(group_id_filter).filter(
+            self._parent_notification_message_base_filter()
+        )
+
+        try:
+            for instance in query:
+                yield GenericNotificationMessage.from_model(instance=instance)
+        except Exception as e:
+            self._logger.exception(
+                "Failed to get parent notifications on filters",
+                exc_info=e,
+                extra=filter.__dict__,
+            )
+            raise

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -105,8 +105,7 @@ def send_incident_alert_notification(
                 repository: GenericNotificationMessageRepository = get_default_generic_repository()
                 try:
                     parent_notification_message = repository.get_parent_notification_message(
-                        group_id=incident.group_id,
-                        rule_action_uuid=action.id,
+                        composite_key=f"{incident.alert_rule_id}:{incident.id}:{action.id}"
                     )
                 except Exception as e:
                     lifecycle.record_halt(e)

--- a/tests/sentry/integrations/repository/generic/test_generic_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/generic/test_generic_notification_message_repository.py
@@ -1,0 +1,246 @@
+from uuid import uuid4
+
+from sentry.integrations.repository.generic import (
+    GenericNotificationMessage,
+    GenericNotificationMessageRepository,
+    NewGenericNotificationMessage,
+)
+from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.notifications.models.notificationmessage import NotificationMessage
+from sentry.testutils.cases import TestCase
+
+# TODO: Test that we raise validation errors when the composite key is not set or if the other FK fields are set
+
+
+class TestGetParentNotificationMessageMetricAlert(TestCase):
+    def setUp(self) -> None:
+        self.incident = self.create_incident()
+        self.trigger_action = self.create_alert_rule_trigger_action()
+        self.composite_key = (
+            f"{self.incident.alert_rule.id}:{self.incident.id}:{self.trigger_action.id}"
+        )
+        self.parent_notification_message = NotificationMessage.objects.create(
+            message_identifier="123abc",
+            composite_key=self.composite_key,
+        )
+        self.repository: GenericNotificationMessageRepository = (
+            GenericNotificationMessageRepository.default()
+        )
+
+    def test_returns_parent_notification_message(self) -> None:
+        instance = self.repository.get_parent_notification_message(
+            composite_key=self.composite_key,
+        )
+
+        assert instance is not None
+        assert instance == GenericNotificationMessage.from_model(self.parent_notification_message)
+
+    def test_returns_none_when_filter_does_not_exist(self) -> None:
+        instance = self.repository.get_parent_notification_message(composite_key="")
+
+        assert instance is None
+
+    def test_when_parent_has_child(self) -> None:
+        child = NotificationMessage.objects.create(
+            incident=self.incident,
+            trigger_action=self.trigger_action,
+            message_identifier="456abc",
+            parent_notification_message=self.parent_notification_message,
+        )
+
+        assert child.id != self.parent_notification_message.id
+
+        instance = self.repository.get_parent_notification_message(
+            composite_key=self.composite_key,
+        )
+
+        assert instance is not None
+        assert instance == GenericNotificationMessage.from_model(self.parent_notification_message)
+
+
+class TestGetParentNotificationMessageIssueAlert(TestCase):
+    def setUp(self) -> None:
+        self.action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.action_uuid,
+            }
+        ]
+        self.rule = self.create_project_rule(
+            project=self.project, action_data=self.notify_issue_owners_action
+        )
+        self.event_id = 456
+        self.notification_uuid = str(uuid4())
+        self.rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.group,
+            event_id=self.event_id,
+            notification_uuid=self.notification_uuid,
+        )
+        # TODO: Test with the composite key builders when they are implemented
+        self.composite_key = f"{self.rule.id}:{self.group.id}:{self.action_uuid}"
+        self.parent_notification_message = NotificationMessage.objects.create(
+            message_identifier="123abc",
+            composite_key=self.composite_key,
+        )
+        self.repository = GenericNotificationMessageRepository.default()
+
+    def test_returns_parent_notification_message(self) -> None:
+        instance = self.repository.get_parent_notification_message(
+            composite_key=self.composite_key,
+        )
+
+        assert instance is not None
+        assert instance == GenericNotificationMessage.from_model(self.parent_notification_message)
+
+    def test_returns_latest_parent_notification_message(self) -> None:
+        latest = NotificationMessage.objects.create(
+            message_identifier="abc123new",
+            composite_key=self.composite_key,
+            group_id=self.group.id,
+        )
+
+        instance = self.repository.get_parent_notification_message(
+            composite_key=self.composite_key,
+        )
+
+        assert instance is not None
+        assert instance == GenericNotificationMessage.from_model(latest)
+
+    def test_returns_none_when_filter_does_not_exist(self) -> None:
+        instance = self.repository.get_parent_notification_message(
+            composite_key="",
+        )
+
+        assert instance is None
+
+    def test_when_parent_has_child(self) -> None:
+        child = NotificationMessage.objects.create(
+            message_identifier="456abc",
+            parent_notification_message=self.parent_notification_message,
+            composite_key=self.composite_key,
+        )
+
+        assert child.id != self.parent_notification_message.id
+
+        instance = self.repository.get_parent_notification_message(
+            composite_key=self.composite_key,
+        )
+
+        assert instance is not None
+        assert instance == GenericNotificationMessage.from_model(self.parent_notification_message)
+
+
+class TestCreateNotificationMessageMetricAlert(TestCase):
+    def setUp(self) -> None:
+        self.incident = self.create_incident()
+        self.trigger_action = self.create_alert_rule_trigger_action()
+        self.composite_key = (
+            f"{self.incident.alert_rule.id}:{self.incident.id}:{self.trigger_action.id}"
+        )
+        self.parent_notification_message = NotificationMessage.objects.create(
+            message_identifier="123abc",
+            composite_key=self.composite_key,
+        )
+        self.repository: GenericNotificationMessageRepository = (
+            GenericNotificationMessageRepository.default()
+        )
+
+    def test_simple(self) -> None:
+        message_identifier = "1a2b3c"
+        data = NewGenericNotificationMessage(
+            composite_key=self.composite_key,
+            message_identifier=message_identifier,
+        )
+
+        result = self.repository.create_notification_message(data=data)
+        assert result is not None
+        assert result.message_identifier == message_identifier
+
+    def test_with_error_details(self) -> None:
+        error_detail = {
+            "message": "message",
+            "some_nested_obj": {
+                "some_nested_key": "some_nested_value",
+                "some_array": ["some_array"],
+                "int": 203,
+            },
+        }
+        data = NewGenericNotificationMessage(
+            composite_key=self.composite_key,
+            error_code=405,
+            error_details=error_detail,
+        )
+
+        result = self.repository.create_notification_message(data=data)
+        assert result is not None
+        assert result.error_details == error_detail
+
+
+class TestCreateNotificationMessageIssueAlert(TestCase):
+    def setUp(self) -> None:
+        self.action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.action_uuid,
+            }
+        ]
+        self.rule = self.create_project_rule(
+            project=self.project, action_data=self.notify_issue_owners_action
+        )
+        self.event_id = 456
+        self.notification_uuid = str(uuid4())
+        self.rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.group,
+            event_id=self.event_id,
+            notification_uuid=self.notification_uuid,
+        )
+        # TODO: Test with the composite key builders when they are implemented
+        self.composite_key = f"{self.rule.id}:{self.group.id}:{self.action_uuid}"
+        self.parent_notification_message = NotificationMessage.objects.create(
+            message_identifier="123abc",
+            composite_key=self.composite_key,
+        )
+        self.repository = GenericNotificationMessageRepository.default()
+
+    def test_simple(self) -> None:
+        message_identifier = "1a2b3c"
+        data = NewGenericNotificationMessage(
+            composite_key=self.composite_key,
+            message_identifier=message_identifier,
+        )
+
+        result = self.repository.create_notification_message(data=data)
+        assert result is not None
+        assert result.message_identifier == message_identifier
+
+    def test_with_error_details(self) -> None:
+        error_detail = {
+            "message": "message",
+            "some_nested_obj": {
+                "some_nested_key": "some_nested_value",
+                "some_array": ["some_array"],
+                "int": 203,
+            },
+        }
+
+        data = NewGenericNotificationMessage(
+            composite_key=self.composite_key,
+            error_code=405,
+            error_details=error_detail,
+        )
+
+        result = self.repository.create_notification_message(data=data)
+        assert result is not None
+        assert result.error_details == error_detail

--- a/tests/sentry/integrations/repository/generic/test_new_generic_notification_message.py
+++ b/tests/sentry/integrations/repository/generic/test_new_generic_notification_message.py
@@ -1,0 +1,69 @@
+import pytest
+
+from sentry.integrations.repository.base import MessageIdentifierWithErrorValidationError
+from sentry.integrations.repository.generic import (
+    CompositeKeyValidationError,
+    NewGenericNotificationMessage,
+)
+
+
+class TestGetValidationError:
+    @classmethod
+    def _raises_error_for_obj(
+        cls, obj: NewGenericNotificationMessage, expected_error: type[Exception]
+    ) -> None:
+        error = obj.get_validation_error()
+        assert error is not None
+        with pytest.raises(expected_error):
+            raise error
+
+    def test_returns_error_when_message_identifier_has_error_code(self) -> None:
+        obj = NewGenericNotificationMessage(
+            message_identifier="abc",
+            error_code=400,
+        )
+        self._raises_error_for_obj(obj, MessageIdentifierWithErrorValidationError)
+
+    def test_returns_error_when_message_identifier_has_error_details(self) -> None:
+        obj = NewGenericNotificationMessage(
+            message_identifier="abc",
+            error_details={"some_key": 123},
+        )
+        self._raises_error_for_obj(obj, MessageIdentifierWithErrorValidationError)
+
+    def test_returns_error_when_message_identifier_has_error(self) -> None:
+        obj = NewGenericNotificationMessage(
+            message_identifier="abc",
+            error_code=400,
+            error_details={"some_key": 123},
+        )
+        self._raises_error_for_obj(obj, MessageIdentifierWithErrorValidationError)
+
+    def test_returns_error_when_composite_key_is_missing(self) -> None:
+        obj = NewGenericNotificationMessage(
+            message_identifier="abc",
+            group_id=123,
+        )
+        self._raises_error_for_obj(obj, CompositeKeyValidationError)
+
+    def test_returns_error_when_message_identifier_does_not_have_trigger_action(self) -> None:
+        obj = NewGenericNotificationMessage(
+            message_identifier="abc",
+            group_id=123,
+        )
+        self._raises_error_for_obj(obj, CompositeKeyValidationError)
+
+    def test_simple_without_group_id(self) -> None:
+        obj = NewGenericNotificationMessage(
+            composite_key="abc",
+        )
+        error = obj.get_validation_error()
+        assert error is None
+
+    def test_simple_with_group_id(self) -> None:
+        obj = NewGenericNotificationMessage(
+            composite_key="abc",
+            group_id=123,
+        )
+        error = obj.get_validation_error()
+        assert error is None

--- a/tests/sentry/integrations/slack/service/test_slack_service_generic.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service_generic.py
@@ -1,0 +1,360 @@
+from datetime import datetime
+from unittest import mock
+from uuid import uuid4
+
+import orjson
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from sentry.integrations.repository.generic import GenericNotificationMessage
+from sentry.integrations.slack.sdk_client import SlackSdkClient
+from sentry.integrations.slack.service import RuleDataError, SlackService
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.models.activity import Activity
+from sentry.models.options.organization_option import OrganizationOption
+from sentry.notifications.models.notificationmessage import NotificationMessage
+from sentry.silo.base import SiloMode
+from sentry.testutils.asserts import assert_slo_metric
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.types.activity import ActivityType
+
+
+class TestGetNotificationMessageToSendGeneric(TestCase):
+    def setUp(self) -> None:
+        self.service = SlackService.default()
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_ignores_unsupported_activity(self) -> None:
+        activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.FIRST_SEEN.value,
+            user_id=self.user.id,
+            data={},
+        )
+        result = self.service._get_notification_message_to_send(activity=activity)
+        assert result is None
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_simple(self) -> None:
+        activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.SET_IGNORED.value,
+            user_id=self.user.id,
+            data={"ignoreUntilEscalating": True},
+        )
+        result = self.service._get_notification_message_to_send(activity=activity)
+        assert result == "admin@localhost archived BAR-1"
+
+
+class TestNotifyAllThreadsForActivity(TestCase):
+    def setUp(self) -> None:
+        self.service = SlackService.default()
+        self.activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.SET_IGNORED.value,
+            user_id=self.user.id,
+            data={"ignoreUntilEscalating": True},
+        )
+
+        self.rule_action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.rule_action_uuid,
+            }
+        ]
+        self.rule = self.create_project_rule(
+            project=self.project, action_data=self.notify_issue_owners_action
+        )
+
+        self.parent_notification = NotificationMessage.objects.create(
+            composite_key=f"{self.rule.id}:{self.group.id}:{self.rule_action_uuid}",
+            group_id=self.group.id,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="slack",
+                provider="slack",
+                external_id="slack:1",
+                metadata={"access_token": "xoxb-access-token"},
+            )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_none_group(self):
+        self.activity.update(group=None)
+
+        with mock.patch.object(self.service, "_logger") as mock_logger:
+            self.service.notify_all_threads_for_activity(activity=self.activity)
+            mock_logger.info.assert_called_with(
+                "no group associated on the activity, nothing to do",
+                extra={"activity_id": self.activity.id},
+            )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_none_user_id(self):
+        self.activity.update(user_id=None)
+
+        with mock.patch.object(self.service, "_logger") as mock_logger:
+            self.service.notify_all_threads_for_activity(activity=self.activity)
+            mock_logger.info.assert_called_with(
+                "machine/system updates are ignored at this time, nothing to do",
+                extra={"activity_id": self.activity.id},
+            )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_disabled_option(self):
+        OrganizationOption.objects.set_value(
+            self.organization, "sentry:issue_alerts_thread_flag", False
+        )
+
+        with mock.patch.object(self.service, "_logger") as mock_logger:
+            self.service.notify_all_threads_for_activity(activity=self.activity)
+            mock_logger.info.assert_called_with(
+                "feature is turned off for this organization",
+                extra={
+                    "activity_id": self.activity.id,
+                    "organization_id": self.organization.id,
+                    "project_id": self.activity.project.id,
+                },
+            )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_no_message_to_send(self):
+        # unsupported activity
+        self.activity.update(type=ActivityType.FIRST_SEEN.value)
+
+        with mock.patch.object(self.service, "_logger") as mock_logger:
+            self.service.notify_all_threads_for_activity(activity=self.activity)
+            mock_logger.info.assert_called_with(
+                "notification to send is invalid", extra={"activity_id": self.activity.id}
+            )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    def test_no_integration(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.delete()
+
+        with mock.patch.object(self.service, "_logger") as mock_logger:
+            self.service.notify_all_threads_for_activity(activity=self.activity)
+            mock_logger.info.assert_called_with(
+                "no integration found for activity",
+                extra={
+                    "activity_id": self.activity.id,
+                    "organization_id": self.organization.id,
+                    "project_id": self.activity.project.id,
+                },
+            )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    @mock.patch("sentry.integrations.slack.service.SlackService._handle_parent_notification")
+    def test_no_parent_notification(self, mock_handle):
+        self.parent_notification.delete()
+        self.service.notify_all_threads_for_activity(activity=self.activity)
+        assert not mock_handle.called
+
+    @with_feature("organizations:generic-notification-message-repository")
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch(
+        "sentry.integrations.slack.service.SlackService._handle_parent_notification_generic"
+    )
+    def test_calls_handle_parent_notification_sdk_client(self, mock_handle, mock_record):
+        parent_notification = GenericNotificationMessage.from_model(
+            instance=self.parent_notification
+        )
+        self.service.notify_all_threads_for_activity(activity=self.activity)
+
+        mock_handle.assert_called()
+        assert mock_handle.call_args.kwargs["parent_notification"] == parent_notification
+
+        # check client type
+        assert isinstance(mock_handle.call_args.kwargs["client"], SlackSdkClient)
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+
+
+class TestHandleParentNotification(TestCase):
+    def setUp(self) -> None:
+        """
+        Setup default and reusable testing data or objects
+        """
+        self.service = SlackService.default()
+
+        self.rule_action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.rule_action_uuid,
+            }
+        ]
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="slack",
+                provider="slack",
+                external_id="slack:1",
+                metadata={"access_token": "xoxb-access-token"},
+            )
+        self.slack_action = {
+            "workspace": str(self.integration.id),
+            "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+            "channel_id": "C0123456789",
+            "tags": "",
+            "channel": "test-notifications",
+            "uuid": self.rule_action_uuid,
+        }
+        self.rule = self.create_project_rule(
+            project=self.project, action_data=self.notify_issue_owners_action
+        )
+
+        self.slack_rule = self.create_project_rule(
+            project=self.project, action_data=[self.slack_action]
+        )
+        self.parent_notification = GenericNotificationMessage(
+            id=123,
+            date_added=datetime.now(),
+            message_identifier="1a2s3d",
+            composite_key=f"{self.slack_rule.id}:{self.group.id}:{self.rule_action_uuid}",
+            group_id=self.group.id,
+        )
+
+    @with_feature("organizations:generic-notification-message-repository")
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_handles_parent_notification_sdk(self, mock_api_call, mock_record):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+        self.service._handle_parent_notification_generic(
+            parent_notification=self.parent_notification,
+            notification_to_send="hello",
+            client=SlackSdkClient(integration_id=self.integration.id),
+        )
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_handles_parent_notification_sdk_error(
+        self,
+        mock_record,
+    ) -> None:
+        with pytest.raises(SlackApiError):
+            self.service._handle_parent_notification_generic(
+                parent_notification=self.parent_notification,
+                notification_to_send="hello",
+                client=SlackSdkClient(integration_id=self.integration.id),
+            )
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
+
+    def test_raises_exception_when_parent_notification_does_not_have_rule_fire_history_data(
+        self,
+    ) -> None:
+        """
+        Purposefully create a domain object that does not have rule_fire_history
+        """
+        parent_notification = GenericNotificationMessage(
+            id=123,
+            date_added=datetime.now(),
+            message_identifier="1a2s3d",
+            composite_key=f"{self.rule.id}:{self.group.id}:{self.rule_action_uuid}",
+            group_id=self.group.id,
+        )
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification_generic(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"parent notification {parent_notification.id} does not have a rule_fire_history"
+            )
+
+    def test_raises_exception_when_parent_notification_does_not_have_rule_action_uuid(self) -> None:
+        """
+        Purposefully create a domain object that does not have the rule_action_uuid
+        """
+        parent_notification = GenericNotificationMessage(
+            id=123,
+            date_added=datetime.now(),
+            message_identifier="1a2s3d",
+            composite_key=f"{self.rule.id}:{self.group.id}:{self.rule_action_uuid}",
+            group_id=self.group.id,
+        )
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification_generic(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"parent notification {parent_notification.id} does not have a rule_action_uuid"
+            )
+
+    def test_raises_exception_when_rule_action_does_not_exist(self) -> None:
+        """
+        Purposefully create a mismatch between the rule action uuid so that it does not exist
+        """
+        notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": (uuid4()),
+            }
+        ]
+        rule = self.create_project_rule(
+            project=self.project, action_data=notify_issue_owners_action
+        )
+
+        fake_rule_action_uuid = str(uuid4())
+        parent_notification_message = NotificationMessage.objects.create(
+            composite_key=f"{rule.id}:{self.group.id}:{fake_rule_action_uuid}",
+            group_id=self.group.id,
+            message_identifier="123abc",
+        )
+        parent_notification = GenericNotificationMessage.from_model(parent_notification_message)
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification_generic(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"failed to find rule action {fake_rule_action_uuid} for rule {rule.id}"
+            )
+
+    def test_raises_exception_when_rule_action_does_not_have_channel_id(self) -> None:
+        parent_notification_message = NotificationMessage.objects.create(
+            composite_key=f"{self.rule.id}:{self.group.id}:{self.rule_action_uuid}",
+            group_id=self.group.id,
+            message_identifier="123abc",
+        )
+        parent_notification = GenericNotificationMessage.from_model(parent_notification_message)
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification_generic(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"failed to get channel_id for rule {self.rule.id} and rule action {self.rule_action_uuid}"
+            )


### PR DESCRIPTION
This spike is to figure out if we can refactor our Slack Threading logic such that it is model agnostic.

This was done for 2 reasons:
1. Currently Uptime threading isn't a good product experience. Because we maintain a single thread for multiple "open periods," we are currently threading is a single thread repeatedly.
	- This is because Uptime Issues use Issue Alert logic and we use `group_id`, `rule_id`, and `rule_action_uuid` to find a thread and because the group doesn't change, the thread doesn't either.
3. ACI Project's Notification Action has to rebuild existing notification related models because they are used as FK in the slack threading logic.

Here are my findings:
Yes its possible. I introduced a `composite_key`, which is flexible and allows the callee to determine how they would like their threading behavior to work.


Unfortunately, I couldn't completely remove the dependency on Rule and RuleFireHistory. This is because Workflow notifications basically lookup the channel_id by multiple lookups to notify all threads of a GroupActivity.

This is also the reason I had to add a "group_id` field. Without it, the lookup to find all relevant threads for a particular group would require me to do a str LIKE comparison which would be slow.