### PR TITLE
feat(span metrics): Add support for making division queries

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -121,6 +121,67 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0][fieldRelease2] == 1
         assert meta["dataset"] == "spansMetrics"
 
+    def test_division(self):
+        # 10 slow frames, 20 frozen frames, 100 total frames
+        self.store_span_metric(
+            {
+                "min": 1,
+                "max": 1,
+                "sum": 10,
+                "count": 10,
+                "last": 1,
+            },
+            entity="metrics_gauges",
+            metric="mobile.slow_frames",
+            timestamp=self.three_days_ago,
+        )
+        self.store_span_metric(
+            {
+                "min": 1,
+                "max": 1,
+                "sum": 20,
+                "count": 20,
+                "last": 1,
+            },
+            entity="metrics_gauges",
+            metric="mobile.frozen_frames",
+            timestamp=self.three_days_ago,
+        )
+        self.store_span_metric(
+            {
+                "min": 1,
+                "max": 1,
+                "sum": 100,
+                "count": 100,
+                "last": 1,
+            },
+            entity="metrics_gauges",
+            metric="mobile.total_frames",
+            timestamp=self.three_days_ago,
+        )
+
+        slow_frame_rate = "division(mobile.slow_frames,mobile.total_frames)"
+        frozen_frame_rate = "division(mobile.frozen_frames,mobile.total_frames)"
+
+        response = self.do_request(
+            {
+                "field": [slow_frame_rate, frozen_frame_rate],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "7d",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+
+        assert data[0][slow_frame_rate] == 10 / 100
+        assert data[0][frozen_frame_rate] == 20 / 100
+
+        assert meta["dataset"] == "spansMetrics"
+
     def test_division_if(self):
         self.store_span_metric(
             {


### PR DESCRIPTION
Allows the frontend to request division queries, e.g. `division(mobiles.slow_frames, mobile.total_frames)`

Fixes https://github.com/getsentry/sentry/issues/75317
