### PR TITLE
chore(explore): Default to RPC behind feature flag

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
@@ -4,11 +4,11 @@ import {defined} from 'sentry/utils';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 
-export function defaultDataset(): DiscoverDatasets {
-  return DiscoverDatasets.SPANS_EAP;
+export function defaultDataset(): DiscoverDatasets | undefined {
+  return undefined;
 }
 
-export function getDatasetFromLocation(location: Location): DiscoverDatasets {
+export function getDatasetFromLocation(location: Location): DiscoverDatasets | undefined {
   const rawDataset = decodeScalar(location.query.dataset);
   return parseDataset(rawDataset);
 }
@@ -22,7 +22,11 @@ export function parseDataset(rawDataset: string | undefined) {
     return DiscoverDatasets.SPANS_EAP_RPC;
   }
 
-  return defaultDataset();
+  if (rawDataset === 'spans') {
+    return DiscoverDatasets.SPANS_EAP;
+  }
+
+  return undefined;
 }
 
 export function updateLocationWithDataset(

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -70,7 +70,7 @@ describe('PageParamsProvider', function () {
     );
 
     expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP,
+      dataset: undefined,
       fields: [
         'id',
         'project',

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -2,10 +2,12 @@ import type React from 'react';
 import {createContext, useCallback, useContext, useMemo} from 'react';
 import type {Location} from 'history';
 
+import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
-import type {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {
   defaultDataset,
@@ -34,7 +36,7 @@ import {
 } from './visualizes';
 
 interface ReadablePageParams {
-  dataset: DiscoverDatasets;
+  dataset: DiscoverDatasets | undefined;
   fields: string[];
   groupBys: string[];
   mode: Mode;
@@ -128,8 +130,16 @@ export function useExplorePageParams(): ReadablePageParams {
 }
 
 export function useExploreDataset(): DiscoverDatasets {
+  const organization = useOrganization();
   const pageParams = useExplorePageParams();
-  return pageParams.dataset;
+
+  if (defined(pageParams.dataset)) {
+    return pageParams.dataset;
+  }
+
+  return organization.features.includes('visibility-explore-rpc')
+    ? DiscoverDatasets.SPANS_EAP_RPC
+    : DiscoverDatasets.SPANS_EAP;
 }
 
 export function useExploreFields(): string[] {


### PR DESCRIPTION
This switches explore to use the RPC layer to make queries by default behind a feature flag.