### PR TITLE
feat(issue-views): add query counts back to tabs 

### DIFF
--- a/static/app/views/issueList/issueViews/editableTabTitle.tsx
+++ b/static/app/views/issueList/issueViews/editableTabTitle.tsx
@@ -144,6 +144,7 @@ const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
   text-overflow: ellipsis;
   padding-right: 1px;
   cursor: pointer;
+  line-height: 1.45;
 `;
 
 const StyledGrowingInput = styled(GrowingInput)<{
@@ -160,6 +161,7 @@ const StyledGrowingInput = styled(GrowingInput)<{
   text-overflow: ellipsis;
   cursor: text;
   max-width: 325px;
+  line-height: 1.45;
 
   &,
   &:focus,

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -39,7 +39,11 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
 
   // TODO(msun): Once page filters are saved to views, remember to use the view's specific
   // page filters here instead of the global pageFilters, if they exist.
-  const {data: queryCount, isFetching: queryCountFetching} = useFetchIssueCounts({
+  const {
+    data: queryCount,
+    isLoading,
+    isFetching,
+  } = useFetchIssueCounts({
     orgSlug: organization.slug,
     query: [view.unsavedChanges ? view.unsavedChanges[0] : view.query],
     project: pageFilters.selection.projects,
@@ -54,7 +58,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
     <QueryCountBubble
       layout="size"
       animate={{
-        backgroundColor: queryCountFetching
+        backgroundColor: isFetching
           ? [theme.surface400, theme.surface100, theme.surface400]
           : `#00000000`,
       }}
@@ -64,15 +68,15 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
         },
         default: {
           duration: 2,
-          repeat: queryCountFetching ? Infinity : 0,
+          repeat: isFetching ? Infinity : 0,
           ease: 'easeInOut',
         },
       }}
     >
       <motion.span
         layout="position"
