### PR TITLE
🔧 chore: remove redundant slack logging & metrics

### DIFF
--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -60,18 +60,15 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
                     client.send_message(channel_id, message, notification_uuid=notification_uuid)
                 except Exception as e:
                     # TODO(iamrajjoshi): Update some of these failures to halts
-                    lifecycle.record_failure(e)
-                    # TODO(iamrajjoshi): Remove the logger after we audit lifecycle
-                    self.logger.error(
-                        "discord.notification.message_send_failure",
-                        extra={
-                            "error": str(e),
+                    lifecycle.add_extras(
+                        {
                             "project_id": event.project_id,
                             "event_id": event.event_id,
                             "guild_id": integration.external_id,
                             "channel_id": channel_id,
-                        },
+                        }
                     )
+                    lifecycle.record_failure(e)
 
             rule = rules[0] if rules else None
             self.record_notification_sent(event, channel_id, rule, notification_uuid)

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -64,11 +64,12 @@ def send_incident_alert_notification(
             client.send_message(channel, message)
         except Exception as error:
             # TODO(iamrajjoshi): Update some of these failures to halts
-            lifecycle.record_failure(error)
-            # TODO(iamrajjoshi): Remove the logger after we audit lifecycle
-            logger.warning(
-                "discord.metric_alert.message_send_failure",
-                extra={"error": error, "incident_id": incident.id, "channel_id": channel},
+            lifecycle.add_extras(
+                {
+                    "incident_id": incident.id,
+                    "channel_id": channel,
+                }
             )
+            lifecycle.record_failure(error)
             return False
         return True

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -460,8 +460,6 @@ class DatabaseBackedIntegrationService(IntegrationService):
                 client.send_card(channel, attachment)
                 return True
             except Exception as e:
-                # TODO(iamrajjoshi): Remove the logger after we audit lifecycle
-                logger.info("rule.fail.msteams_post", exc_info=True)
                 lifecycle.add_extras({"integration_id": integration_id, "channel": channel})
                 lifecycle.record_failure(e)
             return False

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -10,9 +10,6 @@ from sentry.integrations.utils.metrics import EventLifecycle
 
 SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.success"
 SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.failure"
-SLACK_ACTIVITY_THREAD_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.activity_thread.success"
-SLACK_ACTIVITY_THREAD_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.activity_thread.failure"
-SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.success"
 SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.failure"
 SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.notify_recipient.success"
 SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.notify_recipient.failure"

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -10,9 +10,6 @@ from sentry.integrations.utils.metrics import EventLifecycle
 
 SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.success"
 SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.failure"
-SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.metric_alert.failure"
-SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.notify_recipient.success"
-SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.notify_recipient.failure"
 
 # Webhooks
 SLACK_WEBHOOK_DM_ENDPOINT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.dm_endpoint.success"

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -275,7 +275,11 @@ class SlackService:
                     {
                         "rule_action_uuid": parent_notification.rule_action_uuid,
                         "channel_id": channel_id,
-                        "thread_ts": parent_notification.message_identifier,
+                        "thread_ts": (
+                            str(parent_notification.message_identifier)
+                            if parent_notification.message_identifier
+                            else ""
+                        ),
                     }
                 )
                 record_lifecycle_termination_level(lifecycle, e)

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -12,10 +12,6 @@ from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident, IncidentStatus, IncidentStatusMethod
 from sentry.integrations.messaging.spec import MessagingActionHandler
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
-from sentry.integrations.slack.metrics import (
-    SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC,
-    SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC,
-)
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.options.organization_option import OrganizationOption
@@ -122,10 +118,6 @@ class SlackActionHandlerTest(FireTest):
         self._assert_blocks(mock_post, incident, 1000, chart_url)
 
         assert NotificationMessage.objects.all().count() == 1
-        mock_metrics.incr.assert_called_with(
-            SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC,
-            sample_rate=1.0,
-        )
 
         assert len(mock_record.mock_calls) == 4
         thread_ts_start, thread_ts_success, send_notification_start, send_notification_success = (
@@ -146,12 +138,6 @@ class SlackActionHandlerTest(FireTest):
         assert msg.error_code == 200
         assert msg.error_details is not None
         assert msg.error_details["data"] == {"ok": False, "error": "invalid_auth"}
-
-        mock_metrics.incr.assert_called_with(
-            SLACK_METRIC_ALERT_FAILURE_DATADOG_METRIC,
-            sample_rate=1.0,
-            tags={"ok": False, "status": 200},
-        )
 
         assert len(mock_record.mock_calls) == 4
         thread_ts_start, thread_ts_failure, send_notification_start, send_notification_failure = (

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -15,7 +15,6 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.silo.base import SiloMode
-from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -161,7 +160,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @mock.patch("sentry.integrations.slack.service.SlackService._handle_parent_notification")
-    def test_calls_handle_parent_notification_sdk_client(self, mock_handle, mock_record):
+    def test_calls_handle_parent_notification(self, mock_handle, mock_record):
         parent_notification = IssueAlertNotificationMessage.from_model(
             instance=self.parent_notification
         )
@@ -173,7 +172,12 @@ class TestNotifyAllThreadsForActivity(TestCase):
         # check client type
         assert isinstance(mock_handle.call_args.kwargs["client"], SlackSdkClient)
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+        assert len(mock_record.mock_calls) == 4
+        start_1, end_1, start_2, end_2 = mock_record.mock_calls
+        assert start_1.args[0] == EventLifecycleOutcome.STARTED
+        assert start_2.args[0] == EventLifecycleOutcome.STARTED
+        assert end_1.args[0] == EventLifecycleOutcome.SUCCESS
+        assert end_2.args[0] == EventLifecycleOutcome.SUCCESS
 
 
 class TestHandleParentNotification(TestCase):
@@ -240,7 +244,7 @@ class TestHandleParentNotification(TestCase):
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @mock.patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
-    def test_handles_parent_notification_sdk(self, mock_api_call, mock_record):
+    def test_handles_parent_notification(self, mock_api_call, mock_record):
         mock_api_call.return_value = {
             "body": orjson.dumps({"ok": True}).decode(),
             "headers": {},
@@ -252,10 +256,8 @@ class TestHandleParentNotification(TestCase):
             client=SlackSdkClient(integration_id=self.integration.id),
         )
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
-
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_handles_parent_notification_sdk_error(
+    def test_handles_parent_notification_error(
         self,
         mock_record,
     ) -> None:
@@ -265,8 +267,6 @@ class TestHandleParentNotification(TestCase):
                 notification_to_send="hello",
                 client=SlackSdkClient(integration_id=self.integration.id),
             )
-
-        assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
 
     def test_raises_exception_when_parent_notification_does_not_have_rule_fire_history_data(
         self,

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -23,8 +23,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         super().setUp()
         self.notification = DummyNotification(self.organization)
 
-    @patch("sentry.integrations.slack.service.metrics")
-    def test_additional_attachment(self, mock_metrics):
+    def test_additional_attachment(self):
         with (
             patch.dict(
                 manager.attachment_generators,
@@ -64,8 +63,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             assert blocks[3]["text"]["text"] == self.organization.slug
             assert blocks[4]["text"]["text"] == self.integration.id
 
-    @patch("sentry.integrations.slack.service.metrics")
-    def test_no_additional_attachment(self, mock_metrics):
+    def test_no_additional_attachment(self):
         with self.tasks():
             send_notification_as_slack(self.notification, [self.user], {}, {})
 
@@ -96,8 +94,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             "type": "actions",
         }
 
-    @patch("sentry.integrations.slack.service.metrics")
-    def test_send_notification_as_slack(self, mock_metrics):
+    def test_send_notification_as_slack(self):
         with patch.dict(
             manager.attachment_generators,
             {ExternalProviders.SLACK: additional_attachment_generator_block_kit},
@@ -105,8 +102,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             with self.tasks():
                 send_notification_as_slack(self.notification, [self.user], {}, {})
 
-    @patch("sentry.integrations.slack.service.metrics")
-    def test_send_notification_as_slack_error(self, mock_metrics):
+    def test_send_notification_as_slack_error(self):
         mock_slack_response = SlackResponse(
             client=None,
             http_verb="POST",

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -4,10 +4,6 @@ import orjson
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
-from sentry.integrations.slack.metrics import (
-    SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
-    SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
-)
 from sentry.integrations.slack.notifications import send_notification_as_slack
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.additional_attachment_manager import manager
@@ -68,11 +64,6 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             assert blocks[3]["text"]["text"] == self.organization.slug
             assert blocks[4]["text"]["text"] == self.integration.id
 
-        mock_metrics.incr.assert_called_with(
-            SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
-            sample_rate=1.0,
-        )
-
     @patch("sentry.integrations.slack.service.metrics")
     def test_no_additional_attachment(self, mock_metrics):
         with self.tasks():
@@ -114,11 +105,6 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             with self.tasks():
                 send_notification_as_slack(self.notification, [self.user], {}, {})
 
-        mock_metrics.incr.assert_called_with(
-            SLACK_NOTIFY_RECIPIENT_SUCCESS_DATADOG_METRIC,
-            sample_rate=1.0,
-        )
-
     @patch("sentry.integrations.slack.service.metrics")
     def test_send_notification_as_slack_error(self, mock_metrics):
         mock_slack_response = SlackResponse(
@@ -143,9 +129,3 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         ):
             with self.tasks():
                 send_notification_as_slack(self.notification, [self.user], {}, {})
-
-        mock_metrics.incr.assert_called_with(
-            SLACK_NOTIFY_RECIPIENT_FAILURE_DATADOG_METRIC,
-            sample_rate=1.0,
-            tags={"ok": False, "status": 200},
-        )


### PR DESCRIPTION
we have completed the audit of our integration slos, so going back and cleaning up redundant logging and metrics.

we should also monitor our DD monitors to see if they need updating.