### PR TITLE
fix(insights): Fix total weights calculation

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1854,14 +1854,16 @@ class MetricsDatasetConfig(DatasetConfig):
                         "isZeroOrNull",
                         [
                             Function(
-                                "countIf",
+                                "sumIf",
                                 [
                                     Column("value"),
                                     Function(
                                         "equals",
                                         [
                                             Column("metric_id"),
-                                            self.resolve_metric(f"measurements.score.{vital}"),
+                                            self.resolve_metric(
+                                                f"measurements.score.weight.{vital}"
+                                            ),
                                         ],
                                     ),
                                 ],


### PR DESCRIPTION
Updates total weights calculation to check for sum of metric is greater than zero, instead of count. This avoids cases where scores that should have 0 weight are falsely detected.