### PR TITLE
fixed missing underscore

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -436,7 +436,7 @@ A list of filters that determine if a rule fires after the necessary conditions 
 ```
 
 **The event's `attribute` value `match` `value`**
-- `attribute` - Valid values are `message`, `platform`, `environment`, `type`, `error.handled`, `error.unhandled`, `error.main_thread`, `exception.type`, `exception.value`, `user.id`, `user.email`, `user.username`, `user.ip_address`, `http.method`, `http.url`, `http.status_code`, `sdk.name`, `stacktrace.code`, `stacktrace.module`, `stacktrace.filename`, `stacktrace.abs_path`, `stacktrace.package`, `unreal.crashtype`, and `app.in_foreground`.
+- `attribute` - Valid values are `message`, `platform`, `environment`, `type`, `error.handled`, `error.unhandled`, `error.main_thread`, `exception.type`, `exception.value`, `user.id`, `user.email`, `user.username`, `user.ip_address`, `http.method`, `http.url`, `http.status_code`, `sdk.name`, `stacktrace.code`, `stacktrace.module`, `stacktrace.filename`, `stacktrace.abs_path`, `stacktrace.package`, `unreal.crash_type`, `app.in_foreground`.
 - `match` - The comparison operator. Valid values are `eq` (equals), `ne` (does not equal), `sw` (starts with), `ew` (ends with), `co` (contains), `nc` (does not contain), `is` (is set), and `ns` (is not set).
 - `value` - A string. Not required when `match` is `is` or `ns`.
 ```json

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -61,7 +61,7 @@ ATTR_CHOICES = {
     "stacktrace.filename": Columns.STACK_FILENAME,
     "stacktrace.abs_path": Columns.STACK_ABS_PATH,
     "stacktrace.package": Columns.STACK_PACKAGE,
-    "unreal.crashtype": Columns.UNREAL_CRASH_TYPE,
+    "unreal.crash_type": Columns.UNREAL_CRASH_TYPE,
     "app.in_foreground": Columns.APP_IN_FOREGROUND,
     "os.distribution_name": Columns.OS_DISTRIBUTION_NAME,
     "os.distribution_version": Columns.OS_DISTRIBUTION_VERSION,


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unreal/issues/256

Since we're checking for `crash_type` https://github.com/getsentry/sentry/blob/c11f4c099257b2388d150f71fb39516e3d3f2328/src/sentry/rules/conditions/event_attribute.py#L393 this seems to be a typo.