### PR TITLE
:bug: fix(msteams): enable personal notification settings

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -86,12 +86,8 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
         `/users/me/notification-providers/`,
         {query: getQueryParams(notificationType)},
       ],
-      ['identities', `/users/me/identities/`, {query: {provider: 'slack'}}],
-      [
-        'organizationIntegrations',
-        `/users/me/organization-integrations/`,
-        {query: {provider: 'slack'}},
-      ],
+      ['identities', `/users/me/identities/`],
+      ['organizationIntegrations', `/users/me/organization-integrations/`],
       ['defaultSettings', '/notification-defaults/'],
     ];
   }


### PR DESCRIPTION
Because we filtered for only Slack, currently users have no ability to configure msteams for personal notifications. By removing this filter, we populate the form correctly:
![image](https://github.com/user-attachments/assets/9bd955b9-9a5d-4a54-95ca-93d5fb6ced9c)

Sending a test notification to the user looks like:
![image](https://github.com/user-attachments/assets/a5a58dac-1d97-4965-b7ca-c03c9a4ce486)
