### PR TITLE
chore(issues): Add a couple of simple missing type annotations

### DIFF
--- a/src/sentry/issues/endpoints/group_similar_issues.py
+++ b/src/sentry/issues/endpoints/group_similar_issues.py
@@ -25,7 +25,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         features = similarity.features
 
         limit_s = request.GET.get("limit", None)
@@ -54,13 +54,13 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         # We need to preserve the ordering of the Redis results, as that
         # ordering is directly shown in the UI
         for group_id, scores in zip(group_ids, group_scores):
-            group = serialized_groups.get(group_id)
-            if group is None:
+            serialized_group = serialized_groups.get(group_id)
+            if serialized_group is None:
                 # TODO(tkaemming): This should log when we filter out a group that is
                 # unable to be retrieved from the database. (This will soon be
                 # unexpected behavior, but still possible.)
                 continue
 
-            results.append((group, {_fix_label(k): v for k, v in scores.items()}))
+            results.append((serialized_group, {_fix_label(k): v for k, v in scores.items()}))
 
         return Response(results)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -429,6 +429,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         assert links["previous"]["results"] == "false"
         assert links["next"]["results"] == "true"
+        assert links["next"]["href"] is not None
 
         response = self.client.get(links["next"]["href"], format="json")
         assert response.status_code == 200

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3989,10 +3989,10 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert int(issue["id"]) != feedback_group.id
         assert issue["issueCategory"] != "feedback"
 
-    def test_feedback_filtered_by_default_no_snuba_search(self) -> None:
+    def test_feedback_filtered_by_default_no_snuba_search(self, _: MagicMock) -> None:
         self.run_feedback_filtered_by_default_test(False)
 
-    def test_feedback_filtered_by_default_use_snuba_search(self) -> None:
+    def test_feedback_filtered_by_default_use_snuba_search(self, _: MagicMock) -> None:
         self.run_feedback_filtered_by_default_test(True)
 
     def run_feedback_category_filter_test(self, use_group_snuba_dataset: bool) -> None:
@@ -4025,10 +4025,10 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert int(issue["id"]) == feedback_group.id
         assert issue["issueCategory"] == "feedback"
 
-    def test_feedback_category_filter_no_snuba_search(self) -> None:
+    def test_feedback_category_filter_no_snuba_search(self, _: MagicMock) -> None:
         self.run_feedback_category_filter_test(False)
 
-    def test_feedback_category_filter_use_snuba_search(self) -> None:
+    def test_feedback_category_filter_use_snuba_search(self, _: MagicMock) -> None:
         self.run_feedback_category_filter_test(True)
 
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -83,7 +83,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def _parse_links(self, header):
+    def _parse_links(self, header: str) -> dict[str | None, dict[str, str | None]]:
         # links come in {url: {...attrs}}, but we need {rel: {...attrs}}
         links = {}
         for url, attrs in parse_link_header(header).items():
@@ -165,7 +165,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         )
         self.login_as(user=self.user)
 
-        aggregate_kwargs: dict = {
+        aggregate_kwargs: dict[str, str] = {
             "log_level": "3",
             "has_stacktrace": "5",
             "relative_volume": "1",
@@ -3804,7 +3804,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["inbox"]["reason"] == GroupInboxReason.NEW.value
 
     @patch("sentry.analytics.record")
-    def test_snuba_heavy_advanced_search_errors(self, mock_record: MagicMock, _: MagicMock):
+    def test_snuba_heavy_advanced_search_errors(self, mock_record: MagicMock, _: MagicMock) -> None:
         self.login_as(user=self.user)
         response = self.get_response(sort_by="date", query="!has:user")
         assert response.status_code == 200, response.data
@@ -3961,7 +3961,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert len(response_handled_0.data) == 1
         assert int(response_handled_0.data[0]["id"]) == handled_event.group.id
 
-    def run_feedback_filtered_by_default_test(self, use_group_snuba_dataset: bool):
+    def run_feedback_filtered_by_default_test(self, use_group_snuba_dataset: bool) -> None:
         with Feature(
             {
                 FeedbackGroup.build_visible_feature_name(): True,
@@ -3989,13 +3989,13 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert int(issue["id"]) != feedback_group.id
         assert issue["issueCategory"] != "feedback"
 
-    def test_feedback_filtered_by_default_no_snuba_search(self, _):
+    def test_feedback_filtered_by_default_no_snuba_search(self) -> None:
         self.run_feedback_filtered_by_default_test(False)
 
-    def test_feedback_filtered_by_default_use_snuba_search(self, _):
+    def test_feedback_filtered_by_default_use_snuba_search(self) -> None:
         self.run_feedback_filtered_by_default_test(True)
 
-    def run_feedback_category_filter_test(self, use_group_snuba_dataset: bool):
+    def run_feedback_category_filter_test(self, use_group_snuba_dataset: bool) -> None:
         with Feature(
             {
                 FeedbackGroup.build_visible_feature_name(): True,
@@ -4025,10 +4025,10 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert int(issue["id"]) == feedback_group.id
         assert issue["issueCategory"] == "feedback"
 
-    def test_feedback_category_filter_no_snuba_search(self, _):
+    def test_feedback_category_filter_no_snuba_search(self) -> None:
         self.run_feedback_category_filter_test(False)
 
-    def test_feedback_category_filter_use_snuba_search(self, _):
+    def test_feedback_category_filter_use_snuba_search(self) -> None:
         self.run_feedback_category_filter_test(True)
 
 

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -72,7 +72,7 @@ class OccurrenceTestMixin:
         return IssueOccurrence.from_dict(self.build_occurrence_data(**overrides))
 
     def process_occurrence(
-        self, event_data: dict[str, Any], **overrides
+        self, event_data: dict[str, Any], **overrides: Any
     ) -> tuple[IssueOccurrence, GroupInfo | None]:
         """
         Testutil to build and process occurrence data instead of going through Kafka.


### PR DESCRIPTION
A couple of very easy fixes - this gets us down to 4 remaining errors before `tests.sentry.issues.*` can be fully opted into the stronger typing list.