### PR TITLE
feat(aci): event frequency condition handler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -1,0 +1,168 @@
+import contextlib
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta
+from typing import Any, Literal, TypedDict
+
+from django.db.models import QuerySet
+
+from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
+from sentry.models.group import Group
+from sentry.rules.conditions.event_frequency import SNUBA_LIMIT
+from sentry.tsdb.base import TSDBModel
+from sentry.utils.iterators import chunked
+from sentry.utils.snuba import options_override
+
+
+class _QSTypedDict(TypedDict):
+    id: int
+    type: int
+    project_id: int
+    project__organization_id: int
+
+
+class BaseEventFrequencyConditionHandler(ABC):
+    @property
+    @abstractmethod
+    def intervals(self) -> dict[str, tuple[str, timedelta]]:
+        raise NotImplementedError
+
+    def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
+        """
+        Calculate the start and end times for the query.
+        "duration" is the length of the window we're querying over.
+        """
+        start = end - duration
+        return (start, end)
+
+    def disable_consistent_snuba_mode(
+        self, duration: timedelta
+    ) -> contextlib.AbstractContextManager[object]:
+        """For conditions with interval >= 1 hour we don't need to worry about read your writes
+        consistency. Disable it so that we can scale to more nodes.
+        """
+        option_override_cm: contextlib.AbstractContextManager[object] = contextlib.nullcontext()
+        if duration >= timedelta(hours=1):
+            option_override_cm = options_override({"consistent": False})
+        return option_override_cm
+
+    def get_snuba_query_result(
+        self,
+        tsdb_function: Callable[..., Any],
+        keys: list[int],
+        group_id: int,
+        organization_id: int,
+        model: TSDBModel,
+        start: datetime,
+        end: datetime,
+        environment_id: int,
+        referrer_suffix: str,
+    ) -> Mapping[int, int]:
+        result: Mapping[int, int] = tsdb_function(
+            model=model,
+            keys=keys,
+            start=start,
+            end=end,
+            environment_id=environment_id,
+            use_cache=True,
+            jitter_value=group_id,
+            tenant_ids={"organization_id": organization_id},
+            referrer_suffix=referrer_suffix,
+        )
+        return result
+
+    def get_chunked_result(
+        self,
+        tsdb_function: Callable[..., Any],
+        model: TSDBModel,
+        group_ids: list[int],
+        organization_id: int,
+        start: datetime,
+        end: datetime,
+        environment_id: int,
+        referrer_suffix: str,
+    ) -> dict[int, int]:
+        batch_totals: dict[int, int] = defaultdict(int)
+        group_id = group_ids[0]
+        for group_chunk in chunked(group_ids, SNUBA_LIMIT):
+            result = self.get_snuba_query_result(
+                tsdb_function=tsdb_function,
+                model=model,
+                keys=[group_id for group_id in group_chunk],
+                group_id=group_id,
+                organization_id=organization_id,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+                referrer_suffix=referrer_suffix,
+            )
+            batch_totals.update(result)
+        return batch_totals
+
+    def get_group_ids_by_category(
+        self,
+        groups: QuerySet[Group, _QSTypedDict],
+    ) -> dict[GroupCategory, list[int]]:
+        """
+        Separate group ids into error group ids and generic group ids
+        """
+        category_group_ids: dict[GroupCategory, list[int]] = defaultdict(list)
+
+        for group in groups:
+            issue_type = get_group_type_by_type_id(group["type"])
+            category = GroupCategory(issue_type.category)
+            category_group_ids[category].append(group["id"])
+
+        return category_group_ids
+
+    def get_value_from_groups(
+        self,
+        groups: QuerySet[Group, _QSTypedDict] | None,
+        value: Literal["id", "project_id", "project__organization_id"],
+    ) -> int | None:
+        result = None
+        if groups:
+            group = groups[0]
+            result = group.get(value)
+        return result
+
+    @abstractmethod
+    def batch_query(
+        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
+    ) -> dict[int, int]:
+        """
+        Abstract method that specifies how to query Snuba for multiple groups
+        depending on the condition. Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def get_rate_bulk(
+        self,
+        duration: timedelta,
+        group_ids: set[int],
+        environment_id: int,
+        current_time: datetime,
+        comparison_interval: timedelta | None,
+    ) -> dict[int, int]:
+        """
+        Make a batch query for multiple groups. The return value is a dictionary
+        of group_id to the result for that group.
+        If comparison_interval is not None, we're making the second query in a
+        percent comparison condition. For example, if the condition is:
+            - num of issues is {}% higher in 1 hr compared to 5 min ago
+        The second query would be querying for num of events from:
+            -  5 min ago to 1 hr 5 min ago
+        """
+        if comparison_interval:
+            current_time -= comparison_interval
+        start, end = self.get_query_window(end=current_time, duration=duration)
+
+        with self.disable_consistent_snuba_mode(duration):
+            result = self.batch_query(
+                group_ids=group_ids,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+            )
+        return result

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -28,7 +28,7 @@ class _QSTypedDict(TypedDict):
     project__organization_id: int
 
 
-class BaseEventFrequencyConditionHandler(DataConditionHandler[int], ABC):
+class BaseEventFrequencyConditionHandler(ABC):
     @property
     @abstractmethod
     def intervals(self) -> dict[str, tuple[str, timedelta]]:
@@ -176,7 +176,7 @@ class BaseEventFrequencyConditionHandler(DataConditionHandler[int], ABC):
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY)
-class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
+class EventFrequencyConditionHandler(DataConditionHandler[int], BaseEventFrequencyConditionHandler):
     @staticmethod
     def evaluate_value(value: int, comparison: Any) -> DataConditionResult:
         return value == json.loads(comparison)["value"]

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -1,199 +1,21 @@
-import contextlib
-from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
-from typing import Any, Literal, TypedDict
-
-from django.db.models import QuerySet
+from typing import Any
 
 from sentry import tsdb
 from sentry.issues.constants import get_issue_tsdb_group_model
-from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.models.group import Group
-from sentry.rules.conditions.event_frequency import (
-    SNUBA_LIMIT,
-    STANDARD_INTERVALS,
-    ComparisonType,
-    percent_increase,
-)
+from sentry.rules.conditions.event_frequency import STANDARD_INTERVALS, percent_increase
 from sentry.tsdb.base import TSDBModel
-from sentry.utils.iterators import chunked
-from sentry.utils.snuba import options_override
+from sentry.workflow_engine.handlers.condition.event_frequency_base_handler import (
+    BaseEventFrequencyConditionHandler,
+)
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult
 
 
-class _QSTypedDict(TypedDict):
-    id: int
-    type: int
-    project_id: int
-    project__organization_id: int
-
-
-class BaseEventFrequencyConditionHandler(ABC):
-    @property
-    @abstractmethod
-    def intervals(self) -> dict[str, tuple[str, timedelta]]:
-        raise NotImplementedError
-
-    def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
-        """
-        Calculate the start and end times for the query.
-        "duration" is the length of the window we're querying over.
-        """
-        start = end - duration
-        return (start, end)
-
-    def disable_consistent_snuba_mode(
-        self, duration: timedelta
-    ) -> contextlib.AbstractContextManager[object]:
-        """For conditions with interval >= 1 hour we don't need to worry about read your writes
-        consistency. Disable it so that we can scale to more nodes.
-        """
-        option_override_cm: contextlib.AbstractContextManager[object] = contextlib.nullcontext()
-        if duration >= timedelta(hours=1):
-            option_override_cm = options_override({"consistent": False})
-        return option_override_cm
-
-    def get_snuba_query_result(
-        self,
-        tsdb_function: Callable[..., Any],
-        keys: list[int],
-        group_id: int,
-        organization_id: int,
-        model: TSDBModel,
-        start: datetime,
-        end: datetime,
-        environment_id: int,
-        referrer_suffix: str,
-    ) -> Mapping[int, int]:
-        result: Mapping[int, int] = tsdb_function(
-            model=model,
-            keys=keys,
-            start=start,
-            end=end,
-            environment_id=environment_id,
-            use_cache=True,
-            jitter_value=group_id,
-            tenant_ids={"organization_id": organization_id},
-            referrer_suffix=referrer_suffix,
-        )
-        return result
-
-    def get_chunked_result(
-        self,
-        tsdb_function: Callable[..., Any],
-        model: TSDBModel,
-        group_ids: list[int],
-        organization_id: int,
-        start: datetime,
-        end: datetime,
-        environment_id: int,
-        referrer_suffix: str,
-    ) -> dict[int, int]:
-        batch_totals: dict[int, int] = defaultdict(int)
-        group_id = group_ids[0]
-        for group_chunk in chunked(group_ids, SNUBA_LIMIT):
-            result = self.get_snuba_query_result(
-                tsdb_function=tsdb_function,
-                model=model,
-                keys=[group_id for group_id in group_chunk],
-                group_id=group_id,
-                organization_id=organization_id,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-                referrer_suffix=referrer_suffix,
-            )
-            batch_totals.update(result)
-        return batch_totals
-
-    def get_group_ids_by_category(
-        self,
-        groups: QuerySet[Group, _QSTypedDict],
-    ) -> dict[GroupCategory, list[int]]:
-        """
-        Separate group ids into error group ids and generic group ids
-        """
-        category_group_ids: dict[GroupCategory, list[int]] = defaultdict(list)
-
-        for group in groups:
-            issue_type = get_group_type_by_type_id(group["type"])
-            category = GroupCategory(issue_type.category)
-            category_group_ids[category].append(group["id"])
-
-        return category_group_ids
-
-    def get_value_from_groups(
-        self,
-        groups: QuerySet[Group, _QSTypedDict] | None,
-        value: Literal["id", "project_id", "project__organization_id"],
-    ) -> int | None:
-        result = None
-        if groups:
-            group = groups[0]
-            result = group.get(value)
-        return result
-
-    @abstractmethod
-    def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
-    ) -> dict[int, int]:
-        """
-        Abstract method that specifies how to query Snuba for multiple groups
-        depending on the condition. Must be implemented by subclasses.
-        """
-        raise NotImplementedError
-
-    def get_rate_bulk(
-        self,
-        duration: timedelta,
-        group_ids: set[int],
-        environment_id: int,
-        current_time: datetime,
-        comparison_interval: timedelta | None,
-    ) -> dict[int, int]:
-        """
-        Make a batch query for multiple groups. The return value is a dictionary
-        of group_id to the result for that group.
-
-        If comparison_interval is not None, we're making the second query in a
-        percent comparison condition. For example, if the condition is:
-            - num of issues is {}% higher in 1 hr compared to 5 min ago
-        The second query would be querying for num of events from:
-            -  5 min ago to 1 hr 5 min ago
-        """
-        if comparison_interval:
-            current_time -= comparison_interval
-        start, end = self.get_query_window(end=current_time, duration=duration)
-
-        with self.disable_consistent_snuba_mode(duration):
-            result = self.batch_query(
-                group_ids=group_ids,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-            )
-        return result
-
-
-@condition_handler_registry.register(Condition.EVENT_FREQUENCY)
-class EventFrequencyConditionHandler(
-    DataConditionHandler[list[int]], BaseEventFrequencyConditionHandler
-):
-    @staticmethod
-    def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
-        comparison_type = comparison["comparison_type"]
-        if comparison_type == ComparisonType.COUNT:
-            return value[0] > comparison["value"]
-
-        if comparison_type == ComparisonType.PERCENT:
-            return percent_increase(value[0], value[1]) > comparison["value"]
-
-        return False
-
+class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     @property
     def intervals(self) -> dict[str, tuple[str, timedelta]]:
         return STANDARD_INTERVALS
@@ -230,3 +52,18 @@ class EventFrequencyConditionHandler(
             batch_sums.update(get_result(model, issue_ids))
 
         return batch_sums
+
+
+@condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
+class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHandler[int]):
+    @staticmethod
+    def evaluate_value(value: int, comparison: Any) -> DataConditionResult:
+        return value > comparison["value"]
+
+
+@condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
+class EventFrequencyPercentHandler(EventFrequencyConditionHandler, DataConditionHandler[list[int]]):
+    @staticmethod
+    def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
+        assert len(value) == 2
+        return percent_increase(value[0], value[1]) > comparison["value"]

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -65,5 +65,6 @@ class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHa
 class EventFrequencyPercentHandler(EventFrequencyConditionHandler, DataConditionHandler[list[int]]):
     @staticmethod
     def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
-        assert len(value) == 2
+        if len(value) != 2:
+            return False
         return percent_increase(value[0], value[1]) > comparison["value"]

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -1,0 +1,245 @@
+import contextlib
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta
+from typing import Any, Literal, TypedDict
+
+from django.db.models import QuerySet
+
+from sentry import tsdb
+from sentry.issues.constants import get_issue_tsdb_group_model
+from sentry.issues.grouptype import get_group_type_by_type_id
+from sentry.models.group import Group, GroupCategory
+from sentry.tsdb.base import TSDBModel
+from sentry.utils import json
+from sentry.utils.iterators import chunked
+from sentry.utils.snuba import options_override
+from sentry.workflow_engine.models.data_condition import Condition, DataConditionResult
+from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.types import DataConditionHandler
+
+SNUBA_LIMIT = 10000
+STANDARD_INTERVALS: dict[str, tuple[str, timedelta]] = {
+    "1m": ("one minute", timedelta(minutes=1)),
+    "5m": ("5 minutes", timedelta(minutes=5)),
+    "15m": ("15 minutes", timedelta(minutes=15)),
+    "1h": ("one hour", timedelta(hours=1)),
+    "1d": ("one day", timedelta(hours=24)),
+    "1w": ("one week", timedelta(days=7)),
+    "30d": ("30 days", timedelta(days=30)),
+}
+COMPARISON_INTERVALS: dict[str, tuple[str, timedelta]] = {
+    "5m": ("5 minutes", timedelta(minutes=5)),
+    "15m": ("15 minutes", timedelta(minutes=15)),
+    "1h": ("one hour", timedelta(hours=1)),
+    "1d": ("one day", timedelta(hours=24)),
+    "1w": ("one week", timedelta(days=7)),
+    "30d": ("30 days", timedelta(days=30)),
+}
+
+
+class _QSTypedDict(TypedDict):
+    id: int
+    type: int
+    project_id: int
+    project__organization_id: int
+
+
+class BaseEventFrequencyConditionHandler(DataConditionHandler[int], ABC):
+    @property
+    @abstractmethod
+    def intervals(self) -> dict[str, tuple[str, timedelta]]:
+        raise NotImplementedError
+
+    def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
+        """
+        Calculate the start and end times for the query.
+        "duration" is the length of the window we're querying over.
+        """
+        start = end - duration
+        return (start, end)
+
+    def disable_consistent_snuba_mode(
+        self, duration: timedelta
+    ) -> contextlib.AbstractContextManager[object]:
+        """For conditions with interval >= 1 hour we don't need to worry about read your writes
+        consistency. Disable it so that we can scale to more nodes.
+        """
+        option_override_cm: contextlib.AbstractContextManager[object] = contextlib.nullcontext()
+        if duration >= timedelta(hours=1):
+            option_override_cm = options_override({"consistent": False})
+        return option_override_cm
+
+    def get_snuba_query_result(
+        self,
+        tsdb_function: Callable[..., Any],
+        keys: list[int],
+        group_id: int,
+        organization_id: int,
+        model: TSDBModel,
+        start: datetime,
+        end: datetime,
+        environment_id: int,
+        referrer_suffix: str,
+    ) -> Mapping[int, int]:
+        result: Mapping[int, int] = tsdb_function(
+            model=model,
+            keys=keys,
+            start=start,
+            end=end,
+            environment_id=environment_id,
+            use_cache=True,
+            jitter_value=group_id,
+            tenant_ids={"organization_id": organization_id},
+            referrer_suffix=referrer_suffix,
+        )
+        return result
+
+    def get_chunked_result(
+        self,
+        tsdb_function: Callable[..., Any],
+        model: TSDBModel,
+        group_ids: list[int],
+        organization_id: int,
+        start: datetime,
+        end: datetime,
+        environment_id: int,
+        referrer_suffix: str,
+    ) -> dict[int, int]:
+        batch_totals: dict[int, int] = defaultdict(int)
+        group_id = group_ids[0]
+        for group_chunk in chunked(group_ids, SNUBA_LIMIT):
+            result = self.get_snuba_query_result(
+                tsdb_function=tsdb_function,
+                model=model,
+                keys=[group_id for group_id in group_chunk],
+                group_id=group_id,
+                organization_id=organization_id,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+                referrer_suffix=referrer_suffix,
+            )
+            batch_totals.update(result)
+        return batch_totals
+
+    def get_error_and_generic_group_ids(
+        self,
+        groups: QuerySet[Group, _QSTypedDict],
+    ) -> tuple[list[int], list[int]]:
+        """
+        Separate group ids into error group ids and generic group ids
+        """
+        generic_issue_ids = []
+        error_issue_ids = []
+
+        for group in groups:
+            issue_type = get_group_type_by_type_id(group["type"])
+            if GroupCategory(issue_type.category) == GroupCategory.ERROR:
+                error_issue_ids.append(group["id"])
+            else:
+                generic_issue_ids.append(group["id"])
+        return (error_issue_ids, generic_issue_ids)
+
+    def get_value_from_groups(
+        self,
+        groups: QuerySet[Group, _QSTypedDict] | None,
+        value: Literal["id", "project_id", "project__organization_id"],
+    ) -> int | None:
+        result = None
+        if groups:
+            group = groups[0]
+            result = group.get(value)
+        return result
+
+    @abstractmethod
+    def batch_query(
+        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
+    ) -> dict[int, int]:
+        """
+        Abstract method that specifies how to query Snuba for multiple groups
+        depending on the condition. Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def get_rate_bulk(
+        self,
+        duration: timedelta,
+        group_ids: set[int],
+        environment_id: int,
+        current_time: datetime,
+        comparison_interval: timedelta | None,
+    ) -> dict[int, int]:
+        """
+        Make a batch query for multiple groups. The return value is a dictionary
+        of group_id to the result for that group.
+
+        If comparison_interval is not None, we're making the second query in a
+        percent comparison condition. For example, if the condition is:
+            - num of issues is {}% higher in 1 hr compared to 5 min ago
+        The second query would be querying for num of events from:
+            -  5 min ago to 1 hr 5 min ago
+        """
+        if comparison_interval:
+            current_time -= comparison_interval
+        start, end = self.get_query_window(end=current_time, duration=duration)
+
+        with self.disable_consistent_snuba_mode(duration):
+            result = self.batch_query(
+                group_ids=group_ids,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+            )
+        return result
+
+
+@condition_handler_registry.register(Condition.EVENT_FREQUENCY)
+class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
+    @staticmethod
+    def evaluate_value(value: int, comparison: Any) -> DataConditionResult:
+        return value == json.loads(comparison)["value"]
+
+    @property
+    def intervals(self) -> dict[str, tuple[str, timedelta]]:
+        return STANDARD_INTERVALS
+
+    def batch_query(
+        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
+    ) -> dict[int, int]:
+        batch_sums: dict[int, int] = defaultdict(int)
+        groups = Group.objects.filter(id__in=group_ids).values(
+            "id", "type", "project_id", "project__organization_id"
+        )
+        error_issue_ids, generic_issue_ids = self.get_error_and_generic_group_ids(groups)
+        organization_id = self.get_value_from_groups(groups, "project__organization_id")
+
+        if error_issue_ids and organization_id:
+            error_sums = self.get_chunked_result(
+                tsdb_function=tsdb.get_sums,
+                model=get_issue_tsdb_group_model(GroupCategory.ERROR),
+                group_ids=error_issue_ids,
+                organization_id=organization_id,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+                referrer_suffix="batch_alert_event_frequency",
+            )
+            batch_sums.update(error_sums)
+
+        if generic_issue_ids and organization_id:
+            generic_sums = self.get_chunked_result(
+                tsdb_function=tsdb.get_sums,
+                # this isn't necessarily performance, just any non-error category
+                model=get_issue_tsdb_group_model(GroupCategory.PERFORMANCE),
+                group_ids=generic_issue_ids,
+                organization_id=organization_id,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+                referrer_suffix="batch_alert_event_frequency",
+            )
+            batch_sums.update(generic_sums)
+
+        return batch_sums

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -9,15 +9,15 @@ from django.db.models import QuerySet
 
 from sentry import tsdb
 from sentry.issues.constants import get_issue_tsdb_group_model
