### PR TITLE
feat(issues): Persist attachments view to lcoalstorage

### DIFF
--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
@@ -10,7 +11,9 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group, IssueAttachment} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
@@ -35,9 +38,34 @@ function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
   const hasStreamlinedUI = useHasStreamlinedUI();
   const eventQuery = useEventQuery({groupId: group.id});
   const eventView = useIssueDetailsEventView({group});
+  const navigate = useNavigate();
+  const [previouslyUsedAttachmentsTab, setPreviouslyUsedAttachmentsTab] =
+    useLocalStorageState(
+      `issue-details-attachments-default-tab-${project.id}`,
+      EventAttachmentFilter.ALL
+    );
+
   const activeAttachmentsTab =
     (location.query.attachmentFilter as EventAttachmentFilter | undefined) ??
+    previouslyUsedAttachmentsTab ??
     EventAttachmentFilter.ALL;
+
+  // Persist the previously used attachments tab in the URL if it's not already set
+  useEffect(() => {
+    if (
+      !location.query.attachmentFilter &&
+      previouslyUsedAttachmentsTab !== EventAttachmentFilter.ALL
+    ) {
+      navigate(
+        {
+          pathname: location.pathname,
+          query: {...location.query, attachmentFilter: previouslyUsedAttachmentsTab},
+        },
+        {replace: true}
+      );
+    }
+  }, [previouslyUsedAttachmentsTab, location, navigate]);
+
   const {attachments, isPending, isError, getResponseHeader, refetch} =
     useGroupEventAttachments({
       group,
@@ -128,7 +156,9 @@ function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
             <IconFilter size="xs" />
             {t('Results are filtered by the selections above.')}
           </FilterMessage>
-          <GroupEventAttachmentsFilter />
+          <GroupEventAttachmentsFilter
+            onChange={key => setPreviouslyUsedAttachmentsTab(key)}
+          />
         </Flex>
       ) : (
         <GroupEventAttachmentsFilter />

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -32,6 +32,8 @@ type GroupEventAttachmentsProps = {
   project: Project;
 };
 
+const DEFAULT_ATTACHMENTS_TAB = EventAttachmentFilter.ALL;
+
 function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
   const location = useLocation();
   const organization = useOrganization();
@@ -42,19 +44,19 @@ function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
   const [previouslyUsedAttachmentsTab, setPreviouslyUsedAttachmentsTab] =
     useLocalStorageState(
       `issue-details-attachments-default-tab-${project.id}`,
-      EventAttachmentFilter.ALL
+      DEFAULT_ATTACHMENTS_TAB
     );
 
   const activeAttachmentsTab =
     (location.query.attachmentFilter as EventAttachmentFilter | undefined) ??
     previouslyUsedAttachmentsTab ??
-    EventAttachmentFilter.ALL;
+    DEFAULT_ATTACHMENTS_TAB;
 
-  // Persist the previously used attachments tab in the URL if it's not already set
+  // Persist the previously used attachments tab in the url if it's not already set
   useEffect(() => {
     if (
       !location.query.attachmentFilter &&
-      previouslyUsedAttachmentsTab !== EventAttachmentFilter.ALL
+      previouslyUsedAttachmentsTab !== DEFAULT_ATTACHMENTS_TAB
     ) {
       navigate(
         {

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -13,7 +13,11 @@ export const enum EventAttachmentFilter {
 
 type AttachmentFilterValue = `${EventAttachmentFilter}`;
 
-function GroupEventAttachmentsFilter() {
+interface GroupEventAttachmentsFilterProps {
+  onChange?: (filter: EventAttachmentFilter) => void;
+}
+
+function GroupEventAttachmentsFilter({onChange}: GroupEventAttachmentsFilterProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -35,6 +39,7 @@ function GroupEventAttachmentsFilter() {
             },
             {replace: true}
           );
+          onChange?.(key as EventAttachmentFilter);
         }}
       >
         <SegmentedControl.Item key={EventAttachmentFilter.ALL}>


### PR DESCRIPTION
Per project, if the user previously filtered by screenshots, will default to the screenshots filter on next visit.
