### PR TITLE
support stale topic for ingest-events

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -348,7 +348,6 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         },
         "dlq_topic": Topic.INGEST_EVENTS_DLQ,
         "stale_topic": Topic.INGEST_EVENTS_DLQ,
-
     },
     "ingest-feedback-events": {
         "topic": Topic.INGEST_FEEDBACK_EVENTS,

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -347,6 +347,8 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
             "consumer_type": ConsumerType.Events,
         },
         "dlq_topic": Topic.INGEST_EVENTS_DLQ,
+        "stale_topic": Topic.INGEST_EVENTS_DLQ,
+
     },
     "ingest-feedback-events": {
         "topic": Topic.INGEST_FEEDBACK_EVENTS,


### PR DESCRIPTION
similarly to transactions, will get a dedicated lowpri topic later, for now testing by sending stale events to ingest-events-dlq
