### PR TITLE
chore(issue-stream): Add a feature flag for the issue stream component refactor

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -187,6 +187,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-stream-search-query-builder", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable issue stream table layout changes
     manager.add("organizations:issue-stream-table-layout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # When enabled, uses the functional issue stream component
+    manager.add("organizations:issue-stream-functional-refactor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable members to invite teammates to organizations


### PR DESCRIPTION
I have a draft PR open for a functional component refactor of the issue stream: https://github.com/getsentry/sentry/pull/82784

It's a bit risky though, so I wanted to roll it out carefully. But I wouldn't expect this flag to last very long.