### PR TITLE
feat(widget-builder): Implement error message for title field

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -62,4 +62,19 @@ describe('WidgetBuilder', () => {
       })
     );
   });
+
+  it('displays error', async function () {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderNameAndDescription
+          error={{title: 'Title is required during creation.'}}
+        />
+      </WidgetBuilderProvider>,
+      {router, organization}
+    );
+
+    expect(
+      await screen.findByText('Title is required during creation.')
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -12,6 +12,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 }));
 
 const mockUseNavigate = jest.mocked(useNavigate);
+const mockSetError = jest.fn();
 
 describe('WidgetBuilder', () => {
   let router!: ReturnType<typeof RouterFixture>;
@@ -33,7 +34,7 @@ describe('WidgetBuilder', () => {
 
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderNameAndDescription error={{}} />
+        <WidgetBuilderNameAndDescription error={{}} setError={mockSetError} />
       </WidgetBuilderProvider>,
       {
         router,
@@ -68,6 +69,7 @@ describe('WidgetBuilder', () => {
       <WidgetBuilderProvider>
         <WidgetBuilderNameAndDescription
           error={{title: 'Title is required during creation.'}}
+          setError={mockSetError}
         />
       </WidgetBuilderProvider>,
       {router, organization}

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -32,10 +32,10 @@ function WidgetBuilderNameAndDescription({
         title={t('Widget Name')}
         aria-label={t('Widget Name')}
         value={state.title}
-        onChange={e => {
+        onChange={newTitle => {
           // clear error once user starts typing
           setError({...error, title: undefined});
-          dispatch({type: BuilderStateAction.SET_TITLE, payload: e});
+          dispatch({type: BuilderStateAction.SET_TITLE, payload: newTitle});
         }}
         required
         error={error.title}

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -12,9 +12,13 @@ import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/us
 
 interface WidgetBuilderNameAndDescriptionProps {
   error: Record<string, any>;
+  setError: (error: Record<string, any>) => void;
 }
 
-function WidgetBuilderNameAndDescription({error}: WidgetBuilderNameAndDescriptionProps) {
+function WidgetBuilderNameAndDescription({
+  error,
+  setError,
+}: WidgetBuilderNameAndDescriptionProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   const [isDescSelected, setIsDescSelected] = useState(state.description ? true : false);
 
@@ -29,6 +33,8 @@ function WidgetBuilderNameAndDescription({error}: WidgetBuilderNameAndDescriptio
         aria-label={t('Widget Name')}
         value={state.title}
         onChange={e => {
+          // clear error once user starts typing
+          setError({...error, title: undefined});
           dispatch({type: BuilderStateAction.SET_TITLE, payload: e});
         }}
         required

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import TextArea from 'sentry/components/forms/controls/textarea';
-import Input from 'sentry/components/input';
+import TextField from 'sentry/components/forms/fields/textField';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
@@ -14,7 +14,7 @@ interface WidgetBuilderNameAndDescriptionProps {
   error: Record<string, any>;
 }
 
-function WidgetBuilderNameAndDescription({}: WidgetBuilderNameAndDescriptionProps) {
+function WidgetBuilderNameAndDescription({error}: WidgetBuilderNameAndDescriptionProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   const [isDescSelected, setIsDescSelected] = useState(state.description ? true : false);
 
@@ -22,15 +22,18 @@ function WidgetBuilderNameAndDescription({}: WidgetBuilderNameAndDescriptionProp
     <Fragment>
       <SectionHeader title={t('Widget Name & Description')} />
       <StyledInput
+        name={t('Widget Name')}
         size="md"
         placeholder={t('Name')}
         title={t('Widget Name')}
-        type="text"
         aria-label={t('Widget Name')}
         value={state.title}
         onChange={e => {
-          dispatch({type: BuilderStateAction.SET_TITLE, payload: e.target.value});
+          dispatch({type: BuilderStateAction.SET_TITLE, payload: e});
         }}
+        required
+        error={error.title}
+        inline={false}
       />
       {!isDescSelected && (
         <AddDescriptionButton
@@ -62,8 +65,10 @@ function WidgetBuilderNameAndDescription({}: WidgetBuilderNameAndDescriptionProp
 
 export default WidgetBuilderNameAndDescription;
 
-const StyledInput = styled(Input)`
+const StyledInput = styled(TextField)`
   margin-bottom: ${space(1)};
+  padding: 0;
+  border: none;
 `;
 
 const AddDescriptionButton = styled(Button)`

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -162,7 +162,7 @@ function WidgetBuilderSlideout({
           </Section>
         )}
         <Section>
-          <WidgetBuilderNameAndDescription error={error} />
+          <WidgetBuilderNameAndDescription error={error} setError={setError} />
         </Section>
         <SaveButton isEditing={isEditing} onSave={onSave} setError={setError} />
       </SlideoutBodyWrapper>


### PR DESCRIPTION
Added an error message to the name field to handle validation errors on submit. I've just repurposed the type of field that we use on the current widget builder as it has the error message functionality built in. When the user starts typing in that field it will get rid of the error.

Looks like this :
<img width="724" alt="image" src="https://github.com/user-attachments/assets/b8ac2ec2-aed4-4495-ae00-6d10fc7dea34" />

Contributes to https://github.com/getsentry/sentry/issues/81729