### PR TITLE
feat(issues): Split out issue event navigation, fix preloading

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -238,7 +238,6 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
   } = useGroupEvent({
     groupId,
     eventId: params.eventId,
-    environments,
   });
 
   const {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -57,7 +57,6 @@ function GroupEventDetails() {
   } = useGroupEvent({
     groupId: params.groupId,
     eventId: params.eventId,
-    environments,
   });
 
   const {

--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -5,9 +5,8 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import * as useMedia from 'sentry/utils/useMedia';
 import {SectionKey, useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 
@@ -16,7 +15,7 @@ import {IssueEventNavigation} from './eventNavigation';
 jest.mock('sentry/views/issueDetails/streamline/context');
 
 describe('EventNavigation', () => {
-  const {organization, router} = initializeOrg();
+  const {organization} = initializeOrg();
   const group = GroupFixture({id: 'group-id'});
   const testEvent = EventFixture({
     id: 'event-id',
@@ -89,96 +88,6 @@ describe('EventNavigation', () => {
         expect.stringContaining(`/organizations/${organization.slug}/issues/${group.id}/`)
       );
     });
-  });
-
-  describe('recommended event tabs', () => {
-    it('can navigate to the oldest event', async () => {
-      jest.spyOn(useMedia, 'default').mockReturnValue(true);
-
-      render(<IssueEventNavigation {...defaultProps} />, {router});
-
-      await userEvent.click(await screen.findByRole('tab', {name: 'First'}));
-
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/issues/group-id/events/oldest/',
-        query: {referrer: 'oldest-event'},
-      });
-    });
-
-    it('can navigate to the latest event', async () => {
-      jest.spyOn(useMedia, 'default').mockReturnValue(true);
-
-      render(<IssueEventNavigation {...defaultProps} />, {router});
-
-      await userEvent.click(await screen.findByRole('tab', {name: 'Last'}));
-
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/issues/group-id/events/latest/',
-        query: {referrer: 'latest-event'},
-      });
-    });
-
-    it('can navigate to the recommended event', async () => {
-      jest.spyOn(useMedia, 'default').mockReturnValue(true);
-
-      const recommendedEventRouter = RouterFixture({
-        params: {eventId: 'latest'},
-        location: LocationFixture({
-          pathname: `/organizations/org-slug/issues/group-id/events/latest/`,
-        }),
-      });
-
-      render(<IssueEventNavigation {...defaultProps} />, {
-        router: recommendedEventRouter,
-      });
-
-      await userEvent.click(await screen.findByRole('tab', {name: 'Rec.'}));
-
-      expect(recommendedEventRouter.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/issues/group-id/events/recommended/',
-        query: {referrer: 'recommended-event'},
-      });
-    });
-  });
-
-  it('can navigate next/previous events', async () => {
-    render(<IssueEventNavigation {...defaultProps} />);
-
-    expect(await screen.findByRole('button', {name: 'Previous Event'})).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/issues/group-id/events/prev-event-id/?referrer=previous-event`
-    );
-    expect(screen.getByRole('button', {name: 'Next Event'})).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/issues/group-id/events/next-event-id/?referrer=next-event`
-    );
-  });
-
-  it('can preload next/previous events', async () => {
-    const event = EventFixture({
-      nextEventID: 'next-event-id',
-      previousEventID: 'prev-event-id',
-    });
-    const mockNextEvent = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/group-id/events/next-event-id/`,
-      body: EventFixture(),
-    });
-    const mockPreviousEvent = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/group-id/events/prev-event-id/`,
-      body: EventFixture(),
-    });
-    render(<IssueEventNavigation {...defaultProps} event={event} />);
-
-    expect(mockNextEvent).not.toHaveBeenCalled();
-    expect(mockPreviousEvent).not.toHaveBeenCalled();
-
-    await userEvent.hover(await screen.findByRole('button', {name: 'Next Event'}));
-
-    await waitFor(() => expect(mockNextEvent).toHaveBeenCalled());
-    expect(mockPreviousEvent).not.toHaveBeenCalled();
-
-    await userEvent.hover(screen.getByRole('button', {name: 'Previous Event'}));
-    await waitFor(() => expect(mockPreviousEvent).toHaveBeenCalled());
   });
 
   describe('counts', () => {

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -1,5 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
-import {css, useTheme} from '@emotion/react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
@@ -7,50 +6,26 @@ import ButtonBar from 'sentry/components/buttonBar';
 import Count from 'sentry/components/count';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {TabList, Tabs} from 'sentry/components/tabs';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconChevron, IconTelescope} from 'sentry/icons';
+import {IconTelescope} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
-import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
+import {keepPreviousData} from 'sentry/utils/queryClient';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
-import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {useGroupEventAttachments} from 'sentry/views/issueDetails/groupEventAttachments/useGroupEventAttachments';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
+import {IssueDetailsEventNavigation} from 'sentry/views/issueDetails/streamline/issueDetailsEventNavigation';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
-import {
-  getGroupEventQueryKey,
-  useDefaultIssueEvent,
-  useEnvironmentsFromUrl,
-} from 'sentry/views/issueDetails/utils';
-
-const enum EventNavOptions {
-  RECOMMENDED = 'recommended',
-  LATEST = 'latest',
-  OLDEST = 'oldest',
-  CUSTOM = 'custom',
-}
-
-const EventNavOrder = [
-  EventNavOptions.OLDEST,
-  EventNavOptions.LATEST,
-  EventNavOptions.RECOMMENDED,
-  EventNavOptions.CUSTOM,
-];
 
 const TabName = {
   [Tab.DETAILS]: t('Events'),
@@ -66,15 +41,9 @@ interface IssueEventNavigationProps {
 }
 
 export function IssueEventNavigation({event, group}: IssueEventNavigationProps) {
-  const theme = useTheme();
   const organization = useOrganization();
   const {baseUrl, currentTab} = useGroupDetailsRoute();
   const location = useLocation();
-  const params = useParams<{eventId?: string}>();
-  const defaultIssueEvent = useDefaultIssueEvent();
-  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
-  const [shouldPreload, setShouldPreload] = useState({next: false, previous: false});
-  const environments = useEnvironmentsFromUrl();
   const eventView = useIssueDetailsEventView({group});
   const {eventCount} = useIssueDetails();
   const issueTypeConfig = getConfigForIssueType(group, group.project);
@@ -88,53 +57,6 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
     organization.slug,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
-  );
-
-  // Reset shouldPreload when the groupId changes
-  useEffect(() => {
-    setShouldPreload({next: false, previous: false});
-  }, [group.id]);
-
-  const handleHoverPagination = useCallback(
-    (direction: 'next' | 'previous', isEnabled: boolean) => () => {
-      if (isEnabled) {
-        setShouldPreload(prev => ({...prev, [direction]: true}));
-      }
-    },
-    []
-  );
-
-  // Prefetch next
-  useApiQuery(
-    getGroupEventQueryKey({
-      orgSlug: organization.slug,
-      groupId: group.id,
-      // Will be defined when enabled
-      eventId: event?.nextEventID!,
-      environments,
-    }),
-    {
-      enabled: shouldPreload.next && defined(event?.nextEventID),
-      staleTime: Infinity,
-      // Ignore state changes from the query
-      notifyOnChangeProps: [],
-    }
-  );
-  // Prefetch previous
-  useApiQuery(
-    getGroupEventQueryKey({
-      orgSlug: organization.slug,
-      groupId: group.id,
-      // Will be defined when enabled
-      eventId: event?.previousEventID!,
-      environments,
-    }),
-    {
-      enabled: shouldPreload.previous && defined(event?.previousEventID),
-      staleTime: Infinity,
-      // Ignore state changes from the query
-      notifyOnChangeProps: [],
-    }
   );
 
   const {getReplayCountForIssue} = useReplayCountForIssues({
@@ -154,40 +76,6 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
   // Since we reuse whatever page the user was on, we can look at pagination to determine if there are more attachments
   const hasManyAttachments =
     attachmentPagination.next?.results || attachmentPagination.previous?.results;
-
-  const selectedOption = useMemo(() => {
-    switch (params.eventId) {
-      case EventNavOptions.RECOMMENDED:
-      case EventNavOptions.LATEST:
-      case EventNavOptions.OLDEST:
-        return params.eventId;
-      case undefined:
-        return defaultIssueEvent;
-      default:
-        return EventNavOptions.CUSTOM;
-    }
-  }, [params.eventId, defaultIssueEvent]);
-
-  const onTabChange = (tabKey: typeof selectedOption) => {
-    trackAnalytics('issue_details.event_navigation_selected', {
-      organization,
-      content: EventNavLabels[tabKey],
-    });
-  };
-
-  const baseEventsPath = `/organizations/${organization.slug}/issues/${group.id}/events/`;
-
-  const grayText = css`
-    color: ${theme.subText};
-    font-weight: ${theme.fontWeightNormal};
-  `;
-
-  const EventNavLabels = {
-    [EventNavOptions.RECOMMENDED]: isSmallScreen ? t('Rec.') : t('Recommended'),
-    [EventNavOptions.OLDEST]: t('First'),
-    [EventNavOptions.LATEST]: t('Last'),
-    [EventNavOptions.CUSTOM]: t('Specific'),
-  };
 
   return (
     <EventNavigationWrapper role="navigation">
@@ -292,93 +180,19 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
       <NavigationWrapper>
         {currentTab === Tab.DETAILS && (
           <Fragment>
-            <Navigation>
-              <Tooltip title={t('Previous Event')} skipWrapper>
-                <LinkButton
-                  aria-label={t('Previous Event')}
-                  borderless
-                  size="xs"
-                  icon={<IconChevron direction="left" />}
-                  disabled={!defined(event?.previousEventID)}
-                  analyticsEventKey="issue_details.previous_event_clicked"
-                  analyticsEventName="Issue Details: Previous Event Clicked"
-                  to={{
-                    pathname: `${baseEventsPath}${event?.previousEventID}/`,
-                    query: {...location.query, referrer: 'previous-event'},
-                  }}
-                  css={grayText}
-                  onMouseEnter={handleHoverPagination(
-                    'previous',
-                    defined(event?.previousEventID)
-                  )}
-                  onClick={() => {
-                    // Assume they will continue to paginate
-                    setShouldPreload({next: true, previous: true});
-                  }}
-                />
-              </Tooltip>
-              <Tooltip title={t('Next Event')} skipWrapper>
-                <LinkButton
-                  aria-label={t('Next Event')}
-                  borderless
-                  size="xs"
-                  icon={<IconChevron direction="right" />}
-                  disabled={!defined(event?.nextEventID)}
-                  analyticsEventKey="issue_details.next_event_clicked"
-                  analyticsEventName="Issue Details: Next Event Clicked"
-                  to={{
-                    pathname: `${baseEventsPath}${event?.nextEventID}/`,
-                    query: {...location.query, referrer: 'next-event'},
-                  }}
-                  css={grayText}
-                  onMouseEnter={handleHoverPagination(
-                    'next',
-                    defined(event?.nextEventID)
-                  )}
-                  onClick={() => {
-                    // Assume they will continue to paginate
-                    setShouldPreload({next: true, previous: true});
-                  }}
-                />
-              </Tooltip>
-            </Navigation>
-            <Tabs value={selectedOption} disableOverflow onChange={onTabChange}>
-              <TabList hideBorder variant="floating">
-                {EventNavOrder.map(label => {
-                  const eventPath =
-                    label === selectedOption
-                      ? undefined
-                      : {
-                          pathname: normalizeUrl(baseEventsPath + label + '/'),
-                          query: {...location.query, referrer: `${label}-event`},
-                        };
-                  return (
-                    <TabList.Item
-                      to={eventPath}
-                      key={label}
-                      hidden={label === EventNavOptions.CUSTOM}
-                      textValue={EventNavLabels[label]}
-                    >
-                      {EventNavLabels[label]}
-                    </TabList.Item>
-                  );
-                })}
-              </TabList>
-            </Tabs>
+            <IssueDetailsEventNavigation event={event} group={group} />
+            <LinkButton
+              to={{
+                pathname: `${baseUrl}${TabPaths[Tab.EVENTS]}`,
+                query: location.query,
+              }}
+              size="xs"
+              analyticsEventKey="issue_details.all_events_clicked"
+              analyticsEventName="Issue Details: All Events Clicked"
+            >
+              {t('All Events')}
+            </LinkButton>
           </Fragment>
-        )}
-        {currentTab === Tab.DETAILS && (
-          <LinkButton
-            to={{
-              pathname: `${baseUrl}${TabPaths[Tab.EVENTS]}`,
-              query: location.query,
-            }}
-            size="xs"
-            analyticsEventKey="issue_details.all_events_clicked"
-            analyticsEventName="Issue Details: All Events Clicked"
-          >
-            {t('All Events')}
-          </LinkButton>
         )}
 
         {currentTab === Tab.EVENTS && (
@@ -456,12 +270,6 @@ const NavigationWrapper = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.xsmall}) {
     gap: ${space(0.5)};
   }
-`;
-
-const Navigation = styled('div')`
-  display: flex;
-  padding-right: ${space(0.25)};
-  border-right: 1px solid ${p => p.theme.gray100};
 `;
 
 const DropdownCountWrapper = styled('div')<{isCurrentTab: boolean}>`

--- a/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.spec.tsx
@@ -1,0 +1,131 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as useMedia from 'sentry/utils/useMedia';
+
+import {IssueDetailsEventNavigation} from './issueDetailsEventNavigation';
+
+describe('IssueDetailsEventNavigation', () => {
+  const {organization, router} = initializeOrg();
+  const group = GroupFixture({id: 'group-id'});
+  const testEvent = EventFixture({
+    id: 'event-id',
+    size: 7,
+    dateCreated: '2019-03-20T00:00:00.000Z',
+    errors: [],
+    entries: [],
+    tags: [
+      {key: 'environment', value: 'dev'},
+      {key: 'replayId', value: 'replay-id'},
+    ],
+    previousEventID: 'prev-event-id',
+    nextEventID: 'next-event-id',
+  });
+  const defaultProps: React.ComponentProps<typeof IssueDetailsEventNavigation> = {
+    event: testEvent,
+    group,
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
+      body: [],
+    });
+  });
+
+  describe('recommended event tabs', () => {
+    it('can navigate to the oldest event', async () => {
+      jest.spyOn(useMedia, 'default').mockReturnValue(true);
+
+      render(<IssueDetailsEventNavigation {...defaultProps} />, {router});
+
+      await userEvent.click(await screen.findByRole('tab', {name: 'First'}));
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/issues/group-id/events/oldest/',
+        query: {referrer: 'oldest-event'},
+      });
+    });
+
+    it('can navigate to the latest event', async () => {
+      jest.spyOn(useMedia, 'default').mockReturnValue(true);
+
+      render(<IssueDetailsEventNavigation {...defaultProps} />, {router});
+
+      await userEvent.click(await screen.findByRole('tab', {name: 'Last'}));
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/issues/group-id/events/latest/',
+        query: {referrer: 'latest-event'},
+      });
+    });
+
+    it('can navigate to the recommended event', async () => {
+      jest.spyOn(useMedia, 'default').mockReturnValue(true);
+
+      const recommendedEventRouter = RouterFixture({
+        params: {eventId: 'latest'},
+        location: LocationFixture({
+          pathname: `/organizations/org-slug/issues/group-id/events/latest/`,
+        }),
+      });
+
+      render(<IssueDetailsEventNavigation {...defaultProps} />, {
+        router: recommendedEventRouter,
+      });
+
+      await userEvent.click(await screen.findByRole('tab', {name: 'Rec.'}));
+
+      expect(recommendedEventRouter.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/issues/group-id/events/recommended/',
+        query: {referrer: 'recommended-event'},
+      });
+    });
+  });
+
+  it('can navigate next/previous events', async () => {
+    render(<IssueDetailsEventNavigation {...defaultProps} />);
+
+    expect(await screen.findByRole('button', {name: 'Previous Event'})).toHaveAttribute(
+      'href',
+      `/organizations/org-slug/issues/group-id/events/prev-event-id/?referrer=previous-event`
+    );
+    expect(screen.getByRole('button', {name: 'Next Event'})).toHaveAttribute(
+      'href',
+      `/organizations/org-slug/issues/group-id/events/next-event-id/?referrer=next-event`
+    );
+  });
+
+  it('can preload next/previous events', async () => {
+    const event = EventFixture({
+      nextEventID: 'next-event-id',
+      previousEventID: 'prev-event-id',
+    });
+    const mockNextEvent = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/group-id/events/next-event-id/`,
+      body: EventFixture(),
+    });
+    const mockPreviousEvent = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/group-id/events/prev-event-id/`,
+      body: EventFixture(),
+    });
+    render(<IssueDetailsEventNavigation {...defaultProps} event={event} />);
+
+    expect(mockNextEvent).not.toHaveBeenCalled();
+    expect(mockPreviousEvent).not.toHaveBeenCalled();
+
+    await userEvent.hover(await screen.findByRole('button', {name: 'Next Event'}));
+
+    await waitFor(() => expect(mockNextEvent).toHaveBeenCalled());
+    expect(mockPreviousEvent).not.toHaveBeenCalled();
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Previous Event'}));
+    await waitFor(() => expect(mockPreviousEvent).toHaveBeenCalled());
+  });
+});

