### PR TITLE
fix(update_groups): Handle group ids being the slugs

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -256,7 +256,9 @@ def update_groups_with_search_fn(
 ) -> Response:
     group_list = []
     if group_ids:
-        group_list = get_group_list(organization_id, projects, group_ids)
+        # Convert all group IDs to integers and filter out any non-integer values
+        group_ids_int = [int(gid) for gid in group_ids if str(gid).isdigit()]
+        group_list = get_group_list(organization_id, projects, group_ids_int)
 
     if not group_list:
         try:
@@ -308,7 +310,7 @@ def validate_request(
 def get_group_list(
     organization_id: int,
     projects: Sequence[Project],
-    group_ids: Sequence[int | str],
+    group_ids: Sequence[int],
 ) -> list[Group]:
     """
     Gets group list based on provided filters.

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -256,9 +256,7 @@ def update_groups_with_search_fn(
 ) -> Response:
     group_list = []
     if group_ids:
-        # Convert all group IDs to integers and filter out any non-integer values
-        group_ids_int = [int(gid) for gid in group_ids if str(gid).isdigit()]
-        group_list = get_group_list(organization_id, projects, group_ids_int)
+        group_list = get_group_list(organization_id, projects, group_ids)
 
     if not group_list:
         try:
@@ -310,7 +308,7 @@ def validate_request(
 def get_group_list(
     organization_id: int,
     projects: Sequence[Project],
-    group_ids: Sequence[int],
+    group_ids: Sequence[int | str],
 ) -> list[Group]:
     """
     Gets group list based on provided filters.
@@ -322,11 +320,21 @@ def get_group_list(
 
     Returns: List of Group objects filtered to only valid groups in the org/projects
     """
-    return list(
-        Group.objects.filter(
-            project__organization_id=organization_id, project__in=projects, id__in=group_ids
+    groups = []
+    # Convert all group IDs to integers and filter out any non-integer values
+    group_ids_int = [int(gid) for gid in group_ids if str(gid).isdigit()]
+    if group_ids_int:
+        return list(
+            Group.objects.filter(
+                project__organization_id=organization_id, project__in=projects, id__in=group_ids_int
+            )
         )
-    )
+    else:
+        for group_id in group_ids:
+            if isinstance(group_id, str):
+                groups.append(Group.objects.by_qualified_short_id(organization_id, group_id))
+
+    return groups
 
 
 def handle_resolve_in_release(


### PR DESCRIPTION
The UI sends the group slugs rather than the group IDs. In such a case, do not call `get_group_list` and allow using the search function.

This issue was discovered in [this PR comment](https://github.com/getsentry/sentry/pull/82245#issuecomment-2556471208)

From oldest to newest (since I have been doing refactorings):
- [SENTRY-11B2](https://sentry.sentry.io/issues/4186505988/)
- [SENTRY-3K08](https://sentry.sentry.io/issues/6112609094/)
- [SENTRY-3KHH](https://sentry.sentry.io/issues/6136579423/)
- [SENTRY-3KT1](https://sentry.sentry.io/issues/6163780463/)

<img width="736" alt="image" src="https://github.com/user-attachments/assets/a32caf08-ea72-4a56-9b27-c91d0ec0d783" />
