### PR TITLE
feat(seer grouping): Add platform to ingest metrics

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -73,11 +73,13 @@ def _event_content_is_seer_eligible(event: Event) -> bool:
     """
     Determine if an event's contents makes it fit for using with Seer's similar issues model.
     """
+    platform = event.platform
+
     if not event_content_has_stacktrace(event):
         metrics.incr(
             "grouping.similarity.event_content_seer_eligible",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"eligible": False, "blocker": "no-stacktrace"},
+            tags={"platform": platform, "eligible": False, "blocker": "no-stacktrace"},
         )
         return False
 
@@ -85,14 +87,14 @@ def _event_content_is_seer_eligible(event: Event) -> bool:
         metrics.incr(
             "grouping.similarity.event_content_seer_eligible",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"eligible": False, "blocker": "unsupported-platform"},
+            tags={"platform": platform, "eligible": False, "blocker": "unsupported-platform"},
         )
         return False
 
     metrics.incr(
         "grouping.similarity.event_content_seer_eligible",
         sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-        tags={"eligible": True, "blocker": "none"},
+        tags={"platform": platform, "eligible": True, "blocker": "none"},
     )
     return True
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -265,11 +265,11 @@ def event_content_has_stacktrace(event: GroupEvent | Event) -> bool:
     return exception_stacktrace or threads_stacktrace or only_stacktrace
 
 
-def record_did_call_seer_metric(*, call_made: bool, blocker: str) -> None:
+def record_did_call_seer_metric(event: Event, *, call_made: bool, blocker: str) -> None:
     metrics.incr(
         "grouping.similarity.did_call_seer",
         sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-        tags={"call_made": call_made, "blocker": blocker},
+        tags={"call_made": call_made, "blocker": blocker, "platform": event.platform},
     )
 
 
@@ -334,7 +334,7 @@ def has_too_many_contributing_frames(
 def killswitch_enabled(
     project_id: int | None,
     referrer: ReferrerOptions,
-    event: GroupEvent | Event | None = None,
+    event: Event | None = None,
 ) -> bool:
     """
     Check both the global and similarity-specific Seer killswitches.
@@ -348,8 +348,9 @@ def killswitch_enabled(
             f"{logger_prefix}.seer_global_killswitch_enabled",  # noqa
             extra=logger_extra,
         )
-        if is_ingest:
-            record_did_call_seer_metric(call_made=False, blocker="global-killswitch")
+        # When it's ingest, `event` will always be defined - the second check is purely for mypy
+        if is_ingest and event:
+            record_did_call_seer_metric(event, call_made=False, blocker="global-killswitch")
 
         return True
 
@@ -358,8 +359,8 @@ def killswitch_enabled(
             f"{logger_prefix}.seer_similarity_killswitch_enabled",  # noqa
             extra=logger_extra,
         )
-        if is_ingest:
-            record_did_call_seer_metric(call_made=False, blocker="similarity-killswitch")
+        if is_ingest and event:
+            record_did_call_seer_metric(event, call_made=False, blocker="similarity-killswitch")
 
         return True
 
@@ -370,8 +371,8 @@ def killswitch_enabled(
             f"{logger_prefix}.seer_similarity_project_killswitch_enabled",  # noqa
             extra=logger_extra,
         )
-        if is_ingest:
-            record_did_call_seer_metric(call_made=False, blocker="project-killswitch")
+        if is_ingest and event:
+            record_did_call_seer_metric(event, call_made=False, blocker="project-killswitch")
 
         return True
 

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -203,7 +203,7 @@ class ShouldCallSeerTest(TestCase):
 
         assert should_call_seer_for_grouping(new_event, new_event.get_grouping_variants()) is False
         mock_record_did_call_seer.assert_any_call(
-            call_made=False, blocker="empty-stacktrace-string"
+            new_event, call_made=False, blocker="empty-stacktrace-string"
         )
 
     @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
@@ -466,7 +466,9 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
                 "outcome": "block",
             },
         )
-        mock_record_did_call_seer.assert_any_call(call_made=False, blocker="excess-frames")
+        mock_record_did_call_seer.assert_any_call(
+            new_event, call_made=False, blocker="excess-frames"
+        )
 
         mock_get_similar_issues.assert_not_called()
 


### PR DESCRIPTION
This adds a `platform` tag to both the `did_call_seer` and `event_content_seer_eligible` metrics we collect as part of ingest.