### PR TITLE
feat(statistical-detectors): Skip low volume objects for regression d…

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2116,6 +2116,20 @@ register(
 )
 
 register(
+    "statistical_detectors.throughput.threshold.transactions",
+    default=50,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "statistical_detectors.throughput.threshold.functions",
+    default=25,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "options_automator_slack_webhook_enabled",
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -109,6 +109,7 @@ class RegressionDetector(ABC):
         unique_project_ids: set[int] = set()
 
         total_count = 0
+        skipped_count = 0
         regressed_count = 0
         improved_count = 0
 
@@ -127,6 +128,7 @@ class RegressionDetector(ABC):
                 # If the number of events is too low, then we skip updating
                 # to minimize false positives
                 if payload.count <= cls.min_throughput_threshold():
+                    skipped_count += 1
                     continue
 
                 metrics.distribution(
@@ -166,6 +168,13 @@ class RegressionDetector(ABC):
         metrics.incr(
             "statistical_detectors.objects.total",
             amount=total_count,
+            tags={"source": cls.source, "kind": cls.kind},
+            sample_rate=1.0,
+        )
+
+        metrics.incr(
+            "statistical_detectors.objects.skipped",
+            amount=skipped_count,
             tags={"source": cls.source, "kind": cls.kind},
             sample_rate=1.0,
         )

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -237,6 +237,10 @@ class EndpointRegressionDetector(RegressionDetector):
     escalation_rel_threshold = 0.75
 
     @classmethod
+    def min_throughput_threshold(cls) -> int:
+        return options.get("statistical_detectors.throughput.threshold.transactions")
+
+    @classmethod
     def detector_algorithm_factory(cls) -> DetectorAlgorithm:
         return MovingAverageRelativeChangeDetector(
             source=cls.source,
@@ -277,6 +281,10 @@ class FunctionRegressionDetector(RegressionDetector):
     buffer_period = timedelta(days=1)
     resolution_rel_threshold = 0.1
     escalation_rel_threshold = 0.75
+
+    @classmethod
+    def min_throughput_threshold(cls) -> int:
+        return options.get("statistical_detectors.throughput.threshold.functions")
 
     @classmethod
     def detector_algorithm_factory(cls) -> DetectorAlgorithm:


### PR DESCRIPTION
…etection

Sometimes, the transactions + functions being monitored has such low volume that any changes in duration is not significant but rather due to noise. So we should skip them during the detection phase and not emit issues for them.