### PR TITLE
ci(eslint): Remove jquery from env list

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -789,7 +789,6 @@ module.exports = {
     browser: true,
     es6: true,
     jest: true,
-    jquery: true, // hard-loaded into vendor.js
   },
 
   globals: {


### PR DESCRIPTION
The `vendor.js` file mentioned is gone now.