### PR TITLE
chore(auth): remove max scope for partners

### DIFF
--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -132,20 +132,6 @@ class OAuthAuthorizeView(AuthLoginView):
             scopes = scopes.split(" ")
         else:
             scopes = []
-        if application.requires_org_level_access:
-            # Applications that require org level access have a maximum scope limit set
-            # in admin that should not pass
-            max_scopes = application.scopes
-            for scope in scopes:
-                if scope not in max_scopes:
-                    return self.error(
-                        request=request,
-                        client_id=client_id,
-                        response_type=response_type,
-                        redirect_uri=redirect_uri,
-                        name="invalid_scope",
-                        state=state,
-                    )
 
         for scope in scopes:
             if scope not in settings.SENTRY_SCOPES:

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -411,16 +411,6 @@ class OAuthAuthorizeOrgScopedTest(TestCase):
 
         assert not ApiToken.objects.filter(user=self.owner).exists()
 
-    def test_exceed_scope(self):
-        self.login_as(self.owner)
-
-        resp = self.client.get(
-            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=org:write&state=foo"
-        )
-
-        assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?error=invalid_scope&state=foo"
-
     def test_second_time(self):
         self.login_as(self.owner)
 


### PR DESCRIPTION
I added this piece of code a couple of weeks ago because we wanted to limit partners max scope but we decided not to. Removing it because it adds extra complexity 