### PR TITLE
ref(replay): Update hydration Before/After labels to have timestamps in their tooltip

### DIFF
--- a/static/app/components/replays/diff/replayMutationTree.tsx
+++ b/static/app/components/replays/diff/replayMutationTree.tsx
@@ -3,6 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import DiffFeedbackBanner from 'sentry/components/replays/diff/diffFeedbackBanner';
+import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import useExtractDiffMutations from 'sentry/utils/replays/hooks/useExtractDiffMutations';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -32,6 +33,10 @@ export function ReplayMutationTree({replay, leftOffsetMs, rightOffsetMs}: Props)
 
   return (
     <Fragment>
+      <DiffHeader>
+        <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs} />
+        <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs} />
+      </DiffHeader>
       {!isLoading && Object.keys(timeIndexedMutations).length === 0 ? (
         <DiffFeedbackBanner />
       ) : null}

--- a/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
+++ b/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
@@ -20,8 +20,8 @@ export function ReplaySideBySideImageDiff({leftOffsetMs, replay, rightOffsetMs}:
   return (
     <Flex column>
       <DiffHeader>
-        <Before />
-        <After />
+        <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs} />
+        <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs} />
       </DiffHeader>
 
       <ReplayGrid>

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -38,8 +38,8 @@ export function ReplaySliderDiff({
   return (
     <Fragment>
       <DiffHeader>
-        <Before />
-        <After />
+        <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs} />
+        <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs} />
       </DiffHeader>
       <WithPadding>
         <Positioned style={{minHeight}} ref={positionedRef}>

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -32,7 +32,7 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
     <Container>
       {!isLoading && leftBody === rightBody ? <DiffFeedbackBanner /> : null}
       <DiffHeader>
-        <Before>
+        <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs}>
           <CopyToClipboardButton
             text={leftBody ?? ''}
             size="xs"
@@ -41,7 +41,7 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
             aria-label={t('Copy Before')}
           />
         </Before>
-        <After>
+        <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs}>
           <CopyToClipboardButton
             text={rightBody ?? ''}
             size="xs"

--- a/static/app/components/replays/diff/utils.tsx
+++ b/static/app/components/replays/diff/utils.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import ReplayTooltipTime from 'sentry/components/replays/replayTooltipTime';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -22,15 +23,27 @@ export const DiffHeader = styled('div')`
   }
 `;
 
-const Label = styled('div')`
-  display: flex;
-  align-items: center;
-  font-weight: bold;
-`;
+interface BeforeAfterProps {
+  offset: number;
+  startTimestampMs: number;
+  children?: React.ReactNode;
+}
 