--- a/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
@@ -1,0 +1,195 @@
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import {TabList, Tabs} from 'sentry/components/tabs';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import useMedia from 'sentry/utils/useMedia';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
+import {useDefaultIssueEvent} from 'sentry/views/issueDetails/utils';
+
+const enum EventNavOptions {
+  RECOMMENDED = 'recommended',
+  LATEST = 'latest',
+  OLDEST = 'oldest',
+  CUSTOM = 'custom',
+}
+
+const EventNavOrder = [
+  EventNavOptions.OLDEST,
+  EventNavOptions.LATEST,
+  EventNavOptions.RECOMMENDED,
+  EventNavOptions.CUSTOM,
+];
+
+interface IssueDetailsEventNavigationProps {
+  event: Event | undefined;
+  group: Group;
+}
+
+export function IssueDetailsEventNavigation({
+  event,
+  group,
+}: IssueDetailsEventNavigationProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const params = useParams<{eventId?: string}>();
+  const theme = useTheme();
+  const defaultIssueEvent = useDefaultIssueEvent();
+  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
+  const [shouldPreload, setShouldPreload] = useState({next: false, previous: false});
+
+  // Reset shouldPreload when the groupId changes
+  useEffect(() => {
+    setShouldPreload({next: false, previous: false});
+  }, [group.id]);
+
+  // Prefetch next
+  useGroupEvent({
+    groupId: group.id,
+    eventId: event?.nextEventID ?? undefined,
+    options: {enabled: shouldPreload.next},
+  });
+  // Prefetch previous
+  useGroupEvent({
+    groupId: group.id,
+    eventId: event?.previousEventID ?? undefined,
+    options: {enabled: shouldPreload.previous},
+  });
+
+  const handleHoverPagination = useCallback(
+    (direction: 'next' | 'previous', isEnabled: boolean) => () => {
+      if (isEnabled) {
+        setShouldPreload(prev => ({...prev, [direction]: true}));
+      }
+    },
+    []
+  );
+
+  const selectedOption = useMemo(() => {
+    switch (params.eventId) {
+      case EventNavOptions.RECOMMENDED:
+      case EventNavOptions.LATEST:
+      case EventNavOptions.OLDEST:
+        return params.eventId;
+      case undefined:
+        return defaultIssueEvent;
+      default:
+        return EventNavOptions.CUSTOM;
+    }
+  }, [params.eventId, defaultIssueEvent]);
+
+  const EventNavLabels = {
+    [EventNavOptions.RECOMMENDED]: isSmallScreen ? t('Rec.') : t('Recommended'),
+    [EventNavOptions.OLDEST]: t('First'),
+    [EventNavOptions.LATEST]: t('Last'),
+    [EventNavOptions.CUSTOM]: t('Specific'),
+  };
+
+  const onTabChange = (tabKey: typeof selectedOption) => {
+    trackAnalytics('issue_details.event_navigation_selected', {
+      organization,
+      content: EventNavLabels[tabKey],
+    });
+  };
+
+  const baseEventsPath = `/organizations/${organization.slug}/issues/${group.id}/events/`;
+
+  const grayText = css`
+    color: ${theme.subText};
+    font-weight: ${theme.fontWeightNormal};
+  `;
+
+  return (
+    <Fragment>
+      <Navigation>
+        <Tooltip title={t('Previous Event')} skipWrapper>
+          <LinkButton
+            aria-label={t('Previous Event')}
+            borderless
+            size="xs"
+            icon={<IconChevron direction="left" />}
+            disabled={!defined(event?.previousEventID)}
+            analyticsEventKey="issue_details.previous_event_clicked"
+            analyticsEventName="Issue Details: Previous Event Clicked"
+            to={{
+              pathname: `${baseEventsPath}${event?.previousEventID}/`,
+              query: {...location.query, referrer: 'previous-event'},
+            }}
+            css={grayText}
+            onMouseEnter={handleHoverPagination(
+              'previous',
+              defined(event?.previousEventID)
+            )}
+            onClick={() => {
+              // Assume they will continue to paginate
+              setShouldPreload({next: true, previous: true});
+            }}
+          />
+        </Tooltip>
+        <Tooltip title={t('Next Event')} skipWrapper>
+          <LinkButton
+            aria-label={t('Next Event')}
+            borderless
+            size="xs"
+            icon={<IconChevron direction="right" />}
+            disabled={!defined(event?.nextEventID)}
+            analyticsEventKey="issue_details.next_event_clicked"
+            analyticsEventName="Issue Details: Next Event Clicked"
+            to={{
+              pathname: `${baseEventsPath}${event?.nextEventID}/`,
+              query: {...location.query, referrer: 'next-event'},
+            }}
+            css={grayText}
+            onMouseEnter={handleHoverPagination('next', defined(event?.nextEventID))}
+            onClick={() => {
+              // Assume they will continue to paginate
+              setShouldPreload({next: true, previous: true});
+            }}
+          />
+        </Tooltip>
+      </Navigation>
+      <Tabs value={selectedOption} disableOverflow onChange={onTabChange}>
+        <TabList hideBorder variant="floating">
+          {EventNavOrder.map(label => {
+            const eventPath =
+              label === selectedOption
+                ? undefined
+                : {
+                    pathname: normalizeUrl(baseEventsPath + label + '/'),
+                    query: {...location.query, referrer: `${label}-event`},
+                  };
+            return (
+              <TabList.Item
+                to={eventPath}
+                key={label}
+                hidden={label === EventNavOptions.CUSTOM}
+                textValue={EventNavLabels[label]}
+              >
+                {EventNavLabels[label]}
+              </TabList.Item>
+            );
+          })}
+        </TabList>
+      </Tabs>
+    </Fragment>
+  );
+}
+
+const Navigation = styled('div')`
+  display: flex;
+  padding-right: ${space(0.25)};
+  border-right: 1px solid ${p => p.theme.gray100};
+`;

