### PR TITLE
fix(processor): only log 1%

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from itertools import islice
+from random import random
 from typing import Any, DefaultDict, NamedTuple
 
 from django.db.models import OuterRef, Subquery
@@ -239,16 +240,17 @@ def build_group_to_groupevent(
         group = group_id_to_group.get(int(rule_group[1]))
 
         if not group or not event:
-            logger.info(
-                "delayed_processing.missing_event_or_group",
-                extra={
-                    "rule": rule_group[0],
-                    "project_id": project_id,
-                    "event_id": event_id,
-                    "group_id": group.id if group else None,
-                },
-            )
-            continue
+            if random.random() < 0.01:
+                logger.info(
+                    "delayed_processing.missing_event_or_group",
+                    extra={
+                        "rule": rule_group[0],
+                        "project_id": project_id,
+                        "event_id": event_id,
+                        "group_id": group.id if group else None,
+                    },
+                )
+                continue
 
         group_event = event.for_group(group)
         if occurrence_id:
@@ -587,10 +589,11 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
         rules_to_fire = get_rules_to_fire(
             condition_group_results, rules_to_slow_conditions, rules_to_groups, project.id
         )
-        logger.info(
-            "delayed_processing.rule_to_fire",
-            extra={"rules_to_fire": list(rules_to_fire.keys()), "project_id": project_id},
-        )
+        if random.random() < 0.01:
+            logger.info(
+                "delayed_processing.rule_to_fire",
+                extra={"rules_to_fire": list(rules_to_fire.keys()), "project_id": project_id},
+            )
 
     parsed_rulegroup_to_event_data = parse_rulegroup_to_event_data(rulegroup_to_event_data)
     with metrics.timer("delayed_processing.fire_rules.duration"):

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -1,11 +1,11 @@
 import logging
 import math
+import random
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from itertools import islice
-from random import random
 from typing import Any, DefaultDict, NamedTuple
 
 from django.db.models import OuterRef, Subquery

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -250,7 +250,7 @@ def build_group_to_groupevent(
                         "group_id": group.id if group else None,
                     },
                 )
-                continue
+            continue
 
         group_event = event.for_group(group)
         if occurrence_id:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
+import random
 import uuid
 from collections.abc import Callable, Collection, Mapping, MutableMapping, Sequence
 from datetime import timedelta
-from random import random, randrange
+from random import randrange
 from typing import Any
 
 from django.core.cache import cache

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from collections.abc import Callable, Collection, Mapping, MutableMapping, Sequence
 from datetime import timedelta
-from random import randrange
+from random import random, randrange
 from typing import Any
 
 from django.core.cache import cache
@@ -251,10 +251,11 @@ class RuleProcessor:
         return fast_conditions, slow_conditions
 
     def enqueue_rule(self, rule: Rule) -> None:
-        logger.info(
-            "rule_processor.rule_enqueued",
-            extra={"rule": rule.id, "group": self.group.id, "project": rule.project.id},
-        )
+        if random.random() < 0.01:
+            logger.info(
+                "rule_processor.rule_enqueued",
+                extra={"rule": rule.id, "group": self.group.id, "project": rule.project.id},
+            )
         buffer.backend.push_to_sorted_set(PROJECT_ID_BUFFER_LIST_KEY, rule.project.id)
 
         value = json.dumps(


### PR DESCRIPTION
The noisiest logs seemed to be `delayed_processing.missing_event_or_group`, `rule_processor.rule_enqueued` and, `delayed_processing.rule_to_fire`. Only log 1% of these. 