### PR TITLE
ref(rr6): Rename RouteContext to TestRouteContext for clarity

### DIFF
--- a/static/app/utils/useLocation.spec.tsx
+++ b/static/app/utils/useLocation.spec.tsx
@@ -5,7 +5,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import {useLocation} from 'sentry/utils/useLocation';
-import {RouteContext} from 'sentry/views/routeContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
 describe('useLocation', () => {
   it('returns the current location object', function () {
@@ -26,9 +26,9 @@ describe('useLocation', () => {
     };
 
     render(
-      <RouteContext.Provider value={routeContext}>
+      <TestRouteContext.Provider value={routeContext}>
         <HomePage />
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     expect(location.pathname).toBe('/mock-pathname/');

--- a/static/app/utils/useLocation.tsx
+++ b/static/app/utils/useLocation.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import {useLocation as useReactRouter6Location} from 'react-router-dom';
 import type {Location, Query} from 'history';
 
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import {useTestRouteContext} from 'sentry/utils/useRouteContext';
 
 import {location6ToLocation3} from './reactRouter6Compat/location';
 
@@ -13,10 +13,10 @@ type DefaultQuery<T = string> = {
 export function useLocation<Q extends Query = DefaultQuery>(): Location<Q> {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
-  const legacyRouterContext = useRouteContext();
+  const testRouteContext = useTestRouteContext();
 
-  if (legacyRouterContext) {
-    return legacyRouterContext.location;
+  if (testRouteContext) {
+    return testRouteContext.location;
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/static/app/utils/useNavigate.spec.tsx
+++ b/static/app/utils/useNavigate.spec.tsx
@@ -7,7 +7,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 import ConfigStore from 'sentry/stores/configStore';
 import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {RouteContext} from 'sentry/views/routeContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
 describe('useNavigate', () => {
   const configState = ConfigStore.getState();
@@ -32,9 +32,9 @@ describe('useNavigate', () => {
     };
 
     render(
-      <RouteContext.Provider value={routeContext}>
+      <TestRouteContext.Provider value={routeContext}>
         <HomePage />
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     expect(typeof navigate).toBe('function');
@@ -64,9 +64,9 @@ describe('useNavigate', () => {
     };
 
     render(
-      <RouteContext.Provider value={routeContext}>
+      <TestRouteContext.Provider value={routeContext}>
         <HomePage />
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     expect(routeContext.router.push).toHaveBeenCalledWith({

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -5,7 +5,7 @@ import type {LocationDescriptor} from 'history';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
 import {locationDescriptorToTo} from './reactRouter6Compat/location';
-import {useRouteContext} from './useRouteContext';
+import {useTestRouteContext} from './useRouteContext';
 
 type NavigateOptions = {
   replace?: boolean;
@@ -26,9 +26,9 @@ export interface ReactRouter3Navigate {
 export function useNavigate(): ReactRouter3Navigate {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
-  const legacyRouterContext = useRouteContext();
+  const testRouteContext = useTestRouteContext();
 
-  if (!legacyRouterContext) {
+  if (!testRouteContext) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const router6Navigate = useReactRouter6Navigate();
 
@@ -50,7 +50,7 @@ export function useNavigate(): ReactRouter3Navigate {
   // XXX(epurkihser): We are using react-router 3 here, to avoid recursive
   // dependencies we just use the useRouteContext instead of useRouter here
 
-  const {router} = legacyRouterContext;
+  const {router} = testRouteContext;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const hasMountedRef = useRef(false);

--- a/static/app/utils/useParams.spec.tsx
+++ b/static/app/utils/useParams.spec.tsx
@@ -5,8 +5,8 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import {useParams} from 'sentry/utils/useParams';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
-import {RouteContext} from 'sentry/views/routeContext';
+import {useTestRouteContext} from 'sentry/utils/useRouteContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
 const mockUsingCustomerDomain = jest.fn();
 const mockCustomerDomain = jest.fn();
@@ -43,9 +43,9 @@ describe('useParams', () => {
       };
 
       render(
-        <RouteContext.Provider value={routeContext}>
+        <TestRouteContext.Provider value={routeContext}>
           <HomePage />
-        </RouteContext.Provider>
+        </TestRouteContext.Provider>
       );
 
       expect(params).toEqual({});
@@ -68,9 +68,9 @@ describe('useParams', () => {
       };
 
       render(
-        <RouteContext.Provider value={routeContext}>
+        <TestRouteContext.Provider value={routeContext}>
           <HomePage />
-        </RouteContext.Provider>
+        </TestRouteContext.Provider>
       );
       expect(params).toEqual({slug: 'sentry'});
     });
@@ -89,7 +89,7 @@ describe('useParams', () => {
       let useParamsValue;
 
       function Component() {
-        const {params} = useRouteContext()!;
+        const {params} = useTestRouteContext()!;
         originalParams = params;
         useParamsValue = useParams();
         return (
@@ -105,9 +105,9 @@ describe('useParams', () => {
       };
 
       render(
-        <RouteContext.Provider value={routeContext}>
+        <TestRouteContext.Provider value={routeContext}>
           <Component />
-        </RouteContext.Provider>
+        </TestRouteContext.Provider>
       );
 
       expect(
@@ -127,7 +127,7 @@ describe('useParams', () => {
       let useParamsValue;
 
       function Component() {
-        const {params} = useRouteContext()!;
+        const {params} = useTestRouteContext()!;
         originalParams = params;
         useParamsValue = useParams();
         return (
@@ -143,9 +143,9 @@ describe('useParams', () => {
       };
 
       render(
-        <RouteContext.Provider value={routeContext}>
+        <TestRouteContext.Provider value={routeContext}>
           <Component />
-        </RouteContext.Provider>
+        </TestRouteContext.Provider>
       );
 
       expect(

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -3,20 +3,20 @@ import {useParams as useReactRouter6Params} from 'react-router-dom';
 
 import {CUSTOMER_DOMAIN, USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 
-import {useRouteContext} from './useRouteContext';
+import {useTestRouteContext} from './useRouteContext';
 
 export function useParams<P = Record<string, string>>(): P {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
-  const legacyRouterContext = useRouteContext();
+  const testRouteContext = useTestRouteContext();
 
   let contextParams: any;
 
-  if (!legacyRouterContext) {
+  if (!testRouteContext) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     contextParams = useReactRouter6Params();
   } else {
-    contextParams = legacyRouterContext.params;
+    contextParams = testRouteContext.params;
   }
 
   // Memoize params as mutating for customer domains causes other hooks

--- a/static/app/utils/useRouteContext.tsx
+++ b/static/app/utils/useRouteContext.tsx
@@ -1,7 +1,13 @@
 import {useContext} from 'react';
 
-import {RouteContext} from 'sentry/views/routeContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
-export function useRouteContext() {
-  return useContext(RouteContext);
+/**
+ * @deprecated
+ *
+ * DO NOT USE. This is currently only used to support our tests as we find a
+ * way to transition our tests to a more react-router 6 style approach.
+ */
+export function useTestRouteContext() {
+  return useContext(TestRouteContext);
 }

--- a/static/app/utils/useRouter.spec.tsx
+++ b/static/app/utils/useRouter.spec.tsx
@@ -5,7 +5,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import useRouter from 'sentry/utils/useRouter';
-import {RouteContext} from 'sentry/views/routeContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
 describe('useRouter', () => {
   it('returns the current router object', function () {
@@ -23,9 +23,9 @@ describe('useRouter', () => {
     };
 
     render(
-      <RouteContext.Provider value={routeContext}>
+      <TestRouteContext.Provider value={routeContext}>
         <HomePage />
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
     expect(actualRouter).toEqual(routeContext.router);
   });

--- a/static/app/utils/useRouter.tsx
+++ b/static/app/utils/useRouter.tsx
@@ -6,7 +6,7 @@ import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import {useLocation} from './useLocation';
 import {useNavigate} from './useNavigate';
 import {useParams} from './useParams';
-import {useRouteContext} from './useRouteContext';
+import {useTestRouteContext} from './useRouteContext';
 import {useRoutes} from './useRoutes';
 
 /**
@@ -18,10 +18,10 @@ import {useRoutes} from './useRoutes';
 function useRouter(): InjectedRouter<any, any> {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
-  const legacyRouterContext = useRouteContext();
+  const testRouteContext = useTestRouteContext();
 
-  if (legacyRouterContext) {
-    return legacyRouterContext.router;
+  if (testRouteContext) {
+    return testRouteContext.router;
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/static/app/utils/useRoutes.spec.tsx
+++ b/static/app/utils/useRoutes.spec.tsx
@@ -5,7 +5,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import {useRoutes} from 'sentry/utils/useRoutes';
-import {RouteContext} from 'sentry/views/routeContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
 describe('useRoutes', () => {
   it('returns the current routes object', function () {
@@ -28,9 +28,9 @@ describe('useRoutes', () => {
     };
 
     render(
-      <RouteContext.Provider value={routeContext}>
+      <TestRouteContext.Provider value={routeContext}>
         <HomePage />
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
     expect(routes).toHaveLength(1);
     expect(routes[0]).toEqual({path: '/', component: HomePage});

--- a/static/app/utils/useRoutes.tsx
+++ b/static/app/utils/useRoutes.tsx
@@ -3,15 +3,15 @@ import {useMatches} from 'react-router-dom';
 
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 
-import {useRouteContext} from './useRouteContext';
+import {useTestRouteContext} from './useRouteContext';
 
 export function useRoutes(): PlainRoute<any>[] {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
-  const legacyRouterContext = useRouteContext();
+  const testRouteContext = useTestRouteContext();
 
-  if (legacyRouterContext) {
-    return legacyRouterContext.routes;
+  if (testRouteContext) {
+    return testRouteContext.routes;
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/static/app/views/organizationContext.spec.tsx
+++ b/static/app/views/organizationContext.spec.tsx
@@ -18,7 +18,7 @@ import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {OrganizationContextProvider, useEnsureOrganization} from './organizationContext';
-import {RouteContext} from './routeContext';
+import {TestRouteContext} from './routeContext';
 
 jest.mock('sentry/actionCreators/sudoModal');
 
@@ -122,12 +122,12 @@ describe('OrganizationContext', function () {
   it('fetches new org when router params change', async function () {
     // First render with org-slug
     const {rerender} = render(
-      <RouteContext.Provider value={router}>
+      <TestRouteContext.Provider value={router}>
         <OrganizationContextProvider>
           <OrganizationLoaderStub />
           <OrganizationName />
         </OrganizationContextProvider>
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     expect(await screen.findByText(organization.slug)).toBeInTheDocument();
@@ -139,12 +139,12 @@ describe('OrganizationContext', function () {
 
     // re-render with another-org
     rerender(
-      <RouteContext.Provider value={{...router, params: {orgId: 'another-org'}}}>
+      <TestRouteContext.Provider value={{...router, params: {orgId: 'another-org'}}}>
         <OrganizationContextProvider>
           <OrganizationLoaderStub />
           <OrganizationName />
         </OrganizationContextProvider>
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     expect(await screen.findByText(anotherOrg.slug)).toBeInTheDocument();
@@ -209,12 +209,12 @@ describe('OrganizationContext', function () {
 
     // orgId is not present in the router.
     render(
-      <RouteContext.Provider value={{...router, params: {}}}>
+      <TestRouteContext.Provider value={{...router, params: {}}}>
         <OrganizationContextProvider>
           <OrganizationLoaderStub />
           <OrganizationName />
         </OrganizationContextProvider>
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     expect(await screen.findByText(configStoreOrg.slug)).toBeInTheDocument();

--- a/static/app/views/routeContext.tsx
+++ b/static/app/views/routeContext.tsx
@@ -3,9 +3,14 @@ import {createContext} from 'react';
 import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 
 /**
- * This is a legacy context that is primarily used in tests currently to allow
- * for mocking the use{Location,Navigate,Routes,Params} hooks
+ * This is a legacy context that is only used in tests currently to allow for
+ * mocking the use{Location,Navigate,Routes,Params} hooks
  *
  * DO NOT use this outside of tests!
  */
-export const RouteContext = createContext<RouteContextInterface | null>(null);
+export const TestRouteContext = createContext<RouteContextInterface | null>(null);
+
+/**
+ * Temporary while fixing getsentry
+ */
+export const RouteContext = TestRouteContext;

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -16,7 +16,7 @@ import {DANGEROUS_SET_TEST_HISTORY} from 'sentry/utils/browserHistory';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {lightTheme} from 'sentry/utils/theme';
 import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
+import {TestRouteContext} from 'sentry/views/routeContext';
 
 import {instrumentUserEvent} from '../instrumentedEnv/userEventIntegration';
 
@@ -27,7 +27,7 @@ interface ProviderOptions {
    * Do not shim the router use{Routes,Router,Navigate,Location} functions, and
    * instead allow them to work as normal, rendering inside of a memory router.
    *
-   * Wehn enabling this passing a `router` object *will do nothing*!
+   * When enabling this passing a `router` object *will do nothing*!
    */
   disableRouterMocks?: boolean;
   /**
@@ -61,7 +61,7 @@ function makeAllTheProviders(options: ProviderOptions) {
     const wrappedContent = options.disableRouterMocks ? (
       content
     ) : (
-      <RouteContext.Provider
+      <TestRouteContext.Provider
         value={{
           router,
           location: router.location,
@@ -70,7 +70,7 @@ function makeAllTheProviders(options: ProviderOptions) {
         }}
       >
         {content}
-      </RouteContext.Provider>
+      </TestRouteContext.Provider>
     );
 
     const history = createMemoryHistory();


### PR DESCRIPTION
We don't want people accidentally misusing this, make it clear this is
JUST for testing at the moment