### PR TITLE
feat(aci): add automation + monitor views

### DIFF
--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable no-alert */
+import {Fragment} from 'react';
+
+import {Button, LinkButton} from 'sentry/components/button';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
+import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
+import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
+import {IconEdit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export default function AutomationDetail() {
+  return (
+    <SentryDocumentTitle title={t('Automation')} noSuffix>
+      <BreadcrumbsProvider crumb={{label: t('Automations'), to: '/automations'}}>
+        <ActionsProvider actions={<Actions />}>
+          <DetailLayout>
+            <DetailLayout.Main>main</DetailLayout.Main>
+            <DetailLayout.Sidebar>sidebar</DetailLayout.Sidebar>
+          </DetailLayout>
+        </ActionsProvider>
+      </BreadcrumbsProvider>
+    </SentryDocumentTitle>
+  );
+}
+
+function Actions() {
+  const disable = () => {
+    window.alert('disable');
+  };
+  return (
+    <Fragment>
+      <Button onClick={disable}>{t('Disable')}</Button>
+      <LinkButton to="/monitors/edit" priority="primary" icon={<IconEdit />}>
+        {t('Edit')}
+      </LinkButton>
+    </Fragment>
+  );
+}

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable no-alert */
+import {Fragment} from 'react';
+
+import {Button} from 'sentry/components/button';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
+import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
+import EditLayout from 'sentry/components/workflowEngine/layout/edit';
+import {t} from 'sentry/locale';
+
+export default function AutomationEdit() {
+  return (
+    <SentryDocumentTitle title={t('Edit Automation')} noSuffix>
+      <BreadcrumbsProvider crumb={{label: t('Automations'), to: '/automations'}}>
+        <ActionsProvider actions={<Actions />}>
+          <EditLayout>
+            <h2>Edit Automation</h2>
+          </EditLayout>
+        </ActionsProvider>
+      </BreadcrumbsProvider>
+    </SentryDocumentTitle>
+  );
+}
+
+function Actions() {
+  const disable = () => {
+    window.alert('disable');
+  };
+  const del = () => {
+    window.alert('delete');
+  };
+  const save = () => {
+    window.alert('save');
+  };
+  return (
+    <Fragment>
+      <Button onClick={disable}>{t('Disable')}</Button>
+      <Button onClick={del} priority="danger">
+        {t('Delete')}
+      </Button>
+      <Button onClick={save} priority="primary">
+        {t('Save')}
+      </Button>
+    </Fragment>
+  );
+}

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-alert */
+import {Fragment} from 'react';
+
+import {Button} from 'sentry/components/button';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
+import ListLayout from 'sentry/components/workflowEngine/layout/list';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export default function AutomationsList() {
+  return (
+    <SentryDocumentTitle title={t('Automations')} noSuffix>
+      <ActionsProvider actions={<Actions />}>
+        <ListLayout>
+          <h2>Automations</h2>
+        </ListLayout>
+      </ActionsProvider>
+    </SentryDocumentTitle>
+  );
+}
+
+function Actions() {
+  const create = () => {
+    window.alert('create');
+  };
+  return (
+    <Fragment>
+      <Button onClick={create} priority="primary" icon={<IconAdd isCircled />}>
+        {t('Create Automation')}
+      </Button>
+    </Fragment>
+  );
+}

--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable no-alert */
+import {Fragment} from 'react';
+
+import {Button, LinkButton} from 'sentry/components/button';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
+import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
+import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
+import {IconEdit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export default function DetectorDetail() {
+  return (
+    <SentryDocumentTitle title={t('Edit Monitor')} noSuffix>
+      <BreadcrumbsProvider crumb={{label: t('Monitors'), to: '/monitors'}}>
+        <ActionsProvider actions={<Actions />}>
+          <DetailLayout>
+            <DetailLayout.Main>main</DetailLayout.Main>
+            <DetailLayout.Sidebar>sidebar</DetailLayout.Sidebar>
+          </DetailLayout>
+        </ActionsProvider>
+      </BreadcrumbsProvider>
+    </SentryDocumentTitle>
+  );
+}
+
+function Actions() {
+  const disable = () => {
+    window.alert('disable');
+  };
+  return (
+    <Fragment>
+      <Button onClick={disable}>{t('Disable')}</Button>
+      <LinkButton to="/monitors/edit" priority="primary" icon={<IconEdit />}>
+        {t('Edit')}
+      </LinkButton>
+    </Fragment>
+  );
+}

--- a/static/app/views/detectors/edit.tsx
+++ b/static/app/views/detectors/edit.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable no-alert */
+import {Fragment} from 'react';
+
+import {Button} from 'sentry/components/button';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
+import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
+import EditLayout from 'sentry/components/workflowEngine/layout/edit';
+import {t} from 'sentry/locale';
+
+export default function DetectorEdit() {
+  return (
+    <SentryDocumentTitle title={t('Edit Monitor')} noSuffix>
+      <BreadcrumbsProvider crumb={{label: t('Monitors'), to: '/monitors'}}>
+        <ActionsProvider actions={<Actions />}>
+          <EditLayout>
+            <h2>Edit Monitor</h2>
+          </EditLayout>
+        </ActionsProvider>
+      </BreadcrumbsProvider>
+    </SentryDocumentTitle>
+  );
+}
+
+function Actions() {
+  const disable = () => {
+    window.alert('disable');
+  };
+  const del = () => {
+    window.alert('delete');
+  };
+  const save = () => {
+    window.alert('save');
+  };
+  return (
+    <Fragment>
+      <Button onClick={disable}>{t('Disable')}</Button>
+      <Button onClick={del} priority="danger">
+        {t('Delete')}
+      </Button>
+      <Button onClick={save} priority="primary">
+        {t('Save')}
+      </Button>
+    </Fragment>
+  );
+}

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-alert */
+import {Fragment} from 'react';
+
+import {Button} from 'sentry/components/button';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
+import ListLayout from 'sentry/components/workflowEngine/layout/list';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export default function DetectorsList() {
+  return (
+    <SentryDocumentTitle title={t('Monitors')} noSuffix>
+      <ActionsProvider actions={<Actions />}>
+        <ListLayout>
+          <h2>Monitors</h2>
+        </ListLayout>
+      </ActionsProvider>
+    </SentryDocumentTitle>
+  );
+}
+
+function Actions() {
+  const create = () => {
+    window.alert('create');
+  };
+  return (
+    <Fragment>
+      <Button onClick={create} priority="primary" icon={<IconAdd isCircled />}>
+        {t('Create Monitor')}
+      </Button>
+    </Fragment>
+  );
+}


### PR DESCRIPTION
## ACI M6.2: View Scaffolding

Adds directories + files for new ACI views (both Automations and Monitors). Uses components added in #82973.

Since these aren't hooked up to the router yet, none of this is visible to the user.

✅ Closes [`ACI-64`](https://getsentry.atlassian.net/browse/ACI-64)