### PR TITLE
chore(audit-logs): Make sure that valid data is passed into `create_audit_entry_from_user`

### DIFF
--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -75,6 +75,7 @@ def create_audit_entry_from_user(
     **kwargs: Any,
 ) -> AuditLogEntry:
     organization_id = _org_id(organization, organization_id)
+    assert user is not None or api_key is not None or ip_address is not None
 
     entry = AuditLogEntry(
         actor_id=user.id if user else None,


### PR DESCRIPTION
It was possible to create an audit log without passing one of user, api_key or ip_address to `create_audit_entry_from_user`. This then got stuck in the outboxes and had to be cleaned up manually. Adding an assert so tests will catch it.

<!-- Describe your PR here. -->