### PR TITLE
fix(discover): Console warnings for series not exists

### DIFF
--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -212,9 +212,14 @@ class Chart extends Component<ChartProps, State> {
 
     const data = [
       ...(currentSeriesNames.length > 0 ? currentSeriesNames : [t('Current')]),
-      ...(previousSeriesNames.length > 0 ? previousSeriesNames : [t('Previous')]),
       ...(additionalSeries ? additionalSeries.map(series => series.name as string) : []),
     ];
+
+    if (defined(previousTimeseriesData)) {
+      data.push(
+        ...(previousSeriesNames.length > 0 ? previousSeriesNames : [t('Previous')])
+      );
+    }
 
     const releasesLegend = t('Releases');
 
@@ -223,7 +228,7 @@ class Chart extends Component<ChartProps, State> {
       data.push('Other');
     }
 
-    if (Array.isArray(releaseSeries)) {
+    if (Array.isArray(releaseSeries) && releaseSeries.length > 0) {
       data.push(releasesLegend);
     }
 


### PR DESCRIPTION
There were a number of echarts warnings in the console because the legend automatically included certain series, but they weren't always in the series for the chart. This only applies them (i.e. the previous series, or the release series) when there is data.

![Screenshot 2025-01-08 at 3 54 21 PM](https://github.com/user-attachments/assets/3e5b411e-7a35-4448-9a2f-62cf8a49f46a)
