### PR TITLE
chore(issue-details): Fix mismatch in tag distributions with same value

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -15,7 +15,9 @@ export function TagPreviewDistribution({tag}: {tag: GroupTag}) {
   const totalVisible = tag.topValues.reduce((sum, value) => sum + value.count, 0);
   const hasOther = totalVisible < tag.totalValues;
 
-  const otherPercentage = percent(tag.totalValues - totalVisible, tag.totalValues);
+  const otherPercentage = Math.round(
+    percent(tag.totalValues - totalVisible, tag.totalValues)
+  );
   const otherDisplayPercentage =
     otherPercentage < 1 ? '<1%' : `${otherPercentage.toFixed(0)}%`;
 
@@ -26,7 +28,7 @@ export function TagPreviewDistribution({tag}: {tag: GroupTag}) {
       </TagHeader>
       <TagValueContent>
         {tag.topValues.map((tagValue, tagValueIdx) => {
-          const percentage = percent(tagValue.count, tag.totalValues);
+          const percentage = Math.round(percent(tagValue.count, tag.totalValues));
           const displayPercentage = percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
           return (
             <TagValueRow key={tagValueIdx}>


### PR DESCRIPTION
this pr fixes a minor issue where two tags could show the same value but their tag distributions looked different because we weren't rounding the numbers 


before: 
![Screenshot 2025-01-07 at 4 09 46 PM](https://github.com/user-attachments/assets/e6c6cc57-80c3-47c1-bb19-eec184841cea)
