### PR TITLE
fix(widget-builder): Bypass sort reset for issue widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -876,6 +876,33 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.sort).toEqual([{field: 'newSortField', kind: 'desc'}]);
     });
+
+    it('does not reset the table sort for issue widgets', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ISSUE,
+            field: ['testField'],
+            sort: ['-notInFields'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.sort).toEqual([{field: 'notInFields', kind: 'desc'}]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_FIELDS,
+          payload: [{field: 'testField', kind: FieldValueKind.FIELD}],
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([{field: 'notInFields', kind: 'desc'}]);
+    });
   });
 
   describe('yAxis', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -241,6 +241,12 @@ function useWidgetBuilderState(): {
               field => generateFieldAsString(field) === sort?.[0]?.field
             )
           ) {
+            if (dataset === WidgetType.ISSUE) {
+              // Issue widgets can sort their tables by limited fields that aren't
+              // in the fields array.
+              return;
+            }
+
             if (isRemoved) {
               setSort([
                 {
@@ -308,6 +314,7 @@ function useWidgetBuilderState(): {
       displayType,
       query,
       sort,
+      dataset,
     ]
   );
 


### PR DESCRIPTION
Bypasses the sorting reset for issue widgets. This is because they use a different API and they don't need to enforce that the field needs to be in the table.