### PR TITLE
chore(issue-details): Add event action analytics

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -29,6 +29,10 @@ type SourceMapWizardParam = {
 
 interface GroupEventParams extends CommonGroupAnalyticsData, BaseEventAnalyticsParams {}
 
+interface StreamlineGroupEventParams extends GroupEventParams {
+  streamline: boolean;
+}
+
 interface EventDropdownParams {
   event_id: string;
   from_event_type: string;
@@ -95,7 +99,8 @@ export type IssueEventParameters = {
   'issue_details.comment_created': {streamline: boolean};
   'issue_details.comment_deleted': {streamline: boolean};
   'issue_details.comment_updated': {streamline: boolean};
-  'issue_details.copy_event_link_clicked': GroupEventParams;
+  'issue_details.copy_event_id_clicked': StreamlineGroupEventParams;
+  'issue_details.copy_event_link_clicked': StreamlineGroupEventParams;
   'issue_details.escalating_feedback_received': {
     group_id: string;
     is_high_priority: boolean;
@@ -458,6 +463,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'source_map_debug.expand_clicked': 'Source Map Debug: Expand Clicked',
   'actionable_items.expand_clicked': 'Actionable Item: Expand Clicked',
   'issue_details.copy_event_link_clicked': 'Issue Details: Copy Event Link Clicked',
+  'issue_details.copy_event_id_clicked': 'Issue Details: Copy Event ID Clicked',
   'issue_details.event_details_clicked': 'Issue Details: Full Event Details Clicked',
   'issue_details.event_dropdown_option_selected':
     'Issue Details: Event Dropdown Option Selected',

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -104,7 +104,7 @@ export type TeamInsightsEventParameters = {
   'issue_details.attachment_tab.screenshot_modal_download': {};
   'issue_details.attachment_tab.screenshot_modal_opened': {};
   'issue_details.attachment_tab.screenshot_title_clicked': {};
-  'issue_details.event_json_clicked': {group_id: number};
+  'issue_details.event_json_clicked': {group_id: number; streamline: boolean};
   'issue_details.event_navigation_clicked': {button: string; project_id: number};
   'issue_details.issue_tab.screenshot_dropdown_deleted': {};
   'issue_details.issue_tab.screenshot_dropdown_download': {};

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -251,6 +251,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
     trackAnalytics('issue_details.event_json_clicked', {
       organization,
       group_id: parseInt(`${event.groupID}`, 10),
+      streamline: false,
     });
   };
 
@@ -264,12 +265,20 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
         organization,
         ...getAnalyticsDataForGroup(group),
         ...getAnalyticsDataForEvent(event),
+        streamline: false,
       }),
   });
 
   const {onClick: copyEventId} = useCopyToClipboard({
     successMessage: t('Event ID copied to clipboard'),
     text: event.id,
+    onCopy: () =>
+      trackAnalytics('issue_details.copy_event_id_clicked', {
+        organization,
+        ...getAnalyticsDataForGroup(group),
+        ...getAnalyticsDataForEvent(event),
+        streamline: false,
+      }),
   });
 
   return (

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -95,6 +95,7 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
       trackAnalytics('issue_details.event_json_clicked', {
         organization,
         group_id: parseInt(`${event.groupID}`, 10),
+        streamline: true,
       });
     };
 
@@ -106,12 +107,20 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
           organization,
           ...getAnalyticsDataForGroup(group),
           ...getAnalyticsDataForEvent(event),
+          streamline: true,
         }),
     });
 
     const {onClick: copyEventId} = useCopyToClipboard({
       successMessage: t('Event ID copied to clipboard'),
       text: event.id,
+      onCopy: () =>
+        trackAnalytics('issue_details.copy_event_id_clicked', {
+          organization,
+          ...getAnalyticsDataForGroup(group),
+          ...getAnalyticsDataForEvent(event),
+          streamline: true,
+        }),
     });
 
     return (


### PR DESCRIPTION
this pr improves or adds analytics for the open json, copy event id, and copy event link actions on the issue details page