### PR TITLE
fix(dashboards): Left alignment for edit access in table view

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -162,16 +162,11 @@ function EditAccessSelector({
   // Avatars/Badges in the Edit Access Selector Button
   const triggerAvatars =
     selectedOptions.includes('_allUsers') || !dashboardCreator ? (
-      <StyledBadge
-        key="_all"
-        text={'All'}
-        size={listOnly ? 26 : 20}
-        listonly={listOnly.toString()}
-      />
+      <StyledBadge key="_all" text={'All'} size={listOnly ? 26 : 20} />
     ) : selectedOptions.length === 2 ? (
       // Case where we display 1 Creator Avatar + 1 Team Avatar
       <StyledAvatarList
-        listonly={listOnly.toString()}
+        listonly={listOnly}
         key="avatar-list-2-badges"
         typeAvatars="users"
         users={[dashboardCreator]}
@@ -185,7 +180,7 @@ function EditAccessSelector({
       // Case where we display 1 Creator Avatar + a Badge with no. of teams selected
       <StyledAvatarList
         key="avatar-list-many-teams"
-        listonly={listOnly.toString()}
+        listonly={listOnly}
         typeAvatars="users"
         users={Array(selectedOptions.length).fill(dashboardCreator)}
         maxVisibleAvatars={1}
@@ -289,7 +284,7 @@ function EditAccessSelector({
                 type="new"
                 tooltipProps={{position: 'left', delay: 1000, isHoverable: true}}
               />,
-              t('Edit Access:'),
+              <LabelContainer key="selector-label">{t('Edit Access:')}</LabelContainer>,
               triggerAvatars,
             ]
       }
@@ -335,10 +330,14 @@ const StyledDisplayName = styled('div')`
   font-weight: normal;
 `;
 
-const StyledAvatarList = styled(AvatarList)<{listonly: string}>`
-  margin-left: ${p => (p.listonly === 'true' ? 6 : 10)}px;
-  margin-right: ${p => (p.listonly === 'true' ? 0 : -3)}px;
+const StyledAvatarList = styled(AvatarList)<{listonly: boolean}>`
+  margin-left: ${space(0.75)};
+  margin-right: ${p => (p.listonly ? 0 : -3)}px;
   font-weight: normal;
+`;
+
+const LabelContainer = styled('div')`
+  margin-right: ${space(1)};
 `;
 
 const StyledFeatureBadge = styled(FeatureBadge)`
@@ -346,16 +345,16 @@ const StyledFeatureBadge = styled(FeatureBadge)`
   margin-right: 6px;
 `;
 
-const StyledBadge = styled(Badge)<{listonly: string; size: number}>`
+const StyledBadge = styled(Badge)<{size: number}>`
   color: ${p => p.theme.white};
   background: ${p => p.theme.purple300};
   padding: 0;
-  ${p => p.listonly === 'true' && 'margin-left: 0px;'}
   height: ${p => p.size}px;
   width: ${p => p.size}px;
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-left: 0px;
 `;
 
 const FilterButtons = styled(ButtonBar)`

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -162,10 +162,16 @@ function EditAccessSelector({
   // Avatars/Badges in the Edit Access Selector Button
   const triggerAvatars =
     selectedOptions.includes('_allUsers') || !dashboardCreator ? (
-      <StyledBadge key="_all" text={'All'} size={listOnly ? 26 : 20} />
+      <StyledBadge
+        key="_all"
+        text={'All'}
+        size={listOnly ? 26 : 20}
+        listOnly={listOnly}
+      />
     ) : selectedOptions.length === 2 ? (
       // Case where we display 1 Creator Avatar + 1 Team Avatar
       <StyledAvatarList
+        listOnly={listOnly}
         key="avatar-list-2-badges"
         typeAvatars="users"
         users={[dashboardCreator]}
@@ -179,6 +185,7 @@ function EditAccessSelector({
       // Case where we display 1 Creator Avatar + a Badge with no. of teams selected
       <StyledAvatarList
         key="avatar-list-many-teams"
+        listOnly={listOnly}
         typeAvatars="users"
         users={Array(selectedOptions.length).fill(dashboardCreator)}
         maxVisibleAvatars={1}
@@ -286,7 +293,7 @@ function EditAccessSelector({
               triggerAvatars,
             ]
       }
-      triggerProps={{borderless: listOnly}}
+      triggerProps={{borderless: listOnly, style: listOnly ? {padding: 2} : {}}}
       searchPlaceholder={t('Search Teams')}
       isOpen={isMenuOpen}
       onOpenChange={() => {
@@ -328,9 +335,9 @@ const StyledDisplayName = styled('div')`
   font-weight: normal;
 `;
 
-const StyledAvatarList = styled(AvatarList)`
-  margin-left: 10px;
-  margin-right: -3px;
+const StyledAvatarList = styled(AvatarList)<{listOnly: boolean}>`
+  margin-left: ${p => (p.listOnly ? 6 : 10)}px;
+  margin-right: ${p => (p.listOnly ? 0 : -3)}px;
   font-weight: normal;
 `;
 
@@ -339,10 +346,11 @@ const StyledFeatureBadge = styled(FeatureBadge)`
   margin-right: 6px;
 `;
 
-const StyledBadge = styled(Badge)<{size: number}>`
+const StyledBadge = styled(Badge)<{listOnly: boolean; size: number}>`
   color: ${p => p.theme.white};
   background: ${p => p.theme.purple300};
   padding: 0;
+  ${p => p.listOnly && 'margin-left: 0px;'}
   height: ${p => p.size}px;
   width: ${p => p.size}px;
   display: flex;

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -166,12 +166,12 @@ function EditAccessSelector({
         key="_all"
         text={'All'}
         size={listOnly ? 26 : 20}
-        listOnly={listOnly}
+        listonly={listOnly.toString()}
       />
     ) : selectedOptions.length === 2 ? (
       // Case where we display 1 Creator Avatar + 1 Team Avatar
       <StyledAvatarList
-        listOnly={listOnly}
+        listonly={listOnly.toString()}
         key="avatar-list-2-badges"
         typeAvatars="users"
         users={[dashboardCreator]}
@@ -185,7 +185,7 @@ function EditAccessSelector({
       // Case where we display 1 Creator Avatar + a Badge with no. of teams selected
       <StyledAvatarList
         key="avatar-list-many-teams"
-        listOnly={listOnly}
+        listonly={listOnly.toString()}
         typeAvatars="users"
         users={Array(selectedOptions.length).fill(dashboardCreator)}
         maxVisibleAvatars={1}
@@ -335,9 +335,9 @@ const StyledDisplayName = styled('div')`
   font-weight: normal;
 `;
 
-const StyledAvatarList = styled(AvatarList)<{listOnly: boolean}>`
-  margin-left: ${p => (p.listOnly ? 6 : 10)}px;
-  margin-right: ${p => (p.listOnly ? 0 : -3)}px;
+const StyledAvatarList = styled(AvatarList)<{listonly: string}>`
+  margin-left: ${p => (p.listonly === 'true' ? 6 : 10)}px;
+  margin-right: ${p => (p.listonly === 'true' ? 0 : -3)}px;
   font-weight: normal;
 `;
 
@@ -346,11 +346,11 @@ const StyledFeatureBadge = styled(FeatureBadge)`
   margin-right: 6px;
 `;
 
-const StyledBadge = styled(Badge)<{listOnly: boolean; size: number}>`
+const StyledBadge = styled(Badge)<{listonly: string; size: number}>`
   color: ${p => p.theme.white};
   background: ${p => p.theme.purple300};
   padding: 0;
-  ${p => p.listOnly && 'margin-left: 0px;'}
+  ${p => p.listonly === 'true' && 'margin-left: 0px;'}
   height: ${p => p.size}px;
   width: ${p => p.size}px;
   display: flex;


### PR DESCRIPTION
Before rolling out I wanted to fix this small alignment issue that Vasudha brought up. We wanted the access column to have the same alignment as the rest of the columns. Before and after below :) 

| Before | After |
|--------|--------|
| <img width="584" alt="image" src="https://github.com/user-attachments/assets/dcee10d3-4f3c-4548-8b9d-4aa379ef0640" /> | <img width="601" alt="image" src="https://github.com/user-attachments/assets/10def1d4-d053-46c6-97b9-939cc27dfcb2" /> | 

(access column is properly left aligned)