### PR TITLE
ref: remove ui for monitor checkin attachments

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {LinkButton} from 'sentry/components/button';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
@@ -17,7 +16,6 @@ import {
 } from 'sentry/components/statusIndicator';
 import Text from 'sentry/components/text';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -76,14 +74,8 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
     return <LoadingError />;
   }
 
-  const generateDownloadUrl = (checkin: CheckIn) =>
-    `/api/0/organizations/${orgSlug}/monitors/${monitor.slug}/checkins/${checkin.id}/attachment/`;
-
   const emptyCell = <Text>{'\u2014'}</Text>;
 
-  // XXX(epurkhiser): Attachmnets are still experimental and may not exist in
-  // the future. For now hide these if they're not being used.
-  const hasAttachments = checkInList?.some(checkin => checkin.attachmentId !== null);
   const hasMultiEnv = monitorEnvs.length > 1;
 
   const headers = [
@@ -91,7 +83,6 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
     t('Started'),
     t('Duration'),
     t('Issues'),
-    ...(hasAttachments ? [t('Attachment')] : []),
     ...(hasMultiEnv ? [t('Environment')] : []),
     t('Expected At'),
   ];
@@ -174,19 +165,6 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                       </QuickContextHovercard>
                     ))}
                   </IssuesContainer>
-                ) : (
-                  emptyCell
-                )}
-                {!hasAttachments ? null : checkIn.attachmentId ? (
-                  <div>
-                    <LinkButton
-                      size="xs"
-                      icon={<IconDownload />}
-                      href={generateDownloadUrl(checkIn)}
-                    >
-                      {t('Attachment')}
-                    </LinkButton>
-                  </div>
                 ) : (
                   emptyCell
                 )}

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -148,13 +148,6 @@ export interface MonitorStat {
 
 export interface CheckIn {
   /**
-   * Attachment ID for attachments sent via the legacy attachment HTTP
-   * endpoint. This will likely be removed in the future.
-   *
-   * @deprecated
-   */
-  attachmentId: number | null;
-  /**
    * Date the opening check-in was sent
    */
   dateCreated: string;


### PR DESCRIPTION
datadog confirms this is unused, cleaning up the frontend first!

<!-- Describe your PR here. -->