### PR TITLE
fix(code mappings): Handle non-int project ids

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -196,6 +196,14 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
 
         try:
             project = Project.objects.get(id=request.data.get("projectId"))
+        except ValueError as exc:
+            if "invalid literal for int() with base 10" in str(exc):
+                return self.respond(
+                    "Invalid projectId param. Expected an integer.",
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            else:
+                raise
         except Project.DoesNotExist:
             return self.respond("Could not find project", status=status.HTTP_404_NOT_FOUND)
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -261,6 +261,11 @@ class OrganizationCodeMappingsTest(APITestCase):
         response = self.make_post({"stackRoot": "", "sourceRoot": ""})
         assert response.status_code == 201, response.content
 
+    def test_invalid_project_id(self):
+        response = self.make_post({"projectId": "dogs_are_great"})
+        assert response.status_code == 400, response.content
+        assert response.data == "Invalid projectId param. Expected an integer."
+
     def test_project_does_not_exist(self):
         bad_org = self.create_organization()
         bad_project = self.create_project(organization=bad_org)


### PR DESCRIPTION
It's unclear how this happens (user error? misconfigured integration?), but from time to time our code mappings endpoint gets hit with a request where the project id is a string or a hex value rather than an integer. This adds handling for that case, returning a 400 response rather than simply erroring out.