### PR TITLE
fix(issues): Remove duplicate span in sdk_crash_monitoring

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1292,15 +1292,13 @@ def sdk_crash_monitoring(job: PostProcessJob):
     if not features.has("organizations:sdk-crash-detection", event.project.organization):
         return
 
-    configs = build_sdk_crash_detection_configs()
-    if not configs or len(configs) == 0:
-        return None
+    with sentry_sdk.start_span(op="post_process.build_sdk_crash_config"):
+        configs = build_sdk_crash_detection_configs()
+        if not configs or len(configs) == 0:
+            return None
 
-    with sentry_sdk.start_span(op="tasks.post_process_group.sdk_crash_monitoring"):
-        sdk_crash_detection.detect_sdk_crash(
-            event=event,
-            configs=configs,
-        )
+    with sentry_sdk.start_span(op="post_process.detect_sdk_crash"):
+        sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
 
 
 def plugin_post_process_group(plugin_slug, event, **kwargs):


### PR DESCRIPTION
This op is already being auto-instrumented in run_post_process_job, the duplicate span here with the same name is not helpful when looking at aggregates.

This renames the op and adds another around config building - in the future I suspect we can get a very easy win by not rebuilding config for every single event - this will give us some data to back up that theory.

Aggregate showing the 2x duplicate (`update_existing_attachments` is fixed in a separate PR): https://sentry.sentry.io/traces/?groupBy=span.op&mode=aggregate&project=1&query=span.op%3Atasks.post_process_group.%2A&statsPeriod=24h&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D

See also: #82911