### PR TITLE
chore(issue-details): Only make one request to readable tags

### DIFF
--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -97,6 +97,7 @@ export default function TagFacets({
   const {isPending, isError, data, refetch} = useGroupTagsReadable({
     groupId,
     environment: environments,
+    limit: 4,
   });
 
   const tagsData = useMemo((): Record<string, GroupTag> => {

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -97,7 +97,6 @@ export default function TagFacets({
   const {isPending, isError, data, refetch} = useGroupTagsReadable({
     groupId,
     environment: environments,
-    limit: 4,
   });
 
   const tagsData = useMemo((): Record<string, GroupTag> => {

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -5,6 +5,7 @@ import {
   type UseApiQueryOptions,
 } from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 export interface GroupTag {
   key: string;
@@ -79,13 +80,14 @@ export function useGroupTags(
  * Primarily used for tag facets
  */
 export function useGroupTagsReadable(
-  parameters: Omit<FetchIssueTagsParameters, 'orgSlug' | 'readable'>,
+  parameters: Omit<FetchIssueTagsParameters, 'orgSlug' | 'limit' | 'readable'>,
   options: GroupTagUseQueryOptions = {}
 ) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
   return useGroupTags(
     {
       readable: true,
-      limit: 3,
+      limit: hasStreamlinedUI ? 3 : 4,
       ...parameters,
     },
     options

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -85,7 +85,7 @@ export function useGroupTagsReadable(
   return useGroupTags(
     {
       readable: true,
-      limit: 4,
+      limit: 3,
       ...parameters,
     },
     options

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -20,7 +20,6 @@ export default function IssueTagsPreview({
   } = useGroupTagsReadable({
     groupId,
     environment: environments,
-    limit: 3,
   });
   const tagsToPreview = useMemo(() => {
     const priorityTags = ['browser.name', 'os.name', 'runtime.name', 'environment'];


### PR DESCRIPTION
this pr updates the calls to `useGroupTagsReadable` so that we only make one call, instead of 2 