### PR TITLE
feat(workflow_engine): Add the ErrorDetectorValidator to the Error Issue Group

### DIFF
--- a/src/sentry/incidents/endpoints/validators.py
+++ b/src/sentry/incidents/endpoints/validators.py
@@ -14,12 +14,12 @@ from sentry.snuba.models import (
 )
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.workflow_engine.endpoints.validators.base import (
-    BaseDataSourceValidator,
     BaseGroupTypeDetectorValidator,
     NumericComparisonConditionValidator,
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_enigne.endpoints.validators.base_data_source import BaseDataSourceValidator
 
 
 class SnubaQueryDataSourceValidator(BaseDataSourceValidator[QuerySubscription]):

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -18,6 +18,7 @@ from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
+from sentry.workflow_engine.endpoints.validators.error_detector import ErrorDetectorValidator
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -261,7 +262,7 @@ class ErrorGroupType(GroupType):
     category = GroupCategory.ERROR.value
     default_priority = PriorityLevel.MEDIUM
     released = True
-    # TODO(cathy): add detector validator
+    detector_validator = ErrorDetectorValidator
     detector_config_schema = {"type": "object", "additionalProperties": False}  # empty schema
 
 

--- a/src/sentry/workflow_engine/endpoints/validators/base_data_source.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base_data_source.py
@@ -1,0 +1,35 @@
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.db.models import Model
+from sentry.workflow_engine.registry import data_source_type_registry
+from sentry.workflow_engine.types import DataSourceTypeHandler
+
+T = TypeVar("T", bound=Model)
+
+
+class DataSourceCreator(Generic[T]):
+    def __init__(self, create_fn: Callable[[], T]):
+        self._create_fn = create_fn
+        self._instance: T | None = None
+
+    def create(self) -> T:
+        if self._instance is None:
+            self._instance = self._create_fn()
+        return self._instance
+
+
+class BaseDataSourceValidator(CamelSnakeSerializer, Generic[T]):
+    @property
+    def data_source_type_handler(self) -> type[DataSourceTypeHandler]:
+        raise NotImplementedError
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        attrs["_creator"] = DataSourceCreator[T](lambda: self.create_source(attrs))
+        attrs["data_source_type"] = data_source_type_registry.get_key(self.data_source_type_handler)
+        return attrs
+
+    def create_source(self, validated_data) -> T:
+        raise NotImplementedError

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -24,10 +24,12 @@ from sentry.snuba.models import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import (
-    BaseDataSourceValidator,
     BaseGroupTypeDetectorValidator,
-    DataSourceCreator,
     NumericComparisonConditionValidator,
+)
+from sentry.workflow_engine.endpoints.validators.base_data_source import (
+    BaseDataSourceValidator,
+    DataSourceCreator,
 )
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource
 from sentry.workflow_engine.models.data_condition import Condition


### PR DESCRIPTION
## Description
https://github.com/getsentry/sentry/pull/82578 but re-imagined a little. Rather than pulling apart the `grouptype` file to fix the circular imports, this adds an `if TYPE_CHECKING` to stop the cycle and begins to break apart the validators instead. (We might want to pull out the condition validators, possibly the detector)