### PR TITLE
feat(crons): add audit logs for upsert and bulk edit endpoint

### DIFF
--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -366,3 +366,19 @@ class DataSecrecyWaivedAuditLogEvent(AuditLogEvent):
             rendered_text += f" from {formatted_start} to {formatted_end}"
 
         return rendered_text
+
+
+class MonitorAddAuditLogEvent(AuditLogEvent):
+    def __init__(self):
+        super().__init__(
+            event_id=120,
+            name="MONITOR_ADD",
+            api_name="monitor.add",
+        )
+
+    def render(self, audit_log_entry: AuditLogEntry):
+        entry_data = audit_log_entry.data
+        name = entry_data.get("name")
+        upsert = entry_data.get("upsert")
+
+        return f"added{" upsert " if upsert else " "}monitor {name}"

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -282,22 +282,7 @@ default_manager.add(
         template="rotated a client secret for {status} integration {sentry_app}",
     )
 )
-default_manager.add(
-    AuditLogEvent(
-        event_id=120,
-        name="MONITOR_ADD",
-        api_name="monitor.add",
-        template="added monitor {name}",
-    )
-)
-default_manager.add(
-    AuditLogEvent(
-        event_id=213,
-        name="UPSERT_MONITOR_ADD",
-        api_name="upsert_monitor.add",
-        template="added upsert monitor {name}",
-    )
-)
+default_manager.add(events.MonitorAddAuditLogEvent())
 default_manager.add(
     AuditLogEvent(
         event_id=121,

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -292,6 +292,14 @@ default_manager.add(
 )
 default_manager.add(
     AuditLogEvent(
+        event_id=213,
+        name="UPSERT_MONITOR_ADD",
+        api_name="upsert_monitor.add",
+        template="added upsert monitor {name}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
         event_id=121,
         name="MONITOR_EDIT",
         api_name="monitor.edit",

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -22,7 +22,7 @@ from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_monitors_v1 import IngestMonitorMessage
 from sentry_sdk.tracing import Span, Transaction
 
-from sentry import quotas, ratelimits
+from sentry import audit_log, quotas, ratelimits
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
@@ -76,6 +76,7 @@ from sentry.monitors.utils import (
 from sentry.monitors.validators import ConfigValidator, MonitorCheckInValidator
 from sentry.types.actor import parse_and_validate_actor
 from sentry.utils import json, metrics
+from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.dates import to_datetime
 from sentry.utils.outcomes import Outcome, track_outcome
 
@@ -587,6 +588,12 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span):
         seat_outcome = quotas.backend.assign_monitor_seat(monitor)
         if seat_outcome != Outcome.ACCEPTED:
             monitor.update(status=ObjectStatus.DISABLED)
+        create_system_audit_entry(
+            organization_id=project.organization_id,
+            target_object=monitor.id,
+            event=audit_log.get_event_id("UPSERT_MONITOR_ADD"),
+            data=monitor.get_audit_log_data(),
+        )
 
     if not monitor:
         metrics.incr(

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -308,16 +308,8 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         if seat_outcome != Outcome.ACCEPTED:
             monitor.update(status=ObjectStatus.DISABLED)
 
-        self.create_audit_entry(
-            request=request,
-            organization=organization,
-            target_object=monitor.id,
-            event=audit_log.get_event_id("MONITOR_ADD"),
-            data=monitor.get_audit_log_data(),
-        )
-
         project = result["project"]
-        signal_monitor_created(project, request.user, False)
+        signal_monitor_created(project, request.user, False, monitor, request)
 
         validated_issue_alert_rule = result.get("alert_rule")
         if validated_issue_alert_rule:

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -393,6 +393,13 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
 
                 monitor.update(**result)
                 updated.append(monitor)
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=monitor.id,
+                event=audit_log.get_event_id("MONITOR_EDIT"),
+                data=monitor.get_audit_log_data(),
+            )
 
         return self.respond(
             {

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -44,9 +44,7 @@ def check_and_signal_first_monitor_created(project: Project, user, from_upsert: 
         )
 
 
-def signal_monitor_created(
-    project: Project, user, from_upsert: bool, monitor: Monitor, request: Request | None
-):
+def signal_monitor_created(project: Project, user, from_upsert: bool, monitor: Monitor, request):
     cron_monitor_created.send_robust(
         project=project, user=user, from_upsert=from_upsert, sender=Project
     )

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -1163,8 +1163,8 @@ class MonitorConsumerTest(TestCase):
 
         assert_org_audit_log_exists(
             organization=self.organization,
-            event=audit_log.get_event_id("UPSERT_MONITOR_ADD"),
-            data=monitor.get_audit_log_data(),
+            event=audit_log.get_event_id("MONITOR_ADD"),
+            data={"upsert": True, **monitor.get_audit_log_data()},
         )
 
     @mock.patch("sentry.quotas.backend.assign_monitor_seat")

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -14,7 +14,7 @@ from django.test.utils import override_settings
 from rest_framework.exceptions import ErrorDetail
 from sentry_kafka_schemas.schema_types.ingest_monitors_v1 import CheckIn
 
-from sentry import killswitches
+from sentry import audit_log, killswitches
 from sentry.constants import ObjectStatus
 from sentry.db.models import BoundedPositiveIntegerField
 from sentry.models.environment import Environment
@@ -31,7 +31,9 @@ from sentry.monitors.models import (
 )
 from sentry.monitors.processing_errors.errors import ProcessingErrorsException, ProcessingErrorType
 from sentry.monitors.types import CheckinItem
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.utils import json
 from sentry.utils.outcomes import Outcome
 
@@ -1143,11 +1145,12 @@ class MonitorConsumerTest(TestCase):
         check_accept_monitor_checkin.return_value = PermitCheckInStatus.ACCEPTED_FOR_UPSERT
         assign_monitor_seat.return_value = Outcome.ACCEPTED
 
-        self.send_checkin(
-            "my-monitor",
-            monitor_config={"schedule": {"type": "crontab", "value": "13 * * * *"}},
-            environment="my-environment",
-        )
+        with outbox_runner():
+            self.send_checkin(
+                "my-monitor",
+                monitor_config={"schedule": {"type": "crontab", "value": "13 * * * *"}},
+                environment="my-environment",
+            )
 
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         assert checkin.status == CheckInStatus.OK
@@ -1157,6 +1160,12 @@ class MonitorConsumerTest(TestCase):
 
         check_accept_monitor_checkin.assert_called_with(self.project.id, monitor.slug)
         assign_monitor_seat.assert_called_with(monitor)
+
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("UPSERT_MONITOR_ADD"),
+            data=monitor.get_audit_log_data(),
+        )
 
     @mock.patch("sentry.quotas.backend.assign_monitor_seat")
     @mock.patch("sentry.quotas.backend.check_accept_monitor_checkin")

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -8,12 +8,15 @@ from django.conf import settings
 from django.test.utils import override_settings
 from rest_framework.exceptions import ErrorDetail
 
+from sentry import audit_log
 from sentry.constants import ObjectStatus
 from sentry.models.rule import Rule, RuleSource
 from sentry.monitors.models import Monitor, MonitorStatus, MonitorType, ScheduleType
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.slug.errors import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import MonitorTestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.utils.outcomes import Outcome
 
 
@@ -597,13 +600,24 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
             "ids": [monitor_one.guid, monitor_two.guid],
             "isMuted": True,
         }
-        response = self.get_success_response(self.organization.slug, **data)
-        assert response.status_code == 200
+        with outbox_runner():
+            response = self.get_success_response(self.organization.slug, **data)
+            assert response.status_code == 200
 
         monitor_one.refresh_from_db()
         monitor_two.refresh_from_db()
         assert monitor_one.is_muted
         assert monitor_two.is_muted
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MONITOR_EDIT"),
+            data=monitor_one.get_audit_log_data(),
+        )
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MONITOR_EDIT"),
+            data=monitor_two.get_audit_log_data(),
+        )
 
         data = {
             "ids": [monitor_one.guid, monitor_two.guid],

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -400,7 +400,7 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         assert_org_audit_log_exists(
             organization=self.organization,
             event=audit_log.get_event_id("MONITOR_ADD"),
-            data=monitor.get_audit_log_data(),
+            data={"upsert": False, **monitor.get_audit_log_data()},
         )
 
         self.project.refresh_from_db()


### PR DESCRIPTION
- adds `monitor.edit` audit log for bulk edit endpoint
- changes copy on `monitor.add` audit log to distinguish monitors added with the ui vs upsert

resolves confusion that some customers had about their usage