### PR TITLE
feat: Add a flag to wait for delivery callback in taskworker

### DIFF
--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import time
 from collections.abc import Callable
 from functools import cached_property
 from typing import Any
@@ -140,8 +139,7 @@ class TaskNamespace:
             KafkaPayload(key=None, value=activation.SerializeToString(), headers=[]),
         )
         if wait_for_delivery:
-            while not produce_future.is_done():
-                time.sleep(0.1)
+            produce_future.result(timeout=None)
 
 
 class TaskRegistry:

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -139,7 +139,10 @@ class TaskNamespace:
             KafkaPayload(key=None, value=activation.SerializeToString(), headers=[]),
         )
         if wait_for_delivery:
-            produce_future.result(timeout=None)
+            try:
+                produce_future.result(timeout=10)
+            except Exception:
+                logger.exception("Failed to wait for delivery")
 
 
 class TaskRegistry:

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -41,6 +41,11 @@ def simple_task() -> None:
     logger.info("simple_task complete")
 
 
+@exampletasks.register(name="examples.simple_task_wait_delivery", wait_for_delivery=True)
+def simple_task_wait_delivery() -> None:
+    logger.info("simple_task_wait_delivery complete")
+
+
 @exampletasks.register(name="examples.retry_task", retry=Retry(times=2))
 def retry_task() -> None:
     raise RetryError

--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from unittest.mock import patch
 
 import pytest
@@ -192,7 +193,10 @@ def test_namespace_with_wait_for_delivery_send_task() -> None:
     activation = simple_task.create_activation()
 
     with patch.object(namespace, "producer") as mock_producer:
-        namespace.send_task(activation)
+        ret_value = Future()
+        ret_value.set_result(None)
+        mock_producer.produce.return_value = ret_value
+        namespace.send_task(activation, wait_for_delivery=True)
         assert mock_producer.produce.call_count == 1
 
         mock_call = mock_producer.produce.call_args

--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -193,7 +193,7 @@ def test_namespace_with_wait_for_delivery_send_task() -> None:
     activation = simple_task.create_activation()
 
     with patch.object(namespace, "producer") as mock_producer:
-        ret_value = Future()
+        ret_value: Future[None] = Future()
         ret_value.set_result(None)
         mock_producer.produce.return_value = ret_value
         namespace.send_task(activation, wait_for_delivery=True)


### PR DESCRIPTION
Sometimes it is helpful to have the taskworker actually wait for the kafka producer to acknowledge
that the sent task has been successfully added to Kafka. In particular this is useful for testing
scenarios. Add a flag to the task definition that can determine whether the worker should wait for
the produce to be acknowledged before continuing.