### PR TITLE
fix(uptime): only log 1%

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -123,7 +123,8 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         update_remote_uptime_subscription.delay(subscription.id)
 
     def handle_result(self, subscription: UptimeSubscription | None, result: CheckResult):
-        logger.info("process_result", extra=result)
+        if random.random() < 0.01:
+            logger.info("process_result", extra=result)
 
         if subscription is None:
             # If no subscription in the Postgres, this subscription has been orphaned. Remove


### PR DESCRIPTION
according to our [logs COGS dashboard](https://console.cloud.google.com/monitoring/dashboards/builder/2fac5642-c4b9-4359-8f84-fb9065a40cbe;duration=P1D?invt=AbmPOQ&project=internal-sentry&pageState=(%22eventTypes%22:(%22selected%22:%5B%22CLOUD_ALERTING_ALERT%22,%22SERVICE_HEALTH_INCIDENT%22%5D))&rapt=AEjHL4NCUEF-waTDFCefln8J_mb73pn137mfvPCvLcx3Ty2wDipb97htOPzstzDigWxmvnYvrkROV2CWcdTYieT6_xF31j88VjetE2pD9mcXwhnKHu_VOdE) (something i'm WIP), this log costs ~$30,000 a year. let's sample it at 1%