### PR TITLE
feat(uptime): Use `UptimeSubscriptionRegion` to direct config updates to the appropriate region topic

### DIFF
--- a/src/sentry/uptime/config_producer.py
+++ b/src/sentry/uptime/config_producer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 from arroyo import Topic as ArroyoTopic
@@ -8,8 +9,11 @@ from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+
+logger = logging.getLogger(__name__)
 
 UPTIME_CONFIGS_CODEC: Codec[CheckConfig] = get_topic_codec(Topic.UPTIME_CONFIGS)
 
@@ -25,16 +29,30 @@ def _get_producer() -> KafkaProducer:
 _configs_producer = SingletonProducer(_get_producer)
 
 
-def produce_config(config: CheckConfig):
-    _produce_to_kafka(UUID(config["subscription_id"]), UPTIME_CONFIGS_CODEC.encode(config))
+def produce_config(destination_region_slug: str, config: CheckConfig):
+    _produce_to_kafka(
+        destination_region_slug,
+        UUID(config["subscription_id"]),
+        UPTIME_CONFIGS_CODEC.encode(config),
+    )
 
 
-def produce_config_removal(subscription_id: str):
-    _produce_to_kafka(UUID(subscription_id), None)
+def produce_config_removal(destination_region_slug: str, subscription_id: str):
+    _produce_to_kafka(destination_region_slug, UUID(subscription_id), None)
 
 
-def _produce_to_kafka(subscription_id: UUID, value: bytes | None) -> None:
-    topic = get_topic_definition(Topic.UPTIME_CONFIGS)["real_topic_name"]
+def _produce_to_kafka(
+    destination_region_slug: str, subscription_id: UUID, value: bytes | None
+) -> None:
+    region_config = get_region_config(destination_region_slug)
+    if region_config is None:
+        logger.error(
+            "Attempted to create uptime subscription with invalid region slug",
+            extra={"region_slug": destination_region_slug, "subscription_id": subscription_id},
+        )
+        return
+
+    topic = get_topic_definition(region_config.config_topic)["real_topic_name"]
     payload = KafkaPayload(
         subscription_id.bytes,
         # Typically None is not allowed for the arroyo payload, but in this

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -25,6 +25,7 @@ from sentry.uptime.models import (
     UptimeStatus,
     UptimeSubscription,
 )
+from sentry.uptime.subscriptions.regions import get_active_region_configs
 from sentry.uptime.subscriptions.subscriptions import (
     delete_uptime_subscriptions_for_project,
     get_or_create_uptime_subscription,
@@ -79,7 +80,10 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         if subscription is None:
             # If no subscription in the Postgres, this subscription has been orphaned. Remove
             # from the checker
-            send_uptime_config_deletion(result["subscription_id"])
+            # TODO: Send to region specifically from this check result once we update the schema
+            send_uptime_config_deletion(
+                get_active_region_configs()[0].slug, result["subscription_id"]
+            )
             metrics.incr("uptime.result_processor.subscription_not_found", sample_rate=1.0)
             return
 

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -10,15 +10,8 @@ def get_active_region_configs() -> list[UptimeRegionConfig]:
 
 
 def get_region_config(region_slug: str) -> UptimeRegionConfig | None:
-    region = get_region_lookup().get(region_slug)
+    region = next((r for r in settings.UPTIME_REGIONS if r.slug == region_slug), None)
     if region is None:
         # XXX: Temporary hack to guarantee we get a config
         region = get_active_region_configs()[0]
     return region
-
-
-def get_region_lookup() -> dict[str, UptimeRegionConfig]:
-    global region_lookup
-    if region_lookup is None:
-        region_lookup = {r.slug: r for r in settings.UPTIME_REGIONS}
-    return region_lookup

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -2,8 +2,6 @@ from django.conf import settings
 
 from sentry.conf.types.uptime import UptimeRegionConfig
 
-region_lookup = None
-
 
 def get_active_region_configs() -> list[UptimeRegionConfig]:
     return [v for v in settings.UPTIME_REGIONS if v.enabled]

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -11,6 +11,7 @@ from sentry.snuba.models import QuerySubscription
 from sentry.tasks.base import instrumented_task
 from sentry.uptime.config_producer import produce_config, produce_config_removal
 from sentry.uptime.models import UptimeRegionScheduleMode, UptimeSubscription
+from sentry.uptime.subscriptions.regions import get_active_region_configs
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -35,10 +36,17 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         metrics.incr("uptime.subscriptions.create.incorrect_status", sample_rate=1.0)
         return
 
-    subscription_id = send_uptime_subscription_config(subscription)
-    # TODO: Ideally this should actually be `PENDING_FIRST_UPDATE` so we can validate it's really working as expected
+    region_slugs = [s.region_slug for s in subscription.regions.all()]
+    if not region_slugs:
+        # XXX: Hack to make sure that region configs are sent even if we don't have region rows present.
+        # Remove once everything is in place
+        region_slugs = [get_active_region_configs()[0].slug]
+
+    for region_slug in region_slugs:
+        send_uptime_subscription_config(region_slug, subscription)
     subscription.update(
-        status=QuerySubscription.Status.ACTIVE.value, subscription_id=subscription_id
+        status=QuerySubscription.Status.ACTIVE.value,
+        subscription_id=subscription.subscription_id,
     )
 
 
@@ -62,6 +70,12 @@ def delete_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         metrics.incr("uptime.subscriptions.delete.incorrect_status", sample_rate=1.0)
         return
 
+    region_slugs = [s.region_slug for s in subscription.regions.all()]
+    if not region_slugs:
+        # XXX: Hack to make sure that region configs are sent even if we don't have regions present.
+        # Remove once everything is in place
+        region_slugs = [get_active_region_configs()[0].slug]
+
     subscription_id = subscription.subscription_id
     if subscription.status == QuerySubscription.Status.DELETING.value:
         subscription.delete()
@@ -69,15 +83,16 @@ def delete_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         subscription.update(subscription_id=None)
 
     if subscription_id is not None:
-        send_uptime_config_deletion(subscription_id)
+        for region_slug in region_slugs:
+            send_uptime_config_deletion(region_slug, subscription_id)
 
 
-def send_uptime_subscription_config(subscription: UptimeSubscription) -> str:
-    # Whenever we create/update a config we always want to generate a new subscription id. This allows us to validate
-    # that the config took effect
-    subscription_id = uuid4().hex
-    produce_config(uptime_subscription_to_check_config(subscription, subscription_id))
-    return subscription_id
+def send_uptime_subscription_config(region_slug: str, subscription: UptimeSubscription):
+    if subscription.subscription_id is None:
+        subscription.subscription_id = uuid4().hex
+    produce_config(
+        region_slug, uptime_subscription_to_check_config(subscription, subscription.subscription_id)
+    )
 
 
 def uptime_subscription_to_check_config(
@@ -104,8 +119,8 @@ def uptime_subscription_to_check_config(
     return config
 
 
-def send_uptime_config_deletion(subscription_id: str) -> None:
-    produce_config_removal(subscription_id)
+def send_uptime_config_deletion(destination_region_slug: str, subscription_id: str) -> None:
+    produce_config_removal(destination_region_slug, subscription_id)
 
 
 @instrumented_task(

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -379,7 +379,7 @@ class ProcessResultTest(ProducerTestMixin):
             metrics.incr.assert_has_calls(
                 [call("uptime.result_processor.subscription_not_found", sample_rate=1.0)]
             )
-            self.assert_producer_calls(subscription_id)
+            self.assert_producer_calls((subscription_id, kafka_definition.Topic.UPTIME_CONFIGS))
 
     def test_skip_already_processed(self):
         result = self.create_uptime_result(self.subscription.subscription_id)

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -1,14 +1,8 @@
-from unittest import mock
-
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.conf.types.uptime import UptimeRegionConfig
-from sentry.uptime.subscriptions.regions import (
-    get_active_region_configs,
-    get_region_config,
-    get_region_lookup,
-)
+from sentry.uptime.subscriptions.regions import get_active_region_configs, get_region_config
 
 
 class TestBase(TestCase):
@@ -34,16 +28,10 @@ class TestBase(TestCase):
             ),
         ]
 
-    def tearDown(self):
-        # Reset the global region_lookup between tests
-        from sentry.uptime.subscriptions import regions
-
-        regions.region_lookup = None
-
 
 class GetActiveRegionConfigsTest(TestBase):
     def test_returns_only_enabled_regions(self):
-        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+        with override_settings(UPTIME_REGIONS=self.test_regions):
             active_regions = get_active_region_configs()
             assert len(active_regions) == 2
             assert all(region.enabled for region in active_regions)
@@ -52,28 +40,14 @@ class GetActiveRegionConfigsTest(TestBase):
 
 class GetRegionConfigTest(TestBase):
     def test_returns_existing_region(self):
-        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+        with override_settings(UPTIME_REGIONS=self.test_regions):
             region = get_region_config("us")
             assert region is not None
             assert region.slug == "us"
             assert region.name == "United States"
 
     def test_returns_first_active_region_for_invalid_slug(self):
-        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
+        with override_settings(UPTIME_REGIONS=self.test_regions):
             region = get_region_config("invalid")
             assert region is not None
             assert region.slug == "us"  # First active region
-
-
-class GetRegionLookupTest(TestBase):
-    def test_creates_lookup_dictionary(self):
-        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
-            lookup = get_region_lookup()
-            assert len(lookup) == 3
-            assert set(lookup.keys()) == {"us", "eu", "ap"}
-
-    def test_caches_lookup_dictionary(self):
-        with mock.patch("django.conf.settings.UPTIME_REGIONS", self.test_regions):
-            lookup1 = get_region_lookup()
-            lookup2 = get_region_lookup()
-            assert lookup1 is lookup2

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -93,7 +93,6 @@ class CreateUptimeSubscriptionTest(UptimeTestCase):
         assert uptime_sub.id == new_sub.id
         assert new_sub.status == UptimeSubscription.Status.ACTIVE.value
         assert new_sub.subscription_id is not None
-        assert new_sub.subscription_id != uptime_sub.subscription_id
 
     def test_without_task(self):
         url = "https://sentry.io"

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -5,13 +5,18 @@ from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
+from arroyo import Topic as ArroyoTopic
+from django.test import override_settings
 from django.utils import timezone
 
+from sentry.conf.types.kafka_definition import Topic
+from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.skips import requires_kafka
 from sentry.uptime.config_producer import UPTIME_CONFIGS_CODEC
 from sentry.uptime.models import UptimeSubscription
+from sentry.uptime.subscriptions.regions import get_active_region_configs
 from sentry.uptime.subscriptions.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
     create_remote_uptime_subscription,
@@ -20,6 +25,7 @@ from sentry.uptime.subscriptions.tasks import (
     subscription_checker,
     uptime_subscription_to_check_config,
 )
+from sentry.utils.kafka_config import get_topic_definition
 
 pytestmark = [requires_kafka]
 
@@ -33,25 +39,31 @@ class ProducerTestMixin(UptimeTestCase):
             self.producer = producer
             yield
 
-    def assert_producer_calls(self, *args: UptimeSubscription | str):
-        expected_payloads = [
-            (
+    def assert_producer_calls(self, *args: tuple[UptimeSubscription | str, Topic]):
+        # Verify the number of calls matches what we expect
+        assert len(self.producer.produce.call_args_list) == len(args)
+
+        for (arg, expected_topic), producer_call in zip(args, self.producer.produce.call_args_list):
+            # Check topic
+            assert producer_call[0][0] == ArroyoTopic(
+                get_topic_definition(expected_topic)["real_topic_name"]
+            )
+
+            # Check message ID
+            expected_message_id = UUID(
+                arg.subscription_id if isinstance(arg, UptimeSubscription) else arg
+            ).bytes
+            assert producer_call[0][1].key == expected_message_id
+
+            # Check payload
+            expected_payload = (
                 UPTIME_CONFIGS_CODEC.encode(
                     uptime_subscription_to_check_config(arg, str(arg.subscription_id))
                 )
                 if isinstance(arg, UptimeSubscription)
                 else None
             )
-            for arg in args
-        ]
-        expected_message_ids = [
-            UUID(arg.subscription_id if isinstance(arg, UptimeSubscription) else arg).bytes
-            for arg in args
-        ]
-        passed_message_ids = [ca[0][1].key for ca in self.producer.produce.call_args_list]
-        assert expected_message_ids == passed_message_ids
-        passed_payloads = [ca[0][1].value for ca in self.producer.produce.call_args_list]
-        assert expected_payloads == passed_payloads
+            assert producer_call[0][1].value == expected_payload
 
 
 class BaseUptimeSubscriptionTaskTest(ProducerTestMixin, metaclass=abc.ABCMeta):
@@ -122,7 +134,69 @@ class CreateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         sub.refresh_from_db()
         assert sub.status == UptimeSubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
-        self.assert_producer_calls(sub)
+        self.assert_producer_calls((sub, Topic.UPTIME_CONFIGS))
+
+    def test_with_regions(self):
+        sub = self.create_uptime_subscription(
+            status=UptimeSubscription.Status.CREATING, region_slugs=["default"]
+        )
+        create_remote_uptime_subscription(sub.id)
+        sub.refresh_from_db()
+        assert sub.status == UptimeSubscription.Status.ACTIVE.value
+        assert sub.subscription_id is not None
+        self.assert_producer_calls((sub, Topic.UPTIME_CONFIGS))
+
+    def test_without_regions_uses_default(self):
+        sub = self.create_uptime_subscription(status=UptimeSubscription.Status.CREATING)
+        create_remote_uptime_subscription(sub.id)
+        sub.refresh_from_db()
+        assert sub.status == UptimeSubscription.Status.ACTIVE.value
+        assert sub.subscription_id is not None
+        self.assert_producer_calls((sub, get_active_region_configs()[0].config_topic))
+
+    def test_multi_overlapping_regions(self):
+        regions = [
+            UptimeRegionConfig(
+                slug="region1",
+                name="Region 1",
+                config_topic=Topic.UPTIME_CONFIGS,
+                enabled=True,
+            ),
+            UptimeRegionConfig(
+                slug="region2",
+                name="Region 2",
+                config_topic=Topic.UPTIME_RESULTS,  # Using a different topic
+                enabled=True,
+            ),
+            UptimeRegionConfig(
+                slug="region3",
+                name="Region 3",
+                config_topic=Topic.MONITORS_CLOCK_TASKS,  # Another different topic
+                enabled=True,
+            ),
+        ]
+        with override_settings(UPTIME_REGIONS=regions):
+            # First subscription with regions 1 and 2
+            sub1 = self.create_uptime_subscription(
+                status=UptimeSubscription.Status.CREATING, region_slugs=["region1", "region2"]
+            )
+            create_remote_uptime_subscription(sub1.id)
+            sub1.refresh_from_db()
+
+            # Second subscription with regions 2 and 3
+            sub2 = self.create_uptime_subscription(
+                status=UptimeSubscription.Status.CREATING, region_slugs=["region2", "region3"]
+            )
+            create_remote_uptime_subscription(sub2.id)
+            sub2.refresh_from_db()
+
+            # Verify that each subscription was sent to the correct topics for its regions
+            self.assert_producer_calls(
+                (sub1, Topic.UPTIME_CONFIGS),
+                (sub1, Topic.UPTIME_RESULTS),
+                (sub2, Topic.UPTIME_RESULTS),
+                (sub2, Topic.MONITORS_CLOCK_TASKS),
+            )
 
 
 class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
@@ -136,7 +210,7 @@ class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         )
         delete_remote_uptime_subscription(sub.id)
         assert not UptimeSubscription.objects.filter(id=sub.id).exists()
-        self.assert_producer_calls(subscription_id)
+        self.assert_producer_calls((subscription_id, Topic.UPTIME_CONFIGS))
 
     def test_no_subscription_id(self):
         sub = self.create_subscription(UptimeSubscription.Status.DELETING)
@@ -145,10 +219,32 @@ class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         assert not UptimeSubscription.objects.filter(id=sub.id).exists()
         self.assert_producer_calls()
 
+    def test_delete_with_regions(self):
+        sub = self.create_uptime_subscription(
+            status=UptimeSubscription.Status.DELETING,
+            subscription_id=uuid4().hex,
+            region_slugs=["default"],
+        )
+        delete_remote_uptime_subscription(sub.id)
+        assert sub.subscription_id is not None
+        self.assert_producer_calls((sub.subscription_id, Topic.UPTIME_CONFIGS))
+        with pytest.raises(UptimeSubscription.DoesNotExist):
+            sub.refresh_from_db()
+
+    def test_delete_without_regions_uses_default(self):
+        sub = self.create_uptime_subscription(
+            status=UptimeSubscription.Status.DELETING, subscription_id=uuid4().hex
+        )
+        delete_remote_uptime_subscription(sub.id)
+        assert sub.subscription_id is not None
+        self.assert_producer_calls((sub.subscription_id, Topic.UPTIME_CONFIGS))
+        with pytest.raises(UptimeSubscription.DoesNotExist):
+            sub.refresh_from_db()
+
 
 class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
     def test_basic(self):
-        sub = self.create_uptime_subscription(region_slugs=["us-east-1", "eu-west-1"])
+        sub = self.create_uptime_subscription(region_slugs=["default"])
 
         subscription_id = uuid4().hex
         assert uptime_subscription_to_check_config(sub, subscription_id) == {
@@ -159,7 +255,7 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "request_method": "GET",
             "request_headers": [],
             "trace_sampling": False,
-            "active_regions": ["us-east-1", "eu-west-1"],
+            "active_regions": ["default"],
             "region_schedule_mode": "round_robin",
         }
 
@@ -172,7 +268,7 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             headers=headers,
             body=body,
             trace_sampling=True,
-            region_slugs=["us-east-1"],
+            region_slugs=["default"],
         )
         sub.refresh_from_db()
 
@@ -186,13 +282,13 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "request_headers": headers,
             "request_body": body,
             "trace_sampling": True,
-            "active_regions": ["us-east-1"],
+            "active_regions": ["default"],
             "region_schedule_mode": "round_robin",
         }
 
     def test_header_translation(self):
         headers = {"hi": "bye"}
-        sub = self.create_uptime_subscription(headers=headers, region_slugs=["us-east-1"])
+        sub = self.create_uptime_subscription(headers=headers, region_slugs=["default"])
         sub.refresh_from_db()
 
         subscription_id = uuid4().hex
@@ -204,7 +300,7 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "request_method": "GET",
             "request_headers": [["hi", "bye"]],
             "trace_sampling": False,
-            "active_regions": ["us-east-1"],
+            "active_regions": ["default"],
             "region_schedule_mode": "round_robin",
         }
 
@@ -225,10 +321,11 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
 
 
 class SendUptimeConfigDeletionTest(ProducerTestMixin):
-    def test(self):
+    def test_with_region(self):
         subscription_id = uuid4().hex
-        send_uptime_config_deletion(subscription_id)
-        self.assert_producer_calls(subscription_id)
+        region_slug = "default"
+        send_uptime_config_deletion(region_slug, subscription_id)
+        self.assert_producer_calls((subscription_id, Topic.UPTIME_CONFIGS))
 
 
 class SubscriptionCheckerTest(UptimeTestCase):


### PR DESCRIPTION
This uses `UptimeSubscriptionRegion` to determine which regions a subscription should be run in, and sends config updates to each of those regions.

Changes the config producer to use `UPTIME_REGIONS` to route messages to the appropriate topic, instead of being hardcoded.

Also includes hacks to use the default region when no regions exist for a subscription. This is temporary until we start writing `UptimeSubscriptionRegion` rows.

We should wait until https://github.com/getsentry/ops/pull/13422 is merged before going ahead, so that regions are appropriately configured in production.
