### PR TITLE
feat(issue-details): Update docs link 

### DIFF
--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -15,7 +15,7 @@ import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconGlobe, IconQuestion} from 'sentry/icons';
+import {IconGlobe, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -130,12 +130,13 @@ export default function StreamlinedGroupHeader({
               size="xs"
               external
               title={t('Learn more about the new UI')}
-              aria-label={t('Learn more about the new UI')}
               href={`https://sentry.zendesk.com/hc/en-us/articles/30882241712795`}
-              icon={<IconQuestion />}
+              icon={<IconInfo />}
               analyticsEventKey="issue_details.streamline_ui_learn_more"
               analyticsEventName="Issue Details: Streamline UI Learn More"
-            />
+            >
+              {t("See What's New")}
+            </LinkButton>
             <NewIssueExperienceButton />
           </ButtonBar>
         </Flex>

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -23,6 +23,7 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getMessage, getTitle} from 'sentry/utils/events';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {GroupActions} from 'sentry/views/issueDetails/actions/index';
@@ -66,6 +67,11 @@ export default function StreamlinedGroupHeader({
 
   const statusProps = getBadgeProperties(group.status, group.substatus);
   const shareUrl = group?.shareId ? getShareUrl(group) : null;
+
+  const [showLearnMore, setShowLearnMore] = useLocalStorageState(
+    'issue-details-learn-more',
+    true
+  );
 
   return (
     <Fragment>
@@ -131,11 +137,13 @@ export default function StreamlinedGroupHeader({
               external
               title={t('Learn more about the new UI')}
               href={`https://sentry.zendesk.com/hc/en-us/articles/30882241712795`}
+              aria-label={t('Learn more about the new UI')}
               icon={<IconInfo />}
               analyticsEventKey="issue_details.streamline_ui_learn_more"
               analyticsEventName="Issue Details: Streamline UI Learn More"
+              onClick={() => setShowLearnMore(false)}
             >
-              {t("See What's New")}
+              {showLearnMore ? t("See What's New") : null}
             </LinkButton>
             <NewIssueExperienceButton />
           </ButtonBar>


### PR DESCRIPTION
this pr updates the link to issue details docs to have text, but after you've clicked on it once, it will just show the icon (which is the current experience

first time: 
<img width="215" alt="Screenshot 2025-01-06 at 3 30 09 PM" src="https://github.com/user-attachments/assets/126f6586-6fe7-4295-8763-457f320c0128" />

after: 
<img width="133" alt="Screenshot 2025-01-06 at 3 30 19 PM" src="https://github.com/user-attachments/assets/c1bad080-3c7f-4437-a988-a19ceecfd503" />

