### PR TITLE
chore(alerts): Remove activated alerts subscription to projects

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -24,7 +24,6 @@ from sentry.incidents.logic import (
 from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleDetectionType,
-    AlertRuleMonitorTypeInt,
     AlertRuleStatus,
     AlertRuleThresholdType,
     AlertRuleTrigger,

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -30,7 +30,6 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTrigger,
     AlertRuleTriggerActionMethod,
 )
-from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
 from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
@@ -640,19 +639,6 @@ class SubscriptionProcessor:
             # Only create a new incident if we don't already have an active incident for the AlertRule
             if not self.active_incident:
                 detected_at = self.calculate_event_date_from_update_date(self.last_update)
-                activation: AlertRuleActivations | None = None
-                if self.alert_rule.monitor_type == AlertRuleMonitorTypeInt.ACTIVATED:
-                    activations = list(self.subscription.alertruleactivations_set.all())
-                    if len(activations) != 1:
-                        logger.error(
-                            "activated alert rule subscription has unexpected activation instances",
-                            extra={
-                                "activations_count": len(activations),
-                            },
-                        )
-                    else:
-                        activation = activations[0]
-
                 self.active_incident = create_incident(
                     organization=self.alert_rule.organization,
                     incident_type=IncidentType.ALERT_TRIGGERED,
@@ -662,7 +648,6 @@ class SubscriptionProcessor:
                     date_started=detected_at,
                     date_detected=self.last_update,
                     projects=[self.subscription.project],
-                    activation=activation,
                     subscription=self.subscription,
                 )
             # Now create (or update if it already exists) the incident trigger so that

--- a/tests/sentry/backup/snapshots/SanitizationExhaustiveTests/test_clean_pks.pysnap
+++ b/tests/sentry/backup/snapshots/SanitizationExhaustiveTests/test_clean_pks.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-07T00:26:32.322405+00:00'
+created: '2025-01-07T23:12:05.475202+00:00'
 creator: sentry
 source: tests/sentry/backup/test_sanitize.py
 ---
@@ -587,6 +587,11 @@ source: tests/sentry/backup/test_sanitize.py
   - date_updated
 - model_name: sentry.querysubscription
   ordinal: 3
+  sanitized_fields:
+  - date_added
+  - date_updated
+- model_name: sentry.querysubscription
+  ordinal: 4
   sanitized_fields:
   - date_added
   - date_updated

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from django.core.cache import cache
@@ -140,74 +140,6 @@ class IncidentAlertRuleRelationTest(TestCase):
         all_alert_rules = list(AlertRule.objects.all())
         assert self.alert_rule not in all_alert_rules
         assert self.incident.alert_rule.id == self.alert_rule.id
