### PR TITLE
fix(alerts): updates span alerts image

### DIFF
--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -192,6 +192,6 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
       t('When your average time in queue exceeds 100ms.'),
       t('When your app runs more than 1000 queries in a minute.'),
     ],
-    illustration: diagramCustomMetrics,
+    illustration: diagramThroughput,
   },
 };


### PR DESCRIPTION
Updates the span alerts image in the alert creation wizard to use to throughput graphic, instead of the old metrics code snippet.