### PR TITLE
ref(scm): use SCM webhook ABC

### DIFF
--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -1,6 +1,6 @@
 import ipaddress
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Mapping
 from datetime import timezone
 from typing import Any
@@ -17,6 +17,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
+from sentry.integrations.source_code_management.webhook import SCMWebhook
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -30,17 +31,12 @@ logger = logging.getLogger("sentry.webhooks")
 PROVIDER_NAME = "integrations:bitbucket"
 
 
-class Webhook(ABC):
+class BitbucketWebhook(SCMWebhook, ABC):
     @property
-    @abstractmethod
-    def event_type(self) -> IntegrationWebhookEventType:
-        raise NotImplementedError
+    def provider(self) -> str:
+        return "bitbucket"
 
-    @abstractmethod
-    def __call__(self, organization: Organization, event: Mapping[str, Any]):
-        raise NotImplementedError
-
-    def update_repo_data(self, repo, event):
+    def update_repo_data(self, repo: Repository, event: Mapping[str, Any]) -> None:
         """
         Given a webhook payload, update stored repo data if needed.
 
@@ -68,15 +64,18 @@ class Webhook(ABC):
             )
 
 
-class PushEventWebhook(Webhook):
+class PushEventWebhook(BitbucketWebhook):
     # https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push
 
     @property
     def event_type(self) -> IntegrationWebhookEventType:
         return IntegrationWebhookEventType.PUSH
 
-    def __call__(self, organization: Organization, event: Mapping[str, Any]):
+    def __call__(self, event: Mapping[str, Any], **kwargs) -> None:
         authors = {}
+
+        if not (organization := kwargs.get("organization")):
+            raise ValueError("Missing organization")
 
         try:
             repo = Repository.objects.get(
@@ -131,9 +130,9 @@ class BitbucketWebhookEndpoint(Endpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = ()
-    _handlers: dict[str, type[Webhook]] = {"repo:push": PushEventWebhook}
+    _handlers: dict[str, type[BitbucketWebhook]] = {"repo:push": PushEventWebhook}
 
-    def get_handler(self, event_type) -> type[Webhook] | None:
+    def get_handler(self, event_type) -> type[BitbucketWebhook] | None:
         return self._handlers.get(event_type)
 
     @method_decorator(csrf_exempt)
@@ -205,8 +204,8 @@ class BitbucketWebhookEndpoint(Endpoint):
         with IntegrationWebhookEvent(
             interaction_type=event_handler.event_type,
             domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            provider_key="bitbucket",
+            provider_key=event_handler.provider,
         ).capture():
-            event_handler(organization, event)
+            event_handler(event, organization=organization)
 
         return HttpResponse(status=204)

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -12,6 +12,7 @@ from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import BadRequest
 from sentry.integrations.base import IntegrationDomain
@@ -137,6 +138,7 @@ class PushEventWebhook(BitbucketServerWebhook):
 class BitbucketServerWebhookEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
+    owner = ApiOwner.ECOSYSTEM
 
     _handlers: dict[str, type[BitbucketServerWebhook]] = {"repo:refs_changed": PushEventWebhook}
 

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -13,6 +13,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import BadRequest
 from sentry.integrations.base import IntegrationDomain
@@ -139,6 +140,9 @@ class BitbucketServerWebhookEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
     owner = ApiOwner.ECOSYSTEM
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
 
     _handlers: dict[str, type[BitbucketServerWebhook]] = {"repo:refs_changed": PushEventWebhook}
 

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -1,13 +1,14 @@
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any
 
 import orjson
 import sentry_sdk
+from django.core.exceptions import SuspiciousOperation
 from django.db import IntegrityError, router, transaction
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -15,6 +16,7 @@ from django.views.generic.base import View
 
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.webhook import SCMWebhook
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -29,15 +31,10 @@ logger = logging.getLogger("sentry.webhooks")
 PROVIDER_NAME = "integrations:bitbucket_server"
 
 
-class Webhook(ABC):
+class BitbucketServerWebhook(SCMWebhook, ABC):
     @property
-    @abstractmethod
-    def event_type(self) -> IntegrationWebhookEventType:
-        raise NotImplementedError
-
-    @abstractmethod
-    def __call__(self, organization: Organization, integration_id: int, event: Mapping[str, Any]):
-        raise NotImplementedError
+    def provider(self):
+        return "bitbucket_server"
 
     def update_repo_data(self, repo, event):
         """
