### PR TITLE
test(rr6): Remove a lot of browserHistory from tests

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -5,8 +5,6 @@ import {renderHook} from 'sentry-test/reactTestingLibrary';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 
-const mockPush = jest.mocked(browserHistory.push);
-
 function mockLocation(query: string = '') {
   window.location.search = qs.stringify({query});
 }
@@ -14,13 +12,10 @@ function mockLocation(query: string = '') {
 describe('useActiveReplayTab', () => {
   beforeEach(() => {
     mockLocation();
-    mockPush.mockReset();
   });
 
   it('should use Breadcrumbs as a default', () => {
-    const {result} = renderHook(useActiveReplayTab, {
-      initialProps: {},
-    });
+    const {result} = renderHook(useActiveReplayTab, {initialProps: {}});
 
     expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
   });
@@ -42,7 +37,7 @@ describe('useActiveReplayTab', () => {
     expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
 
     result.current.setActiveTab('nEtWoRk');
-    expect(mockPush).toHaveBeenLastCalledWith({
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
       pathname: '/',
       state: undefined,
       query: {query: '', t_main: TabKey.NETWORK},
@@ -56,7 +51,7 @@ describe('useActiveReplayTab', () => {
     expect(result.current.getActiveTab()).toBe(TabKey.BREADCRUMBS);
 
     result.current.setActiveTab('foo bar');
-    expect(mockPush).toHaveBeenLastCalledWith({
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
       pathname: '/',
       query: {query: '', t_main: TabKey.BREADCRUMBS},
     });

--- a/static/app/views/acceptOrganizationInvite/index.spec.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.spec.tsx
@@ -1,11 +1,11 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {logout} from 'sentry/actionCreators/account';
 import ConfigStore from 'sentry/stores/configStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import AcceptOrganizationInvite from 'sentry/views/acceptOrganizationInvite';
 
 jest.mock('sentry/actionCreators/account');
@@ -25,6 +25,7 @@ const getJoinButton = () => {
 };
 
 describe('AcceptOrganizationInvite', function () {
+  const router = RouterFixture();
   const organization = OrganizationFixture({slug: 'org-slug'});
   const configState = ConfigStore.getState();
 
@@ -46,7 +47,8 @@ describe('AcceptOrganizationInvite', function () {
       <AcceptOrganizationInvite
         {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
+      />,
+      {router}
     );
 
     const acceptMock = MockApiClient.addMockResponse({
@@ -58,7 +60,7 @@ describe('AcceptOrganizationInvite', function () {
 
     await userEvent.click(joinButton!);
     expect(acceptMock).toHaveBeenCalled();
-    expect(browserHistory.replace).toHaveBeenCalledWith('/org-slug/');
+    expect(router.replace).toHaveBeenCalledWith('/org-slug/');
   });
 
   it('can accept invitation on customer-domains', async function () {
@@ -85,7 +87,8 @@ describe('AcceptOrganizationInvite', function () {
       <AcceptOrganizationInvite
         {...RouteComponentPropsFixture()}
         params={{memberId: '1', token: 'abc'}}
-      />
+      />,
+      {router}
     );
 
     const acceptMock = MockApiClient.addMockResponse({
@@ -97,7 +100,7 @@ describe('AcceptOrganizationInvite', function () {
 
     await userEvent.click(joinButton!);
     expect(acceptMock).toHaveBeenCalled();
-    expect(browserHistory.replace).toHaveBeenCalledWith('/org-slug/');
+    expect(router.replace).toHaveBeenCalledWith('/org-slug/');
   });
 
   it('renders error message', function () {

--- a/static/app/views/alerts/incidentRedirect.spec.tsx
+++ b/static/app/views/alerts/incidentRedirect.spec.tsx
@@ -4,7 +4,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 
 import IncidentRedirect from './incidentRedirect';
 
@@ -44,7 +43,7 @@ describe('IncidentRedirect', () => {
     );
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/alerts/rules/details/4/',
         query: {
           alert: '123',

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -9,7 +9,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 
 import AlertRuleDetails from './ruleDetails';
 
@@ -110,7 +109,7 @@ describe('AlertRuleDetails', () => {
     expect(await screen.findByLabelText('Next')).toBeEnabled();
     await userEvent.click(screen.getByLabelText('Next'));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(context.router.push).toHaveBeenCalledWith({
       pathname: '/mock-pathname/',
       query: {
         cursor: '0:100:0',

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -27,7 +27,6 @@ import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import {metric} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import IssueRuleEditor from 'sentry/views/alerts/rules/issue';
 import {permissionAlertText} from 'sentry/views/settings/project/permissionAlert';
 import ProjectAlerts from 'sentry/views/settings/projectAlerts';
@@ -226,8 +225,8 @@ describe('IssueRuleEditor', function () {
         method: 'DELETE',
         body: {},
       });
-      createWrapper();
-      renderGlobalModal();
+      const {router} = createWrapper();
+      renderGlobalModal({router});
       await userEvent.click(screen.getByLabelText('Delete Rule'));
 
       expect(
@@ -236,7 +235,7 @@ describe('IssueRuleEditor', function () {
       await userEvent.click(screen.getByTestId('confirm-button'));
 
       await waitFor(() => expect(deleteMock).toHaveBeenCalled());
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(router.replace).toHaveBeenCalledWith(
         '/settings/org-slug/projects/project-slug/alerts/'
       );
     });

--- a/static/app/views/auth/loginForm.spec.tsx
+++ b/static/app/views/auth/loginForm.spec.tsx
@@ -1,7 +1,8 @@
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import LoginForm from 'sentry/views/auth/loginForm';
 
 async function doLogin() {
@@ -38,6 +39,7 @@ describe('LoginForm', function () {
   });
 
   it('handles success', async function () {
+    const router = RouterFixture();
     const userObject = {
       id: 1,
       name: 'Joe',
@@ -53,7 +55,7 @@ describe('LoginForm', function () {
       },
     });
 
-    render(<LoginForm authConfig={emptyAuthConfig} />);
+    render(<LoginForm authConfig={emptyAuthConfig} />, {router});
     await doLogin();
 
     expect(mockRequest).toHaveBeenCalledWith(
@@ -64,7 +66,7 @@ describe('LoginForm', function () {
     );
 
     await waitFor(() => expect(ConfigStore.get('user')).toEqual(userObject));
-    expect(browserHistory.push).toHaveBeenCalledWith({pathname: '/next/'});
+    expect(router.push).toHaveBeenCalledWith({pathname: '/next/'});
   });
 
   it('renders login provider buttons', function () {

--- a/static/app/views/auth/registerForm.spec.tsx
+++ b/static/app/views/auth/registerForm.spec.tsx
@@ -1,7 +1,8 @@
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import RegisterForm from 'sentry/views/auth/registerForm';
 
 describe('Register', function () {
@@ -52,6 +53,7 @@ describe('Register', function () {
   });
 
   it('handles success', async function () {
+    const router = RouterFixture();
     const userObject = {
       id: 1,
       name: 'Joe',
@@ -67,10 +69,10 @@ describe('Register', function () {
       },
     });
 
-    render(<RegisterForm authConfig={emptyAuthConfig} />);
+    render(<RegisterForm authConfig={emptyAuthConfig} />, {router});
     await doLogin(mockRequest);
 
     await waitFor(() => expect(ConfigStore.get('user')).toEqual(userObject));
-    expect(browserHistory.push).toHaveBeenCalledWith({pathname: '/next/'});
+    expect(router.push).toHaveBeenCalledWith({pathname: '/next/'});
   });
 });

--- a/static/app/views/auth/ssoForm.spec.tsx
+++ b/static/app/views/auth/ssoForm.spec.tsx
@@ -1,6 +1,7 @@
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import SsoForm from 'sentry/views/auth/ssoForm';
 
 describe('SsoForm', function () {
@@ -54,6 +55,7 @@ describe('SsoForm', function () {
   });
 
   it('handles success', async function () {
+    const router = RouterFixture();
     const mockRequest = MockApiClient.addMockResponse({
       url: '/auth/sso-locate/',
       method: 'POST',
@@ -63,11 +65,9 @@ describe('SsoForm', function () {
       },
     });
 
-    render(<SsoForm authConfig={emptyAuthConfig} />);
+    render(<SsoForm authConfig={emptyAuthConfig} />, {router});
     await doSso(mockRequest);
 
-    await waitFor(() =>
-      expect(browserHistory.push).toHaveBeenCalledWith({pathname: '/next/'})
-    );
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith({pathname: '/next/'}));
   });
 });

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -24,7 +24,6 @@ import ConfigStore from 'sentry/stores/configStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
 import DashboardDetail, {
   handleUpdateDashboardSplit,
@@ -1232,7 +1231,7 @@ describe('Dashboards > Detail', function () {
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenCalledWith(
+        expect(testData.router.push).toHaveBeenCalledWith(
           expect.objectContaining({
             query: expect.objectContaining({
               release: '',
@@ -1340,7 +1339,7 @@ describe('Dashboards > Detail', function () {
       await userEvent.click(screen.getByText('Cancel'));
 
       screen.getByText('All Releases');
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(testData.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             project: undefined,
@@ -1550,7 +1549,7 @@ describe('Dashboards > Detail', function () {
       await userEvent.click(screen.getByText('Cancel'));
 
       // release isn't used in the redirect
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(testData.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
             end: undefined,
@@ -1605,7 +1604,7 @@ describe('Dashboards > Detail', function () {
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenCalledWith(
+        expect(testData.router.push).toHaveBeenCalledWith(
           expect.objectContaining({
             query: expect.objectContaining({
               release: ['sentry-android-shop@1.2.0'],

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -5,7 +5,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import OrgDashboards from 'sentry/views/dashboards/orgDashboards';
 import {DashboardState} from 'sentry/views/dashboards/types';
@@ -97,7 +96,7 @@ describe('OrgDashboards', () => {
     );
 
     await waitFor(() =>
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(initialData.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             project: [1, 2],
@@ -161,7 +160,7 @@ describe('OrgDashboards', () => {
     );
 
     await waitFor(() =>
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(initialData.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             project: [1, 2],
@@ -260,7 +259,7 @@ describe('OrgDashboards', () => {
       {router: initialData.router}
     );
 
-    expect(browserHistory.replace).not.toHaveBeenCalled();
+    expect(initialData.router.replace).not.toHaveBeenCalled();
   });
 
   it('does not redirect to add query params if location is cleared manually', async () => {
@@ -305,7 +304,7 @@ describe('OrgDashboards', () => {
       {router: initialData.router}
     );
 
-    await waitFor(() => expect(browserHistory.replace).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(initialData.router.replace).toHaveBeenCalledTimes(1));
 
     rerender(
       <OrgDashboards
@@ -331,6 +330,6 @@ describe('OrgDashboards', () => {
     );
 
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-    expect(browserHistory.replace).toHaveBeenCalledTimes(1);
+    expect(initialData.router.replace).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/dashboards/view.spec.tsx
+++ b/static/app/views/dashboards/view.spec.tsx
@@ -1,35 +1,36 @@
 import {Fragment} from 'react';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import ViewEditDashboard from 'sentry/views/dashboards/view';
 
 describe('Dashboards > ViewEditDashboard', function () {
   const initialData = initializeOrg();
 
   it('removes widget params from url and preserves selection params', function () {
-    const location = {
-      pathname: '/',
-      query: {
-        environment: 'canary',
-        period: '7d',
-        project: '11111',
-        start: null,
-        end: null,
-        utc: null,
-        displayType: 'line',
-        interval: '5m',
-        queryConditions: '',
-        queryFields: 'count()',
-        queryNames: '',
-        queryOrderby: '',
-        title: 'test',
-        statsPeriod: '7d',
+    const router = RouterFixture({
+      location: {
+        pathname: '/',
+        query: {
+          environment: 'canary',
+          period: '7d',
+          project: '11111',
+          start: null,
+          end: null,
+          utc: null,
+          displayType: 'line',
+          interval: '5m',
+          queryConditions: '',
+          queryFields: 'count()',
+          queryNames: '',
+          queryOrderby: '',
+          title: 'test',
+          statsPeriod: '7d',
+        },
       },
-    };
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${initialData.organization.slug}/dashboards/1/visit/`,
@@ -39,7 +40,7 @@ describe('Dashboards > ViewEditDashboard', function () {
 
     render(
       <ViewEditDashboard
-        location={LocationFixture(location)}
+        location={router.location}
         organization={initialData.organization}
         router={initialData.router}
         params={{
@@ -51,10 +52,11 @@ describe('Dashboards > ViewEditDashboard', function () {
         routeParams={{}}
       >
         <Fragment />
-      </ViewEditDashboard>
+      </ViewEditDashboard>,
+      {router}
     );
 
-    expect(browserHistory.replace).toHaveBeenCalledWith(
+    expect(router.replace).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/',
         query: {

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -14,7 +14,6 @@ import {
 
 import * as pageFilterUtils from 'sentry/components/organizations/pageFilters/persistence';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
 
 import {DEFAULT_EVENT_VIEW} from './data';
@@ -184,7 +183,7 @@ describe('Discover > Homepage', () => {
       />,
       {router: initialData.router, organization: initialData.organization}
     );
-    renderGlobalModal();
+    renderGlobalModal({router: initialData.router});
 
     await userEvent.click(await screen.findByText('Columns'));
 
@@ -194,7 +193,7 @@ describe('Discover > Homepage', () => {
     await userEvent.click(within(modal).getByText('event.type'));
     await userEvent.click(within(modal).getByText('Apply'));
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(initialData.router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/organizations/org-slug/discover/homepage/',
         query: expect.objectContaining({

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -13,7 +13,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {DisplayModes, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {DashboardWidgetSource, DisplayType} from 'sentry/views/dashboards/types';
 import QueryList from 'sentry/views/discover/queryList';
@@ -253,7 +252,8 @@ describe('Discover > QueryList', function () {
         renderPrebuilt={false}
         onQueryChange={queryChangeMock}
         location={location}
-      />
+      />,
+      {router}
     );
 
     const card = screen.getAllByTestId(/card-*/).at(0)!;
@@ -264,7 +264,7 @@ describe('Discover > QueryList', function () {
     await userEvent.click(withinCard.getByText('Duplicate Query'));
 
     await waitFor(() => {
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: location.pathname,
         query: {},
       });
@@ -348,7 +348,7 @@ describe('Discover > QueryList', function () {
     expect(queryChangeMock).not.toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: location.pathname,
         query: {cursor: undefined, statsPeriod: '14d'},
       });

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -9,7 +9,6 @@ import selectEvent from 'sentry-test/selectEvent';
 import * as PageFilterPersistence from 'sentry/components/organizations/pageFilters/persistence';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {SavedSearchType} from 'sentry/types/group';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
 import Results from 'sentry/views/discover/results';
 
@@ -270,7 +269,7 @@ describe('Results', function () {
       expect(mockRequests.eventsStatsMock).not.toHaveBeenCalled();
 
       // Should redirect and retain the old query value
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           pathname: '/organizations/org-slug/discover/results/',
           query: expect.objectContaining({

--- a/static/app/views/discover/table/quickContext/actionDropdown.spec.tsx
+++ b/static/app/views/discover/table/quickContext/actionDropdown.spec.tsx
@@ -1,10 +1,10 @@
 import type {Location} from 'history';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
 
@@ -33,6 +33,8 @@ const mockedLocation = LocationFixture({
   },
 });
 
+const mockedRouter = RouterFixture();
+
 const renderActionDropdown = (
   location: Location,
   eventView: EventView,
@@ -51,7 +53,7 @@ const renderActionDropdown = (
       value={value}
       contextValueType={contextValueType}
     />,
-    {organization}
+    {organization, router: mockedRouter}
   );
 };
 
@@ -122,7 +124,7 @@ describe('Quick Context Actions', function () {
 
     await userEvent.click(addAsColumn);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockedRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({
@@ -150,7 +152,7 @@ describe('Quick Context Actions', function () {
 
     await userEvent.click(addToFilter);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockedRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({
@@ -180,7 +182,7 @@ describe('Quick Context Actions', function () {
 
     await userEvent.click(addToFilter);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockedRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({
@@ -210,7 +212,7 @@ describe('Quick Context Actions', function () {
 
     await userEvent.click(showGreaterThanBtn);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockedRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({
@@ -240,7 +242,7 @@ describe('Quick Context Actions', function () {
 
     await userEvent.click(showLessThanBtn);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockedRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -6,7 +6,6 @@ import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLi
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
@@ -72,9 +71,6 @@ describe('TableView > CellActions', function () {
   }
 
   beforeEach(function () {
-    jest.mocked(browserHistory.push).mockReset();
-    jest.mocked(browserHistory.replace).mockReset();
-
     const organization = OrganizationFixture({
       features: ['discover-basic'],
     });
@@ -161,7 +157,7 @@ describe('TableView > CellActions', function () {
     await openContextMenu(1);
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: '!has:title',
@@ -178,7 +174,7 @@ describe('TableView > CellActions', function () {
     await openContextMenu(1);
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'tag:value !has:title',
@@ -194,7 +190,7 @@ describe('TableView > CellActions', function () {
     await openContextMenu(1);
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'tag:value title:"some title"',
@@ -209,7 +205,7 @@ describe('TableView > CellActions', function () {
     await openContextMenu(1);
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'title:"some title"',
@@ -225,7 +221,7 @@ describe('TableView > CellActions', function () {
       screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
     );
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: '!title:"some title"',
@@ -243,7 +239,7 @@ describe('TableView > CellActions', function () {
       screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
     );
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'tag:value !title:"some title"',
@@ -260,7 +256,7 @@ describe('TableView > CellActions', function () {
       screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
     );
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'has:title',
@@ -279,7 +275,7 @@ describe('TableView > CellActions', function () {
       screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
     );
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'tag:value has:title',
@@ -294,7 +290,7 @@ describe('TableView > CellActions', function () {
       screen.getByRole('menuitemradio', {name: 'Show values greater than'})
     );
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'count():>9',
@@ -309,7 +305,7 @@ describe('TableView > CellActions', function () {
       screen.getByRole('menuitemradio', {name: 'Show values less than'})
     );
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'count():<9',
@@ -404,7 +400,7 @@ describe('TableView > CellActions', function () {
     await openContextMenu(5);
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Go to release'}));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/releases/v1.0.2/',
       query: expect.objectContaining({
         environment: eventView.environment,
@@ -507,13 +503,14 @@ describe('TableView > CellActions', function () {
         measurementKeys={null}
         showTags={false}
         title=""
-      />
+      />,
+      {router: initialData.router}
     );
     await userEvent.hover(screen.getByText('444.3 KB'));
     const buttons = screen.getAllByRole('button');
     await userEvent.click(buttons[buttons.length - 1]);
     await userEvent.click(screen.getByText('Show values less than'));
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
         query: 'p99(measurements.custom.kilobyte):<444300',

--- a/static/app/views/insights/mobile/screenload/components/platformSelector.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/platformSelector.spec.tsx
@@ -1,6 +1,7 @@
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import localStorage from 'sentry/utils/localStorage';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
 
@@ -15,10 +16,11 @@ describe('PlatformSelector', function () {
   });
 
   it('updates url params on click', async function () {
-    render(<PlatformSelector />);
+    const router = RouterFixture();
+    render(<PlatformSelector />, {router});
     await userEvent.click(screen.getByRole('radio', {name: 'iOS'}));
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(router.push).toHaveBeenCalledWith({
       pathname: '/mock-pathname/',
       query: {
         platform: 'iOS',

--- a/static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.spec.tsx
@@ -1,17 +1,20 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {NewQuery} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
 import {EventSamplesTable} from 'sentry/views/insights/mobile/screenload/components/tables/eventSamplesTable';
 
 describe('EventSamplesTable', function () {
+  let mockRouter: InjectedRouter;
   let mockLocation: ReturnType<typeof LocationFixture>;
   let mockQuery: NewQuery;
   let mockEventView: EventView;
   beforeEach(function () {
+    mockRouter = RouterFixture();
     mockLocation = LocationFixture({
       query: {
         statsPeriod: '99d',
@@ -52,7 +55,8 @@ describe('EventSamplesTable', function () {
           kind: 'desc',
         }}
         sortKey=""
-      />
+      />,
+      {router: mockRouter}
     );
 
     expect(screen.getByText('Readable Column Name')).toBeInTheDocument();
@@ -82,7 +86,8 @@ describe('EventSamplesTable', function () {
         }}
         sortKey=""
         data={{data: [{id: '1', 'transaction.id': 'abc'}], meta: {}}}
-      />
+      />,
+      {router: mockRouter}
     );
 
     // Test only one column to isolate event ID
@@ -118,7 +123,8 @@ describe('EventSamplesTable', function () {
           data: [{id: '1', 'profile.id': 'abc', 'project.name': 'project'}],
           meta: {fields: {'profile.id': 'string', 'project.name': 'string'}},
         }}
-      />
+      />,
+      {router: mockRouter}
     );
 
     // Test only one column to isolate profile column
@@ -151,13 +157,14 @@ describe('EventSamplesTable', function () {
         }}
         sortKey=""
         data={{data: [{id: '1', 'transaction.id': 'abc'}], meta: {}}}
-      />
+      />,
+      {router: mockRouter}
     );
 
     expect(screen.getByRole('button', {name: /device class all/i})).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', {name: /device class all/i}));
     await userEvent.click(screen.getByText('Medium'));
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({
@@ -187,11 +194,12 @@ describe('EventSamplesTable', function () {
         sortKey=""
         data={{data: [{id: '1', 'transaction.id': 'abc'}], meta: {}}}
         pageLinks={pageLinks}
-      />
+      />,
+      {router: mockRouter}
     );
     expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(mockRouter.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/mock-pathname/',
         query: expect.objectContaining({
@@ -225,7 +233,8 @@ describe('EventSamplesTable', function () {
         }}
         sortKey="customSortKey"
         data={{data: [{id: '1', 'transaction.id': 'abc', duration: 'def'}], meta: {}}}
-      />
+      />,
+      {router: mockRouter}
     );
 
     // Ascending sort in transaction ID because the default is descending
@@ -262,7 +271,8 @@ describe('EventSamplesTable', function () {
         }}
         sortKey="customSortKey"
         data={{data: [{id: '1', 'transaction.id': 'abc', duration: 'def'}], meta: {}}}
-      />
+      />,
+      {router: mockRouter}
     );
 
     // Although ID is queried for, because it's not defined in the map

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -3,6 +3,7 @@ import {EventStacktraceExceptionFixture} from 'sentry-fixture/eventStacktraceExc
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -17,7 +18,6 @@ import ConfigStore from 'sentry/stores/configStore';
 import ModalStore from 'sentry/stores/modalStore';
 import {GroupStatus, IssueCategory} from 'sentry/types/group';
 import * as analytics from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import GroupActions from 'sentry/views/issueDetails/actions';
 
 const project = ProjectFixture({
@@ -215,6 +215,7 @@ describe('GroupActions', function () {
 
   describe('delete', function () {
     it('opens delete confirm modal from more actions dropdown', async () => {
+      const router = RouterFixture();
       const org = OrganizationFixture({
         ...organization,
         access: [...organization.access, 'event:admin'],
@@ -240,7 +241,7 @@ describe('GroupActions', function () {
             event={null}
           />
         </Fragment>,
-        {organization: org}
+        {router, organization: org}
       );
 
       await userEvent.click(screen.getByLabelText('More Actions'));
@@ -254,7 +255,7 @@ describe('GroupActions', function () {
       await userEvent.click(within(modal).getByRole('button', {name: 'Delete'}));
 
       expect(deleteMock).toHaveBeenCalled();
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: `/organizations/${org.slug}/issues/`,
         query: {project: project.id},
       });

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -2,16 +2,18 @@ import {ConfigFixture} from 'sentry-fixture/config';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import * as useMedia from 'sentry/utils/useMedia';
 import {GroupEventCarousel} from 'sentry/views/issueDetails/groupEventCarousel';
 
 describe('GroupEventCarousel', () => {
+  const router = RouterFixture();
+
   const testEvent = EventFixture({
     id: 'event-id',
     size: 7,
@@ -66,12 +68,12 @@ describe('GroupEventCarousel', () => {
     it('can navigate to the oldest event', async () => {
       jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
-      render(<GroupEventCarousel {...defaultProps} />);
+      render(<GroupEventCarousel {...defaultProps} />, {router});
 
       await userEvent.click(screen.getByRole('button', {name: /recommended/i}));
       await userEvent.click(screen.getByRole('option', {name: /oldest/i}));
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/issues/group-id/events/oldest/',
         query: {referrer: 'oldest-event'},
       });
@@ -80,30 +82,27 @@ describe('GroupEventCarousel', () => {
     it('can navigate to the latest event', async () => {
       jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
-      render(<GroupEventCarousel {...defaultProps} />);
+      render(<GroupEventCarousel {...defaultProps} />, {router});
 
       await userEvent.click(screen.getByRole('button', {name: /recommended/i}));
       await userEvent.click(screen.getByRole('option', {name: /latest/i}));
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/issues/group-id/events/latest/',
         query: {referrer: 'latest-event'},
       });
     });
 
     it('can navigate to the recommended event', async () => {
+      const newRouter = RouterFixture({params: {eventId: 'latest'}});
       jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
-      render(<GroupEventCarousel {...defaultProps} />, {
-        router: {
-          params: {eventId: 'latest'},
-        },
-      });
+      render(<GroupEventCarousel {...defaultProps} />, {router: newRouter});
 
       await userEvent.click(screen.getByRole('button', {name: /latest/i}));
       await userEvent.click(screen.getByRole('option', {name: /recommended/i}));
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(newRouter.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/issues/group-id/events/recommended/',
         query: {referrer: 'recommended-event'},
       });

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -19,7 +19,6 @@ import {IssueCategory, IssueType} from 'sentry/types/group';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type {QuickTraceEvent} from 'sentry/utils/performance/quickTrace/types';
 import GroupEventDetails from 'sentry/views/issueDetails/groupEventDetails/groupEventDetails';
 
@@ -346,7 +345,6 @@ describe('groupEventDetails', () => {
 
   afterEach(function () {
     MockApiClient.clearMockResponses();
-    jest.mocked(browserHistory.replace).mockClear();
   });
 
   it('redirects on switching to an invalid environment selection for event', async function () {
@@ -364,12 +362,12 @@ describe('groupEventDetails', () => {
       router: props.router,
     });
     expect(await screen.findByTestId('group-event-details')).toBeInTheDocument();
-    expect(browserHistory.replace).not.toHaveBeenCalled();
+    expect(props.router.replace).not.toHaveBeenCalled();
 
     props.router.location.query.environment = ['prod'];
     rerender(<GroupEventDetails />);
 
-    await waitFor(() => expect(browserHistory.replace).toHaveBeenCalled());
+    await waitFor(() => expect(props.router.replace).toHaveBeenCalled());
   });
 
   it('does not redirect when switching to a valid environment selection for event', async function () {
@@ -381,13 +379,13 @@ describe('groupEventDetails', () => {
       router: props.router,
     });
 
-    expect(browserHistory.replace).not.toHaveBeenCalled();
+    expect(props.router.replace).not.toHaveBeenCalled();
     props.router.location.query.environment = [];
     rerender(<GroupEventDetails />);
 
     expect(await screen.findByTestId('group-event-details')).toBeInTheDocument();
 
-    expect(browserHistory.replace).not.toHaveBeenCalled();
+    expect(props.router.replace).not.toHaveBeenCalled();
   });
 
   it('displays error on event error', async function () {
@@ -509,7 +507,6 @@ describe('EventCause', () => {
 
   afterEach(function () {
     MockApiClient.clearMockResponses();
-    jest.mocked(browserHistory.replace).mockClear();
   });
 
   it('renders suspect commit', async function () {

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -13,7 +13,6 @@ import {
 
 import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import GroupEvents from 'sentry/views/issueDetails/groupEvents';
 
 describe('groupEvents', () => {
@@ -143,7 +142,7 @@ describe('groupEvents', () => {
     await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
-      expect(browserHistory.push).toHaveBeenCalledWith(
+      expect(router.push).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {query: 'foo'},
         })

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -10,7 +10,6 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import GroupReplays from 'sentry/views/issueDetails/groupReplays';
@@ -573,14 +572,13 @@ describe('GroupReplays', () => {
         );
       });
 
-      const mockReplace = jest.mocked(browserHistory.replace);
       const replayPlayPlause = (
         await screen.findAllByTestId('replay-table-play-button')
       )[0];
       await userEvent.click(replayPlayPlause);
 
       await waitFor(() =>
-        expect(mockReplace).toHaveBeenCalledWith(
+        expect(router.replace).toHaveBeenCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/replays/',
             query: {

--- a/static/app/views/issueDetails/groupTagValues.spec.tsx
+++ b/static/app/views/issueDetails/groupTagValues.spec.tsx
@@ -13,7 +13,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {GroupTagValues} from 'sentry/views/issueDetails/groupTagValues';
 
 describe('GroupTagValues', () => {
@@ -92,7 +91,7 @@ describe('GroupTagValues', () => {
     // Clicking next button loads page with query param ?cursor=0:100:0
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
     await waitFor(() => {
-      expect(browserHistory.push).toHaveBeenCalledWith(
+      expect(router.push).toHaveBeenCalledWith(
         expect.objectContaining({query: expect.objectContaining({cursor: '0:100:0'})})
       );
     });

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -5,6 +5,7 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {SearchFixture} from 'sentry-fixture/search';
 import {TagsFixture} from 'sentry-fixture/tags';
 
@@ -24,7 +25,6 @@ import {DEFAULT_QUERY} from 'sentry/constants';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
 import {SavedSearchVisibility} from 'sentry/types/group';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import localStorageWrapper from 'sentry/utils/localStorage';
 import * as parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import IssueListWithStores, {IssueListOverview} from 'sentry/views/issueList/overview';
@@ -486,7 +486,7 @@ describe('IssueList', function () {
       await userEvent.click(screen.getByRole('button', {name: /custom search/i}));
       await userEvent.click(screen.getByRole('button', {name: localSavedSearch.name}));
 
-      expect(browserHistory.push).toHaveBeenLastCalledWith(
+      expect(router.push).toHaveBeenLastCalledWith(
         expect.objectContaining({
           pathname: '/organizations/org-slug/issues/searches/789/',
         })
@@ -519,7 +519,7 @@ describe('IssueList', function () {
       await userEvent.click(getSearchInput());
       await userEvent.keyboard('dogs{Enter}');
 
-      expect(browserHistory.push).toHaveBeenLastCalledWith(
+      expect(router.push).toHaveBeenLastCalledWith(
         expect.objectContaining({
           pathname: '/organizations/org-slug/issues/',
           query: {
@@ -560,7 +560,7 @@ describe('IssueList', function () {
       await userEvent.paste('assigned:me level:fatal');
       await userEvent.keyboard('{Enter}');
 
-      expect(browserHistory.push as jest.Mock).toHaveBeenCalledWith(
+      expect(router.push).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             query: 'assigned:me level:fatal',
@@ -590,7 +590,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(createPin).toHaveBeenCalled();
-        expect(browserHistory.replace).toHaveBeenLastCalledWith(
+        expect(router.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/searches/666/',
             query: {
@@ -620,9 +620,9 @@ describe('IssueList', function () {
         method: 'DELETE',
       });
 
-      const routerWithSavedSearch = {
+      const routerWithSavedSearch = RouterFixture({
         params: {searchId: pinnedSearch.id},
-      };
+      });
 
       render(<IssueListWithStores {...merge({}, routerProps, routerWithSavedSearch)} />, {
         router: routerWithSavedSearch,
@@ -639,7 +639,7 @@ describe('IssueList', function () {
       });
 
       await waitFor(() => {
-        expect(browserHistory.replace).toHaveBeenLastCalledWith(
+        expect(routerWithSavedSearch.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/',
           })
@@ -671,7 +671,7 @@ describe('IssueList', function () {
           isPinned: true,
         },
       });
-      const routerWithSavedSearch = {params: {searchId: '789'}};
+      const routerWithSavedSearch = RouterFixture({params: {searchId: '789'}});
 
       render(<IssueListWithStores {...merge({}, routerProps, routerWithSavedSearch)} />, {
         router: routerWithSavedSearch,
@@ -685,7 +685,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(createPin).toHaveBeenCalled();
-        expect(browserHistory.replace).toHaveBeenLastCalledWith(
+        expect(routerWithSavedSearch.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/searches/789/',
           })
@@ -747,7 +747,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(createPin).toHaveBeenCalled();
-        expect(browserHistory.replace).toHaveBeenLastCalledWith(
+        expect(newRouter.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/searches/666/',
             query: expect.objectContaining({
@@ -816,7 +816,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(deletePin).toHaveBeenCalled();
-        expect(browserHistory.replace).toHaveBeenLastCalledWith(
+        expect(newRouter.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/',
             query: expect.objectContaining({
@@ -863,7 +863,7 @@ describe('IssueList', function () {
       };
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenLastCalledWith(pushArgs);
+        expect(router.push).toHaveBeenLastCalledWith(pushArgs);
       });
 
       rerender(<IssueListWithStores {...merge({}, routerProps, {location: pushArgs})} />);
@@ -887,7 +887,7 @@ describe('IssueList', function () {
       };
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenLastCalledWith(pushArgs);
+        expect(router.push).toHaveBeenLastCalledWith(pushArgs);
       });
 
       rerender(<IssueListWithStores {...merge({}, routerProps, {location: pushArgs})} />);
@@ -909,7 +909,7 @@ describe('IssueList', function () {
       };
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenLastCalledWith(pushArgs);
+        expect(router.push).toHaveBeenLastCalledWith(pushArgs);
       });
 
       rerender(<IssueListWithStores {...merge({}, routerProps, {location: pushArgs})} />);
@@ -919,7 +919,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         // cursor is undefined because "prev" cursor is === initial "next" cursor
-        expect(browserHistory.push).toHaveBeenLastCalledWith({
+        expect(router.push).toHaveBeenLastCalledWith({
           pathname: '/organizations/org-slug/issues/',
           query: {
             cursor: undefined,
@@ -955,7 +955,7 @@ describe('IssueList', function () {
       await userEvent.keyboard('{enter}');
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenCalledWith({
+        expect(router.push).toHaveBeenCalledWith({
           pathname: '/organizations/org-slug/issues/',
           query: {
             environment: [],

--- a/static/app/views/onboarding/createSampleEventButton.spec.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.tsx
@@ -1,17 +1,18 @@
 import * as Sentry from '@sentry/react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
 
 jest.useFakeTimers();
 jest.mock('sentry/utils/analytics');
 
 describe('CreateSampleEventButton', function () {
+  const router = RouterFixture();
   const org = OrganizationFixture();
   const project = ProjectFixture();
   const groupID = '123';
@@ -25,7 +26,7 @@ describe('CreateSampleEventButton', function () {
       >
         {createSampleText}
       </CreateSampleEventButton>,
-      {organization: org}
+      {organization: org, router}
     );
   }
 
@@ -66,7 +67,7 @@ describe('CreateSampleEventButton', function () {
     // Wait for the api request and latestEventAvailable to resolve
     expect(sampleButton).toBeEnabled();
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(router.push).toHaveBeenCalledWith(
       `/organizations/${org.slug}/issues/${groupID}/?project=${project.id}&referrer=sample-error`
     );
   });
@@ -107,7 +108,7 @@ describe('CreateSampleEventButton', function () {
     jest.runAllTimers();
     await waitFor(() => expect(latestIssueRequest).toHaveBeenCalled());
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(router.push).toHaveBeenCalledWith(
       `/organizations/${org.slug}/issues/${groupID}/?project=${project.id}&referrer=sample-error`
     );
 

--- a/static/app/views/performance/content.spec.tsx
+++ b/static/app/views/performance/content.spec.tsx
@@ -10,7 +10,6 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import PerformanceContent from 'sentry/views/performance/content';
 import {DEFAULT_MAX_DURATION} from 'sentry/views/performance/trends/utils';
@@ -372,7 +371,7 @@ describe('Performance > Content', function () {
 
     expect(pageFilters.updateDateTime).toHaveBeenCalledTimes(0);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/organizations/org-slug/performance/trends/',
         query: {
@@ -395,7 +394,7 @@ describe('Performance > Content', function () {
     });
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
 
-    expect(browserHistory.push).toHaveBeenCalledTimes(0);
+    expect(router.push).toHaveBeenCalledTimes(0);
   });
 
   it('Default page (transactions) with trends feature will not update filters if none are set', async function () {
@@ -405,7 +404,7 @@ describe('Performance > Content', function () {
       router,
     });
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
-    expect(browserHistory.push).toHaveBeenCalledTimes(0);
+    expect(router.push).toHaveBeenCalledTimes(0);
   });
 
   it('Tags are replaced with trends default query if navigating to trends', async function () {
@@ -419,7 +418,7 @@ describe('Performance > Content', function () {
     await userEvent.click(trendsLinks[0]);
 
     expect(await screen.findByTestId('performance-landing-v3')).toBeInTheDocument();
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/organizations/org-slug/performance/trends/',
         query: {

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -1,4 +1,5 @@
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {addMetricsDataMock} from 'sentry-test/performance/addMetricsDataMock';
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
@@ -13,7 +14,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -244,15 +244,16 @@ describe('Performance > Landing > Index', function () {
   });
 
   it('Can switch between landing displays', async function () {
+    const router = RouterFixture();
     const data = initializeData({
       query: {landingDisplay: LandingDisplayField.FRONTEND_OTHER, abc: '123'},
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {router});
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('tab', {name: 'All Transactions'}));
 
-    expect(browserHistory.push).toHaveBeenNthCalledWith(
+    expect(router.push).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         pathname: data.location.pathname,

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -5,7 +5,6 @@ import {initializeData as _initializeData} from 'sentry-test/performance/initial
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -241,11 +240,11 @@ describe('Performance > Table', function () {
       expect(transactionCellTrigger).toBeInTheDocument();
       await userEvent.click(transactionCellTrigger);
 
-      expect(browserHistory.push).toHaveBeenCalledTimes(0);
+      expect(data.router.push).toHaveBeenCalledTimes(0);
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
-      expect(browserHistory.push).toHaveBeenCalledTimes(1);
-      expect(browserHistory.push).toHaveBeenNthCalledWith(1, {
+      expect(data.router.push).toHaveBeenCalledTimes(1);
+      expect(data.router.push).toHaveBeenNthCalledWith(1, {
         pathname: undefined,
         query: expect.objectContaining({
           query: 'transaction:/apple/cart',

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -5,7 +5,6 @@ import {initializeData as _initializeData} from 'sentry-test/performance/initial
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {useLocation} from 'sentry/utils/useLocation';
 import TransactionEvents from 'sentry/views/performance/transactionSummary/transactionEvents';
@@ -200,7 +199,7 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
 
     await userEvent.click(p50);
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(data.router.push).toHaveBeenCalledWith(
       expect.objectContaining({query: expect.objectContaining({showTransactions: 'p50'})})
     );
   });

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -17,7 +17,6 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {
@@ -836,11 +835,11 @@ describe('Performance > TransactionSummary', function () {
       await userEvent.keyboard('{enter}');
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenCalledTimes(1);
+        expect(router.push).toHaveBeenCalledTimes(1);
       });
 
       // Check the navigation.
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: '/',
         query: {
           transaction: '/performance',
@@ -912,7 +911,7 @@ describe('Performance > TransactionSummary', function () {
       await userEvent.click(screen.getAllByText('Slow Transactions (p95)')[1]);
 
       // Check the navigation.
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: '/',
         query: {
           transaction: '/performance',
@@ -948,7 +947,7 @@ describe('Performance > TransactionSummary', function () {
       await userEvent.click(await findByLabelText(pagination, 'Next'));
 
       // Check the navigation.
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: '/',
         query: {
           transaction: '/performance',
@@ -1060,8 +1059,8 @@ describe('Performance > TransactionSummary', function () {
 
       await userEvent.click(screen.getByTestId('status-ok'));
 
-      expect(browserHistory.push).toHaveBeenCalledTimes(1);
-      expect(browserHistory.push).toHaveBeenCalledWith(
+      expect(router.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
             query: expect.stringContaining('transaction.status:ok'),

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -12,7 +12,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import SpanDetails from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 
@@ -38,7 +37,6 @@ describe('Performance > Transaction Spans > Span Summary', function () {
   afterEach(function () {
     MockApiClient.clearMockResponses();
     ProjectsStore.reset();
-    jest.mocked(browserHistory.push).mockReset();
   });
 
   describe('Without Span Data', function () {
@@ -445,7 +443,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           name: /reset view/i,
         });
         await userEvent.click(resetButton);
-        expect(browserHistory.push).toHaveBeenCalledWith(
+        expect(data.router.push).toHaveBeenCalledWith(
           expect.not.objectContaining({min: expect.any(String), max: expect.any(String)})
         );
       });
@@ -465,7 +463,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         await userEvent.click(searchBarNode);
         await userEvent.paste('count():>3');
         expect(searchBarNode).toHaveTextContent('count():>3');
-        expect(browserHistory.push).not.toHaveBeenCalled();
+        expect(data.router.push).not.toHaveBeenCalled();
       });
 
       it('renders a display toggle that changes a chart view between timeseries and histogram by pushing it to the browser history', async function () {
@@ -506,7 +504,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           })
         );
 
-        expect(browserHistory.push).toHaveBeenCalledWith(
+        expect(data.router.push).toHaveBeenCalledWith(
           expect.objectContaining({
             query: {
               display: 'histogram',

--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -6,7 +6,6 @@ import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingL
 import selectEvent from 'sentry-test/selectEvent';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
 import TransactionTags from 'sentry/views/performance/transactionSummary/transactionTags';
 
@@ -184,7 +183,7 @@ describe('Performance > Transaction Tags', function () {
     expect(screen.getByText('Heat Map')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         query: {
           project: '1',
           statsPeriod: '14d',
@@ -211,7 +210,7 @@ describe('Performance > Transaction Tags', function () {
     });
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         query: {
           project: '1',
           statsPeriod: '14d',
@@ -250,7 +249,7 @@ describe('Performance > Transaction Tags', function () {
     });
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         query: {
           project: '1',
           statsPeriod: '14d',
@@ -312,7 +311,7 @@ describe('Performance > Transaction Tags', function () {
     expect(await screen.findByText('Suspect Tags')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         query: {
           project: '1',
           statsPeriod: '14d',
@@ -332,7 +331,7 @@ describe('Performance > Transaction Tags', function () {
     await userEvent.click(screen.getByLabelText('Next'));
 
     await waitFor(() =>
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/performance/summary/tags/',
         query: {
           project: '1',
@@ -348,7 +347,7 @@ describe('Performance > Transaction Tags', function () {
     await userEvent.click(screen.getByRole('radio', {name: 'effectiveConnectionType'}));
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         query: {
           project: '1',
           statsPeriod: '14d',

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -17,7 +17,6 @@ import {
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {WebVital} from 'sentry/utils/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import TrendsIndex from 'sentry/views/performance/trends/';
@@ -359,7 +358,7 @@ describe('Performance > Trends', function () {
     const menuAction = within(firstTransaction).getAllByRole('menuitemradio')[2];
     await clickEl(menuAction);
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(data.router.push).toHaveBeenCalledWith({
       pathname: '/trends/',
       query: expect.objectContaining({
         project: expect.anything(),
@@ -384,7 +383,7 @@ describe('Performance > Trends', function () {
     enterSearch(input, 'transaction.duration:>9000');
 
     await waitFor(() =>
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(data.router.push).toHaveBeenCalledWith({
         pathname: '/trends/',
         query: expect.objectContaining({
           project: ['1'],
@@ -423,7 +422,7 @@ describe('Performance > Trends', function () {
     const menuAction = within(firstTransaction).getAllByRole('menuitemradio')[0];
     await clickEl(menuAction);
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(data.router.push).toHaveBeenCalledWith({
       pathname: '/trends/',
       query: expect.objectContaining({
         project: expect.anything(),
@@ -459,7 +458,7 @@ describe('Performance > Trends', function () {
     const menuAction = within(firstTransaction).getAllByRole('menuitemradio')[1];
     await clickEl(menuAction);
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(data.router.push).toHaveBeenCalledWith({
       pathname: '/trends/',
       query: expect.objectContaining({
         project: expect.anything(),
@@ -489,7 +488,7 @@ describe('Performance > Trends', function () {
       const option = screen.getByRole('option', {name: trendFunction.label});
       await clickEl(option);
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(data.router.push).toHaveBeenCalledWith({
         pathname: '/trends/',
         query: expect.objectContaining({
           regressionCursor: undefined,
@@ -569,7 +568,7 @@ describe('Performance > Trends', function () {
       const option = screen.getByRole('option', {name: parameter.label});
       await clickEl(option);
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
+      expect(data.router.push).toHaveBeenCalledWith({
         pathname: '/trends/',
         query: expect.objectContaining({
           trendParameter: parameter.label,
@@ -718,7 +717,7 @@ describe('Performance > Trends', function () {
     );
 
     await waitFor(() =>
-      expect(browserHistory.push).toHaveBeenNthCalledWith(
+      expect(data.router.push).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
           query: {
@@ -746,7 +745,7 @@ describe('Performance > Trends', function () {
       }
     );
 
-    jest.mocked(browserHistory.push).mockReset();
+    jest.mocked(data.router.push).mockReset();
 
     const byTransactionLink = await screen.findByTestId('breadcrumb-link');
 

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -14,7 +14,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {WebVital} from 'sentry/utils/fields';
 import {Browser} from 'sentry/utils/performance/vitals/constants';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/performance/data';
@@ -268,10 +267,10 @@ describe('Performance > VitalDetail', function () {
 
     // Check the navigation.
     await waitFor(() => {
-      expect(browserHistory.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenCalledTimes(1);
     });
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(router.push).toHaveBeenCalledWith({
       pathname: undefined,
       query: {
         project: '1',
@@ -396,8 +395,8 @@ describe('Performance > VitalDetail', function () {
     expect(menuItem).toBeInTheDocument();
     await userEvent.click(menuItem);
 
-    expect(browserHistory.push).toHaveBeenCalledTimes(1);
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(newRouter.push).toHaveBeenCalledTimes(1);
+    expect(newRouter.push).toHaveBeenCalledWith({
       pathname: undefined,
       query: {
         project: 1,

--- a/static/app/views/releases/detail/header/releaseActions.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.spec.tsx
@@ -6,6 +6,7 @@ import {ReleaseFixture} from 'sentry-fixture/release';
 import {ReleaseMetaFixture} from 'sentry-fixture/releaseMeta';
 import {ReleaseProjectFixture} from 'sentry-fixture/releaseProject';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -17,10 +18,10 @@ import {
 
 import type {ReleaseProject} from 'sentry/types/release';
 import {ReleaseStatus} from 'sentry/types/release';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import ReleaseActions from 'sentry/views/releases/detail/header/releaseActions';
 
 describe('ReleaseActions', function () {
+  const router = RouterFixture();
   const organization = OrganizationFixture();
 
   const project1 = ReleaseProjectFixture({
@@ -70,9 +71,10 @@ describe('ReleaseActions', function () {
         refetchData={jest.fn()}
         releaseMeta={{...ReleaseMetaFixture(), projects: release.projects}}
         location={location}
-      />
+      />,
+      {router}
     );
-    renderGlobalModal();
+    renderGlobalModal({router});
 
     await userEvent.click(screen.getByLabelText('Actions'));
 
@@ -101,7 +103,7 @@ describe('ReleaseActions', function () {
       })
     );
     await waitFor(() =>
-      expect(browserHistory.push).toHaveBeenCalledWith(
+      expect(router.push).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/releases/`
       )
     );
@@ -119,9 +121,10 @@ describe('ReleaseActions', function () {
         refetchData={refetchDataMock}
         releaseMeta={{...ReleaseMetaFixture(), projects: release.projects}}
         location={location}
-      />
+      />,
+      {router}
     );
-    renderGlobalModal();
+    renderGlobalModal({router});
 
     await userEvent.click(screen.getByLabelText('Actions'));
 
@@ -162,7 +165,8 @@ describe('ReleaseActions', function () {
         refetchData={jest.fn()}
         releaseMeta={{...ReleaseMetaFixture(), projects: release.projects}}
         location={location}
-      />
+      />,
+      {router}
     );
 
     expect(screen.getByLabelText('Oldest')).toHaveAttribute(

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -8,7 +8,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {ReleaseProject} from 'sentry/types/release';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import ReleaseComparisonChart from 'sentry/views/releases/detail/overview/releaseComparisonChart';
 
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
@@ -81,7 +80,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
 
     await userEvent.click(screen.getByLabelText(/crash free user rate/i));
 
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({query: {chart: 'crashFreeUsers'}})
     );
 

--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.tsx
@@ -6,7 +6,6 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import type {Config} from 'sentry/types/system';
-import {browserHistory} from 'sentry/utils/browserHistory';
 
 import {OrganizationCrumb} from './organizationCrumb';
 import type {RouteWithName} from './types';
@@ -29,7 +28,6 @@ describe('OrganizationCrumb', function () {
     OrganizationsStore.load(organizations);
 
     initialData = ConfigStore.getState();
-    jest.mocked(browserHistory.push).mockReset();
     jest.mocked(window.location.assign).mockReset();
   });
 
@@ -67,7 +65,7 @@ describe('OrganizationCrumb', function () {
     renderComponent({routes, route});
     await switchOrganization();
 
-    expect(browserHistory.push).toHaveBeenCalledWith('/settings/org-slug2/');
+    expect(router.push).toHaveBeenCalledWith('/settings/org-slug2/');
   });
 
   it('switches organizations while on API Keys Details route', async function () {
@@ -88,7 +86,7 @@ describe('OrganizationCrumb', function () {
     renderComponent({routes, route});
     await switchOrganization();
 
-    expect(browserHistory.push).toHaveBeenCalledWith('/settings/org-slug2/api-keys/');
+    expect(router.push).toHaveBeenCalledWith('/settings/org-slug2/api-keys/');
   });
 
   it('switches organizations while on API Keys List route', async function () {
@@ -108,7 +106,7 @@ describe('OrganizationCrumb', function () {
     renderComponent({routes, route});
     await switchOrganization();
 
-    expect(browserHistory.push).toHaveBeenCalledWith('/settings/org-slug2/api-keys/');
+    expect(router.push).toHaveBeenCalledWith('/settings/org-slug2/api-keys/');
   });
 
   it('switches organizations while in Project Client Keys Details route', async function () {
@@ -130,7 +128,7 @@ describe('OrganizationCrumb', function () {
     });
     await switchOrganization();
 
-    expect(browserHistory.push).toHaveBeenCalledWith('/settings/org-slug2/');
+    expect(router.push).toHaveBeenCalledWith('/settings/org-slug2/');
   });
 
   it('switches organizations for child route with customer domains', async function () {

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -21,7 +21,6 @@ import ConfigStore from 'sentry/stores/configStore';
 import ModalStore from 'sentry/stores/modalStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
 jest.mock('sentry/utils/analytics');
@@ -165,8 +164,8 @@ describe('OrganizationMembersList', function () {
       method: 'DELETE',
     });
 
-    render(<OrganizationMembersList />, {organization});
-    renderGlobalModal();
+    render(<OrganizationMembersList />, {organization, router});
+    renderGlobalModal({router});
 
     // The organization member row
     expect(await screen.findByTestId(members[0].email)).toBeInTheDocument();
@@ -191,7 +190,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList />, {organization, router});
-    renderGlobalModal();
+    renderGlobalModal({router});
 
     // The organization member row
     expect(await screen.findByTestId(members[0].email)).toBeInTheDocument();
@@ -215,7 +214,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList />, {organization, router});
-    renderGlobalModal();
+    renderGlobalModal({router});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Leave'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
@@ -223,8 +222,8 @@ describe('OrganizationMembersList', function () {
     await waitFor(() => expect(addSuccessMessage).toHaveBeenCalled());
 
     expect(deleteMock).toHaveBeenCalled();
-    expect(browserHistory.push).toHaveBeenCalledTimes(1);
-    expect(browserHistory.push).toHaveBeenCalledWith('/organizations/new/');
+    expect(router.push).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledWith('/organizations/new/');
   });
 
   it('can redirect to remaining org after leaving', async function () {
@@ -242,7 +241,7 @@ describe('OrganizationMembersList', function () {
     OrganizationsStore.addOrReplace(secondOrg);
 
     render(<OrganizationMembersList />, {organization, router});
-    renderGlobalModal();
+    renderGlobalModal({router});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Leave'}));
     await userEvent.click(screen.getByTestId('confirm-button'));
@@ -250,8 +249,8 @@ describe('OrganizationMembersList', function () {
     await waitFor(() => expect(addSuccessMessage).toHaveBeenCalled());
 
     expect(deleteMock).toHaveBeenCalled();
-    expect(browserHistory.push).toHaveBeenCalledTimes(1);
-    expect(browserHistory.push).toHaveBeenCalledWith('/organizations/org-two/issues/');
+    expect(router.push).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledWith('/organizations/org-two/issues/');
     expect(OrganizationsStore.getAll()).toEqual([secondOrg]);
   });
 
@@ -262,8 +261,8 @@ describe('OrganizationMembersList', function () {
       statusCode: 500,
     });
 
-    render(<OrganizationMembersList />, {organization});
-    renderGlobalModal();
+    render(<OrganizationMembersList />, {organization, router});
+    renderGlobalModal({router});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Leave'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
@@ -474,13 +473,13 @@ describe('OrganizationMembersList', function () {
         method: 'PUT',
       });
 
-      render(<OrganizationMembersList />, {organization});
+      render(<OrganizationMembersList />, {organization, router});
 
       expect(await screen.findByText('Pending Members')).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', {name: 'Approve'}));
 
-      renderGlobalModal();
+      renderGlobalModal({router});
       await userEvent.click(screen.getByTestId('confirm-button'));
 
       expect(screen.queryByText('Pending Members')).not.toBeInTheDocument();
@@ -544,7 +543,7 @@ describe('OrganizationMembersList', function () {
         method: 'PUT',
       });
 
-      render(<OrganizationMembersList />, {organization: org});
+      render(<OrganizationMembersList />, {organization: org, router});
 
       expect(await screen.findByText('Pending Members')).toBeInTheDocument();
       await selectEvent.select(screen.getByRole('textbox', {name: 'Role: Member'}), [
@@ -553,7 +552,7 @@ describe('OrganizationMembersList', function () {
 
       await userEvent.click(screen.getByRole('button', {name: 'Approve'}));
 
-      renderGlobalModal();
+      renderGlobalModal({router});
       await userEvent.click(screen.getByTestId('confirm-button'));
 
       expect(updateWithApprove).toHaveBeenCalledWith(
@@ -574,8 +573,8 @@ describe('OrganizationMembersList', function () {
         },
       });
 
-      render(<OrganizationMembersList />, {organization: inviteOrg});
-      renderGlobalModal();
+      render(<OrganizationMembersList />, {organization: inviteOrg, router});
+      renderGlobalModal({router});
 
       await userEvent.click(await screen.findByRole('button', {name: 'Invite Members'}));
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -591,8 +590,8 @@ describe('OrganizationMembersList', function () {
         },
       });
 
-      render(<OrganizationMembersList />, {organization: org});
-      renderGlobalModal();
+      render(<OrganizationMembersList />, {organization: org, router});
+      renderGlobalModal({router});
 
       expect(await screen.findByRole('button', {name: 'Invite Members'})).toBeDisabled();
     });
@@ -608,8 +607,8 @@ describe('OrganizationMembersList', function () {
         requiresSso: true,
       });
 
-      render(<OrganizationMembersList />, {organization: org});
-      renderGlobalModal();
+      render(<OrganizationMembersList />, {organization: org, router});
+      renderGlobalModal({router});
 
       await userEvent.click(screen.getByRole('button', {name: 'Invite Members'}));
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -625,8 +624,8 @@ describe('OrganizationMembersList', function () {
         },
       });
 
-      render(<OrganizationMembersList />, {organization: org});
-      renderGlobalModal();
+      render(<OrganizationMembersList />, {organization: org, router});
+      renderGlobalModal({router});
 
       await userEvent.click(await screen.findByRole('button', {name: 'Invite Members'}));
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -643,8 +642,8 @@ describe('OrganizationMembersList', function () {
         method: 'GET',
         body: {},
       });
-      render(<OrganizationMembersList />, {organization});
-      renderGlobalModal();
+      render(<OrganizationMembersList />, {organization, router});
+      renderGlobalModal({router});
 
       expect(await screen.findByText('Members')).toBeInTheDocument();
       expect(screen.getByText(member.name)).toBeInTheDocument();

--- a/static/app/views/settings/organizationProjects/index.spec.tsx
+++ b/static/app/views/settings/organizationProjects/index.spec.tsx
@@ -1,8 +1,8 @@
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {browserHistory} from 'sentry/utils/browserHistory';
 import OrganizationProjectsContainer from 'sentry/views/settings/organizationProjects';
 
 describe('OrganizationProjects', function () {
@@ -10,6 +10,7 @@ describe('OrganizationProjects', function () {
   let statsGetMock: jest.Mock;
   let projectsPutMock: jest.Mock;
   const project = ProjectFixture();
+  const router = RouterFixture();
 
   beforeEach(function () {
     projectsGetMock = MockApiClient.addMockResponse({
@@ -33,7 +34,7 @@ describe('OrganizationProjects', function () {
   });
 
   it('should render the projects in the store', async function () {
-    render(<OrganizationProjectsContainer />);
+    render(<OrganizationProjectsContainer />, {router});
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 
@@ -62,7 +63,7 @@ describe('OrganizationProjects', function () {
   });
 
   it('should search organization projects', async function () {
-    render(<OrganizationProjectsContainer />);
+    render(<OrganizationProjectsContainer />, {router});
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 
@@ -70,7 +71,7 @@ describe('OrganizationProjects', function () {
     await userEvent.type(searchBox, 'random');
 
     await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenLastCalledWith({
+      expect(router.replace).toHaveBeenLastCalledWith({
         pathname: '/mock-pathname/',
         query: {query: 'random'},
       });

--- a/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
@@ -11,11 +11,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import TeamSettings from 'sentry/views/settings/organizationTeams/teamSettings';
 
 describe('TeamSettings', function () {
-  const {routerProps} = initializeOrg();
+  const {router, routerProps} = initializeOrg();
 
   beforeEach(function () {
     TeamStore.reset();
@@ -37,7 +36,9 @@ describe('TeamSettings', function () {
       },
     });
 
-    render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />);
+    render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
+      router,
+    });
 
     const input = screen.getByRole('textbox', {name: 'Team Slug'});
 
@@ -56,7 +57,7 @@ describe('TeamSettings', function () {
     );
 
     await waitFor(() =>
-      expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect(router.replace).toHaveBeenCalledWith(
         '/settings/org-slug/teams/new-slug/settings/'
       )
     );
@@ -68,6 +69,7 @@ describe('TeamSettings', function () {
 
     render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
       organization,
+      router,
     });
 
     expect(screen.getByTestId('button-remove-team')).toBeDisabled();
@@ -81,13 +83,15 @@ describe('TeamSettings', function () {
     });
     TeamStore.loadInitialData([team]);
 
-    render(<TeamSettings {...routerProps} params={{teamId: team.slug}} team={team} />);
+    render(<TeamSettings {...routerProps} params={{teamId: team.slug}} team={team} />, {
+      router,
+    });
 
     // Click "Remove Team button
     await userEvent.click(screen.getByRole('button', {name: 'Remove Team'}));
 
     // Wait for modal
-    renderGlobalModal();
+    renderGlobalModal({router});
     await userEvent.click(screen.getByTestId('confirm-button'));
 
     expect(deleteMock).toHaveBeenCalledWith(
@@ -98,7 +102,7 @@ describe('TeamSettings', function () {
     );
 
     await waitFor(() =>
-      expect(browserHistory.replace).toHaveBeenCalledWith('/settings/org-slug/teams/')
+      expect(router.replace).toHaveBeenCalledWith('/settings/org-slug/teams/')
     );
 
     expect(TeamStore.getAll()).toEqual([]);
@@ -110,6 +114,7 @@ describe('TeamSettings', function () {
 
     render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
       organization,
+      router,
     });
 
     expect(

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -17,7 +17,6 @@ import selectEvent from 'sentry-test/selectEvent';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {removePageFiltersStorage} from 'sentry/components/organizations/pageFilters/persistence';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import ProjectContextProvider from 'sentry/views/projects/projectContext';
 import ProjectGeneralSettings from 'sentry/views/settings/projectGeneralSettings';
 
@@ -298,7 +297,7 @@ describe('projectGeneralSettings', function () {
           params={params}
         />
       </ProjectContextProvider>,
-      {organization}
+      {organization, router}
     );
 
     await userEvent.type(
@@ -313,7 +312,7 @@ describe('projectGeneralSettings', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Save'}));
 
     // Redirects the user
-    await waitFor(() => expect(browserHistory.replace).toHaveBeenCalled());
+    await waitFor(() => expect(router.replace).toHaveBeenCalled());
     expect(ProjectsStore.getById('2')!.slug).toBe('new-project');
   });
 


### PR DESCRIPTION
Instead consistently test that `router.{push,replace}` is called. This works even when the actual implementation is using browserHistory since we assign the same mocks that the router functions use to the browserHistory object.