### PR TITLE
fix(uptime): Audit when uptime monitors are auto created

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -6,7 +6,7 @@ from urllib.robotparser import RobotFileParser
 
 from django.utils import timezone
 
-from sentry import features
+from sentry import audit_log, features
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -22,7 +22,7 @@ from sentry.uptime.detectors.ranking import (
     should_detect_for_organization,
     should_detect_for_project,
 )
-from sentry.uptime.models import ProjectUptimeSubscriptionMode
+from sentry.uptime.models import ProjectUptimeSubscription, ProjectUptimeSubscriptionMode
 from sentry.uptime.subscriptions.subscriptions import (
     delete_uptime_subscriptions_for_project,
     get_auto_monitored_subscriptions_for_project,
@@ -30,6 +30,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     is_url_auto_monitored_for_project,
 )
 from sentry.utils import metrics
+from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.hashlib import md5_text
 from sentry.utils.locking import UnableToAcquireLock
 
@@ -221,16 +222,23 @@ def process_candidate_url(
     )
     if features.has("organizations:uptime-automatic-subscription-creation", project.organization):
         # If we hit this point, then the url looks worth monitoring. Create an uptime subscription in monitor mode.
-        monitor_url_for_project(project, url)
+        uptime_monitor = monitor_url_for_project(project, url)
         # Disable auto-detection on this project and organization now that we've successfully found a hostname
         project.update_option("sentry:uptime_autodetection", False)
         project.organization.update_option("sentry:uptime_autodetection", False)
+        create_audit_entry_from_user(
+            user=None,
+            organization=project.organization,
+            target_object=uptime_monitor.id,
+            event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
+            data=uptime_monitor.get_audit_log_data(),
+        )
 
     metrics.incr("uptime.detectors.candidate_url.succeeded", sample_rate=1.0)
     return True
 
 
-def monitor_url_for_project(project: Project, url: str):
+def monitor_url_for_project(project: Project, url: str) -> ProjectUptimeSubscription:
     """
     Start monitoring a url for a project. Creates a subscription using our onboarding interval and links the project to
     it. Also deletes any other auto-detected monitors since this one should replace them.
@@ -244,7 +252,8 @@ def monitor_url_for_project(project: Project, url: str):
                 ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
             ],
         )
-    get_or_create_project_uptime_subscription(
+    metrics.incr("uptime.detectors.candidate_url.monitor_created", sample_rate=1.0)
+    return get_or_create_project_uptime_subscription(
         project,
         # TODO(epurkhiser): This is where we would put the environment object
         # from autodetection if we decide to do that.
@@ -253,8 +262,7 @@ def monitor_url_for_project(project: Project, url: str):
         interval_seconds=ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS,
         timeout_ms=ONBOARDING_SUBSCRIPTION_TIMEOUT_MS,
         mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
-    )
-    metrics.incr("uptime.detectors.candidate_url.monitor_created", sample_rate=1.0)
+    )[0]
 
 
 def is_failed_url(url: str) -> bool:


### PR DESCRIPTION
We don't add an audit log when an uptime monitor is auto created, so fixing that.

<!-- Describe your PR here. -->