-export function Before({children}: {children?: React.ReactNode}) {
+export function Before({children, offset, startTimestampMs}: BeforeAfterProps) {
   return (
-    <Tooltip title={t('How the initial server-rendered page looked.')}>
+    <Tooltip
+      title={
+        <LeftAligned>
+          {t('The server-rendered page')}
+          <div>
+            <ReplayTooltipTime
+              timestampMs={startTimestampMs + offset}
+              startTimestampMs={startTimestampMs}
+            />
+          </div>
+        </LeftAligned>
+      }
+    >
       <Label>
         {t('Before')}
         {children}
@@ -38,12 +51,21 @@ export function Before({children}: {children?: React.ReactNode}) {
     </Tooltip>
   );
 }
-export function After({children}: {children?: React.ReactNode}) {
+
+export function After({children, offset, startTimestampMs}: BeforeAfterProps) {
   return (
     <Tooltip
-      title={t(
-        'How React re-rendered the page on your browser, after detecting a hydration error.'
-      )}
+      title={
+        <LeftAligned>
+          {t('After React re-rendered the page, and reported a hydration error')}
+          <div>
+            <ReplayTooltipTime
+              timestampMs={startTimestampMs + offset}
+              startTimestampMs={startTimestampMs}
+            />
+          </div>
+        </LeftAligned>
+      }
     >
       <Label>
         {t('After')}
@@ -52,3 +74,16 @@ export function After({children}: {children?: React.ReactNode}) {
     </Tooltip>
   );
 }
+
+const LeftAligned = styled('div')`
+  text-align: left;
+  display: flex;
+  gap: ${space(1)};
+  flex-direction: column;
+`;
+
+const Label = styled('div')`
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+`;

--- a/static/app/components/replays/replayTooltipTime.tsx
+++ b/static/app/components/replays/replayTooltipTime.tsx
@@ -1,0 +1,44 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
+import formatDuration from 'sentry/utils/duration/formatDuration';
+
+interface Props {
+  startTimestampMs: number;
+  timestampMs: number;
+}
+
+export default function ReplayTooltipTime({startTimestampMs, timestampMs}: Props) {
+  return (
+    <Fragment>
+      <TooltipTime>
+        {t(
+          'Date: %s',
+          getFormattedDate(
+            timestampMs,
+            `${getFormat({year: true, seconds: true, timeZone: true})}`,
+            {
+              local: true,
+            }
+          )
+        )}
+      </TooltipTime>
+      <TooltipTime>
+        {t(
+          'Time within replay: %s',
+          formatDuration({
+            duration: [Math.abs(timestampMs - startTimestampMs), 'ms'],
+            precision: 'ms',
+            style: 'hh:mm:ss.sss',
+          })
+        )}
+      </TooltipTime>
+    </Fragment>
+  );
+}
+
+const TooltipTime = styled('div')`
+  text-align: left;
+`;

--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -3,12 +3,10 @@ import styled from '@emotion/styled';
 
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration/duration';
+import ReplayTooltipTime from 'sentry/components/replays/replayTooltipTime';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getFormat, getFormattedDate} from 'sentry/utils/dates';
-import formatDuration from 'sentry/utils/duration/formatDuration';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 
 type Props = {
@@ -32,28 +30,10 @@ export default function TimestampButton({
     <Tooltip
       title={
         <div>
-          <TooltipTime>
-            {t(
-              'Date: %s',
-              getFormattedDate(
-                timestampMs,
-                `${getFormat({year: true, seconds: true, timeZone: true})}`,
-                {
-                  local: true,
-                }
-              )
-            )}
-          </TooltipTime>
-          <TooltipTime>
-            {t(
-              'Time within replay: %s',
-              formatDuration({
-                duration: [Math.abs(timestampMs - startTimestampMs), 'ms'],
-                precision: 'ms',
-                style: 'hh:mm:ss.sss',
-              })
-            )}
-          </TooltipTime>
+          <ReplayTooltipTime
+            timestampMs={timestampMs}
+            startTimestampMs={startTimestampMs}
+          />
         </div>
       }
       skipWrapper
@@ -76,10 +56,6 @@ export default function TimestampButton({
     </Tooltip>
   );
 }
-
-const TooltipTime = styled('div')`
-  text-align: left;
-`;
 
 const StyledButton = styled('button')`
   background: transparent;


### PR DESCRIPTION
This refactored `<TimestampButton>` to pull `<ReplayTooltipTime>` out. 

Then i stuck that new `<ReplayTooltipTime>` thing (don't love the name, suggestions plz?) into the tooltips for the before/after labels above hydration diffs


| | Left | Right |
| --- | --- | --- |
| Before | <img width="260" alt="SCR-20250103-luqi" src="https://github.com/user-attachments/assets/f1827fa5-7021-473e-914a-6e5d64971470" /> | <img width="296" alt="SCR-20250103-lupp" src="https://github.com/user-attachments/assets/3229e91e-2006-4953-b88c-aff490e6cea8" />
| After | <img width="309" alt="SCR-20250103-lvtg" src="https://github.com/user-attachments/assets/14d68a49-b6bb-4fd3-97f2-d3959cb8bb0f" /> | <img width="293" alt="SCR-20250103-lvue" src="https://github.com/user-attachments/assets/4e5544c6-12cf-491a-86ae-6c5c8f8a325e" />

I also added the Before/After labels to the Mutations tab. Kinda just to keep things consistent. Might take them out again.
| Before | After |
| --- | --- |
| <img width="720" alt="SCR-20250103-lwae" src="https://github.com/user-attachments/assets/b974ce6a-6c36-4979-8a04-71667017a56b" /> | <img width="722" alt="SCR-20250103-lwbh" src="https://github.com/user-attachments/assets/7dbc30de-62bd-473c-b479-306c521af6fa" />

Tooltips inside the Replay details page still look the same:
<img width="269" alt="SCR-20250103-ltss" src="https://github.com/user-attachments/assets/a7817485-3457-4f72-878f-5610a2733994" />

