### PR TITLE
test(ui): Prevent importing from .spec files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -546,6 +546,11 @@ const appRules = {
           group: ['sentry/components/devtoolbar/*'],
           message: 'Do not depend on toolbar internals',
         },
+        {
+          group: ['*.spec*'],
+          message:
+            'Do not import from test files. This causes tests to be executed multiple times.',
+        },
       ],
       paths: [
         {

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -14,13 +14,11 @@ import {openModal} from 'sentry/actionCreators/modal';
 import EditHighlightsModal, {
   type EditHighlightsModalProps,
 } from 'sentry/components/events/highlights/editHighlightsModal';
-import {
-  TEST_EVENT_CONTEXTS,
-  TEST_EVENT_TAGS,
-} from 'sentry/components/events/highlights/util.spec';
 import ModalStore from 'sentry/stores/modalStore';
 import type {Project} from 'sentry/types/project';
 import * as analytics from 'sentry/utils/analytics';
+
+import {TEST_EVENT_CONTEXTS, TEST_EVENT_TAGS} from './testUtils';
 
 describe('EditHighlightsModal', function () {
   const organization = OrganizationFixture();

--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -7,12 +7,10 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 import * as modal from 'sentry/actionCreators/modal';
 import HighlightsDataSection from 'sentry/components/events/highlights/highlightsDataSection';
 import {EMPTY_HIGHLIGHT_DEFAULT} from 'sentry/components/events/highlights/util';
-import {
-  TEST_EVENT_CONTEXTS,
-  TEST_EVENT_TAGS,
-} from 'sentry/components/events/highlights/util.spec';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import * as analytics from 'sentry/utils/analytics';
+
+import {TEST_EVENT_CONTEXTS, TEST_EVENT_TAGS} from './testUtils';
 
 describe('HighlightsDataSection', function () {
   const organization = OrganizationFixture();

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -5,10 +5,8 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {HighlightsIconSummary} from 'sentry/components/events/highlights/highlightsIconSummary';
-import {
-  TEST_EVENT_CONTEXTS,
-  TEST_EVENT_TAGS,
-} from 'sentry/components/events/highlights/util.spec';
+
+import {TEST_EVENT_CONTEXTS, TEST_EVENT_TAGS} from './testUtils';
 
 jest.mock('sentry/components/events/contexts/contextIcon', () => ({
   ...jest.requireActual('sentry/components/events/contexts/contextIcon'),

--- a/static/app/components/events/highlights/testUtils.tsx
+++ b/static/app/components/events/highlights/testUtils.tsx
@@ -1,0 +1,64 @@
+export const TEST_EVENT_CONTEXTS = {
+  keyboard: {
+    type: 'default',
+    brand: 'keychron',
+    percent: 75,
+    switches: {
+      form: 'tactile',
+      brand: 'wuque studios',
+    },
+  },
+  client_os: {
+    type: 'os',
+    name: 'Mac OS X',
+    version: '10.15',
+  },
+  runtime: {
+    type: 'runtime',
+    name: 'CPython',
+    version: '3.8.13',
+  },
+};
+
+export const TEST_EVENT_TAGS = [
+  {
+    key: 'browser',
+    value: 'Chrome 1.2.3',
+  },
+  {
+    key: 'browser.name',
+    value: 'Chrome',
+  },
+  {
+    key: 'device.family',
+    value: 'Mac',
+  },
+  {
+    key: 'environment',
+    value: 'production',
+  },
+  {
+    key: 'handled',
+    value: 'no',
+  },
+  {
+    key: 'level',
+    value: 'error',
+  },
+  {
+    key: 'release',
+    value: '1.8',
+  },
+  {
+    key: 'runtime',
+    value: 'CPython 3.8.13',
+  },
+  {
+    key: 'runtime.name',
+    value: 'CPython',
+  },
+  {
+    key: 'url',
+    value: 'https://example.com',
+  },
+];

--- a/static/app/components/events/highlights/util.spec.tsx
+++ b/static/app/components/events/highlights/util.spec.tsx
@@ -9,70 +9,7 @@ import {
   getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
 
-export const TEST_EVENT_CONTEXTS = {
-  keyboard: {
-    type: 'default',
-    brand: 'keychron',
-    percent: 75,
-    switches: {
-      form: 'tactile',
-      brand: 'wuque studios',
-    },
-  },
-  client_os: {
-    type: 'os',
-    name: 'Mac OS X',
-    version: '10.15',
-  },
-  runtime: {
-    type: 'runtime',
-    name: 'CPython',
-    version: '3.8.13',
-  },
-};
-
-export const TEST_EVENT_TAGS = [
-  {
-    key: 'browser',
-    value: 'Chrome 1.2.3',
-  },
-  {
-    key: 'browser.name',
-    value: 'Chrome',
-  },
-  {
-    key: 'device.family',
-    value: 'Mac',
-  },
-  {
-    key: 'environment',
-    value: 'production',
-  },
-  {
-    key: 'handled',
-    value: 'no',
-  },
-  {
-    key: 'level',
-    value: 'error',
-  },
-  {
-    key: 'release',
-    value: '1.8',
-  },
-  {
-    key: 'runtime',
-    value: 'CPython 3.8.13',
-  },
-  {
-    key: 'runtime.name',
-    value: 'CPython',
-  },
-  {
-    key: 'url',
-    value: 'https://example.com',
-  },
-];
+import {TEST_EVENT_CONTEXTS, TEST_EVENT_TAGS} from './testUtils';
 
 describe('getHighlightContextData', function () {
   it('returns only highlight context data', function () {

--- a/static/app/utils/profiling/profile/continuousProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/continuousProfile.spec.tsx
@@ -1,44 +1,7 @@
-import merge from 'lodash/merge';
-
-import type {DeepPartial} from 'sentry/types/utils';
 import {ContinuousProfile} from 'sentry/utils/profiling/profile/continuousProfile';
 import {createContinuousProfileFrameIndex} from 'sentry/utils/profiling/profile/utils';
 
-import {makeTestingBoilerplate} from './profile.spec';
-
-export function makeSentryContinuousProfile(
-  profile?: DeepPartial<Profiling.SentryContinousProfileChunk>
-): Profiling.SentryContinousProfileChunk {
-  return merge(
-    {
-      chunk_id: 'chunk_id',
-      environment: '',
-      project_id: 0,
-      received: 0,
-      release: '',
-      organization_id: 0,
-      retention_days: 0,
-      version: '2',
-      platform: 'node',
-      profile: {
-        samples: [
-          {timestamp: Date.now() / 1e3, stack_id: 0, thread_id: '0'},
-          // 10ms later
-          {timestamp: Date.now() / 1e3 + 0.01, stack_id: 1, thread_id: '0'},
-        ],
-        frames: [
-          {function: 'foo', in_app: true},
-          {function: 'bar', in_app: true},
-        ],
-        stacks: [
-          [0, 1],
-          [0, 1],
-        ],
-      },
-    },
-    profile
-  ) as Profiling.SentryContinousProfileChunk;
-}
+import {makeSentryContinuousProfile, makeTestingBoilerplate} from './testUtils';
 
 describe('ContinuousProfile', () => {
   it('imports the base properties', () => {

--- a/static/app/utils/profiling/profile/eventedProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.spec.tsx
@@ -3,7 +3,7 @@ import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
 
 import {Frame} from '../frame';
 
-import {firstCallee, makeTestingBoilerplate} from './profile.spec';
+import {firstCallee, makeTestingBoilerplate} from './testUtils';
 
 describe('EventedProfile', () => {
   it('imports the base properties', () => {

--- a/static/app/utils/profiling/profile/importProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/importProfile.spec.tsx
@@ -7,9 +7,8 @@ import {
 import {JSSelfProfile} from 'sentry/utils/profiling/profile/jsSelfProfile';
 import {SampledProfile} from 'sentry/utils/profiling/profile/sampledProfile';
 
-import {makeSentryContinuousProfile} from './continuousProfile.spec';
 import {SentrySampledProfile} from './sentrySampledProfile';
-import {makeSentrySampledProfile} from './sentrySampledProfile.spec';
+import {makeSentryContinuousProfile, makeSentrySampledProfile} from './testUtils';
 
 describe('importProfile', () => {
   it('imports evented profile', () => {

--- a/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
@@ -1,7 +1,7 @@
 import {JSSelfProfile} from 'sentry/utils/profiling/profile/jsSelfProfile';
 import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
 
-import {firstCallee, makeTestingBoilerplate, nthCallee} from './profile.spec';
+import {firstCallee, makeTestingBoilerplate, nthCallee} from './testUtils';
 
 describe('jsSelfProfile', () => {
   it('imports the base properties', () => {

--- a/static/app/utils/profiling/profile/profile.spec.tsx
+++ b/static/app/utils/profiling/profile/profile.spec.tsx
@@ -1,39 +1,8 @@
-import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
+import type {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {Frame} from 'sentry/utils/profiling/frame';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 
-// Test utils to keep the tests code dry
-export const f = (name: string, key: number, in_app: boolean = true) =>
-  new Frame({name, key, is_application: in_app});
-export const c = (fr: Frame) => new CallTreeNode(fr, null);
-export const firstCallee = (node: CallTreeNode) => node.children[0];
-export const nthCallee = (node: CallTreeNode, n: number) => {
-  const child = node.children[n];
-  if (!child) {
-    throw new Error('Child not found');
-  }
-  return child;
-};
-
-export const makeTestingBoilerplate = () => {
-  const timings: [Frame['name'], string][] = [];
-
-  const openSpy = jest.fn();
-  const closeSpy = jest.fn();
-
-  // We need to wrap the spy fn because they are not allowed to reference external variables
-  const open = (node, value) => {
-    timings.push([node.frame.name, 'open']);
-    openSpy(node, value);
-  };
-  // We need to wrap the spy fn because they are not allowed to reference external variables
-  const close = (node, val) => {
-    timings.push([node.frame.name, 'close']);
-    closeSpy(node, val);
-  };
-
-  return {open, close, timings, openSpy, closeSpy};
-};
+import {c, f, makeTestingBoilerplate} from './testUtils';
 
 // Since it's easy to make mistakes or accidentally assign parents to the wrong nodes, this utility fn
 // will format the stack samples as a tree string so it's more human friendly.

--- a/static/app/utils/profiling/profile/sampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.spec.tsx
@@ -3,7 +3,7 @@ import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
 
 import {Frame} from '../frame';
 
-import {firstCallee, makeTestingBoilerplate} from './profile.spec';
+import {firstCallee, makeTestingBoilerplate} from './testUtils';
 
 describe('SampledProfile', () => {
   it('imports the base properties', () => {

--- a/static/app/utils/profiling/profile/sentrySampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.spec.tsx
@@ -1,75 +1,8 @@
-import merge from 'lodash/merge';
-
-import type {DeepPartial} from 'sentry/types/utils';
-
 import {Frame} from '../frame';
 
-import {makeTestingBoilerplate} from './profile.spec';
 import {SentrySampledProfile} from './sentrySampledProfile';
+import {makeSentrySampledProfile, makeTestingBoilerplate} from './testUtils';
 import {createSentrySampleProfileFrameIndex} from './utils';
-
-export const makeSentrySampledProfile = (
-  profile?: DeepPartial<Profiling.SentrySampledProfile>
-) => {
-  return merge(
-    {
-      event_id: '1',
-      version: '1',
-      os: {
-        name: 'iOS',
-        version: '16.0',
-        build_number: '19H253',
-      },
-      device: {
-        architecture: 'arm64e',
-        is_emulator: false,
-        locale: 'en_US',
-        manufacturer: 'Apple',
-        model: 'iPhone14,3',
-      },
-      timestamp: '2022-09-01T09:45:00.000Z',
-      platform: 'cocoa',
-      profile: {
-        samples: [
-          {
-            stack_id: 0,
-            thread_id: '0',
-            elapsed_since_start_ns: 0,
-          },
-          {
-            stack_id: 1,
-            thread_id: '0',
-            elapsed_since_start_ns: 1000,
-          },
-        ],
-        frames: [
-          {
-            function: 'main',
-            instruction_addr: '',
-            lineno: 1,
-            colno: 1,
-            file: 'main.c',
-          },
-          {
-            function: 'foo',
-            instruction_addr: '',
-            lineno: 2,
-            colno: 2,
-            file: 'main.c',
-          },
-        ],
-        stacks: [[1, 0], [0]],
-      },
-      transaction: {
-        id: '',
-        name: 'foo',
-        active_thread_id: 0,
-        trace_id: '1',
-      },
-    },
-    profile
-  ) as Profiling.SentrySampledProfile;
-};
 
 describe('SentrySampledProfile', () => {
   it('constructs a profile', () => {

--- a/static/app/utils/profiling/profile/testUtils.tsx
+++ b/static/app/utils/profiling/profile/testUtils.tsx
@@ -1,0 +1,134 @@
+import merge from 'lodash/merge';
+
+import type {DeepPartial} from 'sentry/types/utils';
+import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
+import {Frame} from 'sentry/utils/profiling/frame';
+
+export const f = (name: string, key: number, in_app: boolean = true) =>
+  new Frame({name, key, is_application: in_app});
+export const c = (fr: Frame) => new CallTreeNode(fr, null);
+export const firstCallee = (node: CallTreeNode) => node.children[0];
+export const nthCallee = (node: CallTreeNode, n: number) => {
+  const child = node.children[n];
+  if (!child) {
+    throw new Error('Child not found');
+  }
+  return child;
+};
+
+export const makeTestingBoilerplate = () => {
+  const timings: [Frame['name'], string][] = [];
+
+  const openSpy = jest.fn();
+  const closeSpy = jest.fn();
+
+  // We need to wrap the spy fn because they are not allowed to reference external variables
+  const open = (node: CallTreeNode, value: number) => {
+    timings.push([node.frame.name, 'open']);
+    openSpy(node, value);
+  };
+  // We need to wrap the spy fn because they are not allowed to reference external variables
+  const close = (node: CallTreeNode, val: number) => {
+    timings.push([node.frame.name, 'close']);
+    closeSpy(node, val);
+  };
+
+  return {open, close, timings, openSpy, closeSpy};
+};
+
+export function makeSentryContinuousProfile(
+  profile?: DeepPartial<Profiling.SentryContinousProfileChunk>
+): Profiling.SentryContinousProfileChunk {
+  return merge(
+    {
+      chunk_id: 'chunk_id',
+      environment: '',
+      project_id: 0,
+      received: 0,
+      release: '',
+      organization_id: 0,
+      retention_days: 0,
+      version: '2',
+      platform: 'node',
+      profile: {
+        samples: [
+          {timestamp: Date.now() / 1e3, stack_id: 0, thread_id: '0'},
+          // 10ms later
+          {timestamp: Date.now() / 1e3 + 0.01, stack_id: 1, thread_id: '0'},
+        ],
+        frames: [
+          {function: 'foo', in_app: true},
+          {function: 'bar', in_app: true},
+        ],
+        stacks: [
+          [0, 1],
+          [0, 1],
+        ],
+      },
+    },
+    profile
+  ) as Profiling.SentryContinousProfileChunk;
+}
+
+export const makeSentrySampledProfile = (
+  profile?: DeepPartial<Profiling.SentrySampledProfile>
+) => {
+  return merge(
+    {
+      event_id: '1',
+      version: '1',
+      os: {
+        name: 'iOS',
+        version: '16.0',
+        build_number: '19H253',
+      },
+      device: {
+        architecture: 'arm64e',
+        is_emulator: false,
+        locale: 'en_US',
+        manufacturer: 'Apple',
+        model: 'iPhone14,3',
+      },
+      timestamp: '2022-09-01T09:45:00.000Z',
+      platform: 'cocoa',
+      profile: {
+        samples: [
+          {
+            stack_id: 0,
+            thread_id: '0',
+            elapsed_since_start_ns: 0,
+          },
+          {
+            stack_id: 1,
+            thread_id: '0',
+            elapsed_since_start_ns: 1000,
+          },
+        ],
+        frames: [
+          {
+            function: 'main',
+            instruction_addr: '',
+            lineno: 1,
+            colno: 1,
+            file: 'main.c',
+          },
+          {
+            function: 'foo',
+            instruction_addr: '',
+            lineno: 2,
+            colno: 2,
+            file: 'main.c',
+          },
+        ],
+        stacks: [[1, 0], [0]],
+      },
+      transaction: {
+        id: '',
+        name: 'foo',
+        active_thread_id: 0,
+        trace_id: '1',
+      },
+    },
+    profile
+  ) as Profiling.SentrySampledProfile;
+};


### PR DESCRIPTION
Importing from other test files causes tests to be run multiple times. Adds a lint rule preventing it.
