### PR TITLE
fix(new-trace): Displaying additional data values correctly

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/additionalData.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/additionalData.tsx
@@ -40,7 +40,7 @@ function getEventExtraDataKnownDataDetails({
     default:
       return {
         subject: type,
-        value: [type],
+        value: data[type],
       };
   }
 }
@@ -62,6 +62,7 @@ export function AdditionalData({event}: {event: EventTransaction}) {
     meta: event._meta?.context,
     onGetKnownDataDetails: v => getEventExtraDataKnownDataDetails(v),
   });
+
   const formattedDataItems: SectionCardKeyValueList = raw
     ? knownData
     : knownData.map(data => {


### PR DESCRIPTION
Before:
<img width="733" alt="Screenshot 2025-01-08 at 7 16 30 PM" src="https://github.com/user-attachments/assets/e5d7a86b-5d89-4753-a853-06e0423a70d6" />


After:
<img width="599" alt="Screenshot 2025-01-08 at 7 15 58 PM" src="https://github.com/user-attachments/assets/0a18416d-006d-4e3f-a8dc-9e9e4de678a1" />
