### PR TITLE
feat(hydration error): Before/After Hydration Diff Picker

### DIFF
--- a/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffContent.tsx
@@ -34,19 +34,23 @@ export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: P
     return null;
   }
 
-  const {leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromEvent(replay, event);
+  const {frameOrEvent, leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromEvent(
+    replay,
+    event
+  );
   return (
     <InterimSection
       type={SectionKey.HYDRATION_DIFF}
       title={t('Hydration Error Diff')}
       actions={
         <OpenReplayComparisonButton
+          frameOrEvent={frameOrEvent}
+          initialLeftOffsetMs={leftOffsetMs}
+          initialRightOffsetMs={rightOffsetMs}
           key="open-modal-button"
-          leftOffsetMs={leftOffsetMs}
           replay={replay}
-          rightOffsetMs={rightOffsetMs}
-          surface="issue-details" // TODO: refactor once this component is used in more surfaces
           size="xs"
+          surface="issue-details" // TODO: refactor once this component is used in more surfaces
         >
           {t('Open Diff Viewer')}
         </OpenReplayComparisonButton>
@@ -56,6 +60,7 @@ export default function ReplayDiffContent({event, group, orgSlug, replaySlug}: P
         <ReplayGroupContextProvider groupId={group?.id} eventId={event.id}>
           <DiffCompareContextProvider
             replay={replay}
+            frameOrEvent={frameOrEvent}
             initialLeftOffsetMs={leftOffsetMs}
             initialRightOffsetMs={rightOffsetMs}
           >

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -269,16 +269,20 @@ function CrumbHydrationButton({
   frame: HydrationErrorFrame;
   replay: ReplayReader;
 }) {
-  const {leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromFrame(replay, frame);
+  const {frameOrEvent, leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromFrame(
+    replay,
+    frame
+  );
 
   return (
     <div>
       <OpenReplayComparisonButton
+        frameOrEvent={frameOrEvent}
+        initialLeftOffsetMs={leftOffsetMs}
+        initialRightOffsetMs={rightOffsetMs}
         replay={replay}
-        leftOffsetMs={leftOffsetMs}
-        rightOffsetMs={rightOffsetMs}
-        surface="replay-breadcrumbs"
         size="xs"
+        surface="replay-breadcrumbs"
       >
         {t('Open Hydration Diff')}
       </OpenReplayComparisonButton>

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -5,7 +5,9 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Button, type ButtonProps} from 'sentry/components/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
+import type {HydrationErrorFrame} from 'sentry/utils/replays/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const LazyComparisonModal = lazy(
@@ -14,20 +16,22 @@ const LazyComparisonModal = lazy(
 
 interface Props {
   children: ReactNode;
-  leftOffsetMs: number;
+  frameOrEvent: HydrationErrorFrame | Event;
+  initialLeftOffsetMs: number;
+  initialRightOffsetMs: number;
   replay: ReplayReader;
-  rightOffsetMs: number;
   surface: string;
   size?: ButtonProps['size'];
 }
 
 export function OpenReplayComparisonButton({
   children,
-  leftOffsetMs,
+  frameOrEvent,
+  initialLeftOffsetMs,
+  initialRightOffsetMs,
   replay,
-  rightOffsetMs,
-  surface,
   size,
+  surface,
 }: Props) {
   const organization = useOrganization();
 
@@ -59,8 +63,9 @@ export function OpenReplayComparisonButton({
               <LazyComparisonModal
                 replay={replay}
                 organization={organization}
-                initialLeftOffsetMs={leftOffsetMs}
-                initialRightOffsetMs={rightOffsetMs}
+                frameOrEvent={frameOrEvent}
+                initialLeftOffsetMs={initialLeftOffsetMs}
+                initialRightOffsetMs={initialRightOffsetMs}
                 {...deps}
               />
             </Suspense>

--- a/static/app/components/replays/diff/diffCompareContext.tsx
+++ b/static/app/components/replays/diff/diffCompareContext.tsx
@@ -7,9 +7,12 @@ import {
   useState,
 } from 'react';
 
+import type {Event} from 'sentry/types/event';
 import ReplayReader from 'sentry/utils/replays/replayReader';
+import type {HydrationErrorFrame} from 'sentry/utils/replays/types';
 
 type ContextType = {
+  frameOrEvent: HydrationErrorFrame | Event;
   leftOffsetMs: number;
   leftTimestampMs: number;
   replay: ReplayReader;
@@ -20,6 +23,7 @@ type ContextType = {
 };
 
 const context = createContext<ContextType>({
+  frameOrEvent: {} as Event,
   replay: ReplayReader.factory({
     attachments: [],
     errors: [],
@@ -39,6 +43,7 @@ export function useDiffCompareContext() {
 }
 
 interface Props {
+  frameOrEvent: HydrationErrorFrame | Event;
   initialLeftOffsetMs: number;
   initialRightOffsetMs: number;
   replay: ReplayReader;
@@ -46,10 +51,11 @@ interface Props {
 }
 
 export function DiffCompareContextProvider({
-  replay,
+  children,
+  frameOrEvent,
   initialLeftOffsetMs,
   initialRightOffsetMs,
-  children,
+  replay,
 }: Props) {
   const [leftOffsetMs, setLeftOffsetMs] = useState(initialLeftOffsetMs);
   const [rightOffsetMs, setRightOffsetMs] = useState(initialRightOffsetMs);
@@ -61,6 +67,7 @@ export function DiffCompareContextProvider({
   return (
     <context.Provider
       value={{
+        frameOrEvent,
         leftOffsetMs,
         leftTimestampMs,
         replay,

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -71,7 +71,6 @@ export default function LearnMoreButton(
             bodyClassName={css`
               padding: ${space(1)};
             `}
-            position="top-end"
           >
             <Button
               size="sm"

--- a/static/app/components/replays/diff/picker/crumbItem.tsx
+++ b/static/app/components/replays/diff/picker/crumbItem.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+
+import {Flex} from 'sentry/components/container/flex';
+import ReplayTooltipTime from 'sentry/components/replays/replayTooltipTime';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import formatDuration from 'sentry/utils/duration/formatDuration';
+import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
+import type {BreadcrumbFrame} from 'sentry/utils/replays/types';
+
+export default function CrumbItem({
+  crumb,
+  startTimestampMs,
+}: {
+  crumb: BreadcrumbFrame;
+  startTimestampMs: number;
+}) {
+  const {title, icon} = getFrameDetails(crumb);
+
+  const formattedDuration = formatDuration({
+    duration: [crumb.offsetMs, 'ms'],
+    precision: 'ms',
+    style: 'hh:mm:ss.sss',
+  });
+
+  return (
+    <CenterRelative>
+      <ErrorLine />
+      <ErrorLabel>
+        <Tooltip
+          skipWrapper
+          title={
+            <LeftAligned>
+              {t('Detected: %s', title)}
+              <div>
+                <ReplayTooltipTime
+                  timestampMs={crumb.timestampMs}
+                  startTimestampMs={startTimestampMs}
+                />
+              </div>
+            </LeftAligned>
+          }
+        >
+          <Flex column gap={space(0.5)}>
+            <Flex gap={space(0.75)} align="center">
+              {icon}
+              {formattedDuration}
+            </Flex>
+          </Flex>
+        </Tooltip>
+      </ErrorLabel>
+    </CenterRelative>
+  );
+}
+
+const CenterRelative = styled('div')`
+  position: relative;
+  justify-self: center;
+`;
+
+const ErrorLine = styled('div')`
+  border: 1px solid ${p => p.theme.purple400};
+  height: 100%;
+`;
+
+const ErrorLabel = styled('div')`
+  color: ${p => p.theme.purple400};
+  position: absolute;
+  top: 0;
+  transform: translate(-50%, -100%);
+  padding-bottom: ${space(0.5)};
+`;
+
+const LeftAligned = styled('div')`
+  text-align: left;
+  display: flex;
+  gap: ${space(1)};
+  flex-direction: column;
+`;

--- a/static/app/components/replays/diff/picker/diffTimestampPicker.tsx
+++ b/static/app/components/replays/diff/picker/diffTimestampPicker.tsx
@@ -32,12 +32,17 @@ export default function DiffTimestampPicker() {
     }
     const timestamp = frameOrEvent.timestamp.getTime();
     const rrwebFrames = replay.getRRWebFrames().filter(isRRWebChangeFrame);
-
+    const dedupedTimestamps = rrwebFrames.filter((frame, index) => {
+      if (index === 0) {
+        return true;
+      }
+      return frame.timestamp !== rrwebFrames[index - 1]?.timestamp;
+    });
     return {
-      beforeOptions: rrwebFrames
+      beforeOptions: dedupedTimestamps
         .filter(frame => frame.timestamp < timestamp)
         .slice(maxOptions * -1),
-      afterOptions: rrwebFrames
+      afterOptions: dedupedTimestamps
         .filter(frame => frame.timestamp > timestamp)
         .slice(0, maxOptions),
     };

--- a/static/app/components/replays/diff/picker/diffTimestampPicker.tsx
+++ b/static/app/components/replays/diff/picker/diffTimestampPicker.tsx
@@ -1,0 +1,141 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
+import CrumbItem from 'sentry/components/replays/diff/picker/crumbItem';
+import MutationOption from 'sentry/components/replays/diff/picker/mutationOption';
+import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {isHydrateCrumb, isRRWebChangeFrame} from 'sentry/utils/replays/types';
+
+const maxOptions = 3;
+
+export default function DiffTimestampPicker() {
+  const {
+    frameOrEvent,
+    leftOffsetMs,
+    leftTimestampMs,
+    replay,
+    rightOffsetMs,
+    rightTimestampMs,
+    setLeftOffsetMs,
+    setRightOffsetMs,
+  } = useDiffCompareContext();
+
+  const startTimestampMs = replay.getReplay().started_at.getTime() ?? 0;
+
+  const {beforeOptions, afterOptions} = useMemo(() => {
+    if (!isHydrateCrumb(frameOrEvent)) {
+      return {beforeOptions: [], afterOptions: []};
+    }
+    const timestamp = frameOrEvent.timestamp.getTime();
+    const rrwebFrames = replay.getRRWebFrames().filter(isRRWebChangeFrame);
+
+    return {
+      beforeOptions: rrwebFrames
+        .filter(frame => frame.timestamp < timestamp)
+        .slice(maxOptions * -1),
+      afterOptions: rrwebFrames
+        .filter(frame => frame.timestamp > timestamp)
+        .slice(0, maxOptions),
+    };
+  }, [frameOrEvent, replay]);
+
+  if (!isHydrateCrumb(frameOrEvent)) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <DiffHeader>
+        <Before offset={leftOffsetMs} startTimestampMs={startTimestampMs} />
+        <After offset={rightOffsetMs} startTimestampMs={startTimestampMs} />
+      </DiffHeader>
+      <Wrapper>
+        <List>
+          {beforeOptions.map((item, i) => (
+            <ListItem key={i} data-before="true" data-selected={undefined}>
+              <Tooltip title={t('Select this change as the Before moment')}>
+                <MutationOption
+                  key={i}
+                  frame={item}
+                  startTimestampMs={startTimestampMs}
+                  radioName="left"
+                  onChange={() => {
+                    setLeftOffsetMs(item.timestamp - startTimestampMs);
+                  }}
+                  isChecked={item.timestamp === leftTimestampMs}
+                />
+              </Tooltip>
+            </ListItem>
+          ))}
+        </List>
+
+        <CrumbItem crumb={frameOrEvent} startTimestampMs={startTimestampMs} />
+
+        <List>
+          {afterOptions.map((item, i) => (
+            <ListItem key={i} data-after="true" data-selected={undefined}>
+              <Tooltip title={t('Select this change as the After moment')}>
+                <MutationOption
+                  key={i}
+                  frame={item}
+                  startTimestampMs={startTimestampMs}
+                  radioName="right"
+                  onChange={() => {
+                    setRightOffsetMs(item.timestamp - startTimestampMs);
+                  }}
+                  isChecked={item.timestamp === rightTimestampMs}
+                />
+              </Tooltip>
+            </ListItem>
+          ))}
+        </List>
+      </Wrapper>
+    </Fragment>
+  );
+}
+
+const Wrapper = styled('div')`
+  display: grid;
+  grid-template-columns: max-content ${space(4)} max-content;
+  justify-content: center;
+  margin-top: 1em; /* Reserve space for the CrumbItem title */
+`;
+
+const List = styled('ul')`
+  display: flex;
+  flex-direction: row;
+
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: ${space(1)};
+`;
+
+const ListItem = styled('li')`
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  background-color: transparent;
+
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid transparent;
+
+  &[data-before='true'] {
+    border-color: ${p => p.theme.red400};
+  }
+  &[data-after='true'] {
+    border-color: ${p => p.theme.green400};
+  }
+
+  &[data-before='true']:hover,
+  &[data-before='true'][data-selected='true'] {
+    background-color: ${p => p.theme.red100};
+  }
+  &[data-after='true']:hover,
+  &[data-after='true'][data-selected='true'] {
+    background-color: ${p => p.theme.green100};
+  }
+`;

--- a/static/app/components/replays/diff/picker/mutationOption.tsx
+++ b/static/app/components/replays/diff/picker/mutationOption.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+import {Flex} from 'sentry/components/container/flex';
+import Radio from 'sentry/components/radio';
+import {IconClock} from 'sentry/icons/iconClock';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import formatDuration from 'sentry/utils/duration/formatDuration';
+import {EventType, type RecordingFrame} from 'sentry/utils/replays/types';
+
+interface Props {
+  frame: RecordingFrame;
+  isChecked: boolean;
+  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+  radioName: string;
+  startTimestampMs: number;
+}
+
+export default function MutationOption({
+  frame,
+  startTimestampMs,
+  isChecked,
+  onChange,
+  radioName,
+}: Props) {
+  const name =
+    frame.type === EventType.FullSnapshot ? t('Full Snapshot') : t('Inc. Snapshot');
+
+  const formattedDuration = formatDuration({
+    duration: [frame.timestamp - startTimestampMs, 'ms'],
+    precision: 'ms',
+    style: 'hh:mm:ss.sss',
+  });
+
+  const id = `mutation-${formattedDuration}`;
+
+  return (
+    <Label htmlFor={id}>
+      <Flex column gap={space(0.5)} align="center">
+        <Flex gap={space(0.75)} align="center">
+          <IconClock color="gray500" size="sm" />
+          <span>{formattedDuration}</span>
+        </Flex>
+        <span>{name}</span>
+        <Radio
+          id={id}
+          aria-label={formattedDuration}
+          checked={isChecked}
+          name={radioName}
+          value={frame.timestamp - startTimestampMs}
+          onChange={onChange}
+        />
+      </Flex>
+    </Label>
+  );
+}
+
+const Label = styled('label')`
+  cursor: pointer;
+  padding: ${space(1)};
+  font-weight: normal;
+  text-align: left;
+`;

--- a/static/app/components/replays/diff/picker/mutationOption.tsx
+++ b/static/app/components/replays/diff/picker/mutationOption.tsx
@@ -23,8 +23,7 @@ export default function MutationOption({
   onChange,
   radioName,
 }: Props) {
-  const name =
-    frame.type === EventType.FullSnapshot ? t('Full Snapshot') : t('Inc. Snapshot');
+  const name = frame.type === EventType.FullSnapshot ? t('Full') : t('Incremental');
 
   const formattedDuration = formatDuration({
     duration: [frame.timestamp - startTimestampMs, 'ms'],

--- a/static/app/utils/replays/getDiffTimestamps.spec.tsx
+++ b/static/app/utils/replays/getDiffTimestamps.spec.tsx
@@ -117,7 +117,11 @@ describe('getReplayDiffOffsetsFromFrame', () => {
       []
     );
 
+    const [hydratedHydrationCrumbFrame] = hydrateBreadcrumbs(replayRecord, [
+      rawHydrationCrumbFrame,
+    ]);
     expect(getReplayDiffOffsetsFromFrame(replay, hydrationErrorFrame)).toEqual({
+      frameOrEvent: hydratedHydrationCrumbFrame,
       leftOffsetMs: 200, // offset of FULL_DATE
       rightOffsetMs: 5_000, // offset of the INCR_DATE
     });
@@ -133,7 +137,11 @@ describe('getReplayDiffOffsetsFromFrame', () => {
       []
     );
 
+    const [hydratedHydrationCrumbFrame] = hydrateBreadcrumbs(replayRecord, [
+      rawHydrationCrumbFrame,
+    ]);
     expect(getReplayDiffOffsetsFromFrame(replay, hydrationErrorFrame)).toEqual({
+      frameOrEvent: hydratedHydrationCrumbFrame,
       leftOffsetMs: 5_000, // offset of INCR_DATE
       rightOffsetMs: 1, // no next mutation date, so offset is 1
     });
@@ -150,7 +158,11 @@ describe('getReplayDiffOffsetsFromEvent', () => {
       errorEvent as any as ReplayError,
     ]);
 
+    const [hydratedHydrationCrumbFrame] = hydrateBreadcrumbs(replayRecord, [
+      rawHydrationCrumbFrame,
+    ]);
     expect(getReplayDiffOffsetsFromEvent(replay!, errorEvent)).toEqual({
+      frameOrEvent: hydratedHydrationCrumbFrame,
       leftOffsetMs: 200, // offset of FULL_DATE
       rightOffsetMs: 5_000, // offset of the INCR_DATE
     });
@@ -161,6 +173,7 @@ describe('getReplayDiffOffsetsFromEvent', () => {
     const {replay} = getMockReplay(RRWEB_EVENTS, [errorEvent as any as ReplayError]);
 
     expect(getReplayDiffOffsetsFromEvent(replay!, errorEvent)).toEqual({
+      frameOrEvent: errorEvent,
       leftOffsetMs: 1_000, // offset of ERROR_DATE
       rightOffsetMs: 5_000, // offset of the INCR_DATE
     });

--- a/static/app/utils/replays/getDiffTimestamps.tsx
+++ b/static/app/utils/replays/getDiffTimestamps.tsx
@@ -3,12 +3,19 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 import type {HydrationErrorFrame} from 'sentry/utils/replays/types';
 import {isHydrationErrorFrame, isRRWebChangeFrame} from 'sentry/utils/replays/types';
 
+type ReplayDiffOffsets = {
+  frameOrEvent: HydrationErrorFrame | Event;
+  leftOffsetMs: number;
+  rightOffsetMs: number;
+};
+
 export function getReplayDiffOffsetsFromFrame(
   replay: ReplayReader | null,
   hydrationError: HydrationErrorFrame
-) {
+): ReplayDiffOffsets {
   if (!replay) {
     return {
+      frameOrEvent: hydrationError,
       leftOffsetMs: 0,
       rightOffsetMs: 0,
     };
@@ -29,12 +36,16 @@ export function getReplayDiffOffsetsFromFrame(
   const rightOffsetMs = Math.max(1, (rightFrame?.timestamp ?? 0) - startTimestampMs);
 
   return {
+    frameOrEvent: hydrationError,
     leftOffsetMs,
     rightOffsetMs,
   };
 }
 
-export function getReplayDiffOffsetsFromEvent(replay: ReplayReader, event: Event) {
+export function getReplayDiffOffsetsFromEvent(
+  replay: ReplayReader,
+  event: Event
+): ReplayDiffOffsets {
   const startTimestampMS =
     'startTimestamp' in event ? event.startTimestamp * 1000 : undefined;
   const timeOfEvent = event.dateCreated ?? startTimestampMS ?? event.dateReceived;
@@ -69,5 +80,9 @@ export function getReplayDiffOffsetsFromEvent(replay: ReplayReader, event: Event
       ?.timestamp ?? eventTimestampMs) - replayStartTimestamp
   );
 
-  return {leftOffsetMs, rightOffsetMs};
+  return {
+    frameOrEvent: event,
+    leftOffsetMs,
+    rightOffsetMs,
+  };
 }

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -5,6 +5,8 @@ import {
   MouseInteractions,
 } from '@sentry-internal/rrweb';
 
+import type {Event} from 'sentry/types/event';
+
 export type {serializedNodeWithId} from '@sentry-internal/rrweb-snapshot';
 export type {fullSnapshotEvent, incrementalSnapshotEvent} from '@sentry-internal/rrweb';
 
@@ -203,6 +205,10 @@ export function isBreadcrumbFrame(
 
 export function isFeedbackFrame(frame: ReplayFrame | undefined): frame is FeedbackFrame {
   return Boolean(frame && 'category' in frame && frame.category === 'feedback');
+}
+
+export function isHydrateCrumb(item: BreadcrumbFrame | Event): item is BreadcrumbFrame {
+  return 'category' in item && item.category === 'replay.hydrate-error';
 }
 
 export function isSpanFrame(frame: ReplayFrame | undefined): frame is SpanFrame {


### PR DESCRIPTION
This PR adds a timestamp picker to the Hydration Error modal. 

It looks like this:
<img width="1129" alt="SCR-20250106-rois" src="https://github.com/user-attachments/assets/7efd287c-efac-4472-b09a-075fb4076e08" />

There are a lot of tooltips in here:
| Before/After | The Breadcrumb | Buttons |
| --- | --- | --- |
| <img width="623" alt="SCR-20250106-rsxs" src="https://github.com/user-attachments/assets/20026833-2c63-4703-916a-9ee74b586058" /> | <img width="589" alt="SCR-20250106-rsyx" src="https://github.com/user-attachments/assets/f0820939-83d8-423b-b19d-36c2bc0644e3" /> | <img width="571" alt="SCR-20250106-rszt" src="https://github.com/user-attachments/assets/d6cfcbe2-e047-497b-861a-8acf4bcc812c" /> |

Basically what happens is:
- We pick Before/After timestamps that might be reasonable, based on what happened right before we detected the 'hydration error' and recorded a replay breadcrumb
- If there's nothing in the diff then you can expand the timeframe. A wider timeframe, more mutations basically, means that something can appear in the diff. But not every mutation is visible in the viewport, so the "Mutations" tab and "HTML Diff" tab are good places to go hunt for changes.

Here's an example from my error. As select different 'After' times, more content becomes available inside the diff tool i'm looking at. In this case i'm using the Mutations tool, but all tools work the same.
| 00:03.482 | 00:04.726 | 00:06.300 |
| --- | --- | --- |
| <img width="1188" alt="SCR-20250106-rwlx" src="https://github.com/user-attachments/assets/d7d7c311-ea0f-424b-bcd8-9167dd425fdd" /> | <img width="1188" alt="SCR-20250106-rwmx" src="https://github.com/user-attachments/assets/39b83a66-7e98-423f-b871-abe8750fbf6f" /> | <img width="1188" alt="SCR-20250106-rwoa" src="https://github.com/user-attachments/assets/6712def8-a093-4fff-a642-f8fe09d16bf3" />


Related to https://www.notion.so/sentry/Hydration-Error-Issue-Diff-Tool-Displays-an-Empty-Mutations-Tab-15e8b10e4b5d803883f2ed5c2e850680
Related to https://github.com/getsentry/sentry/issues/74358
