### PR TITLE
fix(empty-state): Wider range on recommended

### DIFF
--- a/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
+++ b/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
@@ -33,7 +33,13 @@ export function EventMissingBanner() {
       {
         link: (
           <Link
-            to={`${baseUrl}/recommended/statsPeriod=${MAX_PICKABLE_DAYS}d`}
+            to={{
+              pathname: `${baseUrl}/recommended/`,
+              query: {
+                statsPeriod: `${MAX_PICKABLE_DAYS}d`,
+                ...(location.query.project ? {project: location.query.project} : {}),
+              },
+            }}
             aria-label={t('View recommended event')}
           />
         ),
@@ -50,8 +56,8 @@ export function EventMissingBanner() {
           to={{
             pathname: `${baseUrl}/${eventId}/`,
             query: {
-              project: location.query.project ?? undefined,
               statsPeriod: `${MAX_PICKABLE_DAYS}d`,
+              ...(location.query.project ? {project: location.query.project} : {}),
             },
           }}
           aria-label={t('Clear event filters')}

--- a/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
+++ b/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
@@ -4,6 +4,7 @@ import compassImage from 'sentry-images/spot/onboarding-compass.svg';
 
 import {Flex} from 'sentry/components/container/flex';
 import Link from 'sentry/components/links/link';
+import {MAX_PICKABLE_DAYS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -29,7 +30,10 @@ export function EventMissingBanner() {
       'Switch over to a [link:recommended] event instead, it should have more useful data.',
       {
         link: (
-          <Link to={`${baseUrl}/recommended/`} aria-label={t('View recommended event')} />
+          <Link
+            to={`${baseUrl}/recommended/statsPeriod=${MAX_PICKABLE_DAYS}d`}
+            aria-label={t('View recommended event')}
+          />
         ),
       }
     ),
@@ -39,7 +43,15 @@ export function EventMissingBanner() {
       'Change up your filters. Try more environments, a wider date range, or a different query'
     ),
     tct('If nothing stands out, try [link:clearing your filters] all together', {
-      link: <Link to={`${baseUrl}/${eventId}/`} aria-label={t('Clear event filters')} />,
+      link: (
+        <Link
+          to={{
+            pathname: `${baseUrl}/${eventId}`,
+            query: {statsPeriod: `${MAX_PICKABLE_DAYS}d`},
+          }}
+          aria-label={t('Clear event filters')}
+        />
+      ),
     }),
   ];
 

--- a/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
+++ b/static/app/views/issueDetails/streamline/eventMissingBanner.tsx
@@ -7,12 +7,14 @@ import Link from 'sentry/components/links/link';
 import {MAX_PICKABLE_DAYS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {RESERVED_EVENT_IDS} from 'sentry/views/issueDetails/useGroupEvent';
 import {useDefaultIssueEvent} from 'sentry/views/issueDetails/utils';
 
 export function EventMissingBanner() {
+  const location = useLocation();
   const organization = useOrganization();
   const defaultEventId = useDefaultIssueEvent();
   const {groupId, eventId = defaultEventId} = useParams<{
@@ -46,8 +48,11 @@ export function EventMissingBanner() {
       link: (
         <Link
           to={{
-            pathname: `${baseUrl}/${eventId}`,
-            query: {statsPeriod: `${MAX_PICKABLE_DAYS}d`},
+            pathname: `${baseUrl}/${eventId}/`,
+            query: {
+              project: location.query.project ?? undefined,
+              statsPeriod: `${MAX_PICKABLE_DAYS}d`,
+            },
           }}
           aria-label={t('Clear event filters')}
         />


### PR DESCRIPTION
In the chance someone lands on an issue with a day filter like 14d, with events 15+ days before, this will allow the recommended event to be filtered across all that we have, instead of the default (which will still be empty).