### PR TITLE
chore(devservices): Bump devservices version to 1.0.7

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -37,7 +37,7 @@ cryptography==43.0.1
 cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
-devservices==1.0.6
+devservices==1.0.7
 distlib==0.3.8
 distro==1.8.0
 django==5.1.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 sentry-devenv>=1.14.2
-devservices>=1.0.6
+devservices>=1.0.7
 
 covdefaults>=2.3.0
 sentry-covdefaults-disable-branch-coverage>=1.0.2


### PR DESCRIPTION
Bumps devservices to 1.0.7

Picks up https://github.com/getsentry/devservices/releases/tag/1.0.7