### PR TITLE
ref(quick-start): Default feature flag to true

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -343,7 +343,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable the new quick start guide
     manager.add("organizations:quick-start-updates", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new small design changes for the quick start guide GA
-    manager.add("organizations:quick-start-updates-ga", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:quick-start-updates-ga", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable the new Related Events feature
     manager.add("organizations:related-events", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable related issues feature

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -89,6 +89,7 @@ class OrganizationSerializerTest(TestCase):
             "minute-resolution-sessions",
             "new-page-filter",
             "open-membership",
+            "quick-start-updates-ga",
             "relay",
             "shared-issues",
             "session-replay-ui",


### PR DESCRIPTION
defaulting the feature flag to `true` as described in [the guide](https://develop.sentry.dev/backend/application-domains/feature-flags/flagpole/#removing-flagpole-features)