### PR TITLE
feat(widget-builder): Validate widget before saving

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -11,6 +11,7 @@ import {
   deleteDashboard,
   updateDashboard,
   updateDashboardPermissions,
+  validateWidget,
 } from 'sentry/actionCreators/dashboards';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
@@ -763,6 +764,7 @@ class DashboardDetail extends Component<Props, State> {
     index: number | undefined;
     widget: Widget;
   }) => {
+    const {organization, api} = this.props;
     if (
       !this.props.organization.features.includes('dashboards-widget-builder-redesign')
     ) {
@@ -784,6 +786,7 @@ class DashboardDetail extends Component<Props, State> {
       : [...currentDashboard.widgets, mergedWidget];
 
     try {
+      await validateWidget(api, organization.slug, widget);
       if (!this.isEditingDashboard) {
         // If we're not in edit mode, send a request to update the dashboard
         await this.handleUpdateWidgetList(newWidgets);

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -11,7 +11,6 @@ import {
   deleteDashboard,
   updateDashboard,
   updateDashboardPermissions,
-  validateWidget,
 } from 'sentry/actionCreators/dashboards';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
@@ -764,7 +763,6 @@ class DashboardDetail extends Component<Props, State> {
     index: number | undefined;
     widget: Widget;
   }) => {
-    const {organization, api} = this.props;
     if (
       !this.props.organization.features.includes('dashboards-widget-builder-redesign')
     ) {
@@ -786,7 +784,6 @@ class DashboardDetail extends Component<Props, State> {
       : [...currentDashboard.widgets, mergedWidget];
 
     try {
-      await validateWidget(api, organization.slug, widget);
       if (!this.isEditingDashboard) {
         // If we're not in edit mode, send a request to update the dashboard
         await this.handleUpdateWidgetList(newWidgets);

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -1,7 +1,11 @@
 import {useCallback} from 'react';
 
+import {validateWidget} from 'sentry/actionCreators/dashboards';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {t} from 'sentry/locale';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
@@ -15,11 +19,18 @@ interface SaveButtonProps {
 function SaveButton({isEditing, onSave}: SaveButtonProps) {
   const {state} = useWidgetBuilderContext();
   const {widgetIndex} = useParams();
+  const api = useApi();
+  const organization = useOrganization();
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     const widget = convertBuilderStateToWidget(state);
-    onSave({index: Number(widgetIndex), widget});
-  }, [onSave, state, widgetIndex]);
+    try {
+      await validateWidget(api, organization.slug, widget);
+      onSave({index: Number(widgetIndex), widget});
+    } catch (error) {
+      addErrorMessage('Unable to save widget');
+    }
+  }, [api, onSave, organization.slug, state, widgetIndex]);
 
   return (
     <Button priority="primary" onClick={handleSave}>

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -28,7 +28,7 @@ function SaveButton({isEditing, onSave}: SaveButtonProps) {
       await validateWidget(api, organization.slug, widget);
       onSave({index: Number(widgetIndex), widget});
     } catch (error) {
-      addErrorMessage('Unable to save widget');
+      addErrorMessage(t('Unable to save widget'));
     }
   }, [api, onSave, organization.slug, state, widgetIndex]);
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -11,6 +11,7 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import ModalStore from 'sentry/stores/modalStore';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -20,6 +21,7 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
+jest.mock('sentry/actionCreators/indicator');
 
 describe('WidgetBuilderSlideout', () => {
   let organization!: ReturnType<typeof OrganizationFixture>;
@@ -34,6 +36,15 @@ describe('WidgetBuilderSlideout', () => {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/widgets/',
+      method: 'POST',
+      body: {
+        title: 'Title is required during creation',
+      },
+      statusCode: 400,
     });
   });
 
@@ -201,5 +212,45 @@ describe('WidgetBuilderSlideout', () => {
         screen.queryByText('You have unsaved changes. Are you sure you want to leave?')
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('should not save and close the widget builder if the widget is invalid', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: [],
+              yAxis: ['count()'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+              title: undefined,
+            },
+          }),
+        }),
+      }
+    );
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByText('Add Widget'));
+
+    await waitFor(() => {
+      expect(addErrorMessage).toHaveBeenCalledWith('Unable to save widget');
+    });
+
+    expect(screen.getByText('Create Custom Widget')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -243,7 +243,6 @@ describe('WidgetBuilderSlideout', () => {
         }),
       }
     );
-    renderGlobalModal();
 
     await userEvent.click(await screen.findByText('Add Widget'));
 


### PR DESCRIPTION
We're reusing the `validateWidget` function that is being used in the current widget builder. I've added that validation check to the save button so it will validate before carrying out the saving and closing process. When the widget is not valid it displays the message as such:

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/78698bd0-186b-4454-a870-f5f3479ad5db" />

In future PRs I will implement field highlighting for the fields that are causing validation errors.

Related to https://github.com/getsentry/sentry/issues/81729
