### PR TITLE
feat(metric-issues): Add open period to BaseGroup response

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -824,9 +824,17 @@ export interface BaseGroup {
   integrationIssues?: ExternalIssue[];
   latestEvent?: Event;
   latestEventHasAttachments?: boolean;
+  openPeriods?: GroupOpenPeriod[] | null;
   owners?: SuggestedOwner[] | null;
   sentryAppIssues?: PlatformExternalIssue[];
   substatus?: GroupSubstatus | null;
+}
+
+export interface GroupOpenPeriod {
+  duration: string;
+  end: string;
+  isOpen: boolean;
+  start: string;
 }
 
 export interface GroupReprocessing extends BaseGroup, GroupStats {


### PR DESCRIPTION
Adding the `openPeriods` field from https://github.com/getsentry/sentry/pull/82978 to the response in the frontend.