### PR TITLE
fix(issues):  Open tag csv in new window

### DIFF
--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -115,7 +115,13 @@ export function GroupTagsDrawer({group}: {group: Group}) {
         {
           key: 'export-page',
           label: t('Export Page to CSV'),
-          to: `${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
+          // TODO(issues): Dropdown menu doesn't support hrefs yet
+          onAction: () => {
+            window.open(
+              `/${organization.slug}/${project.slug}/issues/${group.id}/tags/${tagKey}/export/`,
+              '_blank'
+            );
+          },
         },
         {
           key: 'export-all',


### PR DESCRIPTION
Currently the `to` link is going to a dead page. Note: this link does not work because of how our proxies  are setup.