--- a/static/app/views/issueDetails/useGroupEvent.tsx
+++ b/static/app/views/issueDetails/useGroupEvent.tsx
@@ -8,25 +8,27 @@ import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
 import {
   getGroupEventQueryKey,
   useDefaultIssueEvent,
+  useEnvironmentsFromUrl,
   useHasStreamlinedUI,
 } from 'sentry/views/issueDetails/utils';
 
 export const RESERVED_EVENT_IDS = new Set(['recommended', 'latest', 'oldest']);
 interface UseGroupEventOptions {
-  environments: string[];
   eventId: string | undefined;
   groupId: string;
+  options?: {enabled?: boolean};
 }
 
 export function useGroupEvent({
   groupId,
   eventId: eventIdProp,
-  environments,
+  options,
 }: UseGroupEventOptions) {
   const organization = useOrganization();
   const location = useLocation<{query?: string}>();
   const defaultIssueEvent = useDefaultIssueEvent();
   const hasStreamlinedUI = useHasStreamlinedUI();
+  const environments = useEnvironmentsFromUrl();
   const eventQuery = useEventQuery({groupId});
   const eventId = eventIdProp ?? defaultIssueEvent;
 
@@ -58,6 +60,7 @@ export function useGroupEvent({
 
   return useApiQuery<Event>(queryKey, {
     staleTime: hasStreamlinedUI ? streamlineStaleTime : staleTime,
+    enabled: options?.enabled && !!eventId,
     retry: false,
   });
 }


### PR DESCRIPTION
Fixes an issue where preloading the next event didn't have the correct query parameters, meaning preloading wasn't working. Splits out the hooks and components for all that preloading stuff into its own component.

this new component will handle these buttons
![image](https://github.com/user-attachments/assets/b1932979-5527-47d5-abaf-f992685ea03d)
