### PR TITLE
feat(insights): update total opportunity score function to handle missing vitals

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1754,6 +1754,7 @@ class MetricsDatasetConfig(DatasetConfig):
             )
             for vital in vitals
         }
+        # TODO: Divide by the total weights to factor out any missing web vitals
         return Function(
             "divide",
             [

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3021,6 +3021,90 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[1]["total_opportunity_score()"] == 0.36
         assert meta["isMetricsData"]
 
+    def test_opportunity_score_with_fixed_weights_and_missing_vitals(self):
+        self.store_transaction_metric(
+            0.5,
+            metric="measurements.score.inp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            1.0,
+            metric="measurements.score.weight.inp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.2,
+            metric="measurements.score.inp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            1.0,
+            metric="measurements.score.weight.inp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.2,
+            metric="measurements.score.inp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.5,
+            metric="measurements.score.weight.inp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.1,
+            metric="measurements.score.lcp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.3,
+            metric="measurements.score.weight.lcp",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.2,
+            metric="measurements.score.inp",
+            tags={"transaction": "bar_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.5,
+            metric="measurements.score.weight.inp",
+            tags={"transaction": "bar_transaction"},
+            timestamp=self.min_ago,
+        )
+
+        with self.feature({"organizations:performance-vitals-handle-missing-webvitals": True}):
+            response = self.do_request(
+                {
+                    "field": [
+                        "transaction",
+                        "total_opportunity_score()",
+                    ],
+                    "query": "event.type:transaction",
+                    "orderby": "transaction",
+                    "dataset": "metrics",
+                    "per_page": 50,
+                }
+            )
+            assert response.status_code == 200, response.content
+            assert len(response.data["data"]) == 2
+            data = response.data["data"]
+            meta = response.data["meta"]
+
+            assert data[0]["total_opportunity_score()"] == 0.09999999999999999
+            assert data[1]["total_opportunity_score()"] == 0.6
+            assert meta["isMetricsData"]
+
     def test_total_performance_score(self):
         self.store_transaction_metric(
             0.03,
@@ -4089,6 +4173,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_opportunity_score_with_fixed_weights(self):
         super().test_opportunity_score_with_fixed_weights()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_opportunity_score_with_fixed_weights_and_missing_vitals(self):
+        super().test_opportunity_score_with_fixed_weights_and_missing_vitals()
 
     @pytest.mark.xfail(reason="Not implemented")
     def test_count_scores(self):


### PR DESCRIPTION
Updates total opportunity score function to upscale if there are any missing webvitals score. Consolidates the total weight logic in performance and opportunity scores into a single `_resolve_total_weights_function` function. 

Similar to https://github.com/getsentry/sentry/pull/82750