### PR TITLE
fix(aci milestone 3): data condition group fix

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -11,7 +11,6 @@ from sentry.workflow_engine.models import (
     DetectorState,
     DetectorWorkflow,
     Workflow,
-    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -20,7 +19,7 @@ def create_metric_alert_lookup_tables(
     alert_rule: AlertRule,
     detector: Detector,
     workflow: Workflow,
-) -> tuple[AlertRuleDetector, AlertRuleWorkflow, DetectorWorkflow, WorkflowDataConditionGroup]:
+) -> tuple[AlertRuleDetector, AlertRuleWorkflow, DetectorWorkflow]:
     alert_rule_detector = AlertRuleDetector.objects.create(alert_rule=alert_rule, detector=detector)
     alert_rule_workflow = AlertRuleWorkflow.objects.create(alert_rule=alert_rule, workflow=workflow)
     detector_workflow = DetectorWorkflow.objects.create(detector=detector, workflow=workflow)
@@ -108,7 +107,6 @@ def migrate_alert_rule(
         AlertRuleDetector,
         AlertRuleWorkflow,
         DetectorWorkflow,
-        WorkflowDataConditionGroup,
     ]
     | None
 ):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -12,7 +12,6 @@ from sentry.workflow_engine.models import (
     DetectorState,
     DetectorWorkflow,
     Workflow,
-    WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -53,8 +52,7 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         detector_workflow = DetectorWorkflow.objects.get(detector=detector)
         assert detector_workflow.workflow == workflow
 
-        workflow_data_condition_group = WorkflowDataConditionGroup.objects.get(workflow=workflow)
-        assert workflow_data_condition_group.condition_group == workflow.when_condition_group
+        assert workflow.when_condition_group is None
 
         assert self.metric_alert.snuba_query
         query_subscription = QuerySubscription.objects.get(


### PR DESCRIPTION
The detector's data condition group and the workflow's when condition group should be separate (the when condition group should be None). The remaining workflow data condition groups are created when dual writing Actions.