### PR TITLE
feat(insights): Removes unused webvitals function query and code

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -72,11 +72,6 @@ describe('PerformanceScoreBreakdownChart', function () {
         method: 'GET',
         query: expect.objectContaining({
           yAxis: [
-            'weighted_performance_score(measurements.score.lcp)',
-            'weighted_performance_score(measurements.score.fcp)',
-            'weighted_performance_score(measurements.score.cls)',
-            'weighted_performance_score(measurements.score.inp)',
-            'weighted_performance_score(measurements.score.ttfb)',
             'performance_score(measurements.score.lcp)',
             'performance_score(measurements.score.fcp)',
             'performance_score(measurements.score.cls)',

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
@@ -72,13 +72,13 @@ export function PerformanceScoreBreakdownChart({
     chartSeriesOrder
   );
 
-  const unweightedTimeseries = formatTimeSeriesResultsToChartData(
+  const timeseries = formatTimeSeriesResultsToChartData(
     {
-      lcp: timeseriesData.unweightedLcp,
-      fcp: timeseriesData.unweightedFcp,
-      cls: timeseriesData.unweightedCls,
-      ttfb: timeseriesData.unweightedTtfb,
-      inp: timeseriesData.unweightedInp,
+      lcp: timeseriesData.lcp,
+      fcp: timeseriesData.fcp,
+      cls: timeseriesData.cls,
+      ttfb: timeseriesData.ttfb,
+      inp: timeseriesData.inp,
       total: timeseriesData.total,
     },
     segmentColors,
@@ -128,10 +128,10 @@ export function PerformanceScoreBreakdownChart({
           },
           valueFormatter: (_value, _label, seriesParams: any) => {
             const timestamp = seriesParams?.data[0];
-            const unweightedValue = unweightedTimeseries
+            const value = timeseries
               .find(series => series.seriesName === seriesParams?.seriesName)
               ?.data.find(dataPoint => dataPoint.name === timestamp)?.value;
-            return `<span class="tooltip-label-value">${unweightedValue}</span>`;
+            return `<span class="tooltip-label-value">${value}</span>`;
           },
         }}
       />

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -32,14 +32,6 @@ export type WebVitalsScoreBreakdown = {
   ttfb: SeriesDataUnit[];
 };
 
-export type UnweightedWebVitalsScoreBreakdown = {
-  unweightedCls: SeriesDataUnit[];
-  unweightedFcp: SeriesDataUnit[];
-  unweightedInp: SeriesDataUnit[];
-  unweightedLcp: SeriesDataUnit[];
-  unweightedTtfb: SeriesDataUnit[];
-};
-
 export const useProjectWebVitalsScoresTimeseriesQuery = ({
   transaction,
   tag,
@@ -66,11 +58,6 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {
       yAxis: [
-        'weighted_performance_score(measurements.score.lcp)',
-        'weighted_performance_score(measurements.score.fcp)',
-        'weighted_performance_score(measurements.score.cls)',
-        'weighted_performance_score(measurements.score.inp)',
-        'weighted_performance_score(measurements.score.ttfb)',
         'performance_score(measurements.score.lcp)',
         'performance_score(measurements.score.fcp)',
         'performance_score(measurements.score.cls)',
@@ -115,36 +102,19 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
     referrer: 'api.performance.browser.web-vitals.timeseries-scores',
   });
 
-  const data: WebVitalsScoreBreakdown & UnweightedWebVitalsScoreBreakdown = {
+  const data: WebVitalsScoreBreakdown = {
     lcp: [],
     fcp: [],
     cls: [],
     ttfb: [],
     inp: [],
     total: [],
-    unweightedCls: [],
-    unweightedFcp: [],
-    unweightedInp: [],
-    unweightedLcp: [],
-    unweightedTtfb: [],
   };
 
-  result?.data?.['weighted_performance_score(measurements.score.lcp)']?.data.forEach(
+  result?.data?.['performance_score(measurements.score.lcp)']?.data.forEach(
     (interval, index) => {
-      // Weighted data
       ['lcp', 'fcp', 'cls', 'ttfb', 'inp'].forEach(webVital => {
         data[webVital].push({
-          value:
-            result?.data?.[`weighted_performance_score(measurements.score.${webVital})`]
-              ?.data[index][1][0].count * 100,
-          name: interval[0] * 1000,
-        });
-      });
-      // Unweighted data
-      ['lcp', 'fcp', 'cls', 'ttfb', 'inp'].forEach(webVital => {
-        // Capitalize first letter of webVital
-        const capitalizedWebVital = webVital.charAt(0).toUpperCase() + webVital.slice(1);
-        data[`unweighted${capitalizedWebVital}`].push({
           value:
             result?.data?.[`performance_score(measurements.score.${webVital})`]?.data[
               index

--- a/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.spec.tsx
@@ -3,28 +3,23 @@ import {applyStaticWeightsToTimeseries} from 'sentry/views/insights/browser/webV
 describe('applyStaticWeightsToTimeseries', function () {
   it('updates timeseries scores with static weighing', function () {
     const timeseriesData = {
-      lcp: [],
-      fcp: [],
-      cls: [],
-      ttfb: [],
-      inp: [],
-      unweightedLcp: [
+      lcp: [
         {name: '2024-07-01T00:00:00.000Z', value: 90},
         {name: '2024-07-02T00:00:00.000Z', value: 40},
       ],
-      unweightedFcp: [
+      fcp: [
         {name: '2024-07-01T00:00:00.000Z', value: 30},
         {name: '2024-07-02T00:00:00.000Z', value: 20},
       ],
-      unweightedCls: [
+      cls: [
         {name: '2024-07-01T00:00:00.000Z', value: 10},
         {name: '2024-07-02T00:00:00.000Z', value: 90},
       ],
-      unweightedTtfb: [
+      ttfb: [
         {name: '2024-07-01T00:00:00.000Z', value: 22},
         {name: '2024-07-02T00:00:00.000Z', value: 43},
       ],
-      unweightedInp: [
+      inp: [
         {name: '2024-07-01T00:00:00.000Z', value: 100},
         {name: '2024-07-02T00:00:00.000Z', value: 0},
       ],

--- a/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.tsx
@@ -1,23 +1,16 @@
-import type {
-  UnweightedWebVitalsScoreBreakdown,
-  WebVitalsScoreBreakdown,
-} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery';
+import type {WebVitalsScoreBreakdown} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery';
 import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
 
 // Returns a weighed score timeseries with each interval calculated from applying hardcoded weights to unweighted scores
-export function applyStaticWeightsToTimeseries(
-  timeseriesData: WebVitalsScoreBreakdown & UnweightedWebVitalsScoreBreakdown
-) {
+export function applyStaticWeightsToTimeseries(timeseriesData: WebVitalsScoreBreakdown) {
   return {
     ...Object.keys(PERFORMANCE_SCORE_WEIGHTS).reduce((acc, webVital) => {
-      acc[webVital] = timeseriesData[
-        `unweighted${webVital.charAt(0).toUpperCase()}${webVital.slice(1)}`
-      ].map(({name, value}) => ({
+      acc[webVital] = timeseriesData[webVital].map(({name, value}) => ({
         name,
         value: value * PERFORMANCE_SCORE_WEIGHTS[webVital] * 0.01,
       }));
       return acc;
     }, {}),
     total: timeseriesData.total,
-  } as WebVitalsScoreBreakdown & UnweightedWebVitalsScoreBreakdown;
+  } as WebVitalsScoreBreakdown;
 }


### PR DESCRIPTION
The frontend doesn't actually use the `weighted_performance_score` function anymore. Removes all calls and references from frontend code. 

backend changes to remove function here: https://github.com/getsentry/sentry/pull/82486