### PR TITLE
fix(widget-builder): Wipe aliases on dataset and display type changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -462,7 +462,7 @@ function Visualize({error, setError}: VisualizeProps) {
                       type="text"
                       name="name"
                       placeholder={t('Add Alias')}
-                      value={field.alias}
+                      value={field.alias ?? ''}
                       onChange={e => {
                         const newFields = cloneDeep(fields);
                         newFields[index]!.alias = e.target.value;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -253,7 +253,7 @@ describe('WidgetBuilderSlideout', () => {
     expect(screen.getByText('Create Custom Widget')).toBeInTheDocument();
   });
 
-  it('clears the alias when dataset or display type changes', async () => {
+  it('clears the alias when dataset changes', async () => {
     render(
       <WidgetBuilderProvider>
         <WidgetBuilderSlideout
@@ -286,6 +286,36 @@ describe('WidgetBuilderSlideout', () => {
     await userEvent.click(screen.getByText('Errors'));
 
     expect(await screen.findByPlaceholderText('Add Alias')).toHaveValue('');
+  });
+
+  it('clears the alias when display type changes', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['count()'],
+              yAxis: [],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
 
     await userEvent.type(
       await screen.findByPlaceholderText('Add Alias'),

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -252,4 +252,51 @@ describe('WidgetBuilderSlideout', () => {
 
     expect(screen.getByText('Create Custom Widget')).toBeInTheDocument();
   });
+
+  it('clears the alias when dataset or display type changes', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['count()'],
+              yAxis: [],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.type(await screen.findByPlaceholderText('Add Alias'), 'test alias');
+    await userEvent.click(screen.getByText('Errors'));
+
+    expect(await screen.findByPlaceholderText('Add Alias')).toHaveValue('');
+
+    await userEvent.type(
+      await screen.findByPlaceholderText('Add Alias'),
+      'test alias again'
+    );
+
+    await userEvent.click(screen.getByText('Table'));
+    await userEvent.click(screen.getByText('Area'));
+    await userEvent.click(screen.getByText('Area'));
+    await userEvent.click(screen.getByText('Table'));
+
+    expect(await screen.findByPlaceholderText('Add Alias')).toHaveValue('');
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -828,6 +828,75 @@ describe('useWidgetBuilderState', () => {
       ]);
     });
 
+    it('wipes the alias when the dataset is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ERRORS,
+            displayType: DisplayType.TABLE,
+            field: ['{"field":"event.type","alias":"test"}'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.fields).toEqual([
+        {field: 'event.type', alias: 'test', kind: FieldValueKind.FIELD},
+      ]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.TRANSACTIONS,
+        });
+      });
+
+      expect(result.current.state.fields).toEqual([
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+    });
+
+    it('wipes the alias when the display type is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.TABLE,
+            field: ['{"field":"count()","alias":"test"}'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.fields).toEqual([
+        {function: ['count', '', undefined, undefined], alias: 'test', kind: 'function'},
+      ]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.LINE,
+        });
+      });
+
+      expect(result.current.state.yAxis).toEqual([
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+    });
+
     it('resets the sort when the field that is being sorted is removed', () => {
       mockedUsedLocation.mockReturnValue(
         LocationFixture({

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -162,11 +162,23 @@ function useWidgetBuilderState(): {
             const fieldString = generateFieldAsString(field);
             return isAggregateFieldOrEquation(fieldString);
           });
+          const columnsWithoutAlias = columns.map(column => {
+            return {...column, alias: undefined};
+          });
+          const aggregatesWithoutAlias = aggregates.map(aggregate => {
+            return {...aggregate, alias: undefined};
+          });
+          const yAxisWithoutAlias = yAxis?.map(axis => {
+            return {...axis, alias: undefined};
+          });
           if (action.payload === DisplayType.TABLE) {
             setYAxis([]);
             setLegendAlias([]);
-
-            const newFields = [...columns, ...aggregates, ...(yAxis ?? [])];
+            const newFields = [
+              ...columnsWithoutAlias,
+              ...aggregatesWithoutAlias,
+              ...(yAxisWithoutAlias ?? []),
+            ];
             setFields(newFields);
 
             // Keep the sort if it's already contained in the new fields
@@ -188,13 +200,13 @@ function useWidgetBuilderState(): {
             setYAxis([]);
             setLegendAlias([]);
             // Columns are ignored for big number widgets because there is no grouping
-            setFields([...aggregates, ...(yAxis ?? [])]);
+            setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])]);
             setQuery(query?.slice(0, 1));
           } else {
-            setFields(columns);
+            setFields(columnsWithoutAlias);
             setYAxis([
-              ...aggregates.slice(0, MAX_NUM_Y_AXES),
-              ...(yAxis?.slice(0, MAX_NUM_Y_AXES) ?? []),
+              ...aggregatesWithoutAlias.slice(0, MAX_NUM_Y_AXES),
+              ...(yAxisWithoutAlias?.slice(0, MAX_NUM_Y_AXES) ?? []),
             ]);
           }
           break;


### PR DESCRIPTION
Currently the visualize aliases we're not being wiped when the dataset or the display type changed. I've implemented a change in the hook to set all aliases to undefined when changing display types. For dataset changes it was already clearing the aliases but the field wasn't registering that change because it was reading in `undefined` so I updated the value field to have an empty string default. 

This is what it looks like now:


https://github.com/user-attachments/assets/dfd02843-c9fd-4aef-be15-678665ea22c3


Closes https://github.com/getsentry/sentry/issues/83158