### PR TITLE
ref(flags): update types allowed for createdBy and createdByType

### DIFF
--- a/static/app/views/issueDetails/streamline/featureFlagUtils.tsx
+++ b/static/app/views/issueDetails/streamline/featureFlagUtils.tsx
@@ -1,8 +1,8 @@
 export type RawFlag = {
   action: string;
   createdAt: string;
-  createdBy: string;
-  createdByType: string;
+  createdBy: string | null | undefined;
+  createdByType: string | null | undefined;
   flag: string;
   id: number;
   tags: Record<string, any>;


### PR DESCRIPTION
merge before https://github.com/getsentry/sentry/pull/83054

it looks like we weren't using the `createdBy` or `createdByType` field anywhere