### PR TITLE
fix(discover): Fix tag facet breakdown for errors

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -12,7 +12,6 @@ from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
 from sentry.search.utils import DEVICE_CLASS
-from sentry.snuba import discover
 
 
 class _TopValue(TypedDict):
@@ -43,10 +42,12 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
 
         update_snuba_params_with_timestamp(request, snuba_params, timestamp_key="traceTimestamp")
 
+        dataset = self.get_dataset(request)
+
         def data_fn(offset, limit):
             with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
                 with handle_query_errors():
-                    facets = discover.get_facets(
+                    facets = dataset.get_facets(
                         query=request.GET.get("query"),
                         snuba_params=snuba_params,
                         referrer="api.organization-events-facets.top-tags",

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -17,7 +17,9 @@ from sentry.search.events.builder.errors import (
 )
 from sentry.search.events.types import EventsResponse, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.discover import OTHER_KEY, create_result_key, transform_tips, zerofill
+from sentry.snuba.discover import OTHER_KEY, TOP_KEYS_DEFAULT_LIMIT, FacetResult, create_result_key
+from sentry.snuba.discover import get_facets as get_discover_facets
+from sentry.snuba.discover import transform_tips, zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.query_sources import QuerySource
 from sentry.utils.snuba import SnubaTSResult, bulk_snuba_queries
@@ -362,3 +364,14 @@ def top_events_timeseries(
             )
 
     return top_events_results
+
+
+def get_facets(
+    query: str | None,
+    snuba_params: SnubaParams,
+    referrer: str,
+    per_page: int | None = TOP_KEYS_DEFAULT_LIMIT,
+    cursor: int | None = 0,
+    dataset: Dataset | None = Dataset.Events,
+) -> list[FacetResult]:
+    return get_discover_facets(query, snuba_params, referrer, per_page, cursor, Dataset.Events)

--- a/src/sentry/snuba/transactions.py
+++ b/src/sentry/snuba/transactions.py
@@ -157,3 +157,16 @@ def top_events_timeseries(
         dataset=Dataset.Transactions,
         query_source=query_source,
     )
+
+
+def get_facets(
+    query: str | None,
+    snuba_params: SnubaParams,
+    referrer: str,
+    per_page: int | None = discover.TOP_KEYS_DEFAULT_LIMIT,
+    cursor: int | None = 0,
+    dataset: Dataset | None = Dataset.Transactions,
+) -> list[discover.FacetResult]:
+    return discover.get_facets(
+        query, snuba_params, referrer, per_page, cursor, Dataset.Transactions
+    )


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/82149

Make events-facets endpoint dataset aware. Fixes the
issue where tag breakdown numbers were funky for
errors.