### PR TITLE
ref: remove dlq limits

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -9,7 +9,7 @@ from arroyo.backends.abstract import Consumer
 from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
 from arroyo.backends.kafka.consumer import KafkaConsumer
 from arroyo.commit import ONCE_PER_SECOND
-from arroyo.dlq import DlqLimit, DlqPolicy
+from arroyo.dlq import DlqPolicy
 from arroyo.processing.processor import StreamProcessor
 from arroyo.processing.strategies import Healthcheck
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -382,8 +382,6 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
             "ingest_profile": "release-health",
         },
         "dlq_topic": Topic.INGEST_METRICS_DLQ,
-        "dlq_max_invalid_ratio": 0.01,
-        "dlq_max_consecutive_count": 1000,
     },
     "ingest-generic-metrics": {
         "topic": Topic.INGEST_PERFORMANCE_METRICS,
@@ -393,8 +391,6 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
             "ingest_profile": "performance",
         },
         "dlq_topic": Topic.INGEST_GENERIC_METRICS_DLQ,
-        "dlq_max_invalid_ratio": None,
-        "dlq_max_consecutive_count": None,
     },
     "generic-metrics-last-seen-updater": {
         "topic": Topic.SNUBA_GENERIC_METRICS,
@@ -607,10 +603,7 @@ def get_stream_processor(
     if dlq_producer:
         dlq_policy = DlqPolicy(
             dlq_producer,
-            DlqLimit(
-                max_invalid_ratio=consumer_definition.get("dlq_max_invalid_ratio"),
-                max_consecutive_count=consumer_definition.get("dlq_max_consecutive_count"),
-            ),
+            None,
             None,
         )
 


### PR DESCRIPTION
we no longer impose any limits on how many messages can be dlq'ed on any other consumers, remove it from `ingest-metrics`, which was the last remaining one
