### PR TITLE
fix(insights): update to handle when there are no value segments provided to the score ring

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
@@ -76,14 +76,17 @@ function PerformanceScoreRing({
       const ringSegmentPadding = values.length > 1 ? PADDING : 0;
       // TODO: Hacky way to add padding to ring segments. Should clean this up so it's more accurate to the value.
       // This only mostly works because we expect values to be somewhere between 0 and 100.
-      const maxOffset =
-        (1 - Math.max(maxValue - ringSegmentPadding, 0) / sumMaxValues) * circumference;
-      const progressOffset =
-        (1 - Math.max(boundedValue - ringSegmentPadding, 0) / sumMaxValues) *
-        circumference;
+      const maxOffset = sumMaxValues
+        ? (1 - Math.max(maxValue - ringSegmentPadding, 0) / sumMaxValues) * circumference
+        : 0;
+      const progressOffset = sumMaxValues
+        ? (1 - Math.max(boundedValue - ringSegmentPadding, 0) / sumMaxValues) *
+          circumference
+        : 0;
       const rotate = currentRotate;
-      currentRotate += (360 * maxValue) / sumMaxValues;
-
+      if (sumMaxValues) {
+        currentRotate += (360 * maxValue) / sumMaxValues;
+      }
       const cx = radius + barWidth / 2;
 
       return [


### PR DESCRIPTION
Slight update to PerformanceScoreRing to better handle when no segments/values are passed to the component.