### PR TITLE
chore(seer grouping): Change extra data sent with old excess frames behavior log

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -9,6 +9,7 @@ from sentry import options
 from sentry import ratelimits as ratelimiter
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
+from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
@@ -210,6 +211,10 @@ def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant])
             event, variants, ReferrerOptions.INGEST, record_metrics=False
         ),
     }
+    _, contributing_component = get_contributing_variant_and_component(variants)
+    if contributing_component is not None and hasattr(contributing_component, "frame_counts"):
+        logger_extra["frame_counts"] = contributing_component.frame_counts
+
     stacktrace_string = get_stacktrace_string_with_metrics(
         get_grouping_info_from_variants(variants),
         event.platform,

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any, TypedDict, TypeVar
@@ -288,8 +287,6 @@ def get_stacktrace_string_with_metrics(
         )
         if referrer == ReferrerOptions.INGEST:
             # Temporary log to debug how we're still landing here, which we shouldn't be anymore
-            logger_extra = logger_extra or {}
-            logger_extra.update({"current_stacktrace": "".join(traceback.format_stack())})
             logger.info(
                 "record_did_call_seer_metric.over-threshold-frames",
                 extra=logger_extra,


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/83082, which added a temporary log to help debug how we're still landing in the old excess-frame-check logic. Some logs have come through and a) the stacktrace is what you'd expect, so we can stop sending it, and b) the new check is giving a false negative, so now we need to see the data on which it's basing its decision (the frame counts). 

Interestingly, so far all of the events in question come from the same project. I spot-checked one event and it looked normal... We'll see what this new log data turns up.