### PR TITLE
fix(hybrid-cloud): Adds option to skip invalid audit log events by event id

### DIFF
--- a/src/sentry/audit_log/services/log/impl.py
+++ b/src/sentry/audit_log/services/log/impl.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import datetime
+import logging
 
-import sentry_sdk
 from django.db import IntegrityError, router, transaction
 
 from sentry import options
@@ -14,6 +14,8 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.safety import unguarded_write
 from sentry.users.models.user import User
 from sentry.users.models.userip import UserIP
+
+logger = logging.getLogger("sentry.audit_log_rpc_service")
 
 
 class DatabaseBackedLogService(LogService):
@@ -96,9 +98,7 @@ class DatabaseBackedLogService(LogService):
                     break
 
         if not list_valid:
-            sentry_sdk.capture_message(
-                f"Invalid audit_log skip list. Verify that the '{self.event_id_skip_list_option}' option is a list of ints."
-            )
+            logger.error("audit_log.invalid_audit_log_pass_list", extra={"pass_list": pass_list})
             return []
 
         return pass_list

--- a/src/sentry/audit_log/services/log/impl.py
+++ b/src/sentry/audit_log/services/log/impl.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import datetime
 
+import sentry_sdk
 from django.db import IntegrityError, router, transaction
 
+from sentry import options
 from sentry.audit_log.services.log import AuditLogEvent, LogService, UserIpEvent
 from sentry.db.postgres.transactions import enforce_constraints
 from sentry.hybridcloud.models.outbox import RegionOutbox
@@ -15,23 +17,48 @@ from sentry.users.models.userip import UserIP
 
 
 class DatabaseBackedLogService(LogService):
+    event_id_skip_list_option = "hybrid_cloud.audit_log_event_id_invalid_pass_list"
+
     def record_audit_log(self, *, event: AuditLogEvent) -> None:
         entry = AuditLogEntry.from_event(event)
         try:
             with enforce_constraints(transaction.atomic(router.db_for_write(AuditLogEntry))):
                 entry.save()
-        except IntegrityError as e:
-            error_message = str(e)
-            if '"auth_user"' in error_message:
-                # It is possible that a user existed at the time of serialization but was deleted by the time of consumption
-                # in which case we follow the database's SET NULL on delete handling.
-                if event.actor_user_id:
-                    event.actor_user_id = None
-                if event.target_user_id:
-                    event.target_user_id = None
-                return self.record_audit_log(event=event)
-            else:
+        except Exception as e:
+            if isinstance(e, IntegrityError):
+                error_message = str(e)
+                if '"auth_user"' in error_message:
+                    # It is possible that a user existed at the time of serialization but was deleted by the time of consumption
+                    # in which case we follow the database's SET NULL on delete handling.
+                    if event.actor_user_id:
+                        event.actor_user_id = None
+                    if event.target_user_id:
+                        event.target_user_id = None
+                    return self.record_audit_log(event=event)
+
+            # Relief hatch for audit logs with known bad states. This allows us
+            # to clear backlogged outboxes with invalid data.
+            skip_list = self._get_invalid_event_id_pass_list()
+            if event.event_id not in skip_list:
                 raise
