### PR TITLE
fix(hydration issue): Disable focusTrap when using a hovercard inside hydration issue modal

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -60,19 +60,24 @@ export default function ReplayComparisonModal({
                 <IconInfo />
               </Tooltip>
             </Title>
-            <LearnMoreButton />
-            {focusTrap ? (
-              <FeedbackWidgetButton
-                optionOverrides={{
-                  onFormOpen: () => {
-                    focusTrap.pause();
-                  },
-                  onFormClose: () => {
-                    focusTrap.unpause();
-                  },
-                }}
+            <div>
+              <LearnMoreButton
+                onHover={() => focusTrap?.pause()}
+                onBlur={() => focusTrap?.unpause()}
               />
-            ) : null}
+              {focusTrap ? (
+                <FeedbackWidgetButton
+                  optionOverrides={{
+                    onFormOpen: () => {
+                      focusTrap.pause();
+                    },
+                    onFormClose: () => {
+                      focusTrap.unpause();
+                    },
+                  }}
+                />
+              ) : null}
+            </div>
           </ModalHeader>
         </Header>
         <Body>

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import type {ComponentProps, ReactNode} from 'react';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -58,12 +58,15 @@ function Buttons() {
   );
 }
 
-export default function LearnMoreButton() {
+export default function LearnMoreButton(
+  hoverCardProps: Partial<ComponentProps<typeof Hovercard>>
+) {
   return (
     <ClassNames>
       {({css}) => (
         <AnalyticsArea name="learn-more">
           <Hovercard
+            {...hoverCardProps}
             body={<Buttons />}
             bodyClassName={css`
               padding: ${space(1)};

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -98,6 +98,19 @@ interface UseHoverOverlayProps {
    * Offset along the main axis.
    */
   offset?: number;
+
+  /**
+   * Callback whenever the hovercard is blurred
+   * See also `onHover`
+   */
+  onBlur?: () => void;
+
+  /**
+   * Callback whenever the hovercard is hovered
+   * See also `onBlur`
+   */
+  onHover?: () => void;
+
   /**
    * Position for the overlay.
    */
@@ -115,6 +128,7 @@ interface UseHoverOverlayProps {
    * If child node supports ref forwarding, you can skip apply a wrapper
    */
   skipWrapper?: boolean;
+
   /**
    * Color of the dotted underline, if available. See also: showUnderline.
    */
@@ -159,6 +173,8 @@ function useHoverOverlay(
     offset = 8,
     position = 'top',
     containerDisplayMode = 'inline-block',
+    onHover,
+    onBlur,
   }: UseHoverOverlayProps
 ) {
   const theme = useTheme();
@@ -166,6 +182,14 @@ function useHoverOverlay(
 
   const [isVisible, setIsVisible] = useState(forceVisible ?? false);
   const isOpen = forceVisible ?? isVisible;
+
+  useEffect(() => {
+    if (isOpen) {
+      onHover?.();
+    } else {
+      onBlur?.();
+    }
+  }, [isOpen, onBlur, onHover]);
 
   const [triggerElement, setTriggerElement] = useState<HTMLElement | null>(null);
   const [overlayElement, setOverlayElement] = useState<HTMLElement | null>(null);


### PR DESCRIPTION
These links will accept clicks now:
<img width="559" alt="SCR-20241231-kcqh" src="https://github.com/user-attachments/assets/4f3e4ec3-0033-4ced-8c53-dbfdcf445af6" />


Fixes #82776