### PR TITLE
fix(data-secrecy): update fe state & address a couple bugs

### DIFF
--- a/static/app/views/settings/components/dataSecrecy/index.spec.tsx
+++ b/static/app/views/settings/components/dataSecrecy/index.spec.tsx
@@ -103,4 +103,38 @@ describe('DataSecrecy', function () {
       expect(accessMessage).toBeInTheDocument();
     });
   });
+
+  it('can update permanent access', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-secrecy/`,
+      body: {
+        accessStart: '2023-08-29T01:05:00+00:00',
+        accessEnd: '2024-08-29T01:05:00+00:00',
+      },
+    });
+
+    const mockUpdate = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+    });
+
+    organization.allowSuperuserAccess = false;
+    render(<DataSecrecy />, {organization});
+
+    // Toggle permanent access on
+    const allowAccessToggle = screen.getByRole('checkbox', {
+      name: /Sentry employees will not have access to your data unless granted permission/,
+    });
+    allowAccessToggle.click();
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/`,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {allowSuperuserAccess: true},
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
followup of https://github.com/getsentry/sentry/pull/82754.

here, i am fixing some of the bugs i found while fixing the data secrecy waiver. i added comments where relevant. after this deploys, we should be ready to GA

video demo:

https://github.com/user-attachments/assets/54159198-e572-4e7b-907e-9a0e28d65b05

