### PR TITLE
fix(widget-builder): Deep clone new field so updates don't alias

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -474,7 +474,7 @@ function Visualize() {
           onClick={() =>
             dispatch({
               type: updateAction,
-              payload: [...(fields ?? []), datasetConfig.defaultField],
+              payload: [...(fields ?? []), cloneDeep(datasetConfig.defaultField)],
             })
           }
         >


### PR DESCRIPTION
When adding new fields, we were just adding the default query each time which would always point to the same memory address. We need to clone it so each additional field is treated individually and modifying the fields array doesn't trickle changes to the other added fields because they reference the same object.

Closes #82945