### PR TITLE
ref(insights): Move feedback button to left of other actions

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -98,8 +98,8 @@ export function DomainViewHeader({
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <ButtonBar gap={1}>
-            {additonalHeaderActions}
             <FeedbackWidgetButton />
+            {additonalHeaderActions}
           </ButtonBar>
         </Layout.HeaderActions>
         <Tabs value={tabValue} onChange={tabs?.onTabChange}>


### PR DESCRIPTION
It feels a bit weird to have the "primary" actions on the left side and
the feedback button on the right here

<img alt="clipboard.png" width="1613" src="https://i.imgur.com/aYL8OHL.jpeg" />

vs

<img alt="clipboard.png" width="1613" src="https://i.imgur.com/jAtDzxN.jpeg" />