### PR TITLE
fix(dashboards): Allow sorting Dashboards table by release

### DIFF
--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -831,4 +831,80 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       expect(mock).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('fetches releases if required', async () => {
+    const dataMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/metrics/data/',
+      body: SessionsFieldFixture(`session.all`),
+    });
+
+    const releasesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [
+        {id: 1, version: '0.0.1'},
+        {id: 2, version: '0.0.2'},
+      ],
+    });
+
+    const releasesWidget = {
+      title: 'Crash Rate',
+      interval: '5m',
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: [`count_unique(user)`],
+          aggregates: [`count_unique(user)`],
+          columns: ['release'],
+          orderby: '-count_unique(user)',
+        },
+      ],
+      widgetType: WidgetType.RELEASE,
+    };
+
+    const children = jest.fn(() => <div />);
+
+    const {rerender} = render(
+      <ReleaseWidgetQueries
+        api={api}
+        widget={releasesWidget}
+        organization={organization}
+        selection={selection}
+      >
+        {children}
+      </ReleaseWidgetQueries>
+    );
+
+    await waitFor(() => {
+      expect(dataMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(releasesMock).not.toHaveBeenCalled();
+
+    rerender(
+      <ReleaseWidgetQueries
+        api={api}
+        widget={{
+          ...releasesWidget,
+          queries: [
+            {
+              ...releasesWidget.queries[0]!,
+              orderby: '-release',
+            },
+          ],
+        }}
+        organization={organization}
+        selection={selection}
+      >
+        {children}
+      </ReleaseWidgetQueries>
+    );
+
+    await waitFor(() => {
+      expect(dataMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(releasesMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -14,6 +14,7 @@ import type {Series} from 'sentry/types/echarts';
 import type {MetricsApiResponse} from 'sentry/types/metrics';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import type {Release} from 'sentry/types/release';
+import {defined} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {stripDerivedMetricsPrefix} from 'sentry/utils/discover/fields';
 import {TOP_N} from 'sentry/utils/discover/types';
@@ -146,7 +147,7 @@ export function requiresCustomReleaseSorting(query: WidgetQuery): boolean {
 
 class ReleaseWidgetQueries extends Component<Props, State> {
   state: State = {
-    loading: true,
+    loading: false,
     errorMessage: undefined,
     releases: undefined,
   };
@@ -154,6 +155,18 @@ class ReleaseWidgetQueries extends Component<Props, State> {
   componentDidMount() {
     this._isMounted = true;
     if (requiresCustomReleaseSorting(this.props.widget.queries[0]!)) {
+      this.fetchReleases();
+      return;
+    }
+  }
+
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (
+      !requiresCustomReleaseSorting(prevProps.widget.queries[0]!) &&
+      requiresCustomReleaseSorting(this.props.widget.queries[0]!) &&
+      !this.state.loading &&
+      !defined(this.state.releases)
+    ) {
       this.fetchReleases();
       return;
     }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/82925. Somewhere along the line, the logic that sorts data by release on the frontend (due to backend dataset limitation) broke. If someone created a widget, sorted by release, and _saved it_, it works. But, when someone is _switching to_ sorting by release the preview is busted because we forgot to fetch releases for them.

This PR makes sure that if they update widget settings to start sorting by release, we fetch the releases.
