### PR TITLE
fix(widget-builder) Clean up error code for widget builder components

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -12,7 +12,6 @@ jest.mock('sentry/utils/useNavigate', () => ({
 }));
 
 const mockUseNavigate = jest.mocked(useNavigate);
-const mockSetError = jest.fn();
 
 describe('WidgetBuilder', () => {
   let router!: ReturnType<typeof RouterFixture>;
@@ -34,7 +33,7 @@ describe('WidgetBuilder', () => {
 
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderNameAndDescription error={{}} setError={mockSetError} />
+        <WidgetBuilderNameAndDescription />
       </WidgetBuilderProvider>,
       {
         router,
@@ -69,7 +68,6 @@ describe('WidgetBuilder', () => {
       <WidgetBuilderProvider>
         <WidgetBuilderNameAndDescription
           error={{title: 'Title is required during creation.'}}
-          setError={mockSetError}
         />
       </WidgetBuilderProvider>,
       {router, organization}

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -11,8 +11,8 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
 interface WidgetBuilderNameAndDescriptionProps {
-  error: Record<string, any>;
-  setError: (error: Record<string, any>) => void;
+  error?: Record<string, any>;
+  setError?: (error: Record<string, any>) => void;
 }
 
 function WidgetBuilderNameAndDescription({
@@ -34,11 +34,11 @@ function WidgetBuilderNameAndDescription({
         value={state.title}
         onChange={newTitle => {
           // clear error once user starts typing
-          setError({...error, title: undefined});
+          setError?.({...error, title: undefined});
           dispatch({type: BuilderStateAction.SET_TITLE, payload: newTitle});
         }}
         required
-        error={error.title}
+        error={error?.title}
         inline={false}
       />
       {!isDescSelected && (

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -33,7 +33,7 @@ describe('QueryFilterBuilder', () => {
   it('renders a dataset-specific query filter bar', async () => {
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} error={{}} />
+        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
       </WidgetBuilderProvider>,
       {
         organization,
@@ -54,7 +54,7 @@ describe('QueryFilterBuilder', () => {
 
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} error={{}} />
+        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
       </WidgetBuilderProvider>,
       {
         organization,
@@ -77,7 +77,7 @@ describe('QueryFilterBuilder', () => {
   it('renders a legend alias input for charts', async () => {
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} error={{}} />
+        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
       </WidgetBuilderProvider>,
       {
         organization,

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -22,7 +22,6 @@ import {getDiscoverDatasetFromWidgetType} from 'sentry/views/dashboards/widgetBu
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 
 interface WidgetBuilderQueryFilterBuilderProps {
-  error: Record<string, any>;
   onQueryConditionChange: (valid: boolean) => void;
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -12,7 +12,6 @@ jest.mock('sentry/utils/useNavigate', () => ({
 }));
 
 const mockUseNavigate = jest.mocked(useNavigate);
-const mockSetError = jest.fn();
 
 describe('TypeSelector', () => {
   let router!: ReturnType<typeof RouterFixture>;
@@ -28,7 +27,7 @@ describe('TypeSelector', () => {
 
     render(
       <WidgetBuilderProvider>
-        <TypeSelector error={{}} setError={mockSetError} />
+        <TypeSelector />
       </WidgetBuilderProvider>,
       {
         router,
@@ -52,10 +51,7 @@ describe('TypeSelector', () => {
   it('displays error message when there is an error', async function () {
     render(
       <WidgetBuilderProvider>
-        <TypeSelector
-          error={{displayType: 'Please select a type'}}
-          setError={mockSetError}
-        />
+        <TypeSelector error={{displayType: 'Please select a type'}} />
       </WidgetBuilderProvider>,
       {router, organization}
     );

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -30,8 +30,8 @@ const displayTypes = {
 };
 
 interface WidgetBuilderTypeSelectorProps {
-  error: Record<string, any>;
-  setError: (error: Record<string, any>) => void;
+  error?: Record<string, any>;
+  setError?: (error: Record<string, any>) => void;
 }
 
 function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorProps) {
@@ -44,7 +44,11 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
         tooltipText={t('This is the type of visualization (ex. line chart)')}
         title={t('Type')}
       />
-      <StyledFieldGroup error={error.displayType} inline={false} flexibleControlStateSize>
+      <StyledFieldGroup
+        error={error?.displayType}
+        inline={false}
+        flexibleControlStateSize
+      >
         <SelectControl
           name="displayType"
           value={state.displayType}
@@ -59,7 +63,7 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
             if (newValue?.value === state.displayType) {
               return;
             }
-            setError({...error, displayType: undefined});
+            setError?.({...error, displayType: undefined});
 
             dispatch({
               type: BuilderStateAction.SET_DISPLAY_TYPE,

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -148,7 +148,6 @@ function WidgetBuilderSlideout({
         <Section>
           <WidgetBuilderQueryFilterBuilder
             onQueryConditionChange={onQueryConditionChange}
-            error={error}
           />
         </Section>
         {isChartWidget && (


### PR DESCRIPTION
I didn't like how we had to pass in the error state in all tests so I changed error to be an optional prop. Also deleted some redundant code that I found while poking around. 🧹 