### PR TITLE
ref(save_event): dont update processing store for transactions

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -570,10 +570,15 @@ def _do_save_event(
             )
             # Put the updated event back into the cache so that post_process
             # has the most recent data.
-            data = manager.get_data()
-            if not isinstance(data, dict):
-                data = dict(data.items())
-            processing_store.store(data)
+
+            # We don't need to update the event in the processing_store for transaction events
+            # because they're not used in post_process.
+            if consumer_type != ConsumerType.Transactions:
+                data = manager.get_data()
+                if not isinstance(data, dict):
+                    data = dict(data.items())
+                processing_store.store(data)
+
         except HashDiscarded:
             # Delete the event payload from cache since it won't show up in post-processing.
             if cache_key:

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -392,3 +392,4 @@ def test_store_consumer_type(
 
     mock_transaction_processing_store.get.assert_called_once_with("tx:3")
     mock_transaction_processing_store.delete_by_key.assert_called_once_with("tx:3")
+    mock_transaction_processing_store.store.assert_not_called()


### PR DESCRIPTION
as https://github.com/getsentry/sentry/issues/81065 is rolled out, we no longer have transactions go through post_process. therefore, we can go ahead and not update the processing store with the event in this case. (the event is deleted in the `finally` block below, at any rate).

this should save a decent amount of load on our processing store, as it does this for every transaction at the moment.