### PR TITLE
ref(ui): More granular URL checking for `GlobalDrawer`

### DIFF
--- a/static/app/components/globalDrawer/index.stories.tsx
+++ b/static/app/components/globalDrawer/index.stories.tsx
@@ -50,7 +50,7 @@ export default storyBook('GlobalDrawer', story => {
   ariaLabel: 'test drawer',
   closeOnEscapeKeypress: false, // defaults to true
   closeOnOutsideClick: false, // defaults to true
-  shouldCloseOnLocationChange: (newPathname) => !newPathname.includes('tags'),
+  shouldCloseOnLocationChange: (newLocation) => !newLocation.pathname.includes('tags'),
 })}>
   Open Drawer
 </Button>`}

--- a/static/app/components/globalDrawer/index.stories.tsx
+++ b/static/app/components/globalDrawer/index.stories.tsx
@@ -15,7 +15,8 @@ export default storyBook('GlobalDrawer', story => {
       </CodeSnippet>
       <p>
         By default the drawer can be closed with an 'escape' press, or an outside click.
-        This behavior can be changed by passing in options to <code>openDrawer</code>.
+        It also closes by default on location change. This behavior can be changed by
+        passing in options to <code>openDrawer</code>.
       </p>
     </Fragment>
   ));
@@ -49,6 +50,7 @@ export default storyBook('GlobalDrawer', story => {
   ariaLabel: 'test drawer',
   closeOnEscapeKeypress: false, // defaults to true
   closeOnOutsideClick: false, // defaults to true
+  shouldCloseOnLocationChange: (newPathname) => !newPathname.includes('tags'),
 })}>
   Open Drawer
 </Button>`}

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -115,6 +115,7 @@ export function GlobalDrawer({children}) {
         currentDrawerConfig?.options.shouldCloseOnLocationChange?.(location.pathname) ??
         true
       ) {
+        // Call `closeDrawer` without invoking `onClose` callback, since those callbacks often update the URL
         closeDrawer();
       }
     },

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -121,6 +121,8 @@ export function GlobalDrawer({children}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       location?.pathname,
+      location?.search,
+      location?.hash,
       closeDrawer,
       currentDrawerConfig?.options.shouldCloseOnLocationChange,
     ]

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import type {AnimationProps} from 'framer-motion';
 import {AnimatePresence} from 'framer-motion';
+import type {Location} from 'history';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import DrawerComponents from 'sentry/components/globalDrawer/components';
@@ -50,7 +51,7 @@ export interface DrawerOptions {
   /**
    * If true (default), closes the drawer when the location changes
    */
-  shouldCloseOnLocationChange?: (newPathname: Location['pathname']) => boolean;
+  shouldCloseOnLocationChange?: (newPathname: Location) => boolean;
   //
   // Custom framer motion transition for the drawer
   //
@@ -111,10 +112,7 @@ export function GlobalDrawer({children}) {
   useLayoutEffect(
     () => {
       // Defaults to closing the drawer when the location changes
-      if (
-        currentDrawerConfig?.options.shouldCloseOnLocationChange?.(location.pathname) ??
-        true
-      ) {
+      if (currentDrawerConfig?.options.shouldCloseOnLocationChange?.(location) ?? true) {
         // Call `closeDrawer` without invoking `onClose` callback, since those callbacks often update the URL
         closeDrawer();
       }

--- a/static/app/views/issueDetails/groupTags/useGroupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTagsDrawer.tsx
@@ -29,8 +29,8 @@ export function useGroupTagsDrawer({group}: {group: Group}) {
           {replace: true}
         );
       },
-      shouldCloseOnLocationChange: newPathname => {
-        return !newPathname.includes('/tags/');
+      shouldCloseOnLocationChange: newLocation => {
+        return !newLocation.pathname.includes('/tags/');
       },
     });
   }, [location, navigate, drawer, group, baseUrl]);


### PR DESCRIPTION
Right now, `GlobalDrawer` passes `location.pathname` to `shouldCloseonLocationChange` so the check can keep the drawer open for some URL transitions. For Insights, that doesn't work because we don't render drawers at new paths, we render drawers for specific URL parameters.

This PR passes the entire `location` object to the check, so it can figure out when to keep the drawer open.

- **Document `shouldCloseOnLocationChange` prop**
- **Add comment**
- **Pass entire location to callback**
- **Run URL hook on all URL sections**
