### PR TITLE
feat(widget-builder): Add default title

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
@@ -8,7 +8,7 @@ describe('getDefaultWidget', () => {
     expect(widget).toEqual({
       displayType: DisplayType.TABLE,
       interval: '',
-      title: '',
+      title: 'Custom Widget',
       widgetType: WidgetType.ERRORS,
       queries: [
         {
@@ -29,7 +29,7 @@ describe('getDefaultWidget', () => {
     expect(widget).toEqual({
       displayType: DisplayType.TABLE,
       interval: '',
-      title: '',
+      title: 'Custom Widget',
       widgetType: WidgetType.SPANS,
       queries: [
         {
@@ -50,7 +50,7 @@ describe('getDefaultWidget', () => {
     expect(widget).toEqual({
       displayType: DisplayType.TABLE,
       interval: '',
-      title: '',
+      title: 'Custom Widget',
       widgetType: WidgetType.ISSUE,
       queries: [
         {
@@ -71,7 +71,7 @@ describe('getDefaultWidget', () => {
     expect(widget).toEqual({
       displayType: DisplayType.TABLE,
       interval: '',
-      title: '',
+      title: 'Custom Widget',
       widgetType: WidgetType.RELEASE,
       queries: [
         {

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
@@ -6,7 +6,7 @@ export function getDefaultWidget(widgetType: WidgetType): Widget {
   return {
     displayType: DisplayType.TABLE,
     interval: '',
-    title: '',
+    title: 'Custom Widget',
     widgetType,
     queries: [config.defaultWidgetQuery],
   };


### PR DESCRIPTION
Because we have no form validation, the dashboard currently tries to submit without a title and it's annoying because I always forget to add one. Adding a default for now so we don't accidentally drop a widget in progress.