### PR TITLE
feat(aci): enforce workflow frequency when firing actions

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -40,7 +40,7 @@ def filter_recently_fired_workflow_actions(
             output_field=DurationField(),
         ),
         difference=ExpressionWrapper(
-            now - F("date_updated"), output_field=DurationField()
+            Value(now) - F("date_updated"), output_field=DurationField()
         ),  # how long ago the action fired
     )
     actions_to_include = set(

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -1,7 +1,69 @@
+from datetime import timedelta
+
+from django.db.models import DurationField, ExpressionWrapper, F, IntegerField, Value
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast, Coalesce
+from django.utils import timezone
+
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.workflow_engine.models import Action, DataConditionGroup, Workflow
+from sentry.models.group import Group
+from sentry.workflow_engine.models import Action, ActionGroupStatus, DataConditionGroup, Workflow
 from sentry.workflow_engine.processors.data_condition_group import evaluate_condition_group
 from sentry.workflow_engine.types import WorkflowJob
+
+
+def filter_recently_fired_workflow_actions(
+    actions: BaseQuerySet[Action], group: Group
+) -> BaseQuerySet[Action]:
+    # TODO(cathy): only reinforce workflow frequency for certain issue types
+    now = timezone.now()
+
+    statuses = ActionGroupStatus.objects.filter(group=group, action__in=actions)
+    actions_without_statuses = actions.exclude(id__in=statuses.values_list("action_id", flat=True))
+
+    # filter out actions that have recently fired for the Group according to workflow frequency
+    statuses = statuses.annotate(
+        frequency=Cast(
+            Coalesce(
+                KeyTextTransform(
+                    "frequency",
+                    F(
+                        "action__dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow__config"
+                    ),
+                ),
+                Value("30"),  # default 30
+            ),
+            output_field=IntegerField(),
+        ),
+        frequency_seconds=ExpressionWrapper(
+            F("frequency") * timedelta(minutes=1),  # convert to timedelta
+            output_field=DurationField(),
+        ),
+        difference=ExpressionWrapper(
+            now - F("date_updated"), output_field=DurationField()
+        ),  # how long ago the action fired
+    )
+    actions_to_include = set(
+        statuses.filter(difference__gt=F("frequency_seconds")).values_list("action_id", flat=True)
+    )
+
+    ActionGroupStatus.objects.filter(action__in=actions_to_include, group=group).update(
+        date_updated=now
+    )
+    ActionGroupStatus.objects.bulk_create(
+        [
+            ActionGroupStatus(action=action, group=group, date_updated=now)
+            for action in actions_without_statuses
+        ],
+        batch_size=1000,
+    )
+
+    actions_without_statuses_ids = {action.id for action in actions_without_statuses}
+    filtered_actions = Action.objects.filter(
+        id__in=actions_to_include | actions_without_statuses_ids
+    )
+
+    return filtered_actions
 
 
 def evaluate_workflow_action_filters(
@@ -23,6 +85,8 @@ def evaluate_workflow_action_filters(
             filtered_action_groups.add(action_condition)
 
     # get the actions for any of the triggered data condition groups
-    return Action.objects.filter(
+    actions = Action.objects.filter(
         dataconditiongroupaction__condition_group__in=filtered_action_groups
     ).distinct()
+
+    return filter_recently_fired_workflow_actions(actions, job["event"].group)

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -12,8 +12,8 @@ from sentry.workflow_engine.processors.data_condition_group import evaluate_cond
 from sentry.workflow_engine.types import WorkflowJob
 
 
-def get_action_statuses(now: datetime, actions: BaseQuerySet[Action], group: Group):
-    # filter out actions that have recently fired for the Group according to workflow frequency
+def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action], group: Group):
+    # Annotate the actions with the amount of time since the last update
     statuses = ActionGroupStatus.objects.filter(group=group, action__in=actions)
 
     check_workflow_frequency = Cast(
@@ -52,7 +52,7 @@ def filter_recently_fired_workflow_actions(
     actions: BaseQuerySet[Action], group: Group
 ) -> BaseQuerySet[Action]:
     now = timezone.now()
-    statuses = get_action_statuses(now, actions, group)
+    statuses = get_action_last_updated_statuses(now, actions, group)
 
     actions_without_statuses = actions.exclude(id__in=statuses.values_list("action_id", flat=True))
     actions_to_include = set(

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -1,5 +1,15 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.workflow_engine.models.action import Action
+from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors.action import evaluate_workflow_action_filters
+from sentry.workflow_engine.processors.action import (
+    evaluate_workflow_action_filters,
+    filter_recently_fired_workflow_actions,
+)
 from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -45,3 +55,56 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
         triggered_actions = evaluate_workflow_action_filters({self.workflow}, self.job)
         assert not triggered_actions
+
+
+@freeze_time("2024-01-09")
+class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
+    def setUp(self):
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
+
+        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
+        )
+        self.job = WorkflowJob({"event": self.group_event})
+
+    def test(self):
+        # test default frequency when no workflow.config set
+        status_1 = ActionGroupStatus.objects.create(action=self.action, group=self.group)
+        status_1.update(date_updated=timezone.now() - timedelta(days=1))
+
+        _, action = self.create_workflow_action(workflow=self.workflow)
+        status_2 = ActionGroupStatus.objects.create(action=action, group=self.group)
+
+        triggered_actions = filter_recently_fired_workflow_actions(Action.objects.all(), self.group)
+        assert set(triggered_actions) == {self.action}
+
+        for status in [status_1, status_2]:
+            status.refresh_from_db()
+            assert status.date_updated == timezone.now()
+
+    def test_multiple_workflows(self):
+        status_1 = ActionGroupStatus.objects.create(action=self.action, group=self.group)
+        status_1.update(date_updated=timezone.now() - timedelta(hours=1))
+
+        workflow = self.create_workflow(organization=self.organization, config={"frequency": 1440})
+        self.create_detector_workflow(detector=self.detector, workflow=workflow)
+        _, action_2 = self.create_workflow_action(workflow=workflow)
+        status_2 = ActionGroupStatus.objects.create(action=action_2, group=self.group)
+
+        _, action_3 = self.create_workflow_action(workflow=workflow)
+        status_3 = ActionGroupStatus.objects.create(action=action_3, group=self.group)
+        status_3.update(date_updated=timezone.now() - timedelta(days=2))
+
+        triggered_actions = filter_recently_fired_workflow_actions(Action.objects.all(), self.group)
+        assert set(triggered_actions) == {self.action, action_3}
+
+        for status in [status_1, status_2, status_3]:
+            status.refresh_from_db()
+            assert status.date_updated == timezone.now()


### PR DESCRIPTION
When firing actions, utilize the new `ActionGroupStatus` table to check if that action should be firing, given how long ago it last fired for the group and the `frequency` configured in `workflow.config` (default 30 min).

This involves some Django annotations and hopping through quite a few lookup tables to go from Action to Workflow 😓 