### PR TITLE
feat(widget-builder): Add functionality to Legend Alias fields for filters

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -1,21 +1,24 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import type {Organization} from 'sentry/types/organization';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
-import {WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetBuilderQueryFilterBuilder from 'sentry/views/dashboards/widgetBuilder/components/queryFilterBuilder';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import useWidgetBuilderState from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
-jest.mock('sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState');
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
 
 describe('QueryFilterBuilder', () => {
+  let organization: Organization;
   beforeEach(() => {
-    jest.mocked(useWidgetBuilderState).mockReturnValue({
-      dispatch: jest.fn(),
-      state: {dataset: WidgetType.ERRORS},
+    organization = OrganizationFixture({
+      features: ['dashboards-widget-builder-redesign'],
     });
     jest.mocked(useCustomMeasurements).mockReturnValue({
       customMeasurements: {},
@@ -28,27 +31,68 @@ describe('QueryFilterBuilder', () => {
   });
 
   it('renders a dataset-specific query filter bar', async () => {
-    const {rerender} = render(
+    render(
       <WidgetBuilderProvider>
         <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
-      </WidgetBuilderProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              query: [],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
     );
     expect(
       await screen.findByPlaceholderText('Search for events, users, tags, and more')
     ).toBeInTheDocument();
 
-    jest.mocked(useWidgetBuilderState).mockReturnValue({
-      dispatch: jest.fn(),
-      state: {dataset: WidgetType.SPANS},
-    });
-
-    rerender(
+    render(
       <WidgetBuilderProvider>
         <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
-      </WidgetBuilderProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              query: [],
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
     );
     expect(
       await screen.findByPlaceholderText('Search for spans, users, tags, and more')
     ).toBeInTheDocument();
+  });
+
+  it('renders a legend alias input for charts', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              query: [],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(await screen.findByPlaceholderText('Legend Alias')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -151,7 +151,7 @@ function WidgetBuilderQueryFilterBuilder({
               type="text"
               name="name"
               placeholder={t('Legend Alias')}
-              value={state.legendAlias?.[index]}
+              value={state.legendAlias?.[index] || ''}
               onChange={e => {
                 dispatch({
                   type: BuilderStateAction.SET_LEGEND_ALIAS,

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -52,6 +52,11 @@ function WidgetBuilderQueryFilterBuilder({
       type: BuilderStateAction.SET_QUERY,
       payload: state.query?.length ? [...state.query, ''] : ['', ''],
     });
+
+    dispatch({
+      type: BuilderStateAction.SET_LEGEND_ALIAS,
+      payload: state.legendAlias?.length ? [...state.legendAlias, ''] : ['', ''],
+    });
   };
 
   const handleClose = useCallback(
@@ -80,8 +85,18 @@ function WidgetBuilderQueryFilterBuilder({
         type: BuilderStateAction.SET_QUERY,
         payload: state.query?.filter((_, i) => i !== queryIndex) ?? [],
       });
+      dispatch({
+        type: BuilderStateAction.SET_LEGEND_ALIAS,
+        payload: state.legendAlias?.filter((_, i) => i !== queryIndex) ?? [],
+      });
     },
-    [dispatch, queryConditionValidity, state.query, onQueryConditionChange]
+    [
+      dispatch,
+      queryConditionValidity,
+      state.query,
+      onQueryConditionChange,
+      state.legendAlias,
+    ]
   );
 
   const getOnDemandFilterWarning = createOnDemandFilterWarning(
@@ -106,12 +121,12 @@ function WidgetBuilderQueryFilterBuilder({
         }
         optional
       />
-      {!state.query?.length ? (
-        <QueryFieldRowWrapper key={0}>
+      {state.query?.map((_, index) => (
+        <QueryFieldRowWrapper key={index}>
           <datasetConfig.SearchBar
             getFilterWarning={
               shouldDisplayOnDemandWidgetWarning(
-                widget.queries[0],
+                widget.queries[index],
                 widgetType,
                 organization
               )
@@ -119,14 +134,15 @@ function WidgetBuilderQueryFilterBuilder({
                 : undefined
             }
             pageFilters={selection}
-            onClose={handleClose(0)}
+            onClose={handleClose(index)}
             onSearch={queryString => {
               dispatch({
                 type: BuilderStateAction.SET_QUERY,
-                payload: [queryString],
+                payload:
+                  state.query?.map((q, i) => (i === index ? queryString : q)) ?? [],
               });
             }}
-            widgetQuery={widget.queries[0]}
+            widgetQuery={widget.queries[index]}
             dataset={getDiscoverDatasetFromWidgetType(widgetType)}
           />
           {canAddSearchConditions && (
@@ -135,50 +151,22 @@ function WidgetBuilderQueryFilterBuilder({
               type="text"
               name="name"
               placeholder={t('Legend Alias')}
-              onChange={() => {}}
-            />
-          )}
-        </QueryFieldRowWrapper>
-      ) : (
-        state.query?.map((_, index) => (
-          <QueryFieldRowWrapper key={index}>
-            <datasetConfig.SearchBar
-              getFilterWarning={
-                shouldDisplayOnDemandWidgetWarning(
-                  widget.queries[index],
-                  widgetType,
-                  organization
-                )
-                  ? getOnDemandFilterWarning
-                  : undefined
-              }
-              pageFilters={selection}
-              onClose={handleClose(index)}
-              onSearch={queryString => {
+              value={state.legendAlias?.[index]}
+              onChange={e => {
                 dispatch({
-                  type: BuilderStateAction.SET_QUERY,
-                  payload:
-                    state.query?.map((q, i) => (i === index ? queryString : q)) ?? [],
+                  type: BuilderStateAction.SET_LEGEND_ALIAS,
+                  payload: state.legendAlias?.length
+                    ? state.legendAlias?.map((q, i) => (i === index ? e.target.value : q))
+                    : [e.target.value],
                 });
               }}
-              widgetQuery={widget.queries[index]}
-              dataset={getDiscoverDatasetFromWidgetType(widgetType)}
             />
-            {canAddSearchConditions && (
-              // TODO: Hook up alias to query hook when it's implemented
-              <LegendAliasInput
-                type="text"
-                name="name"
-                placeholder={t('Legend Alias')}
-                onChange={() => {}}
-              />
-            )}
-            {state.query && state.query?.length > 1 && canAddSearchConditions && (
-              <DeleteButton onDelete={handleRemove(index)} />
-            )}
-          </QueryFieldRowWrapper>
-        ))
-      )}
+          )}
+          {state.query && state.query?.length > 1 && canAddSearchConditions && (
+            <DeleteButton onDelete={handleRemove(index)} />
+          )}
+        </QueryFieldRowWrapper>
+      ))}
       {canAddSearchConditions && (
         <Button size="sm" icon={<IconAdd isCircled />} onClick={onAddSearchConditions}>
           {t('Add Filter')}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -102,6 +102,7 @@ function useWidgetBuilderState(): {
   const [query, setQuery] = useQueryParamState<string[]>({
     fieldName: 'query',
     decoder: decodeList,
+    deserializer: deserializeQuery,
   });
   const [sort, setSort] = useQueryParamState<Sort[]>({
     fieldName: 'sort',
@@ -313,6 +314,17 @@ function serializeSorts(sorts: Sort[]): string[] {
  */
 function deserializeLimit(value: string): number {
   return decodeInteger(value, DEFAULT_RESULTS_LIMIT);
+}
+
+/**
+ * Decodes the query from the query params
+ * Returns an array with an empty string if the query is empty
+ */
+function deserializeQuery(queries: string[]): string[] {
+  if (queries.length === 0) {
+    return [''];
+  }
+  return queries;
 }
 
 export default useWidgetBuilderState;


### PR DESCRIPTION
Now the legend alias field is functional and can be added to the widget preview legend as shown below. Also fixed the issue where the filter field wasn't working.

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/6b5e431b-463c-45ab-bcdc-4aae74223951" />

Closes https://github.com/getsentry/sentry/issues/82369