@@ -49,15 +46,19 @@ class Webhook(ABC):
             repo.update(name=name_from_event, config=dict(repo.config, name=name_from_event))
 
 
-class PushEventWebhook(Webhook):
+class PushEventWebhook(BitbucketServerWebhook):
     @property
     def event_type(self) -> IntegrationWebhookEventType:
         return IntegrationWebhookEventType.PUSH
 
-    def __call__(
-        self, organization: Organization, integration_id: int, event: Mapping[str, Any]
-    ) -> HttpResponse:
+    def __call__(self, event: Mapping[str, Any], **kwargs) -> None:
         authors = {}
+
+        if not (
+            (organization := kwargs.get("organization"))
+            and (integration_id := kwargs.get("integration_id"))
+        ):
+            raise ValueError("Organization and integration_id must be provided")
 
         try:
             repo = Repository.objects.get(
@@ -66,18 +67,18 @@ class PushEventWebhook(Webhook):
                 external_id=str(event["repository"]["id"]),
             )
         except Repository.DoesNotExist:
-            return HttpResponse(status=404)
+            raise Http404()
 
         provider = repo.get_provider()
         try:
             installation = provider.get_installation(integration_id, organization.id)
         except Integration.DoesNotExist:
-            return HttpResponse(status=404)
+            raise Http404()
 
         try:
             client = installation.get_client()
         except IntegrationError:
-            return HttpResponse(status=400)
+            raise SuspiciousOperation()
 
         # while we're here, make sure repo data is up to date
         self.update_repo_data(repo, event)
@@ -91,12 +92,12 @@ class PushEventWebhook(Webhook):
                     project_name, repo_name, from_hash, change.get("toHash")
                 )
             except ApiHostError:
-                return HttpResponse(status=409)
+                raise SuspiciousOperation()
             except ApiUnauthorized:
-                return HttpResponse(status=400)
+                raise SuspiciousOperation()
             except Exception as e:
                 sentry_sdk.capture_exception(e)
-                return HttpResponse(status=400)
+                raise SuspiciousOperation()
 
             for commit in commits:
                 if IntegrationRepositoryProvider.should_ignore_commit(commit["message"]):
@@ -131,14 +132,12 @@ class PushEventWebhook(Webhook):
                 except IntegrityError:
                     pass
 
-        return HttpResponse(status=204)
-
 
 @region_silo_view
 class BitbucketServerWebhookEndpoint(View):
-    _handlers: dict[str, type[Webhook]] = {"repo:refs_changed": PushEventWebhook}
+    _handlers: dict[str, type[BitbucketServerWebhook]] = {"repo:refs_changed": PushEventWebhook}
 
-    def get_handler(self, event_type) -> type[Webhook] | None:
+    def get_handler(self, event_type) -> type[BitbucketServerWebhook] | None:
         return self._handlers.get(event_type)
 
     @method_decorator(csrf_exempt)
@@ -150,7 +149,7 @@ class BitbucketServerWebhookEndpoint(View):
 
     def post(self, request: HttpRequest, organization_id, integration_id) -> HttpResponseBase:
         try:
