### PR TITLE
feat(aci): connect automations + monitors views to router

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -12,6 +12,8 @@ import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 import App from 'sentry/views/app';
 import AuthLayout from 'sentry/views/auth/layout';
+import {AutomationRoutes} from 'sentry/views/automations/routes';
+import {DetectorRoutes} from 'sentry/views/detectors/routes';
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {SUMMARY_PAGE_BASE_URL} from 'sentry/views/insights/mobile/screenRendering/settings';
 import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
@@ -2275,6 +2277,8 @@ function buildRoutes() {
 
   const organizationRoutes = (
     <Route component={errorHandler(OrganizationLayout)}>
+      <AutomationRoutes />
+      <DetectorRoutes />
       {settingsRoutes}
       {projectsRoutes}
       {dashboardRoutes}

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -3,7 +3,7 @@ import {IndexRoute, Route} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/routes';
 
 export function AutomationRoutes() {
-  const root = `/issues/automations/`;
+  const root = `/automations/`;
   return (
     <Feature features="workflow-engine-ui">
       <Route path={root} withOrgPath>

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,0 +1,21 @@
+import {IndexRoute, Redirect, Route} from 'sentry/components/route';
+import {makeLazyloadComponent as make} from 'sentry/routes';
+
+export function AutomationRoutes() {
+  const root = `/automations/`;
+  return (
+    <Route path={root} withOrgPath>
+      <IndexRoute component={make(() => import('sentry/views/automations/list'))} />
+      <Redirect from=":slug/" to={root} />
+      <Redirect from=":slug/edit/" to={root} />
+      <Route
+        path=":projectId/:slug/"
+        component={make(() => import('sentry/views/automations/detail'))}
+      />
+      <Route
+        path=":projectId/:slug/edit/"
+        component={make(() => import('sentry/views/automations/edit'))}
+      />
+    </Route>
+  );
+}

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,21 +1,22 @@
-import {IndexRoute, Redirect, Route} from 'sentry/components/route';
+import Feature from 'sentry/components/acl/feature';
+import {IndexRoute, Route} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/routes';
 
 export function AutomationRoutes() {
-  const root = `/automations/`;
+  const root = `/issues/automations/`;
   return (
-    <Route path={root} withOrgPath>
-      <IndexRoute component={make(() => import('sentry/views/automations/list'))} />
-      <Redirect from=":slug/" to={root} />
-      <Redirect from=":slug/edit/" to={root} />
-      <Route
-        path=":projectId/:slug/"
-        component={make(() => import('sentry/views/automations/detail'))}
-      />
-      <Route
-        path=":projectId/:slug/edit/"
-        component={make(() => import('sentry/views/automations/edit'))}
-      />
-    </Route>
+    <Feature features="workflow-engine-ui">
+      <Route path={root} withOrgPath>
+        <IndexRoute component={make(() => import('sentry/views/automations/list'))} />
+        <Route
+          path=":automationId/"
+          component={make(() => import('sentry/views/automations/detail'))}
+        />
+        <Route
+          path=":automationId/edit/"
+          component={make(() => import('sentry/views/automations/edit'))}
+        />
+      </Route>
+    </Feature>
   );
 }

--- a/static/app/views/detectors/routes.tsx
+++ b/static/app/views/detectors/routes.tsx
@@ -1,0 +1,21 @@
+import {IndexRoute, Redirect, Route} from 'sentry/components/route';
+import {makeLazyloadComponent as make} from 'sentry/routes';
+
+export function DetectorRoutes() {
+  const root = `/monitors/`;
+  return (
+    <Route path={root} withOrgPath>
+      <IndexRoute component={make(() => import('sentry/views/detectors/list'))} />
+      <Redirect from=":slug/" to={root} />
+      <Redirect from=":slug/edit/" to={root} />
+      <Route
+        path=":projectId/:slug/"
+        component={make(() => import('sentry/views/detectors/detail'))}
+      />
+      <Route
+        path=":projectId/:slug/edit/"
+        component={make(() => import('sentry/views/detectors/edit'))}
+      />
+    </Route>
+  );
+}

--- a/static/app/views/detectors/routes.tsx
+++ b/static/app/views/detectors/routes.tsx
@@ -1,21 +1,22 @@
-import {IndexRoute, Redirect, Route} from 'sentry/components/route';
+import Feature from 'sentry/components/acl/feature';
+import {IndexRoute, Route} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/routes';
 
 export function DetectorRoutes() {
-  const root = `/monitors/`;
+  const root = `/issues/monitors/`;
   return (
-    <Route path={root} withOrgPath>
-      <IndexRoute component={make(() => import('sentry/views/detectors/list'))} />
-      <Redirect from=":slug/" to={root} />
-      <Redirect from=":slug/edit/" to={root} />
-      <Route
-        path=":projectId/:slug/"
-        component={make(() => import('sentry/views/detectors/detail'))}
-      />
-      <Route
-        path=":projectId/:slug/edit/"
-        component={make(() => import('sentry/views/detectors/edit'))}
-      />
-    </Route>
+    <Feature features="workflow-engine-ui">
+      <Route path={root} withOrgPath>
+        <IndexRoute component={make(() => import('sentry/views/detectors/list'))} />
+        <Route
+          path=":monitorId/"
+          component={make(() => import('sentry/views/detectors/detail'))}
+        />
+        <Route
+          path=":monitorId/edit/"
+          component={make(() => import('sentry/views/detectors/edit'))}
+        />
+      </Route>
+    </Feature>
   );
 }

--- a/static/app/views/detectors/routes.tsx
+++ b/static/app/views/detectors/routes.tsx
@@ -3,7 +3,7 @@ import {IndexRoute, Route} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/routes';
 
 export function DetectorRoutes() {
-  const root = `/issues/monitors/`;
+  const root = `/monitors/`;
   return (
     <Feature features="workflow-engine-ui">
       <Route path={root} withOrgPath>


### PR DESCRIPTION
## ACI M6.2: View Scaffolding

Connects new ACI views (Automations and Monitors) to router. Uses a new pattern where the route definitions are exported from the relevant directory rather than managed in the monolithic file.

✅ Closes [`ACI-65`](https://getsentry.atlassian.net/browse/ACI-65)