### PR TITLE
feat(similarity): Do not block on project platform

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -445,8 +445,7 @@ def _is_snipped_context_line(context_line: str) -> bool:
 
 def project_is_seer_eligible(project: Project) -> bool:
     """
-    Return True if the project hasn't already been backfilled, is a Seer-eligible platform, and
-    the feature is enabled in the region.
+    Return True if the project hasn't already been backfilled and the feature is enabled in the region.
     """
     is_backfill_completed = project.get_option("sentry:similarity_backfill_completed")
     is_region_enabled = options.get("similarity.new_project_seer_grouping.enabled")

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -36,16 +36,6 @@ EVENT_PLATFORMS_BYPASSING_FRAME_COUNT_CHECK = frozenset(
         "ruby",
     ]
 )
-# Existing projects with these platforms shouldn't be backfilled and new projects with these
-# platforms shouldn't have Seer enabled.
-SEER_INELIGIBLE_PROJECT_PLATFORMS = frozenset(
-    [
-        # We have no clue what's in these projects
-        "other",
-        "",
-        None,
-    ]
-)
 BASE64_ENCODED_PREFIXES = [
     "data:text/html;base64",
     "data:text/javascript;base64",
@@ -459,7 +449,6 @@ def project_is_seer_eligible(project: Project) -> bool:
     the feature is enabled in the region.
     """
     is_backfill_completed = project.get_option("sentry:similarity_backfill_completed")
-    is_seer_eligible_platform = project.platform not in SEER_INELIGIBLE_PROJECT_PLATFORMS
     is_region_enabled = options.get("similarity.new_project_seer_grouping.enabled")
 
-    return not is_backfill_completed and is_seer_eligible_platform and is_region_enabled
+    return not is_backfill_completed and is_region_enabled


### PR DESCRIPTION
This will allow attempting to backfill all projects. Only the event platform would prevent attempting a backfill.

The code that prevents the `other` event platform from being eligible is here:
https://github.com/getsentry/sentry/blob/66f0791eb20a6bbd055da1047f632f84d3207d86/src/sentry/grouping/ingest/seer.py#L84-L90
https://github.com/getsentry/sentry/blob/66f0791eb20a6bbd055da1047f632f84d3207d86/src/sentry/grouping/ingest/seer.py#L43-L44

The test that prevents `other` from being eligible can be found here:
https://github.com/getsentry/sentry/blob/66f0791eb20a6bbd055da1047f632f84d3207d86/tests/sentry/grouping/ingest/test_seer.py#L670-L689