### PR TITLE
ref(post-process): remove transactions logic

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -14,7 +14,6 @@ from django.utils import timezone
 from google.api_core.exceptions import ServiceUnavailable
 
 from sentry import features, options, projectoptions
-from sentry.eventstream.types import EventStreamEventType
 from sentry.exceptions import PluginError
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -23,14 +22,13 @@ from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.lib.kafka import initialize_replays_publisher
 from sentry.sentry_metrics.client import generic_metrics_backend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.signals import event_processed, issue_unignored, transaction_processed
+from sentry.signals import event_processed, issue_unignored
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
 from sentry.utils.event_frames import get_sdk_name
-from sentry.utils.event_tracker import TransactionStageStatus, track_sampled_event
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.locking.backends import LockBackend
 from sentry.utils.locking.manager import LockManager
@@ -471,10 +469,9 @@ def should_retry_fetch(attempt: int, e: Exception) -> bool:
 fetch_retry_policy = ConditionalRetryPolicy(should_retry_fetch, exponential_delay(1.00))
 
 
-def should_update_escalating_metrics(event: Event, is_transaction_event: bool) -> bool:
+def should_update_escalating_metrics(event: Event) -> bool:
     return (
         features.has("organizations:escalating-metrics-backend", event.project.organization)
-        and not is_transaction_event
         and event.group is not None
         and event.group.issue_type.should_detect_escalation()
     )
@@ -501,32 +498,21 @@ def post_process_group(
     """
     Fires post processing hooks for a group.
     """
-    from sentry.ingest.types import ConsumerType
     from sentry.utils import snuba
 
     with snuba.options_override({"consistent": True}):
         from sentry import eventstore
-        from sentry.eventstore.processing import (
-            event_processing_store,
-            transaction_processing_store,
-        )
-        from sentry.ingest.transaction_clusterer.datasource.redis import (
-            record_transaction_name as record_transaction_name_for_clustering,
-        )
+        from sentry.eventstore.processing import event_processing_store
         from sentry.issues.occurrence_consumer import EventLookupError
         from sentry.models.organization import Organization
         from sentry.models.project import Project
         from sentry.reprocessing2 import is_reprocessed_event
 
-        if eventstream_type == EventStreamEventType.Transaction.value:
-            processing_store = transaction_processing_store
-        else:
-            processing_store = event_processing_store
         if occurrence_id is None:
             # We use the data being present/missing in the processing store
             # to ensure that we don't duplicate work should the forwarding consumers
             # need to rewind history.
-            data = processing_store.get(cache_key)
+            data = event_processing_store.get(cache_key)
             if not data:
 
                 logger.info(
@@ -535,7 +521,7 @@ def post_process_group(
                 )
                 return
             with metrics.timer("tasks.post_process.delete_event_cache"):
-                processing_store.delete_by_key(cache_key)
+                event_processing_store.delete_by_key(cache_key)
             occurrence = None
             event = process_event(data, group_id)
         else:
@@ -607,25 +593,6 @@ def post_process_group(
         is_reprocessed = is_reprocessed_event(event.data)
         sentry_sdk.set_tag("is_reprocessed", is_reprocessed)
 
-        is_transaction_event = event.get_event_type() == "transaction"
-
-        # Simplified post processing for transaction events.
-        # This should eventually be completely removed and transactions
-        # will not go through any post processing.
-        if is_transaction_event:
-            record_transaction_name_for_clustering(event.project, event.data)
-            with sentry_sdk.start_span(op="tasks.post_process_group.transaction_processed_signal"):
-                transaction_processed.send_robust(
-                    sender=post_process_group,
-                    project=event.project,
-                    event=event,
-                )
-            track_sampled_event(
-                event.event_id,
-                ConsumerType.Transactions,
-                TransactionStageStatus.POST_PROCESS_FINISHED,
-            )
-
         metric_tags = {}
         if group_id:
             group_state: GroupState = {
@@ -638,7 +605,7 @@ def post_process_group(
             group_event = update_event_group(event, group_state)
             bind_organization_context(event.project.organization)
             _capture_event_stats(event)
-            if should_update_escalating_metrics(event, is_transaction_event):
+            if should_update_escalating_metrics(event):
                 _update_escalating_metrics(event)
 
             group_event.occurrence = occurrence


### PR DESCRIPTION
now that https://github.com/getsentry/sentry/issues/81065 has been completed, we can remove all transactions logic from post_process.

re-opening of https://github.com/getsentry/sentry/pull/81821