### PR TITLE
ref(issue-views): Fold navigate behavior into issueViews context

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -267,17 +267,12 @@ function CustomViewsIssueListHeaderTabsContent({
     }
     if (query) {
       if (!tabListState?.selectionManager.isSelected(TEMPORARY_TAB_KEY)) {
-        dispatch({type: 'SET_TEMP_VIEW', query, sort});
-        navigate(
-          normalizeUrl({
-            ...location,
-            query: {
-              ...queryParamsWithPageFilters,
-              viewId: undefined,
-            },
-          }),
-          {replace: true}
-        );
+        dispatch({
+          type: 'SET_TEMP_VIEW',
+          query,
+          sort,
+          updateQueryParams: {newQueryParams: {viewId: undefined}, replace: true},
+        });
         tabListState?.setSelectedKey(TEMPORARY_TAB_KEY);
         return;
       }

--- a/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/issueViews.tsx
@@ -42,9 +42,20 @@ export interface IssueView {
   unsavedChanges?: [string, IssueSortOptions];
 }
 
+export type IssueViewsQueryUpdateParams = {
+  // TODO(msun): Once project/env/datetime are added as view configs, add them here
+  newQueryParams: {
+    query?: string;
+    sort?: IssueSortOptions;
+    viewId?: string;
+  };
+  replace?: boolean;
+};
+
 type BaseIssueViewsAction = {
   /** If true, the new views state created by the action will be synced to the backend */
   syncViews?: boolean;
+  updateQueryParams?: IssueViewsQueryUpdateParams;
 };
 
 type ReorderTabsAction = {
@@ -112,7 +123,7 @@ type SetViewsAction = {
 type SyncViewsToBackendAction = {
   /** Syncs the current views state to the backend. Does not make any changes to the views state. */
   type: 'SYNC_VIEWS_TO_BACKEND';
-};
+} & Exclude<BaseIssueViewsAction, 'syncViews'>;
 
 export type IssueViewsActions =
   | ReorderTabsAction
@@ -247,7 +258,11 @@ function deleteView(state: IssueViewsState, tabListState: TabListState<any>) {
   return {...state, views: newViews};
 }
 
-function createNewView(state: IssueViewsState, action: CreateNewViewAction) {
+function createNewView(
+  state: IssueViewsState,
+  action: CreateNewViewAction,
+  tabListState: TabListState<any>
+) {
   const newTabs: IssueView[] = [
     ...state.views,
     {
@@ -259,6 +274,7 @@ function createNewView(state: IssueViewsState, action: CreateNewViewAction) {
       isCommitted: false,
     },
   ];
+  tabListState?.setSelectedKey(action.tempId);
   return {...state, views: newTabs};
 }
 
@@ -417,30 +433,6 @@ export function IssueViewsStateProvider({
     onSuccess: replaceWithPersistantViewIds,
   });
 
-  const debounceUpdateViews = useMemo(
-    () =>
-      debounce((newTabs: IssueView[]) => {
-        if (newTabs) {
-          updateViews({
-            orgSlug: organization.slug,
-            groupSearchViews: newTabs
-              .filter(tab => tab.isCommitted)
-              .map(tab => ({
-                // Do not send over an ID if it's a temporary or default tab so that
-                // the backend will save these and generate permanent Ids for them
-                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
-                  ? {id: tab.id}
-                  : {}),
-                name: tab.label,
-                query: tab.query,
-                querySort: tab.querySort,
-              })),
-          });
-        }
-      }, 500),
-    [organization.slug, updateViews]
-  );
-
   const reducer: Reducer<IssueViewsState, IssueViewsActions> = useCallback(
     (state, action): IssueViewsState => {
       if (!tabListState) {
@@ -460,7 +452,7 @@ export function IssueViewsStateProvider({
         case 'DELETE_VIEW':
           return deleteView(state, tabListState);
         case 'CREATE_NEW_VIEW':
-          return createNewView(state, action);
+          return createNewView(state, action, tabListState);
         case 'SET_TEMP_VIEW':
           return setTempView(state, action);
         case 'DISCARD_TEMP_VIEW':
@@ -504,12 +496,57 @@ export function IssueViewsStateProvider({
     tempView: initialTempView,
   });
 
+  const debounceUpdateViews = useMemo(
+    () =>
+      debounce((newTabs: IssueView[]) => {
+        if (newTabs) {
+          updateViews({
+            orgSlug: organization.slug,
+            groupSearchViews: newTabs
+              .filter(tab => tab.isCommitted)
+              .map(tab => ({
+                // Do not send over an ID if it's a temporary or default tab so that
+                // the backend will save these and generate permanent Ids for them
+                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
+                  ? {id: tab.id}
+                  : {}),
+                name: tab.label,
+                query: tab.query,
+                querySort: tab.querySort,
+              })),
+          });
+        }
+      }, 500),
+    [organization.slug, updateViews]
+  );
+
+  const updateQueryParams = (params: IssueViewsQueryUpdateParams) => {
+    const {newQueryParams, replace = false} = params;
+    navigate(
+      normalizeUrl({
+        ...location,
+        query: {
+          ...queryParams,
+          ...newQueryParams,
+        },
+      }),
+      {replace}
+    );
+  };
+
   const dispatchWrapper = (action: IssueViewsActions) => {
     const newState = reducer(state, action);
     dispatch(action);
 
+    // These actions are outside of the dispatch to avoid introducing side effects in the reducer
     if (action.type === 'SYNC_VIEWS_TO_BACKEND' || action.syncViews) {
       debounceUpdateViews(newState.views);
+    }
+
+    if (action.updateQueryParams) {
+      queueMicrotask(() => {
+        updateQueryParams(action.updateQueryParams!);
+      });
     }
 
     const actionAnalyticsKey = ACTION_ANALYTICS_MAP[action.type];


### PR DESCRIPTION
This PR refactors the issue views family of components by moving lots of the navigation logic into the IssueViews context created in [this PR](https://github.com/getsentry/sentry/pull/82429). 

Many of the tab actions that were folded into the IssueViews context require changes to the query parameters, which is why it makes sense to combine these two actions in the reducer function. For example:
* Duplicating a tab requires the newly created tab to be selected (change viewId parameter) 
* Discarding a tab's changes requires the query/sort to be reset to the original query/sort (change query/sort param

