### PR TITLE
ref(alerts): Consistent bread crumb labels

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -88,7 +88,7 @@ describe('AlertRuleDetails', () => {
 
   it('displays alert rule with list of issues', async () => {
     createWrapper();
-    expect(await screen.findAllByText('My alert rule')).toHaveLength(2);
+    expect(await screen.findByText('My alert rule')).toBeInTheDocument();
     expect(await screen.findByText('RequestError:')).toBeInTheDocument();
     expect(screen.getByText('Apr 11, 2019 1:08:59 AM UTC')).toBeInTheDocument();
     expect(screen.getByText('RequestError:')).toHaveAttribute(
@@ -181,7 +181,7 @@ describe('AlertRuleDetails', () => {
 
   it('incompatible rule banner hidden for good rule', async () => {
     createWrapper();
-    expect(await screen.findAllByText('My alert rule')).toHaveLength(2);
+    expect(await screen.findByText('My alert rule')).toBeInTheDocument();
     expect(
       screen.queryByText(
         'The conditions in this alert rule conflict and might not be working properly.'

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -382,8 +382,7 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
                 to: `/organizations/${organization.slug}/alerts/rules/`,
               },
               {
-                label: rule.name,
-                to: null,
+                label: t('Issue Alert'),
               },
             ]}
           />

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -58,7 +58,7 @@ function DetailsHeader({
         <Breadcrumbs
           crumbs={[
             {label: t('Alerts'), to: `/organizations/${organization.slug}/alerts/rules/`},
-            {label: ruleTitle},
+            {label: t('Metric Alert')},
           ]}
         />
         <RuleTitle data-test-id="incident-rule-title" loading={!isRuleReady}>

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -75,7 +75,7 @@ describe('MetricAlertDetails', () => {
       {router, organization}
     );
 
-    expect(await screen.findAllByText(rule.name)).toHaveLength(2);
+    expect(await screen.findByText(rule.name)).toBeInTheDocument();
     expect(screen.getByText('Change alert status to Resolved')).toBeInTheDocument();
     expect(screen.getByText(`#${incident.identifier}`)).toBeInTheDocument();
     // Related issues
@@ -130,7 +130,7 @@ describe('MetricAlertDetails', () => {
       {router, organization}
     );
 
-    expect(await screen.findAllByText(rule.name)).toHaveLength(2);
+    expect(await screen.findByText(rule.name)).toBeInTheDocument();
     // Related issues
     expect(screen.getByTestId('group')).toBeInTheDocument();
     expect(trackAnalytics).toHaveBeenCalledWith(
@@ -228,7 +228,7 @@ describe('MetricAlertDetails', () => {
       {router, organization}
     );
 
-    expect(await screen.findAllByText(rule.name)).toHaveLength(2);
+    expect(await screen.findByText(rule.name)).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toHaveAttribute(
       'href',
       expect.stringContaining('dataset=errors')

--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -36,7 +36,7 @@ describe('UptimeAlertDetails', function () {
       />,
       {organization}
     );
-    expect(await screen.findAllByText('Uptime Test Rule')).toHaveLength(2);
+    expect(await screen.findByText('Uptime Test Rule')).toBeInTheDocument();
   });
 
   it('shows a message for invalid uptime alert', async function () {

--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -77,8 +77,7 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
                 to: `/organizations/${organization.slug}/alerts/rules/`,
               },
               {
-                label: uptimeRule.name,
-                to: null,
+                label: t('Uptime Monitor'),
               },
             ]}
           />

--- a/static/app/views/monitors/components/monitorHeader.tsx
+++ b/static/app/views/monitors/components/monitorHeader.tsx
@@ -21,7 +21,7 @@ export function MonitorHeader({monitor, orgSlug, onUpdate}: Props) {
       preservePageFilters: true,
     },
     {
-      label: t('Cron Monitor Details'),
+      label: t('Cron Monitor'),
     },
   ];
 


### PR DESCRIPTION
Instead of using the name of the thing, which is displayed directly in
the header below, use the name of the alert type we're looking at.