### PR TITLE
fix(alerts): Add back interval select field

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -526,18 +526,16 @@ class RuleConditionsForm extends PureComponent<Props, State> {
               required
             />
           )}
-          {
-            <SelectControl
-              name="timeWindow"
-              styles={this.selectControlStyles}
-              options={this.timeWindowOptions}
-              isDisabled={disabled}
-              value={timeWindow}
-              onChange={({value}) => onTimeWindowChange(value)}
-              inline={false}
-              flexibleControlStateSize
-            />
-          }
+          <SelectControl
+            name="timeWindow"
+            styles={this.selectControlStyles}
+            options={this.timeWindowOptions}
+            isDisabled={disabled}
+            value={timeWindow}
+            onChange={({value}) => onTimeWindowChange(value)}
+            inline={false}
+            flexibleControlStateSize
+          />
         </FormRow>
       </Fragment>
     );

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -490,7 +490,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   renderInterval() {
-    const {organization, disabled, alertType, project, isForLlmMetric} = this.props;
+    const {organization, timeWindow, disabled, alertType, project, isForLlmMetric} =
+      this.props;
 
     return (
       <Fragment>
@@ -518,6 +519,18 @@ class RuleConditionsForm extends PureComponent<Props, State> {
               required
             />
           )}
+          {
+            <SelectControl
+              name="timeWindow"
+              styles={this.selectControlStyles}
+              options={this.timeWindowOptions}
+              isDisabled={disabled}
+              value={timeWindow}
+              onChange={({value}) => onTimeWindowChange(value)}
+              inline={false}
+              flexibleControlStateSize
+            />
+          }
         </FormRow>
       </Fragment>
     );

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -490,8 +490,15 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   renderInterval() {
-    const {organization, timeWindow, disabled, alertType, project, isForLlmMetric} =
-      this.props;
+    const {
+      organization,
+      timeWindow,
+      disabled,
+      alertType,
+      project,
+      isForLlmMetric,
+      onTimeWindowChange,
+    } = this.props;
 
     return (
       <Fragment>

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -142,6 +142,12 @@ describe('Incident Rules Form', () => {
       expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
     });
 
+    it('renders time window', async () => {
+      createWrapper({rule});
+
+      expect(await screen.findByText('1 hour interval')).toBeInTheDocument();
+    });
+
     it('is enabled with project-level alerts:write', async () => {
       organization.access = [];
       project.access = ['alerts:write'];


### PR DESCRIPTION
I unintentionally removed the interval select field on metric alerts when removing the monitor type in https://github.com/getsentry/sentry/pull/81218 this PR puts it back

<img width="1077" alt="Screenshot 2025-01-07 at 9 45 10 AM" src="https://github.com/user-attachments/assets/d249600f-665a-43f3-bcfa-d6f2c567cfdd" />
