### PR TITLE
fix(profiling): events-stats meta units wrong for profile functions

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -288,10 +288,11 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         return decision
 
     def handle_unit_meta(
-        self, meta: dict[str, str]
+        self, result_meta: dict[str, str]
     ) -> tuple[dict[str, str], dict[str, str | None]]:
         units: dict[str, str | None] = {}
-        for key, value in meta.items():
+        meta: dict[str, str] = result_meta.copy()
+        for key, value in result_meta.items():
             if value in SIZE_UNITS:
                 units[key] = value
                 meta[key] = "size"

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -2969,12 +2969,18 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
             timestamp=self.two_days_ago,
         )
 
+        y_axes = [
+            "cpm()",
+            "p95(function.duration)",
+            "all_examples()",
+        ]
+
         data = {
             "dataset": "profileFunctions",
             "field": ["function", "count()"],
             "start": self.three_days_ago.isoformat(),
             "end": self.one_day_ago.isoformat(),
-            "yAxis": ["cpm()", "p95(function.duration)"],
+            "yAxis": y_axes,
             "interval": "1d",
             "topEvents": "2",
             "excludeOther": "1",
@@ -2999,6 +3005,17 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
         assert any(
             row[1][0]["count"] > 0 for row in response.data["bar"]["p95(function.duration)"]["data"]
         )
+
+        for func in ["foo", "bar"]:
+            for y_axis in y_axes:
+                assert response.data[func][y_axis]["meta"]["units"] == {
+                    "time": None,
+                    "count": None,
+                    "cpm": None,
+                    "function": None,
+                    "p95_function_duration": "nanosecond",
+                    "all_examples": None,
+                }
 
 
 class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):


### PR DESCRIPTION
In top N mode, the meta is shared across the results and the units set is lost on the second iteration where it sees `duration` which is set earliers.