### PR TITLE
feat(uptime): Add list uptime alerts endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -315,6 +315,9 @@ from sentry.sentry_apps.api.endpoints.sentry_internal_app_tokens import (
 )
 from sentry.tempest.endpoints.tempest_credentials import TempestCredentialsEndpoint
 from sentry.tempest.endpoints.tempest_credentials_details import TempestCredentialsDetailsEndpoint
+from sentry.uptime.endpoints.organiation_uptime_alert_index import (
+    OrganizationUptimeAlertIndexEndpoint,
+)
 from sentry.uptime.endpoints.project_uptime_alert_details import ProjectUptimeAlertDetailsEndpoint
 from sentry.uptime.endpoints.project_uptime_alert_index import ProjectUptimeAlertIndexEndpoint
 from sentry.users.api.endpoints.authenticator_index import AuthenticatorIndexEndpoint
@@ -2198,6 +2201,12 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/fork/$",
         OrganizationForkEndpoint.as_view(),
         name="sentry-api-0-organization-fork",
+    ),
+    # Uptime
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/uptime/$",
+        OrganizationUptimeAlertIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-uptime-alert-index",
     ),
 ]
 

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -418,6 +418,13 @@ class UptimeParams:
         type=int,
         description="The ID of the uptime alert rule you'd like to query.",
     )
+    OWNER = OpenApiParameter(
+        name="owner",
+        location="query",
+        required=False,
+        type=str,
+        description="The owner of the uptime alert, in the format `user:id` or `team:id`. May be specified multiple times.",
+    )
 
 
 class EventParams:

