### PR TITLE
fix(hydration issue): Fix useExtractDiffMutations so account for full-snapshots after hydration error happened

### DIFF
--- a/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
+++ b/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
@@ -5,6 +5,7 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 import {
   EventType,
   IncrementalSource,
+  isRRWebChangeFrame,
   type RecordingFrame,
   type ReplayFrame,
 } from 'sentry/utils/replays/types';
@@ -48,11 +49,7 @@ async function extractDiffMutations({
       // within the range, so we visit.
       if (isWithinRange) {
         hasStartedVisiting = true;
-        return (
-          frame.type === EventType.IncrementalSnapshot &&
-          'source' in frame.data &&
-          frame.data.source === IncrementalSource.Mutation
-        );
+        return isRRWebChangeFrame(frame);
       }
       // if we started, but didn't record that visiting is finished, then this
       // is the first frame outside of the range. we'll visit it, so we can
@@ -66,8 +63,22 @@ async function extractDiffMutations({
     },
     onVisitFrame: (frame, collection, replayer) => {
       const mirror = replayer.getMirror();
-
-      if (
+      if (lastFrame && lastFrame.type === EventType.FullSnapshot) {
+        const node = mirror.getNode(lastFrame.data.node.id) as Document | null;
+        const item = collection.get(lastFrame);
+        if (node && item) {
+          const formattedTimestamp = formatDuration({
+            duration: [Math.abs(lastFrame.timestamp - startTimestampMs), 'ms'],
+            precision: 'ms',
+            style: 'hh:mm:ss.sss',
+          });
+          item[formattedTimestamp].adds = {
+            document: {
+              html: node?.documentElement?.outerHTML,
+            },
+          };
+        }
+      } else if (
         lastFrame &&
         lastFrame.type === EventType.IncrementalSnapshot &&
         'source' in lastFrame.data &&
@@ -86,7 +97,7 @@ async function extractDiffMutations({
           }
 
           adds[selector] = {
-            html: node.outerHTML,
+            document: node.outerHTML,
           };
         }
 
@@ -114,14 +125,29 @@ async function extractDiffMutations({
         }
       }
 
-      if (
+      const offset = Math.abs(frame.timestamp - startTimestampMs);
+      const formattedTimestamp = formatDuration({
+        duration: [offset, 'ms'],
+        precision: 'ms',
+        style: 'hh:mm:ss.sss',
+      });
+
+      lastFrame = frame;
+      if (frame.type === EventType.FullSnapshot) {
+        collection.set(frame, {
+          [formattedTimestamp]: {
+            adds: {},
+            attributes: {},
+            removes: {document: '*'},
+            offset,
+            timestamp: frame.timestamp,
+          },
+        });
+      } else if (
         frame.type === EventType.IncrementalSnapshot &&
         'source' in frame.data &&
         frame.data.source === IncrementalSource.Mutation
       ) {
-        // fill the cache
-        lastFrame = frame;
-
         const removes = {};
         for (const removal of frame.data.removes) {
           const node = mirror.getNode(removal.id) as HTMLElement | null;
@@ -141,13 +167,6 @@ async function extractDiffMutations({
           };
         }
 
-        const offset = Math.abs(frame.timestamp - startTimestampMs);
-        const formattedTimestamp = formatDuration({
-          duration: [offset, 'ms'],
-          precision: 'ms',
-          style: 'hh:mm:ss.sss',
-        });
-
         collection.set(frame, {
           [formattedTimestamp]: {
             adds: {},
@@ -160,6 +179,15 @@ async function extractDiffMutations({
       }
     },
   });
+
+  if (lastFrame) {
+    // An extra frame is added because we increment past the target when we run
+    // these two statements: `hasFinishedVisiting = true; return true;`, the
+    // intention is that we'll step one more time and fill in `lastFrame`.
+    // But for the extra frame, we don't fill it in later, we'll just pop it off.
+    results.delete(lastFrame);
+  }
+
   return results;
 }
 


### PR DESCRIPTION
This PR makes the whole hydration-error diff experience more consistent as we're now always looking only at `isRRWebChangeFrame` data. That is: only `EventType.FullSnapshot` or `EventType.IncrementalSnapshot && IncrementalSource.Mutation`.

As we're looking at those two types this PR also makes sure to collect data from them, which wasn't happening before. 

Now when we see a FullSnapshot we'll grab the document html, which is replacing whatever was there before, and include it as a step in the Mutations tree. It's not the easiest chunk of text to parse through, but that's not the point. The point is that we show everything, the better diff view is one of the visual ones... or the HTML Diff which will do and end-to-end diff including that but chunk of html text. We're talking about this section `{adds: {document: {html : ....}}}`:
<img width="1238" alt="SCR-20250106-sbui" src="https://github.com/user-attachments/assets/9db013a4-dd7f-442c-8a93-5ca5f9453f7b" />

