### PR TITLE
feat(aci): registry for dual writing issue alert conditions

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -2,11 +2,11 @@ __all__ = [
     "EventCreatedByDetectorConditionHandler",
     "EventSeenCountConditionHandler",
     "ReappearedEventConditionHandler",
-    "RegressedEventConditionHandler",
+    "RegressionEventConditionHandler",
 ]
 
 from .group_event_handlers import (
     EventCreatedByDetectorConditionHandler,
     EventSeenCountConditionHandler,
 )
-from .group_state_handlers import ReappearedEventConditionHandler, RegressedEventConditionHandler
+from .group_state_handlers import ReappearedEventConditionHandler, RegressionEventConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/group_state_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/group_state_handlers.py
@@ -6,7 +6,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 @condition_handler_registry.register(Condition.REGRESSION_EVENT)
-class RegressedEventConditionHandler(DataConditionHandler[WorkflowJob]):
+class RegressionEventConditionHandler(DataConditionHandler[WorkflowJob]):
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
         state = job.get("group_state", None)

--- a/src/sentry/workflow_engine/handlers/condition/group_state_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/group_state_handlers.py
@@ -5,7 +5,7 @@ from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
-@condition_handler_registry.register(Condition.REGRESSED_EVENT)
+@condition_handler_registry.register(Condition.REGRESSION_EVENT)
 class RegressedEventConditionHandler(DataConditionHandler[WorkflowJob]):
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -1,0 +1,41 @@
+from collections.abc import Callable
+from typing import Any
+
+from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
+from sentry.rules.conditions.regression_event import RegressionEventCondition
+from sentry.utils.registry import Registry
+from sentry.workflow_engine.models.data_condition import Condition, DataCondition
+from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+
+data_condition_translator_registry = Registry[
+    Callable[[dict[str, Any], DataConditionGroup], DataCondition]
+]()
+
+
+def translate_to_data_condition(data: dict[str, Any], dcg: DataConditionGroup):
+    translator = data_condition_translator_registry.get(data["id"])
+    return translator(data, dcg)
+
+
+@data_condition_translator_registry.register(ReappearedEventCondition.id)
+def create_reappeared_event_data_condition(
+    data: dict[str, Any], dcg: DataConditionGroup
+) -> DataCondition:
+    return DataCondition.objects.create(
+        type=Condition.REAPPEARED_EVENT,
+        comparison=True,
+        condition_result=True,
+        condition_group=dcg,
+    )
+
+
+@data_condition_translator_registry.register(RegressionEventCondition.id)
+def create_regressed_event_data_condition(
+    data: dict[str, Any], dcg: DataConditionGroup
+) -> DataCondition:
+    return DataCondition.objects.create(
+        type=Condition.REGRESSION_EVENT,
+        comparison=True,
+        condition_result=True,
+        condition_group=dcg,
+    )

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -22,7 +22,7 @@ class Condition(models.TextChoices):
     NOT_EQUAL = "ne"
     EVENT_CREATED_BY_DETECTOR = "event_created_by_detector"
     EVENT_SEEN_COUNT = "event_seen_count"
-    REGRESSED_EVENT = "regressed_event"
+    REGRESSION_EVENT = "regression_event"
     REAPPEARED_EVENT = "reappeared_event"
 
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from sentry.rules.base import RuleBase
+from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
+    translate_to_data_condition as dual_write_condition,
+)
+from sentry.workflow_engine.models.data_condition import Condition, DataCondition
+from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.types import WorkflowJob
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class ConditionTestCase(BaseWorkflowTest):
+    def setUp(self):
+        self.group, self.event, self.group_event = self.create_group_event()
+
+    @property
+    def condition(self) -> Condition:
+        raise NotImplementedError
+
+    @property
+    def rule_cls(self) -> type[RuleBase]:
+        # for mapping purposes, can delete later
+        raise NotImplementedError
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        # for dual write, can delete later
+        raise NotImplementedError
+
+    def translate_to_data_condition(
+        self, data: dict[str, Any], dcg: DataConditionGroup
+    ) -> DataCondition:
+        return dual_write_condition(data, dcg)
+
+    def assert_passes(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+        assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
+
+    def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+        assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
+
+    # TODO: activity

--- a/tests/sentry/workflow_engine/handlers/condition/test_group_state_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_group_state_handlers.py
@@ -1,0 +1,79 @@
+from sentry.eventstream.base import GroupState
+from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
+from sentry.rules.conditions.regression_event import RegressionEventCondition
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import WorkflowJob
+from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
+
+
+class TestReappearedEventCondition(ConditionTestCase):
+    condition = Condition.REAPPEARED_EVENT
+    rule_cls = ReappearedEventCondition
+    payload = {"id": ReappearedEventCondition.id}
+
+    def test(self):
+        job = WorkflowJob(
+            {
+                "event": self.group_event,
+                "has_reappeared": True,
+            }
+        )
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison=True,
+            condition_result=True,
+        )
+
+        self.assert_passes(dc, job)
+
+        job["has_reappeared"] = False
+        self.assert_does_not_pass(dc, job)
+
+    def test_dual_write(self):
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison is True
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
+
+class TestRegressionEventCondition(ConditionTestCase):
+    condition = Condition.REGRESSION_EVENT
+    rule_cls = RegressionEventCondition
+    payload = {"id": RegressionEventCondition.id}
+
+    def test(self):
+        job = WorkflowJob(
+            {
+                "event": self.group_event,
+                "group_state": GroupState(
+                    {
+                        "id": 1,
+                        "is_regression": True,
+                        "is_new": False,
+                        "is_new_group_environment": False,
+                    }
+                ),
+            }
+        )
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison=True,
+            condition_result=True,
+        )
+
+        self.assert_passes(dc, job)
+
+        job["group_state"]["is_regression"] = False
+        self.assert_does_not_pass(dc, job)
+
+    def test_dual_write(self):
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison is True
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -50,7 +50,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_regressed_event(self):
         dcg = self.create_data_condition_group()
         self.create_data_condition(
-            type=Condition.REGRESSED_EVENT,
+            type=Condition.REGRESSION_EVENT,
             comparison=True,
             condition_result=True,
             condition_group=dcg,


### PR DESCRIPTION
Add a registry for dual writing a condition on a `Rule` to a `DataCondition` based on the condition `id`.