### PR TITLE
ref(metrics-extraction): Clean up logs

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -660,12 +660,6 @@ def should_use_on_demand_metrics(
             metrics.incr("on_demand_metrics.should_use_on_demand_metrics.cache_hit")
             return cached_result
         else:
-            logger.info(
-                "should_use_on_demand_metrics.cache_miss",
-                extra={
-                    "cache_key": local_cache_key,
-                },
-            )
             result = _should_use_on_demand_metrics(
                 dataset=dataset,
                 aggregate=aggregate,


### PR DESCRIPTION
### Summary
These logs are noisy and we can remove them since the cacheing is already out and working.
