### PR TITLE
chore(sentr apps): Allow sentry app errors messages to take in kwargs

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -141,7 +141,7 @@ class IntegrationPlatformEndpoint(Endpoint):
             error_id = sentry_sdk.capture_exception(exception)
             return Response(
                 {
-                    "detail": f"An issue occured during the integration platform process. Sentry error ID: {error_id}"
+                    "detail": f"An issue occurred during the integration platform process. Sentry error ID: {error_id}"
                 },
                 status=500,
             )

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -131,9 +131,7 @@ class IntegrationPlatformEndpoint(Endpoint):
 
     def _handle_sentry_app_exception(self, exception: Exception):
         if isinstance(exception, SentryAppIntegratorError) or isinstance(exception, SentryAppError):
-            response = Response(
-                {"detail": str(exception), **exception.details}, status=exception.status_code
-            )
+            response = Response({"detail": str(exception)}, status=exception.status_code)
             response.exception = True
             return response
 

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -131,7 +131,9 @@ class IntegrationPlatformEndpoint(Endpoint):
 
     def _handle_sentry_app_exception(self, exception: Exception):
         if isinstance(exception, SentryAppIntegratorError) or isinstance(exception, SentryAppError):
-            response = Response({"detail": str(exception)}, status=exception.status_code)
+            response = Response(
+                {"detail": str(exception), **exception.details}, status=exception.status_code
+            )
             response.exception = True
             return response
 

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any
 
 
 class SentryAppErrorType(Enum):
@@ -16,9 +17,12 @@ class SentryAppError(Exception):
         self,
         error: Exception | None = None,
         status_code: int | None = None,
+        **details: Any,
     ) -> None:
         if status_code:
             self.status_code = status_code
+        self.details = details
+        self.error = error
 
 
 # Represents an error caused by a 3p integrator during a Sentry App process
@@ -30,9 +34,12 @@ class SentryAppIntegratorError(Exception):
         self,
         error: Exception | None = None,
         status_code: int | None = None,
+        **details: Any,
     ) -> None:
         if status_code:
             self.status_code = status_code
+        self.error = error
+        self.details = details
 
 
 # Represents an error that's our (sentry's) fault
@@ -47,3 +54,4 @@ class SentryAppSentryError(Exception):
     ) -> None:
         if status_code:
             self.status_code = status_code
+        self.error = error

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import Any
+
+from sentry.utils import json
 
 
 class SentryAppErrorType(Enum):
@@ -8,50 +9,37 @@ class SentryAppErrorType(Enum):
     SENTRY = "sentry"
 
 
+class SentryAppBaseError(Exception):
+    error_type: SentryAppErrorType
+    status_code: int
+
+    def __init__(
+        self,
+        error: Exception | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        self.status_code = status_code or self.status_code
+        self.error = error
+
+    def __str__(self) -> str:
+        if self.error is not None:
+            return json.dumps(self.error.args)
+        return ""
+
+
 # Represents a user/client error that occured during a Sentry App process
-class SentryAppError(Exception):
+class SentryAppError(SentryAppBaseError):
     error_type = SentryAppErrorType.CLIENT
     status_code = 400
 
-    def __init__(
-        self,
-        error: Exception | None = None,
-        status_code: int | None = None,
-        **details: Any,
-    ) -> None:
-        if status_code:
-            self.status_code = status_code
-        self.details = details
-        self.error = error
-
 
 # Represents an error caused by a 3p integrator during a Sentry App process
-class SentryAppIntegratorError(Exception):
+class SentryAppIntegratorError(SentryAppBaseError):
     error_type = SentryAppErrorType.INTEGRATOR
     status_code = 400
 
-    def __init__(
-        self,
-        error: Exception | None = None,
-        status_code: int | None = None,
-        **details: Any,
-    ) -> None:
-        if status_code:
-            self.status_code = status_code
-        self.error = error
-        self.details = details
-
 
 # Represents an error that's our (sentry's) fault
-class SentryAppSentryError(Exception):
+class SentryAppSentryError(SentryAppBaseError):
     error_type = SentryAppErrorType.SENTRY
     status_code = 500
-
-    def __init__(
-        self,
-        error: Exception | None = None,
-        status_code: int | None = None,
-    ) -> None:
-        if status_code:
-            self.status_code = status_code
-        self.error = error

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from enum import Enum
 
 from sentry.utils import json
@@ -22,9 +23,10 @@ class SentryAppBaseError(Exception):
         self.error = error
 
     def __str__(self) -> str:
-        if self.error is not None:
-            return json.dumps(self.error.args)
-        return ""
+        if isinstance(Mapping, self.error.args[0]):
+            return json.dumps(self.error.args[0])
+        else:
+            return str(self.error.args[0])
 
 
 # Represents a user/client error that occured during a Sentry App process

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from enum import Enum
 
 from sentry.utils import json
@@ -23,7 +23,7 @@ class SentryAppBaseError(Exception):
         self.error = error
 
     def __str__(self) -> str:
-        if isinstance(Mapping, self.error.args[0]):
+        if isinstance((Mapping, Sequence), self.error.args[0]):
             return json.dumps(self.error.args[0])
         else:
             return str(self.error.args[0])


### PR DESCRIPTION
Because of how we stringify an error in the current error handler we're lmited to only strings (i.e can't accept/stringify dictionaries) in the error messages which is limiting. This PR has the constructor for the error take in extras that we insert in the handler.

-->> Please give suggestions on how to do this better if possible ;-;