### PR TITLE
feat(uptime): Add regions to new uptime monitors, and slowly roll them out to existing uptime monitors

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from datetime import datetime, timedelta, timezone
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
@@ -24,6 +25,7 @@ from sentry.uptime.models import (
     ProjectUptimeSubscriptionMode,
     UptimeStatus,
     UptimeSubscription,
+    UptimeSubscriptionRegion,
 )
 from sentry.uptime.subscriptions.regions import get_active_region_configs
 from sentry.uptime.subscriptions.subscriptions import (
@@ -31,7 +33,10 @@ from sentry.uptime.subscriptions.subscriptions import (
     get_or_create_uptime_subscription,
     remove_uptime_subscription_if_unused,
 )
-from sentry.uptime.subscriptions.tasks import send_uptime_config_deletion
+from sentry.uptime.subscriptions.tasks import (
+    send_uptime_config_deletion,
+    update_remote_uptime_subscription,
+)
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -74,6 +79,38 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
     def get_subscription_id(self, result: CheckResult) -> str:
         return result["subscription_id"]
 
+    def check_and_update_regions(self, subscription: UptimeSubscription):
+        # Run region checks and updates roughly once an hour
+        chance_to_run = subscription.interval_seconds / timedelta(hours=1).total_seconds()
+        if random.random() < chance_to_run:
+            subscription_region_slugs = {r.region_slug for r in subscription.regions.all()}
+            active_region_slugs = {c.slug for c in get_active_region_configs()}
+            if subscription_region_slugs != active_region_slugs:
+                new_region_slugs = active_region_slugs - subscription_region_slugs
+                removed_region_slugs = subscription_region_slugs - active_region_slugs
+                if new_region_slugs:
+                    new_regions = [
+                        UptimeSubscriptionRegion(uptime_subscription=subscription, region_slug=slug)
+                        for slug in new_region_slugs
+                    ]
+                    UptimeSubscriptionRegion.objects.bulk_create(new_regions, ignore_conflicts=True)
+
+                if removed_region_slugs:
+                    for deleted_region in UptimeSubscriptionRegion.objects.filter(
+                        uptime_subscription=subscription, region_slug__in=removed_region_slugs
+                    ):
+                        if subscription.subscription_id:
+                            # We need to explicitly send deletes here before we remove the region
+                            send_uptime_config_deletion(
+                                deleted_region.region_slug, subscription.subscription_id
+                            )
+                        deleted_region.delete()
+
+                # Regardless of whether we added or removed regions, we need to send an updated config to all active
+                # regions for this subscription so that they all get an update set of currently active regions.
+                subscription.update(status=UptimeSubscription.Status.UPDATING.value)
+                update_remote_uptime_subscription.delay(subscription.id)
+
     def handle_result(self, subscription: UptimeSubscription | None, result: CheckResult):
         logger.info("process_result", extra=result)
 
@@ -86,6 +123,8 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             )
             metrics.incr("uptime.result_processor.subscription_not_found", sample_rate=1.0)
             return
+
+        self.check_and_update_regions(subscription)
 
         project_subscriptions = list(subscription.projectuptimesubscription_set.all())
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -80,36 +80,47 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         return result["subscription_id"]
 
     def check_and_update_regions(self, subscription: UptimeSubscription):
+        """
+        This method will check if regions have been added or removed from our region configuration,
+        and updates regions associated with this uptime monitor to reflect the new state. This is
+        done probabilistically, so that the check is performed roughly once an hour for each uptime
+        monitor.
+        """
         # Run region checks and updates roughly once an hour
         chance_to_run = subscription.interval_seconds / timedelta(hours=1).total_seconds()
-        if random.random() < chance_to_run:
-            subscription_region_slugs = {r.region_slug for r in subscription.regions.all()}
-            active_region_slugs = {c.slug for c in get_active_region_configs()}
-            if subscription_region_slugs != active_region_slugs:
-                new_region_slugs = active_region_slugs - subscription_region_slugs
-                removed_region_slugs = subscription_region_slugs - active_region_slugs
-                if new_region_slugs:
-                    new_regions = [
-                        UptimeSubscriptionRegion(uptime_subscription=subscription, region_slug=slug)
-                        for slug in new_region_slugs
-                    ]
-                    UptimeSubscriptionRegion.objects.bulk_create(new_regions, ignore_conflicts=True)
+        if random.random() >= chance_to_run:
+            return
 
-                if removed_region_slugs:
-                    for deleted_region in UptimeSubscriptionRegion.objects.filter(
-                        uptime_subscription=subscription, region_slug__in=removed_region_slugs
-                    ):
-                        if subscription.subscription_id:
-                            # We need to explicitly send deletes here before we remove the region
-                            send_uptime_config_deletion(
-                                deleted_region.region_slug, subscription.subscription_id
-                            )
-                        deleted_region.delete()
+        subscription_region_slugs = {r.region_slug for r in subscription.regions.all()}
+        active_region_slugs = {c.slug for c in get_active_region_configs()}
+        if subscription_region_slugs == active_region_slugs:
+            # Regions haven't changed, exit early.
+            return
 
