### PR TITLE
ref(flags): don't show flag legend if no lines to show

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
@@ -39,6 +39,14 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
     evaluatedFlagNames?.includes(f.name)
   );
 
+  if (!intersectionFlags.length) {
+    return {
+      seriesName: t('Feature Flags'),
+      markLine: {},
+      data: [],
+    };
+  }
+
   // create a markline series using hydrated flag data
   const markLine = MarkLine({
     animation: false,


### PR DESCRIPTION
if there are no intersection flags, we won't show any lines -- let's hide the feature flag label from the legend