### PR TITLE
fix(discover): Handles when issue is in top events with transactions

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -575,7 +575,7 @@ def top_events_timeseries(
         result = top_events_builder.process_results(result)
 
         issues: Mapping[int, str | None] = {}
-        if "issue" in selected_columns:
+        if "issue" in selected_columns and dataset in {Dataset.Discover, Dataset.Events}:
             issues = Group.objects.get_issues_mapping(
                 {cast(int, event["issue.id"]) for event in top_events["data"]},
                 snuba_params.project_ids,


### PR DESCRIPTION
- Sometimes queries are being run on the transactions dataset with the issues field, but since issue doesn't exist there its causing the query to fail
- Fixes SENTRY-3DPS