### PR TITLE
feat(widget-builder): Implement add to dashboard for redesign

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -152,7 +152,14 @@ function AddToDashboardModal({
         ? `/organizations/${organization.slug}/dashboards/new/`
         : `/organizations/${organization.slug}/dashboard/${selectedDashboardId}/`;
 
-    const pathname = page === 'builder' ? `${dashboardsPath}widget/new/` : dashboardsPath;
+    const builderSuffix = organization.features.includes(
+      'dashboards-widget-builder-redesign'
+    )
+      ? 'widget-builder/widget/new/'
+      : 'widget/new/';
+
+    const pathname =
+      page === 'builder' ? `${dashboardsPath}${builderSuffix}` : dashboardsPath;
 
     router.push(
       normalizeUrl({

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -25,7 +25,7 @@ export type WidgetBuilderStateQueryParams = {
   dataset?: WidgetType;
   description?: string;
   displayType?: DisplayType;
-  field?: (string | undefined)[];
+  field?: string[];
   legendAlias?: string[];
   limit?: number;
   query?: string[];

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -588,7 +588,7 @@ describe('Discover > QueryList', function () {
           expect.objectContaining({
             widget: {
               title: 'Saved query #1',
-              displayType: DisplayType.LINE,
+              displayType: DisplayType.AREA,
               queries: [
                 {
                   aggregates: ['count()'],
@@ -607,7 +607,7 @@ describe('Discover > QueryList', function () {
               defaultTitle: 'Saved query #1',
               defaultWidgetQuery:
                 'name=&aggregates=count()&columns=&fields=count()&conditions=&orderby=',
-              displayType: DisplayType.LINE,
+              displayType: DisplayType.AREA,
               source: DashboardWidgetSource.DISCOVERV2,
             }),
           })
@@ -656,7 +656,7 @@ describe('Discover > QueryList', function () {
       expect(openAddToDashboardModal).toHaveBeenCalledWith(
         expect.objectContaining({
           widget: {
-            displayType: 'line',
+            displayType: 'area',
             interval: undefined,
             limit: undefined,
             queries: [
@@ -679,7 +679,7 @@ describe('Discover > QueryList', function () {
             defaultTitle: 'Saved query #1',
             defaultWidgetQuery:
               'name=&aggregates=count()&columns=&fields=count()&conditions=&orderby=',
-            displayType: 'line',
+            displayType: 'area',
             source: 'discoverv2',
             statsPeriod: '14d',
           }),

--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -176,7 +176,7 @@ describe('Discover > SaveQueryButtonGroup', function () {
       expect(openAddToDashboardModal).toHaveBeenCalledWith(
         expect.objectContaining({
           widget: {
-            displayType: 'line',
+            displayType: 'area',
             interval: undefined,
             limit: undefined,
             queries: [
@@ -198,7 +198,7 @@ describe('Discover > SaveQueryButtonGroup', function () {
             defaultTitle: 'Errors by Title',
             defaultWidgetQuery:
               'name=&aggregates=count()%2Cfailure_count()&columns=&fields=count()%2Cfailure_count()&conditions=event.type%3Aerror&orderby=-count()',
-            displayType: 'line',
+            displayType: 'area',
             end: undefined,
             limit: undefined,
             source: 'discoverv2',

--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -243,10 +243,15 @@ export function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery
 
 export function displayModeToDisplayType(displayMode: DisplayModes): DisplayType {
   switch (displayMode) {
+    case DisplayModes.DAILYTOP5:
+    case DisplayModes.DAILY:
     case DisplayModes.BAR:
       return DisplayType.BAR;
     case DisplayModes.TOP5:
       return DisplayType.TOP_N;
+    case DisplayModes.PREVIOUS:
+    case DisplayModes.DEFAULT:
+      return DisplayType.AREA;
     default:
       return DisplayType.LINE;
   }

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -741,12 +741,15 @@ export function handleAddQueryToDashboard({
         {
           ...defaultWidgetQuery,
           aggregates: [...(typeof yAxis === 'string' ? [yAxis] : yAxis ?? ['count()'])],
-          fields: widgetAsQueryParams?.field ?? [],
-          columns: widgetAsQueryParams?.field
-            ? widgetAsQueryParams.field.filter(
-                column => !isAggregateFieldOrEquation(column)
-              )
-            : [],
+          ...(organization.features.includes('dashboards-widget-builder-redesign')
+            ? {
+                // The widget query params filters out aggregate fields
+                // so we can use the fields as columns. This is so yAxes
+                // can be grouped by the fields.
+                fields: widgetAsQueryParams?.field ?? [],
+                columns: widgetAsQueryParams?.field ?? [],
+              }
+            : {}),
         },
       ],
       interval: eventView.interval!,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -750,10 +750,7 @@ export function handleAddQueryToDashboard({
         },
       ],
       interval: eventView.interval!,
-      limit:
-        displayType === DisplayType.TOP_N
-          ? Number(eventView.topEvents) || TOP_N
-          : undefined,
+      limit: widgetAsQueryParams?.limit,
       widgetType,
     },
     router,
@@ -828,11 +825,18 @@ export function constructAddQueryToDashboardLink({
   const defaultTitle =
     query?.name ?? (eventView.name !== 'All Events' ? eventView.name : undefined);
 
+  const limit =
+    displayType === DisplayType.TOP_N || eventView.display === DisplayModes.DAILYTOP5
+      ? Number(eventView.topEvents) || TOP_N
+      : undefined;
+
   if (organization.features.includes('dashboards-widget-builder-redesign')) {
     const widget: Widget = {
       title: defaultTitle!,
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,
-      interval: eventView.interval!,
+      widgetType,
+      limit,
+      interval: eventView.interval ?? '',
       queries: [
         {
           ...defaultWidgetQuery,
@@ -850,11 +854,6 @@ export function constructAddQueryToDashboardLink({
               : [],
         },
       ],
-      limit:
-        displayType === DisplayType.TOP_N
-          ? Number(eventView.topEvents) || TOP_N
-          : undefined,
-      widgetType,
     };
     return {
       pathname: `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/new/`,
@@ -882,10 +881,7 @@ export function constructAddQueryToDashboardLink({
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,
       dataset: widgetType,
       field: eventView.getFields(),
-      limit:
-        displayType === DisplayType.TOP_N
-          ? Number(eventView.topEvents) || TOP_N
-          : undefined,
+      limit,
     },
   };
 }

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -37,13 +37,22 @@ export function useAddToDashboard() {
   const sampleFields = useExploreFields();
   const query = useExploreQuery();
 
+  const hasWidgetBuilderRedesign = organization.features.includes(
+    'dashboards-widget-builder-redesign'
+  );
+
   const getEventView = useCallback(
     (visualizeIndex: number) => {
       const yAxes = visualizes[visualizeIndex]!.yAxes.slice(0, MAX_NUM_Y_AXES);
 
       let fields;
       if (mode === Mode.SAMPLES) {
-        fields = sampleFields.filter(Boolean);
+        if (hasWidgetBuilderRedesign) {
+          // TODO: Handle the fields for the widget builder if we've selected the samples mode
+          fields = [];
+        } else {
+          fields = sampleFields.filter(Boolean);
+        }
       } else {
         fields = [...groupBys, ...yAxes].filter(Boolean);
       }
@@ -67,7 +76,17 @@ export function useAddToDashboard() {
       newEventView.dataset = dataset;
       return newEventView;
     },
-    [visualizes, mode, sampleFields, groupBys, query, dataset, selection, sortBys]
+    [
+      visualizes,
+      mode,
+      sampleFields,
+      groupBys,
+      query,
+      dataset,
+      selection,
+      sortBys,
+      hasWidgetBuilderRedesign,
+    ]
   );
 
   const addToDashboard = useCallback(


### PR DESCRIPTION
- Updates some display types so the right type is chosen instead of
  defaulting to a line
- Changes the URL to point to the new widget builder
- Updates which fields are sent with explore queries
  - For sample mode we drop the fields so the charts match

The Add to Dashboard flow should work as expected for 

⚠️ Switching to a table doesn't currently work well here. It doesn't just give you the table results. I need to determine if switching to a table should persist the samples table, or if it's fine that the table just gets the fields in the timeseries chart but as a table. e.g. this works nicely for "Top Period" charts, but table state isn't persisted for "Total Period"