### PR TITLE
ref(integrations): integration webhook endpoint ABC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,6 @@ module = [
     "sentry.integrations.jira.integration",
     "sentry.integrations.jira.views.base",
     "sentry.integrations.jira.webhooks.base",
-    "sentry.integrations.jira.webhooks.issue_updated",
     "sentry.integrations.jira_server.client",
     "sentry.integrations.jira_server.integration",
     "sentry.integrations.metric_alerts",

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -57,7 +57,7 @@ class JiraWebhookBase(Generic[T, U], IntegrationWebhookEndpoint[T, U], ABC):
         ):
             logger.info(
                 "Atlassian Connect Security Request Tester tried disallowed method",
-                extra=self.log_extra,
+                extra={"path": request.path, "method": request.method},
             )
             return self.respond(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from collections.abc import MutableMapping
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Generic, TypeVar
 
 from psycopg2 import OperationalError
 from rest_framework import status
@@ -18,12 +18,15 @@ from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+U = TypeVar("U")
+
 
 class JiraTokenError(Exception):
     pass
 
 
-class JiraWebhookBase(IntegrationWebhookEndpoint, ABC):
+class JiraWebhookBase(Generic[T, U], IntegrationWebhookEndpoint[T, U], ABC):
     """
     Base class for webhooks used in the Jira integration
     """
@@ -34,7 +37,7 @@ class JiraWebhookBase(IntegrationWebhookEndpoint, ABC):
         self,
         request: Request,
         exc: Exception,
-        handler_context: MutableMapping[str, Any] | None = None,
+        handler_context: Mapping[str, Any] | None = None,
         scope: Scope | None = None,
     ) -> Response:
         handler_context = handler_context or {}

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -18,12 +18,12 @@ from .base import JiraWebhookBase
 
 
 @control_silo_endpoint
-class JiraSentryInstalledWebhook(JiraWebhookBase):
+class JiraSentryInstalledWebhook(JiraWebhookBase[None, dict[str, Any] | None]):
     """
     Webhook hit by Jira whenever someone installs the Sentry integration in their Jira instance.
     """
 
-    def authenticate(self, request: Request, **kwargs) -> Any:
+    def authenticate(self, request: Request, **kwargs) -> None:
         token = self.get_token(request)
 
         key_id = jwt.peek_header(token).get("kid")
@@ -31,7 +31,7 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
             decoded_claims = authenticate_asymmetric_jwt(token, key_id)
             verify_claims(decoded_claims, request.path, request.GET, method="POST")
 
-    def unpack_payload(self, request: Request, **kwargs) -> Any:
+    def unpack_payload(self, request: Request, **kwargs) -> dict[str, Any] | None:
         state = request.data
         if not state:
             kwargs["lifecycle"].record_failure(

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
-class JiraIssueUpdatedWebhook(JiraWebhookBase):
+class JiraIssueUpdatedWebhook(JiraWebhookBase[RpcIntegration, dict[str, Any] | None]):
     """
     Webhook hit by Jira whenever an issue is updated in Jira's database.
     """
@@ -39,7 +39,7 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         )
         return rpc_integration
 
-    def unpack_payload(self, request: Request, **kwargs) -> Any:
+    def unpack_payload(self, request: Request, **kwargs) -> dict[str, Any] | None:
         data = request.data
         if not data.get("changelog"):
             self.log_extra["integration_id"] = kwargs["rpc_integration"].id

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,17 +8,20 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
 from sentry.integrations.utils.scope import bind_org_context_from_integration
+from sentry.integrations.webhook import IntegrationWebhookEndpoint
 
 from .base import JiraWebhookBase
 
 
 @control_silo_endpoint
-class JiraSentryUninstalledWebhook(JiraWebhookBase):
+class JiraSentryUninstalledWebhook(
+    JiraWebhookBase, IntegrationWebhookEndpoint[RpcIntegration, None]
+):
     """
     Webhook hit by Jira whenever someone uninstalls the Sentry integration from their Jira instance.
     """
 
-    def authenticate(self, request: Request, **kwargs) -> Any:
+    def authenticate(self, request: Request, **kwargs) -> RpcIntegration:
         token = self.get_token(request)
         rpc_integration = get_integration_from_jwt(
             token=token,
@@ -31,7 +32,7 @@ class JiraSentryUninstalledWebhook(JiraWebhookBase):
         )
         return rpc_integration
 
-    def unpack_payload(self, request: Request, **kwargs) -> Any:
+    def unpack_payload(self, request: Request, **kwargs) -> None:
         # unused
         return None
 

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -1,12 +1,13 @@
+from typing import Any
+
 import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.api_owners import ApiOwner
-from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
 from sentry.integrations.utils.scope import bind_org_context_from_integration
 
@@ -15,15 +16,11 @@ from .base import JiraWebhookBase
 
 @control_silo_endpoint
 class JiraSentryUninstalledWebhook(JiraWebhookBase):
-    owner = ApiOwner.INTEGRATIONS
-    publish_status = {
-        "POST": ApiPublishStatus.PRIVATE,
-    }
     """
     Webhook hit by Jira whenever someone uninstalls the Sentry integration from their Jira instance.
     """
 
-    def post(self, request: Request, *args, **kwargs) -> Response:
+    def authenticate(self, request: Request, **kwargs) -> Any:
         token = self.get_token(request)
         rpc_integration = get_integration_from_jwt(
             token=token,
@@ -32,6 +29,16 @@ class JiraSentryUninstalledWebhook(JiraWebhookBase):
             query_params=request.GET,
             method="POST",
         )
