### PR TITLE
chore(snuba): Fix testcase to account for stricter Rust errors processor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,8 @@
 /src/sentry/snuba/metrics/query.py                       @getsentry/owners-snuba @getsentry/telemetry-experience
 /src/sentry/snuba/metrics_layer/                         @getsentry/owners-snuba
 /src/sentry/search/events/datasets/metrics_layer.py      @getsentry/owners-snuba
+/tests/snuba/test_snql_snuba.py                          @getsentry/owners-snuba
+/tests/snuba/test_snuba.py                               @getsentry/owners-snuba
 
 ## Event Ingestion
 /src/sentry/attachments/                                 @getsentry/ingest

--- a/tests/snuba/test_snql_snuba.py
+++ b/tests/snuba/test_snql_snuba.py
@@ -35,6 +35,7 @@ class SnQLTest(TestCase, SnubaTestCase):
                     "datetime": ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     "data": {"received": time.mktime(ts.timetuple())},
                 },
+                {},
             )
         )
         return event_id


### PR DESCRIPTION
The Rust errors processor in Snuba has been in prod for a long time now,
but has never been used in tests. Update testcase so that we can get rid
of the Python one.
