### PR TITLE
chore(issue-details): Adjust min width for tags

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -192,7 +192,7 @@ const TagBarContainer = styled('div')`
   position: absolute;
   left: 0;
   top: 0;
-  min-width: ${space(1)};
+  min-width: ${space(0.25)};
   &:before {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
this pr updates the min width for tags to allow for a wider range of widths to better differentiate values in the breakdown 

before: 
<img width="105" alt="Screenshot 2025-01-03 at 2 34 01 PM" src="https://github.com/user-attachments/assets/5fd19144-4bd3-4d1c-b66d-ed62f8a6e4e9" />

after:
<img width="173" alt="Screenshot 2025-01-03 at 2 34 07 PM" src="https://github.com/user-attachments/assets/39b20381-6f5a-410c-84e9-6f10566e9c2a" />
