### PR TITLE
ref: remove timestamp_format

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
-import time
 from datetime import UTC, datetime, timedelta
 
 import time_machine
 
-__all__ = ["before_now", "timestamp_format"]
+__all__ = ["before_now"]
 
 
 def before_now(**kwargs: float) -> datetime:
     date = datetime.now(UTC) - timedelta(**kwargs)
     return date - timedelta(microseconds=date.microsecond % 1000)
-
-
-def timestamp_format(datetime):
-    return time.mktime(datetime.utctimetuple()) + datetime.microsecond / 1e6
 
 
 class MockClock:

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -9,7 +9,7 @@ from selenium.webdriver.common.keys import Keys
 
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
-from sentry.testutils.helpers.datetime import before_now, timestamp_format
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
 from sentry.utils.samples import load_data
 
@@ -117,8 +117,8 @@ def generate_transaction(trace=None, span=None):
             (start_delta, span_length) = time_offsets.get(span_id, (timedelta(), timedelta()))
 
             span_start_time = start_datetime + start_delta
-            span["start_timestamp"] = timestamp_format(span_start_time)
-            span["timestamp"] = timestamp_format(span_start_time + span_length)
+            span["start_timestamp"] = span_start_time.timestamp()
+            span["timestamp"] = (span_start_time + span_length).timestamp()
             spans.append(span)
 
             if isinstance(child, dict):
@@ -135,8 +135,8 @@ def generate_transaction(trace=None, span=None):
                 (start_delta, span_length) = time_offsets.get(span_id, (timedelta(), timedelta()))
 
                 span_start_time = start_datetime + start_delta
-                span["start_timestamp"] = timestamp_format(span_start_time)
-                span["timestamp"] = timestamp_format(span_start_time + span_length)
+                span["start_timestamp"] = span_start_time.timestamp()
+                span["timestamp"] = (span_start_time + span_length).timestamp()
                 spans.append(span)
 
         return spans

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -7,7 +7,7 @@ import pytest
 from sentry.models.eventattachment import EventAttachment
 from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers.datetime import before_now, timestamp_format
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka
 
@@ -158,8 +158,8 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
                     "op": "react.mount",
                     "parent_span_id": "8f5a2b8768cafb4e",
                     "span_id": "bd429c44b67a3eb4",
-                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=250)),
-                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "start_timestamp": before_now(minutes=1, milliseconds=250).timestamp(),
+                    "timestamp": before_now(minutes=1).timestamp(),
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                 },
                 {
@@ -167,8 +167,8 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
                     "op": "browser",
                     "parent_span_id": "bd429c44b67a3eb4",
                     "span_id": "a99fd04e79e17631",
-                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
-                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "start_timestamp": before_now(minutes=1, milliseconds=200).timestamp(),
+                    "timestamp": before_now(minutes=1).timestamp(),
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                 },
                 {
@@ -176,8 +176,8 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
                     "op": "resource",
                     "parent_span_id": "bd429c44b67a3eb4",
                     "span_id": "a71a5e67db5ce938",
-                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
-                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "start_timestamp": before_now(minutes=1, milliseconds=200).timestamp(),
+                    "timestamp": before_now(minutes=1).timestamp(),
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                 },
                 {
@@ -185,8 +185,8 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
                     "op": "http",
                     "parent_span_id": "a99fd04e79e17631",
                     "span_id": "abe79ad9292b90a9",
-                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
-                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "start_timestamp": before_now(minutes=1, milliseconds=200).timestamp(),
+                    "timestamp": before_now(minutes=1).timestamp(),
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                 },
                 {
@@ -194,8 +194,8 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
                     "op": "db",
                     "parent_span_id": "abe79ad9292b90a9",
                     "span_id": "9c045ea336297177",
-                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
-                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "start_timestamp": before_now(minutes=1, milliseconds=200).timestamp(),
+                    "timestamp": before_now(minutes=1).timestamp(),
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                 },
             ],

--- a/tests/sentry/api/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/api/endpoints/test_organization_events_anomalies.py
@@ -19,7 +19,7 @@ from sentry.seer.anomaly_detection.types import (
 )
 from sentry.seer.anomaly_detection.utils import translate_direction
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.datetime import before_now, freeze_time, timestamp_format
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 
@@ -39,10 +39,10 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         direction=translate_direction(AlertRuleThresholdType.ABOVE.value),
         expected_seasonality=AlertRuleSeasonality.AUTO.value,
     )
-    historical_timestamp_1 = timestamp_format(four_weeks_ago)
-    historical_timestamp_2 = timestamp_format(four_weeks_ago + timedelta(days=10))
-    current_timestamp_1 = timestamp_format(one_week_ago)
-    current_timestamp_2 = timestamp_format(one_week_ago + timedelta(minutes=10))
+    historical_timestamp_1 = four_weeks_ago.timestamp()
+    historical_timestamp_2 = (four_weeks_ago + timedelta(days=10)).timestamp()
+    current_timestamp_1 = one_week_ago.timestamp()
+    current_timestamp_2 = (one_week_ago + timedelta(minutes=10)).timestamp()
     data = {
         "project_id": 1,
         "config": config,

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -12,7 +12,7 @@ from sentry.models.eventerror import EventError
 from sentry.models.release import Release
 from sentry.sdk_updates import SdkIndexState
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.datetime import before_now, timestamp_format
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.samples import load_data
@@ -579,10 +579,8 @@ class SqlFormatEventSerializerTest(TestCase):
                         "op": "db",
                         "parent_span_id": "abe79ad9292b90a9",
                         "span_id": "9c045ea336297177",
-                        "start_timestamp": timestamp_format(
-                            before_now(minutes=1, milliseconds=200)
-                        ),
-                        "timestamp": timestamp_format(before_now(minutes=1)),
+                        "start_timestamp": before_now(minutes=1, milliseconds=200).timestamp(),
+                        "timestamp": before_now(minutes=1).timestamp(),
                         "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     },
                     {
@@ -590,10 +588,8 @@ class SqlFormatEventSerializerTest(TestCase):
                         "op": "http",
                         "parent_span_id": "a99fd04e79e17631",
                         "span_id": "abe79ad9292b90a9",
-                        "start_timestamp": timestamp_format(
-                            before_now(minutes=1, milliseconds=200)
-                        ),
-                        "timestamp": timestamp_format(before_now(minutes=1)),
+                        "start_timestamp": before_now(minutes=1, milliseconds=200).timestamp(),
+                        "timestamp": before_now(minutes=1).timestamp(),
                         "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     },
                 ],


### PR DESCRIPTION
no reason to use this over the .timestamp() method

<!-- Describe your PR here. -->