### PR TITLE
feat(devservices): Only display deprecation warning message if `USE_NEW_DEVSERVICES` is not set

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -303,19 +303,20 @@ def up(
     """
     from sentry.runner import configure
 
-    click.secho(
-        """
+    if os.environ.get("USE_NEW_DEVSERVICES", "0") != "1":
+        click.secho(
+            """
 WARNING: We're transitioning from `sentry devservices` to the new and improved `devservices` in January 2025.
 To give the new devservices a try, set the `USE_NEW_DEVSERVICES` environment variable to `1`. For a full list of commands, see
 https://github.com/getsentry/devservices?tab=readme-ov-file#commands
 
-Instead of running `sentry devservices up`, consider using `devservices up`.
+Instead of running `sentry devservices down`, consider using `devservices down`.
 For Sentry employees - if you hit any bumps or have feedback, we'd love to hear from you in #discuss-dev-infra.
 Thanks for helping the Dev Infra team improve this experience!
 
     """,
-        fg="yellow",
-    )
+            fg="yellow",
+        )
 
     configure()
 
@@ -534,8 +535,9 @@ def down(project: str, service: list[str]) -> None:
     an explicit list of services to bring down.
     """
 
-    click.secho(
-        """
+    if os.environ.get("USE_NEW_DEVSERVICES", "0") != "1":
+        click.secho(
+            """
 WARNING: We're transitioning from `sentry devservices` to the new and improved `devservices` in January 2025.
 To give the new devservices a try, set the `USE_NEW_DEVSERVICES` environment variable to `1`. For a full list of commands, see
 https://github.com/getsentry/devservices?tab=readme-ov-file#commands
@@ -544,9 +546,9 @@ Instead of running `sentry devservices down`, consider using `devservices down`.
 For Sentry employees - if you hit any bumps or have feedback, we'd love to hear from you in #discuss-dev-infra.
 Thanks for helping the Dev Infra team improve this experience!
 
-    """,
-        fg="yellow",
-    )
+        """,
+            fg="yellow",
+        )
 
     def _down(container: docker.models.containers.Container) -> None:
         click.secho(f"> Stopping '{container.name}' container", fg="red")

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -310,7 +310,7 @@ WARNING: We're transitioning from `sentry devservices` to the new and improved `
 To give the new devservices a try, set the `USE_NEW_DEVSERVICES` environment variable to `1`. For a full list of commands, see
 https://github.com/getsentry/devservices?tab=readme-ov-file#commands
 
-Instead of running `sentry devservices down`, consider using `devservices down`.
+Instead of running `sentry devservices up`, consider using `devservices up`.
 For Sentry employees - if you hit any bumps or have feedback, we'd love to hear from you in #discuss-dev-infra.
 Thanks for helping the Dev Infra team improve this experience!
 


### PR DESCRIPTION
If people are setting `USE_NEW_DEVSERVICES`, they already know that `sentry devservices` will be deprecated soon.