### PR TITLE
:wrench: chore: Change SLO to Halt temporarily for Slack Team Linking

### DIFF
--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -200,7 +200,7 @@ class SlackCommandDispatcher(MessagingIntegrationCommandDispatcher[Response]):
         for message, reason in self.TEAM_HALT_MAPPINGS.items():
             if message in str(response.data):
                 return IntegrationResponse(
-                    interaction_result=EventLifecycleOutcome.SUCCESS,
+                    interaction_result=EventLifecycleOutcome.HALTED,
                     response=response,
                     outcome_reason=str(reason),
                 )

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -65,7 +65,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         data = orjson.loads(response.content)
         assert CHANNEL_ALREADY_LINKED_MESSAGE in get_response_text(data)
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
     @with_feature("organizations:slack-multiple-team-single-channel-linking")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -109,7 +109,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         data = orjson.loads(response.content)
         assert LINK_FROM_CHANNEL_MESSAGE in get_response_text(data)
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -123,7 +123,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         data = self.send_slack_message("link team", user_id=OTHER_SLACK_ID)
         assert LINK_USER_FIRST_MESSAGE in get_response_text(data)
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -142,7 +142,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         data = self.send_slack_message("link team", user_id=OTHER_SLACK_ID)
         assert INSUFFICIENT_ROLE_MESSAGE in get_response_text(data)
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")


### PR DESCRIPTION
currently team link/unlinking seems to be broken. even with the correct perms, we receive "You must be a Sentry organization admin/manager/owner or a team admin to link or unlink teams." when trying to link a channel. 

In https://github.com/getsentry/sentry/pull/82397, i added some logging and updated our SLO to record the even as a halt, but i did it for `team_unlink`. i also need to change it to `team_link` so i can debug what the problem is for when we try to link