### PR TITLE
feat(issue-details): Make View JSON button more visible

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -152,6 +152,12 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
                   label: t('Copy Event Link'),
                   onAction: copyLink,
                 },
+                {
+                  key: 'view-json',
+                  label: t('View JSON'),
+                  onAction: downloadJson,
+                  className: 'hidden-sm hidden-md hidden-lg',
+                },
               ]}
             />
             <StyledTimeSince

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -326,6 +326,7 @@ const JsonLinkWrapper = styled('div')`
 const JsonLink = styled(ExternalLink)`
   color: ${p => p.theme.gray300};
   text-decoration: underline;
+  text-decoration-color: ${p => p.theme.translucentGray200};
 
   :hover {
     color: ${p => p.theme.gray300};

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -316,7 +316,7 @@ const JsonButtonWrapper = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${space(0.5)};
 
   @media (max-width: ${p => p.theme.breakpoints.xsmall}) {
     display: none;

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -161,15 +161,17 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
               css={grayText}
               aria-label={t('Event timestamp')}
             />
-            <Divider />
-            <ViewJsonButton
-              borderless
-              size="zero"
-              onClick={downloadJson}
-              icon={<IconJson />}
-            >
-              {t('View JSON')}
-            </ViewJsonButton>
+            <JsonButtonWrapper>
+              <Divider />
+              <ViewJsonButton
+                borderless
+                size="zero"
+                onClick={downloadJson}
+                icon={<IconJson />}
+              >
+                {t('View JSON')}
+              </ViewJsonButton>
+            </JsonButtonWrapper>
             {hasEventError && (
               <Fragment>
                 <Divider />
@@ -308,4 +310,15 @@ const ViewJsonButton = styled(Button)`
   color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const JsonButtonWrapper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(1)};
+
+  @media (max-width: ${p => p.theme.breakpoints.xsmall}) {
+    display: none;
+  }
 `;

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -6,9 +6,10 @@ import {Button, LinkButton} from 'sentry/components/button';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {useActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import TimeSince from 'sentry/components/timeSince';
-import {IconJson, IconWarning} from 'sentry/icons';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -88,9 +89,10 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
       font-weight: ${theme.fontWeightNormal};
     `;
 
+    const host = organization.links.regionUrl;
+    const jsonUrl = `${host}/api/0/projects/${organization.slug}/${group.project.slug}/events/${event.id}/json/`;
+
     const downloadJson = () => {
-      const host = organization.links.regionUrl;
-      const jsonUrl = `${host}/api/0/projects/${organization.slug}/${group.project.slug}/events/${event.id}/json/`;
       window.open(jsonUrl);
       trackAnalytics('issue_details.event_json_clicked', {
         organization,
@@ -167,17 +169,21 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
               css={grayText}
               aria-label={t('Event timestamp')}
             />
-            <JsonButtonWrapper>
+            <JsonLinkWrapper className="hidden-xs">
               <Divider />
-              <ViewJsonButton
-                borderless
-                size="zero"
-                onClick={downloadJson}
-                icon={<IconJson />}
+              <JsonLink
+                href={jsonUrl}
+                onClick={() =>
+                  trackAnalytics('issue_details.event_json_clicked', {
+                    organization,
+                    group_id: parseInt(`${event.groupID}`, 10),
+                    streamline: true,
+                  })
+                }
               >
-                {t('View JSON')}
-              </ViewJsonButton>
-            </JsonButtonWrapper>
+                {t('JSON')}
+              </JsonLink>
+            </JsonLinkWrapper>
             {hasEventError && (
               <Fragment>
                 <Divider />
@@ -312,19 +318,16 @@ const ProcessingErrorButton = styled(Button)`
   }
 `;
 
-const ViewJsonButton = styled(Button)`
-  color: ${p => p.theme.subText};
-  font-weight: ${p => p.theme.fontWeightNormal};
-  font-size: ${p => p.theme.fontSizeSmall};
+const JsonLinkWrapper = styled('div')`
+  display: flex;
+  gap: ${space(0.5)};
 `;
 
-const JsonButtonWrapper = styled('div')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: ${space(0.5)};
+const JsonLink = styled(ExternalLink)`
+  color: ${p => p.theme.gray300};
+  text-decoration: underline;
 
-  @media (max-width: ${p => p.theme.breakpoints.xsmall}) {
-    display: none;
+  :hover {
+    color: ${p => p.theme.gray300};
   }
 `;

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -8,7 +8,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {useActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import TimeSince from 'sentry/components/timeSince';
-import {IconWarning} from 'sentry/icons';
+import {IconJson, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -152,11 +152,6 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
                   label: t('Copy Event Link'),
                   onAction: copyLink,
                 },
-                {
-                  key: 'view-json',
-                  label: t('View JSON'),
-                  onAction: downloadJson,
-                },
               ]}
             />
             <StyledTimeSince
@@ -166,6 +161,15 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
               css={grayText}
               aria-label={t('Event timestamp')}
             />
+            <Divider />
+            <ViewJsonButton
+              borderless
+              size="zero"
+              onClick={downloadJson}
+              icon={<IconJson />}
+            >
+              {t('View JSON')}
+            </ViewJsonButton>
             {hasEventError && (
               <Fragment>
                 <Divider />
@@ -298,4 +302,10 @@ const ProcessingErrorButton = styled(Button)`
   :hover {
     color: ${p => p.theme.red300};
   }
+`;
+
+const ViewJsonButton = styled(Button)`
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;


### PR DESCRIPTION
this pr makes the view JSON button more visible in the streamlined issue details experience, which addresses a common piece of feedback. design follows what we are doing for  the "Processing Error" button in the same section of the page

<img width="304" alt="Screenshot 2025-01-09 at 11 15 35 AM" src="https://github.com/user-attachments/assets/c4a94475-8c72-4f45-8ce7-4d0776ed243e" />

