### PR TITLE
feat(dashboards): Improve `WidgetFrame` error handling

### DIFF
--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -11,3 +11,6 @@ export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a
 
 export const MISSING_DATA_MESSAGE = t('No Data');
 export const NON_FINITE_NUMBER_MESSAGE = t('Value is not a finite number.');
+export const WIDGET_RENDER_ERROR_MESSAGE = t(
+  'Sorry, something went wrong when rendering this widget.'
+);

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -12,6 +12,24 @@ describe('WidgetFrame', () => {
       await userEvent.hover(screen.getByRole('button', {name: 'Widget description'}));
       expect(await screen.findByText('Number of events per second')).toBeInTheDocument();
     });
+
+    it('Catches errors in the visualization', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      render(
+        <WidgetFrame title="Uh Oh">
+          <UhOh />
+        </WidgetFrame>
+      );
+
+      expect(screen.getByText('Uh Oh')).toBeInTheDocument();
+
+      expect(
+        await screen.findByText('Sorry, something went wrong when rendering this widget.')
+      ).toBeInTheDocument();
+
+      jest.resetAllMocks();
+    });
   });
 
   describe('Warnings', () => {
@@ -257,3 +275,8 @@ describe('WidgetFrame', () => {
     });
   });
 });
+
+function UhOh() {
+  const items: string[] = [];
+  return <div>{items[0].toUpperCase()}</div>;
+}

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -184,6 +184,41 @@ describe('WidgetFrame', () => {
       await userEvent.hover($trigger);
       expect(await screen.findByText('Actions are not supported')).toBeInTheDocument();
     });
