### PR TITLE
ref: add ProjectKey as an AuthenticatedToken type

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -515,7 +515,7 @@ class DSNAuthentication(StandardAuthentication):
         scope.set_tag("api_token_type", self.token_name)
         scope.set_tag("api_project_key", key.id)
 
-        return (AnonymousUser(), key)
+        return (AnonymousUser(), AuthenticatedToken.from_token(key))
 
 
 @AuthenticationSiloLimit(SiloMode.REGION)

--- a/src/sentry/auth/services/auth/model.py
+++ b/src/sentry/auth/services/auth/model.py
@@ -62,6 +62,7 @@ class AuthenticatedToken(RpcModel):
     user_id: int | None = None  # only relevant for ApiToken
     organization_id: int | None = None
     application_id: int | None = None  # only relevant for ApiToken
+    project_id: int | None = None  # only relevant for ProjectKey
 
     def token_has_org_access(self, organization_id: int) -> bool:
         return self.kind == "api_token" and self.organization_id == organization_id
@@ -73,12 +74,14 @@ class AuthenticatedToken(RpcModel):
         from sentry.models.apikey import ApiKey
         from sentry.models.apitoken import ApiToken
         from sentry.models.orgauthtoken import OrgAuthToken
+        from sentry.models.projectkey import ProjectKey
 
         return {
             "system": frozenset([SystemToken]),
             "api_token": frozenset([ApiToken, ApiTokenReplica]),
             "org_auth_token": frozenset([OrgAuthToken, OrgAuthTokenReplica]),
             "api_key": frozenset([ApiKey, ApiKeyReplica]),
+            "project_key": frozenset((ProjectKey,)),
         }
 
     @classmethod
@@ -109,6 +112,7 @@ class AuthenticatedToken(RpcModel):
             user_id=getattr(token, "user_id", None),
             organization_id=getattr(token, "organization_id", None),
             application_id=getattr(token, "application_id", None),
+            project_id=getattr(token, "project_id", None),
         )
 
     def get_audit_log_data(self) -> Mapping[str, Any]:

--- a/src/sentry/monitors/endpoints/base_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/base_monitor_checkin_index.py
@@ -9,7 +9,6 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
-from sentry.models.projectkey import ProjectKey
 from sentry.monitors.models import MonitorCheckIn
 from sentry.monitors.serializers import MonitorCheckInSerializer
 
@@ -20,7 +19,7 @@ class MonitorCheckInMixin(BaseEndpointMixin):
         Retrieve a list of check-ins for a monitor
         """
         # we don't allow read permission with DSNs
-        if isinstance(request.auth, ProjectKey):
+        if request.auth is not None and request.auth.kind == "project_key":  # type: ignore[union-attr]
             return self.respond(status=401)
 
         start, end = get_date_range_from_params(request.GET)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -124,7 +124,7 @@ class TestDSNAuthentication(TestCase):
 
         user, auth = result
         assert user.is_anonymous
-        assert auth == self.project_key
+        assert auth == AuthenticatedToken.from_token(self.project_key)
 
     def test_inactive_key(self):
         self.project_key.update(status=ProjectKeyStatus.INACTIVE)


### PR DESCRIPTION
after this I can standardize the typing of `request.auth` to be `AuthenticatedToken | None` -- the DSN auth appears to be the only place we're not using `AuthenticatedToken`

it's not super clear to me why this one was left out / special cased?  maybe I'm overlooking something 🤔 

<!-- Describe your PR here. -->