### PR TITLE
ref(hydration error): Refactor the hydration modal to have a shared context for before/after timestamps

### DIFF
--- a/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
@@ -1,6 +1,7 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Placeholder from 'sentry/components/placeholder';
 import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
+import {DiffCompareContextProvider} from 'sentry/components/replays/diff/diffCompareContext';
 import {ReplaySliderDiff} from 'sentry/components/replays/diff/replaySliderDiff';
 import {ReplayGroupContextProvider} from 'sentry/components/replays/replayGroupContext';
 import {t} from 'sentry/locale';
@@ -53,12 +54,13 @@ export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: P
     >
       <ErrorBoundary mini>
         <ReplayGroupContextProvider groupId={group?.id} eventId={event.id}>
-          <ReplaySliderDiff
-            minHeight="355px"
-            leftOffsetMs={leftOffsetMs}
+          <DiffCompareContextProvider
             replay={replay}
-            rightOffsetMs={rightOffsetMs}
-          />
+            initialLeftOffsetMs={leftOffsetMs}
+            initialRightOffsetMs={rightOffsetMs}
+          >
+            <ReplaySliderDiff minHeight="355px" />
+          </DiffCompareContextProvider>
         </ReplayGroupContextProvider>
       </ErrorBoundary>
     </InterimSection>

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -59,8 +59,8 @@ export function OpenReplayComparisonButton({
               <LazyComparisonModal
                 replay={replay}
                 organization={organization}
-                leftOffsetMs={leftOffsetMs}
-                rightOffsetMs={rightOffsetMs}
+                initialLeftOffsetMs={leftOffsetMs}
+                initialRightOffsetMs={rightOffsetMs}
                 {...deps}
               />
             </Suspense>

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -6,6 +6,7 @@ import AnalyticsArea from 'sentry/components/analyticsArea';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
 import ExternalLink from 'sentry/components/links/externalLink';
+import {DiffCompareContextProvider} from 'sentry/components/replays/diff/diffCompareContext';
 import LearnMoreButton from 'sentry/components/replays/diff/learnMoreButton';
 import ReplayDiffChooser from 'sentry/components/replays/diff/replayDiffChooser';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -17,84 +18,86 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 interface Props extends ModalRenderProps {
-  leftOffsetMs: number;
+  initialLeftOffsetMs: number;
+  initialRightOffsetMs: number;
   organization: Organization;
   replay: ReplayReader;
-  rightOffsetMs: number;
 }
 
 export default function ReplayComparisonModal({
   Body,
   Header,
-  leftOffsetMs,
+  initialLeftOffsetMs,
+  initialRightOffsetMs,
   organization,
   replay,
-  rightOffsetMs,
 }: Props) {
   // Callbacks set by GlobalModal on-render.
   // We need these to interact with feedback opened while a modal is active.
   const {focusTrap} = useGlobalModal();
 
-  const isSameTimestamp = leftOffsetMs === rightOffsetMs;
+  const isSameTimestamp = initialLeftOffsetMs === initialRightOffsetMs;
 
   return (
     <OrganizationContext.Provider value={organization}>
       <AnalyticsArea name="hydration-error-modal">
-        <Header closeButton>
-          <ModalHeader>
-            <Title>
-              {t('Hydration Error')}
-              <Tooltip
-                isHoverable
-                title={tct(
-                  'This modal helps with debugging hydration errors by diffing the DOM before and after the app hydrated. [boldBefore:Before] refers to the HTML rendered on the server. [boldAfter:After] refers to the HTML rendered on the client. Read more about [link:resolving hydration errors].',
-                  {
-                    boldBefore: <Before />,
-                    boldAfter: <After />,
-                    link: (
-                      <ExternalLink href="https://sentry.io/answers/hydration-error-nextjs/" />
-                    ),
-                  }
-                )}
-              >
-                <IconInfo />
-              </Tooltip>
-            </Title>
-            <div>
-              <LearnMoreButton
-                onHover={() => focusTrap?.pause()}
-                onBlur={() => focusTrap?.unpause()}
-              />
-              {focusTrap ? (
-                <FeedbackWidgetButton
-                  optionOverrides={{
-                    onFormOpen: () => {
-                      focusTrap.pause();
-                    },
-                    onFormClose: () => {
-                      focusTrap.unpause();
-                    },
-                  }}
+        <DiffCompareContextProvider
+          replay={replay}
+          initialLeftOffsetMs={initialLeftOffsetMs}
+          initialRightOffsetMs={initialRightOffsetMs}
+        >
+          <Header closeButton>
+            <ModalHeader>
+              <Title>
+                {t('Hydration Error')}
+                <Tooltip
+                  isHoverable
+                  title={tct(
+                    'This modal helps with debugging hydration errors by diffing the DOM before and after the app hydrated. [boldBefore:Before] refers to the HTML rendered on the server. [boldAfter:After] refers to the HTML rendered on the client. Read more about [link:resolving hydration errors].',
+                    {
+                      boldBefore: <Before />,
+                      boldAfter: <After />,
+                      link: (
+                        <ExternalLink href="https://sentry.io/answers/hydration-error-nextjs/" />
+                      ),
+                    }
+                  )}
+                >
+                  <IconInfo />
+                </Tooltip>
+              </Title>
+              <div>
+                <LearnMoreButton
+                  onHover={() => focusTrap?.pause()}
+                  onBlur={() => focusTrap?.unpause()}
                 />
-              ) : null}
-            </div>
-          </ModalHeader>
-        </Header>
-        <Body>
-          {isSameTimestamp ? (
-            <Alert type="warning" showIcon>
-              {t(
-                "Cannot display diff for this hydration error. Sentry wasn't able to identify the correct event."
-              )}
-            </Alert>
-          ) : null}
+                {focusTrap ? (
+                  <FeedbackWidgetButton
+                    optionOverrides={{
+                      onFormOpen: () => {
+                        focusTrap.pause();
+                      },
+                      onFormClose: () => {
+                        focusTrap.unpause();
+                      },
+                    }}
+                  />
+                ) : null}
+              </div>
+            </ModalHeader>
+          </Header>
+          <Body>
+            {isSameTimestamp ? (
+              <Alert type="warning" showIcon>
+                {t(
+                  "Cannot display diff for this hydration error. Sentry wasn't able to identify the correct event."
+                )}
+              </Alert>
+            ) : null}
 
-          <ReplayDiffChooser
-            replay={replay}
-            leftOffsetMs={leftOffsetMs}
-            rightOffsetMs={rightOffsetMs}
-          />
-        </Body>
+            <ReplayDiffChooser />
+          </Body>
+        </DiffCompareContextProvider>
       </AnalyticsArea>
     </OrganizationContext.Provider>
   );

--- a/static/app/components/replays/diff/diffCompareContext.tsx
+++ b/static/app/components/replays/diff/diffCompareContext.tsx
@@ -1,0 +1,76 @@
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useState,
+} from 'react';
+
+import ReplayReader from 'sentry/utils/replays/replayReader';
+
+type ContextType = {
+  leftOffsetMs: number;
+  leftTimestampMs: number;
+  replay: ReplayReader;
+  rightOffsetMs: number;
+  rightTimestampMs: number;
+  setLeftOffsetMs: Dispatch<SetStateAction<number>>;
+  setRightOffsetMs: Dispatch<SetStateAction<number>>;
+};
+
+const context = createContext<ContextType>({
+  replay: ReplayReader.factory({
+    attachments: [],
+    errors: [],
+    fetching: false,
+    replayRecord: undefined,
+  })!,
+  leftOffsetMs: 0,
+  leftTimestampMs: 0,
+  rightOffsetMs: 0,
+  rightTimestampMs: 0,
+  setLeftOffsetMs: () => {},
+  setRightOffsetMs: () => {},
+});
+
+export function useDiffCompareContext() {
+  return useContext(context);
+}
+
+interface Props {
+  initialLeftOffsetMs: number;
+  initialRightOffsetMs: number;
+  replay: ReplayReader;
+  children?: ReactNode;
+}
+
+export function DiffCompareContextProvider({
+  replay,
+  initialLeftOffsetMs,
+  initialRightOffsetMs,
+  children,
+}: Props) {
+  const [leftOffsetMs, setLeftOffsetMs] = useState(initialLeftOffsetMs);
+  const [rightOffsetMs, setRightOffsetMs] = useState(initialRightOffsetMs);
+
+  const startTimestampMs = replay.getReplay().started_at.getTime() ?? 0;
+  const leftTimestampMs = startTimestampMs + leftOffsetMs;
+  const rightTimestampMs = startTimestampMs + rightOffsetMs;
+
+  return (
+    <context.Provider
+      value={{
+        leftOffsetMs,
+        leftTimestampMs,
+        replay,
+        rightOffsetMs,
+        rightTimestampMs,
+        setLeftOffsetMs,
+        setRightOffsetMs,
+      }}
+    >
+      {children}
+    </context.Provider>
+  );
+}

--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -8,13 +8,9 @@ import {TabList, TabPanels, TabStateProvider} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
-  leftOffsetMs: number;
-  replay: ReplayReader;
-  rightOffsetMs: number;
   defaultTab?: DiffType;
 }
 
@@ -25,12 +21,7 @@ export const enum DiffType {
   MUTATIONS = 'mutations',
 }
 
-export default function ReplayDiffChooser({
-  defaultTab = DiffType.SLIDER,
-  leftOffsetMs,
-  replay,
-  rightOffsetMs,
-}: Props) {
+export default function ReplayDiffChooser({defaultTab = DiffType.SLIDER}: Props) {
   const organization = useOrganization();
   const onTabChange = (tabKey: DiffType) => {
     trackAnalytics('replay.hydration-modal.tab-change', {tabKey, organization});
@@ -48,32 +39,16 @@ export default function ReplayDiffChooser({
 
         <StyledTabPanels>
           <TabPanels.Item key={DiffType.VISUAL}>
-            <ReplaySideBySideImageDiff
-              leftOffsetMs={leftOffsetMs}
-              replay={replay}
-              rightOffsetMs={rightOffsetMs}
-            />
+            <ReplaySideBySideImageDiff />
           </TabPanels.Item>
           <TabPanels.Item key={DiffType.HTML}>
-            <ReplayTextDiff
-              leftOffsetMs={leftOffsetMs}
-              replay={replay}
-              rightOffsetMs={rightOffsetMs}
-            />
+            <ReplayTextDiff />
           </TabPanels.Item>
           <TabPanels.Item key={DiffType.SLIDER}>
-            <ReplaySliderDiff
-              leftOffsetMs={leftOffsetMs}
-              replay={replay}
-              rightOffsetMs={rightOffsetMs}
-            />
+            <ReplaySliderDiff />
           </TabPanels.Item>
           <TabPanels.Item key={DiffType.MUTATIONS}>
-            <ReplayMutationTree
-              leftOffsetMs={leftOffsetMs}
-              replay={replay}
-              rightOffsetMs={rightOffsetMs}
-            />
+            <ReplayMutationTree />
           </TabPanels.Item>
         </StyledTabPanels>
       </TabStateProvider>

--- a/static/app/components/replays/diff/replayMutationTree.tsx
+++ b/static/app/components/replays/diff/replayMutationTree.tsx
@@ -2,18 +2,14 @@ import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
 import DiffFeedbackBanner from 'sentry/components/replays/diff/diffFeedbackBanner';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import useExtractDiffMutations from 'sentry/utils/replays/hooks/useExtractDiffMutations';
-import type ReplayReader from 'sentry/utils/replays/replayReader';
 
-interface Props {
-  leftOffsetMs: number;
-  replay: ReplayReader;
-  rightOffsetMs: number;
-}
+export function ReplayMutationTree() {
+  const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
 
-export function ReplayMutationTree({replay, leftOffsetMs, rightOffsetMs}: Props) {
   const {data, isLoading} = useExtractDiffMutations({
     leftOffsetMs,
     replay,

--- a/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
+++ b/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
+import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
 import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
@@ -8,15 +9,10 @@ import {space} from 'sentry/styles/space';
 import {ReplayPlayerPluginsContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerPluginsContext';
 import {ReplayPlayerStateContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerStateContext';
 import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
-import type ReplayReader from 'sentry/utils/replays/replayReader';
 
-interface Props {
-  leftOffsetMs: number;
-  replay: ReplayReader;
-  rightOffsetMs: number;
-}
+export function ReplaySideBySideImageDiff() {
+  const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
 
-export function ReplaySideBySideImageDiff({leftOffsetMs, replay, rightOffsetMs}: Props) {
   return (
     <Flex column>
       <DiffHeader>

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
 import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
@@ -17,20 +18,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
 interface Props {
-  leftOffsetMs: number;
-  replay: ReplayReader;
-  rightOffsetMs: number;
   minHeight?: `${number}px` | `${number}%`;
 }
 
 const BORDER_WIDTH = 3;
 
-export function ReplaySliderDiff({
-  minHeight = '0px',
-  leftOffsetMs,
-  replay,
-  rightOffsetMs,
-}: Props) {
+export function ReplaySliderDiff({minHeight = '0px'}: Props) {
+  const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
+
   const positionedRef = useRef<HTMLDivElement>(null);
   const viewDimensions = useDimensions({elementRef: positionedRef});
   const width = toPixels(viewDimensions.width);

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -3,21 +3,17 @@ import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
 import DiffFeedbackBanner from 'sentry/components/replays/diff/diffFeedbackBanner';
 import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import SplitDiff from 'sentry/components/splitDiff';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useExtractPageHtml from 'sentry/utils/replays/hooks/useExtractPageHtml';
-import type ReplayReader from 'sentry/utils/replays/replayReader';
 
-interface Props {
-  leftOffsetMs: number;
-  replay: ReplayReader;
-  rightOffsetMs: number;
-}
+export function ReplayTextDiff() {
+  const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
 
-export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
   const {data, isLoading} = useExtractPageHtml({
     replay,
     offsetMsToStopAt: [leftOffsetMs, rightOffsetMs],


### PR DESCRIPTION
This shared context will help to centralize the before/after timestamps and stops us from having to do prop-drilling to get these values down into all the places they're used. 

The Provider is added to the section inside the Issue Details page, where `<ReplaySliderDiff>` is rendered unconditionally.
The timestamps in use there are then sent into the modal, where another Provider is created to wrap all the tabs inside the hydration modal. 

There are unused setters in the Provider right now. If a setter inside the modal is used, it won't affect the diff on Issue Details page (which is how the modal can be triggered). But all tabs within the modal will share the same before/after timestamps.