### PR TITLE
feat(explore): Separate confidence per chart

### DIFF
--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -80,7 +80,7 @@ function ExploreContentImpl({}: ExploreContentProps) {
     });
   }, [location, navigate]);
 
-  const [confidence, setConfidence] = useState<Confidence>(null);
+  const [confidences, setConfidences] = useState<Confidence[]>([]);
   const [chartError, setChartError] = useState<string>('');
   const [tableError, setTableError] = useState<string>('');
 
@@ -174,10 +174,10 @@ function ExploreContentImpl({}: ExploreContentProps) {
               )}
               <ExploreCharts
                 query={query}
-                setConfidence={setConfidence}
+                setConfidences={setConfidences}
                 setError={setChartError}
               />
-              <ExploreTables confidence={confidence} setError={setTableError} />
+              <ExploreTables confidences={confidences} setError={setTableError} />
             </MainSection>
           </Body>
         </Layout.Page>

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -19,11 +19,11 @@ export function useAnalytics({
   organization,
   columns,
   userQuery,
-  confidence,
+  confidences,
   title,
 }: {
   columns: string[];
-  confidence: Confidence;
+  confidences: Confidence[];
   dataset: DiscoverDatasets;
   organization: Organization;
   resultLength: number | undefined;
@@ -49,7 +49,7 @@ export function useAnalytics({
       organization,
       columns,
       columns_count: columns.filter(Boolean).length,
-      confidence,
+      confidences,
       dataset,
       query_status: resultStatus,
       result_length: resultLength || 0,
@@ -75,7 +75,7 @@ export function useAnalytics({
     visualizes,
     columns,
     userQuery,
-    confidence,
+    confidences,
     dataset,
     title,
   ]);

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -50,11 +50,11 @@ import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery'
 import {FieldRenderer} from './fieldRenderer';
 
 interface AggregatesTableProps {
-  confidence: Confidence;
+  confidences: Confidence[];
   setError: Dispatch<SetStateAction<string>>;
 }
 
-export function AggregatesTable({confidence, setError}: AggregatesTableProps) {
+export function AggregatesTable({confidences, setError}: AggregatesTableProps) {
   const {selection} = usePageFilters();
   const topEvents = useTopEvents();
   const organization = useOrganization();
@@ -133,7 +133,7 @@ export function AggregatesTable({confidence, setError}: AggregatesTableProps) {
     organization,
     columns: groupBys,
     userQuery: query,
-    confidence,
+    confidences,
     title,
   });
 

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -23,7 +23,7 @@ import {SpansTable} from 'sentry/views/explore/tables/spansTable';
 import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
 interface ExploreTablesProps {
-  confidence: Confidence;
+  confidences: Confidence[];
   setError: Dispatch<SetStateAction<string>>;
 }
 

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -42,11 +42,11 @@ import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery'
 import {FieldRenderer} from './fieldRenderer';
 
 interface SpansTableProps {
-  confidence: Confidence;
+  confidences: Confidence[];
   setError: Dispatch<SetStateAction<string>>;
 }
 
-export function SpansTable({confidence, setError}: SpansTableProps) {
+export function SpansTable({confidences, setError}: SpansTableProps) {
   const {selection} = usePageFilters();
 
   const dataset = useExploreDataset();
@@ -115,7 +115,7 @@ export function SpansTable({confidence, setError}: SpansTableProps) {
     organization,
     columns: fields,
     userQuery: query,
-    confidence,
+    confidences,
     title,
   });
 

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -53,11 +53,11 @@ import {
 } from 'sentry/views/explore/tables/tracesTable/styles';
 
 interface TracesTableProps {
-  confidence: Confidence;
+  confidences: Confidence[];
   setError: Dispatch<SetStateAction<string>>;
 }
 
-export function TracesTable({confidence, setError}: TracesTableProps) {
+export function TracesTable({confidences, setError}: TracesTableProps) {
   const title = useExploreTitle();
   const dataset = useExploreDataset();
   const query = useExploreQuery();
@@ -96,7 +96,7 @@ export function TracesTable({confidence, setError}: TracesTableProps) {
       'timestamp',
     ],
     userQuery: query,
-    confidence,
+    confidences,
     title,
   });
 


### PR DESCRIPTION
This gives each chart a confidence based on the series present in it instead of a single confidence for all time series that is repeated in every footer.