### PR TITLE
chore(sentry apps): Deprecate send_alert_event

### DIFF
--- a/src/sentry/sentry_apps/tasks/__init__.py
+++ b/src/sentry/sentry_apps/tasks/__init__.py
@@ -4,7 +4,6 @@ from .sentry_apps import (
     create_or_update_service_hooks_for_sentry_app,
     installation_webhook,
     process_resource_change_bound,
-    send_alert_event,
     send_alert_webhook,
     send_resource_change_webhook,
     workflow_notification,
@@ -12,7 +11,6 @@ from .sentry_apps import (
 from .service_hooks import process_service_hook
 
 __all__ = (
-    "send_alert_event",
     "build_comment_webhook",
     "clear_region_cache",
     "create_or_update_service_hooks_for_sentry_app",

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -30,7 +30,6 @@ from sentry.sentry_apps.tasks.sentry_apps import (
     installation_webhook,
     notify_sentry_app,
     process_resource_change_bound,
-    send_alert_event,
     send_alert_webhook,
     send_webhooks,
     workflow_notification,
@@ -105,15 +104,6 @@ class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
         self.install = self.create_sentry_app_installation(
             organization=self.organization, slug=self.sentry_app.slug
         )
-
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    def test_no_sentry_app(self, safe_urlopen):
-        event = self.store_event(data={}, project_id=self.project.id)
-        assert event.group is not None
-        group_event = GroupEvent.from_event(event, event.group)
-        send_alert_event(group_event, self.rule, 9999)
-
-        assert not safe_urlopen.called
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     def test_no_sentry_app_for_send_alert_event_v2(self, safe_urlopen):


### PR DESCRIPTION
Since we've moved all traffic from `send_alert_event` task to `send_alert_webhook` task we can deprecate the old task now