### PR TITLE
chore(snetry apps): Make SentryAppSentryErrors for Sentry side errors

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -130,7 +130,6 @@ class IntegrationPlatformEndpoint(Endpoint):
         ) or super().handle_exception_with_details(request, exc, handler_context, scope)
 
     def _handle_sentry_app_exception(self, exception: Exception):
-        # If the error_type attr exists we know the error is one of SentryAppError or SentryAppIntegratorError
         if isinstance(exception, SentryAppIntegratorError) or isinstance(exception, SentryAppError):
             response = Response({"detail": str(exception)}, status=exception.status_code)
             response.exception = True
@@ -140,7 +139,7 @@ class IntegrationPlatformEndpoint(Endpoint):
             error_id = sentry_sdk.capture_exception(exception)
             return Response(
                 {
-                    "error": f"An issue occured during the Sentry App process. Sentry error ID: {error_id}"
+                    "detail": f"An issue occured during the integration platform process. Sentry error ID: {error_id}"
                 },
                 status=500,
             )

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import capture_exception
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -45,22 +44,14 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
 
         serializer = PlatformExternalIssueSerializer(data=request.data)
         if serializer.is_valid():
-            try:
-                external_issue = ExternalIssueCreator(
-                    install=installation,
-                    group=group,
-                    web_url=data["webUrl"],
-                    project=data["project"],
-                    identifier=data["identifier"],
-                ).run()
-            except Exception as e:
-                error_id = capture_exception(e)
-                return Response(
-                    {
-                        "error": f"An issue occured while trying to create external issue. Sentry error ID: {error_id}"
-                    },
-                    status=500,
-                )
+            external_issue = ExternalIssueCreator(
+                install=installation,
+                group=group,
+                web_url=data["webUrl"],
+                project=data["project"],
+                identifier=data["identifier"],
+            ).run()
+
             return Response(
                 serialize(
                     objects=external_issue, serializer=ResponsePlatformExternalIssueSerializer()

--- a/src/sentry/sentry_apps/external_issues/external_issue_creator.py
+++ b/src/sentry/sentry_apps/external_issues/external_issue_creator.py
@@ -7,6 +7,7 @@ from django.db import router, transaction
 from sentry.models.group import Group
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
+from sentry.sentry_apps.utils.errors import SentryAppSentryError
 
 logger = logging.getLogger("sentry.sentry_apps.external_issues")
 
@@ -45,4 +46,4 @@ class ExternalIssueCreator:
                     "sentry_app_slug": self.install.sentry_app.slug,
                 },
             )
-            raise
+            raise SentryAppSentryError(e) from e

--- a/src/sentry/sentry_apps/external_issues/issue_link_creator.py
+++ b/src/sentry/sentry_apps/external_issues/issue_link_creator.py
@@ -9,6 +9,7 @@ from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIs
 from sentry.sentry_apps.external_requests.issue_link_requester import IssueLinkRequester
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation
+from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.users.services.user import RpcUser
 
 VALID_ACTIONS = ["link", "create"]
@@ -32,7 +33,7 @@ class IssueLinkCreator:
 
     def _verify_action(self) -> None:
         if self.action not in VALID_ACTIONS:
-            raise APIUnauthorized(f"Invalid action '{self.action}'")
+            raise SentryAppSentryError(APIUnauthorized(f"Invalid action '{self.action}'"))
 
     def _make_external_request(self) -> dict[str, Any]:
         response = IssueLinkRequester(

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -33,3 +33,17 @@ class SentryAppIntegratorError(Exception):
     ) -> None:
         if status_code:
             self.status_code = status_code
+
+
+# Represents an error that's our (sentry's) fault
+class SentryAppSentryError(Exception):
+    error_type = SentryAppErrorType.SENTRY
+    status_code = 500
+
+    def __init__(
+        self,
+        error: Exception | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        if status_code:
+            self.status_code = status_code

--- a/tests/sentry/sentry_apps/external_issues/test_issue_link_creator.py
+++ b/tests/sentry/sentry_apps/external_issues/test_issue_link_creator.py
@@ -1,10 +1,10 @@
 import pytest
 import responses
 
-from sentry.coreapi import APIUnauthorized
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.testutils.cases import TestCase
 from sentry.users.services.user.serial import serialize_rpc_user
 
@@ -60,7 +60,7 @@ class TestIssueLinkCreator(TestCase):
         assert external_issue.display_name == "Projectname#issue-1"
 
     def test_invalid_action(self):
-        with pytest.raises(APIUnauthorized):
+        with pytest.raises(SentryAppSentryError):
             IssueLinkCreator(
                 install=self.install,
                 group=self.group,


### PR DESCRIPTION
tl:dr This PR adds a new error type for Sentry side errors that shouldnt be sent to the integrator but still should be handled gracefully. So we can distinguish between truly Unhandled exceptions, and exceptions we have audited and thought about.

Context: Currently with only `SentryAppErrors` (client side errors) & `SentryAppIntegratorErrors` (integrator side errors) if we have a non wrapped error (i.e our fault error) then it will go through the default django rest_framework exception handler. This is okay for certain errors like authentication (i.e children of `APIException`) which rest_framework handles gracefully. However, if the exception does not inherit from `APIException`, they will be considered 'Unhandled' in Sentry. 