### PR TITLE
fix(dashboards): Turn off axis animation for `LineChartWidget` and `AreaChartWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization.tsx
@@ -180,6 +180,7 @@ export function AreaChartWidgetVisualization(props: AreaChartWidgetVisualization
         formatter,
       }}
       xAxis={{
+        animation: false,
         axisLabel: {
           padding: [0, 10, 0, 10],
           width: 60,
@@ -187,6 +188,7 @@ export function AreaChartWidgetVisualization(props: AreaChartWidgetVisualization
         splitNumber: 0,
       }}
       yAxis={{
+        animation: false,
         axisLabel: {
           formatter(value: number) {
             return formatYAxisValue(value, type, unit);

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -213,6 +213,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
         formatter,
       }}
       xAxis={{
+        animation: false,
         axisLabel: {
           padding: [0, 10, 0, 10],
           width: 60,
@@ -220,6 +221,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
         splitNumber: 0,
       }}
       yAxis={{
+        animation: false,
         axisLabel: {
           formatter(value: number) {
             return formatYAxisValue(value, type, unit);


### PR DESCRIPTION
Otherwise the numbers float around awkwardly when series are turned on and off.
