### PR TITLE
feat(widget-builder): Switching display type to big number

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -555,6 +555,57 @@ describe('Visualize', () => {
     expect(screen.queryByLabelText('Legend Alias')).not.toBeInTheDocument();
   });
 
+  it('does not show the legend alias input for big number widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.BIG_NUMBER,
+              field: ['count()'],
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toHaveTextContent('count');
+    expect(screen.queryByLabelText('Legend Alias')).not.toBeInTheDocument();
+  });
+
+  it('does not allow for selecting individual fields in big number widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.BIG_NUMBER,
+              field: ['count()'],
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+
+    // Being unable to choose "None" in the aggregate selection means that the
+    // individual field is not allowed, i.e. only aggregates appear.
+    expect(screen.queryByRole('option', {name: 'None'})).not.toBeInTheDocument();
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -60,6 +60,7 @@ function Visualize() {
   const isChartWidget =
     state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER;
+  const isBigNumberWidget = state.displayType === DisplayType.BIG_NUMBER;
   const numericSpanTags = useSpanTags('number');
   const stringSpanTags = useSpanTags('string');
 
@@ -197,9 +198,10 @@ function Visualize() {
             value: option.value.meta.name,
             label: option.value.meta.name,
           }));
-          aggregateOptions = isChartWidget
-            ? aggregateOptions
-            : [NONE_AGGREGATE, ...aggregateOptions];
+          aggregateOptions =
+            isChartWidget || isBigNumberWidget
+              ? aggregateOptions
+              : [NONE_AGGREGATE, ...aggregateOptions];
 
           let matchingAggregate;
           if (
@@ -427,8 +429,8 @@ function Visualize() {
                   </Fragment>
                 )}
               </FieldBar>
-              <FieldExtras isChartWidget={isChartWidget}>
-                {!isChartWidget && (
+              <FieldExtras isChartWidget={isChartWidget || isBigNumberWidget}>
+                {!isChartWidget && !isBigNumberWidget && (
                   <LegendAliasInput
                     type="text"
                     name="name"

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -375,6 +375,73 @@ describe('useWidgetBuilderState', () => {
         },
       ]);
     });
+
+    it('sets the aggregate as fields when switching to big number', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.TABLE,
+            field: ['event.type', 'count()'],
+            sort: ['-count()'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.fields).toEqual([
+        {field: 'event.type', alias: undefined, kind: 'field'},
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.BIG_NUMBER,
+        });
+      });
+
+      expect(result.current.state.fields).toEqual([
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+      expect(result.current.state.sort).toEqual([]);
+    });
+
+    it('selects the first filter when switching to big number', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            field: ['event.type', 'count()', 'count_unique(user)'],
+            query: ['event.type:test', 'event.type:test2'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.query).toEqual(['event.type:test', 'event.type:test2']);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.BIG_NUMBER,
+        });
+      });
+
+      expect(result.current.state.query).toEqual(['event.type:test']);
+    });
   });
 
   describe('dataset', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -157,10 +157,6 @@ function useWidgetBuilderState(): {
           break;
         case BuilderStateAction.SET_DISPLAY_TYPE:
           setDisplayType(action.payload);
-          if (action.payload === DisplayType.BIG_NUMBER) {
-            setSort([]);
-            setLegendAlias([]);
-          }
           const [aggregates, columns] = partition(fields, field => {
             const fieldString = generateFieldAsString(field);
             return isAggregateFieldOrEquation(fieldString);
@@ -169,6 +165,14 @@ function useWidgetBuilderState(): {
             setYAxis([]);
             setFields([...columns, ...aggregates, ...(yAxis ?? [])]);
             setLegendAlias([]);
+          } else if (action.payload === DisplayType.BIG_NUMBER) {
+            // TODO: Reset the selected aggregate here for widgets with equations
+            setSort([]);
+            setYAxis([]);
+            setLegendAlias([]);
+            // Columns are ignored for big number widgets because there is no grouping
+            setFields([...aggregates, ...(yAxis ?? [])]);
+            setQuery(query?.slice(0, 1));
           } else {
             setFields(columns);
             setYAxis([
@@ -239,6 +243,7 @@ function useWidgetBuilderState(): {
       fields,
       yAxis,
       displayType,
+      query,
     ]
   );
 


### PR DESCRIPTION
Handles switching the display type to big number. To accomplish this, I had to remove some fields from the UI because they aren't compatible i.e. this PR does the following:

1. Only allow the user to select aggregates for the visualize step
2. Avoid displaying the alias field for big number widgets in the visualize step
3. Update the hook to:
  - clear sort, yaxes, and legend aliases (there can only be one filter)
  - set the fields to only the aggregates or yaxes (depending if you're coming from table or chart)
  - persist only the first filter query (big numbers don't support multiple series)

Contributes to #81511