### PR TITLE
feat(aci): add `frequency` as optional key in workflow config schema

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2113,13 +2113,18 @@ class Factories:
     def create_workflow(
         name: str | None = None,
         organization: Organization | None = None,
+        config: dict[str, Any] | None = None,
         **kwargs,
     ) -> Workflow:
         if organization is None:
             organization = Factories.create_organization()
         if name is None:
             name = petname.generate(2, " ", letters=10).title()
-        return Workflow.objects.create(organization=organization, name=name, **kwargs)
+        if config is None:
+            config = {}
+        return Workflow.objects.create(
+            organization=organization, name=name, config=config, **kwargs
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -74,6 +74,7 @@ def create_workflow(
         when_condition_group=data_condition_group,
         enabled=True,
         created_by_id=user.id if user else None,
+        config={},
     )
 
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -40,7 +40,6 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     def config_schema(self) -> dict[str, Any]:
         return {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "https://example.com/product.schema.json",
             "title": "Workflow Schema",
             "type": "object",
             "properties": {

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -38,8 +38,20 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
 
     @property
     def config_schema(self) -> dict[str, Any]:
-        # TODO: fill in
-        return {}
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/product.schema.json",
+            "title": "Workflow Schema",
+            "type": "object",
+            "properties": {
+                "frequency": {
+                    "description": "How often the workflow should fire for a Group (minutes)",
+                    "type": "integer",
+                    "minimum": 0,
+                },
+            },
+            "additionalProperties": False,
+        }
 
     __repr__ = sane_repr("name", "organization_id")
 

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from unittest.mock import PropertyMock, patch
 
 import pytest
 from jsonschema import ValidationError
@@ -19,17 +18,6 @@ class TestJsonConfigBase(BaseGroupTypeTest):
             "location": "Cityville",
             "interests": ["Travel", "Technology"],
         }
-
-        @dataclass(frozen=True)
-        class TestGroupType(GroupType):
-            type_id = 1
-            slug = "test"
-            description = "Test"
-            category = GroupCategory.ERROR.value
-            detector_config_schema = self.example_schema
-
-    @pytest.fixture(autouse=True)
-    def initialize_configs(self):
         self.example_schema = {
             "$id": "https://example.com/user-profile.schema.json",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -45,15 +33,14 @@ class TestJsonConfigBase(BaseGroupTypeTest):
                 "interests": {"type": "array", "items": {"type": "string"}},
             },
         }
-        with (
-            patch(
-                "sentry.workflow_engine.models.Workflow.config_schema",
-                return_value=self.example_schema,
-                new_callable=PropertyMock,
-            ),
-        ):
-            # Run test case
-            yield
+
+        @dataclass(frozen=True)
+        class TestGroupType(GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.ERROR.value
+            detector_config_schema = self.example_schema
 
 
 class TestDetectorConfig(TestJsonConfigBase):
@@ -75,8 +62,13 @@ class TestWorkflowConfig(TestJsonConfigBase):
             self.create_workflow(
                 organization=self.organization, name="test_workflow", config={"hi": "there"}
             )
+        with pytest.raises(ValidationError):
+            self.create_workflow(
+                organization=self.organization, name="test_workflow", config={"frequency": "-1"}
+            )
 
     def test_workflow_correct_schema(self):
+        self.create_workflow(organization=self.organization, name="test_workflow", config={})
         self.create_workflow(
-            organization=self.organization, name="test_workflow", config=self.correct_config
+            organization=self.organization, name="test_workflow2", config={"frequency": 5}
         )


### PR DESCRIPTION
Frequency in workflow is only applicable to issue alerts and not metric alerts, so we can have it as an optional `config` key. It controls how often issue alert actions can fire for a single Group, and is enforced using `GroupRuleStatus`.

We can pull the key out when we should be enforcing the firing frequency. The UI should make clear when the workflow `frequency` is enforced for a detector.

See discussion https://github.com/getsentry/sentry/pull/80710#discussion_r1847052467