+
+    it('Shows actions even in error state', async () => {
+      const onAction = jest.fn();
+      const error = new Error('Something is wrong');
+
+      render(
+        <WidgetFrame
+          title="EPS"
+          description="Number of events per second"
+          error={error}
+          actions={[
+            {
+              key: 'hello',
+              label: 'Make Go',
+              onAction,
+            },
+          ]}
+        />
+      );
+
+      const $button = screen.getByRole('button', {name: 'Make Go'});
+      expect($button).toBeInTheDocument();
+      await userEvent.click($button);
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('Shows a "Retry" action if a retry callback is provided', () => {
+      const onRetry = jest.fn();
+      const error = new Error('Something is wrong');
+
+      render(<WidgetFrame title="EPS" error={error} onRetry={onRetry} />);
+
+      expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+    });
   });
 
   describe('Full Screen View Button', () => {

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -205,5 +205,20 @@ describe('WidgetFrame', () => {
 
       expect(onFullScreenViewClick).toHaveBeenCalledTimes(1);
     });
+
+    it('Hides full screen button if the widget has an error', () => {
+      const onFullScreenViewClick = jest.fn();
+
+      render(
+        <WidgetFrame
+          title="count()"
+          onFullScreenViewClick={onFullScreenViewClick}
+          error={new Error('Something went wrong')}
+        />
+      );
+
+      const $button = screen.queryByRole('button', {name: 'Open Full-Screen View'});
+      expect($button).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -48,7 +48,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
   const shouldShowFullScreenViewButton =
     Boolean(props.onFullScreenViewClick) && !props.error;
 
-  const hasActions = actions && actions.length > 0;
+  const shouldShowActions = actions && actions.length > 0;
 
   return (
     <Frame aria-label="Widget panel" borderless={props.borderless}>
@@ -70,7 +70,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
             (currentBadgeProps, i) => <RigidBadge key={i} {...currentBadgeProps} />
           )}
 
-        {(props.description || shouldShowFullScreenViewButton || hasActions) && (
+        {(props.description || shouldShowFullScreenViewButton || shouldShowActions) && (
           <TitleHoverItems>
             {props.description && (
               // Ideally we'd use `QuestionTooltip` but we need to firstly paint the icon dark, give it 100% opacity, and remove hover behaviour.

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -42,7 +42,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
               onAction: props.onRetry,
             },
           ]
-        : []
+        : props.actions
       : props.actions) ?? [];
 
   const shouldShowFullScreenViewButton =

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -45,7 +45,8 @@ export function WidgetFrame(props: WidgetFrameProps) {
         : []
       : props.actions) ?? [];
 
-  const shouldShowFullScreenViewButton = Boolean(props.onFullScreenViewClick);
+  const shouldShowFullScreenViewButton =
+    Boolean(props.onFullScreenViewClick) && !props.error;
 
   const hasActions = actions && actions.length > 0;
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -99,48 +99,50 @@ export function WidgetFrame(props: WidgetFrameProps) {
               </Tooltip>
             )}
 
-            <TitleActionsWrapper
-              disabled={Boolean(props.actionsDisabled)}
-              disabledMessage={props.actionsMessage ?? ''}
-            >
-              {actions.length === 1 ? (
-                actions[0].to ? (
-                  <LinkButton
-                    size="xs"
-                    disabled={props.actionsDisabled}
-                    onClick={actions[0].onAction}
-                    to={actions[0].to}
-                  >
-                    {actions[0].label}
-                  </LinkButton>
-                ) : (
-                  <Button
-                    size="xs"
-                    disabled={props.actionsDisabled}
-                    onClick={actions[0].onAction}
-                  >
-                    {actions[0].label}
-                  </Button>
-                )
-              ) : null}
+            {shouldShowActions && (
+              <TitleActionsWrapper
+                disabled={Boolean(props.actionsDisabled)}
+                disabledMessage={props.actionsMessage ?? ''}
+              >
+                {actions.length === 1 ? (
+                  actions[0].to ? (
+                    <LinkButton
+                      size="xs"
+                      disabled={props.actionsDisabled}
+                      onClick={actions[0].onAction}
+                      to={actions[0].to}
+                    >
+                      {actions[0].label}
+                    </LinkButton>
+                  ) : (
+                    <Button
+                      size="xs"
+                      disabled={props.actionsDisabled}
+                      onClick={actions[0].onAction}
+                    >
+                      {actions[0].label}
+                    </Button>
+                  )
+                ) : null}
 
-              {actions.length > 1 ? (
-                <DropdownMenu
-                  items={actions}
-                  isDisabled={props.actionsDisabled}
-                  triggerProps={{
-                    'aria-label': t('Widget actions'),
-                    size: 'xs',
-                    borderless: true,
-                    showChevron: false,
-                    icon: <IconEllipsis direction="down" size="sm" />,
-                  }}
-                  position="bottom-end"
-                />
-              ) : null}
-            </TitleActionsWrapper>
+                {actions.length > 1 ? (
+                  <DropdownMenu
+                    items={actions}
+                    isDisabled={props.actionsDisabled}
+                    triggerProps={{
+                      'aria-label': t('Widget actions'),
+                      size: 'xs',
+                      borderless: true,
+                      showChevron: false,
+                      icon: <IconEllipsis direction="down" size="sm" />,
+                    }}
+                    position="bottom-end"
+                  />
+                ) : null}
+              </TitleActionsWrapper>
+            )}
 
-            {props.onFullScreenViewClick && (
+            {shouldShowFullScreenViewButton && (
               <Button
                 aria-label={t('Open Full-Screen View')}
                 borderless

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -45,6 +45,10 @@ export function WidgetFrame(props: WidgetFrameProps) {
         : []
       : props.actions) ?? [];
 
+  const shouldShowFullScreenViewButton = Boolean(props.onFullScreenViewClick);
+
+  const hasActions = actions && actions.length > 0;
+
   return (
     <Frame aria-label="Widget panel" borderless={props.borderless}>
       <Header>
@@ -65,9 +69,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
             (currentBadgeProps, i) => <RigidBadge key={i} {...currentBadgeProps} />
           )}
 
-        {(props.description ||
-          props.onFullScreenViewClick ||
-          (actions && actions.length > 0)) && (
+        {(props.description || shouldShowFullScreenViewButton || hasActions) && (
           <TitleHoverItems>
             {props.description && (
               // Ideally we'd use `QuestionTooltip` but we need to firstly paint the icon dark, give it 100% opacity, and remove hover behaviour.

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -4,13 +4,20 @@ import Badge, {type BadgeProps} from 'sentry/components/badge/badge';
 import {Button, LinkButton} from 'sentry/components/button';
 import {HeaderTitle} from 'sentry/components/charts/styles';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis, IconExpand, IconInfo, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 import {ErrorPanel} from './errorPanel';
-import {MIN_HEIGHT, MIN_WIDTH, X_GUTTER, Y_GUTTER} from './settings';
+import {
+  MIN_HEIGHT,
+  MIN_WIDTH,
+  WIDGET_RENDER_ERROR_MESSAGE,
+  X_GUTTER,
+  Y_GUTTER,
+} from './settings';
 import {TooltipIconTrigger} from './tooltipIconTrigger';
 import type {StateProps} from './types';
 import {WarningsList} from './warningsList';
@@ -158,7 +165,15 @@ export function WidgetFrame(props: WidgetFrameProps) {
       </Header>
 
       <VisualizationWrapper>
-        {props.error ? <ErrorPanel error={error} /> : props.children}
+        {props.error ? (
+          <ErrorPanel error={error} />
+        ) : (
+          <ErrorBoundary
+            customComponent={<ErrorPanel error={WIDGET_RENDER_ERROR_MESSAGE} />}
+          >
+            {props.children}
+          </ErrorBoundary>
+        )}
       </VisualizationWrapper>
     </Frame>
   );


### PR DESCRIPTION
- Don't allow full screen in error state
- Show actions in error mode if there is no retry
- Add error boundary
