### PR TITLE
fix(ecosystem): Track metrics for issue detail ticket creation

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -266,12 +266,25 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             )
 
         installation = integration.get_installation(organization_id=organization_id)
-        try:
-            data = installation.create_issue(request.data)
-        except IntegrationFormError as exc:
-            return Response(exc.field_errors, status=400)
-        except IntegrationError as e:
-            return Response({"non_field_errors": [str(e)]}, status=400)
+
+        with ProjectManagementEvent(
+            action_type=ProjectManagementActionType.CREATE_EXTERNAL_ISSUE, integration=integration
+        ).capture() as lifecycle:
+            lifecycle.add_extras(
+                {
+                    "provider": integration.provider,
+                    "integration_id": integration.id,
+                }
+            )
+
+            try:
+                data = installation.create_issue(request.data)
+            except IntegrationFormError as exc:
+                lifecycle.record_halt(exc)
+                return Response(exc.field_errors, status=400)
+            except IntegrationError as e:
+                lifecycle.record_failure(e)
+                return Response({"non_field_errors": [str(e)]}, status=400)
 
         external_issue_key = installation.make_external_key(data)
         external_issue, created = ExternalIssue.objects.get_or_create(

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -268,7 +268,8 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         installation = integration.get_installation(organization_id=organization_id)
 
         with ProjectManagementEvent(
-            action_type=ProjectManagementActionType.CREATE_EXTERNAL_ISSUE, integration=integration
+            action_type=ProjectManagementActionType.CREATE_EXTERNAL_ISSUE_VIA_ISSUE_DETAIL,
+            integration=integration,
         ).capture() as lifecycle:
             lifecycle.add_extras(
                 {

--- a/src/sentry/integrations/project_management/metrics.py
+++ b/src/sentry/integrations/project_management/metrics.py
@@ -15,9 +15,7 @@ class ProjectManagementActionType(StrEnum):
     OUTBOUND_STATUS_SYNC = "outbound_status_sync"
     INBOUND_STATUS_SYNC = "inbound_status_sync"
     LINK_EXTERNAL_ISSUE = "link_external_issue"
-
-    def __str__(self):
-        return self.value.lower()
+    CREATE_EXTERNAL_ISSUE_VIA_ISSUE_DETAIL = "create_external_issue_via_issue_detail"
 
 
 class ProjectManagementHaltReason(StrEnum):


### PR DESCRIPTION
Adds metric gathering and logging to ticket creation on the issue details page. These may need to be recategorized in the future as a different form of issue creation, but for now I think it's fine to track this along with our issue alert rule metrics.


