### PR TITLE
ref: cleanup unused queue name

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -43,7 +43,6 @@ REVERSE_DEVICE_CLASS = {next(iter(tags)): label for label, tags in DEVICE_CLASS.
 
 @instrumented_task(
     name="sentry.profiles.task.process_profile",
-    queue="profiles.process",
     retry_backoff=True,
     retry_backoff_max=20,
     retry_jitter=True,


### PR DESCRIPTION
this now uses split queues and the default is defined here https://github.com/getsentry/sentry/blob/32371819967b9ca39f10aefcfb0da086c80e4141/src/sentry/conf/server.py#L858

remove this line that does nothing except cause noise in logs