### PR TITLE
feat(widget-builder): Add error functionality to type selector

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -12,6 +12,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 }));
 
 const mockUseNavigate = jest.mocked(useNavigate);
+const mockSetError = jest.fn();
 
 describe('TypeSelector', () => {
   let router!: ReturnType<typeof RouterFixture>;
@@ -27,7 +28,7 @@ describe('TypeSelector', () => {
 
     render(
       <WidgetBuilderProvider>
-        <TypeSelector error={{}} />
+        <TypeSelector error={{}} setError={mockSetError} />
       </WidgetBuilderProvider>,
       {
         router,
@@ -46,5 +47,19 @@ describe('TypeSelector', () => {
         query: expect.objectContaining({displayType: 'bar'}),
       })
     );
+  });
+
+  it('displays error message when there is an error', async function () {
+    render(
+      <WidgetBuilderProvider>
+        <TypeSelector
+          error={{displayType: 'Please select a type'}}
+          setError={mockSetError}
+        />
+      </WidgetBuilderProvider>,
+      {router, organization}
+    );
+
+    expect(await screen.findByText('Please select a type')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -3,6 +3,7 @@ import {components} from 'react-select';
 import styled from '@emotion/styled';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
 import {IconGraph, IconNumber, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -30,9 +31,10 @@ const displayTypes = {
 
 interface WidgetBuilderTypeSelectorProps {
   error: Record<string, any>;
+  setError: (error: Record<string, any>) => void;
 }
 
-function WidgetBuilderTypeSelector({}: WidgetBuilderTypeSelectorProps) {
+function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   const config = getDatasetConfig(state.dataset);
 
@@ -42,49 +44,52 @@ function WidgetBuilderTypeSelector({}: WidgetBuilderTypeSelectorProps) {
         tooltipText={t('This is the type of visualization (ex. line chart)')}
         title={t('Type')}
       />
-      <SelectControl
-        name="displayType"
-        value={state.displayType}
-        options={Object.keys(displayTypes).map(value => ({
-          leadingItems: typeIcons[value],
-          label: displayTypes[value],
-          value,
-          disabled: !config.supportedDisplayTypes.includes(value as DisplayType),
-        }))}
-        clearable={false}
-        onChange={newValue => {
-          if (newValue?.value === state.displayType) {
-            return;
-          }
+      <StyledFieldGroup error={error.displayType} inline={false} flexibleControlStateSize>
+        <SelectControl
+          name="displayType"
+          value={state.displayType}
+          options={Object.keys(displayTypes).map(value => ({
+            leadingItems: typeIcons[value],
+            label: displayTypes[value],
+            value,
+            disabled: !config.supportedDisplayTypes.includes(value as DisplayType),
+          }))}
+          clearable={false}
+          onChange={newValue => {
+            if (newValue?.value === state.displayType) {
+              return;
+            }
+            setError({...error, displayType: undefined});
 
-          dispatch({
-            type: BuilderStateAction.SET_DISPLAY_TYPE,
-            payload: newValue?.value,
-          });
-          if (
-            (newValue.value === DisplayType.TABLE ||
-              newValue.value === DisplayType.BIG_NUMBER) &&
-            state.query?.length
-          ) {
             dispatch({
-              type: BuilderStateAction.SET_QUERY,
-              payload: [state.query[0]!],
+              type: BuilderStateAction.SET_DISPLAY_TYPE,
+              payload: newValue?.value,
             });
-          }
-        }}
-        components={{
-          SingleValue: containerProps => {
-            return (
-              <components.SingleValue {...containerProps}>
-                <SelectionWrapper>
-                  {containerProps.data.leadingItems}
-                  {containerProps.children}
-                </SelectionWrapper>
-              </components.SingleValue>
-            );
-          },
-        }}
-      />
+            if (
+              (newValue.value === DisplayType.TABLE ||
+                newValue.value === DisplayType.BIG_NUMBER) &&
+              state.query?.length
+            ) {
+              dispatch({
+                type: BuilderStateAction.SET_QUERY,
+                payload: [state.query[0]!],
+              });
+            }
+          }}
+          components={{
+            SingleValue: containerProps => {
+              return (
+                <components.SingleValue {...containerProps}>
+                  <SelectionWrapper>
+                    {containerProps.data.leadingItems}
+                    {containerProps.children}
+                  </SelectionWrapper>
+                </components.SingleValue>
+              );
+            },
+          }}
+        />
+      </StyledFieldGroup>
     </Fragment>
   );
 }
@@ -94,4 +99,9 @@ export default WidgetBuilderTypeSelector;
 const SelectionWrapper = styled('div')`
   display: flex;
   gap: ${space(1)};
+`;
+
+const StyledFieldGroup = styled(FieldGroup)`
+  width: 100%;
+  padding: 0px;
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -129,7 +129,7 @@ function WidgetBuilderSlideout({
             </Section>
           )}
         <Section>
-          <WidgetBuilderTypeSelector error={error} />
+          <WidgetBuilderTypeSelector error={error} setError={setError} />
         </Section>
         <div ref={previewRef}>
           {isSmallScreen && (


### PR DESCRIPTION
Shows an error beside the widget type selector if there is an error. The way we have the widget builder set up right now there should be no error that arises however it's good to have the error indicator/message there anyways.

This is what it would look like if an error arises: 
<img width="594" alt="Screenshot 2025-01-06 at 4 07 43 PM" src="https://github.com/user-attachments/assets/22a66fad-4955-4a96-8418-71785903eb84" />

Contributes to https://github.com/getsentry/sentry/issues/81729