-            organization = Organization.objects.get_from_cache(id=organization_id)
+            organization: Organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:
             logger.exception(
                 "%s.webhook.invalid-organization",
@@ -194,6 +193,8 @@ class BitbucketServerWebhookEndpoint(View):
         with IntegrationWebhookEvent(
             interaction_type=event_handler.event_type,
             domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            provider_key="bitbucket-server",
+            provider_key=event_handler.provider,
         ).capture():
-            return event_handler(organization, integration_id, event)
+            event_handler(event, organization=organization, integration_id=integration_id)
+
+        return HttpResponse(status=204)

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Mapping
 from datetime import timezone
 from typing import Any
@@ -20,6 +20,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.source_code_management.webhook import SCMWebhook
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models.commit import Commit
@@ -36,17 +37,38 @@ PROVIDER_NAME = "integrations:gitlab"
 GITHUB_WEBHOOK_SECRET_INVALID_ERROR = """Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/organization/integrations/integration-platform/public-integration/#refreshing-tokens."""
 
 
-class Webhook(ABC):
-    @property
-    @abstractmethod
-    def event_type(self) -> IntegrationWebhookEventType:
-        raise NotImplementedError
+def get_gitlab_external_id(request, extra) -> tuple[str, str] | HttpResponse:
+    token = "<unknown>"
+    try:
+        # Munge the token to extract the integration external_id.
+        # gitlab hook payloads don't give us enough unique context
+        # to find data on our side so we embed one in the token.
+        token = request.META["HTTP_X_GITLAB_TOKEN"]
+        # e.g. "example.gitlab.com:group-x:webhook_secret_from_sentry_integration_table"
+        instance, group_path, secret = token.split(":")
+        external_id = f"{instance}:{group_path}"
+        return (external_id, secret)
+    except KeyError:
+        logger.info("gitlab.webhook.missing-gitlab-token")
+        extra["reason"] = "The customer needs to set a Secret Token in their webhook."
+        logger.exception(extra["reason"])
+        return HttpResponse(status=400, reason=extra["reason"])
+    except ValueError:
+        logger.info("gitlab.webhook.malformed-gitlab-token", extra=extra)
+        extra["reason"] = "The customer's Secret Token is malformed."
+        logger.exception(extra["reason"])
+        return HttpResponse(status=400, reason=extra["reason"])
+    except Exception:
+        logger.info("gitlab.webhook.invalid-token", extra=extra)
+        extra["reason"] = "Generic catch-all error."
+        logger.exception(extra["reason"])
+        return HttpResponse(status=400, reason=extra["reason"])
 
-    @abstractmethod
-    def __call__(
-        self, integration: RpcIntegration, organization: RpcOrganization, event: Mapping[str, Any]
-    ):
-        raise NotImplementedError
+
+class GitlabWebhook(SCMWebhook, ABC):
+    @property
+    def provider(self) -> str:
+        return "gitlab"
 
     def get_repo(
         self, integration: RpcIntegration, organization: RpcOrganization, event: Mapping[str, Any]
@@ -94,7 +116,7 @@ class Webhook(ABC):
             )
 
 
-class MergeEventWebhook(Webhook):
+class MergeEventWebhook(GitlabWebhook):
     """
     Handle Merge Request Hook
 
@@ -105,9 +127,13 @@ class MergeEventWebhook(Webhook):
     def event_type(self) -> IntegrationWebhookEventType:
         return IntegrationWebhookEventType.PULL_REQUEST
 
-    def __call__(
-        self, integration: RpcIntegration, organization: RpcOrganization, event: Mapping[str, Any]
-    ):
+    def __call__(self, event: Mapping[str, Any], **kwargs):
+        if not (
+            (organization := kwargs.get("organization"))
+            and (integration := kwargs.get("integration"))
+        ):
+            raise ValueError("Organization and integration must be provided")
+
         repo = self.get_repo(integration, organization, event)
         if repo is None:
             return
@@ -162,7 +188,7 @@ class MergeEventWebhook(Webhook):
             pass
 
 
-class PushEventWebhook(Webhook):
+class PushEventWebhook(GitlabWebhook):
     """
     Handle push hook
 
@@ -173,9 +199,13 @@ class PushEventWebhook(Webhook):
     def event_type(self) -> IntegrationWebhookEventType:
         return IntegrationWebhookEventType.PUSH
 
-    def __call__(
-        self, integration: RpcIntegration, organization: RpcOrganization, event: Mapping[str, Any]
-    ):
+    def __call__(self, event: Mapping[str, Any], **kwargs):
+        if not (
+            (organization := kwargs.get("organization"))
+            and (integration := kwargs.get("integration"))
+        ):
+            raise ValueError("Organization and integration must be provided")
+
         repo = self.get_repo(integration, organization, event)
         if repo is None:
             return
@@ -222,37 +252,8 @@ class PushEventWebhook(Webhook):
                 pass
 
 
-class GitlabWebhookMixin:
-    def _get_external_id(self, request, extra) -> tuple[str, str] | HttpResponse:
-        token = "<unknown>"
-        try:
-            # Munge the token to extract the integration external_id.
-            # gitlab hook payloads don't give us enough unique context
-            # to find data on our side so we embed one in the token.
-            token = request.META["HTTP_X_GITLAB_TOKEN"]
-            # e.g. "example.gitlab.com:group-x:webhook_secret_from_sentry_integration_table"
-            instance, group_path, secret = token.split(":")
-            external_id = f"{instance}:{group_path}"
-            return (external_id, secret)
-        except KeyError:
-            logger.info("gitlab.webhook.missing-gitlab-token")
-            extra["reason"] = "The customer needs to set a Secret Token in their webhook."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-        except ValueError:
-            logger.info("gitlab.webhook.malformed-gitlab-token", extra=extra)
-            extra["reason"] = "The customer's Secret Token is malformed."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-        except Exception:
-            logger.info("gitlab.webhook.invalid-token", extra=extra)
-            extra["reason"] = "Generic catch-all error."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-
-
 @region_silo_endpoint
-class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
+class GitlabWebhookEndpoint(Endpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
@@ -261,7 +262,7 @@ class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
     permission_classes = ()
     provider = "gitlab"
 
-    _handlers: dict[str, type[Webhook]] = {
+    _handlers: dict[str, type[GitlabWebhook]] = {
         "Push Hook": PushEventWebhook,
         "Merge Request Hook": MergeEventWebhook,
     }
@@ -282,7 +283,7 @@ class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
             # AppPlatformEvents also hit this API
             "event-type": request.META.get("HTTP_X_GITLAB_EVENT"),
         }
-        result = self._get_external_id(request=request, extra=extra)
+        result = get_gitlab_external_id(request=request, extra=extra)
         if isinstance(result, HttpResponse):
             return result
         (external_id, secret) = result
@@ -351,8 +352,8 @@ class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
                 with IntegrationWebhookEvent(
                     interaction_type=event_handler.event_type,
                     domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-                    provider_key="gitlab",
+                    provider_key=event_handler.provider,
                 ).capture():
-                    event_handler(integration, organization, event)
+                    event_handler(event, integration=integration, organization=organization)
 
         return HttpResponse(status=204)

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -8,7 +8,7 @@ import orjson
 from django.http.response import HttpResponseBase
 
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
-from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, GitlabWebhookMixin
+from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, get_gitlab_external_id
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -20,7 +20,7 @@ from sentry.utils import metrics
 logger = logging.getLogger(__name__)
 
 
-class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
+class GitlabRequestParser(BaseRequestParser):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.GITLAB]
     webhook_identifier = WebhookProviderIdentifier.GITLAB
     _integration: Integration | None = None
@@ -35,7 +35,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
             # AppPlatformEvents also hit this API
             "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
         }
