### PR TITLE
feat(dynamic-sampling): Scroll to save button

### DIFF
--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -1,5 +1,6 @@
-import {useMemo, useState} from 'react';
+import React, {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
 
 import {
   addErrorMessage,
@@ -11,6 +12,8 @@ import LoadingError from 'sentry/components/loadingError';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
@@ -161,18 +164,101 @@ export function ProjectSampling() {
           <Button disabled={isFormActionDisabled} onClick={handleReset}>
             {t('Reset')}
           </Button>
-          <Button
-            priority="primary"
-            disabled={isFormActionDisabled || !formState.isValid}
-            onClick={handleSubmit}
-          >
-            {t('Apply Changes')}
-          </Button>
+          <ScrollIntoViewButton enabled={!isFormActionDisabled && formState.isValid}>
+            <Button
+              priority="primary"
+              disabled={isFormActionDisabled || !formState.isValid}
+              onClick={handleSubmit}
+            >
+              {t('Apply Changes')}
+            </Button>
+          </ScrollIntoViewButton>
         </FormActions>
       </form>
     </FormProvider>
   );
 }
+
+function ScrollIntoViewButton({
+  children,
+  enabled,
+}: {
+  children: React.ReactElement;
+  enabled: boolean;
+}) {
+  if (React.Children.count(children) !== 1) {
+    throw new Error('ScrollIntoViewButton only accepts a single child');
+  }
+
+  const [isVisible, setIsVisible] = useState(false);
+  const [targetElement, setTargetElement] = useState<HTMLElement>();
+
+  useEffect(() => {
+    if (!targetElement || !enabled) {
+      return () => {};
+    }
+
+    const observer = new IntersectionObserver(
+      observerEntries => {
+        const entry = observerEntries[0];
+        setIsVisible(!entry.isIntersecting);
+      },
+      {
+        root: null,
+        threshold: 0.5,
+      }
+    );
+
+    observer.observe(targetElement);
+    return () => {
+      observer.disconnect();
+      setIsVisible(false);
+    };
+  }, [targetElement, enabled]);
+
+  return (
+    <Fragment>
+      {React.cloneElement(children, {ref: setTargetElement})}
+      {isVisible && (
+        <Tooltip title={t('Scroll down')} skipWrapper>
+          <FloatingButton
+            type="button"
+            onClick={() => {
+              targetElement?.scrollIntoView({behavior: 'smooth'});
+            }}
+            initial={{opacity: 0, scale: 0.5}}
+            animate={{opacity: 1, scale: 1}}
+            transition={{
+              ease: [0, 0.71, 0.2, 1.4],
+            }}
+            data-visible={isVisible}
+          >
+            <IconArrow direction="down" size="sm" />
+          </FloatingButton>
+        </Tooltip>
+      )}
+    </Fragment>
+  );
+}
+
+const FloatingButton = styled(motion.button)`
+  position: fixed;
+  bottom: ${space(4)};
+  right: ${space(1)};
+  border-radius: 50%;
+  border: 1px solid ${p => p.theme.border};
+  background-color: ${p => p.theme.background};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  width: 36px;
+  height: 36px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+
+  &[data-visible='true'] {
+    display: flex;
+  }
+`;
 
 const FormActions = styled('div')`
   display: grid;

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -220,7 +220,7 @@ function ScrollIntoViewButton({
     <Fragment>
       {React.cloneElement(children, {ref: setTargetElement})}
       {isVisible && (
-        <Tooltip title={t('Scroll down')} skipWrapper>
+        <Tooltip title={t('Scroll down to apply changes')} skipWrapper>
           <FloatingButton
             type="button"
             onClick={() => {
@@ -247,7 +247,8 @@ const FloatingButton = styled(motion.button)`
   right: ${space(1)};
   border-radius: 50%;
   border: 1px solid ${p => p.theme.border};
-  background-color: ${p => p.theme.background};
+  background-color: ${p => p.theme.purple400};
+  color: ${p => p.theme.white};
   box-shadow: ${p => p.theme.dropShadowHeavy};
   width: 36px;
   height: 36px;

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -231,7 +231,6 @@ function ScrollIntoViewButton({
             transition={{
               ease: [0, 0.71, 0.2, 1.4],
             }}
-            data-visible={isVisible}
           >
             <IconArrow direction="down" size="sm" />
           </FloatingButton>
@@ -252,13 +251,9 @@ const FloatingButton = styled(motion.button)`
   box-shadow: ${p => p.theme.dropShadowHeavy};
   width: 36px;
   height: 36px;
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
-
-  &[data-visible='true'] {
-    display: flex;
-  }
 `;
 
 const FormActions = styled('div')`


### PR DESCRIPTION
Add a floating button to scroll to save button.
The floating button is displayed only if the save action is enabled and out of view.

![Screenshot 2024-12-20 at 10 48 56](https://github.com/user-attachments/assets/40adbced-97fc-4403-8260-dd8794ee3eba)

Closes https://github.com/getsentry/projects/issues/467