### PR TITLE
fix(alerts): Remove query from metric alert related issues

### DIFF
--- a/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
@@ -108,7 +108,6 @@ function RelatedIssues({rule, organization, projects, query, timePeriod}: Props)
           orgSlug={organization.slug}
           endpointPath={path}
           queryParams={queryParams}
-          query={`start=${start}&end=${end}&groupStatsPeriod=auto`}
           canSelectGroups={false}
           renderEmptyMessage={renderEmptyMessage}
           renderErrorMessage={renderErrorMessage}


### PR DESCRIPTION
We were using this query to attempt to find an event within the time frame of the alert incident. Now that we have the ability to query on issue details and we might not always return an event this is more confusing since the incident time range might have no results. 

related https://github.com/getsentry/sentry/pull/81471
