### PR TITLE
feat(settings): Add project avatar to team dropdown

### DIFF
--- a/static/app/views/settings/organizationTeams/teamProjects.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.tsx
@@ -15,6 +15,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
+import TextOverflow from 'sentry/components/textOverflow';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconFlag, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -101,8 +102,8 @@ function TeamProjects({team, location, params}: TeamProjectsProps) {
         searchKey: p.slug,
         label: (
           <ProjectListElement>
-            <ProjectAvatar project={p} />
-            <span>{p.slug}</span>
+            <ProjectAvatar project={p} size={16} />
+            <TextOverflow>{p.slug}</TextOverflow>
           </ProjectListElement>
         ),
       }));
@@ -131,6 +132,7 @@ function TeamProjects({team, location, params}: TeamProjectsProps) {
             ) : (
               <DropdownAutoComplete
                 items={otherProjects}
+                minWidth={300}
                 onChange={evt => setQuery(evt.target.value)}
                 onSelect={selection => {
                   const project = unlinkedProjects.find(p => p.id === selection.value);

--- a/static/app/views/settings/organizationTeams/teamProjects.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.tsx
@@ -1,8 +1,9 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {hasEveryAccess} from 'sentry/components/acl/access';
+import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import DropdownButton from 'sentry/components/dropdownButton';
@@ -92,13 +93,20 @@ function TeamProjects({team, location, params}: TeamProjectsProps) {
 
   const linkedProjectsPageLinks = linkedProjectsHeaders?.('Link');
   const hasWriteAccess = hasEveryAccess(['team:write'], {organization, team});
-  const otherProjects = unlinkedProjects
-    .filter(p => p.access.includes('project:write'))
-    .map(p => ({
-      value: p.id,
-      searchKey: p.slug,
-      label: <ProjectListElement>{p.slug}</ProjectListElement>,
-    }));
+  const otherProjects = useMemo(() => {
+    return unlinkedProjects
+      .filter(p => p.access.includes('project:write'))
+      .map(p => ({
+        value: p.id,
+        searchKey: p.slug,
+        label: (
+          <ProjectListElement>
+            <ProjectAvatar project={p} />
+            <span>{p.slug}</span>
+          </ProjectListElement>
+        ),
+      }));
+  }, [unlinkedProjects]);
 
   return (
     <Fragment>
@@ -195,6 +203,9 @@ const StyledPanelItem = styled(PanelItem)`
 `;
 
 const ProjectListElement = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
   padding: ${space(0.25)} 0;
 `;
 


### PR DESCRIPTION
adds project avatars to the project selector in the team page

before
![image](https://github.com/user-attachments/assets/d71e8943-fe16-497b-8f81-f49d677af1e6)


after
![image](https://github.com/user-attachments/assets/a615442d-08fb-46d5-81e9-81a333f59dbc)
