### PR TITLE
fix(dashboards): Glitching bar charts on url changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -193,6 +193,19 @@ export function WidgetPreviewContainer({
     position: isDragEnabled ? 'fixed' : undefined,
   };
 
+  const getPreviewHeight = () => {
+    if (isDragEnabled) {
+      return DRAGGABLE_PREVIEW_HEIGHT_PX;
+    }
+    if (state.displayType === DisplayType.TABLE) {
+      return 'auto';
+    }
+    if (state.displayType === DisplayType.BIG_NUMBER && !isSmallScreen) {
+      return '20vw';
+    }
+    return PREVIEW_HEIGHT_PX;
+  };
+
   return (
     <DashboardsMEPProvider>
       <MetricsCardinalityProvider organization={organization} location={location}>
@@ -227,11 +240,7 @@ export function WidgetPreviewContainer({
                   }}
                   style={{
                     width: isDragEnabled ? DRAGGABLE_PREVIEW_WIDTH_PX : undefined,
-                    height: isDragEnabled
-                      ? DRAGGABLE_PREVIEW_HEIGHT_PX
-                      : state.displayType === DisplayType.TABLE
-                        ? 'auto'
-                        : PREVIEW_HEIGHT_PX,
+                    height: getPreviewHeight(),
                     outline: isDragEnabled
                       ? `${space(1)} solid ${theme.border}`
                       : undefined,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -272,7 +272,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
     switch (widget.displayType) {
       case 'bar':
-        return <BarChart {...chartProps} stacked={stacked} />;
+        return <BarChart {...chartProps} stacked={stacked} animation={false} />;
       case 'area':
       case 'top_n':
         return <AreaChart stacked {...chartProps} />;


### PR DESCRIPTION
The glitching bar charts every time the url changes was annoying and it was happening due to the bar chart animations (where it rises from 0). I turned off the animations for dashboard bar charts.

I've also snuck in a fix for the widget preview height on big number widgets.
