### PR TITLE
fix(org-stats): Require project membership

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -498,6 +498,35 @@ describe('OrganizationStats', function () {
     // Should show Profiles (transaction) option
     expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
   });
+
+  it('denies access on no projects', async function () {
+    act(() => ProjectsStore.loadInitialData([]));
+
+    render(<OrganizationStats {...defaultProps} />, {
+      router,
+    });
+
+    expect(
+      await screen.findByText('You need at least one project to use this view')
+    ).toBeInTheDocument();
+  });
+
+  it('denies access without project membership', async function () {
+    const newOrg = initializeOrg({
+      organization: {
+        openMembership: false,
+      },
+    });
+    act(() => ProjectsStore.loadInitialData([ProjectFixture({isMember: false})]));
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      router: newOrg.router,
+    });
+
+    expect(
+      await screen.findByText('You need at least one project to use this view')
+    ).toBeInTheDocument();
+  });
 });
 
 const mockStatsResponse = {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -11,6 +11,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -317,49 +318,53 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
     return (
       <SentryDocumentTitle title={t('Usage Stats')} orgSlug={organization.slug}>
-        <PageFiltersContainer>
-          {hasTeamInsights ? (
-            <HeaderTabs organization={organization} activeTab="stats" />
-          ) : (
-            <Layout.Header>
-              <Layout.HeaderContent>
-                <Layout.Title>{t('Organization Usage Stats')}</Layout.Title>
-                <HeadingSubtitle>
-                  {tct(
-                    'A view of the usage data that Sentry has received across your entire organization. [link: Read the docs].',
-                    {
-                      link: <ExternalLink href="https://docs.sentry.io/product/stats/" />,
-                    }
-                  )}
-                </HeadingSubtitle>
-              </Layout.HeaderContent>
-            </Layout.Header>
-          )}
-          <Body>
-            <Layout.Main fullWidth>
-              <HookHeader organization={organization} />
-              {this.renderProjectPageControl()}
-              <div>
-                <ErrorBoundary mini>{this.renderUsageStatsOrg()}</ErrorBoundary>
-              </div>
-              <ErrorBoundary mini>
-                <UsageStatsProjects
-                  organization={organization}
-                  dataCategory={this.dataCategoryInfo}
-                  dataCategoryName={this.dataCategoryInfo.titleName}
-                  isSingleProject={this.isSingleProject}
-                  projectIds={this.projectIds}
-                  dataDatetime={this.dataDatetime}
-                  tableSort={this.tableSort}
-                  tableQuery={this.tableQuery}
-                  tableCursor={this.tableCursor}
-                  handleChangeState={this.setStateOnUrl}
-                  getNextLocations={this.getNextLocations}
-                />
-              </ErrorBoundary>
-            </Layout.Main>
-          </Body>
-        </PageFiltersContainer>
+        <NoProjectMessage organization={organization}>
+          <PageFiltersContainer>
+            {hasTeamInsights ? (
+              <HeaderTabs organization={organization} activeTab="stats" />
+            ) : (
+              <Layout.Header>
+                <Layout.HeaderContent>
+                  <Layout.Title>{t('Organization Usage Stats')}</Layout.Title>
+                  <HeadingSubtitle>
+                    {tct(
+                      'A view of the usage data that Sentry has received across your entire organization. [link: Read the docs].',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/product/stats/" />
+                        ),
+                      }
+                    )}
+                  </HeadingSubtitle>
+                </Layout.HeaderContent>
+              </Layout.Header>
+            )}
+            <Body>
+              <Layout.Main fullWidth>
+                <HookHeader organization={organization} />
+                {this.renderProjectPageControl()}
+                <div>
+                  <ErrorBoundary mini>{this.renderUsageStatsOrg()}</ErrorBoundary>
+                </div>
+                <ErrorBoundary mini>
+                  <UsageStatsProjects
+                    organization={organization}
+                    dataCategory={this.dataCategoryInfo}
+                    dataCategoryName={this.dataCategoryInfo.titleName}
+                    isSingleProject={this.isSingleProject}
+                    projectIds={this.projectIds}
+                    dataDatetime={this.dataDatetime}
+                    tableSort={this.tableSort}
+                    tableQuery={this.tableQuery}
+                    tableCursor={this.tableCursor}
+                    handleChangeState={this.setStateOnUrl}
+                    getNextLocations={this.getNextLocations}
+                  />
+                </ErrorBoundary>
+              </Layout.Main>
+            </Body>
+          </PageFiltersContainer>
+        </NoProjectMessage>
       </SentryDocumentTitle>
     );
   }


### PR DESCRIPTION
### Problem

If the user is not member of any project (closes team membership) the organization stats page can end up in two different states.

1. Default state for new users. none / all projects are selected
<img width="1401" alt="Screenshot 2025-01-08 at 08 27 42" src="https://github.com/user-attachments/assets/cfdc7915-ad3e-4d02-8f3b-0138f94a1656" />


2. User had once access and a project selection is set or they where led there with a link that includes project selection
<img width="1401" alt="Screenshot 2025-01-08 at 08 23 07" src="https://github.com/user-attachments/assets/37158561-1919-4a82-867d-82f68a06377b" />

Both states are not ideal.
State 1 suggests on a first glance that there is no traffic in this organization and does not provide any valuable information.
But state 2 is problematic as requests fail and the page looks broken.

### Solution

Wrap the page in `<NoProjectMessage />` as we do for other pages that rely on project data.

<img width="1401" alt="Screenshot 2025-01-08 at 08 26 43" src="https://github.com/user-attachments/assets/335b4c23-08f9-42fb-916f-a212e09c21f2" />


Close https://github.com/getsentry/sentry/issues/82998