### PR TITLE
feat(exception-groups): Record analytics for size of exception group trees

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -19,6 +19,8 @@ interface IssueDetailsWithAlert extends CommonGroupAnalyticsData {
 
 export type BaseEventAnalyticsParams = {
   event_id: string;
+  exception_group_height: number;
+  exception_group_width: number;
   has_commit: boolean;
   has_exception_group: boolean;
   has_local_variables: boolean;

--- a/static/app/utils/eventExceptionGroup.spec.tsx
+++ b/static/app/utils/eventExceptionGroup.spec.tsx
@@ -1,0 +1,334 @@
+import {EventEntryExceptionGroupFixture} from 'sentry-fixture/eventEntryExceptionGroup';
+import {ExceptionValueFixture} from 'sentry-fixture/exceptionValue';
+
+import {EntryType} from 'sentry/types/event';
+import {
+  buildExceptionGroupTree,
+  getExceptionGroupHeight,
+  getExceptionGroupWidth,
+} from 'sentry/utils/eventExceptionGroup';
+
+describe('eventExceptionGroup', function () {
+  describe('buildExceptionGroupTree', function () {
+    it('builds the exception group tree', function () {
+      const exception = EventEntryExceptionGroupFixture();
+
+      expect(buildExceptionGroupTree(exception)).toEqual([
+        {
+          value: expect.objectContaining({
+            type: 'ExceptionGroup 1',
+          }),
+          children: [
+            {
+              value: expect.objectContaining({
+                type: 'ExceptionGroup 2',
+              }),
+              children: [
+                {
+                  value: expect.objectContaining({
+                    type: 'ValueError',
+                  }),
+                  children: [],
+                },
+              ],
+            },
+            {
+              value: expect.objectContaining({
+                type: 'TypeError',
+              }),
+              children: [],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('getExceptionGroupHeight', function () {
+    it('gets the height of the exception group', function () {
+      const exception = EventEntryExceptionGroupFixture();
+      expect(getExceptionGroupHeight(exception)).toBe(3);
+    });
+
+    it('returns 0 with no values', function () {
+      expect(
+        getExceptionGroupHeight({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [],
+          },
+        })
+      ).toBe(0);
+    });
+
+    it('returns 1 with single parent', function () {
+      expect(
+        getExceptionGroupHeight({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  exception_id: 1,
+                  is_exception_group: true,
+                  type: 'ExceptionGroup 1',
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(1);
+    });
+
+    it('returns 2 with a parent and a child', function () {
+      expect(
+        getExceptionGroupHeight({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 2',
+                  is_exception_group: false,
+                  exception_id: 2,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 1',
+                  is_exception_group: true,
+                  exception_id: 1,
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(2);
+    });
+
+    it('returns 2 with a parent and 2 children', function () {
+      expect(
+        getExceptionGroupHeight({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 2',
+                  is_exception_group: false,
+                  exception_id: 2,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 3',
+                  is_exception_group: false,
+                  exception_id: 3,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 1',
+                  is_exception_group: true,
+                  exception_id: 1,
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(2);
+    });
+  });
+
+  describe('getExceptionGroupWidth', function () {
+    it('returns 0 with no values', function () {
+      expect(
+        getExceptionGroupWidth({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [],
+          },
+        })
+      ).toBe(0);
+    });
+
+    it('returns 1 with a single parent', function () {
+      expect(
+        getExceptionGroupWidth({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 1',
+                  is_exception_group: true,
+                  exception_id: 1,
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(1);
+    });
+
+    it('returns 1 with a parent and a child', function () {
+      expect(
+        getExceptionGroupWidth({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 2',
+                  is_exception_group: false,
+                  exception_id: 2,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 1',
+                  is_exception_group: true,
+                  exception_id: 1,
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(1);
+    });
+
+    it('returns 2 with a parent and 2 children', function () {
+      expect(
+        getExceptionGroupWidth({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 2',
+                  is_exception_group: false,
+                  exception_id: 2,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 3',
+                  is_exception_group: false,
+                  exception_id: 3,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 1',
+                  is_exception_group: true,
+                  exception_id: 1,
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(2);
+    });
+
+    it('returns 3 with a parent 3 grandchildren', function () {
+      expect(
+        getExceptionGroupWidth({
+          type: EntryType.EXCEPTION,
+          data: {
+            excOmitted: null,
+            hasSystemFrames: false,
+            values: [
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 4',
+                  is_exception_group: false,
+                  exception_id: 4,
+                  parent_id: 2,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 5',
+                  is_exception_group: false,
+                  exception_id: 5,
+                  parent_id: 2,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 6',
+                  is_exception_group: false,
+                  exception_id: 6,
+                  parent_id: 3,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 2',
+                  is_exception_group: false,
+                  exception_id: 2,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 3',
+                  is_exception_group: false,
+                  exception_id: 3,
+                  parent_id: 1,
+                },
+              }),
+              ExceptionValueFixture({
+                mechanism: {
+                  handled: true,
+                  type: 'ExceptionGroup 1',
+                  is_exception_group: true,
+                  exception_id: 1,
+                },
+              }),
+            ],
+          },
+        })
+      ).toBe(3);
+    });
+  });
+});

--- a/static/app/utils/eventExceptionGroup.tsx
+++ b/static/app/utils/eventExceptionGroup.tsx
@@ -1,0 +1,87 @@
+import type {EntryException, ExceptionValue} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
+
+type ExceptionGroupTreeItem = {
+  children: Array<ExceptionGroupTreeItem>;
+  value: ExceptionValue;
+};
+
+function buildExceptionGroupTreeRecursive(
+  values: ExceptionValue[],
+  parentId: number | undefined,
+  visited: Set<number> = new Set<number>()
+): ExceptionGroupTreeItem[] {
+  const tree: ExceptionGroupTreeItem[] = [];
+
+  values.forEach(value => {
+    if (
+      value.mechanism?.parent_id === parentId &&
+      defined(value.mechanism?.exception_id) &&
+      !visited.has(value.mechanism.exception_id)
+    ) {
+      visited.add(value.mechanism.exception_id);
+      tree.push({
+        children: buildExceptionGroupTreeRecursive(
+          values,
+          value.mechanism.exception_id,
+          visited
+        ),
+        value,
+      });
+    }
+  });
+
+  return tree;
+}
+
+export function buildExceptionGroupTree(entry: EntryException) {
+  const values = entry.data.values || [];
+
+  return buildExceptionGroupTreeRecursive(values, undefined);
+}
+
+function getTreeHeightRecursive(tree: ExceptionGroupTreeItem[], maxHeight: number = 0) {
+  if (!tree.length) {
+    return maxHeight;
+  }
+
+  let maxLevelHeight = maxHeight;
+
+  for (const node of tree) {
+    const height = 1 + getTreeHeightRecursive(node.children, maxHeight);
+    maxLevelHeight = Math.max(maxLevelHeight, height);
+  }
+
+  return Math.max(maxHeight, maxLevelHeight);
+}
+
+function getTreeWidthRecursive(
+  tree: ExceptionGroupTreeItem[],
+  depth: number = 0,
+  widthByDepth: number[] = []
+) {
+  if (!tree.length) {
+    return 0;
+  }
+
+  widthByDepth[depth] = widthByDepth[depth] || 0;
+
+  for (const node of tree) {
+    widthByDepth[depth] += 1;
+    getTreeWidthRecursive(node.children, depth + 1, widthByDepth);
+  }
+
+  return Math.max(...widthByDepth);
+}
+
+export function getExceptionGroupHeight(entry: EntryException) {
+  const tree = buildExceptionGroupTree(entry);
+
+  return getTreeHeightRecursive(tree);
+}
+
+export function getExceptionGroupWidth(entry: EntryException) {
+  const tree = buildExceptionGroupTree(entry);
+
+  return getTreeWidthRecursive(tree);
+}


### PR DESCRIPTION
To help inform some better exception group UI. Records the height and width of exception group trees.