### PR TITLE
feat(event-details): Allow filtering next and previous events

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -278,7 +278,7 @@ class EventStorage(Service):
         group_id: int,
         environments: list[str],
         event: Event | GroupEvent,
-        conditions: list[Condition] = None,
+        conditions: list[Condition] | None = None,
     ):
         raise NotImplementedError
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -278,6 +278,7 @@ class EventStorage(Service):
         group_id: int,
         environments: list[str],
         event: Event | GroupEvent,
+        conditions: list[Condition] = None,
     ):
         raise NotImplementedError
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -464,6 +464,8 @@ class SnubaEventStorage(EventStorage):
         app_id = "eventstore"
         referrer = "eventstore.get_next_or_prev_event_id_snql"
         tenant_ids = {"organization_id": organization_id}
+        if not conditions:
+            conditions = []
 
         def make_constant_conditions():
             environment_conditions = []

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -451,7 +451,7 @@ class SnubaEventStorage(EventStorage):
             return Dataset.Discover
 
     def get_adjacent_event_ids_snql(
-        self, organization_id, project_id, group_id, environments, event
+        self, organization_id, project_id, group_id, environments, event, conditions
     ):
         """
         Utility function for grabbing an event's adjascent events,
@@ -464,9 +464,6 @@ class SnubaEventStorage(EventStorage):
         app_id = "eventstore"
         referrer = "eventstore.get_next_or_prev_event_id_snql"
         tenant_ids = {"organization_id": organization_id}
-        environment_conditions = []
-        if environments:
-            environment_conditions.append(Condition(Column("environment"), Op.IN, environments))
 
         def make_constant_conditions():
             environment_conditions = []
@@ -478,6 +475,7 @@ class SnubaEventStorage(EventStorage):
                 group_conditions.append(Condition(Column("group_id"), Op.EQ, group_id))
             project_conditions = [Condition(Column("project_id"), Op.EQ, project_id)]
             return [
+                *conditions,
                 *environment_conditions,
                 *group_conditions,
                 *project_conditions,

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -451,7 +451,7 @@ class SnubaEventStorage(EventStorage):
             return Dataset.Discover
 
     def get_adjacent_event_ids_snql(
-        self, organization_id, project_id, group_id, environments, event, conditions
+        self, organization_id, project_id, group_id, environments, event, conditions=None
     ):
         """
         Utility function for grabbing an event's adjascent events,

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -229,9 +229,11 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             return Response(serialize(event, request.user, EventSerializer()))
 
         data = wrap_event_response(
-            request.user,
-            event,
-            environment_names,
+            request_user=request.user,
+            event=event,
+            # We've already filtered by environments in the conditions list
+            environments=None,
             include_full_release_data="fullRelease" not in collapse,
+            conditions=conditions,
         )
         return Response(data)

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -231,8 +231,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         data = wrap_event_response(
             request_user=request.user,
             event=event,
-            # We've already filtered by environments in the conditions list
-            environments=None,
+            environments=environments,
             include_full_release_data="fullRelease" not in collapse,
             conditions=conditions,
         )

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -231,7 +231,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         data = wrap_event_response(
             request_user=request.user,
             event=event,
-            environments=environments,
+            environments=environment_names,
             include_full_release_data="fullRelease" not in collapse,
             conditions=conditions,
         )


### PR DESCRIPTION
Previously the next and previous events could only be filtered by environment. Now, any conditions that come from the request (e.g. query and date range) can be parsed to adjust what next and previous IDs are returned.

Unfortuantely, SaaS doesn't use snql which is how we get these conditions, so this is not going to change the behavior in production just yet. I'll work on a separate PR that looks into fixing the ordering with snql.