### PR TITLE
ref: fix mock_redis_buffer

### DIFF
--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -9,11 +9,8 @@ from sentry.buffer.redis import RedisBuffer
 from sentry.testutils.helpers import override_options
 
 
-@contextmanager
 def mock_redis_buffer():
-    buffer = RedisBuffer()
-    with patch("sentry.buffer.backend", new=buffer):
-        yield buffer
+    return patch("sentry.buffer.backend", new=RedisBuffer())
 
 
 @contextmanager


### PR DESCRIPTION
when implemented as a `contextmanager` it cannot decorate a class leading to tests/sentry/rules/processing/test_processor.py::RuleProcessorTest never running

<!-- Describe your PR here. -->