+        return rpc_integration
+
+    def unpack_payload(self, request: Request, **kwargs) -> Any:
+        # unused
+        return None
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        rpc_integration = self.authenticate(request)
+        assert isinstance(rpc_integration, RpcIntegration)
+
         integration = Integration.objects.get(id=rpc_integration.id)
         bind_org_context_from_integration(integration.id, {"webhook": "uninstalled"})
         sentry_sdk.set_tag("integration_id", integration.id)

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -76,8 +76,10 @@ class JiraServerIssueUpdatedWebhook(IntegrationWebhookEndpoint):
 
         return data
 
-    def post(self, request: Request, token, *args, **kwargs) -> Response:
+    def post(self, request: Request, *args, **kwargs) -> Response:
         clear_tags_and_context()
+
+        token = kwargs["token"]  # URL param
         integration = self.authenticate(request, token=token)
 
         data = self.unpack_payload(request)

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -58,10 +58,10 @@ class JiraServerIssueUpdatedWebhook(IntegrationWebhookEndpoint):
             integration = get_integration_from_token(token)
             self.log_extra["integration_id"] = integration.id
         except ValueError as err:
-            self.log_extra.update({"token": token, "error": str(err)})
+            self.log_extra["error"] = str(err)
             logger.warning("token-validation-error", extra=self.log_extra)
             metrics.incr("jira_server.webhook.invalid_token")
-            raise BadRequest()
+            raise BadRequest("Invalid token")
 
         return integration
 
@@ -90,7 +90,7 @@ class JiraServerIssueUpdatedWebhook(IntegrationWebhookEndpoint):
             handle_assignee_change(integration, data)
             handle_status_change(integration, data)
         except (ApiError, ObjectDoesNotExist) as err:
-            self.log_extra.update({"token": token, "error": str(err)})
+            self.log_extra["error"] = str(err)
             logger.info("sync-failed", extra=self.log_extra)
             logger.exception("Invalid token.")
             return self.respond(status=400)

--- a/src/sentry/integrations/webhook.py
+++ b/src/sentry/integrations/webhook.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Generic, TypeVar
 
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
@@ -12,8 +12,11 @@ from sentry.api.base import Endpoint
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+U = TypeVar("U")
 
-class IntegrationWebhookEndpoint(Endpoint, ABC):
+
+class IntegrationWebhookEndpoint(Endpoint, Generic[T, U], ABC):
     owner = ApiOwner.ECOSYSTEM
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
@@ -32,11 +35,11 @@ class IntegrationWebhookEndpoint(Endpoint, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def unpack_payload(self, request: Request, **kwargs) -> Any:
+    def authenticate(self, request: Request, **kwargs) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def authenticate(self, request: Request, **kwargs) -> Any:
+    def unpack_payload(self, request: Request, **kwargs) -> U:
         raise NotImplementedError
 
     @csrf_exempt

--- a/src/sentry/integrations/webhook.py
+++ b/src/sentry/integrations/webhook.py
@@ -1,0 +1,52 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationWebhookEndpoint(Endpoint, ABC):
+    owner = ApiOwner.ECOSYSTEM
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    authentication_classes = ()
+    permission_classes = ()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.log_extra = {}
+
+    @property
+    @abstractmethod
+    def provider(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def unpack_payload(self, request: Request, **kwargs) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def authenticate(self, request: Request, **kwargs) -> Any:
+        raise NotImplementedError
+
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        self.log_extra.update(
+            {"request_method": self.request.method, "request_path": self.request.path}
+        )
+        return response
+
+    @abstractmethod
+    def post(self, request: Request, **kwargs) -> Response:
+        raise NotImplementedError

--- a/src/sentry/integrations/webhook.py
+++ b/src/sentry/integrations/webhook.py
@@ -45,9 +45,7 @@ class IntegrationWebhookEndpoint(Endpoint, Generic[T, U], ABC):
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)
-        self.log_extra.update(
-            {"request_method": self.request.method, "request_path": self.request.path}
-        )
+        self.log_extra = {"request_method": self.request.method, "request_path": self.request.path}
         return response
 
     @abstractmethod

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -75,9 +75,12 @@ class JiraInstalledTest(APITestCase):
         )
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_failure")
+    @responses.activate
     def test_missing_body(self, mock_record_failure):
+        self.add_response()
+
         self.get_error_response(
-            extra_headers=dict(HTTP_AUTHORIZATION="JWT anexampletoken"),
+            extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import responses
 from django.test.utils import override_settings
 from rest_framework import status
 from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from fixtures.integrations.stub_service import StubService
@@ -200,6 +202,15 @@ class MockErroringJiraEndpoint(JiraWebhookBase):
 
     def get(self, request):
         raise self.error
+
+    def authenticate(self, request: Request, **kwargs) -> Any:
+        return None
+
+    def unpack_payload(self, request: Request, **kwargs) -> Any:
+        return None
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        return Response()
 
 
 class JiraWebhookBaseTest(TestCase):

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -186,7 +186,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
             self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
 
 
-class MockErroringJiraEndpoint(JiraWebhookBase):
+class MockErroringJiraEndpoint(JiraWebhookBase[Any, Any]):
     permission_classes = ()
     dummy_exception = Exception("whoops")
     # In order to be able to use `as_view`'s `initkwargs` (in other words, in order to be able to


### PR DESCRIPTION
Begin tying together the various integration webhook endpoints. Jira differs from the others in that it has an API for each event. It still has the same basic layout of:
1) Authenticating the incoming event
2) Unpacking the payload
3) Custom logic to address the payload

So the first 2 can be encapsulated in a shared base class.