### PR TITLE
feat(aci): Add helpers to dual write to Actions and DataConditions

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -107,6 +107,11 @@ def migrate_metric_data_condition(
     data_condition_group = DataConditionGroup.objects.create(
         organization_id=alert_rule.organization_id
     )
+    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=alert_rule)
+    WorkflowDataConditionGroup.objects.create(
+        condition_group=data_condition_group,
+        workflow=alert_rule_workflow.workflow,
+    )
 
     condition_result = (
         DetectorPriorityLevel.MEDIUM

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -24,6 +24,7 @@ from sentry.workflow_engine.models import (
     DetectorState,
     DetectorWorkflow,
     Workflow,
+    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -2,13 +2,14 @@ import logging
 
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents.grouptype import MetricAlertFire
-from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
 )
+from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+from sentry.integrations.services.integration import integration_service
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.models import (

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -29,9 +29,23 @@ class Action(DefaultFieldsModel):
     __repr__ = sane_repr("id", "type")
 
     class Type(models.TextChoices):
-        EMAIL = "email"
         SLACK = "slack"
+        MSTEAMS = "msteams"
+        DISCORD = "discord"
+
         PAGERDUTY = "pagerduty"
+        OPSGENIE = "opsgenie"
+
+        GITHUB = "github"
+        GITHUB_ENTERPRISE = "github_enterprise"
+        JIRA = "jira"
+        JIRA_SERVER = "jira_server"
+        AZURE_DEVOPS = "azure_devops"
+
+        EMAIL = "email"
+        SENTRY_APP = "sentry_app"
+
+        PLUGIN = "plugin"
         WEBHOOK = "webhook"
 
     # The type field is used to denote the type of action we want to trigger

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -36,6 +36,7 @@ class Condition(models.TextChoices):
     REGRESSION_EVENT = "regression_event"
     REAPPEARED_EVENT = "reappeared_event"
     TAGGED_EVENT = "tagged_event"
+    ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
 
 
 condition_ops = {

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -1,6 +1,6 @@
-from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from unittest import mock
 
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.grouptype import MetricAlertFire
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.models.integration import Integration
@@ -11,10 +11,6 @@ from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule,
-    create_data_condition_group,
-    create_data_source,
-    create_detector,
-    create_workflow,
     migrate_alert_rule,
     migrate_metric_action,
     migrate_metric_data_condition,
@@ -25,8 +21,8 @@ from sentry.workflow_engine.models import (
     AlertRuleDetector,
     AlertRuleTriggerDataCondition,
     AlertRuleWorkflow,
-    DataConditionGroup,
     DataCondition,
+    DataConditionGroup,
     DataConditionGroupAction,
     DataSource,
     DataSourceDetector,

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -33,6 +33,7 @@ from sentry.workflow_engine.models import (
     DetectorState,
     DetectorWorkflow,
     Workflow,
+    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -217,11 +217,17 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         assert data_conditions[0].comparison == self.alert_rule_trigger_warning.alert_threshold
         assert data_conditions[0].condition_result == DetectorPriorityLevel.MEDIUM
         assert data_conditions[0].condition_group == data_conditions[0].condition_group
+        assert WorkflowDataConditionGroup.objects.filter(
+            condition_group=data_conditions[0].condition_group
+        ).exists()
 
         assert data_conditions[1].type == Condition.GREATER
         assert data_conditions[1].comparison == self.alert_rule_trigger_critical.alert_threshold
         assert data_conditions[1].condition_result == DetectorPriorityLevel.HIGH
         assert data_conditions[1].condition_group == data_conditions[1].condition_group
+        assert WorkflowDataConditionGroup.objects.filter(
+            condition_group=data_conditions[1].condition_group
+        ).exists()
 
     def test_create_metric_alert_trigger_action(self):
         """

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -214,8 +214,8 @@ class AlertRuleMigrationHelpersTest(APITestCase):
 
         data_conditions = DataCondition.objects.filter(
             comparison__in=[
-                self.alert_rule_trigger_warning.alert_threshold,
-                self.alert_rule_trigger_critical.alert_threshold,
+                DetectorPriorityLevel.MEDIUM,
+                DetectorPriorityLevel.HIGH,
                 self.metric_alert.resolve_threshold,
             ]
         )
@@ -224,19 +224,17 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         critical_data_condition = data_conditions[1]
         resolve_data_condition = data_conditions[2]
 
-        assert warning_data_condition.type == Condition.GREATER
-        assert warning_data_condition.comparison == self.alert_rule_trigger_warning.alert_threshold
-        assert warning_data_condition.condition_result == DetectorPriorityLevel.MEDIUM
+        assert warning_data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
+        assert warning_data_condition.comparison == DetectorPriorityLevel.MEDIUM
+        assert warning_data_condition.condition_result is True
         assert warning_data_condition.condition_group == warning_data_condition.condition_group
         assert WorkflowDataConditionGroup.objects.filter(
             condition_group=warning_data_condition.condition_group
         ).exists()
 
-        assert critical_data_condition.type == Condition.GREATER
-        assert (
-            critical_data_condition.comparison == self.alert_rule_trigger_critical.alert_threshold
-        )
-        assert critical_data_condition.condition_result == DetectorPriorityLevel.HIGH
+        assert critical_data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
+        assert critical_data_condition.comparison == DetectorPriorityLevel.HIGH
+        assert critical_data_condition.condition_result is True
         assert critical_data_condition.condition_group == critical_data_condition.condition_group
         assert WorkflowDataConditionGroup.objects.filter(
             condition_group=critical_data_condition.condition_group

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -1,16 +1,32 @@
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
+from unittest import mock
+
 from sentry.incidents.grouptype import MetricAlertFire
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule,
+    create_data_condition_group,
+    create_data_source,
+    create_detector,
+    create_workflow,
     migrate_alert_rule,
+    migrate_metric_action,
+    migrate_metric_data_condition,
 )
 from sentry.workflow_engine.models import (
+    Action,
     AlertRuleDetector,
+    AlertRuleTriggerDataCondition,
     AlertRuleWorkflow,
     DataConditionGroup,
+    DataCondition,
+    DataConditionGroupAction,
     DataSource,
     DataSourceDetector,
     Detector,
@@ -18,13 +34,64 @@ from sentry.workflow_engine.models import (
     DetectorWorkflow,
     Workflow,
 )
+from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
 class AlertRuleMigrationHelpersTest(APITestCase):
     def setUp(self):
-        self.metric_alert = self.create_alert_rule()
+        METADATA = {
+            "api_key": "1234-ABCD",
+            "base_url": "https://api.opsgenie.com/",
+            "domain_name": "test-app.app.opsgenie.com",
+        }
         self.rpc_user = user_service.get_user(user_id=self.user.id)
+        self.og_team = {"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}
+        self.integration = self.create_provider_integration(
+            provider="opsgenie", name="hello-world", external_id="hello-world", metadata=METADATA
+        )
+        self.sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            is_alertable=True,
+            verify_install=False,
+        )
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization, user=self.rpc_user
+        )
+        with assume_test_silo_mode_of(Integration, OrganizationIntegration):
+            self.integration.add_organization(self.organization, self.user)
+            self.org_integration = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.integration.id
+            )
+            self.org_integration.config = {"team_table": [self.og_team]}
+            self.org_integration.save()
+
+        self.metric_alert = self.create_alert_rule()
+        self.alert_rule_trigger_warning = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="warning"
+        )
+        self.alert_rule_trigger_critical = self.create_alert_rule_trigger(
+            alert_rule=self.metric_alert, label="critical"
+        )
+        self.alert_rule_trigger_action_email = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.alert_rule_trigger_warning
+        )
+        self.alert_rule_trigger_action_integration = self.create_alert_rule_trigger_action(
+            target_identifier=self.og_team["id"],
+            type=AlertRuleTriggerAction.Type.OPSGENIE,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=self.integration,
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+        )
+
+        self.alert_rule_trigger_action_sentry_app = self.create_alert_rule_trigger_action(
+            target_identifier=self.sentry_app.id,
+            type=AlertRuleTriggerAction.Type.SENTRY_APP,
+            target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
+            sentry_app=self.sentry_app,
+            alert_rule_trigger=self.alert_rule_trigger_critical,
+        )
 
     def test_create_metric_alert(self):
         """
@@ -123,3 +190,129 @@ class AlertRuleMigrationHelpersTest(APITestCase):
 
         # check data source
         assert not DataSource.objects.filter(id=data_source.id).exists()
+
+    def test_create_metric_alert_trigger(self):
+        """
+        Test that when we call the helper methods we create all the ACI models correctly for alert rule triggers
+        """
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        migrate_metric_data_condition(self.alert_rule_trigger_warning)
+        migrate_metric_data_condition(self.alert_rule_trigger_critical)
+
+        alert_rule_trigger_data_conditions = AlertRuleTriggerDataCondition.objects.filter(
+            alert_rule_trigger__in=[
+                self.alert_rule_trigger_critical,
+                self.alert_rule_trigger_warning,
+            ]
+        )
+        assert len(alert_rule_trigger_data_conditions) == 2
+        data_condition_group_id = alert_rule_trigger_data_conditions[
+            0
+        ].data_condition.condition_group.id
+        data_conditions = DataCondition.objects.filter(condition_group=data_condition_group_id)
+        assert len(data_conditions) == 2
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule=self.metric_alert)
+        workflow = Workflow.objects.get(id=alert_rule_workflow.workflow.id)
+        data_condition_group = workflow.when_condition_group
+
+        assert data_conditions[0].type == Condition.GREATER
+        assert data_conditions[0].comparison == self.alert_rule_trigger_warning.alert_threshold
+        assert data_conditions[0].condition_result == DetectorPriorityLevel.MEDIUM
+        assert data_conditions[0].condition_group == data_condition_group
+
+        assert data_conditions[1].type == Condition.GREATER
+        assert data_conditions[1].comparison == self.alert_rule_trigger_critical.alert_threshold
+        assert data_conditions[1].condition_result == DetectorPriorityLevel.HIGH
+        assert data_conditions[1].condition_group == data_condition_group
+
+    @mock.patch("sentry.workflow_engine.migration_helpers.alert_rule.logger")
+    def test_create_metric_alert_trigger_no_alert_rule_detector(self, mock_logger):
+        create_data_source(self.organization.id, self.metric_alert.snuba_query)
+        data_condition_group = create_data_condition_group(self.organization.id)
+        create_workflow(
+            self.metric_alert.name, self.organization.id, data_condition_group, self.rpc_user
+        )
+        create_detector(self.metric_alert, self.project.id, data_condition_group, self.rpc_user)
+        # skip creating lookup tables
+        migrate_metric_data_condition(self.alert_rule_trigger_critical)
+        mock_logger.exception.assert_called_with(
+            "AlertRuleDetector does not exist",
+            extra={
+                "alert_rule_id": self.alert_rule_trigger_critical.alert_rule.id,
+            },
+        )
+
+    def test_create_metric_alert_trigger_action(self):
+        """
+        Test that when we call the helper methods we create all the ACI models correctly for alert rule trigger actions
+        """
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+
+        migrate_metric_data_condition(self.alert_rule_trigger_warning)
+        migrate_metric_data_condition(self.alert_rule_trigger_critical)
+
+        migrate_metric_action(self.alert_rule_trigger_action_email)
+        migrate_metric_action(self.alert_rule_trigger_action_integration)
+        migrate_metric_action(self.alert_rule_trigger_action_sentry_app)
+
+        alert_rule_trigger_data_condition = AlertRuleTriggerDataCondition.objects.filter(
+            alert_rule_trigger__in=[
+                self.alert_rule_trigger_warning,
+                self.alert_rule_trigger_critical,
+            ]
+        )
+        data_condition_group_id = alert_rule_trigger_data_condition[
+            0
+        ].data_condition.condition_group.id
+        data_condition_group_actions = DataConditionGroupAction.objects.filter(
+            condition_group_id=data_condition_group_id
+        )
+        action = Action.objects.filter(
+            id__in=[item.action.id for item in data_condition_group_actions]
+        )
+        assert len(action) == 3
+
+        assert action[0].type.lower() == Action.Type.EMAIL
+        assert action[1].type.lower() == Action.Type.OPSGENIE
+        assert action[2].type.lower() == Action.Type.SENTRY_APP
+
+    @mock.patch("sentry.workflow_engine.migration_helpers.alert_rule.logger")
+    def test_create_metric_alert_trigger_action_no_alert_rule_trigger_data_condition(
+        self, mock_logger
+    ):
+        """
+        Test that if the AlertRuleTriggerDataCondition doesn't exist we return None and log.
+        """
+        other_metric_alert = self.create_alert_rule()
+        other_alert_rule_trigger = self.create_alert_rule_trigger(alert_rule=other_metric_alert)
+
+        migrate_alert_rule(other_metric_alert, self.rpc_user)
+        migrate_metric_data_condition(other_alert_rule_trigger)
+        migrated_action = migrate_metric_action(self.alert_rule_trigger_action_email)
+        assert migrated_action is None
+        mock_logger.exception.assert_called_with(
+            "AlertRuleTriggerDataCondition does not exist",
+            extra={
+                "alert_rule_trigger_id": self.alert_rule_trigger_warning.id,
+            },
+        )
+
+    @mock.patch("sentry.workflow_engine.migration_helpers.alert_rule.logger")
+    def test_create_metric_alert_trigger_action_no_type(self, mock_logger):
+        """
+        Test that if for some reason we don't find a match for Action.Type for the integration provider we return None and log.
+        """
+        with assume_test_silo_mode_of(Integration, OrganizationIntegration):
+            self.integration.update(provider="hellboy")
+            self.integration.save()
+
+        migrate_alert_rule(self.metric_alert, self.rpc_user)
+        migrate_metric_data_condition(self.alert_rule_trigger_critical)
+        migrated = migrate_metric_action(self.alert_rule_trigger_action_integration)
+        assert migrated is None
+        mock_logger.warning.assert_called_with(
+            "Could not find a matching Action.Type for the trigger action",
+            extra={
+                "alert_rule_trigger_action_id": self.alert_rule_trigger_action_integration.id,
+            },
+        )


### PR DESCRIPTION
2nd part of https://github.com/getsentry/sentry/pull/81953/files to dual write to the `Action` and `DataCondition` models when creating `AlertRuleTrigger` and `AlertRuleTriggerAction` rows. 