-from sentry.issues.grouptype import get_group_type_by_type_id
-from sentry.models.group import Group, GroupCategory
+from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
+from sentry.models.group import Group
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import json
 from sentry.utils.iterators import chunked
 from sentry.utils.snuba import options_override
-from sentry.workflow_engine.models.data_condition import Condition, DataConditionResult
+from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler
+from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult
 
 SNUBA_LIMIT = 10000
 STANDARD_INTERVALS: dict[str, tuple[str, timedelta]] = {
@@ -217,7 +217,7 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
 
         if error_issue_ids and organization_id:
             error_sums = self.get_chunked_result(
-                tsdb_function=tsdb.get_sums,
+                tsdb_function=tsdb.backend.get_sums,
                 model=get_issue_tsdb_group_model(GroupCategory.ERROR),
                 group_ids=error_issue_ids,
                 organization_id=organization_id,
@@ -230,7 +230,7 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
 
         if generic_issue_ids and organization_id:
             generic_sums = self.get_chunked_result(
-                tsdb_function=tsdb.get_sums,
+                tsdb_function=tsdb.backend.get_sums,
                 # this isn't necessarily performance, just any non-error category
                 model=get_issue_tsdb_group_model(GroupCategory.PERFORMANCE),
                 group_ids=generic_issue_ids,

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -266,17 +266,20 @@ def create_latest_adopted_release_data_condition(
 def create_event_frequency_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
+    comparison_type = data["comparisonType"]  # this is camelCase, age comparison is snake_case
     comparison = {
         "interval": data["interval"],
         "value": data["value"],
-        "comparison_type": data["comparisonType"],
     }
 
-    if comparison["comparison_type"] == ComparisonType.PERCENT:
+    if comparison_type == ComparisonType.COUNT:
+        type = Condition.EVENT_FREQUENCY_COUNT
+    else:
+        type = Condition.EVENT_FREQUENCY_PERCENT
         comparison["comparison_interval"] = data["comparisonInterval"]
 
     return DataCondition.objects.create(
-        type=Condition.EVENT_FREQUENCY,
+        type=type,
         comparison=comparison,
         condition_result=True,
         condition_group=dcg,

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from sentry.rules.conditions.event_attribute import EventAttributeCondition
+from sentry.rules.conditions.event_frequency import EventFrequencyCondition
 from sentry.rules.conditions.every_event import EveryEventCondition
 from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
 from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
@@ -20,6 +21,7 @@ from sentry.rules.filters.latest_release import LatestReleaseFilter
 from sentry.rules.filters.level import LevelFilter
 from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.rules.match import MatchType
+from sentry.utils import json
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
@@ -47,7 +49,7 @@ def create_reappeared_event_data_condition(
 
 
 @data_condition_translator_registry.register(RegressionEventCondition.id)
-def create_regressed_event_data_condition(
+def create_regression_event_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
     return DataCondition.objects.create(
@@ -256,6 +258,18 @@ def create_latest_adopted_release_data_condition(
     return DataCondition.objects.create(
         type=Condition.LATEST_ADOPTED_RELEASE,
         comparison=comparison,
+        condition_result=True,
+        condition_group=dcg,
+    )
+
+
+@data_condition_translator_registry.register(EventFrequencyCondition.id)
+def create_event_frequency_data_condition(
+    data: dict[str, Any], dcg: DataConditionGroup
+) -> DataCondition:
+    return DataCondition.objects.create(
+        type=Condition.EVENT_FREQUENCY,
+        comparison=json.dumps({"interval": data["interval"], "value": data["value"]}),
         condition_result=True,
         condition_group=dcg,
     )

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -41,10 +41,20 @@ class Condition(models.TextChoices):
     REAPPEARED_EVENT = "reappeared_event"
     TAGGED_EVENT = "tagged_event"
     ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
-    EVENT_FREQUENCY = "event_frequency"
-    EVENT_UNIQUE_USER_FREQUENCY = "event_unique_user_frequency"
+
+    # Event frequency conditions
+    EVENT_FREQUENCY_COUNT = "event_frequency_count"
     EVENT_FREQUENCY_PERCENT = "event_frequency_percent"
-    EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS = "event_unique_user_frequency_with_conditions"
+    EVENT_UNIQUE_USER_FREQUENCY_COUNT = "event_unique_user_frequency_count"
+    EVENT_UNIQUE_USER_FREQUENCY_PERCENT = "event_unique_user_frequency_percent"
+    PERCENT_SESSIONS_COUNT = "percent_sessions_count"
+    PERCENT_SESSIONS_PERCENT = "percent_sessions_percent"
+    EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT = (
+        "event_unique_user_frequency_with_conditions_count"
+    )
+    EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT = (
+        "event_unique_user_frequency_with_conditions_percent"
+    )
 
 
 CONDITION_OPS = {
@@ -131,10 +141,14 @@ class DataCondition(DefaultFieldsModel):
 
 
 SLOW_CONDITIONS = [
-    Condition.EVENT_FREQUENCY,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY,
+    Condition.EVENT_FREQUENCY_COUNT,
     Condition.EVENT_FREQUENCY_PERCENT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+    Condition.PERCENT_SESSIONS_COUNT,
+    Condition.PERCENT_SESSIONS_PERCENT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT,
 ]
 
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -41,6 +41,10 @@ class Condition(models.TextChoices):
     REAPPEARED_EVENT = "reappeared_event"
     TAGGED_EVENT = "tagged_event"
     ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
+    EVENT_FREQUENCY = "event_frequency"
+    EVENT_UNIQUE_USER_FREQUENCY = "event_unique_user_frequency"
+    EVENT_FREQUENCY_PERCENT = "event_frequency_percent"
+    EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS = "event_unique_user_frequency_with_conditions"
 
 
 CONDITION_OPS = {
@@ -78,6 +82,18 @@ class DataCondition(DefaultFieldsModel):
         related_name="conditions",
         on_delete=models.CASCADE,
     )
+
+    @property
+    def slow_conditions(self) -> list[Condition]:
+        return [
+            Condition.EVENT_FREQUENCY,
+            Condition.EVENT_UNIQUE_USER_FREQUENCY,
+            Condition.EVENT_FREQUENCY_PERCENT,
+            Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS,
+        ]
+
+    def is_slow_condition(self):
+        return Condition(self.type) in self.slow_conditions
 
     def get_condition_result(self) -> DataConditionResult:
         match self.condition_result:

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -13,6 +13,7 @@ from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
 )
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -39,10 +40,17 @@ class ConditionTestCase(BaseWorkflowTest):
     ) -> DataCondition:
         return dual_write_condition(data, dcg)
 
-    def assert_passes(self, data_condition: DataCondition, job: Any) -> None:
+    def assert_passes(self, data_condition: DataCondition, job: WorkflowJob) -> None:
         assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
 
-    def assert_does_not_pass(self, data_condition: DataCondition, job: Any) -> None:
+    def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+        assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
+
+    # Slow conditions are evaluated in delayed processing and take in the results directly
+    def assert_slow_cond_passes(self, data_condition: DataCondition, job: list[int]) -> None:
+        assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
+
+    def assert_slow_cond_does_not_pass(self, data_condition: DataCondition, job: list[int]) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
     # TODO: activity

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -1,12 +1,18 @@
 from typing import Any
+from uuid import uuid4
 
+from django.utils import timezone
+
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.rules.base import RuleBase
+from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
 from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     translate_to_data_condition as dual_write_condition,
 )
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
-from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -33,10 +39,68 @@ class ConditionTestCase(BaseWorkflowTest):
     ) -> DataCondition:
         return dual_write_condition(data, dcg)
 
-    def assert_passes(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+    def assert_passes(self, data_condition: DataCondition, job: Any) -> None:
         assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
 
-    def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
+    def assert_does_not_pass(self, data_condition: DataCondition, job: Any) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
     # TODO: activity
+
+
+class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.start = before_now(minutes=1)
+        self.end = timezone.now()
+
+        self.event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "environment": self.environment.name,
+                "timestamp": before_now(seconds=30).isoformat(),
+                "fingerprint": ["group-1"],
+                "user": {"id": uuid4().hex},
+            },
+            project_id=self.project.id,
+        )
+        self.event2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "environment": self.environment.name,
+                "timestamp": before_now(seconds=12).isoformat(),
+                "fingerprint": ["group-2"],
+                "user": {"id": uuid4().hex},
+            },
+            project_id=self.project.id,
+        )
+        self.environment2 = self.create_environment(name="staging")
+        self.event3 = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "environment": self.environment2.name,
+                "timestamp": before_now(seconds=12).isoformat(),
+                "fingerprint": ["group-3"],
+                "user": {"id": uuid4().hex},
+            },
+            project_id=self.project.id,
+        )
+
+        fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-something_random"
+        perf_event_data = load_data(
+            "transaction-n-plus-one",
+            timestamp=before_now(seconds=12),
+            start_timestamp=before_now(seconds=13),
+            fingerprint=[fingerprint],
+        )
+        perf_event_data["user"] = {"id": uuid4().hex}
+        perf_event_data["environment"] = self.environment.name
+
+        # Store a performance event
+        self.perf_event = self.create_performance_issue(
+            event_data=perf_event_data,
+            project_id=self.project.id,
+            fingerprint=fingerprint,
+        )
+        self.data = {"interval": "5m", "value": 30}

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -47,11 +47,11 @@ class ConditionTestCase(BaseWorkflowTest):
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
     # Slow conditions are evaluated in delayed processing and take in the results directly
-    def assert_slow_cond_passes(self, data_condition: DataCondition, job: list[int]) -> None:
-        assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
+    def assert_slow_cond_passes(self, data_condition: DataCondition, value: Any) -> None:
+        assert data_condition.evaluate_value(value) == data_condition.get_condition_result()
 
-    def assert_slow_cond_does_not_pass(self, data_condition: DataCondition, job: list[int]) -> None:
-        assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
+    def assert_slow_cond_does_not_pass(self, data_condition: DataCondition, value: Any) -> None:
+        assert data_condition.evaluate_value(value) != data_condition.get_condition_result()
 
     # TODO: activity
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -22,7 +22,7 @@ class TestEventFrequencyCondition(ConditionTestCase):
     rule_cls = EventFrequencyCondition
     payload = {
         "interval": "1h",
-        "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+        "id": EventFrequencyCondition.id,
         "value": 1000,
     }
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -1,4 +1,5 @@
 import pytest
+from jsonschema import ValidationError
 
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
@@ -48,6 +49,27 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
+    def test_json_schema(self):
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "asdf",
+                    "value": 100,
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": -1,
+                },
+                condition_result=True,
+            )
+
 
 class TestEventFrequencyPercentCondition(ConditionTestCase):
     condition = Condition.EVENT_FREQUENCY_PERCENT
