### PR TITLE
feat(hydration error): Iterate on formatting of mutation diff data

### DIFF
--- a/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
+++ b/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
@@ -1,3 +1,4 @@
+import formatDuration from 'sentry/utils/duration/formatDuration';
 import {useQuery, type UseQueryResult} from 'sentry/utils/queryClient';
 import replayerStepper from 'sentry/utils/replays/replayerStepper';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -102,8 +103,13 @@ async function extractDiffMutations({
 
         const item = collection.get(lastFrame);
         if (item) {
-          item[lastFrame.timestamp]!.adds = adds;
-          item[lastFrame.timestamp]!.attributes = attributes;
+          const formattedTimestamp = formatDuration({
+            duration: [Math.abs(lastFrame.timestamp - startTimestampMs), 'ms'],
+            precision: 'ms',
+            style: 'hh:mm:ss.sss',
+          });
+          item[formattedTimestamp].adds = adds;
+          item[formattedTimestamp].attributes = attributes;
         }
       }
 
@@ -134,12 +140,19 @@ async function extractDiffMutations({
           };
         }
 
+        const offset = Math.abs(frame.timestamp - startTimestampMs);
+        const formattedTimestamp = formatDuration({
+          duration: [offset, 'ms'],
+          precision: 'ms',
+          style: 'hh:mm:ss.sss',
+        });
+
         collection.set(frame, {
-          [frame.timestamp]: {
+          [formattedTimestamp]: {
             adds: {},
             attributes: {},
             removes,
-            offset: frame.timestamp - startTimestampMs,
+            offset,
           },
         });
       }

--- a/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
+++ b/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
@@ -16,6 +16,7 @@ type DiffMutation = Record<
     attributes: Record<string, unknown>;
     offset: number;
     removes: Record<string, unknown>;
+    timestamp: number;
   }
 >;
 
@@ -153,6 +154,7 @@ async function extractDiffMutations({
             attributes: {},
             removes,
             offset,
+            timestamp: frame.timestamp,
           },
         });
       }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="679" alt="SCR-20250106-jehx" src="https://github.com/user-attachments/assets/2e61f5a3-f63e-414d-bccc-a4771ec104e9" /> | <img width="682" alt="SCR-20250106-ljwv" src="https://github.com/user-attachments/assets/8ce7f3d2-63a9-46f6-8977-7a6ff1ff0a41" /> |

notice that the key is the formatted offset within the replay.
The raw timestamp is moved into the payload, next to the numeric offset.