+
+    def _get_invalid_event_id_pass_list(self) -> list[int]:
+        pass_list = options.get(self.event_id_skip_list_option)
+        list_valid = isinstance(pass_list, list)
+
+        if list_valid:
+            for item in pass_list:
+                if not isinstance(item, int):
+                    list_valid = False
+                    break
+
+        if not list_valid:
+            sentry_sdk.capture_message(
+                f"Invalid audit_log skip list. Verify that the '{self.event_id_skip_list_option}' option is a list of ints."
+            )
+            return []
+
+        return pass_list
 
     def record_user_ip(self, *, event: UserIpEvent) -> None:
         UserIP.objects.create_or_update(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1925,6 +1925,14 @@ register(
 )
 register("hybrid_cloud.disable_tombstone_cleanup", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# List of event IDs to pass through
+register(
+    "hybrid_cloud.audit_log_event_id_invalid_pass_list",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Flagpole Configuration (used in getsentry)
 register("flagpole.debounce_reporting_seconds", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/tests/sentry/audit_log/services/test_log.py
+++ b/tests/sentry/audit_log/services/test_log.py
@@ -140,25 +140,27 @@ def test_skip_list_when_invalid_data_passed() -> None:
 
 @django_db_all
 @control_silo_test(include_monolith_run=True)
-@mock.patch("sentry_sdk.capture_message")
-def test_invalid_skip_list(mock_capture_message: MagicMock) -> None:
+@mock.patch("sentry.audit_log.services.log.impl.logger")
+def test_invalid_skip_list(mock_logger: MagicMock) -> None:
     with override_options({"hybrid_cloud.audit_log_event_id_invalid_pass_list": [100, "foo"]}):
         with pytest.raises(AssertionError):
             log_service.record_audit_log(event=AuditLogEvent(event_id=100))
 
-    mock_capture_message.assert_called_once()
-    mock_capture_message.assert_called_with(
-        "Invalid audit_log skip list. Verify that the 'hybrid_cloud.audit_log_event_id_invalid_pass_list' option is a list of ints."
+    mock_logger.error.assert_called_once()
+    mock_logger.error.assert_called_with(
+        "audit_log.invalid_audit_log_pass_list",
+        extra={"pass_list": [100, "foo"]},
     )
-    mock_capture_message.reset_mock()
+    mock_logger.reset_mock()
 
     with override_options({"hybrid_cloud.audit_log_event_id_invalid_pass_list": None}):
         with pytest.raises(AssertionError):
             log_service.record_audit_log(event=AuditLogEvent(event_id=100))
 
-    mock_capture_message.assert_called_once()
-    mock_capture_message.assert_called_with(
-        "Invalid audit_log skip list. Verify that the 'hybrid_cloud.audit_log_event_id_invalid_pass_list' option is a list of ints."
+    mock_logger.error.assert_called_once()
+    mock_logger.error.assert_called_with(
+        "audit_log.invalid_audit_log_pass_list",
+        extra={"pass_list": None},
     )
 
 

--- a/tests/sentry/audit_log/services/test_log.py
+++ b/tests/sentry/audit_log/services/test_log.py
@@ -1,12 +1,20 @@
+import pytest
+
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_service
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
-from sentry.hybridcloud.models.outbox import RegionOutbox
+from sentry.hybridcloud.models.outbox import OutboxFlushError, RegionOutbox
 from sentry.hybridcloud.outbox.category import OutboxScope
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
+from sentry.testutils.silo import (
+    all_silo_test,
+    assume_test_silo_mode,
+    control_silo_test,
+    region_silo_test,
+)
 from sentry.users.models.userip import UserIP
 
 
@@ -115,3 +123,25 @@ def test_user_ip_event() -> None:
     with assume_test_silo_mode(SiloMode.CONTROL):
         assert UserIP.objects.get(ip_address="1.0.0.5")
         assert UserIP.objects.count() == 2
+
+
+@django_db_all
+@control_silo_test
+def test_skip_list_when_invalid_data_passed() -> None:
+    with pytest.raises(AssertionError):
+        log_service.record_audit_log(event=AuditLogEvent(event_id=100))
+
+    with override_options({"hybrid_cloud.audit_log_event_id_invalid_pass_list": [100]}):
+        log_service.record_audit_log(event=AuditLogEvent(event_id=100))
+
+
+@django_db_all
+@region_silo_test
+def test_skip_list_rpc_call_with_invalid_data_passed() -> None:
+    log_service.record_audit_log(event=AuditLogEvent(event_id=100))
+
+    with pytest.raises(OutboxFlushError):
+        RegionOutbox(shard_scope=OutboxScope.AUDIT_LOG_SCOPE, shard_identifier=-1).drain_shard()
+
+    with override_options({"hybrid_cloud.audit_log_event_id_invalid_pass_list": [100]}):
+        RegionOutbox(shard_scope=OutboxScope.AUDIT_LOG_SCOPE, shard_identifier=-1).drain_shard()

--- a/tests/sentry/audit_log/services/test_log.py
+++ b/tests/sentry/audit_log/services/test_log.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -140,7 +141,7 @@ def test_skip_list_when_invalid_data_passed() -> None:
 @django_db_all
 @control_silo_test(include_monolith_run=True)
 @mock.patch("sentry_sdk.capture_message")
-def test_invalid_skip_list(mock_capture_message) -> None:
+def test_invalid_skip_list(mock_capture_message: MagicMock) -> None:
     with override_options({"hybrid_cloud.audit_log_event_id_invalid_pass_list": [100, "foo"]}):
         with pytest.raises(AssertionError):
             log_service.record_audit_log(event=AuditLogEvent(event_id=100))


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adds a new option named `hybrid_cloud.audit_log_event_id_invalid_pass_list`, which is a list of integers mapping to `AuditLogEvent` `event_id` values. If an exception is raised when processing the `AuditLogEvent`, if the `event_id` is in the pass list, the audit log RPC service will now swallow the exception.

The `AuditLogEntry` model typically raises an exception when the data is missing an actor. This is not an issue for any audit logs generated within the Control Silo, as the underlying service will simply re-raise the exception to the calling code. For region silo generated audit logs which are backed by outboxes + RPC calls, this will cause the outboxes that back these requests to queue indefinitely, retrying them once daily.

This option is intended to be a temporary fix for outboxes stuck in this state, which will never contain valid data, and thus never be properly processed.
