### PR TITLE
feat(react19): Remove findDomNode in ContextPickerModal

### DIFF
--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -65,6 +65,7 @@ describe('ContextPickerModal', function () {
     render(getComponent());
 
     expect(screen.getByText('Select an Organization')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveFocus();
     expect(screen.queryByText('Select a Project to continue')).not.toBeInTheDocument();
   });
 
@@ -144,6 +145,7 @@ describe('ContextPickerModal', function () {
     // Should see 1 selected, and 1 as an option
     expect(screen.getAllByText('org-slug')).toHaveLength(2);
 
+    expect(screen.getByRole('textbox')).toHaveFocus();
     expect(await screen.findByText('My Projects')).toBeInTheDocument();
     expect(screen.getByText(project.slug)).toBeInTheDocument();
     expect(screen.getByText(project2.slug)).toBeInTheDocument();
@@ -180,6 +182,7 @@ describe('ContextPickerModal', function () {
 
     // Should not have anything selected
     expect(screen.getByText('Select an Organization')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveFocus();
 
     // Select org2
     await selectEvent.select(screen.getByText('Select an Organization'), org2.slug);

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -69,11 +69,7 @@ type Props = ModalRenderProps & {
 };
 
 function autoFocusReactSelect(reactSelectRef: any) {
-  if (!reactSelectRef) {
-    return;
-  }
-
-  reactSelectRef.select?.focus?.();
+  reactSelectRef?.select?.focus?.();
 }
 
 const selectStyles: StylesConfig = {

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,5 +1,4 @@
 import {Component, Fragment} from 'react';
-import {findDOMNode} from 'react-dom';
 import {components} from 'react-select';
 import styled from '@emotion/styled';
 import type {Query} from 'history';
@@ -69,6 +68,14 @@ type Props = ModalRenderProps & {
   allowAllProjectsSelection?: boolean;
 };
 
+function autoFocusReactSelect(reactSelectRef: any) {
+  if (!reactSelectRef) {
+    return;
+  }
+
+  reactSelectRef.select?.focus?.();
+}
+
 const selectStyles: StylesConfig = {
   menu: provided => ({
     ...provided,
@@ -115,12 +122,6 @@ class ContextPickerModal extends Component<Props> {
   }
 
   onFinishTimeout: number | undefined = undefined;
-
-  // TODO(ts) The various generics in react-select types make getting this
-  // right hard.
-  orgSelect: any | null = null;
-  projectSelect: any | null = null;
-  configSelect: any | null = null;
 
   // Performs checks to see if we need to prompt user
   // i.e. When there is only 1 org and no project is needed or
@@ -176,21 +177,6 @@ class ContextPickerModal extends Component<Props> {
       onFinish(
         typeof nextPath === 'string' ? newPathname : {...nextPath, pathname: newPathname}
       ) ?? undefined;
-  };
-
-  doFocus = (ref: any | null) => {
-    if (!ref || this.props.loading) {
-      return;
-    }
-
-    // eslint-disable-next-line react/no-find-dom-node
-    const el = findDOMNode(ref) as HTMLElement;
-
-    if (el !== null) {
-      const input = el.querySelector('input');
-
-      input?.focus();
-    }
   };
 
   handleSelectOrganization = ({value}: {value: string}) => {
@@ -316,10 +302,7 @@ class ContextPickerModal extends Component<Props> {
 
     return (
       <StyledSelectControl
-        ref={(ref: any) => {
-          this.projectSelect = ref;
-          this.doFocus(this.projectSelect);
-        }}
+        ref={autoFocusReactSelect}
         placeholder={t('Select a Project to continue')}
         name="project"
         options={projectOptions}
@@ -354,10 +337,7 @@ class ContextPickerModal extends Component<Props> {
     ];
     return (
       <StyledSelectControl
-        ref={(ref: any) => {
-          this.configSelect = ref;
-          this.doFocus(this.configSelect);
-        }}
+        ref={autoFocusReactSelect}
         placeholder={t('Select a configuration to continue')}
         name="configurations"
         options={options}
@@ -398,18 +378,14 @@ class ContextPickerModal extends Component<Props> {
 
     return (
       <Fragment>
-        <Header closeButton>{this.headerText}</Header>
+        <Header closeButton>
+          <h5>{this.headerText}</h5>
+        </Header>
         <Body>
           {loading && <StyledLoadingIndicator overlay />}
           {needOrg && (
             <StyledSelectControl
-              ref={(ref: any) => {
-                this.orgSelect = ref;
-                if (shouldShowProjectSelector) {
-                  return;
-                }
-                this.doFocus(this.orgSelect);
-              }}
+              ref={shouldShowProjectSelector ? undefined : autoFocusReactSelect}
               placeholder={t('Select an Organization')}
               name="organization"
               options={orgChoices}


### PR DESCRIPTION
since we only use the ref to focus, we can pass an autofocus function to the ref prop. Select has a focus that can be used.

the easiest way i've found to trigger this modal currently is clicking "inbound data filters" on [a bad query](https://sentry.sentry.io/issues/?project=1&project=11276&query=%22noresults%22&referrer=issue-list&sort=date&statsPeriod=24h&viewId=60235)

<img width="984" alt="image" src="https://github.com/user-attachments/assets/082d64fb-01c5-4a6d-ab7c-d493b07d826c" />

part of https://github.com/getsentry/frontend-tsc/issues/68