### PR TITLE
feat(widget-builder): add unsaved changes warning on close

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -17,6 +17,7 @@ import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import {openConfirmModal} from 'sentry/components/confirm';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {
@@ -792,7 +793,7 @@ class DashboardDetail extends Component<Props, State> {
         this.onUpdateWidget(newWidgets);
       }
 
-      this.handleCloseWidgetBuilder();
+      this.handleCloseWidgetBuilder({isSaving: true});
     } catch (error) {
       addErrorMessage(t('Failed to save widget'));
     }
@@ -817,8 +818,22 @@ class DashboardDetail extends Component<Props, State> {
     );
   };
 
-  handleCloseWidgetBuilder = () => {
+  handleCloseWidgetBuilder = ({isSaving}: {isSaving?: boolean}) => {
+    if (isSaving) {
+      this.closeWidgetBuilder();
+      return;
+    }
+
+    openConfirmModal({
+      message: t('You have unsaved changes. Are you sure you want to leave?'),
+      priority: 'danger',
+      onConfirm: () => this.closeWidgetBuilder(),
+    });
+  };
+
+  closeWidgetBuilder = () => {
     const {organization, router, location, params} = this.props;
+
     this.setState({isWidgetBuilderOpen: false});
     router.push(
       getDashboardLocation({
@@ -828,7 +843,6 @@ class DashboardDetail extends Component<Props, State> {
       })
     );
   };
-
   onCommit = () => {
     const {api, organization, location, dashboard, onDashboardUpdate} = this.props;
     const {modifiedDashboard, dashboardState} = this.state;
@@ -1307,7 +1321,9 @@ class DashboardDetail extends Component<Props, State> {
 
                                   <WidgetBuilderV2
                                     isOpen={this.state.isWidgetBuilderOpen}
-                                    onClose={this.handleCloseWidgetBuilder}
+                                    onClose={() =>
+                                      this.handleCloseWidgetBuilder({isSaving: false})
+                                    }
                                     dashboardFilters={
                                       getDashboardFiltersFromURL(location) ??
                                       dashboard.filters

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -17,7 +17,6 @@ import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
-import {openConfirmModal} from 'sentry/components/confirm';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {
@@ -793,7 +792,7 @@ class DashboardDetail extends Component<Props, State> {
         this.onUpdateWidget(newWidgets);
       }
 
-      this.handleCloseWidgetBuilder({isSaving: true});
+      this.handleCloseWidgetBuilder();
     } catch (error) {
       addErrorMessage(t('Failed to save widget'));
     }
@@ -818,20 +817,7 @@ class DashboardDetail extends Component<Props, State> {
     );
   };
 
-  handleCloseWidgetBuilder = ({isSaving}: {isSaving?: boolean}) => {
-    if (isSaving) {
-      this.closeWidgetBuilder();
-      return;
-    }
-
-    openConfirmModal({
-      message: t('You have unsaved changes. Are you sure you want to leave?'),
-      priority: 'danger',
-      onConfirm: () => this.closeWidgetBuilder(),
-    });
-  };
-
-  closeWidgetBuilder = () => {
+  handleCloseWidgetBuilder = () => {
     const {organization, router, location, params} = this.props;
 
     this.setState({isWidgetBuilderOpen: false});
@@ -843,6 +829,7 @@ class DashboardDetail extends Component<Props, State> {
       })
     );
   };
+
   onCommit = () => {
     const {api, organization, location, dashboard, onDashboardUpdate} = this.props;
     const {modifiedDashboard, dashboardState} = this.state;
@@ -1321,9 +1308,7 @@ class DashboardDetail extends Component<Props, State> {
 
                                   <WidgetBuilderV2
                                     isOpen={this.state.isWidgetBuilderOpen}
-                                    onClose={() =>
-                                      this.handleCloseWidgetBuilder({isSaving: false})
-                                    }
+                                    onClose={this.handleCloseWidgetBuilder}
                                     dashboardFilters={
                                       getDashboardFiltersFromURL(location) ??
                                       dashboard.filters

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -51,7 +51,7 @@ function WidgetBuilderSlideout({
   isWidgetInvalid,
 }: WidgetBuilderSlideoutProps) {
   const {state} = useWidgetBuilderContext();
-  const [initialState, _setInitialState] = useState(state);
+  const [initialState] = useState(state);
   const {widgetIndex} = useParams();
   const theme = useTheme();
 
@@ -103,7 +103,7 @@ function WidgetBuilderSlideout({
               bypass: isEqual(initialState, state),
               message: t('You have unsaved changes. Are you sure you want to leave?'),
               priority: 'danger',
-              onConfirm: () => onClose(),
+              onConfirm: onClose,
             });
           }}
         >

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,8 +1,10 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 
 import {Button} from 'sentry/components/button';
+import {openConfirmModal} from 'sentry/components/confirm';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -49,6 +51,7 @@ function WidgetBuilderSlideout({
   isWidgetInvalid,
 }: WidgetBuilderSlideoutProps) {
   const {state} = useWidgetBuilderContext();
+  const [initialState, _setInitialState] = useState(state);
   const {widgetIndex} = useParams();
   const theme = useTheme();
 
@@ -95,7 +98,17 @@ function WidgetBuilderSlideout({
           borderless
           aria-label={t('Close Widget Builder')}
           icon={<IconClose size="sm" />}
-          onClick={onClose}
+          onClick={() => {
+            if (isEqual(initialState, state)) {
+              onClose();
+            } else {
+              openConfirmModal({
+                message: t('You have unsaved changes. Are you sure you want to leave?'),
+                priority: 'danger',
+                onConfirm: () => onClose(),
+              });
+            }
+          }}
         >
           {t('Close')}
         </CloseButton>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -99,15 +99,12 @@ function WidgetBuilderSlideout({
           aria-label={t('Close Widget Builder')}
           icon={<IconClose size="sm" />}
           onClick={() => {
-            if (isEqual(initialState, state)) {
-              onClose();
-            } else {
-              openConfirmModal({
-                message: t('You have unsaved changes. Are you sure you want to leave?'),
-                priority: 'danger',
-                onConfirm: () => onClose(),
-              });
-            }
+            openConfirmModal({
+              bypass: isEqual(initialState, state),
+              message: t('You have unsaved changes. Are you sure you want to leave?'),
+              priority: 'danger',
+              onConfirm: () => onClose(),
+            });
           }}
         >
           {t('Close')}


### PR DESCRIPTION
Adds this dialog box to confirm closing the widget builder

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/b39a7ee0-305e-4857-9098-ae4c6968b2dc" />

Closes https://github.com/getsentry/sentry/issues/82328