### PR TITLE
fix(api): Validate `per_page` lower bound

### DIFF
--- a/src/sentry/utils/pagination_factory.py
+++ b/src/sentry/utils/pagination_factory.py
@@ -37,8 +37,8 @@ def clamp_pagination_per_page(
         raise ValueError("Invalid per_page parameter.")
 
     max_per_page = max(max_per_page, default_per_page)
-    if per_page > max_per_page:
-        raise ValueError(f"Invalid per_page value. Cannot exceed {max_per_page}.")
+    if per_page < 1 or per_page > max_per_page:
+        raise ValueError(f"Invalid per_page value. Must be between 1 and {max_per_page}.")
 
     return per_page
 

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -313,7 +313,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
         assert response.status_code == 400, response.data
         assert response.data == {
             "detail": ErrorDetail(
-                string="Invalid per_page value. Cannot exceed 100.", code="parse_error"
+                string="Invalid per_page value. Must be between 1 and 100.", code="parse_error"
             ),
         }
 

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -478,17 +478,22 @@ class PaginateTest(APITestCase):
             == '<http://testserver/?&cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", <http://testserver/?&cursor=0:100:0>; rel="next"; results="false"; cursor="0:100:0"'
         )
 
-    def test_invalid_per_page(self):
-        self.request.GET = {"per_page": "nope"}
-        response = self.view(self.request)
-        assert response.status_code == 400
-
     def test_invalid_cursor(self):
         self.request.GET = {"cursor": "no:no:no"}
         response = self.view(self.request)
         assert response.status_code == 400
 
-    def test_per_page_out_of_bounds(self):
+    def test_non_int_per_page(self):
+        self.request.GET = {"per_page": "nope"}
+        response = self.view(self.request)
+        assert response.status_code == 400
+
+    def test_per_page_too_low(self):
+        self.request.GET = {"per_page": "0"}
+        response = self.view(self.request)
+        assert response.status_code == 400
+
+    def test_per_page_too_high(self):
         self.request.GET = {"per_page": "101"}
         response = self.view(self.request)
         assert response.status_code == 400


### PR DESCRIPTION
In our base endpoint class, we check the incoming `per_page` parameter against [an upper bound](https://github.com/getsentry/sentry/blob/b3f39c22a8e4091225cff850100e1dabdf075ff2/src/sentry/utils/pagination_factory.py#L40-L41), but we don't currently check it against a lower bound... until we go to [actually use it](https://github.com/getsentry/sentry/blob/eb0a3908f93cf8363ff99458de24a7cd26d0975f/src/sentry/api/paginator.py#L515), at which point we error out with a generic 500 response (rather than the more helpful and explanatory 400 generated by `per_page` values which are too high).

This fixes that by checking the lower bound alongside the upper bound.

Note: The changes in `test_base.py` look bigger than they are. Really the only new thing is the `test_per_page_too_low` test. The rest is just a) giving the `per_page` tests more specific names, and b) moving the invalid cursor test so all of the `per_page` tests are together.