### PR TITLE
fix(issue-details): Use correct environments value for tag drawer

### DIFF
--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -33,10 +33,12 @@ import {TagDistribution} from 'sentry/views/issueDetails/groupTags/tagDistributi
 import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 export function GroupTagsDrawer({group}: {group: Group}) {
   const location = useLocation();
   const organization = useOrganization();
+  const environments = useEnvironmentsFromUrl();
   const {tagKey} = useParams<{tagKey: string}>();
   const drawerRef = useRef<HTMLDivElement>(null);
   const {projects} = useProjects();
@@ -62,7 +64,7 @@ export function GroupTagsDrawer({group}: {group: Group}) {
     refetch,
   } = useGroupTags({
     groupId: group.id,
-    environment: location.query.environment as string[] | string | undefined,
+    environment: environments,
   });
 
   const tagValues = useMemo(


### PR DESCRIPTION
this pr fixes an issue with the environment value in the tag drawer. we already made a call for tags in the search bar, but because the tag drawer had a slightly different way of deriving the value of `environment`, we couldn't take advantage of the caching. now, the tag drawer should instantly load on the issue details page. 