### PR TITLE
nit(data-secrecy): Remove "detail" from delete response

### DIFF
--- a/src/sentry/data_secrecy/api/waive_data_secrecy.py
+++ b/src/sentry/data_secrecy/api/waive_data_secrecy.py
@@ -150,6 +150,5 @@ class WaiveDataSecrecyEndpoint(OrganizationEndpoint):
             event=audit_log.get_event_id("DATA_SECRECY_REINSTATED"),
         )
         return Response(
-            {"detail": "Data secrecy has been reinstated."},
             status=status.HTTP_204_NO_CONTENT,
         )


### PR DESCRIPTION
was tinkering with data secrecy and saw that when deleting a waiver, i get the following error:
```
02:38:26 server             | DELETE 204 /api/0/organizations/california/data-secrecy/ HTTP/1.1 1742
02:38:26 webpack            | <e> [webpack-dev-server] [HPM] Error occurred while proxying request dev.getsentry.net:8000/api/0/organizations/california/data-secrecy/ to http://127.0.0.1:8001/ [HPE_INVALID_CONSTANT] (https://nodejs.org/api/errors.html#errors_common_system_errors)
```

and after some googling, ran into https://github.com/postmanlabs/postman-app-support/issues/2418 - which suggests adding "detail" is causing us to add the contentType header that the http parser doesn't like.

this seems to be the backend portion of the long lasting data secrecy bug i have been trying to track down.