### PR TITLE
ref(issue-views): Overhaul issue views state and logic to a new context 

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -23,7 +23,6 @@ import {motion, Reorder} from 'framer-motion';
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import DropdownButton from 'sentry/components/dropdownButton';
-import {TabsContext} from 'sentry/components/tabs';
 import {type BaseTabProps, Tab} from 'sentry/components/tabs/tab';
 import {IconAdd, IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -34,6 +33,7 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {useDimensionsMultiple} from 'sentry/utils/useDimensionsMultiple';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {IssueViewsContext} from 'sentry/views/issueList/utils/issueViews';
 
 import type {DraggableTabListItemProps} from './item';
 import {Item} from './item';
@@ -273,7 +273,7 @@ function BaseDraggableTabList({
 }: BaseDraggableTabListProps) {
   const navigate = useNavigate();
   const [hoveringKey, setHoveringKey] = useState<Key | null>(null);
-  const {rootProps, setTabListState} = useContext(TabsContext);
+  const {rootProps, setTabListState} = useContext(IssueViewsContext);
   const organization = useOrganization();
   const {
     value,

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -33,7 +33,7 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {useDimensionsMultiple} from 'sentry/utils/useDimensionsMultiple';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {IssueViewsContext} from 'sentry/views/issueList/utils/issueViews';
+import {IssueViewsContext} from 'sentry/views/issueList/groupSearchViewTabs/issueViews';
 
 import type {DraggableTabListItemProps} from './item';
 import {Item} from './item';

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -47,7 +47,7 @@ export interface TabsProps<T>
   value?: T;
 }
 
-interface TabContext {
+export interface TabContext {
   rootProps: Omit<TabsProps<any>, 'children' | 'className'>;
   setTabListState: (state: TabListState<any>) => void;
   tabListState?: TabListState<any>;

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -1,6 +1,5 @@
-import {useContext, useEffect, useMemo, useState} from 'react';
+import {useCallback, useContext, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
-import debounce from 'lodash/debounce';
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -9,7 +8,6 @@ import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingA
 import * as Layout from 'sentry/components/layouts/thirds';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import {Tabs, TabsContext} from 'sentry/components/tabs';
 import {IconMegaphone, IconPause, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -17,19 +15,18 @@ import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {
-  DraggableTabBar,
-  type Tab,
-} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabBar';
-import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import {DraggableTabBar} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabBar';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {UpdateGroupSearchViewPayload} from 'sentry/views/issueList/types';
+import {
+  type IssueView,
+  IssueViews,
+  IssueViewsContext,
+} from 'sentry/views/issueList/utils/issueViews';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 
 import {IssueSortOptions} from './utils';
@@ -45,7 +42,13 @@ type CustomViewsIssueListHeaderProps = {
 type CustomViewsIssueListHeaderTabsContentProps = {
   organization: Organization;
   router: InjectedRouter;
-  views: UpdateGroupSearchViewPayload[];
+  // views: UpdateGroupSearchViewPayload[];
+};
+
+type CustomViewsQueryParams = {
+  query?: string;
+  sort?: IssueSortOptions;
+  viewId?: string;
 };
 
 function CustomViewsIssueListHeader({
@@ -59,6 +62,8 @@ function CustomViewsIssueListHeader({
     selectedProjectIds.includes(Number(id))
   );
 
+  const {newViewActive} = useContext(NewTabContext);
+
   const {data: groupSearchViews} = useFetchGroupSearchViews({
     orgSlug: props.organization.slug,
   });
@@ -66,8 +71,6 @@ function CustomViewsIssueListHeader({
   const realtimeTitle = realtimeActive
     ? t('Pause real-time updates')
     : t('Enable real-time updates');
-
-  const {newViewActive} = useContext(NewTabContext);
 
   const openForm = useFeedbackForm();
   const hasNewLayout = props.organization.features.includes('issue-stream-table-layout');
@@ -127,9 +130,28 @@ function CustomViewsIssueListHeader({
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
       {groupSearchViews ? (
-        <StyledTabs>
-          <CustomViewsIssueListHeaderTabsContent {...props} views={groupSearchViews} />
-        </StyledTabs>
+        <StyledIssueViews
+          router={props.router}
+          initialViews={groupSearchViews.map(
+            (
+              {id, name, query: viewQuery, querySort: viewQuerySort},
+              index
+            ): IssueView => {
+              const tabId = id ?? `default${index.toString()}`;
+
+              return {
+                id: tabId,
+                key: tabId,
+                label: name,
+                query: viewQuery,
+                querySort: viewQuerySort,
+                isCommitted: true,
+              };
+            }
+          )}
+        >
+          <CustomViewsIssueListHeaderTabsContent {...props} />
+        </StyledIssueViews>
       ) : (
         <div style={{height: 33}} />
       )}
@@ -140,19 +162,19 @@ function CustomViewsIssueListHeader({
 function CustomViewsIssueListHeaderTabsContent({
   organization,
   router,
-  views,
 }: CustomViewsIssueListHeaderTabsContentProps) {
-  // TODO(msun): Possible replace navigate with useSearchParams() in the future?
   const navigate = useNavigate();
   const location = useLocation();
-  const {setNewViewActive, newViewActive} = useContext(NewTabContext);
   const pageFilters = usePageFilters();
+
+  const {newViewActive, setNewViewActive} = useContext(NewTabContext);
+  const {tabListState, state, dispatch} = useContext(IssueViewsContext);
+
+  const {views: draggableTabs} = state;
 
   // TODO(msun): Use the location from useLocation instead of props router in the future
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location.query;
-
   const {query, sort, viewId, project, environment} = queryParams;
-
   const queryParamsWithPageFilters = useMemo(() => {
     return {
       ...queryParams,
@@ -169,72 +191,20 @@ function CustomViewsIssueListHeaderTabsContent({
     queryParams,
   ]);
 
-  const [draggableTabs, setDraggableTabs] = useState<Tab[]>(
-    views.map(({id, name, query: viewQuery, querySort: viewQuerySort}, index): Tab => {
-      const tabId = id ?? `default${index.toString()}`;
-
-      return {
-        id: tabId,
-        key: tabId,
-        label: name,
-        query: viewQuery,
-        querySort: viewQuerySort,
-        unsavedChanges: undefined,
-        isCommitted: true,
-      };
-    })
-  );
-
-  const getInitialTabKey = () => {
-    if (viewId && draggableTabs.find(tab => tab.id === viewId)) {
-      return draggableTabs.find(tab => tab.id === viewId)!.key;
-    }
-    if (query) {
-      return TEMPORARY_TAB_KEY;
-    }
-    return draggableTabs[0].key;
-  };
-
-  const {tabListState} = useContext(TabsContext);
-
-  // TODO: Try to remove this state if possible
-  const [tempTab, setTempTab] = useState<Tab | undefined>(
-    getInitialTabKey() === TEMPORARY_TAB_KEY && query
-      ? {
-          id: TEMPORARY_TAB_KEY,
-          key: TEMPORARY_TAB_KEY,
-          label: t('Unsaved'),
-          query,
-          querySort: sort ?? IssueSortOptions.DATE,
-          isCommitted: true,
-        }
-      : undefined
-  );
-
-  const {mutate: updateViews} = useUpdateGroupSearchViews();
-
-  const debounceUpdateViews = useMemo(
-    () =>
-      debounce((newTabs: Tab[]) => {
-        if (newTabs) {
-          updateViews({
-            orgSlug: organization.slug,
-            groupSearchViews: newTabs
-              .filter(tab => tab.isCommitted)
-              .map(tab => ({
-                // Do not send over an ID if it's a temporary or default tab so that
-                // the backend will save these and generate permanent Ids for them
-                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
-                  ? {id: tab.id}
-                  : {}),
-                name: tab.label,
-                query: tab.query,
-                querySort: tab.querySort,
-              })),
-          });
-        }
-      }, 500),
-    [organization.slug, updateViews]
+  const updateQueryParams = useCallback(
+    (newQueryParams: CustomViewsQueryParams, replace: boolean = false) => {
+      navigate(
+        normalizeUrl({
+          ...location,
+          query: {
+            ...queryParamsWithPageFilters,
+            ...newQueryParams,
+          },
+        }),
+        {replace: replace}
+      );
+    },
+    [navigate, location, queryParamsWithPageFilters]
   );
 
   // This insane useEffect ensures that the correct tab is selected when the url updates
@@ -275,30 +245,14 @@ function CustomViewsIssueListHeaderTabsContent({
         ) {
           // If there were no unsaved changes before, or the existing unsaved changes
           // don't match the new query and/or sort, update the unsaved changes
-          setDraggableTabs(
-            draggableTabs.map(tab =>
-              tab.key === selectedTab.key
-                ? {
-                    ...tab,
-                    unsavedChanges: newUnsavedChanges,
-                  }
-                : tab
-            )
-          );
+          dispatch({
+            type: 'UPDATE_UNSAVED_CHANGES',
+            unsavedChanges: newUnsavedChanges,
+          });
         } else if (!newUnsavedChanges && selectedTab.unsavedChanges) {
           // If there are no longer unsaved changes but there were before, remove them
-          setDraggableTabs(
-            draggableTabs.map(tab =>
-              tab.key === selectedTab.key
-                ? {
-                    ...tab,
-                    unsavedChanges: undefined,
-                  }
-                : tab
-            )
-          );
+          dispatch({type: 'UPDATE_UNSAVED_CHANGES', unsavedChanges: undefined});
         }
-
         if (!tabListState?.selectionManager.isSelected(selectedTab.key)) {
           navigate(
             normalizeUrl({
@@ -336,15 +290,7 @@ function CustomViewsIssueListHeaderTabsContent({
     }
     if (query) {
       if (!tabListState?.selectionManager.isSelected(TEMPORARY_TAB_KEY)) {
-        tabListState?.setSelectedKey(TEMPORARY_TAB_KEY);
-        setTempTab({
-          id: TEMPORARY_TAB_KEY,
-          key: TEMPORARY_TAB_KEY,
-          label: t('Unsaved'),
-          query,
-          querySort: sort ?? IssueSortOptions.DATE,
-          isCommitted: true,
-        });
+        dispatch({type: 'SET_TEMP_VIEW', query, sort});
         navigate(
           normalizeUrl({
             ...location,
@@ -355,6 +301,7 @@ function CustomViewsIssueListHeaderTabsContent({
           }),
           {replace: true}
         );
+        tabListState?.setSelectedKey(TEMPORARY_TAB_KEY);
         return;
       }
     }
@@ -369,64 +316,11 @@ function CustomViewsIssueListHeaderTabsContent({
     queryParamsWithPageFilters,
     draggableTabs,
     organization,
+    updateQueryParams,
+    dispatch,
   ]);
 
-  // Update local tabs when new views are received from mutation request
-  useEffectAfterFirstRender(() => {
-    const newlyCreatedViews = views.filter(
-      view => !draggableTabs.find(tab => tab.id === view.id)
-    );
-    const currentView = draggableTabs.find(tab => tab.id === viewId);
-
-    setDraggableTabs(oldDraggableTabs => {
-      const assignedIds = new Set();
-      return oldDraggableTabs.map(tab => {
-        // Temp viewIds are prefixed with '_'
-        if (tab.id && tab.id[0] === '_') {
-          const matchingView = newlyCreatedViews.find(
-            view =>
-              view.id &&
-              !assignedIds.has(view.id) &&
-              tab.query === view.query &&
-              tab.querySort === view.querySort &&
-              tab.label === view.name
-          );
-          if (matchingView?.id) {
-            assignedIds.add(matchingView.id);
-            return {
-              ...tab,
-              id: matchingView.id,
-            };
-          }
-        }
-        return tab;
-      });
-    });
-
-    if (viewId?.startsWith('_') && currentView) {
-      const matchingView = newlyCreatedViews.find(
-        view =>
-          view.id &&
-          currentView.query === view.query &&
-          currentView.querySort === view.querySort &&
-          currentView.label === view.name
-      );
-      if (matchingView?.id) {
-        navigate(
-          normalizeUrl({
-            ...location,
-            query: {
-              ...queryParamsWithPageFilters,
-              viewId: matchingView.id,
-            },
-          }),
-          {replace: true}
-        );
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [views]);
-
+  // This useEffect ensures the "new view" page is displayed/hidden correctly
   useEffect(() => {
     if (viewId?.startsWith('_')) {
       if (draggableTabs.find(tab => tab.id === viewId)?.isCommitted) {
@@ -437,17 +331,12 @@ function CustomViewsIssueListHeaderTabsContent({
       // and persist the query
       if (newViewActive && query !== '') {
         setNewViewActive(false);
-        const updatedTabs: Tab[] = draggableTabs.map(tab =>
-          tab.id === viewId
-            ? {
-                ...tab,
-                unsavedChanges: [query, sort ?? IssueSortOptions.DATE],
-                isCommitted: true,
-              }
-            : tab
-        );
-        setDraggableTabs(updatedTabs);
-        debounceUpdateViews(updatedTabs);
+        dispatch({
+          type: 'UPDATE_UNSAVED_CHANGES',
+          unsavedChanges: [query, sort ?? IssueSortOptions.DATE],
+          isCommitted: true,
+          syncViews: true,
+        });
         trackAnalytics('issue_views.add_view.custom_query_saved', {
           organization,
           query,
@@ -461,29 +350,22 @@ function CustomViewsIssueListHeaderTabsContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewId, query]);
 
+  const initialTabKey =
+    viewId && draggableTabs.find(tab => tab.id === viewId)
+      ? draggableTabs.find(tab => tab.id === viewId)!.key
+      : query
+        ? TEMPORARY_TAB_KEY
+        : draggableTabs[0].key;
+
   return (
-    <DraggableTabBar
-      initialTabKey={getInitialTabKey()}
-      tabs={draggableTabs}
-      setTabs={setDraggableTabs}
-      tempTab={tempTab}
-      setTempTab={setTempTab}
-      orgSlug={organization.slug}
-      onReorder={debounceUpdateViews}
-      onAddView={debounceUpdateViews}
-      onDelete={debounceUpdateViews}
-      onDuplicate={debounceUpdateViews}
-      onTabRenamed={newTabs => debounceUpdateViews(newTabs)}
-      onSave={debounceUpdateViews}
-      onSaveTempView={debounceUpdateViews}
-      router={router}
-    />
+    // TODO(msun): look into possibly folding the DraggableTabBar component into this component
+    <DraggableTabBar initialTabKey={initialTabKey} router={router} />
   );
 }
 
 export default CustomViewsIssueListHeader;
 
-const StyledTabs = styled(Tabs)`
+const StyledIssueViews = styled(IssueViews)`
   grid-column: 1 / -1;
 `;
 

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -21,12 +21,12 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {DraggableTabBar} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabBar';
-import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {
   type IssueView,
   IssueViews,
   IssueViewsContext,
-} from 'sentry/views/issueList/utils/issueViews';
+} from 'sentry/views/issueList/groupSearchViewTabs/issueViews';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 
 import {IssueSortOptions} from './utils';

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useContext, useEffect, useMemo} from 'react';
+import {useContext, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -42,13 +42,6 @@ type CustomViewsIssueListHeaderProps = {
 type CustomViewsIssueListHeaderTabsContentProps = {
   organization: Organization;
   router: InjectedRouter;
-  // views: UpdateGroupSearchViewPayload[];
-};
-
-type CustomViewsQueryParams = {
-  query?: string;
-  sort?: IssueSortOptions;
-  viewId?: string;
 };
 
 function CustomViewsIssueListHeader({
@@ -191,22 +184,6 @@ function CustomViewsIssueListHeaderTabsContent({
     queryParams,
   ]);
 
-  const updateQueryParams = useCallback(
-    (newQueryParams: CustomViewsQueryParams, replace: boolean = false) => {
-      navigate(
-        normalizeUrl({
-          ...location,
-          query: {
-            ...queryParamsWithPageFilters,
-            ...newQueryParams,
-          },
-        }),
-        {replace: replace}
-      );
-    },
-    [navigate, location, queryParamsWithPageFilters]
-  );
-
   // This insane useEffect ensures that the correct tab is selected when the url updates
   useEffect(() => {
     // If no query, sort, or viewId is present, set the first tab as the selected tab, update query accordingly
@@ -316,7 +293,6 @@ function CustomViewsIssueListHeaderTabsContent({
     queryParamsWithPageFilters,
     draggableTabs,
     organization,
-    updateQueryParams,
     dispatch,
   ]);
 

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -12,11 +12,8 @@ import {
 } from 'sentry/components/draggableTabs/draggableTabList';
 import type {DraggableTabListItemProps} from 'sentry/components/draggableTabs/item';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
-import {TabsContext} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
-import {defined} from 'sentry/utils';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useHotkeys} from 'sentry/utils/useHotkeys';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -25,97 +22,17 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {DraggableTabMenuButton} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabMenuButton';
 import EditableTabTitle from 'sentry/views/issueList/groupSearchViewTabs/editableTabTitle';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
+import {type IssueView, IssueViewsContext} from 'sentry/views/issueList/utils/issueViews';
 import {NewTabContext, type NewView} from 'sentry/views/issueList/utils/newTabContext';
-
-export interface Tab {
-  id: string;
-  /**
-   * False for tabs that were added view the "Add View" button, but
-   * have not been edited in any way. Only tabs with isCommitted=true
-   * will be saved to the backend.
-   */
-  isCommitted: boolean;
-  key: string;
-  label: string;
-  query: string;
-  querySort: IssueSortOptions;
-  content?: React.ReactNode;
-  unsavedChanges?: [string, IssueSortOptions];
-}
 
 export interface DraggableTabBarProps {
   initialTabKey: string;
-  orgSlug: string;
   router: InjectedRouter;
-  setTabs: (tabs: Tab[]) => void;
-  setTempTab: (tab: Tab | undefined) => void;
-  tabs: Tab[];
-  /**
-   * Callback function to be called when user clicks the `Add View` button.
-   */
-  onAddView?: (newTabs: Tab[]) => void;
-  /**
-   * Callback function to be called when user clicks the `Delete` button.
-   * Note: The `Delete` button only appears for persistent views
-   */
-  onDelete?: (newTabs: Tab[]) => void;
-  /**
-   * Callback function to be called when user clicks on the `Discard Changes` button.
-   * Note: The `Discard Changes` button only appears for persistent views when `isChanged=true`
-   */
-  onDiscard?: () => void;
-  /**
-   * Callback function to be called when user clicks on the `Discard` button for temporary views.
-   * Note: The `Discard` button only appears for temporary views
-   */
-  onDiscardTempView?: () => void;
-  /**
-   * Callback function to be called when user clicks the 'Duplicate' button.
-   * Note: The `Duplicate` button only appears for persistent views
-   */
-  onDuplicate?: (newTabs: Tab[]) => void;
-  /**
-   * Callback function to be called when the user reorders the tabs. Returns the
-   * new order of the tabs along with their props.
-   */
-  onReorder?: (newTabs: Tab[]) => void;
-  /**
-   * Callback function to be called when user clicks the 'Save' button.
-   * Note: The `Save` button only appears for persistent views when `isChanged=true`
-   */
-  onSave?: (newTabs: Tab[]) => void;
-  /**
-   * Callback function to be called when user clicks the 'Save View' button for temporary views.
-   */
-  onSaveTempView?: (newTabs: Tab[]) => void;
-  /**
-   * Callback function to be called when user renames a tab.
-   * Note: The `Rename` button only appears for persistent views
-   */
-  onTabRenamed?: (newTabs: Tab[], newLabel: string) => void;
-  tempTab?: Tab;
 }
 
 export const generateTempViewId = () => `_${Math.random().toString().substring(2, 7)}`;
 
-export function DraggableTabBar({
-  initialTabKey,
-  tabs,
-  setTabs,
-  tempTab,
-  setTempTab,
-  orgSlug,
-  router,
-  onReorder,
-  onAddView,
-  onDelete,
-  onDiscard,
-  onDuplicate,
-  onTabRenamed,
-  onSave,
-  onDiscardTempView,
-  onSaveTempView,
-}: DraggableTabBarProps) {
+export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
   // TODO: Extract this to a separate component encompassing Tab.Item in the future
   const [editingTabKey, setEditingTabKey] = useState<string | null>(null);
 
@@ -126,42 +43,9 @@ export function DraggableTabBar({
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location?.query ?? {};
   const {viewId} = queryParams;
 
-  const {tabListState} = useContext(TabsContext);
   const {setNewViewActive, setOnNewViewsSaved} = useContext(NewTabContext);
-
-  const handleOnReorder = (newOrder: Node<DraggableTabListItemProps>[]) => {
-    const newTabs: Tab[] = newOrder
-      .map(node => {
-        const foundTab = tabs.find(tab => tab.key === node.key);
-        return foundTab?.key === node.key ? foundTab : null;
-      })
-      .filter(defined);
-    setTabs(newTabs);
-    trackAnalytics('issue_views.reordered_views', {
-      organization,
-    });
-  };
-
-  const handleOnSaveChanges = useCallback(() => {
-    const originalTab = tabs.find(tab => tab.key === tabListState?.selectedKey);
-    if (originalTab) {
-      const newTabs: Tab[] = tabs.map(tab => {
-        return tab.key === tabListState?.selectedKey && tab.unsavedChanges
-          ? {
-              ...tab,
-              query: tab.unsavedChanges[0],
-              querySort: tab.unsavedChanges[1],
-              unsavedChanges: undefined,
-            }
-          : tab;
-      });
-      setTabs(newTabs);
-      onSave?.(newTabs);
-      trackAnalytics('issue_views.saved_changes', {
-        organization,
-      });
-    }
-  }, [onSave, organization, setTabs, tabListState?.selectedKey, tabs]);
+  const {tabListState, state, dispatch} = useContext(IssueViewsContext);
+  const {views: tabs, tempView: tempTab} = state;
 
   useHotkeys(
     [
@@ -170,173 +54,48 @@ export function DraggableTabBar({
         includeInputs: true,
         callback: () => {
           if (tabs.find(tab => tab.key === tabListState?.selectedKey)?.unsavedChanges) {
-            handleOnSaveChanges();
+            dispatch({type: 'SAVE_CHANGES'});
             addSuccessMessage(t('Changes saved to view'));
           }
         },
       },
     ],
-    [handleOnSaveChanges, tabListState?.selectedKey, tabs]
+    [dispatch, tabListState?.selectedKey, tabs]
   );
 
-  const handleOnDiscardChanges = () => {
-    const originalTab = tabs.find(tab => tab.key === tabListState?.selectedKey);
+  const handleDuplicateView = () => {
+    const newViewId = generateTempViewId();
+    const duplicatedTab = state.views.find(
+      view => view.key === tabListState?.selectedKey
+    );
+    if (!duplicatedTab) {
+      return;
+    }
+    dispatch({type: 'DUPLICATE_VIEW', newViewId});
+    navigate({
+      ...location,
+      query: {
+        ...queryParams,
+        query: duplicatedTab.query,
+        sort: duplicatedTab.querySort,
+        viewId: newViewId,
+      },
+    });
+  };
+
+  const handleDiscardChanges = () => {
+    dispatch({type: 'DISCARD_CHANGES'});
+    const originalTab = state.views.find(view => view.key === tabListState?.selectedKey);
     if (originalTab) {
-      setTabs(
-        tabs.map(tab => {
-          return tab.key === tabListState?.selectedKey
-            ? {...tab, unsavedChanges: undefined}
-            : tab;
-        })
-      );
+      // TODO(msun): Move navigate logic to IssueViewsContext
       navigate({
         ...location,
         query: {
           ...queryParams,
           query: originalTab.query,
           sort: originalTab.querySort,
-          ...(originalTab.id ? {viewId: originalTab.id} : {}),
+          viewId: originalTab.id,
         },
-      });
-      onDiscard?.();
-      trackAnalytics('issue_views.discarded_changes', {
-        organization,
-      });
-    }
-  };
-
-  const handleOnTabRenamed = (newLabel: string, tabKey: string) => {
-    const renamedTab = tabs.find(tb => tb.key === tabKey);
-    if (renamedTab && newLabel !== renamedTab.label) {
-      const newTabs = tabs.map(tab =>
-        tab.key === renamedTab.key ? {...tab, label: newLabel, isCommitted: true} : tab
-      );
-      setTabs(newTabs);
-      onTabRenamed?.(newTabs, newLabel);
-      trackAnalytics('issue_views.renamed_view', {
-        organization,
-      });
-    }
-  };
-
-  const handleOnDuplicate = () => {
-    const idx = tabs.findIndex(tb => tb.key === tabListState?.selectedKey);
-    if (idx !== -1) {
-      const tempId = generateTempViewId();
-      const duplicatedTab = tabs[idx];
-      const newTabs: Tab[] = [
-        ...tabs.slice(0, idx + 1),
-        {
-          ...duplicatedTab,
-          id: tempId,
-          key: tempId,
-          label: `${duplicatedTab.label} (Copy)`,
-          isCommitted: true,
-        },
-        ...tabs.slice(idx + 1),
-      ];
-      navigate({
-        ...location,
-        query: {
-          ...queryParams,
-          query: duplicatedTab.query,
-          sort: duplicatedTab.querySort,
-          viewId: tempId,
-        },
-      });
-      setTabs(newTabs);
-      tabListState?.setSelectedKey(tempId);
-      onDuplicate?.(newTabs);
-      trackAnalytics('issue_views.duplicated_view', {
-        organization,
-      });
-    }
-  };
-
-  const handleOnDelete = () => {
-    if (tabs.length > 1) {
-      const newTabs = tabs.filter(tb => tb.key !== tabListState?.selectedKey);
-      setTabs(newTabs);
-      tabListState?.setSelectedKey(newTabs[0].key);
-      onDelete?.(newTabs);
-      trackAnalytics('issue_views.deleted_view', {
-        organization,
-      });
-    }
-  };
-
-  const handleOnSaveTempView = () => {
-    if (tempTab) {
-      const tempId = generateTempViewId();
-      const newTab: Tab = {
-        id: tempId,
-        key: tempId,
-        label: 'New View',
-        query: tempTab.query,
-        querySort: tempTab.querySort,
-        isCommitted: true,
-      };
-      const newTabs = [...tabs, newTab];
-      navigate(
-        {
-          ...location,
-          query: {
-            ...queryParams,
-            query: tempTab.query,
-            querySort: tempTab.querySort,
-            viewId: tempId,
-          },
-        },
-        {replace: true}
-      );
-      setTabs(newTabs);
-      setTempTab(undefined);
-      tabListState?.setSelectedKey(tempId);
-      onSaveTempView?.(newTabs);
-      trackAnalytics('issue_views.temp_view_saved', {
-        organization,
-      });
-    }
-  };
-
-  const handleOnDiscardTempView = () => {
-    tabListState?.setSelectedKey(tabs[0].key);
-    setTempTab(undefined);
-    onDiscardTempView?.();
-    trackAnalytics('issue_views.temp_view_discarded', {
-      organization,
-    });
-  };
-
-  const handleCreateNewView = () => {
-    // Triggers the add view flow page
-    setNewViewActive(true);
-    const tempId = generateTempViewId();
-    const currentTab = tabs.find(tab => tab.key === tabListState?.selectedKey);
-    if (currentTab) {
-      const newTabs: Tab[] = [
-        ...tabs,
-        {
-          id: tempId,
-          key: tempId,
-          label: 'New View',
-          query: '',
-          querySort: IssueSortOptions.DATE,
-          isCommitted: false,
-        },
-      ];
-      navigate({
-        ...location,
-        query: {
-          ...queryParams,
-          query: '',
-          viewId: tempId,
-        },
-      });
-      setTabs(newTabs);
-      tabListState?.setSelectedKey(tempId);
-      trackAnalytics('issue_views.add_view.clicked', {
-        organization,
       });
     }
   };
@@ -350,9 +109,9 @@ export function DraggableTabBar({
       }
       setNewViewActive(false);
       const {label, query, saveQueryToView} = newViews[0];
-      const remainingNewViews: Tab[] = newViews.slice(1)?.map(view => {
+      const remainingNewViews: IssueView[] = newViews.slice(1)?.map(view => {
         const newId = generateTempViewId();
-        const viewToTab: Tab = {
+        const viewToTab: IssueView = {
           id: newId,
           key: newId,
           label: view.label,
@@ -365,7 +124,7 @@ export function DraggableTabBar({
         };
         return viewToTab;
       });
-      let updatedTabs: Tab[] = tabs.map(tab => {
+      let updatedTabs: IssueView[] = tabs.map(tab => {
         if (tab.key === viewId) {
           return {
             ...tab,
@@ -383,7 +142,7 @@ export function DraggableTabBar({
         updatedTabs = [...updatedTabs, ...remainingNewViews];
       }
 
-      setTabs(updatedTabs);
+      dispatch({type: 'SET_VIEWS', views: updatedTabs, syncViews: true});
       navigate(
         {
           ...location,
@@ -395,37 +154,57 @@ export function DraggableTabBar({
         },
         {replace: true}
       );
-      onAddView?.(updatedTabs);
     },
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [location, navigate, onAddView, setNewViewActive, setTabs, tabs, viewId]
+    [location, navigate, setNewViewActive, tabs, viewId]
   );
+
+  const handleCreateNewView = () => {
+    const tempId = generateTempViewId();
+    dispatch({type: 'CREATE_NEW_VIEW', tempId});
+    tabListState?.setSelectedKey(tempId);
+    navigate({
+      ...location,
+      query: {
+        ...queryParams,
+        query: '',
+        viewId: tempId,
+      },
+    });
+  };
+
+  const handleDeleteView = (tab: IssueView) => {
+    dispatch({type: 'DELETE_VIEW'});
+    // Including this logic in the dispatch call breaks the tests for some reason
+    // so we're doing it here instead
+    tabListState?.setSelectedKey(tabs.filter(tb => tb.key !== tab.key)[0].key);
+  };
 
   useEffect(() => {
     setOnNewViewsSaved(handleNewViewsSaved);
   }, [setOnNewViewsSaved, handleNewViewsSaved]);
 
-  const makeMenuOptions = (tab: Tab): MenuItemProps[] => {
+  const makeMenuOptions = (tab: IssueView): MenuItemProps[] => {
     if (tab.key === TEMPORARY_TAB_KEY) {
       return makeTempViewMenuOptions({
-        onSaveTempView: handleOnSaveTempView,
-        onDiscardTempView: handleOnDiscardTempView,
+        onSaveTempView: () => dispatch({type: 'SAVE_TEMP_VIEW'}),
+        onDiscardTempView: () => dispatch({type: 'DISCARD_TEMP_VIEW'}),
       });
     }
     if (tab.unsavedChanges) {
       return makeUnsavedChangesMenuOptions({
         onRename: () => setEditingTabKey(tab.key),
-        onDuplicate: handleOnDuplicate,
-        onDelete: tabs.length > 1 ? handleOnDelete : undefined,
-        onSave: handleOnSaveChanges,
-        onDiscard: handleOnDiscardChanges,
+        onDuplicate: handleDuplicateView,
+        onDelete: tabs.length > 1 ? () => handleDeleteView(tab) : undefined,
+        onSave: () => dispatch({type: 'SAVE_CHANGES'}),
+        onDiscard: handleDiscardChanges,
       });
     }
     return makeDefaultMenuOptions({
       onRename: () => setEditingTabKey(tab.key),
-      onDuplicate: handleOnDuplicate,
-      onDelete: tabs.length > 1 ? handleOnDelete : undefined,
+      onDuplicate: handleDuplicateView,
+      onDelete: tabs.length > 1 ? () => handleDeleteView(tab) : undefined,
     });
   };
 
@@ -433,8 +212,13 @@ export function DraggableTabBar({
 
   return (
     <DraggableTabList
-      onReorder={handleOnReorder}
-      onReorderComplete={() => onReorder?.(tabs)}
+      onReorder={(newOrder: Node<DraggableTabListItemProps>[]) =>
+        dispatch({
+          type: 'REORDER_TABS',
+          newKeyOrder: newOrder.map(node => node.key.toString()),
+        })
+      }
+      onReorderComplete={() => dispatch({type: 'SYNC_VIEWS_TO_BACKEND'})}
       defaultSelectedKey={initialTabKey}
       onAddView={handleCreateNewView}
       orientation="horizontal"
@@ -452,7 +236,7 @@ export function DraggableTabBar({
               sort: tab.unsavedChanges?.[1] ?? tab.querySort,
               viewId: tab.id !== TEMPORARY_TAB_KEY ? tab.id : undefined,
             },
-            pathname: `/organizations/${orgSlug}/issues/`,
+            pathname: `/organizations/${organization.slug}/issues/`,
           })}
           disabled={tab.key === editingTabKey}
         >
@@ -461,7 +245,9 @@ export function DraggableTabBar({
               label={tab.label}
               isEditing={editingTabKey === tab.key}
               setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
-              onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
+              onChange={newLabel =>
+                dispatch({type: 'RENAME_TAB', newLabel: newLabel.trim()})
+              }
               isSelected={
                 (tabListState && tabListState?.selectedKey === tab.key) ||
                 (!tabListState && tab.key === initialTabKey)
@@ -516,12 +302,15 @@ const makeDefaultMenuOptions = ({
     },
   ];
   if (onDelete) {
-    menuOptions.push({
-      key: 'delete-tab',
-      label: t('Delete'),
-      priority: 'danger',
-      onAction: onDelete,
-    });
+    return [
+      ...menuOptions,
+      {
+        key: 'delete-tab',
+        label: t('Delete'),
+        priority: 'danger',
+        onAction: onDelete,
+      },
+    ];
   }
   return menuOptions;
 };

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -54,7 +54,7 @@ export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
         includeInputs: true,
         callback: () => {
           if (tabs.find(tab => tab.key === tabListState?.selectedKey)?.unsavedChanges) {
-            dispatch({type: 'SAVE_CHANGES'});
+            dispatch({type: 'SAVE_CHANGES', syncViews: true});
             addSuccessMessage(t('Changes saved to view'));
           }
         },
@@ -71,7 +71,7 @@ export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
     if (!duplicatedTab) {
       return;
     }
-    dispatch({type: 'DUPLICATE_VIEW', newViewId});
+    dispatch({type: 'DUPLICATE_VIEW', newViewId, syncViews: true});
     navigate({
       ...location,
       query: {
@@ -175,7 +175,7 @@ export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
   };
 
   const handleDeleteView = (tab: IssueView) => {
-    dispatch({type: 'DELETE_VIEW'});
+    dispatch({type: 'DELETE_VIEW', syncViews: true});
     // Including this logic in the dispatch call breaks the tests for some reason
     // so we're doing it here instead
     tabListState?.setSelectedKey(tabs.filter(tb => tb.key !== tab.key)[0].key);
@@ -188,7 +188,7 @@ export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
   const makeMenuOptions = (tab: IssueView): MenuItemProps[] => {
     if (tab.key === TEMPORARY_TAB_KEY) {
       return makeTempViewMenuOptions({
-        onSaveTempView: () => dispatch({type: 'SAVE_TEMP_VIEW'}),
+        onSaveTempView: () => dispatch({type: 'SAVE_TEMP_VIEW', syncViews: true}),
         onDiscardTempView: () => dispatch({type: 'DISCARD_TEMP_VIEW'}),
       });
     }
@@ -197,7 +197,7 @@ export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
         onRename: () => setEditingTabKey(tab.key),
         onDuplicate: handleDuplicateView,
         onDelete: tabs.length > 1 ? () => handleDeleteView(tab) : undefined,
-        onSave: () => dispatch({type: 'SAVE_CHANGES'}),
+        onSave: () => dispatch({type: 'SAVE_CHANGES', syncViews: true}),
         onDiscard: handleDiscardChanges,
       });
     }
@@ -246,7 +246,7 @@ export function DraggableTabBar({initialTabKey, router}: DraggableTabBarProps) {
               isEditing={editingTabKey === tab.key}
               setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
               onChange={newLabel =>
-                dispatch({type: 'RENAME_TAB', newLabel: newLabel.trim()})
+                dispatch({type: 'RENAME_TAB', newLabel: newLabel.trim(), syncViews: true})
               }
               isSelected={
                 (tabListState && tabListState?.selectedKey === tab.key) ||

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -21,8 +21,11 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DraggableTabMenuButton} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabMenuButton';
 import EditableTabTitle from 'sentry/views/issueList/groupSearchViewTabs/editableTabTitle';
+import {
+  type IssueView,
+  IssueViewsContext,
+} from 'sentry/views/issueList/groupSearchViewTabs/issueViews';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
-import {type IssueView, IssueViewsContext} from 'sentry/views/issueList/utils/issueViews';
 import {NewTabContext, type NewView} from 'sentry/views/issueList/utils/newTabContext';
 
 export interface DraggableTabBarProps {

--- a/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
@@ -461,13 +461,12 @@ export function IssueViewsStateProvider({
         case 'SET_VIEWS':
           return setViews(state, action);
         case 'SYNC_VIEWS_TO_BACKEND':
-          debounceUpdateViews(state.views);
           return state;
         default:
           return state;
       }
     },
-    [tabListState, debounceUpdateViews]
+    [tabListState]
   );
 
   const sortOption =

--- a/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
@@ -328,7 +328,7 @@ function setViews(state: IssueViewsState, action: SetViewsAction) {
   return {...state, views: action.views};
 }
 
-interface IssueViewsStateProviderProps {
+interface IssueViewsStateProviderProps extends Omit<TabsProps<any>, 'children'> {
   children: React.ReactNode;
   initialViews: IssueView[];
   // TODO(msun): Replace router with useLocation() / useUrlParams() / useSearchParams() in the future
@@ -339,11 +339,14 @@ export function IssueViewsStateProvider({
   children,
   initialViews,
   router,
+  ...props
 }: IssueViewsStateProviderProps) {
   const navigate = useNavigate();
   const pageFilters = usePageFilters();
   const organization = useOrganization();
   const [tabListState, setTabListState] = useState<TabListState<any>>();
+  const {className: _className, ...restProps} = props;
+
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location.query;
   const {query, sort, viewId, project, environment} = queryParams;
 
@@ -500,7 +503,7 @@ export function IssueViewsStateProvider({
   return (
     <IssueViewsContext.Provider
       value={{
-        rootProps: {orientation: 'horizontal'},
+        rootProps: {...restProps, orientation: 'horizontal'},
         tabListState,
         setTabListState,
         dispatch: dispatchWrapper,

--- a/static/app/views/issueList/utils/issueViews.tsx
+++ b/static/app/views/issueList/utils/issueViews.tsx
@@ -41,8 +41,6 @@ export interface IssueView {
   unsavedChanges?: [string, IssueSortOptions];
 }
 
-// export interface IssueViewsProps<T> extends TabsProps<T> {}
-
 type ReorderTabsAction = {
   newKeyOrder: string[];
   type: 'REORDER_TABS';

--- a/static/app/views/issueList/utils/issueViews.tsx
+++ b/static/app/views/issueList/utils/issueViews.tsx
@@ -229,8 +229,6 @@ function duplicateView(
 
 function deleteView(state: IssueViewsState, tabListState: TabListState<any>) {
   const newViews = state.views.filter(tab => tab.key !== tabListState?.selectedKey);
-  // TODO(msun): wtf
-  // tabListState?.setSelectedKey(newViews[0].key);
   return {...state, views: newViews};
 }
 

--- a/static/app/views/issueList/utils/issueViews.tsx
+++ b/static/app/views/issueList/utils/issueViews.tsx
@@ -1,0 +1,560 @@
+import type {Dispatch, Reducer} from 'react';
+import {createContext, useCallback, useMemo, useReducer, useState} from 'react';
+import styled from '@emotion/styled';
+import type {TabListState} from '@react-stately/tabs';
+import type {Orientation} from '@react-types/shared';
+import debounce from 'lodash/debounce';
+
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {TabContext, TabsProps} from 'sentry/components/tabs';
+import {tabsShouldForwardProp} from 'sentry/components/tabs/utils';
+import {t} from 'sentry/locale';
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import {defined} from 'sentry/utils';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {generateTempViewId} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabBar';
+import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import type {
+  GroupSearchView,
+  UpdateGroupSearchViewPayload,
+} from 'sentry/views/issueList/types';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+const TEMPORARY_TAB_KEY = 'temporary-tab';
+
+export interface IssueView {
+  id: string;
+  /**
+   * False for tabs that were added view the "Add View" button, but
+   * have not been edited in any way. Only tabs with isCommitted=true
+   * will be saved to the backend.
+   */
+  isCommitted: boolean;
+  key: string;
+  label: string;
+  query: string;
+  querySort: IssueSortOptions;
+  content?: React.ReactNode;
+  unsavedChanges?: [string, IssueSortOptions];
+}
+
+// export interface IssueViewsProps<T> extends TabsProps<T> {}
+
+type ReorderTabsAction = {
+  newKeyOrder: string[];
+  type: 'REORDER_TABS';
+};
+
+type SaveChangesAction = {
+  type: 'SAVE_CHANGES';
+};
+
+type DiscardChangesAction = {
+  type: 'DISCARD_CHANGES';
+};
+
+type RenameTabAction = {
+  newLabel: string;
+  type: 'RENAME_TAB';
+};
+
+type DuplicateViewAction = {
+  newViewId: string;
+  type: 'DUPLICATE_VIEW';
+};
+
+type DeleteViewAction = {
+  type: 'DELETE_VIEW';
+};
+
+type CreateNewViewAction = {
+  tempId: string;
+  type: 'CREATE_NEW_VIEW';
+};
+
+type SetTempViewAction = {
+  query: string;
+  sort: IssueSortOptions;
+  type: 'SET_TEMP_VIEW';
+};
+
+type DiscardTempViewAction = {
+  type: 'DISCARD_TEMP_VIEW';
+};
+
+type SaveTempViewAction = {
+  type: 'SAVE_TEMP_VIEW';
+};
+
+type UpdateUnsavedChangesAction = {
+  type: 'UPDATE_UNSAVED_CHANGES';
+  unsavedChanges: [string, IssueSortOptions] | undefined;
+  isCommitted?: boolean;
+  syncViews?: boolean;
+};
+
+type UpdateViewIdsAction = {
+  newViews: UpdateGroupSearchViewPayload[];
+  type: 'UPDATE_VIEW_IDS';
+};
+
+type SetViewsAction = {
+  type: 'SET_VIEWS';
+  views: IssueView[];
+  syncViews?: boolean;
+};
+
+type SyncViewsToBackendAction = {
+  type: 'SYNC_VIEWS_TO_BACKEND';
+};
+
+export type IssueViewsActions =
+  | ReorderTabsAction
+  | SaveChangesAction
+  | DiscardChangesAction
+  | RenameTabAction
+  | DuplicateViewAction
+  | DeleteViewAction
+  | CreateNewViewAction
+  | SetTempViewAction
+  | DiscardTempViewAction
+  | SaveTempViewAction
+  | UpdateUnsavedChangesAction
+  | UpdateViewIdsAction
+  | SetViewsAction
+  | SyncViewsToBackendAction;
+
+export interface IssueViewsState {
+  views: IssueView[];
+  tempView?: IssueView;
+}
+
+export interface IssueViewsContextType extends TabContext {
+  dispatch: Dispatch<IssueViewsActions>;
+  state: IssueViewsState;
+}
+
+export const IssueViewsContext = createContext<IssueViewsContextType>({
+  rootProps: {orientation: 'horizontal'},
+  setTabListState: () => {},
+  // Issue Views specific state
+  dispatch: () => {},
+  state: {views: []},
+});
+
+function reorderTabs(state: IssueViewsState, action: ReorderTabsAction) {
+  const newTabs: IssueView[] = action.newKeyOrder
+    .map(key => {
+      const foundTab = state.views.find(tab => tab.key === key);
+      return foundTab?.key === key ? foundTab : null;
+    })
+    .filter(defined);
+  return {...state, views: newTabs};
+}
+
+function saveChanges(state: IssueViewsState, tabListState: TabListState<any>) {
+  const originalTab = state.views.find(tab => tab.key === tabListState?.selectedKey);
+  if (originalTab) {
+    const newViews = state.views.map(tab => {
+      return tab.key === tabListState?.selectedKey && tab.unsavedChanges
+        ? {
+            ...tab,
+            query: tab.unsavedChanges[0],
+            querySort: tab.unsavedChanges[1],
+            unsavedChanges: undefined,
+          }
+        : tab;
+    });
+    return {...state, views: newViews};
+  }
+  return state;
+}
+
+function discardChanges(state: IssueViewsState, tabListState: TabListState<any>) {
+  const originalTab = state.views.find(tab => tab.key === tabListState?.selectedKey);
+  if (originalTab) {
+    const newViews = state.views.map(tab => {
+      return tab.key === tabListState?.selectedKey
+        ? {...tab, unsavedChanges: undefined}
+        : tab;
+    });
+    return {...state, views: newViews};
+  }
+  return state;
+}
+
+function renameView(
+  state: IssueViewsState,
+  action: RenameTabAction,
+  tabListState: TabListState<any>
+) {
+  const renamedTab = state.views.find(tab => tab.key === tabListState?.selectedKey);
+  if (renamedTab && action.newLabel !== renamedTab.label) {
+    const newViews = state.views.map(tab =>
+      tab.key === renamedTab.key
+        ? {...tab, label: action.newLabel, isCommitted: true}
+        : tab
+    );
+    return {...state, views: newViews};
+  }
+  return state;
+}
+
+function duplicateView(
+  state: IssueViewsState,
+  action: DuplicateViewAction,
+  tabListState: TabListState<any>
+) {
+  const idx = state.views.findIndex(tb => tb.key === tabListState?.selectedKey);
+  if (idx !== -1) {
+    const duplicatedTab = state.views[idx];
+    const newTabs: IssueView[] = [
+      ...state.views.slice(0, idx + 1),
+      {
+        ...duplicatedTab,
+        id: action.newViewId,
+        key: action.newViewId,
+        label: `${duplicatedTab.label} (Copy)`,
+        isCommitted: true,
+      },
+      ...state.views.slice(idx + 1),
+    ];
+    return {...state, views: newTabs};
+  }
+  return state;
+}
+
+function deleteView(state: IssueViewsState, tabListState: TabListState<any>) {
+  const newViews = state.views.filter(tab => tab.key !== tabListState?.selectedKey);
+  // TODO(msun): wtf
+  // tabListState?.setSelectedKey(newViews[0].key);
+  return {...state, views: newViews};
+}
+
+function createNewView(state: IssueViewsState, action: CreateNewViewAction) {
+  const newTabs: IssueView[] = [
+    ...state.views,
+    {
+      id: action.tempId,
+      key: action.tempId,
+      label: 'New View',
+      query: '',
+      querySort: IssueSortOptions.DATE,
+      isCommitted: false,
+    },
+  ];
+  return {...state, views: newTabs};
+}
+
+function setTempView(state: IssueViewsState, action: SetTempViewAction) {
+  const tempView: IssueView = {
+    id: TEMPORARY_TAB_KEY,
+    key: TEMPORARY_TAB_KEY,
+    label: t('Unsaved'),
+    query: action.query,
+    querySort: action.sort ?? IssueSortOptions.DATE,
+    isCommitted: true,
+  };
+  return {...state, tempView};
+}
+
+function discardTempView(state: IssueViewsState, tabListState: TabListState<any>) {
+  tabListState?.setSelectedKey(state.views[0].key);
+  return {...state, tempView: undefined};
+}
+
+function saveTempView(state: IssueViewsState, tabListState: TabListState<any>) {
+  if (state.tempView) {
+    const tempId = generateTempViewId();
+    const newTab: IssueView = {
+      id: tempId,
+      key: tempId,
+      label: 'New View',
+      query: state.tempView?.query,
+      querySort: state.tempView?.querySort,
+      isCommitted: true,
+    };
+    tabListState?.setSelectedKey(tempId);
+    return {...state, views: [...state.views, newTab], tempView: undefined};
+  }
+  return state;
+}
+
+function updateUnsavedChanges(
+  state: IssueViewsState,
+  action: UpdateUnsavedChangesAction,
+  tabListState: TabListState<any>
+) {
+  return {
+    ...state,
+    views: state.views.map(tab =>
+      tab.key === tabListState?.selectedKey
+        ? {
+            ...tab,
+            unsavedChanges: action.unsavedChanges,
+            isCommitted: action.isCommitted ?? tab.isCommitted,
+          }
+        : tab
+    ),
+  };
+}
+
+function updateViewIds(state: IssueViewsState, action: UpdateViewIdsAction) {
+  const assignedIds = new Set();
+  const updatedViews = state.views.map(tab => {
+    if (tab.id && tab.id[0] === '_') {
+      const matchingView = action.newViews.find(
+        view =>
+          view.id &&
+          !assignedIds.has(view.id) &&
+          tab.query === view.query &&
+          tab.querySort === view.querySort &&
+          tab.label === view.name
+      );
+      if (matchingView?.id) {
+        assignedIds.add(matchingView.id);
+        return {...tab, id: matchingView.id};
+      }
+    }
+    return tab;
+  });
+  return {...state, views: updatedViews};
+}
+
+function setViews(state: IssueViewsState, action: SetViewsAction) {
+  return {...state, views: action.views};
+}
+
+interface IssueViewsStateProviderProps {
+  children: React.ReactNode;
+  initialViews: IssueView[];
+  // TODO(msun): Replace router with useLocation() / useUrlParams() / useSearchParams() in the future
+  router: InjectedRouter;
+}
+
+export function IssueViewsStateProvider({
+  children,
+  initialViews,
+  router,
+}: IssueViewsStateProviderProps) {
+  const navigate = useNavigate();
+  const pageFilters = usePageFilters();
+  const organization = useOrganization();
+  const [tabListState, setTabListState] = useState<TabListState<any>>();
+  const {cursor: _cursor, page: _page, ...queryParams} = router?.location.query;
+  const {query, sort, viewId, project, environment} = queryParams;
+
+  const queryParamsWithPageFilters = useMemo(() => {
+    return {
+      ...queryParams,
+      project: project ?? pageFilters.selection.projects,
+      environment: environment ?? pageFilters.selection.environments,
+      ...normalizeDateTimeParams(pageFilters.selection.datetime),
+    };
+  }, [
+    environment,
+    pageFilters.selection.datetime,
+    pageFilters.selection.environments,
+    pageFilters.selection.projects,
+    project,
+    queryParams,
+  ]);
+
+  // This function is fired upon receiving new views from the backend - it replaces any previously
+  // generated temporary view ids with the permanent view ids from the backend
+  const replaceWithPersistantViewIds = (views: GroupSearchView[]) => {
+    const newlyCreatedViews = views.filter(
+      view => !state.views.find(tab => tab.id === view.id)
+    );
+    if (newlyCreatedViews.length > 0) {
+      dispatch({type: 'UPDATE_VIEW_IDS', newViews: newlyCreatedViews});
+      const currentView = state.views.find(tab => tab.id === viewId);
+
+      if (viewId?.startsWith('_') && currentView) {
+        const matchingView = newlyCreatedViews.find(
+          view =>
+            view.id &&
+            currentView.query === view.query &&
+            currentView.querySort === view.querySort
+        );
+        if (matchingView?.id) {
+          navigate(
+            normalizeUrl({
+              ...location,
+              query: {
+                ...queryParamsWithPageFilters,
+                viewId: matchingView.id,
+              },
+            }),
+            {replace: true}
+          );
+        }
+      }
+    }
+    return;
+  };
+
+  const {mutate: updateViews} = useUpdateGroupSearchViews({
+    onSuccess: replaceWithPersistantViewIds,
+  });
+
+  const debounceUpdateViews = useMemo(
+    () =>
+      debounce((newTabs: IssueView[]) => {
+        if (newTabs) {
+          updateViews({
+            orgSlug: organization.slug,
+            groupSearchViews: newTabs
+              .filter(tab => tab.isCommitted)
+              .map(tab => ({
+                // Do not send over an ID if it's a temporary or default tab so that
+                // the backend will save these and generate permanent Ids for them
+                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
+                  ? {id: tab.id}
+                  : {}),
+                name: tab.label,
+                query: tab.query,
+                querySort: tab.querySort,
+              })),
+          });
+        }
+      }, 500),
+    [organization.slug, updateViews]
+  );
+
+  const reducer: Reducer<IssueViewsState, IssueViewsActions> = useCallback(
+    (state, action): IssueViewsState => {
+      if (!tabListState) {
+        return state;
+      }
+      // eslint-disable-next-line no-console
+      console.log('executing dispatch', state, action);
+      let newState;
+      switch (action.type) {
+        case 'REORDER_TABS':
+          newState = reorderTabs(state, action);
+          debounceUpdateViews(newState.views);
+          return newState;
+        case 'SAVE_CHANGES':
+          newState = saveChanges(state, tabListState);
+          debounceUpdateViews(newState.views);
+          return newState;
+        case 'DISCARD_CHANGES':
+          return discardChanges(state, tabListState);
+        case 'RENAME_TAB':
+          newState = renameView(state, action, tabListState);
+          debounceUpdateViews(newState.views);
+          return newState;
+        case 'DUPLICATE_VIEW':
+          newState = duplicateView(state, action, tabListState);
+          debounceUpdateViews(newState.views);
+          return newState;
+        case 'DELETE_VIEW':
+          newState = deleteView(state, tabListState);
+          debounceUpdateViews(newState.views);
+          return newState;
+        case 'CREATE_NEW_VIEW':
+          return createNewView(state, action);
+        case 'SET_TEMP_VIEW':
+          return setTempView(state, action);
+        case 'DISCARD_TEMP_VIEW':
+          return discardTempView(state, tabListState);
+        case 'SAVE_TEMP_VIEW':
+          newState = saveTempView(state, tabListState);
+          debounceUpdateViews(newState.views);
+          return newState;
+        case 'UPDATE_UNSAVED_CHANGES':
+          newState = updateUnsavedChanges(state, action, tabListState);
+          if (action.syncViews) {
+            debounceUpdateViews(newState.views);
+          }
+          return newState;
+        case 'UPDATE_VIEW_IDS':
+          return updateViewIds(state, action);
+        case 'SET_VIEWS':
+          newState = setViews(state, action);
+          if (action.syncViews) {
+            debounceUpdateViews(newState.views);
+          }
+          return newState;
+        case 'SYNC_VIEWS_TO_BACKEND':
+          debounceUpdateViews(state.views);
+          return state;
+        default:
+          return state;
+      }
+    },
+    [tabListState, debounceUpdateViews]
+  );
+
+  const sortOption =
+    sort && Object.values(IssueSortOptions).includes(sort.toString() as IssueSortOptions)
+      ? (sort.toString() as IssueSortOptions)
+      : IssueSortOptions.DATE;
+
+  const initialTempView: IssueView | undefined =
+    query && (!viewId || !initialViews.find(tab => tab.id === viewId))
+      ? {
+          id: TEMPORARY_TAB_KEY,
+          key: TEMPORARY_TAB_KEY,
+          label: t('Unsaved'),
+          query: query.toString(),
+          querySort: sortOption,
+          isCommitted: true,
+        }
+      : undefined;
+
+  const [state, dispatch] = useReducer(reducer, {
+    views: initialViews,
+    tempView: initialTempView,
+  });
+
+  return (
+    <IssueViewsContext.Provider
+      value={{
+        rootProps: {orientation: 'horizontal'},
+        tabListState,
+        setTabListState,
+        dispatch,
+        state,
+      }}
+    >
+      {children}
+    </IssueViewsContext.Provider>
+  );
+}
+
+export function IssueViews<T extends string | number>({
+  orientation = 'horizontal',
+  className,
+  children,
+  initialViews,
+  router,
+  ...props
+}: TabsProps<T> & Omit<IssueViewsStateProviderProps, 'children'>) {
+  return (
+    <IssueViewsStateProvider initialViews={initialViews} router={router} {...props}>
+      <TabsWrap orientation={orientation} className={className}>
+        {children}
+      </TabsWrap>
+    </IssueViewsStateProvider>
+  );
+}
+
+const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
+  display: flex;
+  flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
+  flex-grow: 1;
+
+  ${p =>
+    p.orientation === 'vertical' &&
+    `
+      height: 100%;
+      align-items: stretch;
+    `};
+`;


### PR DESCRIPTION
This PR makes a major code refactor to the Issue Views family of components. No functionality should be broken or otherwise altered. 

The purpose of this refactor was to move lots of reused code and duplicated state into one unified context, `IssueViews.tsx`. This allows the displayed components to be much much cleaner and easier to understand while making it easier to add new functionality in the future. The two primary things it does are:

1. **Creates a new context, `IssueViews`,  that extends the old `Tabs` context. This new context now contains the views and temporary tabs state**
2. **Delegates almost all tab alteration logic to a `useReducer` within the `IssueViews` context**
