### PR TITLE
feat(tempest): UI for tempest screenshots project option

### DIFF
--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -60,7 +60,7 @@ export default function TempestSettings({organization, project}: Props) {
                   name: 'tempestFetchScreenshots',
                   type: 'boolean',
                   label: t('Fetch Screenshots'),
-                  help: t('Allow Tempest to fetch screenshots from the project.'),
+                  help: t('Allow Tempest to fetch screenshots for the project.'),
                 },
               ],
             },

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -3,6 +3,8 @@ import {Fragment} from 'react';
 import {openAddTempestCredentialsModal} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -39,6 +41,32 @@ export default function TempestSettings({organization, project}: Props) {
         title={t('PlayStation')}
         action={addNewCredentials(hasWriteAccess, organization, project)}
       />
+
+      <Form
+        apiMethod="PUT"
+        apiEndpoint={`/organizations/${organization.slug}/`}
+        initialData={{
+          tempestFetchScreenshots: project.options?.tempestFetchScreenshots,
+        }}
+        saveOnBlur
+        hideFooter
+      >
+        <JsonForm
+          forms={[
+            {
+              title: t('General Settings'),
+              fields: [
+                {
+                  name: 'tempestFetchScreenshots',
+                  type: 'boolean',
+                  label: t('Fetch Screenshots'),
+                  help: t('Allow Tempest to fetch screenshots from the project.'),
+                },
+              ],
+            },
+          ]}
+        />
+      </Form>
 
       <PanelTable
         headers={[t('Client ID'), t('Client Secret'), t('Created At'), t('Created By')]}


### PR DESCRIPTION
UI form for managing setting if Tempest should fetch screenshots

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/f29bcb7f-d88e-4271-9196-b5bd7633b11b" />

API part: https://github.com/getsentry/sentry/pull/82520

Part of https://github.com/getsentry/team-gdx/issues/53