### PR TITLE
Account Notification Settings Input Issues (UI only)

### DIFF
--- a/static/app/components/forms/fields/selectField.tsx
+++ b/static/app/components/forms/fields/selectField.tsx
@@ -120,7 +120,8 @@ export default class SelectField<OptionType extends SelectValue<any>> extends Co
           placeholder,
           ...props
         }) => {
-          const showTempNoneOption = !multiple && !props.value;
+          const showTempNoneOption =
+            !multiple && (props.value === undefined || props.value === null);
 
           return (
             <Tooltip title={disabledReason} disabled={!disabled}>


### PR DESCRIPTION
False as a value in dropdown was causing unexpected behaviour

<!-- Describe your PR here. -->
Solves this issue : https://github.com/getsentry/sentry/issues/82508

Changed checks, The setting "Off" was internally represented with the value False, but the front-end logic did not properly handle this case.

Earlier : When selected value is Off text field shows "--"
![Screenshot 2024-12-29 at 5 13 46 PM](https://github.com/user-attachments/assets/634e1a55-aa36-4cee-9752-2192a7658440)
![Screenshot 2024-12-29 at 5 13 14 PM](https://github.com/user-attachments/assets/e7bccd89-acb3-4c16-b065-65d444de068d)


After Change
![Screenshot 2024-12-29 at 5 00 43 PM](https://github.com/user-attachments/assets/ecb81db1-d801-4207-aff1-199ee09462fc)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