@@ -86,6 +108,40 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
+
+    def test_json_schema(self):
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "asdf",
+                    "value": 100,
+                    "comparison_interval": "1d",
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": -1,
+                    "comparison_interval": "1d",
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": 100,
+                    "comparison_interval": "asdf",
+                },
+                condition_result=True,
+            )
 
 
 class EventFrequencyQueryTest(EventFrequencyQueryTestBase):

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -33,9 +33,8 @@ class TestEventFrequencyCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.assert_passes(dc, [1001])
-
-        self.assert_does_not_pass(dc, [999])
+        self.assert_slow_cond_passes(dc, [1001])
+        self.assert_slow_cond_does_not_pass(dc, [999])
 
     def test_percent(self):
         dc = self.create_data_condition(
@@ -49,9 +48,8 @@ class TestEventFrequencyCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.assert_passes(dc, [21, 10])
-
-        self.assert_does_not_pass(dc, [20, 10])
+        self.assert_slow_cond_passes(dc, [21, 10])
+        self.assert_slow_cond_does_not_pass(dc, [20, 10])
 
     def test_dual_write_count(self):
         dcg = self.create_data_condition_group()

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -51,7 +51,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query(self):
         batch_query = self.handler().batch_query(
-            group_ids=[self.event.group_id, self.event2.group_id, self.perf_event.group_id],
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -63,7 +63,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
         batch_query = self.handler().batch_query(
-            group_ids=[self.event3.group_id],
+            group_ids={self.event3.group_id},
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -73,7 +73,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
     def test_get_error_and_generic_group_ids(self):
         groups = Group.objects.filter(
             id__in=[self.event.group_id, self.event2.group_id, self.perf_event.group_id]
-        ).values("id", "type", "project__organization_id")
+        ).values("id", "type", "project_id", "project__organization_id")
         error_issue_ids, generic_issue_ids = self.handler().get_error_and_generic_group_ids(groups)
         assert self.event.group_id in error_issue_ids
         assert self.event2.group_id in error_issue_ids

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.rules.conditions.event_frequency import EventFrequencyCondition
 from sentry.testutils.skips import requires_snuba
@@ -74,7 +75,8 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         groups = Group.objects.filter(
             id__in=[self.event.group_id, self.event2.group_id, self.perf_event.group_id]
         ).values("id", "type", "project_id", "project__organization_id")
-        error_issue_ids, generic_issue_ids = self.handler().get_error_and_generic_group_ids(groups)
-        assert self.event.group_id in error_issue_ids
-        assert self.event2.group_id in error_issue_ids
-        assert self.perf_event.group_id in generic_issue_ids
+        category_group_ids = self.handler().get_group_ids_by_category(groups)
+        error_group_ids = category_group_ids[GroupCategory.ERROR]
+        assert self.event.group_id in error_group_ids
+        assert self.event2.group_id in error_group_ids
+        assert self.perf_event.group_id in category_group_ids[GroupCategory.PERFORMANCE]

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -1,0 +1,80 @@
+import pytest
+
+from sentry.models.group import Group
+from sentry.rules.conditions.event_frequency import EventFrequencyCondition
+from sentry.testutils.skips import requires_snuba
+from sentry.utils import json
+from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
+    EventFrequencyConditionHandler,
+)
+from sentry.workflow_engine.models.data_condition import Condition
+from tests.sentry.workflow_engine.handlers.condition.test_base import (
+    ConditionTestCase,
+    EventFrequencyQueryTestBase,
+)
+
+pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
+
+
+class TestEventFrequencyCondition(ConditionTestCase):
+    condition = Condition.EVENT_FREQUENCY
+    rule_cls = EventFrequencyCondition
+    payload = {
+        "interval": "1h",
+        "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+        "value": 1000,
+    }
+
+    def test(self):
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison=json.dumps({"interval": "1h", "value": 1000}),
+            condition_result=True,
+        )
+
+        self.assert_passes(dc, 1000)
+
+        self.assert_does_not_pass(dc, 999)
+
+    def test_dual_write(self):
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison == json.dumps({"interval": "1h", "value": 1000})
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
+
+class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
+    handler = EventFrequencyConditionHandler
+
+    def test_batch_query(self):
+        batch_query = self.handler().batch_query(
+            group_ids=[self.event.group_id, self.event2.group_id, self.perf_event.group_id],
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 1,
+            self.perf_event.group_id: 1,
+        }
+
+        batch_query = self.handler().batch_query(
+            group_ids=[self.event3.group_id],
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment2.id,
+        )
+        assert batch_query == {self.event3.group_id: 1}
+
+    def test_get_error_and_generic_group_ids(self):
+        groups = Group.objects.filter(
+            id__in=[self.event.group_id, self.event2.group_id, self.perf_event.group_id]
+        ).values("id", "type", "project__organization_id")
+        error_issue_ids, generic_issue_ids = self.handler().get_error_and_generic_group_ids(groups)
+        assert self.event.group_id in error_issue_ids
+        assert self.event2.group_id in error_issue_ids
+        assert self.perf_event.group_id in generic_issue_ids


### PR DESCRIPTION
Add base event frequency condition handler, event frequency count and event frequency percent condition handler.

Each existing condition class technically handles two distinct condition types: getting the count for an interval, and comparing percent increase of the count for an interval with the same interval X time in the past.

The base condition handler borrows elements from `BaseEventFrequencyCondition` related to making the bulk Snuba query -- it might not yet contain everything necessary for delayed processing, but is enough for tests.