### PR TITLE
feat(issue-stream): Change unit style for relative seen times from extraShort to short

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -142,7 +142,7 @@ function GroupTimestamp({date, label}: {date: string | null | undefined; label: 
       tooltipPrefix={label}
       date={date}
       suffix="ago"
-      unitStyle="extraShort"
+      unitStyle="short"
     />
   );
 }


### PR DESCRIPTION
Simple change, displays last seen as `2min` instead of `2m` since we have the space. Also fixes the issue where `extraShort` displays weeks as the longest measurement. 