-                # Regardless of whether we added or removed regions, we need to send an updated config to all active
-                # regions for this subscription so that they all get an update set of currently active regions.
-                subscription.update(status=UptimeSubscription.Status.UPDATING.value)
-                update_remote_uptime_subscription.delay(subscription.id)
+        new_region_slugs = active_region_slugs - subscription_region_slugs
+        removed_region_slugs = subscription_region_slugs - active_region_slugs
+        if new_region_slugs:
+            new_regions = [
+                UptimeSubscriptionRegion(uptime_subscription=subscription, region_slug=slug)
+                for slug in new_region_slugs
+            ]
+            UptimeSubscriptionRegion.objects.bulk_create(new_regions, ignore_conflicts=True)
+
+        if removed_region_slugs:
+            for deleted_region in UptimeSubscriptionRegion.objects.filter(
+                uptime_subscription=subscription, region_slug__in=removed_region_slugs
+            ):
+                if subscription.subscription_id:
+                    # We need to explicitly send deletes here before we remove the region
+                    send_uptime_config_deletion(
+                        deleted_region.region_slug, subscription.subscription_id
+                    )
+                deleted_region.delete()
+
+        # Regardless of whether we added or removed regions, we need to send an updated config to all active
+        # regions for this subscription so that they all get an update set of currently active regions.
+        subscription.update(status=UptimeSubscription.Status.UPDATING.value)
+        update_remote_uptime_subscription.delay(subscription.id)
 
     def handle_result(self, subscription: UptimeSubscription | None, result: CheckResult):
         logger.info("process_result", extra=result)

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -57,6 +57,9 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
     max_retries=5,
 )
 def update_remote_uptime_subscription(uptime_subscription_id, **kwargs):
+    """
+    Pushes details of an uptime subscription to uptime subscription regions.
+    """
     try:
         subscription = UptimeSubscription.objects.get(id=uptime_subscription_id)
     except UptimeSubscription.DoesNotExist:

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -51,6 +51,36 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
 
 
 @instrumented_task(
+    name="sentry.uptime.subscriptions.tasks.update_remote_uptime_subscription",
+    queue="uptime",
+    default_retry_delay=5,
+    max_retries=5,
+)
+def update_remote_uptime_subscription(uptime_subscription_id, **kwargs):
+    try:
+        subscription = UptimeSubscription.objects.get(id=uptime_subscription_id)
+    except UptimeSubscription.DoesNotExist:
+        metrics.incr("uptime.subscriptions.update.subscription_does_not_exist", sample_rate=1.0)
+        return
+    if subscription.status != UptimeSubscription.Status.UPDATING.value:
+        metrics.incr("uptime.subscriptions.update.incorrect_status", sample_rate=1.0)
+        return
+
+    region_slugs = [s.region_slug for s in subscription.regions.all()]
+    if not region_slugs:
+        # XXX: Hack to make sure that region configs are sent even if we don't have region rows present.
+        # Remove once everything is in place
+        region_slugs = [get_active_region_configs()[0].slug]
+
+    for region_slug in region_slugs:
+        send_uptime_subscription_config(region_slug, subscription)
+    subscription.update(
+        status=QuerySubscription.Status.ACTIVE.value,
+        subscription_id=subscription.subscription_id,
+    )
+
+
+@instrumented_task(
     name="sentry.uptime.subscriptions.tasks.delete_uptime_subscription",
     queue="uptime",
     default_retry_delay=5,
@@ -137,6 +167,7 @@ def subscription_checker(**kwargs):
     for subscription in UptimeSubscription.objects.filter(
         status__in=(
             UptimeSubscription.Status.CREATING.value,
+            UptimeSubscription.Status.UPDATING.value,
             UptimeSubscription.Status.DELETING.value,
         ),
         date_updated__lt=timezone.now() - SUBSCRIPTION_STATUS_MAX_AGE,

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -1,7 +1,10 @@
 from unittest import mock
 
 import pytest
+from django.test import override_settings
 
+from sentry.conf.types.kafka_definition import Topic
+from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
@@ -225,6 +228,48 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                     timeout_ms=1000,
                     mode=ProjectUptimeSubscriptionMode.MANUAL,
                 )[1]
+
+    def test_auto_associates_active_regions(self):
+        regions = [
+            UptimeRegionConfig(
+                slug="region1",
+                name="Region 1",
+                config_topic=Topic.UPTIME_CONFIGS,
+                enabled=True,
+            ),
+            UptimeRegionConfig(
+                slug="region2",
+                name="Region 2",
+                config_topic=Topic.UPTIME_RESULTS,
+                enabled=True,
+            ),
+            UptimeRegionConfig(
+                slug="region3",
+                name="Region 3",
+                config_topic=Topic.MONITORS_CLOCK_TASKS,
+                enabled=False,  # This one shouldn't be associated
+            ),
+        ]
+        with override_settings(UPTIME_REGIONS=regions):
+            subscription = get_or_create_uptime_subscription(
+                url="https://example.com",
+                interval_seconds=60,
+                timeout_ms=1000,
+            )
+
+            # Should only have the enabled regions
+            subscription_regions = {r.region_slug for r in subscription.regions.all()}
+            assert subscription_regions == {"region1", "region2"}
+
+            # Creating again should return same subscription with same regions
+            subscription2 = get_or_create_uptime_subscription(
+                url="https://example.com",
+                interval_seconds=60,
+                timeout_ms=1000,
+            )
+            assert subscription2.id == subscription.id
+            subscription_regions = {r.region_slug for r in subscription2.regions.all()}
+            assert subscription_regions == {"region1", "region2"}
 
 
 class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):


### PR DESCRIPTION
This pr includes all active regions when a new uptime subscription is created. When we receive an update for an existing subscription, roughly once per hour we compare the regions on that subscription to the existing ones, and update them to match if different.

When regions are updated on a subscription, we send out new configs to all regions. When a region is removed, we'll also specifically send a delete to that region.

<!-- Describe your PR here. -->