### PR TITLE
ref(replay): Refactor replay for mobile touch start/end parity check

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -7,6 +7,7 @@ import {VideoReplayerWithInteractions} from 'sentry/components/replays/videoRepl
 import {trackAnalytics} from 'sentry/utils/analytics';
 import clamp from 'sentry/utils/number/clamp';
 import type useInitialOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
+import useTouchEventsCheck from 'sentry/utils/replays/playback/hooks/useTouchEventsCheck';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 import {ReplayCurrentTimeContextProvider} from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -389,6 +390,8 @@ export function Provider({
     ]
   );
 
+  useTouchEventsCheck({replay});
+
   const initVideoRoot = useCallback(
     (root: RootElem) => {
       if (root === null || isFetching) {
@@ -429,13 +432,8 @@ export function Provider({
         // rrweb specific
         theme,
         eventsWithSnapshots: replay?.getRRWebFramesWithSnapshots() ?? [],
-        touchEvents: replay?.getRRwebTouchEvents() ?? [],
         // common to both
         root,
-        context: {
-          sdkName: replay?.getReplay().sdk.name,
-          sdkVersion: replay?.getReplay().sdk.version,
-        },
       });
       // `.current` is marked as readonly, but it's safe to set the value from
       // inside a `useEffect` hook.

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -390,7 +390,7 @@ export function Provider({
     ]
   );
 
-  useTouchEventsCheck({replay});
+  useTouchEventsCheck({replay: isFetching ? null : replay});
 
   const initVideoRoot = useCallback(
     (root: RootElem) => {

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -1,5 +1,4 @@
 import type {Theme} from '@emotion/react';
-import * as Sentry from '@sentry/react';
 import {Replayer} from '@sentry-internal/rrweb';
 
 import type {VideoReplayerConfig} from 'sentry/components/replays/videoReplayer';
@@ -9,7 +8,6 @@ import type {ClipWindow, RecordingFrame, VideoEvent} from 'sentry/utils/replays/
 type RootElem = HTMLDivElement | null;
 
 interface VideoReplayerWithInteractionsOptions {
-  context: {sdkName: string | undefined | null; sdkVersion: string | undefined | null};
   durationMs: number;
   eventsWithSnapshots: RecordingFrame[];
   onBuffer: (isBuffering: boolean) => void;
@@ -19,7 +17,6 @@ interface VideoReplayerWithInteractionsOptions {
   speed: number;
   start: number;
   theme: Theme;
-  touchEvents: RecordingFrame[];
   videoApiPrefix: string;
   videoEvents: VideoEvent[];
   clipWindow?: ClipWindow;
@@ -37,7 +34,6 @@ export class VideoReplayerWithInteractions {
   constructor({
     videoEvents,
     eventsWithSnapshots,
-    touchEvents,
     root,
     start,
     videoApiPrefix,
@@ -48,7 +44,6 @@ export class VideoReplayerWithInteractions {
     durationMs,
     theme,
     speed,
-    context,
   }: VideoReplayerWithInteractionsOptions) {
     this.config = {
       skipInactive: false,
@@ -68,22 +63,6 @@ export class VideoReplayerWithInteractions {
     });
 
     root?.classList.add('video-replayer');
-
-    const grouped = Object.groupBy(touchEvents, (t: any) => t.data.pointerId);
-    Object.values(grouped).forEach(t => {
-      if (t?.length !== 2) {
-        Sentry.captureMessage(
-          'Mobile replay has mismatching touch start and end events',
-          {
-            tags: {
-              sdk_name: context.sdkName,
-              sdk_version: context.sdkVersion,
-              touch_event_type: typeof t,
-            },
-          }
-        );
-      }
-    });
 
     this.replayer = new Replayer(eventsWithSnapshots, {
       root: root as Element,

--- a/static/app/utils/replays/playback/hooks/useTouchEventsCheck.tsx
+++ b/static/app/utils/replays/playback/hooks/useTouchEventsCheck.tsx
@@ -1,0 +1,32 @@
+import {useEffect} from 'react';
+import * as Sentry from '@sentry/react';
+
+import type ReplayReader from 'sentry/utils/replays/replayReader';
+
+interface Props {
+  replay: ReplayReader | null;
+}
+
+export default function useTouchEventsCheck({replay}: Props) {
+  useEffect(() => {
+    if (!replay || !replay.getVideoEvents()) {
+      return;
+    }
+    const touchEvents = replay.getRRwebTouchEvents() ?? [];
+    const grouped = Object.groupBy(touchEvents, (t: any) => t.data.pointerId);
+    Object.values(grouped).forEach(t => {
+      if (t?.length !== 2) {
+        Sentry.captureMessage(
+          'Mobile replay has mismatching touch start and end events',
+          {
+            tags: {
+              sdk_name: replay.getReplay().sdk.name,
+              sdk_version: replay.getReplay().sdk.version,
+              touch_event_type: typeof t,
+            },
+          }
+        );
+      }
+    });
+  }, [replay]);
+}


### PR DESCRIPTION
Instead of doing this check inside the `VideoReplayerWithInteractions` constructor i just moved it up one level to the react component that creates that new instance, and wrapped it into a hook because react.

It was previously guarded by:
```
      if (root === null || isFetching) {
        return null;
      }

      // check if this is a video replay and if we can use the video (wrapper) replayer
      if (!isVideoReplay || !videoEvents || !startTimestampMs) {
        return null;
      }
```
and now we're just guarding the check with:
```
    replay: isFetching ? null : replay
    ...
    if (!replay || !replay.getVideoEvents()) {
      return;
    }
```
But it'll run at the same time as before: once whenever the replay is fully loaded.