### PR TITLE
chore(issue-views): Add analytics back to tab actions

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
@@ -11,6 +11,7 @@ import {tabsShouldForwardProp} from 'sentry/components/tabs/utils';
 import {t} from 'sentry/locale';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -128,6 +129,18 @@ export type IssueViewsActions =
   | UpdateViewIdsAction
   | SetViewsAction
   | SyncViewsToBackendAction;
+
+const ACTION_ANALYTICS_MAP: Partial<Record<IssueViewsActions['type'], string>> = {
+  REORDER_TABS: 'issue_views.reordered_views',
+  SAVE_CHANGES: 'issue_views.saved_changes',
+  DISCARD_CHANGES: 'issue_views.discarded_changes',
+  RENAME_TAB: 'issue_views.renamed_view',
+  DUPLICATE_VIEW: 'issue_views.duplicated_view',
+  DELETE_VIEW: 'issue_views.deleted_view',
+  SAVE_TEMP_VIEW: 'issue_views.temp_view_saved',
+  DISCARD_TEMP_VIEW: 'issue_views.temp_view_discarded',
+  CREATE_NEW_VIEW: 'issue_views.add_view.clicked',
+};
 
 export interface IssueViewsState {
   views: IssueView[];
@@ -494,8 +507,16 @@ export function IssueViewsStateProvider({
   const dispatchWrapper = (action: IssueViewsActions) => {
     const newState = reducer(state, action);
     dispatch(action);
+
     if (action.type === 'SYNC_VIEWS_TO_BACKEND' || action.syncViews) {
       debounceUpdateViews(newState.views);
+    }
+
+    const actionAnalyticsKey = ACTION_ANALYTICS_MAP[action.type];
+    if (actionAnalyticsKey) {
+      trackAnalytics(actionAnalyticsKey, {
+        organization: organization.slug,
+      });
     }
   };
 

--- a/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
@@ -515,7 +515,7 @@ export function IssueViewsStateProvider({
     const actionAnalyticsKey = ACTION_ANALYTICS_MAP[action.type];
     if (actionAnalyticsKey) {
       trackAnalytics(actionAnalyticsKey, {
-        organization: organization.slug,
+        organization,
       });
     }
   };


### PR DESCRIPTION
I deleted some of the analytics calls in [this refactoring change](https://github.com/getsentry/sentry/pull/82429) and forgot to add them back. This PR adds them back. 

I found what the old analytics keys were [here](https://github.com/getsentry/sentry/blob/7cb3a89c7a0737ea5c53ab0a1e85b03c7d8dd4ee/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx) 