### PR TITLE
meta: Set @getsentry/app-frontend as codeowners for some unowned things

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -359,10 +359,12 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 ## End of DevToolbar
 
 
-## Misc Replay
-/static/app/components/analyticsArea.tsx       @getsentry/replay-frontend
-/static/app/components/analyticsArea.spec.tsx  @getsentry/replay-frontend
-## End of Misc Replay
+## Frontend
+/static/app/components/analyticsArea.spec.tsx  @getsentry/app-frontend
+/static/app/components/analyticsArea.tsx       @getsentry/app-frontend
+/static/app/components/events/interfaces/      @getsentry/app-frontend
+/static/app/components/forms/                  @getsentry/app-frontend
+## End of Frontend
 
 
 ## Integrations


### PR DESCRIPTION
The forms/ and events/interfaces folders are unowned by anyone; so when PRs come up there are no reviewers assigned.

So I'm adding rules where `@getsentry/app-frontend` owns these things... these are the only things owned by app-frontend at the moment.