### PR TITLE
ref(replay): Rename the old `useReplayReader` to `useLoadReplayReader` to disambiguate

### DIFF
--- a/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {getReplayDiffOffsetsFromEvent} from 'sentry/utils/replays/getDiffTimestamps';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: Props) {
-  const replayContext = useReplayReader({
+  const replayContext = useLoadReplayReader({
     orgSlug,
     replaySlug,
   });

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -8,17 +8,17 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventReplay from 'sentry/components/events/eventReplay';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import {
   useHaveSelectedProjectsSentAnyReplayEvents,
   useReplayOnboardingSidebarPanel,
 } from 'sentry/utils/replays/hooks/useReplayOnboarding';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import useProjects from 'sentry/utils/useProjects';
 import type {ReplayError} from 'sentry/views/replays/types';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
-jest.mock('sentry/utils/replays/hooks/useReplayReader');
+jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
 jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 // Replay clip preview is very heavy, mock it out
@@ -70,7 +70,7 @@ const mockReplay = ReplayReader.factory({
   }),
 });
 
-jest.mocked(useReplayReader).mockImplementation(() => {
+jest.mocked(useLoadReplayReader).mockImplementation(() => {
   return {
     attachments: [],
     errors: mockErrors,

--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -7,15 +7,15 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
 
 import ReplayClipPreview from './replayClipPreview';
 
-jest.mock('sentry/utils/replays/hooks/useReplayReader');
+jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
 
-const mockUseReplayReader = jest.mocked(useReplayReader);
+const mockUseLoadReplayReader = jest.mocked(useLoadReplayReader);
 
 const mockOrgSlug = 'sentry-emerging-tech';
 const mockReplaySlug = 'replays:761104e184c64d439ee1014b72b4d83b';
@@ -48,7 +48,7 @@ const mockReplay = ReplayReader.factory({
   },
 });
 
-mockUseReplayReader.mockImplementation(() => {
+mockUseLoadReplayReader.mockImplementation(() => {
   return {
     attachments: [],
     errors: [],
@@ -120,7 +120,7 @@ describe('ReplayClipPreview', () => {
 
   it('Should render a placeholder when is fetching the replay data', () => {
     // Change the mocked hook to return a loading state
-    mockUseReplayReader.mockImplementationOnce(() => {
+    mockUseLoadReplayReader.mockImplementationOnce(() => {
       return {
         attachments: [],
         errors: [],
@@ -141,7 +141,7 @@ describe('ReplayClipPreview', () => {
 
   it('Should throw error when there is a fetch error', () => {
     // Change the mocked hook to return a fetch error
-    mockUseReplayReader.mockImplementationOnce(() => {
+    mockUseLoadReplayReader.mockImplementationOnce(() => {
       return {
         attachments: [],
         errors: [],

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 
 import ReplayClipPreviewPlayer from 'sentry/components/events/eventReplay/replayClipPreviewPlayer';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 
 interface ReplayClipPreviewProps
   extends Omit<
@@ -33,7 +33,7 @@ function ReplayClipPreview({
     [clipOffsets.durationBeforeMs, clipOffsets.durationAfterMs, eventTimestampMs]
   );
 
-  const replayReaderResult = useReplayReader({
+  const replayReaderResult = useLoadReplayReader({
     orgSlug,
     replaySlug,
     clipWindow,

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -18,7 +18,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import type useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -28,7 +28,7 @@ import type {ReplayRecord} from 'sentry/views/replays/types';
 interface ReplayClipPreviewPlayerProps {
   analyticsContext: string;
   orgSlug: string;
-  replayReaderResult: ReturnType<typeof useReplayReader>;
+  replayReaderResult: ReturnType<typeof useLoadReplayReader>;
   focusTab?: TabKey;
   fullReplayButtonProps?: Partial<Omit<LinkButtonProps, 'external'>>;
   handleBackClick?: () => void;

--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -6,15 +6,15 @@ import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render as baseRender, screen} from 'sentry-test/reactTestingLibrary';
 
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
 
 import ReplayPreview from './replayPreview';
 
-jest.mock('sentry/utils/replays/hooks/useReplayReader');
+jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
 
-const mockUseReplayReader = jest.mocked(useReplayReader);
+const mockUseLoadReplayReader = jest.mocked(useLoadReplayReader);
 
 const mockOrgSlug = 'sentry-emerging-tech';
 const mockReplaySlug = 'replays:761104e184c64d439ee1014b72b4d83b';
@@ -39,7 +39,7 @@ const mockReplay = ReplayReader.factory({
   }),
 });
 
-mockUseReplayReader.mockImplementation(() => {
+mockUseLoadReplayReader.mockImplementation(() => {
   return {
     attachments: [],
     errors: [],
@@ -84,7 +84,7 @@ const defaultProps = {
 describe('ReplayPreview', () => {
   it('Should render a placeholder when is fetching the replay data', () => {
     // Change the mocked hook to return a loading state
-    mockUseReplayReader.mockImplementationOnce(() => {
+    mockUseLoadReplayReader.mockImplementationOnce(() => {
       return {
         attachments: [],
         errors: [],
@@ -105,7 +105,7 @@ describe('ReplayPreview', () => {
 
   it('Should throw error when there is a fetch error', () => {
     // Change the mocked hook to return a fetch error
-    mockUseReplayReader.mockImplementationOnce(() => {
+    mockUseLoadReplayReader.mockImplementationOnce(() => {
       return {
         attachments: [],
         errors: [],

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -15,7 +15,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -60,7 +60,7 @@ function ReplayPreview({
   orgSlug,
   replaySlug,
 }: Props) {
-  const {fetching, replay, replayRecord, fetchError, replayId} = useReplayReader({
+  const {fetching, replay, replayRecord, fetchError, replayId} = useLoadReplayReader({
     orgSlug,
     replaySlug,
   });

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -10,7 +10,7 @@ import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 import useProjects from 'sentry/utils/useProjects';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
-jest.mock('sentry/utils/replays/hooks/useReplayReader');
+jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
 jest.mock('sentry/utils/useProjects');
 
 describe('Breadcrumbs', () => {

--- a/static/app/components/replays/player/__stories__/replaySlugChooser.tsx
+++ b/static/app/components/replays/player/__stories__/replaySlugChooser.tsx
@@ -2,7 +2,7 @@ import {Fragment, type ReactNode} from 'react';
 import {css} from '@emotion/react';
 
 import Providers from 'sentry/components/replays/player/__stories__/providers';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
@@ -29,7 +29,7 @@ export default function ReplaySlugChooser({children}: {children: ReactNode}) {
 
 function LoadReplay({children, replaySlug}: {children: ReactNode; replaySlug: string}) {
   const organization = useOrganization();
-  const {fetchError, fetching, replay} = useReplayReader({
+  const {fetchError, fetching, replay} = useLoadReplayReader({
     orgSlug: organization.slug,
     replaySlug,
   });

--- a/static/app/utils/replays/hooks/useLoadReplayReader.spec.tsx
+++ b/static/app/utils/replays/hooks/useLoadReplayReader.spec.tsx
@@ -1,7 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/replays/hooks/useReplayData', () => ({
@@ -17,13 +17,13 @@ const wrapper = ({children}: {children?: React.ReactNode}) => (
   </OrganizationContext.Provider>
 );
 
-describe('useReplayReader', () => {
+describe('useLoadReplayReader', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
   });
 
   it('should accept a replaySlug with project and id parts', () => {
-    const {result} = renderHook(useReplayReader, {
+    const {result} = renderHook(useLoadReplayReader, {
       wrapper,
       initialProps: {
         orgSlug: organization.slug,
@@ -39,7 +39,7 @@ describe('useReplayReader', () => {
   });
 
   it('should accept a replaySlug with only the replay-id', () => {
-    const {result} = renderHook(useReplayReader, {
+    const {result} = renderHook(useLoadReplayReader, {
       wrapper,
       initialProps: {
         orgSlug: organization.slug,

--- a/static/app/utils/replays/hooks/useLoadReplayReader.tsx
+++ b/static/app/utils/replays/hooks/useLoadReplayReader.tsx
@@ -20,7 +20,7 @@ interface ReplayReaderResult extends ReturnType<typeof useReplayData> {
   replayId: string;
 }
 
-export default function useReplayReader({
+export default function useLoadReplayReader({
   orgSlug,
   replaySlug,
   clipWindow,

--- a/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
+++ b/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
@@ -2,14 +2,14 @@ import {useEffect} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import type {BreadcrumbFrame} from 'sentry/utils/replays/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 
 interface Props
   extends Pick<
-    ReturnType<typeof useReplayReader>,
+    ReturnType<typeof useLoadReplayReader>,
     'fetchError' | 'fetching' | 'projectSlug' | 'replay'
   > {}
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -11,7 +11,7 @@ import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import GroupReplays from 'sentry/views/issueDetails/groupReplays';
 
@@ -21,8 +21,8 @@ const mockReplayUrl = '/organizations/org-slug/replays/';
 const REPLAY_ID_1 = '346789a703f6454384f1de473b8b9fcc';
 const REPLAY_ID_2 = 'b05dae9b6be54d21a4d5ad9f8f02b780';
 
-jest.mock('sentry/utils/replays/hooks/useReplayReader');
-const mockUseReplayReader = jest.mocked(useReplayReader);
+jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
+const mockUseLoadReplayReader = jest.mocked(useLoadReplayReader);
 
 const mockEventTimestamp = new Date('2022-09-22T16:59:41Z');
 const mockEventTimestampMs = mockEventTimestamp.getTime();
@@ -50,7 +50,7 @@ const mockReplay = ReplayReader.factory({
   },
 });
 
-mockUseReplayReader.mockImplementation(() => {
+mockUseLoadReplayReader.mockImplementation(() => {
   return {
     attachments: [],
     errors: [],

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -16,8 +16,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useUrlParams from 'sentry/utils/useUrlParams';
@@ -132,7 +132,7 @@ function GroupReplaysTableInner({
   overlayContent?: React.ReactNode;
 }) {
   const orgSlug = organization.slug;
-  const {fetching, replay} = useReplayReader({
+  const {fetching, replay} = useLoadReplayReader({
     orgSlug,
     replaySlug,
     group,

--- a/static/app/views/issueDetails/groupReplays/replayClipPreviewWrapper.tsx
+++ b/static/app/views/issueDetails/groupReplays/replayClipPreviewWrapper.tsx
@@ -1,7 +1,7 @@
 import ReplayClipPreviewPlayer from 'sentry/components/events/eventReplay/replayClipPreviewPlayer';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import type {Group} from 'sentry/types/group';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import type {ReplayColumn} from 'sentry/views/replays/replayTable/types';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
 
@@ -20,7 +20,7 @@ type Props = {
 export function ReplayClipPreviewWrapper(props: Props) {
   const {selectedReplayIndex} = props;
   const {analyticsContext} = useReplayContext();
-  const replayReaderData = useReplayReader({
+  const replayReaderData = useLoadReplayReader({
     orgSlug: props.orgSlug,
     replaySlug: props.replaySlug,
     group: props.group,

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -16,10 +16,10 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type {TimeOffsetLocationQueryParams} from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import useInitialTimeOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import useLogReplayDataLoaded from 'sentry/utils/replays/hooks/useLogReplayDataLoaded';
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
-import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import {ReplayPreferencesContextProvider} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -55,7 +55,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     replay,
     replayId,
     replayRecord,
-  } = useReplayReader({
+  } = useLoadReplayReader({
     replaySlug,
     orgSlug,
   });


### PR DESCRIPTION
This old thing, which i'm renaming, wasn't just a getter, it would actually load up replay data and create a ReplayReader instance. I've thought the name wasn't best most descriptive for a while... but now it's changed!

I'm calling the file in this PR 'old' because https://github.com/getsentry/sentry/pull/82532 recently added a new `useReplayReader` hook which i think is living up to it's name better: this new one is just a pass-through for objects of type ReplayReader. 

