### PR TITLE
feat(issue-views): Add hook to fetch issue counts

### DIFF
--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -21,9 +21,7 @@ export const makeFetchIssueCounts = ({
 }: FetchIssueCountsParameters): ApiQueryKey => [
   `/organizations/${orgSlug}/issues-count/`,
   {
-    query: {
-      ...requestParams,
-    },
+    query: requestParams,
   },
 ];
 

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -1,0 +1,38 @@
+import type {PageFilters} from 'sentry/types/core';
+import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type {QueryCounts} from 'sentry/views/issueList/utils';
+
+// Copied from CountEndpointParams in overview.tsx
+interface FetchIssueCountsParameters extends Partial<PageFilters['datetime']> {
+  environment: string[];
+  orgSlug: string;
+  project: number[];
+  query: string[];
+  groupStatsPeriod?: string | null;
+  sort?: string;
+  statsPeriod?: string | null;
+  useGroupSnubaDataset?: boolean;
+}
+
+export const makeFetchIssueCounts = ({
+  orgSlug,
+  ...requestParams
+}: FetchIssueCountsParameters): ApiQueryKey => [
+  `/organizations/${orgSlug}/issues-count/`,
+  {
+    query: {
+      ...requestParams,
+    },
+  },
+];
+
+export const useFetchIssueCounts = (
+  params: FetchIssueCountsParameters,
+  options: Partial<UseApiQueryOptions<QueryCounts>> = {}
+) => {
+  return useApiQuery<QueryCounts>(makeFetchIssueCounts(params), {
+    staleTime: 0,
+    ...options,
+  });
+};

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -9,8 +9,10 @@ interface FetchIssueCountsParameters extends Partial<PageFilters['datetime']> {
   orgSlug: string;
   project: number[];
   query: string[];
+  end?: string | null;
   groupStatsPeriod?: string | null;
   sort?: string;
+  start?: string | null;
   statsPeriod?: string | null;
   useGroupSnubaDataset?: boolean;
 }

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -1,6 +1,6 @@
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {QueryCounts} from 'sentry/views/issueList/utils';
+import type {QueryCount, QueryCounts} from 'sentry/views/issueList/utils';
 
 interface FetchIssueCountsParameters {
   environment: string[];
@@ -29,7 +29,7 @@ export const makeFetchIssueCounts = ({
 
 export const useFetchIssueCounts = (
   params: FetchIssueCountsParameters,
-  options: Partial<UseApiQueryOptions<QueryCounts>> = {}
+  options: Partial<UseApiQueryOptions<Record<string, QueryCount>>> = {}
 ) => {
   return useApiQuery<QueryCounts>(makeFetchIssueCounts(params), {
     staleTime: 0,

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -1,10 +1,8 @@
-import type {PageFilters} from 'sentry/types/core';
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {QueryCounts} from 'sentry/views/issueList/utils';
 
-// Copied from CountEndpointParams in overview.tsx
-interface FetchIssueCountsParameters extends Partial<PageFilters['datetime']> {
+interface FetchIssueCountsParameters {
   environment: string[];
   orgSlug: string;
   project: number[];

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -163,7 +163,7 @@ export function isForReviewQuery(query: string | undefined) {
 // the tab counts will look like 99+
 export const TAB_MAX_COUNT = 99;
 
-type QueryCount = {
+export type QueryCount = {
   count: number;
   hasMore: boolean;
 };


### PR DESCRIPTION
Adds a hook to fetch issue counts. Will be used to add query counts to the issue views. 

Achieves the same functionality as this [this PR](https://github.com/getsentry/sentry/pull/76277), but with 1,600,000 fewer lines of code!