### PR TITLE
fix(alerts): Fix open in explore date range

### DIFF
--- a/static/app/views/alerts/rules/utils.spec.tsx
+++ b/static/app/views/alerts/rules/utils.spec.tsx
@@ -21,4 +21,21 @@ describe('getExploreUrl', () => {
       '/organizations/slug/traces/?dataset=spansRpc&environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&statsPeriod=7d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
     );
   });
+  it('should return the correct url for 9998m', () => {
+    const rule = MetricRuleFixture();
+    rule.dataset = Dataset.EVENTS_ANALYTICS_PLATFORM;
+    rule.timeWindow = TimeWindow.THIRTY_MINUTES;
+    rule.aggregate = 'p75(span.duration)';
+    rule.query = 'span.op:http.client';
+    rule.environment = 'prod';
+    const url = getAlertRuleExploreUrl({
+      rule,
+      orgSlug: 'slug',
+      period: '9998m',
+      projectId: '1',
+    });
+    expect(url).toEqual(
+      '/organizations/slug/traces/?dataset=spansRpc&environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&statsPeriod=7d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
+    );
+  });
 });

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -137,7 +137,7 @@ export function getAlertRuleExploreUrl({
     orgSlug,
     selection: {
       datetime: {
-        period,
+        period: period === '9998m' ? '7d' : period,
         start: null,
         end: null,
         utc: null,


### PR DESCRIPTION
When rendering alert previews on a 7d time window, the alerts UI actually renders using 9998m instead. Updates the `open in explore` button for eap alerts to map 9998m back to 7d in explore instead.