### PR TITLE
chore(dashboards): Remove edit access FF code from backend

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -50,40 +50,16 @@ class OrganizationDashboardsPermission(OrganizationPermission):
             return super().has_object_permission(request, view, obj)
 
         if isinstance(obj, Dashboard):
-            if features.has(
-                "organizations:dashboards-edit-access", obj.organization, actor=request.user
-            ):
-                # allow for Managers and Owners
-                if request.access.has_scope("org:write"):
-                    return True
-
-                # check if user is restricted from editing dashboard
-                if hasattr(obj, "permissions"):
-                    return obj.permissions.has_edit_permissions(request.user.id)
-
-                # if no permissions are assigned, it is considered accessible to all users
+            # allow for Managers and Owners
+            if request.access.has_scope("org:write"):
                 return True
 
-            else:
-                # 1. Dashboard contains certain projects
-                if obj.projects.exists():
-                    return request.access.has_projects_access(obj.projects.all())
+            # check if user is restricted from editing dashboard
+            if hasattr(obj, "permissions"):
+                return obj.permissions.has_edit_permissions(request.user.id)
 
-                # 2. Dashboard covers all projects or all my projects
-
-                # allow when Open Membership
-                if obj.organization.flags.allow_joinleave:
-                    return True
-
-                # allow for Managers and Owners
-                if request.access.has_scope("org:write"):
-                    return True
-
-                # allow for creator
-                if request.user.id == obj.created_by_id:
-                    return True
-
-                return False
+            # if no permissions are assigned, it is considered accessible to all users
+            return True
 
         return True
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -632,20 +632,15 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                 f"Number of widgets must be less than {Dashboard.MAX_WIDGETS}"
             )
 
-        if features.has(
-            "organizations:dashboards-edit-access",
-            self.context["organization"],
-            actor=self.context["request"].user,
-        ):
-            permissions = data.get("permissions")
-            if permissions and self.instance:
-                currentUser = self.context["request"].user
-                # managers and owners
-                has_write_access = self.context["request"].access.has_scope("org:write")
-                if self.instance.created_by_id != currentUser.id and not has_write_access:
-                    raise serializers.ValidationError(
-                        "Only the Dashboard Creator may modify Dashboard Edit Access"
-                    )
+        permissions = data.get("permissions")
+        if permissions and self.instance:
+            currentUser = self.context["request"].user
+            # managers and owners
+            has_write_access = self.context["request"].access.has_scope("org:write")
+            if self.instance.created_by_id != currentUser.id and not has_write_access:
+                raise serializers.ValidationError(
+                    "Only the Dashboard Creator may modify Dashboard Edit Access"
+                )
 
         return data
 
@@ -718,12 +713,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         self.update_dashboard_filters(self.instance, validated_data)
 
-        if features.has(
-            "organizations:dashboards-edit-access",
-            self.context["organization"],
-            actor=self.context["request"].user,
-        ):
-            self.update_permissions(self.instance, validated_data)
+        self.update_permissions(self.instance, validated_data)
 
         schedule_update_project_configs(self.instance)
 
@@ -749,12 +739,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         self.update_dashboard_filters(instance, validated_data)
 
-        if features.has(
-            "organizations:dashboards-edit-access",
-            self.context["organization"],
-            actor=self.context["request"].user,
-        ):
-            self.update_permissions(instance, validated_data)
+        self.update_permissions(instance, validated_data)
 
         schedule_update_project_configs(instance)
 

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1399,8 +1399,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             "id": "7136",
         }
 
-        with self.feature({"organizations:dashboards-edit-access": True}):
-            response = self.do_request("post", self.url, data=data)
+        response = self.do_request("post", self.url, data=data)
         assert response.status_code == 201, response.content
         assert response.data["permissions"]["isEditableByEveryone"] is False
         assert response.data["permissions"]["teamsWithEditAccess"] == [team1.id, team2.id]
@@ -1431,8 +1430,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             "id": "7136",
         }
 
-        with self.feature({"organizations:dashboards-edit-access": True}):
-            response = self.do_request("post", self.url, data=data)
+        response = self.do_request("post", self.url, data=data)
         assert response.status_code == 201
 
         response = self.do_request("get", self.url)


### PR DESCRIPTION
Removing the edit access feature flag from the backend. This makes all of the edit access permissions code the default now. Also adjusted the tests for this.

Context: https://sentry.slack.com/archives/C01MYDW8Y7K/p1736203608171589

Next step: Removing the feature flag from the options repo.