### PR TITLE
chore(seer grouping): Remove older stacktrace length filtering code

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -201,7 +201,7 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
 
 def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant]) -> bool:
     stacktrace_string = get_stacktrace_string_with_metrics(
-        get_grouping_info_from_variants(variants), event.platform
+        get_grouping_info_from_variants(variants)
     )
     if not stacktrace_string:
         if stacktrace_string == "":
@@ -228,9 +228,7 @@ def get_seer_similar_issues(
 
     stacktrace_string = event.data.get(
         "stacktrace_string",
-        get_stacktrace_string_with_metrics(
-            get_grouping_info_from_variants(variants), event.platform
-        ),
+        get_stacktrace_string_with_metrics(get_grouping_info_from_variants(variants)),
     )
 
     if not stacktrace_string:

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -20,7 +20,7 @@ from sentry.seer.similarity.utils import (
     ReferrerOptions,
     event_content_has_stacktrace,
     filter_null_from_string,
-    get_stacktrace_string_with_metrics,
+    get_stacktrace_string,
     has_too_many_contributing_frames,
     killswitch_enabled,
     record_did_call_seer_metric,
@@ -200,9 +200,7 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
 
 
 def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant]) -> bool:
-    stacktrace_string = get_stacktrace_string_with_metrics(
-        get_grouping_info_from_variants(variants)
-    )
+    stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants(variants))
     if not stacktrace_string:
         if stacktrace_string == "":
             record_did_call_seer_metric(call_made=False, blocker="empty-stacktrace-string")
@@ -228,7 +226,7 @@ def get_seer_similar_issues(
 
     stacktrace_string = event.data.get(
         "stacktrace_string",
-        get_stacktrace_string_with_metrics(get_grouping_info_from_variants(variants)),
+        get_stacktrace_string(get_grouping_info_from_variants(variants)),
     )
 
     if not stacktrace_string:

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -201,7 +201,7 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
 
 def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant]) -> bool:
     stacktrace_string = get_stacktrace_string_with_metrics(
-        get_grouping_info_from_variants(variants), event.platform, ReferrerOptions.INGEST
+        get_grouping_info_from_variants(variants), event.platform
     )
     if not stacktrace_string:
         if stacktrace_string == "":
@@ -229,7 +229,7 @@ def get_seer_similar_issues(
     stacktrace_string = event.data.get(
         "stacktrace_string",
         get_stacktrace_string_with_metrics(
-            get_grouping_info_from_variants(variants), event.platform, ReferrerOptions.INGEST
+            get_grouping_info_from_variants(variants), event.platform
         ),
     )
 

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -92,9 +92,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             ):
                 grouping_info = get_grouping_info_from_variants(variants)
                 try:
-                    stacktrace_string = get_stacktrace_string(
-                        grouping_info, platform=latest_event.platform
-                    )
+                    stacktrace_string = get_stacktrace_string(grouping_info)
                 except Exception:
                     logger.exception("Unexpected exception in stacktrace string formatting")
 

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -19,7 +19,6 @@ from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsRequest
 from sentry.seer.similarity.utils import (
     ReferrerOptions,
-    TooManyOnlySystemFramesException,
     event_content_has_stacktrace,
     get_stacktrace_string,
     has_too_many_contributing_frames,
@@ -96,8 +95,6 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
                     stacktrace_string = get_stacktrace_string(
                         grouping_info, platform=latest_event.platform
                     )
-                except TooManyOnlySystemFramesException:
-                    pass
                 except Exception:
                     logger.exception("Unexpected exception in stacktrace string formatting")
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -63,7 +63,6 @@ class FramesMetrics(TypedDict):
     frame_count: int
     html_frame_count: int  # for a temporary metric
     has_no_filename: bool  # for a temporary metric
-    is_frames_truncated: bool
     found_non_snipped_context_line: bool
 
 
@@ -93,7 +92,6 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
         "frame_count": 0,
         "html_frame_count": 0,  # for a temporary metric
         "has_no_filename": False,  # for a temporary metric
-        "is_frames_truncated": False,
         "found_non_snipped_context_line": False,
     }
 
