### PR TITLE
fix(widget-builder): Field doubles when changing table to chart

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -147,18 +147,18 @@ function useWidgetBuilderState(): {
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);
 
-          let newDisplayType;
+          let nextDisplayType = displayType;
           if (action.payload === WidgetType.ISSUE) {
             // Issues only support table display type
             setDisplayType(DisplayType.TABLE);
-            newDisplayType = DisplayType.TABLE;
+            nextDisplayType = DisplayType.TABLE;
           }
 
           const config = getDatasetConfig(action.payload);
           setFields(
             config.defaultWidgetQuery.fields?.map(field => explodeField({field}))
           );
-          if (newDisplayType === DisplayType.TABLE) {
+          if (nextDisplayType === DisplayType.TABLE) {
             setYAxis([]);
           } else {
             setYAxis(
@@ -201,6 +201,7 @@ function useWidgetBuilderState(): {
       setLimit,
       fields,
       yAxis,
+      displayType,
     ]
   );
 


### PR DESCRIPTION
If you open up the widget builder, change the dataset, and then change the display type from table to line, you'll see that the yAxis gets duplicated. This is because the logic was incorrectly setting a yAxis if we weren't "switching to a table", which would only occur previously if you were selecting the issue dataset.

To test this, start adding a new widget, change the dataset type to Transaction, then change the display type to Line. You'll see two counts appear in the visualize section