--- a/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
@@ -1,0 +1,120 @@
+from django.db.models import Q
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.helpers.teams import get_teams
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, OrganizationParams, UptimeParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.db.models.query import in_iexact
+from sentry.models.organization import Organization
+from sentry.search.utils import tokenize_query
+from sentry.types.actor import Actor
+from sentry.uptime.endpoints.serializers import (
+    ProjectUptimeSubscriptionSerializer,
+    ProjectUptimeSubscriptionSerializerResponse,
+)
+from sentry.uptime.models import ProjectUptimeSubscription
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Crons"])
+class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.CRONS
+    permission_classes = (OrganizationPermission,)
+
+    @extend_schema(
+        operation_id="Retrieve Uptime Alets for an Organization",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OrganizationParams.PROJECT,
+            GlobalParams.ENVIRONMENT,
+            UptimeParams.OWNER,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "UptimeAlertList", list[ProjectUptimeSubscriptionSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Lists uptime alerts. May be filtered to a project or environment.
+        """
+        try:
+            filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
+        except NoProjects:
+            return self.respond([])
+
+        queryset = ProjectUptimeSubscription.objects.filter(
+            project__organization_id=organization.id, project_id__in=filter_params["project_id"]
+        )
+        query = request.GET.get("query")
+        owners = request.GET.getlist("owner")
+
+        if "environment" in filter_params:
+            queryset = queryset.filter(environment__in=filter_params["environment_objects"])
+
+        if owners:
+            owners_set = set(owners)
+
+            # Remove special values from owners, this can't be parsed as an Actor
+            include_myteams = "myteams" in owners_set
+            owners_set.discard("myteams")
+            include_unassigned = "unassigned" in owners_set
+            owners_set.discard("unassigned")
+
+            actors = [Actor.from_identifier(identifier) for identifier in owners_set]
+
+            user_ids = [actor.id for actor in actors if actor.is_user]
+            team_ids = [actor.id for actor in actors if actor.is_team]
+
+            teams = get_teams(
+                request,
+                organization,
+                teams=[*team_ids, *(["myteams"] if include_myteams else [])],
+            )
+            team_ids = [team.id for team in teams]
+
+            owner_filter = Q(owner_user_id__in=user_ids) | Q(owner_team_id__in=team_ids)
+
+            if include_unassigned:
+                unassigned_filter = Q(owner_user_id=None) & Q(owner_team_id=None)
+                queryset = queryset.filter(unassigned_filter | owner_filter)
+            else:
+                queryset = queryset.filter(owner_filter)
+
+        if query:
+            tokens = tokenize_query(query)
+            for key, value in tokens.items():
+                if key == "query":
+                    query_value = " ".join(value)
+                    queryset = queryset.filter(
+                        Q(name__icontains=query_value)
+                        | Q(uptime_subscription__url__icontains=query_value)
+                    )
+                elif key == "name":
+                    queryset = queryset.filter(in_iexact("name", value))
+                else:
+                    queryset = queryset.none()
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            on_results=lambda x: serialize(x, request.user, ProjectUptimeSubscriptionSerializer()),
+            paginator_cls=OffsetPaginator,
+        )

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
@@ -1,0 +1,81 @@
+from sentry.api.serializers import serialize
+from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
+
+
+class OrganizationUptimeAlertIndexBaseEndpointTest(UptimeAlertBaseEndpointTest):
+    endpoint = "sentry-api-0-organization-uptime-alert-index"
+
+
+class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseEndpointTest):
+    method = "get"
+
+    def check_valid_response(self, response, expected_alerts):
+        assert [serialize(uptime_alert) for uptime_alert in expected_alerts] == response.data
+
+    def test(self):
+        alert_1 = self.create_project_uptime_subscription(name="test1")
+        alert_2 = self.create_project_uptime_subscription(name="test2")
+        resp = self.get_success_response(self.organization.slug)
+        self.check_valid_response(resp, [alert_1, alert_2])
+
+    def test_search_by_url(self):
+        self.create_project_uptime_subscription()
+        santry_monitor = self.create_project_uptime_subscription(
+            uptime_subscription=self.create_uptime_subscription(url="https://santry.com")
+        )
+
+        response = self.get_success_response(self.organization.slug, query="santry")
+        self.check_valid_response(response, [santry_monitor])
+
+    def test_environment_filter(self):
+        env = self.create_environment()
+        self.create_project_uptime_subscription()
+        env_monitor = self.create_project_uptime_subscription(env=env)
+
+        response = self.get_success_response(self.organization.slug, environment=[env.name])
+        self.check_valid_response(response, [env_monitor])
+
+    def test_owner_filter(self):
+        user_1 = self.create_user()
+        user_2 = self.create_user()
+        team_1 = self.create_team()
+        team_2 = self.create_team()
+        self.create_team_membership(team_2, user=self.user)
+
+        uptime_a = self.create_project_uptime_subscription(owner=user_1)
+        uptime_b = self.create_project_uptime_subscription(owner=user_2)
+        uptime_c = self.create_project_uptime_subscription(owner=team_1)
+        uptime_d = self.create_project_uptime_subscription(owner=team_2)
+        uptime_e = self.create_project_uptime_subscription(owner=None)
+
+        # Monitor by user
+        response = self.get_success_response(self.organization.slug, owner=[f"user:{user_1.id}"])
+        self.check_valid_response(response, [uptime_a])
+
+        # Monitors by users and teams
+        response = self.get_success_response(
+            self.organization.slug,
+            owner=[f"user:{user_1.id}", f"user:{user_2.id}", f"team:{team_1.id}"],
+        )
+        self.check_valid_response(response, [uptime_a, uptime_b, uptime_c])
+
+        # myteams
+        response = self.get_success_response(
+            self.organization.slug,
+            owner=["myteams"],
+        )
+        self.check_valid_response(response, [uptime_d])
+
+        # unassigned monitors
+        response = self.get_success_response(
+            self.organization.slug,
+            owner=["unassigned", f"user:{user_1.id}"],
+        )
+        self.check_valid_response(response, [uptime_a, uptime_e])
+
+        # Invalid user ID
+        response = self.get_success_response(
+            self.organization.slug,
+            owner=["user:12345"],
+        )
+        self.check_valid_response(response, [])


### PR DESCRIPTION
Adds an endpoint to list all uptime alerts for an organization. Supports typical project / environment filtering as well as some querying of URL / name