### PR TITLE
chore(various): Fix linter warnings

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2376,7 +2376,7 @@ def save_attachment(
         return
     from sentry import ratelimits as ratelimiter
 
-    is_limited, num_requests, reset_time = ratelimiter.backend.is_limited_with_value(
+    is_limited, _, _ = ratelimiter.backend.is_limited_with_value(
         key="event_attachment.save_per_sec",
         limit=options.get("sentry.save-event-attachments.project-per-sec-limit"),
         project=project,
@@ -2384,7 +2384,7 @@ def save_attachment(
     )
     rate_limit_tag = "per_sec"
     if not is_limited:
-        is_limited, num_requests, reset_time = ratelimiter.backend.is_limited_with_value(
+        is_limited, _, _ = ratelimiter.backend.is_limited_with_value(
             key="event_attachment.save_5_min",
             limit=options.get("sentry.save-event-attachments.project-per-5-minute-limit"),
             project=project,

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -265,7 +265,7 @@ class Enhancements:
 
     @classmethod
     @sentry_sdk.tracing.trace
-    def from_config_string(self, s, bases=None, id=None) -> Enhancements:
+    def from_config_string(cls, s, bases=None, id=None) -> Enhancements:
         rust_enhancements = parse_rust_enhancements("config_string", s)
 
         rules = parse_enhancements(s)

--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -56,8 +56,8 @@ class EnhancementAction:
     def _from_config_structure(cls, val, version: int):
         if isinstance(val, list):
             return VarAction(val[0], val[1])
-        flag, range = REVERSE_ACTION_FLAGS[val >> ACTION_BITSIZE]
-        return FlagAction(ACTIONS[val & 0xF], flag, range)
+        flag, range_direction = REVERSE_ACTION_FLAGS[val >> ACTION_BITSIZE]
+        return FlagAction(ACTIONS[val & 0xF], flag, range_direction)
 
 
 class FlagAction(EnhancementAction):

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -591,7 +591,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         in_header = True
         for child in children:
             if isinstance(child, str):
-                if in_header and child[:2] == "##":
+                if in_header and child.startswith("##"):
                     changelog.append(child[2:].rstrip())
                 else:
                     in_header = False

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -452,19 +452,12 @@ class FingerprintMatcher:
         value = values.get(self.key)
         if value is None:
             return False
-        elif self.key == "package":
+        elif self.key in ["package", "release"]:
             if self._positive_path_match(value):
                 return True
-        elif self.key == "family":
+        elif self.key in ["family", "sdk"]:
             flags = self.pattern.split(",")
             if "all" in flags or value in flags:
-                return True
-        elif self.key == "sdk":
-            flags = self.pattern.split(",")
-            if "all" in flags or value in flags:
-                return True
-        elif self.key == "release":
-            if self._positive_path_match(value):
                 return True
         elif self.key == "app":
             ref_val = bool_from_string(self.pattern)

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -111,9 +111,9 @@ def is_recursion_legacy(frame1: Frame, frame2: Frame) -> bool:
 def remove_module_outliers_legacy(module: str, platform: str) -> tuple[str, str | None]:
     """Remove things that augment the module but really should not."""
     if platform == "java":
-        if module[:35] == "sun.reflect.GeneratedMethodAccessor":
+        if module.startswith("sun.reflect.GeneratedMethodAccessor"):
             return "sun.reflect.GeneratedMethodAccessor", "removed reflection marker"
-        if module[:44] == "jdk.internal.reflect.GeneratedMethodAccessor":
+        if module.startswith("jdk.internal.reflect.GeneratedMethodAccessor"):
             return "jdk.internal.reflect.GeneratedMethodAccessor", "removed reflection marker"
         old_module = module
         module = _java_reflect_enhancer_re.sub(r"\1<auto>", module)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -176,11 +176,11 @@ def get_module_component(
     elif platform == "java":
         if "$$Lambda$" in module:
             module_component.update(contributes=False, hint="ignored java lambda")
-        if module[:35] == "sun.reflect.GeneratedMethodAccessor":
+        if module.startswith("sun.reflect.GeneratedMethodAccessor"):
             module_component.update(
                 values=["sun.reflect.GeneratedMethodAccessor"], hint="removed reflection marker"
             )
-        elif module[:44] == "jdk.internal.reflect.GeneratedMethodAccessor":
+        elif module.startswith("jdk.internal.reflect.GeneratedMethodAccessor"):
             module_component.update(
                 values=["jdk.internal.reflect.GeneratedMethodAccessor"],
                 hint="removed reflection marker",

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -152,7 +152,6 @@ def get_filename_component(
         new_filename = _java_assist_enhancer_re.sub(r"\1<auto>", filename)
         if new_filename != filename:
             filename_component.update(values=[new_filename], hint="cleaned javassist parts")
-            filename = new_filename
 
     return filename_component
 

--- a/src/sentry/utils/tag_normalization.py
+++ b/src/sentry/utils/tag_normalization.py
@@ -92,7 +92,7 @@ def normalize_sdk_tag(tag: str) -> str:
 
     # collapse tags other than JavaScript / Native to their top-level SDK
 
-    if not tag.split(".")[1] in {"javascript", "native"}:
+    if tag.split(".")[1] not in {"javascript", "native"}:
         tag = ".".join(tag.split(".", 2)[0:2])
 
     if tag.split(".")[1] == "native":

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1121,7 +1121,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         ).exists()
 
         # ensure we're not erroring on second creation
-        event = self.make_release_event("1.0", project_id)
+        self.make_release_event("1.0", project_id)
 
     def test_group_release_with_env(self) -> None:
         manager = EventManager(make_event(release="1.0", environment="prod", event_id="a" * 32))
@@ -1891,9 +1891,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             with self.feature("organizations:event-attachments"):
                 with self.tasks():
                     with pytest.raises(HashDiscarded):
-                        event = manager.save(
-                            self.project.id, cache_key=cache_key, has_attachments=True
-                        )
+                        manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
 
         assert mock_track_outcome.call_count == 3
 

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -240,19 +240,19 @@ class GetSeerSimilarIssuesTest(TestCase):
 
     @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
     def test_sends_expected_data_to_seer(self, mock_get_similarity_data: MagicMock) -> None:
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         new_event = Event(
             project_id=self.project.id,
             event_id="12312012112120120908201304152013",
             data={
-                "title": f"{type}('{value}')",
+                "title": f"{error_type}('{error_value}')",
                 "exception": {
                     "values": [
                         {
-                            "type": type,
-                            "value": value,
+                            "type": error_type,
+                            "value": error_value,
                             "stacktrace": {
                                 "frames": [
                                     {
@@ -275,7 +275,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "event_id": new_event.event_id,
                 "hash": new_event.get_primary_hash(),
                 "project_id": self.project.id,
-                "stacktrace": f'{type}: {value}\n  File "dogpark.py", function play_fetch\n    {context_line}',
+                "stacktrace": f'{error_type}: {error_value}\n  File "dogpark.py", function play_fetch\n    {context_line}',
                 "exception_type": "FailedToFetchError",
                 "k": 1,
                 "referrer": "ingest",
@@ -353,19 +353,19 @@ class GetSeerSimilarIssuesTest(TestCase):
     def test_too_many_frames(
         self, mock_metrics: Mock, mock_record_did_call_seer: MagicMock
     ) -> None:
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         new_event = Event(
             project_id=self.project.id,
             event_id="22312012112120120908201304152013",
             data={
-                "title": f"{type}('{value}')",
+                "title": f"{error_type}('{error_value}')",
                 "exception": {
                     "values": [
                         {
-                            "type": type,
-                            "value": value,
+                            "type": error_type,
+                            "value": error_value,
                             "stacktrace": {
                                 "frames": [
                                     {
@@ -401,19 +401,19 @@ class GetSeerSimilarIssuesTest(TestCase):
 
     @patch("sentry.seer.similarity.utils.record_did_call_seer_metric")
     def test_too_many_frames_allowed_platform(self, mock_record_did_call_seer: MagicMock) -> None:
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         new_event = Event(
             project_id=self.project.id,
             event_id="22312012112120120908201304152013",
             data={
-                "title": f"{type}('{value}')",
+                "title": f"{error_type}('{error_value}')",
                 "exception": {
                     "values": [
                         {
-                            "type": type,
-                            "value": value,
+                            "type": error_type,
+                            "value": error_value,
                             "stacktrace": {
                                 "frames": [
                                     {
@@ -453,19 +453,19 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
     ) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         new_event = Event(
             project_id=self.project.id,
             event_id="12312012112120120908201304152013",
             data={
-                "title": f"{type}('{value}')",
+                "title": f"{error_type}('{error_value}')",
                 "exception": {
                     "values": [
                         {
-                            "type": type,
-                            "value": value,
+                            "type": error_type,
+                            "value": error_value,
                             "stacktrace": {
                                 "frames": [
                                     {
@@ -494,7 +494,7 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
                 "event_id": new_event.event_id,
                 "hash": new_event.get_primary_hash(),
                 "project_id": self.project.id,
-                "stacktrace": f'{type}: {value}\n  File "dogpark.py", function play_fetch\n    {context_line}',
+                "stacktrace": f'{error_type}: {error_value}\n  File "dogpark.py", function play_fetch\n    {context_line}',
                 "exception_type": "FailedToFetchError",
                 "k": 1,
                 "referrer": "ingest",
@@ -513,19 +513,19 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
     ) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         new_event = Event(
             project_id=self.project.id,
             event_id="22312012112120120908201304152013",
             data={
-                "title": f"{type}('{value}')",
+                "title": f"{error_type}('{error_value}')",
                 "exception": {
                     "values": [
                         {
-                            "type": type,
-                            "value": value,
+                            "type": error_type,
+                            "value": error_value,
                             "stacktrace": {
                                 "frames": [
                                     {
@@ -572,19 +572,19 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
     ) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         new_event = Event(
             project_id=self.project.id,
             event_id="22312012112120120908201304152013",
             data={
-                "title": f"{type}('{value}')",
+                "title": f"{error_type}('{error_value}')",
                 "exception": {
                     "values": [
                         {
-                            "type": type,
-                            "value": value,
+                            "type": error_type,
+                            "value": error_value,
                             "stacktrace": {
                                 "frames": [
                                     {

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -241,8 +241,8 @@ def test_parameterize_regex_experiment():
         regex_pattern_keys=(),
         experiments=(FooExperiment,),
     )
-    input = "blah foobarbaz fooooo"
-    normalized = parameterizer.parameterize_all(input)
+    input_str = "blah foobarbaz fooooo"
+    normalized = parameterizer.parameterize_all(input_str)
     assert normalized == "blah <foo>barbaz <foo>ooo"
     assert len(parameterizer.get_successful_experiments()) == 1
     assert parameterizer.get_successful_experiments()[0] == FooExperiment
@@ -261,9 +261,9 @@ def test_parameterize_regex_experiment_cached_compiled():
             regex_pattern_keys=(),
             experiments=(FooExperiment,),
         )
-        input = "blah foobarbaz fooooo"
-        _ = parameterizer.parameterize_all(input)
-        _ = parameterizer.parameterize_all(input)
+        input_str = "blah foobarbaz fooooo"
+        _ = parameterizer.parameterize_all(input_str)
+        _ = parameterizer.parameterize_all(input_str)
 
     mocked_pattern.assert_called_once()
 

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -686,15 +686,15 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             mock_seer_request.reset_mock()
 
     def test_too_many_system_frames(self) -> None:
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         error_data = {
             "exception": {
                 "values": [
                     {
-                        "type": type,
-                        "value": value,
+                        "type": error_type,
+                        "value": error_value,
                         "stacktrace": {
                             "frames": [
                                 {
@@ -719,15 +719,15 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         assert response.data == []
 
     def test_no_filename_or_module(self) -> None:
-        type = "FailedToFetchError"
-        value = "Charlie didn't bring the ball back"
-        context_line = f"raise {type}('{value}')"
+        error_type = "FailedToFetchError"
+        error_value = "Charlie didn't bring the ball back"
+        context_line = f"raise {error_type}('{error_value}')"
         error_data = {
             "exception": {
                 "values": [
                     {
-                        "type": type,
-                        "value": value,
+                        "type": error_type,
+                        "value": error_value,
                         "stacktrace": {
                             "frames": [
                                 {

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -130,7 +130,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             grouphash=hash_from_values([uuid.uuid4()]),
         )
 
-        for i in range(4):
+        for _ in range(4):
             MonitorCheckIn.objects.create(
                 monitor=monitor,
                 monitor_environment=monitor_environment,


### PR DESCRIPTION
This fixes a number of small issues my linter has been yelling at me about, which I've come across in the last handful of weeks - things like unused variables, shadowing built-ins, etc. No behavior changes just tiny refactors to clear out some noise.