-        return super()._get_external_id(request=self.request, extra=extra)
+        return get_gitlab_external_id(request=self.request, extra=extra)
 
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -3,7 +3,6 @@ from typing import Any
 from unittest.mock import patch
 
 import orjson
-import pytest
 import responses
 from requests.exceptions import ConnectionError
 
@@ -141,14 +140,13 @@ class RefsChangedWebhookTest(WebhookTestBase):
         error = Exception("error")
         mock_event.side_effect = error
 
-        with pytest.raises(Exception):
-            self.get_error_response(
-                self.organization.id,
-                self.integration.id,
-                raw_data=REFS_CHANGED_EXAMPLE,
-                extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
-                status_code=500,
-            )
+        self.get_error_response(
+            self.organization.id,
+            self.integration.id,
+            raw_data=REFS_CHANGED_EXAMPLE,
+            extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
+            status_code=500,
+        )
 
         assert_failure_metric(mock_record, error)
 

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -234,5 +234,5 @@ class RefsChangedWebhookTest(WebhookTestBase):
             self.integration.id,
             raw_data=orjson.dumps(payload),
             extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
-            status_code=409,
+            status_code=400,
         )


### PR DESCRIPTION
Use the SCM webhook ABC for Bitbucket, Bitbucket Server, and Gitlab.

VSTS does not currently use a webhook class, but it can be added in a follow up PR.