### PR TITLE
fix(hydration issue): Only look at IncrementalSource.Mutation types for hydration before/after

### DIFF
--- a/static/app/utils/replays/getDiffTimestamps.tsx
+++ b/static/app/utils/replays/getDiffTimestamps.tsx
@@ -1,7 +1,7 @@
 import type {Event} from 'sentry/types/event';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import type {HydrationErrorFrame} from 'sentry/utils/replays/types';
-import {EventType, isHydrationErrorFrame} from 'sentry/utils/replays/types';
+import {isHydrationErrorFrame, isRRWebChangeFrame} from 'sentry/utils/replays/types';
 
 export function getReplayDiffOffsetsFromFrame(
   replay: ReplayReader | null,
@@ -15,11 +15,7 @@ export function getReplayDiffOffsetsFromFrame(
   }
 
   const startTimestampMs = replay.getReplay().started_at.getTime() ?? 0;
-  const domChangedFrames = replay
-    .getRRWebFrames()
-    .filter(frame =>
-      [EventType.FullSnapshot, EventType.IncrementalSnapshot].includes(frame.type)
-    );
+  const domChangedFrames = replay.getRRWebFrames().filter(isRRWebChangeFrame);
 
   const prevIncremental = domChangedFrames.filter(
     frame => frame.timestamp < hydrationError.timestampMs

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -1,6 +1,7 @@
 import {
   EventType,
   type eventWithTime as TEventWithTime,
+  IncrementalSource,
   MouseInteractions,
 } from '@sentry-internal/rrweb';
 
@@ -143,6 +144,13 @@ export function isRecordingFrame(
   return 'type' in attachment && 'timestamp' in attachment;
 }
 
+export function isRRWebChangeFrame(frame: RecordingFrame) {
+  return (
+    frame.type === EventType.FullSnapshot ||
+    (frame.type === EventType.IncrementalSnapshot &&
+      frame.data.source === IncrementalSource.Mutation)
+  );
+}
 export function isTouchStartFrame(frame: RecordingFrame) {
   return (
     frame.type === EventType.IncrementalSnapshot &&


### PR DESCRIPTION
There are many IncrementalSource possibilities (definition copied below), but we really only want to look at mutations. Mouse moves, input, and possibly even StyleSheetRule shouldn't affect hydrating the DOM that react cares about.

The full list of this enum is:
```
export declare enum IncrementalSource {
    Mutation = 0,
    MouseMove = 1,
    MouseInteraction = 2,
    Scroll = 3,
    ViewportResize = 4,
    Input = 5,
    TouchMove = 6,
    MediaInteraction = 7,
    StyleSheetRule = 8,
    CanvasMutation = 9,
    Font = 10,
    Log = 11,
    Drag = 12,
    StyleDeclaration = 13,
    Selection = 14,
    AdoptedStyleSheet = 15,
    CustomElement = 16
}
```

The parent type that we are refining down from is:
```
export type incrementalSnapshotEvent = {
    type: EventType.IncrementalSnapshot;
    data: incrementalData;
};
```