### PR TITLE
style(flags): confirm message should be green

### DIFF
--- a/static/app/views/settings/featureFlags/newSecretHandler.tsx
+++ b/static/app/views/settings/featureFlags/newSecretHandler.tsx
@@ -25,7 +25,7 @@ function NewSecretHandler({
 
   return (
     <div>
-      <StyledAlert type="warning" showIcon system>
+      <StyledAlert type="success" showIcon system>
         {t('The secret has been posted.')}
       </StyledAlert>
 


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/2d3166c0-c1c6-4655-8aa0-be8c52fd33db)


after:
<img width="961" alt="SCR-20250107-ndmn" src="https://github.com/user-attachments/assets/1727e083-eb8f-4ed0-b471-39bae453a2a2" />
