### PR TITLE
feat(widget-builder): Add RPC toggle for spans dataset

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -21,6 +21,7 @@ import {
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import localStorage from 'sentry/utils/localStorage';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {
@@ -36,6 +37,7 @@ import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
+import {DASHBOARD_RPC_TOGGLE_KEY} from 'sentry/views/dashboards/widgetBuilder/components/rpcToggle';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
@@ -203,11 +205,14 @@ function getEventsRequest(
   const url = `/organizations/${organization.slug}/events/`;
   const eventView = eventViewFromWidget('', query, pageFilters);
 
+  const useRpc = localStorage.getItem(DASHBOARD_RPC_TOGGLE_KEY) === 'true';
+
   const params: DiscoverQueryRequestParams = {
     per_page: limit,
     cursor,
     referrer,
     dataset: DiscoverDatasets.SPANS_EAP,
+    useRpc: useRpc ? '1' : undefined,
     ...queryExtras,
   };
 
@@ -270,5 +275,9 @@ function getSeriesRequest(
     DiscoverDatasets.SPANS_EAP,
     referrer
   );
+
+  const useRpc = localStorage.getItem(DASHBOARD_RPC_TOGGLE_KEY) === 'true';
+  requestData.useRpc = useRpc;
+
   return doEventsRequest<true>(api, requestData);
 }

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -11,6 +11,8 @@ import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {decodeBoolean} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useKeyPress from 'sentry/utils/useKeyPress';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
@@ -21,6 +23,7 @@ import {
   type DashboardFilters,
   DisplayType,
   type Widget,
+  WidgetType,
 } from 'sentry/views/dashboards/types';
 import {
   DEFAULT_WIDGET_DRAG_POSITIONING,
@@ -166,6 +169,11 @@ export function WidgetPreviewContainer({
   const organization = useOrganization();
   const location = useLocation();
   const theme = useTheme();
+  const {useRpc} = useLocationQuery({
+    fields: {
+      useRpc: decodeBoolean,
+    },
+  });
 
   const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
   // if small screen and draggable, enable dragging
@@ -247,6 +255,8 @@ export function WidgetPreviewContainer({
                   }}
                 >
                   <WidgetPreview
+                    // While we test out RPC for spans, force a re-render if the spans toggle changes
+                    key={state.dataset === WidgetType.SPANS && useRpc ? 'spans' : 'other'}
                     dashboardFilters={dashboardFilters}
                     dashboard={dashboard}
                     isWidgetInvalid={isWidgetInvalid}

--- a/static/app/views/dashboards/widgetBuilder/components/rpcToggle.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/rpcToggle.tsx
@@ -1,0 +1,36 @@
+import {Flex} from 'sentry/components/container/flex';
+import SwitchButton from 'sentry/components/switchButton';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useQueryParamState} from 'sentry/views/dashboards/widgetBuilder/hooks/useQueryParamState';
+
+export const DASHBOARD_RPC_TOGGLE_KEY = 'dashboards-spans-use-rpc';
+
+function RPCToggle() {
+  const [_, setIsRpcEnabled] = useQueryParamState<boolean>({
+    fieldName: 'useRpc',
+  });
+  // This is hacky, but we need to access the RPC toggle state in the spans dataset config
+  // and I don't want to pass it down as a prop when it's only temporary.
+  const [isRpcEnabled, setRpcLocalStorage] = useLocalStorageState(
+    DASHBOARD_RPC_TOGGLE_KEY,
+    false
+  );
+
+  return (
+    <Flex gap={space(1)}>
+      <SwitchButton
+        isActive={isRpcEnabled}
+        toggle={() => {
+          const newValue = !isRpcEnabled;
+          setIsRpcEnabled(newValue);
+          setRpcLocalStorage(newValue);
+        }}
+      />
+      <div>{t('Use RPC')}</div>
+    </Flex>
+  );
+}
+
+export default RPCToggle;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -8,6 +8,7 @@ import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useMedia from 'sentry/utils/useMedia';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {
   type DashboardDetails,
@@ -50,6 +51,7 @@ function WidgetBuilderSlideout({
   setIsPreviewDraggable,
   isWidgetInvalid,
 }: WidgetBuilderSlideoutProps) {
+  const organization = useOrganization();
   const {state} = useWidgetBuilderContext();
   const {widgetIndex} = useParams();
   const theme = useTheme();
@@ -109,7 +111,12 @@ function WidgetBuilderSlideout({
         <Section>
           <WidgetBuilderDatasetSelector />
         </Section>
-        <Section>{state.dataset === WidgetType.SPANS && <RPCToggle />}</Section>
+        {organization.features.includes('visibility-explore-dataset') &&
+          state.dataset === WidgetType.SPANS && (
+            <Section>
+              <RPCToggle />
+            </Section>
+          )}
         <Section>
           <WidgetBuilderTypeSelector />
         </Section>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -14,6 +14,7 @@ import {
   type DashboardFilters,
   DisplayType,
   type Widget,
+  WidgetType,
 } from 'sentry/views/dashboards/types';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
@@ -21,6 +22,7 @@ import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
 import {WidgetPreviewContainer} from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 import WidgetBuilderQueryFilterBuilder from 'sentry/views/dashboards/widgetBuilder/components/queryFilterBuilder';
+import RPCToggle from 'sentry/views/dashboards/widgetBuilder/components/rpcToggle';
 import SaveButton from 'sentry/views/dashboards/widgetBuilder/components/saveButton';
 import WidgetBuilderSortBySelector from 'sentry/views/dashboards/widgetBuilder/components/sortBySelector';
 import WidgetBuilderTypeSelector from 'sentry/views/dashboards/widgetBuilder/components/typeSelector';
@@ -107,6 +109,7 @@ function WidgetBuilderSlideout({
         <Section>
           <WidgetBuilderDatasetSelector />
         </Section>
+        <Section>{state.dataset === WidgetType.SPANS && <RPCToggle />}</Section>
         <Section>
           <WidgetBuilderTypeSelector />
         </Section>


### PR DESCRIPTION
This uses a few tricks to set the `useRpc` flag in events/events-stats requests. We use local storage to store the key, but update the query params when the dataset is toggled so we can pick it up on the preview and re-query the dataset.

I'm storing the state in local storage because I don't want to update all of the config interfaces just to support this temporary flag.

<img width="612" alt="Screenshot 2024-12-23 at 11 15 34 AM" src="https://github.com/user-attachments/assets/d4cf729d-fe18-4f91-8c94-c214896a16bc" />
