### PR TITLE
fix(grouping): Fix fingerprinting bugs

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -437,7 +437,7 @@ class FingerprintMatcher:
                 return True
             alt_value = values.get("filename")
             if alt_value != value:
-                if self._positive_path_match(value):
+                if self._positive_path_match(alt_value):
                     return True
             return False
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -116,7 +116,7 @@ def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str |
         # Turn "tags.some_tag" into just "some_tag"
         tag = var[5:]
         for t, value in data.get("tags") or ():
-            if t == tag:
+            if t == tag and value is not None:
                 return value
         return "<no-value-for-tag-%s>" % tag
     else:


### PR DESCRIPTION
This fixes two small bugs in our fingerprinting code:

- In `FingerprintMatcher._positive_match`(which is a helper used when trying to determine if a given fingerprint rule applies to the current event data), when checking the `path` key, we retrieve both the `abs_path` and the `filename`, and we claim to test against both, but we don't. We check `abs_path`, and if we don't find a match, we then check... `abs_path` again.

- In `get_fingerprint_value` (which is a helper used to fill in values in for variables in the actual fingerprint, once we've already decided the rule applies), we consider a variable which resolves to `None` to not have a value, and return a placeholder `<no-message>`, `<no-function>`, etc. Only if we don't recognize the variable do we return `None`, in which case we leave the variable unresolved. However, if instead of `{{ message }}` or `{{ function }}` the variable is `{{ tags.someTag }}`, resolving to `None` doesn't result in our `<no-value-for-tag-someTag>` placeholder, it results in `None`, making it look like an unrecognized variable, which it isn't.