### PR TITLE
ref(settings): Clean up  unused notifications constants

### DIFF
--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -1,29 +1,6 @@
-import {t} from 'sentry/locale';
-
-export const ALL_PROVIDERS = {
-  email: 'default',
-  slack: 'never',
-  msteams: 'never',
-};
-export const ALL_PROVIDER_NAMES = Object.keys(ALL_PROVIDERS);
-
-/**
- * These values are stolen from the DB.
- */
-export const VALUE_MAPPING = {
-  default: 0,
-  never: 10,
-  always: 20,
-  subscribe_only: 30,
-  committed_only: 40,
-};
-
 export const SUPPORTED_PROVIDERS = ['email', 'slack', 'msteams'] as const;
 export type SupportedProviders = (typeof SUPPORTED_PROVIDERS)[number];
 
-export const MIN_PROJECTS_FOR_CONFIRMATION = 3;
-export const MIN_PROJECTS_FOR_SEARCH = 3;
-export const MIN_PROJECTS_FOR_PAGINATION = 100;
 export type ProviderValue = 'always' | 'never';
 
 interface NotificationBaseObject {
@@ -47,25 +24,22 @@ export interface DefaultSettings {
   typeDefaults: Record<string, ProviderValue>;
 }
 
-export const NOTIFICATION_SETTINGS_TYPES = [
-  'alerts',
-  'workflow',
-  'deploy',
-  'approval',
-  'quota',
-  'reports',
-  'email',
-  'spikeProtection',
-  'brokenMonitors',
-] as const;
-
 export const SELF_NOTIFICATION_SETTINGS_TYPES = [
   'personalActivityNotifications',
   'selfAssignOnResolve',
 ];
 
 // 'alerts' | 'workflow' ...
-export type NotificationSettingsType = (typeof NOTIFICATION_SETTINGS_TYPES)[number];
+type NotificationSettingsType =
+  | 'alerts'
+  | 'workflow'
+  | 'deploy'
+  | 'approval'
+  | 'quota'
+  | 'reports'
+  | 'email'
+  | 'spikeProtection'
+  | 'brokenMonitors';
 
 export const NOTIFICATION_SETTINGS_PATHNAMES: Record<NotificationSettingsType, string> = {
   alerts: 'alerts',
@@ -78,19 +52,6 @@ export const NOTIFICATION_SETTINGS_PATHNAMES: Record<NotificationSettingsType, s
   spikeProtection: 'spike-protection',
   brokenMonitors: 'broken-monitors',
 };
-
-export const CONFIRMATION_MESSAGE = (
-  <div>
-    <p style={{marginBottom: '20px'}}>
-      <strong>Are you sure you want to disable these notifications?</strong>
-    </p>
-    <p>
-      {t(
-        'Turning this off will irreversibly overwrite all of your fine-tuning settings to "off".'
-      )}
-    </p>
-  </div>
-);
 
 export const NOTIFICATION_FEATURE_MAP: Partial<
   Record<NotificationSettingsType, string | Array<string>>

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -24,22 +24,25 @@ export interface DefaultSettings {
   typeDefaults: Record<string, ProviderValue>;
 }
 
+export const NOTIFICATION_SETTINGS_TYPES = [
+  'alerts',
+  'workflow',
+  'deploy',
+  'approval',
+  'quota',
+  'reports',
+  'email',
+  'spikeProtection',
+  'brokenMonitors',
+] as const;
+
 export const SELF_NOTIFICATION_SETTINGS_TYPES = [
   'personalActivityNotifications',
   'selfAssignOnResolve',
 ];
 
 // 'alerts' | 'workflow' ...
-type NotificationSettingsType =
-  | 'alerts'
-  | 'workflow'
-  | 'deploy'
-  | 'approval'
-  | 'quota'
-  | 'reports'
-  | 'email'
-  | 'spikeProtection'
-  | 'brokenMonitors';
+type NotificationSettingsType = (typeof NOTIFICATION_SETTINGS_TYPES)[number];
 
 export const NOTIFICATION_SETTINGS_PATHNAMES: Record<NotificationSettingsType, string> = {
   alerts: 'alerts',

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -474,7 +474,7 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
 
 export default withOrganizations(NotificationSettingsByTypeV2);
 
-export const TopJsonForm = styled(JsonForm)`
+const TopJsonForm = styled(JsonForm)`
   ${Panel} {
     border-bottom: 0;
     margin-bottom: 0;
@@ -483,7 +483,7 @@ export const TopJsonForm = styled(JsonForm)`
   }
 `;
 
-export const BottomJsonForm = styled(JsonForm)`
+const BottomJsonForm = styled(JsonForm)`
   ${Panel} {
     border-top-right-radius: 0;
     border-top-left-radius: 0;


### PR DESCRIPTION
mostly unused constants, one was a `const` that was only used as a type