@@ -199,8 +197,6 @@ def _process_frames(
     contributing_frames = [
         frame for frame in frames if frame.get("id") == "frame" and frame.get("contributes")
     ]
-    if len(contributing_frames) + frame_metrics["frame_count"] > MAX_FRAME_COUNT:
-        frame_metrics["is_frames_truncated"] = True
     contributing_frames = _discard_excess_frames(
         contributing_frames, MAX_FRAME_COUNT, frame_metrics["frame_count"]
     )

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -255,16 +255,6 @@ def is_base64_encoded_frame(frame_dict: Mapping[str, Any]) -> bool:
     return base64_encoded
 
 
-def get_stacktrace_string_with_metrics(data: dict[str, Any]) -> str | None:
-    stacktrace_string = None
-    try:
-        stacktrace_string = get_stacktrace_string(data)
-    except Exception:
-        logger.exception("Unexpected exception in stacktrace string formatting")
-
-    return stacktrace_string
-
-
 def event_content_has_stacktrace(event: GroupEvent | Event) -> bool:
     # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
     # API call. If we ever start analyzing message-only events, we'll need to add `event.title in

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -62,7 +62,7 @@ class FramesMetrics(TypedDict):
     found_non_snipped_context_line: bool
 
 
-def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> str:
+def get_stacktrace_string(data: dict[str, Any]) -> str:
     """Format a stacktrace string from the grouping information."""
     app_hash = get_path(data, "app", "hash")
     app_component = get_path(data, "app", "component", "values")
@@ -258,7 +258,7 @@ def is_base64_encoded_frame(frame_dict: Mapping[str, Any]) -> bool:
 def get_stacktrace_string_with_metrics(data: dict[str, Any], platform: str | None) -> str | None:
     stacktrace_string = None
     try:
-        stacktrace_string = get_stacktrace_string(data, platform)
+        stacktrace_string = get_stacktrace_string(data)
     except Exception:
         logger.exception("Unexpected exception in stacktrace string formatting")
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -255,7 +255,7 @@ def is_base64_encoded_frame(frame_dict: Mapping[str, Any]) -> bool:
     return base64_encoded
 
 
-def get_stacktrace_string_with_metrics(data: dict[str, Any], platform: str | None) -> str | None:
+def get_stacktrace_string_with_metrics(data: dict[str, Any]) -> str | None:
     stacktrace_string = None
     try:
         stacktrace_string = get_stacktrace_string(data)

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -263,18 +263,8 @@ def get_stacktrace_string_with_metrics(
     data: dict[str, Any], platform: str | None, referrer: ReferrerOptions
 ) -> str | None:
     stacktrace_string = None
-    sample_rate = options.get("seer.similarity.metrics_sample_rate")
     try:
         stacktrace_string = get_stacktrace_string(data, platform)
-    except TooManyOnlySystemFramesException:
-        platform = platform if platform else "unknown"
-        metrics.incr(
-            "grouping.similarity.over_threshold_only_system_frames",
-            sample_rate=sample_rate,
-            tags={"platform": platform, "referrer": referrer},
-        )
-        if referrer == ReferrerOptions.INGEST:
-            record_did_call_seer_metric(call_made=False, blocker="over-threshold-frames")
     except Exception:
         logger.exception("Unexpected exception in stacktrace string formatting")
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -259,9 +259,7 @@ def is_base64_encoded_frame(frame_dict: Mapping[str, Any]) -> bool:
     return base64_encoded
 
 
-def get_stacktrace_string_with_metrics(
-    data: dict[str, Any], platform: str | None, referrer: ReferrerOptions
-) -> str | None:
+def get_stacktrace_string_with_metrics(data: dict[str, Any], platform: str | None) -> str | None:
     stacktrace_string = None
     try:
         stacktrace_string = get_stacktrace_string(data, platform)

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -51,10 +51,6 @@ class ReferrerOptions(StrEnum):
     SIMILAR_ISSUES_TAB = "similar_issues_tab"
 
 
-class TooManyOnlySystemFramesException(Exception):
-    pass
-
-
 def _get_value_if_exists(exception_value: Mapping[str, Any]) -> str:
     return exception_value["values"][0] if exception_value.get("values") else ""
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -114,11 +114,6 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
         exc_type, exc_value, frame_strings, frame_metrics = process_exception_frames(
             exception, frame_metrics
         )
-        if (
-            platform not in EVENT_PLATFORMS_BYPASSING_FRAME_COUNT_CHECK
-            and frame_metrics["is_frames_truncated"]
-        ):
-            raise TooManyOnlySystemFramesException
 
         # Only exceptions have the type and value properties, so we don't need to handle the threads
         # case here

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -374,7 +374,7 @@ def get_events_from_nodestore(
             if not has_too_many_contributing_frames(event, variants, ReferrerOptions.BACKFILL):
                 grouping_info = get_grouping_info_from_variants(variants)
                 stacktrace_string = get_stacktrace_string_with_metrics(
-                    grouping_info, event.platform, ReferrerOptions.BACKFILL
+                    grouping_info, event.platform
                 )
 
             if not stacktrace_string:

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -34,7 +34,7 @@ from sentry.seer.similarity.utils import (
     ReferrerOptions,
     event_content_has_stacktrace,
     filter_null_from_string,
-    get_stacktrace_string_with_metrics,
+    get_stacktrace_string,
     has_too_many_contributing_frames,
 )
 from sentry.snuba.dataset import Dataset
@@ -373,7 +373,7 @@ def get_events_from_nodestore(
 
             if not has_too_many_contributing_frames(event, variants, ReferrerOptions.BACKFILL):
                 grouping_info = get_grouping_info_from_variants(variants)
-                stacktrace_string = get_stacktrace_string_with_metrics(grouping_info)
+                stacktrace_string = get_stacktrace_string(grouping_info)
 
             if not stacktrace_string:
                 invalid_event_group_ids.append(group_id)

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -373,9 +373,7 @@ def get_events_from_nodestore(
 
             if not has_too_many_contributing_frames(event, variants, ReferrerOptions.BACKFILL):
                 grouping_info = get_grouping_info_from_variants(variants)
-                stacktrace_string = get_stacktrace_string_with_metrics(
-                    grouping_info, event.platform
-                )
+                stacktrace_string = get_stacktrace_string_with_metrics(grouping_info)
 
             if not stacktrace_string:
                 invalid_event_group_ids.append(group_id)

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -685,7 +685,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
             mock_seer_request.reset_mock()
 
-    def test_too_many_system_frames(self) -> None:
+    def test_too_many_frames(self) -> None:
         error_type = "FailedToFetchError"
         error_value = "Charlie didn't bring the ball back"
         context_line = f"raise {error_type}('{error_value}')"

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -558,7 +558,7 @@ class GetStacktraceStringTest(TestCase):
                 ),
             ),
         ]
-        stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
+        stacktrace_str = get_stacktrace_string(data_chained_exception)
 
         # The stacktrace string should be:
         #    25 frames from OuterExcepton (with lines counting up from 1 to 25), followed by
@@ -610,7 +610,7 @@ class GetStacktraceStringTest(TestCase):
                 ),
             ),
         ]
