### PR TITLE
chore(dashboards): Convert list view FF to favourite FF

### DIFF
--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -27,7 +27,7 @@ describe('Dashboards - DashboardTable', function () {
       'dashboards-basic',
       'dashboards-edit',
       'discover-query',
-      'dashboards-table-view',
+      'dashboards-favourite',
     ],
   });
 
@@ -294,7 +294,7 @@ describe('Dashboards - DashboardTable', function () {
         'dashboards-basic',
         'dashboards-edit',
         'discover-query',
-        'dashboards-table-view',
+        'dashboards-favourite',
         'dashboards-edit-access',
       ],
     });
@@ -327,7 +327,7 @@ describe('Dashboards - DashboardTable', function () {
         'dashboards-basic',
         'dashboards-edit',
         'discover-query',
-        'dashboards-table-view',
+        'dashboards-favourite',
         'dashboards-favourite',
       ],
     });

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -226,7 +226,7 @@ describe('Dashboards > Detail', function () {
       ...RouteComponentPropsFixture(),
       organization: {
         ...mockAuthorizedOrg,
-        features: [...FEATURES, 'dashboards-table-view'],
+        features: [...FEATURES, 'dashboards-favourite'],
       },
     });
 

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -255,14 +255,14 @@ function ManageDashboards() {
   function renderActions() {
     const activeSort = getActiveSort();
     return (
-      <StyledActions listView={organization.features.includes('dashboards-table-view')}>
+      <StyledActions listView={organization.features.includes('dashboards-favourite')}>
         <SearchBar
           defaultQuery=""
           query={getQuery()}
           placeholder={t('Search Dashboards')}
           onSearch={query => handleSearch(query)}
         />
-        <Feature features={'organizations:dashboards-table-view'}>
+        <Feature features={'organizations:dashboards-favourite'}>
           <SegmentedControl<DashboardsLayout>
             onChange={setDashboardsLayout}
             size="md"


### PR DESCRIPTION
Converting all of the `dashboards-list-view` FF to `dashboards-favourite` FF to roll them out together. This ensures no one accidentally gets one without the other. (I will make PRs in the options repo to remove the list view ff and start to roll out the favourites ff)
