### PR TITLE
fix(eslint): Disable typescript server in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -621,7 +621,7 @@ export default typescript.config([
         jsDocParsingMode: process.env.SENTRY_DETECT_DEPRECATIONS ? 'all' : 'none',
 
         // https://typescript-eslint.io/packages/parser/#project
-        project: './tsconfig.json',
+        project: process.env.SENTRY_DETECT_DEPRECATIONS ? './tsconfig.json' : false,
 
         // https://typescript-eslint.io/packages/parser/#projectservice
         // `projectService` is recommended, but slower, with our current tsconfig files.


### PR DESCRIPTION
We only use the typescript server when checking deprecations in the old eslint rule set. Running the typescript server changes the time for a full lint from `2m 21s` to `1m 54s` which isn't much but you feel it more when running the pre-commit check.

Linting a single file goes from `8.38s.` before to `1.85s.` which is used in pre-commit.

how we were doing this in the old eslintrc
https://github.com/getsentry/sentry/blob/4172f7b514973bc5713f5803235d3a4a1dda06b3/.eslintrc.js#L770-L780