-
-
-class AlertRuleTest(TestCase):
-    @patch("sentry.incidents.models.alert_rule.bulk_create_snuba_subscriptions")
-    def test_subscribes_projects_to_alert_rule(self, mock_bulk_create_snuba_subscriptions):
-        # eg. creates QuerySubscription's/SnubaQuery's for AlertRule + Project
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
-        assert mock_bulk_create_snuba_subscriptions.call_count == 0
-
-        alert_rule.subscribe_projects(
-            projects=[self.project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activator="testing",
-            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-        )
-        assert mock_bulk_create_snuba_subscriptions.call_count == 1
-
-    def test_conditionally_subscribe_project_to_alert_rules(self):
-        query_extra = "foo:bar"
-        project = self.create_project(name="foo")
-        self.create_alert_rule(
-            projects=[project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-        )
-        with self.tasks():
-            created_subscriptions = (
-                AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
-                    project=project,
-                    activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-                    query_extra=query_extra,
-                    origin="test",
-                    activator="testing",
-                )
-            )
-            assert len(created_subscriptions) == 1
-
-            sub = created_subscriptions[0]
-            fetched_sub = QuerySubscription.objects.get(id=sub.id)
-            assert fetched_sub.subscription_id is not None
-
-    def test_conditionally_subscribing_project_initializes_activation(self):
-        query_extra = "foo:bar"
-        project = self.create_project(name="foo")
-        alert_rule = self.create_alert_rule(
-            projects=[project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-        )
-
-        with self.tasks():
-            created_subscriptions = (
-                AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
-                    project=project,
-                    activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-                    query_extra=query_extra,
-                    origin="test",
-                    activator="testing",
-                )
-            )
-            assert len(created_subscriptions) == 1
-
-            sub = created_subscriptions[0]
-            activations = alert_rule.activations.all()
-            assert len(activations) == 1
-            current_activation = activations[0]
-            assert current_activation.query_subscription == sub
-            assert current_activation.is_complete() is False
 
 
 class AlertRuleFetchForOrganizationTest(TestCase):

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -10,14 +10,11 @@ from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleActivity,
     AlertRuleActivityType,
-    AlertRuleMonitorTypeInt,
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import IncidentStatus
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
-from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.alert_rule import TemporaryAlertRuleTriggerActionRegistry
 from sentry.users.services.user.service import user_service

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -974,33 +974,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         create_metric_issue_mock.assert_not_called()
 
-    def test_activated_alert(self):
-        # Verify that an alert rule that only expects a single update to be over the
-        # alert threshold triggers correctly
-        rule = self.activated_rule
-        trigger = self.activated_trigger
-        subscription = self.activated_sub
-        processor = self.send_update(
-            rule=rule, value=trigger.alert_threshold + 1, subscription=subscription
-        )
-        self.assert_trigger_counts(processor, self.activated_trigger, 0, 0)
-        incident = self.assert_active_incident(rule=rule, subscription=subscription)
-        assert incident.date_started == (
-            timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
-        )
-        self.assert_trigger_exists_with_status(
-            incident, self.activated_trigger, TriggerStatus.ACTIVE
-        )
-        latest_activity = self.latest_activity(incident)
-        uuid = str(latest_activity.notification_uuid)
-        self.assert_actions_fired_for_incident(
-            incident,
-            [self.activated_action],
-            [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
-        )
-        # assert that an incident was created _with_ an activation!
-        assert incident.activation
-
     def test_alert_dedupe(self):
         # Verify that an alert rule that only expects a single update to be over the
         # alert threshold triggers correctly

--- a/tests/sentry/models/test_releaseprojectenvironment.py
+++ b/tests/sentry/models/test_releaseprojectenvironment.py
@@ -1,11 +1,8 @@
 from datetime import timedelta
-from unittest.mock import call as mock_call
 from unittest.mock import patch
 
 from django.utils import timezone
 
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import (
@@ -13,7 +10,6 @@ from sentry.models.releaseprojectenvironment import (
     ReleaseProjectEnvironmentManager,
 )
 from sentry.signals import receivers_raise_on_send
-from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import TestCase
 
 
@@ -106,51 +102,3 @@ class GetOrCreateTest(TestCase):
         )
 
         assert mock_subscribe_project_to_alert_rule.call_count == 1
-
-    @patch(
-        "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
-    )
-    def test_subscribe_project_to_alert_rule_constructs_query(self, mock_conditionally_subscribe):
-        ReleaseProjectEnvironmentManager.subscribe_project_to_alert_rule(
-            project=self.project, release=self.release, environment=self.environment, trigger="test"
-        )
-
-        assert mock_conditionally_subscribe.call_count == 1
-        assert mock_conditionally_subscribe.mock_calls == [
-            mock_call(
-                project=self.project,
-                activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-                query_extra=f"release:{self.release.version} and environment:{self.environment.name}",
-                origin="test",
-                activator=f"release:{self.release.version} and environment:{self.environment.name}",
-            )
-        ]
-
-    def test_unmocked_subscribe_project_to_alert_rule_constructs_query(self):
-        # Let the logic flow through to snuba and see whether we properly construct the snuba query
-        # project = self.create_project(name="foo")
-        # release = Release.objects.create(organization_id=project.organization_id, version="42")
-        self.create_alert_rule(
-            projects=[self.project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-        )
-
-        subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
-        with patch(
-            "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
-            wraps=subscribe_project,
-        ) as wrapped_subscribe_project:
-            with self.tasks():
-                rpe = ReleaseProjectEnvironmentManager.subscribe_project_to_alert_rule(
-                    project=self.project,
-                    release=self.release,
-                    environment=self.environment,
-                    trigger="test",
-                )
-
-                assert rpe
-                assert wrapped_subscribe_project.call_count == 1
-
-                sub = QuerySubscription.objects.get(project=self.project)
-                assert sub.subscription_id is not None


### PR DESCRIPTION
Remove the code for activated alerts to subscribe to projects and put back what we were using before. I can't remove `conditionally_subscribe_project_to_alert_rules` and `subscribe_projects` just yet because some tests rely on them, but in another one I will remove those as well and all the references.