### PR TITLE
ref(quick-start): Move 'Link Sentry to Source Code' above 'Track releases'

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -45,8 +45,8 @@ const orderedGettingStartedTasks = [
   OnboardingTaskKey.INVITE_MEMBER,
   OnboardingTaskKey.ALERT_RULE,
   OnboardingTaskKey.SOURCEMAPS,
-  OnboardingTaskKey.RELEASE_TRACKING,
   OnboardingTaskKey.LINK_SENTRY_TO_SOURCE_CODE,
+  OnboardingTaskKey.RELEASE_TRACKING,
 ];
 
 const orderedBeyondBasicsTasks = [


### PR DESCRIPTION
We think it makes more sense 