-        stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
+        stacktrace_str = get_stacktrace_string(data_chained_exception)
 
         # The stacktrace string should be:
         #    15 frames from OuterExcepton (with lines counting up from 1 to 15), followed by
@@ -664,7 +664,7 @@ class GetStacktraceStringTest(TestCase):
                     ),
                 ),
             ]
-            stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
+            stacktrace_str = get_stacktrace_string(data_chained_exception)
 
             assert (
                 stacktrace_str.count("outer line")
@@ -684,7 +684,7 @@ class GetStacktraceStringTest(TestCase):
             )
             for i in range(1, MAX_FRAME_COUNT + 2)
         ]
-        stacktrace_str = get_stacktrace_string(data_chained_exception, platform="javascript")
+        stacktrace_str = get_stacktrace_string(data_chained_exception)
         for i in range(2, MAX_FRAME_COUNT + 2):
             assert f"exception {i} message!" in stacktrace_str
         assert "exception 1 message!" not in stacktrace_str
@@ -732,7 +732,7 @@ class GetStacktraceStringTest(TestCase):
         data_frames["app"]["component"]["values"][0]["values"][0]["values"] += self.create_frames(
             20, True, 41
         )
-        stacktrace_str = get_stacktrace_string(data_frames, platform="javascript")
+        stacktrace_str = get_stacktrace_string(data_frames)
 
         num_frames = 0
         for i in range(1, 11):
@@ -760,7 +760,7 @@ class GetStacktraceStringTest(TestCase):
                     ),
                 ),
             ]
