### PR TITLE
ref(workflow_engine): remove remaining references to condition in validators

### DIFF
--- a/src/sentry/incidents/endpoints/validators.py
+++ b/src/sentry/incidents/endpoints/validators.py
@@ -89,7 +89,6 @@ class MetricAlertComparisonConditionValidator(NumericComparisonConditionValidato
 
     supported_conditions = frozenset((Condition.GREATER, Condition.LESS))
     supported_results = frozenset((DetectorPriorityLevel.HIGH, DetectorPriorityLevel.MEDIUM))
-    type = "metric_alert"
 
 
 class MetricAlertsDetectorValidator(BaseGroupTypeDetectorValidator):

--- a/src/sentry/workflow_engine/endpoints/validators.py
+++ b/src/sentry/workflow_engine/endpoints/validators.py
@@ -80,13 +80,13 @@ class NumericComparisonConditionValidator(BaseDataConditionValidator):
 
     def validate_type(self, value: str) -> Condition:
         try:
-            condition = Condition(value)
+            type = Condition(value)
         except ValueError:
-            condition = None
+            type = None
 
-        if condition not in self.supported_conditions:
-            raise serializers.ValidationError(f"Unsupported condition {value}")
-        return condition
+        if type not in self.supported_conditions:
+            raise serializers.ValidationError(f"Unsupported type {value}")
+        return type
 
     def validate_result(self, value: str) -> DetectorPriorityLevel:
         try:

--- a/src/sentry/workflow_engine/endpoints/validators.py
+++ b/src/sentry/workflow_engine/endpoints/validators.py
@@ -37,7 +37,7 @@ class DataSourceCreator(Generic[T]):
 
 class BaseDataConditionValidator(CamelSnakeSerializer):
 
-    condition = serializers.CharField(
+    type = serializers.CharField(
         required=True,
         max_length=200,
         help_text="Condition used to compare data value to the stored comparison value",
@@ -51,14 +51,8 @@ class BaseDataConditionValidator(CamelSnakeSerializer):
     def result(self) -> Field:
         raise NotImplementedError
 
-    @property
-    def type(self) -> str:
-        # TODO: This should probably at least be an enum
-        raise NotImplementedError
-
     def validate(self, attrs):
         attrs = super().validate(attrs)
-        attrs["type"] = self.type
         return attrs
 
 
@@ -84,7 +78,7 @@ class NumericComparisonConditionValidator(BaseDataConditionValidator):
     def supported_results(self) -> frozenset[DetectorPriorityLevel]:
         raise NotImplementedError
 
-    def validate_condition(self, value: str) -> Condition:
+    def validate_type(self, value: str) -> Condition:
         try:
             condition = Condition(value)
         except ValueError:
@@ -162,7 +156,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
                 DataCondition.objects.create(
                     comparison=condition["comparison"],
                     condition_result=condition["result"],
-                    type=condition["condition"],
+                    type=condition["type"],
                     condition_group=condition_group,
                 )
             detector = Detector.objects.create(

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -70,7 +70,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
             },
             "data_conditions": [
                 {
-                    "condition": "gt",
+                    "type": Condition.GREATER,
                     "comparison": 100,
                     "result": DetectorPriorityLevel.HIGH,
                 }

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -60,7 +60,7 @@ class TestNumericComparisonConditionValidator(TestCase):
         validator = self.validator_class()
         with pytest.raises(
             ValidationError,
-            match="[ErrorDetail(string='Unsupported condition invalid_condition', code='invalid')]",
+            match="[ErrorDetail(string='Unsupported type invalid_condition', code='invalid')]",
         ):
             validator.validate_type("invalid_condition")
 
@@ -154,7 +154,7 @@ class MetricAlertComparisonConditionValidatorTest(TestCase):
         )
         assert not validator.is_valid()
         assert validator.errors.get("type") == [
-            ErrorDetail(string="Unsupported condition invalid", code="invalid")
+            ErrorDetail(string="Unsupported type invalid", code="invalid")
         ]
 
     def test_invalid_comparison(self):

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -54,7 +54,7 @@ class TestNumericComparisonConditionValidator(TestCase):
 
     def test_validate_condition_valid(self):
         validator = self.validator_class()
-        assert validator.validate_condition("gt") == Condition.GREATER
+        assert validator.validate_type("gt") == Condition.GREATER
 
     def test_validate_condition_invalid(self):
         validator = self.validator_class()
@@ -62,7 +62,7 @@ class TestNumericComparisonConditionValidator(TestCase):
             ValidationError,
             match="[ErrorDetail(string='Unsupported condition invalid_condition', code='invalid')]",
         ):
-            validator.validate_condition("invalid_condition")
+            validator.validate_type("invalid_condition")
 
     def test_validate_result_valid(self):
         validator = self.validator_class()
@@ -135,29 +135,32 @@ class TestBaseGroupTypeDetectorValidator(TestCase):
 class MetricAlertComparisonConditionValidatorTest(TestCase):
     def test(self):
         validator = MetricAlertComparisonConditionValidator(
-            data={"condition": "gt", "comparison": 100, "result": DetectorPriorityLevel.HIGH}
+            data={
+                "type": Condition.GREATER,
+                "comparison": 100,
+                "result": DetectorPriorityLevel.HIGH,
+            }
         )
         assert validator.is_valid()
         assert validator.validated_data == {
             "comparison": 100.0,
-            "condition": Condition.GREATER,
             "result": DetectorPriorityLevel.HIGH,
-            "type": "metric_alert",
+            "type": Condition.GREATER,
         }
 
     def test_invalid_condition(self):
         validator = MetricAlertComparisonConditionValidator(
-            data={"condition": "invalid", "comparison": 100, "result": DetectorPriorityLevel.HIGH}
+            data={"type": "invalid", "comparison": 100, "result": DetectorPriorityLevel.HIGH}
         )
         assert not validator.is_valid()
-        assert validator.errors.get("condition") == [
+        assert validator.errors.get("type") == [
             ErrorDetail(string="Unsupported condition invalid", code="invalid")
         ]
 
     def test_invalid_comparison(self):
         validator = MetricAlertComparisonConditionValidator(
             data={
-                "condition": "gt",
+                "type": Condition.GREATER,
                 "comparison": "not_a_number",
                 "result": DetectorPriorityLevel.HIGH,
             }
@@ -169,7 +172,7 @@ class MetricAlertComparisonConditionValidatorTest(TestCase):
 
     def test_invalid_result(self):
         validator = MetricAlertComparisonConditionValidator(
-            data={"condition": "gt", "comparison": 100, "result": 25}
+            data={"type": Condition.GREATER, "comparison": 100, "result": 25}
         )
         assert not validator.is_valid()
         assert validator.errors.get("result") == [
@@ -195,7 +198,7 @@ class DetectorValidatorTest(TestCase):
             },
             "data_conditions": [
                 {
-                    "condition": "gte",
+                    "type": Condition.GREATER_OR_EQUAL,
                     "comparison": 100,
                     "result": DetectorPriorityLevel.HIGH,
                 }
@@ -287,7 +290,7 @@ class TestMetricAlertsDetectorValidator(TestCase):
             },
             "data_conditions": [
                 {
-                    "condition": "gt",
+                    "type": Condition.GREATER,
                     "comparison": 100,
                     "result": DetectorPriorityLevel.HIGH,
                 }
@@ -342,7 +345,7 @@ class TestMetricAlertsDetectorValidator(TestCase):
         conditions = list(DataCondition.objects.filter(condition_group=condition_group))
         assert len(conditions) == 1
         condition = conditions[0]
-        assert condition.type == "gt"
+        assert condition.type == Condition.GREATER
         assert condition.comparison == 100
         assert condition.condition_result == DetectorPriorityLevel.HIGH
 
@@ -367,9 +370,21 @@ class TestMetricAlertsDetectorValidator(TestCase):
         data = {
             **self.valid_data,
             "data_conditions": [
-                {"condition": "gt", "comparison": 100, "result": DetectorPriorityLevel.HIGH},
-                {"condition": "gt", "comparison": 200, "result": DetectorPriorityLevel.HIGH},
-                {"condition": "gt", "comparison": 300, "result": DetectorPriorityLevel.HIGH},
+                {
+                    "type": Condition.GREATER,
+                    "comparison": 100,
+                    "result": DetectorPriorityLevel.HIGH,
+                },
+                {
+                    "type": Condition.GREATER,
+                    "comparison": 200,
+                    "result": DetectorPriorityLevel.HIGH,
+                },
+                {
+                    "type": Condition.GREATER,
+                    "comparison": 300,
+                    "result": DetectorPriorityLevel.HIGH,
+                },
             ],
         }
         validator = MetricAlertsDetectorValidator(data=data, context=self.context)
@@ -433,7 +448,6 @@ class TestBaseDataSourceValidator(TestCase):
 class MockDataConditionValidator(NumericComparisonConditionValidator):
     supported_conditions = frozenset([Condition.GREATER_OR_EQUAL, Condition.LESS_OR_EQUAL])
     supported_results = frozenset([DetectorPriorityLevel.HIGH, DetectorPriorityLevel.LOW])
-    type = "test"
 
 
 class MockDetectorValidator(BaseGroupTypeDetectorValidator):


### PR DESCRIPTION
Refactor the validator checks for the `condition` field, which was removed, so that they now validate the `type` field. 