### PR TITLE
:wrench: chore: add event lifecycle manager for integration middleware

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -133,6 +133,7 @@ class IntegrationDomain(StrEnum):
     SOURCE_CODE_MANAGEMENT = "source_code_management"
     ON_CALL_SCHEDULING = "on_call_scheduling"
     IDENTITY = "identity"  # for identity pipelines
+    MIDDLEWARE = "middleware"
 
 
 class IntegrationProviderSlug(StrEnum):

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -133,7 +133,6 @@ class IntegrationDomain(StrEnum):
     SOURCE_CODE_MANAGEMENT = "source_code_management"
     ON_CALL_SCHEDULING = "on_call_scheduling"
     IDENTITY = "identity"  # for identity pipelines
-    MIDDLEWARE = "middleware"
 
 
 class IntegrationProviderSlug(StrEnum):

--- a/src/sentry/integrations/errors.py
+++ b/src/sentry/integrations/errors.py
@@ -4,11 +4,3 @@ class InvalidProviderException(Exception):
     """
 
     pass
-
-
-class IntegrationMiddlewareException(Exception):
-    """
-    Exception that is raised when an error occurs in the integration middleware.
-    """
-
-    pass

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -264,12 +264,7 @@ class BaseRequestParser:
             operation_type=MiddlewareOperationType.GET_RESPONSE_FROM_ALL_REGIONS,
             integration_name=self.provider,
         ).capture() as lifecycle:
-            lifecycle.add_extras(
-                {
-                    "path": self.request.path,
-                    "regions": regions,
-                }
-            )
+            lifecycle.add_extra("path", self.request.path)
             if len(successful_responses) == 0:
                 error_map_str = ", ".join(
                     f"{region}: {result.error}" for region, result in response_map.items()

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -85,11 +85,6 @@ class BaseRequestParser:
                 }
             )
             if SiloMode.get_current_mode() != SiloMode.CONTROL:
-                lifecycle.record_failure(
-                    SiloLimit.AvailabilityError(
-                        "Integration Request Parsers should only be run on the control silo."
-                    )
-                )
                 raise SiloLimit.AvailabilityError(
                     "Integration Request Parsers should only be run on the control silo."
                 )

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -55,10 +55,6 @@ class RegionResult:
 class BaseRequestParser:
     """Base Class for Integration Request Parsers"""
 
-    _METRIC_SUCCESS_KEY = "integrations.middleware.request_parser.success"
-    _METRIC_FAILURE_KEY = "integrations.middleware.request_parser.failure"
-    _METRICS_INFO_KEY = "integrations.middleware.request_parser.info"
-
     # abstract
     provider: ClassVar[str]
     webhook_identifier: ClassVar[WebhookProviderIdentifier]
@@ -71,12 +67,15 @@ class BaseRequestParser:
             self.view_class = self.match.func.view_class
         self.response_handler = response_handler
 
+    def get_provider(self) -> str:
+        return getattr(self, "provider", "")
+
     # Common Helpers
 
     def ensure_control_silo(self):
         with MiddlewareOperationEvent(
             operation_type=MiddlewareOperationType.ENSURE_CONTROL_SILO,
-            integration_name=self.provider,
+            integration_name=self.get_provider(),
         ).capture() as lifecycle:
             lifecycle.add_extras(
                 {
@@ -104,7 +103,7 @@ class BaseRequestParser:
 
         with MiddlewareOperationEvent(
             operation_type=MiddlewareOperationType.GET_RESPONSE_FROM_CONTROL_SILO,
-            integration_name=self.provider,
+            integration_name=self.get_provider(),
         ).capture() as lifecycle:
             lifecycle.add_extra("path", self.request.path)
             response = self.response_handler(self.request)
@@ -119,7 +118,7 @@ class BaseRequestParser:
             region_client = RegionSiloClient(region, retry=True)
             with MiddlewareOperationEvent(
                 operation_type=MiddlewareOperationType.GET_RESPONSE_FROM_REGION_SILO,
-                integration_name=self.provider,
+                integration_name=self.get_provider(),
                 region=region.name,
             ).capture() as lifecycle:
                 lifecycle.add_extras(
@@ -300,7 +299,7 @@ class BaseRequestParser:
         """
         with MiddlewareOperationEvent(
             operation_type=MiddlewareOperationType.GET_ORGANIZATIONS_FROM_INTEGRATION,
-            integration_name=self.provider,
+            integration_name=self.get_provider(),
         ).capture() as lifecycle:
             lifecycle.add_extras(
                 {

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -80,7 +80,7 @@ class BaseRequestParser(ABC):
             lifecycle.add_extras(
                 {
                     "path": self.request.path,
-                    "silo": str(SiloMode.get_current_mode().value),
+                    "silo": SiloMode.get_current_mode().value,
                 }
             )
             if SiloMode.get_current_mode() != SiloMode.CONTROL:

--- a/src/sentry/integrations/middleware/metrics.py
+++ b/src/sentry/integrations/middleware/metrics.py
@@ -1,0 +1,57 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
+
+
+class MiddlewareOperationType(StrEnum):
+    """Different types of operations that middleware can perform."""
+
+    ENSURE_CONTROL_SILO = "ensure_control_silo"
+
+    GET_RESPONSE_FROM_CONTROL_SILO = "get_response_from_control_silo"
+    GET_RESPONSE_FROM_REGION_SILO = "get_response_from_region_silo"
+    GET_RESPONSE_FROM_FIRST_REGION = "get_response_from_first_region"
+    GET_RESPONSE_FROM_ALL_REGIONS = "get_response_from_all_regions"
+
+    GET_ORGANIZATIONS_FROM_INTEGRATION = "get_organizations_from_integration"
+
+
+@dataclass
+class MiddlewareOperationEvent(EventLifecycleMetric):
+    """An instance to be recorded of a middleware operation."""
+
+    operation_type: MiddlewareOperationType
+    integration_name: str | None = None
+    region: str | None = None
+
+    def get_integration_name(self) -> str:
+        return self.integration_name or ""
+
+    def get_region(self) -> str:
+        return self.region or ""
+
+    def get_metric_key(self, outcome: EventLifecycleOutcome) -> str:
+        tokens = ("integration", "middleware", str(outcome))
+        return ".".join(tokens)
+
+    def get_metric_tags(self) -> Mapping[str, str]:
+        return {
+            "operation_type": self.operation_type,
+            "integration_name": self.get_integration_name(),
+            "region": self.get_region(),
+        }
+
+
+class MiddlewareFailureReason(StrEnum):
+    """Common reasons why a middleware request may fail."""
+
+    MISSING_DATA = "missing_data"
+    INVALID_STATE = "invalid_state"
+
+
+class MiddlewareHaltReason(StrEnum):
+    """Common reasons why a middleware request may halt."""
+
+    MISSING_ACTION = "missing_action"

--- a/src/sentry/integrations/middleware/metrics.py
+++ b/src/sentry/integrations/middleware/metrics.py
@@ -11,12 +11,12 @@ class MiddlewareOperationType(StrEnum):
 
     ENSURE_CONTROL_SILO = "ensure_control_silo"
 
-    GET_RESPONSE_FROM_CONTROL_SILO = "get_response_from_control_silo"
-    GET_RESPONSE_FROM_REGION_SILO = "get_response_from_region_silo"
+    GET_CONTROL_RESPONSE = "get_control_response"
+    GET_REGION_RESPONSE = "get_region_response"
     GET_RESPONSE_FROM_FIRST_REGION = "get_response_from_first_region"
     GET_RESPONSE_FROM_ALL_REGIONS = "get_response_from_all_regions"
 
-    GET_ORGANIZATIONS_FROM_INTEGRATION = "get_organizations_from_integration"
+    GET_ORGS_FROM_INTEGRATION = "get_orgs_from_integration"
 
 
 @dataclass

--- a/src/sentry/integrations/middleware/metrics.py
+++ b/src/sentry/integrations/middleware/metrics.py
@@ -2,7 +2,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
-from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.integrations.utils.metrics import EventLifecycleMetric
 
 
 class MiddlewareOperationType(StrEnum):

--- a/src/sentry/integrations/middleware/metrics.py
+++ b/src/sentry/integrations/middleware/metrics.py
@@ -42,16 +42,3 @@ class MiddlewareOperationEvent(EventLifecycleMetric):
             "integration_name": self.get_integration_name(),
             "region": self.get_region(),
         }
-
-
-class MiddlewareFailureReason(StrEnum):
-    """Common reasons why a middleware request may fail."""
-
-    MISSING_DATA = "missing_data"
-    INVALID_STATE = "invalid_state"
-
-
-class MiddlewareHaltReason(StrEnum):
-    """Common reasons why a middleware request may halt."""
-
-    MISSING_ACTION = "missing_action"

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -94,3 +94,19 @@ def assert_slo_metric(
     start, end = mock_record.mock_calls
     assert start.args[0] == EventLifecycleOutcome.STARTED
     assert end.args[0] == event_outcome
+
+
+def assert_slo_metric_calls(
+    mock_calls, event_outcome: EventLifecycleOutcome = EventLifecycleOutcome.SUCCESS
+):
+    start, end = mock_calls
+    assert start.args[0] == EventLifecycleOutcome.STARTED
+    assert end.args[0] == event_outcome
+
+
+def assert_middleware_metrics(middleware_calls):
+    start1, end1, start2, end2 = middleware_calls
+    assert start1.args[0] == EventLifecycleOutcome.STARTED
+    assert end1.args[0] == EventLifecycleOutcome.SUCCESS
+    assert start2.args[0] == EventLifecycleOutcome.STARTED
+    assert end2.args[0] == EventLifecycleOutcome.SUCCESS


### PR DESCRIPTION
adding event lifecycle manager for our integration middleware. it allows us to remove a lot of repetitive metrics/slo code.

waiting for CI to fail for failed tests, couldn't find where we test the base parser.l