### PR TITLE
fix(issue-views): Fix issue where new views do not have a query saved

### DIFF
--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -579,7 +579,7 @@ export function IssueViewsStateProvider({
           ...location,
           query: {
             ...queryParams,
-            query,
+            query: newQuery,
             sort: IssueSortOptions.DATE,
           },
         },


### PR DESCRIPTION
Fixes an issue where clicking on a query suggestion in the new view page would not populate the search bar with the query. 