### PR TITLE
chore(issues): Improve FileIOMainThreadDetector performance

### DIFF
--- a/bin/benchmark_detectors
+++ b/bin/benchmark_detectors
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# isort: skip_file
+
+"""
+This script benchmarks the performance of issue detectors in Sentry.
+
+NOTE: This currently only supports FileIOMainThreadDetector.
+
+Usage: python benchmark_detectors
+"""
+from sentry.runner import configure
+
+configure()
+import time
+import sentry_sdk
+from sentry.testutils.performance_issues.event_generators import get_event  # noqa: S007
+from sentry.utils.performance_issues.detectors import FileIOMainThreadDetector
+from sentry.utils.performance_issues.performance_detection import (
+    get_detection_settings,
+    run_detector_on_data,
+)
+
+sentry_sdk.init(None)
+
+
+def main():
+    settings = get_detection_settings()
+
+    # 10 events: 1 ignored, 1 matching, and 8 ignored
+    events = [get_event("file-io-on-main-thread") for _ in range(0, 10)]
+    events[0]["spans"][0]["data"]["file.path"] = "somethins/stuff/blah/yup/KBLayout_iPhone.dat"
+    for i in range(2, 10):
+        events[i]["spans"][0]["data"]["blocked_main_thread"] = False
+
+    count = 100_000
+
+    start = time.perf_counter()
+    for _ in range(0, count):
+        for event in events:
+            detector = FileIOMainThreadDetector(settings, event)
+            run_detector_on_data(detector, event)
+    elapsed = time.perf_counter() - start
+
+    ops = count * len(events)
+    print(f"{ops:,} ops")  # noqa
+    print(f"{elapsed:.3f} s")  # noqa
+    print(f"{ops/elapsed:,.2f} ops/s")  # noqa
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import fnmatch
 import hashlib
-import re
 from collections import defaultdict
 from typing import Any
 
@@ -118,10 +116,7 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
 
     __slots__ = ("stored_problems",)
 
-    IGNORED_LIST = {
-        re.compile(fnmatch.translate(pattern))
-        for pattern in ["*.nib", "*.plist", "*kblayout_iphone.dat"]
-    }
+    IGNORED_SUFFIXES = [".nib", ".plist", "kblayout_iphone.dat"]
     SPAN_PREFIX = "file"
     type = DetectorType.FILE_IO_MAIN_THREAD
     settings_key = DetectorType.FILE_IO_MAIN_THREAD
@@ -199,7 +194,7 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
             return False
         file_path = (data.get("file.path") or "").lower()
 
-        if any(bool(ignored_pattern.match(file_path)) for ignored_pattern in self.IGNORED_LIST):
+        if any(file_path.endswith(suffix) for suffix in self.IGNORED_SUFFIXES):
             return False
         # doing is True since the value can be any type
         return data.get("blocked_main_thread", False) is True


### PR DESCRIPTION
FileIOMainThreadDetector is our most time consuming detector: https://sentry.sentry.io/traces/?groupBy=span.description&interval=15m&mode=aggregate&project=1&query=span.op%3Afunction%20span.description%3Arun_detector_on_data.%2A&statsPeriod=24h&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22sum%28span.duration%29%22%2C%22count%28span.duration%29%22%2C%22p95%28span.duration%29%22%2C%22p99%28span.duration%29%22%5D%7D

This eliminates the need to recompile these glob patterns potentially for every transaction event and adds a synthetic benchmark to measure the (~4x) improvement:

Before:
```
$ ./bin/benchmark_detectors
1,000,000 ops
7.005 s
142,758.90 ops/s
```

After:
```
$ ./bin/benchmark_detectors
1,000,000 ops
1.806 s
553,602.94 ops/s
```