### PR TITLE
fix(insights): Opportunity score forward browser name filter

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -6,7 +6,7 @@ from django.utils.functional import cached_property
 from snuba_sdk import Column, Condition, Function, Op, OrderBy
 
 from sentry import features
-from sentry.api.event_search import SearchFilter
+from sentry.api.event_search import ParenExpression, SearchFilter, parse_search_query
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.search.events import constants, fields
 from sentry.search.events.builder import metrics
@@ -1796,11 +1796,28 @@ class MetricsDatasetConfig(DatasetConfig):
         if column in self.total_score_weights and self.total_score_weights[column] is not None:
             return Function("toFloat64", [self.total_score_weights[column]], alias)
 
+        # Pull out browser.name filters from the query
+        parsed_terms = parse_search_query(self.builder.query)
+        query = " ".join(
+            term.to_query_string()
+            for term in parsed_terms
+            if (isinstance(term, SearchFilter) and term.key.name == "browser.name")
+            or (
+                isinstance(term, ParenExpression)
+                and all(  # type: ignore[unreachable]
+                    (isinstance(child_term, SearchFilter) and child_term.key.name == "browser.name")
+                    or child_term == "OR"
+                    for child_term in term.children
+                )
+            )
+        )
+
         total_query = metrics.MetricsQueryBuilder(
             dataset=self.builder.dataset,
             params={},
             snuba_params=self.builder.params,
             selected_columns=[f"sum({column})"],
+            query=query,
         )
 
         total_query.columns += self.builder.resolve_groupby()

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3025,61 +3025,73 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         self.store_transaction_metric(
             0.5,
             metric="measurements.score.inp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             1.0,
             metric="measurements.score.weight.inp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.2,
             metric="measurements.score.inp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             1.0,
             metric="measurements.score.weight.inp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.2,
             metric="measurements.score.inp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.5,
             metric="measurements.score.weight.inp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.1,
             metric="measurements.score.lcp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Firefox"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.3,
             metric="measurements.score.weight.lcp",
-            tags={"transaction": "foo_transaction"},
+            tags={"transaction": "foo_transaction", "browser.name": "Firefox"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.2,
             metric="measurements.score.inp",
-            tags={"transaction": "bar_transaction"},
+            tags={"transaction": "bar_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.5,
             metric="measurements.score.weight.inp",
-            tags={"transaction": "bar_transaction"},
+            tags={"transaction": "bar_transaction", "browser.name": "Safari"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.5,
+            metric="measurements.score.total",
+            tags={"transaction": "foo_transaction", "browser.name": "Safari"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            0.5,
+            metric="measurements.score.total",
+            tags={"transaction": "bar_transaction", "browser.name": "Safari"},
             timestamp=self.min_ago,
         )
 
@@ -3090,7 +3102,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                         "transaction",
                         "total_opportunity_score()",
                     ],
-                    "query": "event.type:transaction",
+                    "query": 'event.type:transaction transaction.op:[pageload,""] (browser.name:Safari OR browser.name:Firefox) avg(measurements.score.total):>0',
                     "orderby": "transaction",
                     "dataset": "metrics",
                     "per_page": 50,


### PR DESCRIPTION
- Updates opportunity score function to forward `browser.name` query filter to secondary helper query

revised https://github.com/getsentry/sentry/pull/82967
The previous pr was forwarding all query filters including those of type `AggregateFilter`, which causes the query to have a "having" clause which is unsupported. Updates to only forward `browser.name` to support the browser filter in the webvitals module ui.

