### PR TITLE
chore(alerts): Rm activated alerts subscription callback

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -29,7 +29,6 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerActionMethod,
-    invoke_alert_subscription_callback,
 )
 from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
 from sentry.incidents.models.incident import (
@@ -460,16 +459,6 @@ class SubscriptionProcessor:
                     },
                 )
                 return
-
-        # Trigger callbacks for any AlertRules that may need to know about the subscription update
-        # Current callback will update the activation metric values & delete querysubscription on finish
-        # TODO: register over/under triggers as alert rule callbacks as well
-        invoke_alert_subscription_callback(
-            AlertRuleMonitorTypeInt(self.alert_rule.monitor_type),
-            subscription=self.subscription,
-            alert_rule=self.alert_rule,
-            value=aggregation_value,
-        )
 
         if aggregation_value is None:
             metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -31,7 +31,6 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
-    alert_subscription_callback_registry,
 )
 from sentry.incidents.models.incident import (
     Incident,
@@ -2958,15 +2957,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         new_incident = self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(new_incident, trigger, TriggerStatus.ACTIVE)
         self.assert_incident_is_latest_for_rule(new_incident)
-
-    def test_invoke_alert_subscription_callback(self):
-        mock = Mock()
-        alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS] = mock
-
-        self.send_update(self.rule, 1, subscription=self.sub)
-
-        assert mock.call_count == 1
-        assert mock.call_args[0][0] == self.sub
 
     @with_feature("organizations:metric-issue-poc")
     @mock.patch("sentry.incidents.utils.metric_issue_poc.produce_occurrence_to_kafka")


### PR DESCRIPTION
A smaller piece of https://github.com/getsentry/sentry/pull/81287 since it's quite large that just removes the callback logic