-        initial={{opacity: 0}}
-        animate={{opacity: queryCountFetching ? 0 : 1}}
+        initial={{opacity: isLoading ? 0 : 1}}
+        animate={{opacity: isFetching ? 0 : 1}}
         transition={{duration: 0.15}}
       >
         {displayedCount > TAB_MAX_COUNT ? `${TAB_MAX_COUNT}+` : displayedCount}

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -1,10 +1,10 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
-import theme from 'sentry/utils/theme';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
@@ -35,6 +35,7 @@ interface IssueViewQueryCountProps {
 export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
+  const theme = useTheme();
 
   // TODO(msun): Once page filters are saved to views, remember to use the view's specific
   // page filters here instead of the global pageFilters, if they exist.
@@ -54,15 +55,15 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
       layout="size"
       animate={{
         backgroundColor: queryCountFetching
-          ? [theme.gray100, theme.translucentSurface100, theme.gray100]
-          : 'transparent',
+          ? [theme.surface400, theme.surface100, theme.surface400]
+          : `#00000000`,
       }}
       transition={{
         layout: {
-          duration: 0.1,
+          duration: 0.2,
         },
         default: {
-          duration: 2.5,
+          duration: 2,
           repeat: queryCountFetching ? Infinity : 0,
           ease: 'easeInOut',
         },
@@ -72,7 +73,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
         layout="position"
         initial={{opacity: 0}}
         animate={{opacity: queryCountFetching ? 0 : 1}}
-        transition={{duration: 0.1}}
+        transition={{duration: 0.15}}
       >
         {displayedCount > TAB_MAX_COUNT ? `${TAB_MAX_COUNT}+` : displayedCount}
       </motion.span>

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -67,7 +67,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
           duration: 0.2,
         },
         default: {
-          duration: 2,
+          duration: isFetching ? 2 : 0,
           repeat: isFetching ? Infinity : 0,
           ease: 'easeInOut',
         },

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
+import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import theme from 'sentry/utils/theme';
@@ -81,8 +82,8 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
 
 const QueryCountBubble = styled(motion.span)`
   line-height: 20px;
-  font-size: 75%;
-  padding: 0 5px;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 0 ${space(0.5)};
   min-width: 20px;
   display: flex;
   height: 16px;

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import type {PageFilters} from 'sentry/types/core';
+import {getUtcDateString} from 'sentry/utils/dates';
+import theme from 'sentry/utils/theme';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
+import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
+
+const TAB_MAX_COUNT = 99;
+
+const constructCountTimeFrame = (
+  pageFilters: PageFilters['datetime']
+): {
+  end?: string;
+  start?: string;
+  statsPeriod?: string;
+} => {
+  if (pageFilters.period) {
+    return {statsPeriod: pageFilters.period};
+  }
+  return {
+    ...(pageFilters.start ? {start: getUtcDateString(pageFilters.start)} : {}),
+    ...(pageFilters.end ? {end: getUtcDateString(pageFilters.end)} : {}),
+  };
+};
+
+interface IssueViewQueryCountProps {
+  view: IssueView;
+}
+
+export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
+  const organization = useOrganization();
+  const pageFilters = usePageFilters();
+
+  // TODO(msun): Once page filters are saved to views, remember to use the view's specific
+  // page filters here instead of the global pageFilters, if they exist.
+  const {data: queryCount, isFetching: queryCountFetching} = useFetchIssueCounts({
+    orgSlug: organization.slug,
+    query: [view.unsavedChanges ? view.unsavedChanges[0] : view.query],
+    project: pageFilters.selection.projects,
+    environment: pageFilters.selection.environments,
+    ...constructCountTimeFrame(pageFilters.selection.datetime),
+  });
+
+  const displayedCount =
+    queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ?? 0;
+
+  return (
+    <QueryCountBubble
+      layout="size"
+      animate={{
+        backgroundColor: queryCountFetching
+          ? [theme.gray100, theme.translucentSurface100, theme.gray100]
+          : 'transparent',
+      }}
+      transition={{
+        layout: {
+          duration: 0.1,
+        },
+        default: {
+          duration: 2.5,
+          repeat: queryCountFetching ? Infinity : 0,
+          ease: 'easeInOut',
+        },
+      }}
+    >
+      <motion.span
+        layout="position"
+        initial={{opacity: 0}}
+        animate={{opacity: queryCountFetching ? 0 : 1}}
+        transition={{duration: 0.1}}
+      >
+        {displayedCount > TAB_MAX_COUNT ? `${TAB_MAX_COUNT}+` : displayedCount}
+      </motion.span>
+    </QueryCountBubble>
+  );
+}
+
+const QueryCountBubble = styled(motion.span)`
+  line-height: 20px;
+  font-size: 75%;
+  padding: 0 5px;
+  min-width: 20px;
+  display: flex;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 1px solid ${p => p.theme.gray200};
+  color: ${p => p.theme.gray300};
+  margin-left: 0;
+`;

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -89,6 +89,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
     >
       <motion.span
         // Prevents count from fading in if it's already cached on mount
+        layout="preserve-aspect"
         initial={{opacity: isLoading ? 0 : 1}}
         animate={{opacity: isFetching ? 0 : 1}}
         transition={{duration: 0.1}}

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -23,6 +23,7 @@ import {
 import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
 
 const TAB_MAX_COUNT = 99;
+
 interface IssueViewTabProps {
   editingTabKey: string | null;
   initialTabKey: string;
@@ -64,7 +65,7 @@ export function IssueViewTab({
   const pageFilters = usePageFilters();
 
   // TODO(msun): Once page filters are saved to views, remember to use the view's specific
-  // page filters here instead of the global pageFilters, if they exists.
+  // page filters here instead of the global pageFilters, if they exist.
   const {data: queryCount, isLoading: queryCountLoading} = useFetchIssueCounts({
     orgSlug: organization.slug,
     query: [view.query],

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -2,27 +2,19 @@ import {useContext} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
-import Badge from 'sentry/components/badge/badge';
 import {TEMPORARY_TAB_KEY} from 'sentry/components/draggableTabs/draggableTabList';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
-import QueryCount from 'sentry/components/queryCount';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
-import {getUtcDateString} from 'sentry/utils/dates';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import EditableTabTitle from 'sentry/views/issueList/issueViews/editableTabTitle';
 import {IssueViewEllipsisMenu} from 'sentry/views/issueList/issueViews/issueViewEllipsisMenu';
+import {IssueViewQueryCount} from 'sentry/views/issueList/issueViews/issueViewQueryCount';
 import {
   generateTempViewId,
   type IssueView,
   IssueViewsContext,
 } from 'sentry/views/issueList/issueViews/issueViews';
-import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
-
-const TAB_MAX_COUNT = 99;
 
 interface IssueViewTabProps {
   editingTabKey: string | null;
@@ -32,22 +24,6 @@ interface IssueViewTabProps {
   view: IssueView;
 }
 
-const constructCountTimeFrame = (
-  pageFilters: PageFilters['datetime']
-): {
-  end?: string;
-  start?: string;
-  statsPeriod?: string;
-} => {
-  if (pageFilters.period) {
-    return {statsPeriod: pageFilters.period};
-  }
-  return {
-    ...(pageFilters.start ? {start: getUtcDateString(pageFilters.start)} : {}),
-    ...(pageFilters.end ? {end: getUtcDateString(pageFilters.end)} : {}),
-  };
-};
-
 export function IssueViewTab({
   editingTabKey,
   initialTabKey,
@@ -56,23 +32,10 @@ export function IssueViewTab({
   view,
 }: IssueViewTabProps) {
   const navigate = useNavigate();
-  const organization = useOrganization();
 
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location?.query ?? {};
   const {tabListState, state, dispatch} = useContext(IssueViewsContext);
   const {views} = state;
-
-  const pageFilters = usePageFilters();
-
-  // TODO(msun): Once page filters are saved to views, remember to use the view's specific
-  // page filters here instead of the global pageFilters, if they exist.
-  const {data: queryCount, isLoading: queryCountLoading} = useFetchIssueCounts({
-    orgSlug: organization.slug,
-    query: [view.query],
-    project: pageFilters.selection.projects,
-    environment: pageFilters.selection.environments,
-    ...constructCountTimeFrame(pageFilters.selection.datetime),
-  });
 
   const handleDuplicateView = () => {
     const newViewId = generateTempViewId();
@@ -155,18 +118,7 @@ export function IssueViewTab({
           (!tabListState && view.key === initialTabKey)
         }
       />
-      {!queryCountLoading && queryCount && (
-        <motion.div>
-          <QueryCountBadge>
-            <QueryCount
-              count={queryCount?.[view.query]}
-              max={TAB_MAX_COUNT}
-              hideIfEmpty={false}
-              hideParens
-            />
-          </QueryCountBadge>
-        </motion.div>
-      )}
+      <IssueViewQueryCount view={view} />
       {/* If tablistState isn't initialized, we want to load the elipsis menu
           for the initial tab, that way it won't load in a second later
           and cause the tabs to shift and animate on load. */}
@@ -291,16 +243,4 @@ const TabContentWrap = styled('span')`
   flex-direction: row;
   padding: 0;
   gap: 6px;
-`;
-
-const QueryCountBadge = styled(Badge)`
-  display: flex;
-  height: 16px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  background: transparent;
-  border: 1px solid ${p => p.theme.gray200};
-  color: ${p => p.theme.gray300};
-  margin-left: 0;
 `;

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -155,14 +155,16 @@ export function IssueViewTab({
         }
       />
       {!queryCountLoading && queryCount && (
-        <QueryCountBadge>
-          <QueryCount
-            count={queryCount?.[view.query]}
-            max={TAB_MAX_COUNT}
-            hideIfEmpty={false}
-            hideParens
-          />
-        </QueryCountBadge>
+        <motion.div>
+          <QueryCountBadge>
+            <QueryCount
+              count={queryCount?.[view.query]}
+              max={TAB_MAX_COUNT}
+              hideIfEmpty={false}
+              hideParens
+            />
+          </QueryCountBadge>
+        </motion.div>
       )}
       {/* If tablistState isn't initialized, we want to load the elipsis menu
           for the initial tab, that way it won't load in a second later

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -73,6 +73,11 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: getRequestViews,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
+      });
     });
 
     it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
@@ -120,6 +125,11 @@ describe('IssueViewsHeader', () => {
           },
         ],
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
@@ -152,6 +162,11 @@ describe('IssueViewsHeader', () => {
             querySort: IssueSortOptions.DATE,
           },
         ],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
@@ -277,6 +292,11 @@ describe('IssueViewsHeader', () => {
           },
         ],
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
+      });
 
       const defaultTabDifferentQueryRouter = RouterFixture({
         location: LocationFixture({
@@ -319,6 +339,11 @@ describe('IssueViewsHeader', () => {
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
         body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
       });
     });
 
@@ -452,6 +477,11 @@ describe('IssueViewsHeader', () => {
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
         body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
       });
     });
 
@@ -790,6 +820,97 @@ describe('IssueViewsHeader', () => {
           })
         );
       });
+    });
+  });
+
+  describe('Issue views query counts', () => {
+    it('should render the correct count for a single view', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        query: {
+          query: getRequestViews[0]!.query,
+        },
+        body: {
+          [getRequestViews[0]!.query]: 42,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('42')).toBeInTheDocument();
+    });
+
+    it('should render the correct count for multiple views', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {
+          [getRequestViews[0]!.query]: 42,
+          [getRequestViews[1]!.query]: 6,
+          [getRequestViews[2]!.query]: 98,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('42')).toBeInTheDocument();
+      expect(screen.getByText('6')).toBeInTheDocument();
+      expect(screen.getByText('98')).toBeInTheDocument();
+    });
+
+    it('should show a max count of 99+ if the count is greater than 99', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        query: {
+          query: getRequestViews[0]!.query,
+        },
+        body: {
+          [getRequestViews[0]!.query]: 101,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('99+')).toBeInTheDocument();
+    });
+
+    it('should show stil show a 0 query count if the count is 0', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        query: {
+          query: getRequestViews[0]!.query,
+        },
+        body: {
+          [getRequestViews[0]!.query]: 0,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('0')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -83,10 +83,10 @@ describe('IssueViewsHeader', () => {
     it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
-      expect(await screen.findByRole('tab', {name: 'High Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Medium Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Low Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'High Priority'})).toHaveAttribute(
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Low Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /High Priority/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -133,8 +133,8 @@ describe('IssueViewsHeader', () => {
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
-      expect(await screen.findByRole('tab', {name: 'Prioritized'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Prioritized'})).toHaveAttribute(
+      expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Prioritized/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -173,9 +173,9 @@ describe('IssueViewsHeader', () => {
         router: queryOnlyRouter,
       });
 
-      expect(await screen.findByRole('tab', {name: 'Prioritized'})).toBeInTheDocument();
-      expect(await screen.findByRole('tab', {name: 'Unsaved'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Unsaved'})).toHaveAttribute(
+      expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
+      expect(await screen.findByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -204,7 +204,7 @@ describe('IssueViewsHeader', () => {
         router: specificTabRouter,
       });
 
-      expect(await screen.findByRole('tab', {name: 'Medium Priority'})).toHaveAttribute(
+      expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -225,13 +225,13 @@ describe('IssueViewsHeader', () => {
         router: queryOnlyRouter,
       });
 
-      expect(await screen.findByRole('tab', {name: 'High Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Medium Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Low Priority'})).toBeInTheDocument();
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Low Priority/})).toBeInTheDocument();
 
-      expect(screen.getByRole('tab', {name: 'Unsaved'})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
 
-      expect(screen.getByRole('tab', {name: 'Unsaved'})).toHaveAttribute(
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -258,13 +258,13 @@ describe('IssueViewsHeader', () => {
         router: specificTabRouter,
       });
 
-      expect(await screen.findByRole('tab', {name: 'High Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Medium Priority'})).toBeInTheDocument();
-      expect(screen.getByRole('tab', {name: 'Low Priority'})).toBeInTheDocument();
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Low Priority/})).toBeInTheDocument();
 
-      expect(screen.getByRole('tab', {name: 'Unsaved'})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
 
-      expect(screen.getByRole('tab', {name: 'Unsaved'})).toHaveAttribute(
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -317,9 +317,9 @@ describe('IssueViewsHeader', () => {
           router: defaultTabDifferentQueryRouter,
         }
       );
-      expect(await screen.findByRole('tab', {name: 'Prioritized'})).toBeInTheDocument();
+      expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
       expect(screen.getByTestId('unsaved-changes-indicator')).toBeInTheDocument();
-      expect(screen.queryByRole('tab', {name: 'Unsaved'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', {name: /Unsaved/})).not.toBeInTheDocument();
 
       expect(defaultTabDifferentQueryRouter.replace).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -350,7 +350,7 @@ describe('IssueViewsHeader', () => {
     it('switches tabs when clicked, and updates the query params accordingly', async () => {
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
-      await userEvent.click(await screen.findByRole('tab', {name: 'Medium Priority'}));
+      await userEvent.click(await screen.findByRole('tab', {name: /Medium Priority/}));
 
       // This test inexplicably fails on the lines below. which ensure the Medium Priority tab is selected when clicked
       // and the High Priority tab is unselected. This behavior exists in other tests and in browser, so idk why it fails here.
@@ -384,11 +384,11 @@ describe('IssueViewsHeader', () => {
       });
       expect(await screen.findByTestId('unsaved-changes-indicator')).toBeInTheDocument();
 
-      await userEvent.click(await screen.findByRole('tab', {name: 'Medium Priority'}));
+      await userEvent.click(await screen.findByRole('tab', {name: /Medium Priority/}));
       expect(screen.queryByTestId('unsaved-changes-indicator')).not.toBeInTheDocument();
 
-      await userEvent.click(await screen.findByRole('tab', {name: 'High Priority'}));
-      expect(await screen.findByRole('tab', {name: 'High Priority'})).toHaveAttribute(
+      await userEvent.click(await screen.findByRole('tab', {name: /High Priority/}));
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -414,7 +414,7 @@ describe('IssueViewsHeader', () => {
         {router: goodViewIdChangedQueryRouter}
       );
 
-      expect(await screen.findByRole('tab', {name: 'Medium Priority'})).toHaveAttribute(
+      expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -451,7 +451,7 @@ describe('IssueViewsHeader', () => {
         {router: goodViewIdChangedSortRouter}
       );
 
-      expect(await screen.findByRole('tab', {name: 'Medium Priority'})).toHaveAttribute(
+      expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
         'aria-selected',
         'true'
       );

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -30,7 +30,7 @@ export const useFetchIssueCounts = (
   options: Partial<UseApiQueryOptions<Record<string, QueryCount>>> = {}
 ) => {
   return useApiQuery<QueryCounts>(makeFetchIssueCounts(params), {
-    staleTime: 0,
+    staleTime: 180000, // 3 minutes
     placeholderData: keepPreviousData,
     ...options,
   });

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -1,5 +1,5 @@
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
 import type {QueryCount, QueryCounts} from 'sentry/views/issueList/utils';
 
 interface FetchIssueCountsParameters {
@@ -31,6 +31,7 @@ export const useFetchIssueCounts = (
 ) => {
   return useApiQuery<QueryCounts>(makeFetchIssueCounts(params), {
     staleTime: 0,
+    placeholderData: keepPreviousData,
     ...options,
   });
 };


### PR DESCRIPTION
~Pending [this PR](https://github.com/getsentry/sentry/pull/82987)  to be merged.~

Adds the query count back to issue view tabs, this time with a hard max of 99 (counts will not go above 99 even after clicking into the tab, unlike before). 

![image](https://github.com/user-attachments/assets/57398211-20b0-4f9f-8ed2-0c2102fc0f3c)


Temp view also works: 

![image](https://github.com/user-attachments/assets/aae8a60c-7e21-4084-8b16-8804a05d9206)
