### PR TITLE
fix(widget-builder): Use first widget query for shared fields

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -53,4 +53,31 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(widget);
     expect(params.legendAlias).toEqual(['test', 'test2']);
   });
+
+  it('does not duplicate filters because of multiple widget queries', () => {
+    const widget = {
+      ...getDefaultWidget(WidgetType.ERRORS),
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'one condition',
+          orderby: '',
+          name: '',
+        },
+        {
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'second condition',
+          orderby: '',
+          name: '',
+        },
+      ],
+    };
+
+    const params = convertWidgetToBuilderStateParams(widget);
+    expect(params.query).toEqual(['one condition', 'second condition']);
+    expect(params.yAxis).toEqual(['count()']);
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -27,23 +27,24 @@ function stringifyFields(
 export function convertWidgetToBuilderStateParams(
   widget: Widget
 ): WidgetBuilderStateQueryParams {
-  let yAxis = widget.queries.flatMap(q => q.aggregates);
   const query = widget.queries.flatMap(q => q.conditions);
   const sort = widget.queries.flatMap(q => q.orderby);
   let legendAlias = widget.queries.flatMap(q => q.name);
 
+  // y-axes and fields are shared across all queries
+  // so we can just use the first query
+  const firstWidgetQuery = widget.queries[0];
+  let yAxis = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'aggregates') : [];
   let field: string[] = [];
   if (
     widget.displayType === DisplayType.TABLE ||
     widget.displayType === DisplayType.BIG_NUMBER
   ) {
-    field = widget.queries.flatMap(widgetQuery => stringifyFields(widgetQuery, 'fields'));
+    field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'fields') : [];
     yAxis = [];
     legendAlias = [];
   } else {
-    field = widget.queries.flatMap(widgetQuery =>
-      stringifyFields(widgetQuery, 'columns')
-    );
+    field = firstWidgetQuery ? stringifyFields(firstWidgetQuery, 'columns') : [];
   }
 
   return {


### PR DESCRIPTION
Widget query properties such as fields, columns, aggregates are shared so when we `flatMap` we duplicate the values. We should just choose the first one and use that to avoid duplication.

Closes #82548