### PR TITLE
fix(issue-views): Fix bug where unable to rename fresh duplicated view

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -52,6 +52,7 @@ export function IssueViewTab({
         viewId: newViewId,
       },
     });
+    tabListState?.setSelectedKey(newViewId);
   };
 
   const handleDiscardChanges = () => {


### PR DESCRIPTION
Fixes an issue where after users were unable to rename a tab right after it's been duplicated (see this [replay](https://sentry.sentry.io/replays/4290855474744580b0bd4bd264794273/?t=248.437&t_main=breadcrumbs), 3:30 for behavior) 

This was happening because the tabListState's selected key wasn't being set to the duplicated tab after it had been created, causing the active element to still be on the old tab: 

![image](https://github.com/user-attachments/assets/3e665f76-ec0e-4e66-90c0-e5023aaa912c)
^ `document.activeElement` is being highlighted here, it is erroneously on the original tab, and not on the duplicated tab, despite the duplicated tab appearing to be selected. 


fixes JAVASCRIPT-2XA4
