### PR TITLE
:wrench: chore(api): move OpenApiParameters definition to parameters.py

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -1,5 +1,4 @@
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -38,13 +37,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             IssueParams.ISSUE_ID,
             IssueParams.ISSUES_OR_GROUPS,
             GlobalParams.ORG_ID_OR_SLUG,
-            OpenApiParameter(
-                name="key",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-                description="The tag key to look the values up for.",
-                required=True,
-            ),
+            IssueParams.KEY,
             GlobalParams.ENVIRONMENT,
         ],
         responses={

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -1,5 +1,4 @@
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -39,21 +38,8 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
             IssueParams.ISSUE_ID,
             IssueParams.ISSUES_OR_GROUPS,
             GlobalParams.ORG_ID_OR_SLUG,
-            OpenApiParameter(
-                name="key",
-                location=OpenApiParameter.PATH,
-                type=OpenApiTypes.STR,
-                description="The tag key to look the values up for.",
-                required=True,
-            ),
-            OpenApiParameter(
-                name="sort",
-                location="query",
-                required=False,
-                type=str,
-                description="Sort order of the resulting tag values. Prefix with '-' for descending order. Default is '-id'.",
-                enum=["id", "date", "age", "count"],
-            ),
+            IssueParams.KEY,
+            IssueParams.SORT,
             GlobalParams.ENVIRONMENT,
         ],
         responses={

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -284,6 +284,14 @@ class SCIMParams:
 
 
 class IssueParams:
+    KEY = OpenApiParameter(
+        name="key",
+        location=OpenApiParameter.PATH,
+        type=OpenApiTypes.STR,
+        description="The tag key to look the values up for.",
+        required=True,
+    )
+
     ISSUES_OR_GROUPS = OpenApiParameter(
         name="var",
         location="path",
@@ -297,6 +305,15 @@ class IssueParams:
         required=True,
         type=int,
         description="The ID of the issue you'd like to query.",
+    )
+
+    SORT = OpenApiParameter(
+        name="sort",
+        location="query",
+        required=False,
+        type=str,
+        description="Sort order of the resulting tag values. Prefix with '-' for descending order. Default is '-id'.",
+        enum=["id", "date", "age", "count"],
     )
 
 
@@ -450,6 +467,41 @@ class EventParams:
         required=True,
         type=int,
         description="Index of the exception that should be used for source map resolution.",
+    )
+
+    EVENT_ID_EXTENDED = OpenApiParameter(
+        name="event_id",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.PATH,
+        description="The ID of the event to retrieve, or 'latest', 'oldest', or 'recommended'.",
+        required=True,
+        enum=["latest", "oldest", "recommended"],
+    )
+
+    FULL_PAYLOAD = OpenApiParameter(
+        name="full",
+        type=OpenApiTypes.BOOL,
+        location=OpenApiParameter.QUERY,
+        description="Specify true to include the full event body, including the stacktrace, in the event payload.",
+        required=False,
+        default=False,
+    )
+
+    SAMPLE = OpenApiParameter(
+        name="sample",
+        type=OpenApiTypes.BOOL,
+        location=OpenApiParameter.QUERY,
+        description="Return events in pseudo-random order. This is deterministic so an identical query will always return the same events in the same order.",
+        required=False,
+        default=False,
+    )
+
+    QUERY = OpenApiParameter(
+        name="query",
+        location=OpenApiParameter.QUERY,
+        type=OpenApiTypes.STR,
+        description="An optional search query for filtering events.",
+        required=False,
     )
 
 

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -4,8 +4,7 @@ import logging
 from collections.abc import Sequence
 
 from django.contrib.auth.models import AnonymousUser
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,7 +27,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.event_examples import EventExamples
-from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.exceptions import InvalidParams
@@ -138,14 +137,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             IssueParams.ISSUES_OR_GROUPS,
             IssueParams.ISSUE_ID,
             GlobalParams.ENVIRONMENT,
-            OpenApiParameter(
-                name="event_id",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.PATH,
-                description="The ID of the event to retrieve, or 'latest', 'oldest', or 'recommended'.",
-                required=True,
-                enum=["latest", "oldest", "recommended"],
-            ),
+            EventParams.EVENT_ID_EXTENDED,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -5,8 +5,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from django.utils import timezone
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -30,7 +29,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.event_examples import EventExamples
-from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.eventstore.models import Event
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
@@ -68,27 +67,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             GlobalParams.END,
             GlobalParams.STATS_PERIOD,
             GlobalParams.ENVIRONMENT,
-            OpenApiParameter(
-                name="full",
-                type=OpenApiTypes.BOOL,
-                location=OpenApiParameter.QUERY,
-                description="Specify true to include the full event body, including the stacktrace, in the event payload.",
-                required=False,
-            ),
-            OpenApiParameter(
-                name="sample",
-                type=OpenApiTypes.BOOL,
-                location=OpenApiParameter.QUERY,
-                description="Return events in pseudo-random order. This is deterministic so an identical query will always return the same events in the same order.",
-                required=False,
-            ),
-            OpenApiParameter(
-                name="query",
-                location=OpenApiParameter.QUERY,
-                type=OpenApiTypes.STR,
-                description="An optional search query for filtering events.",
-                required=False,
-            ),
+            EventParams.FULL_PAYLOAD,
+            EventParams.SAMPLE,
+            EventParams.QUERY,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/issues/endpoints/project_events.py
+++ b/src/sentry/issues/endpoints/project_events.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from functools import partial
 
 from django.utils import timezone
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,7 +15,7 @@ from sentry.api.serializers import EventSerializer, SimpleEventSerializer, seria
 from sentry.api.serializers.models.event import SimpleEventSerializerResponse
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.event_examples import EventExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.parameters import CursorQueryParam, EventParams, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.project import Project
 from sentry.snuba.events import Columns
@@ -44,22 +44,8 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             CursorQueryParam,
-            OpenApiParameter(
-                name="full",
-                description="If this is set to true, the event payload will include the full event body, including the stacktrace. Set to 1 to enable.",
-                required=False,
-                type=bool,
-                location="query",
-                default=False,
-            ),
-            OpenApiParameter(
-                name="sample",
-                description="Return events in pseudo-random order. This is deterministic so an identical query will always return the same events in the same order.",
-                required=False,
-                type=bool,
-                location="query",
-                default=False,
-            ),
+            EventParams.FULL_PAYLOAD,
+            EventParams.SAMPLE,
         ],
         responses={
             200: inline_sentry_response_serializer(


### PR DESCRIPTION
a smol nit, moving the open api parameter definitions to parameters file.

the open-api diff is b/c i standardized wording for the same params & added a default value to schema that was missing originally.