-            stacktrace_str = get_stacktrace_string(data_frames, platform="javascript")
+            stacktrace_str = get_stacktrace_string(data_frames)
 
             assert stacktrace_str.count("context line") == expected_frame_count
 

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -794,7 +794,7 @@ class GetStacktraceStringTest(TestCase):
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete filename from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][1]
-        stacktrace_string = get_stacktrace_string_with_metrics(exception, "python")
+        stacktrace_string = get_stacktrace_string_with_metrics(exception)
         assert (
             stacktrace_string
             == 'ZeroDivisionError: division by zero\n  File "__main__", function divide_by_zero\n    divide = 1/0'

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -845,9 +845,7 @@ class GetStacktraceStringTest(TestCase):
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete filename from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][1]
-        stacktrace_string = get_stacktrace_string_with_metrics(
-            exception, "python", ReferrerOptions.INGEST
-        )
+        stacktrace_string = get_stacktrace_string_with_metrics(exception, "python")
         assert (
             stacktrace_string
             == 'ZeroDivisionError: division by zero\n  File "__main__", function divide_by_zero\n    divide = 1/0'

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -3,8 +3,6 @@ from collections.abc import Callable
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
-import pytest
-
 from sentry.eventstore.models import Event
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.variants import CustomFingerprintVariant
@@ -12,7 +10,6 @@ from sentry.seer.similarity.utils import (
     BASE64_ENCODED_PREFIXES,
     MAX_FRAME_COUNT,
     ReferrerOptions,
-    TooManyOnlySystemFramesException,
     _is_snipped_context_line,
     filter_null_from_string,
     get_stacktrace_string,
@@ -716,54 +713,6 @@ class GetStacktraceStringTest(TestCase):
         data = {"default": "something"}
         stacktrace_str = get_stacktrace_string(data)
         assert stacktrace_str == ""
-
-    def test_stacktrace_length_filter_single_exception(self):
-        data_system = copy.deepcopy(self.BASE_APP_DATA)
-        data_system["system"] = data_system.pop("app")
-        data_system["system"]["component"]["values"][0]["values"][0][
-            "values"
-        ] += self.create_frames(MAX_FRAME_COUNT + 1, True)
-
-        with pytest.raises(TooManyOnlySystemFramesException):
-            get_stacktrace_string(data_system, platform="java")
-
-    def test_stacktrace_length_filter_single_exception_invalid_platform(self):
-        data_system = copy.deepcopy(self.BASE_APP_DATA)
-        data_system["system"] = data_system.pop("app")
-        data_system["system"]["component"]["values"][0]["values"][0][
-            "values"
-        ] += self.create_frames(MAX_FRAME_COUNT + 1, True)
-
-        stacktrace_string = get_stacktrace_string(data_system, "python")
-        assert stacktrace_string is not None and stacktrace_string != ""
-
-    def test_stacktrace_length_filter_chained_exception(self):
-        data_system = copy.deepcopy(self.CHAINED_APP_DATA)
-        data_system["system"] = data_system.pop("app")
-        # Split MAX_FRAME_COUNT across the two exceptions
-        data_system["system"]["component"]["values"][0]["values"][0]["values"][0][
-            "values"
-        ] += self.create_frames(MAX_FRAME_COUNT // 2, True)
-        data_system["system"]["component"]["values"][0]["values"][1]["values"][0][
-            "values"
-        ] += self.create_frames(MAX_FRAME_COUNT // 2, True)
-
-        with pytest.raises(TooManyOnlySystemFramesException):
-            get_stacktrace_string(data_system, platform="java")
-
-    def test_stacktrace_length_filter_chained_exception_invalid_platform(self):
-        data_system = copy.deepcopy(self.CHAINED_APP_DATA)
-        data_system["system"] = data_system.pop("app")
-        # Split MAX_FRAME_COUNT across the two exceptions
-        data_system["system"]["component"]["values"][0]["values"][0]["values"][0][
-            "values"
-        ] += self.create_frames(MAX_FRAME_COUNT // 2, True)
-        data_system["system"]["component"]["values"][0]["values"][1]["values"][0][
-            "values"
-        ] += self.create_frames(MAX_FRAME_COUNT // 2, True)
-
-        stacktrace_string = get_stacktrace_string(data_system, "python")
-        assert stacktrace_string is not None and stacktrace_string != ""
 
     def test_stacktrace_truncation_uses_in_app_contributing_frames(self):
         """

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -13,7 +13,6 @@ from sentry.seer.similarity.utils import (
     _is_snipped_context_line,
     filter_null_from_string,
     get_stacktrace_string,
-    get_stacktrace_string_with_metrics,
     has_too_many_contributing_frames,
 )
 from sentry.testutils.cases import TestCase
@@ -794,7 +793,7 @@ class GetStacktraceStringTest(TestCase):
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete filename from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][1]
-        stacktrace_string = get_stacktrace_string_with_metrics(exception)
+        stacktrace_string = get_stacktrace_string(exception)
         assert (
             stacktrace_string
             == 'ZeroDivisionError: division by zero\n  File "__main__", function divide_by_zero\n    divide = 1/0'


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/82414, which added a stacktrace length filter on Seer calls based on the frame counts added recently to `StacktraceGroupingComonent`. Now that that code is handling the filtering, the current implementation, which is somewhat more complex and is based on throwing and catching `TooManyOnlySystemFramesException`, can be removed.