### PR TITLE
ref(ui):  use toSpliced in replaceAtArray

### DIFF
--- a/static/app/utils/array/removeAtArrayIndex.tsx
+++ b/static/app/utils/array/removeAtArrayIndex.tsx
@@ -1,8 +1,6 @@
 /**
  * Remove item at `index` in `array` without mutating `array`
  */
-export default function removeAtArrayIndex<T>(array: T[], index: number): T[] {
-  const newArray = [...array];
-  newArray.splice(index, 1);
-  return newArray;
+export default function removeAtArrayIndex<T>(array: Readonly<T[]>, index: number): T[] {
+  return array.toSpliced(index, 1);
 }

--- a/static/app/utils/array/replaceAtArrayIndex.tsx
+++ b/static/app/utils/array/replaceAtArrayIndex.tsx
@@ -1,8 +1,10 @@
 /**
- * Replace item at `index` in `array` with `obj`
+ * Replace item at `index` in `array` with `obj` without mutating `array`
  */
-export default function replaceAtArrayIndex<T>(array: T[], index: number, obj: T): T[] {
-  const newArray = [...array];
-  newArray.splice(index, 1, obj);
-  return newArray;
+export default function replaceAtArrayIndex<T>(
+  array: Readonly<T[]>,
+  index: number,
+  obj: T
+): T[] {
+  return array.toSpliced(index, 1, obj);
 }


### PR DESCRIPTION
toSpliced is polyfilled in browsers via babel / browserslist

mdn - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced