### PR TITLE
fix(onboarding): Support for multiword frameworks

### DIFF
--- a/static/app/utils/gettingStartedDocs/getPlatformPath.spec.ts
+++ b/static/app/utils/gettingStartedDocs/getPlatformPath.spec.ts
@@ -26,6 +26,18 @@ describe('getPlatformPath', () => {
     expect(getPlatformPath(platform)).toEqual('python/python');
   });
 
+  it('returns the correct path for the multi-word framework', () => {
+    const platform: PlatformIntegration = {
+      type: 'framework',
+      id: 'java-spring-boot',
+      language: 'java',
+      link: 'link',
+      name: 'name',
+    };
+
+    expect(getPlatformPath(platform)).toEqual('java/spring-boot');
+  });
+
   it('handles special cases', () => {
     function getFrameworkPlatformWithId(id: PlatformKey): PlatformIntegration {
       return {

--- a/static/app/utils/gettingStartedDocs/getPlatformPath.ts
+++ b/static/app/utils/gettingStartedDocs/getPlatformPath.ts
@@ -6,7 +6,11 @@ export function getPlatformPath(platform: PlatformIntegration) {
     return `${platform.language}/${platform.language}`;
   }
 
-  const framework = platform.id.split('-')[1];
+  // splits the platform.id into language and framework, framework can have multiple words so we
+  // only want to split it at the first hyphen
+  const hyphenIndex = platform.id.indexOf('-');
+  const framework =
+    hyphenIndex !== -1 ? platform.id.substring(hyphenIndex + 1) : undefined;
 
   if (framework) {
     return `${platform.language}/${framework}`;


### PR DESCRIPTION
So far we had a bug when the framework would contain multiple words, e.g. `java-spring-boot` would only return `spring` instead of `spring-boot` as a framework name.