### PR TITLE
fix(settings): Correct settings/members/requests redirect

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -736,7 +736,7 @@ function buildRoutes() {
         name={t('Auth Providers')}
         component={make(() => import('sentry/views/settings/organizationAuth'))}
       />
-      <Redirect from="members/requests" to="members/" />
+      <Redirect from="members/requests" to="../members/" />
       <Route path="members/" name={t('Members')}>
         <IndexRoute
           component={make(


### PR DESCRIPTION
For some reason is redirecting from:
`settings/members/requests/` -> `settings/members/requests/members/`

fixes JAVASCRIPT-2W3P