### PR TITLE
feat(ui): Enable sub-ms precision in `getDuration`

### DIFF
--- a/static/app/utils/duration/getDuration.spec.tsx
+++ b/static/app/utils/duration/getDuration.spec.tsx
@@ -1,5 +1,7 @@
 import getDuration from 'sentry/utils/duration/getDuration';
 
+import {MINUTE, MONTH} from '../formatters';
+
 describe('getDuration()', () => {
   it('should format durations', () => {
     expect(getDuration(0.1)).toBe('100 milliseconds');
@@ -8,11 +10,13 @@ describe('getDuration()', () => {
     expect(getDuration(2)).toBe('2 seconds');
     expect(getDuration(65)).toBe('1 minute');
     expect(getDuration(122)).toBe('2 minutes');
+    expect(getDuration(55, 0, false, false, false, MINUTE)).toBe('1 minute');
     expect(getDuration(3720)).toBe('1 hour');
     expect(getDuration(36000)).toBe('10 hours');
     expect(getDuration(86400)).toBe('1 day');
     expect(getDuration(86400 * 2)).toBe('2 days');
     expect(getDuration(604800)).toBe('1 week');
+    expect(getDuration(604800, 2, false, false, false, MONTH)).toBe('0.23 months');
     expect(getDuration(604800 * 4)).toBe('4 weeks');
     expect(getDuration(2629800)).toBe('1 month');
     expect(getDuration(604800 * 12)).toBe('3 months');
@@ -30,6 +34,7 @@ describe('getDuration()', () => {
     expect(getDuration(-86400)).toBe('-1 day');
     expect(getDuration(-86400 * 2)).toBe('-2 days');
     expect(getDuration(-604800)).toBe('-1 week');
+    expect(getDuration(-604800, 2, false, false, false, MONTH)).toBe('-0.23 months');
     expect(getDuration(-604800 * 4)).toBe('-4 weeks');
     expect(getDuration(-2629800)).toBe('-1 month');
     expect(getDuration(-604800 * 12)).toBe('-3 months');

--- a/static/app/utils/duration/getDuration.spec.tsx
+++ b/static/app/utils/duration/getDuration.spec.tsx
@@ -1,9 +1,12 @@
 import getDuration from 'sentry/utils/duration/getDuration';
 
-import {MINUTE, MONTH} from '../formatters';
+import {MICROSECOND, MINUTE, MONTH} from '../formatters';
 
 describe('getDuration()', () => {
   it('should format durations', () => {
+    expect(getDuration(0.0001, 0, false, false, false, MICROSECOND)).toBe(
+      '100 microseconds'
+    );
     expect(getDuration(0.1)).toBe('100 milliseconds');
     expect(getDuration(0.1, 2)).toBe('100.00 milliseconds');
     expect(getDuration(1)).toBe('1 second');
@@ -23,6 +26,9 @@ describe('getDuration()', () => {
   });
 
   it('should format negative durations', () => {
+    expect(getDuration(-0.0001, 0, false, false, false, MICROSECOND)).toBe(
+      '-100 microseconds'
+    );
     expect(getDuration(-0.1)).toBe('-100 milliseconds');
     expect(getDuration(-0.1, 2)).toBe('-100.00 milliseconds');
     expect(getDuration(-1)).toBe('-1 second');
@@ -41,6 +47,7 @@ describe('getDuration()', () => {
   });
 
   it('should format numbers and abbreviate units', () => {
+    expect(getDuration(0, 2, true, false, false, MICROSECOND)).toBe('0.00μs');
     expect(getDuration(0, 2, true)).toBe('0.00ms');
     expect(getDuration(0, 0, true)).toBe('0ms');
     expect(getDuration(0.1, 0, true)).toBe('100ms');
@@ -57,6 +64,7 @@ describe('getDuration()', () => {
   });
 
   it('should format numbers and abbreviate units with one letter', () => {
+    expect(getDuration(0, 2, false, true, false, MICROSECOND)).toBe('0.00μs');
     expect(getDuration(0, 2, false, true)).toBe('0.00ms');
     expect(getDuration(0, 0, false, true)).toBe('0ms');
     expect(getDuration(0.1, 0, false, true)).toBe('100ms');

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -1,6 +1,15 @@
 import {t, tn} from 'sentry/locale';
 
-import {DAY, HOUR, MILLISECOND, MINUTE, MONTH, SECOND, WEEK} from '../formatters';
+import {
+  DAY,
+  HOUR,
+  MICROSECOND,
+  MILLISECOND,
+  MINUTE,
+  MONTH,
+  SECOND,
+  WEEK,
+} from '../formatters';
 
 function roundWithFixed(
   value: number,
@@ -44,6 +53,9 @@ const DURATION_LABELS = {
   ms: t('ms'),
   millisecond: t('millisecond'),
   milliseconds: t('milliseconds'),
+  us: 'μs', // SI units don't need a translation
+  microsecond: t('microsecond'),
+  microseconds: t('microseconds'),
 };
 
 export default function getDuration(
@@ -114,11 +126,19 @@ export default function getDuration(
     return `${label} ${tn('second', 'seconds', result)}`;
   }
 
-  const {label, result} = roundWithFixed(msValue, fixedDigits);
-
-  if (extraShort || abbreviation) {
-    return `${label}${DURATION_LABELS.ms}`;
+  if (absValue >= MILLISECOND || minimumUnit === MILLISECOND) {
+    const {label, result} = roundWithFixed(msValue / MILLISECOND, fixedDigits);
+    if (extraShort || abbreviation) {
+      return `${label}${DURATION_LABELS.ms}`;
+    }
+    return `${label} ${tn('millisecond', 'milliseconds', result)}`;
   }
 
-  return `${label} ${tn('millisecond', 'milliseconds', result)}`;
+  const {label, result} = roundWithFixed(msValue / MICROSECOND, fixedDigits);
+
+  if (extraShort || abbreviation) {
+    return `${label}${DURATION_LABELS.us}`;
+  }
+
+  return `${label} ${tn('microsecond', 'microseconds', result)}`;
 }

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -1,6 +1,6 @@
 import {t, tn} from 'sentry/locale';
 
-import {DAY, HOUR, MINUTE, MONTH, SECOND, WEEK} from '../formatters';
+import {DAY, HOUR, MILLISECOND, MINUTE, MONTH, SECOND, WEEK} from '../formatters';
 
 function roundWithFixed(
   value: number,
@@ -51,19 +51,20 @@ export default function getDuration(
   fixedDigits: number = 0,
   abbreviation: boolean = false,
   extraShort: boolean = false,
-  absolute: boolean = false
+  absolute: boolean = false,
+  minimumUnit: number = MILLISECOND
 ): string {
   const absValue = Math.abs(seconds * 1000);
 
   // value in milliseconds
   const msValue = absolute ? absValue : seconds * 1000;
 
-  if (absValue >= MONTH && !extraShort) {
+  if ((absValue >= MONTH && !extraShort) || minimumUnit === MONTH) {
     const {label, result} = roundWithFixed(msValue / MONTH, fixedDigits);
     return `${label}${abbreviation ? DURATION_LABELS.mo : ` ${tn('month', 'months', result)}`}`;
   }
 
-  if (absValue >= WEEK) {
+  if (absValue >= WEEK || minimumUnit === WEEK) {
     const {label, result} = roundWithFixed(msValue / WEEK, fixedDigits);
     if (extraShort) {
       return `${label}${DURATION_LABELS.w}`;
@@ -74,7 +75,7 @@ export default function getDuration(
     return `${label} ${tn('week', 'weeks', result)}`;
   }
 
-  if (absValue >= DAY) {
+  if (absValue >= DAY || minimumUnit === DAY) {
     const {label, result} = roundWithFixed(msValue / DAY, fixedDigits);
 
     if (extraShort || abbreviation) {
@@ -83,7 +84,7 @@ export default function getDuration(
     return `${label} ${tn('day', 'days', result)}`;
   }
 
-  if (absValue >= HOUR) {
+  if (absValue >= HOUR || minimumUnit === HOUR) {
     const {label, result} = roundWithFixed(msValue / HOUR, fixedDigits);
     if (extraShort) {
       return `${label}${DURATION_LABELS.h}`;
@@ -94,7 +95,7 @@ export default function getDuration(
     return `${label} ${tn('hour', 'hours', result)}`;
   }
 
-  if (absValue >= MINUTE) {
+  if (absValue >= MINUTE || minimumUnit === MINUTE) {
     const {label, result} = roundWithFixed(msValue / MINUTE, fixedDigits);
     if (extraShort) {
       return `${label}${DURATION_LABELS.m}`;
@@ -105,7 +106,7 @@ export default function getDuration(
     return `${label} ${tn('minute', 'minutes', result)}`;
   }
 
-  if (absValue >= SECOND) {
+  if (absValue >= SECOND || minimumUnit === SECOND) {
     const {label, result} = roundWithFixed(msValue / SECOND, fixedDigits);
     if (extraShort || abbreviation) {
       return `${label}${DURATION_LABELS.s}`;

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -58,6 +58,16 @@ const DURATION_LABELS = {
   microseconds: t('microseconds'),
 };
 
+/**
+ *
+ * @param seconds Duration in seconds
+ * @param fixedDigits Number of digits after the decimal
+ * @param abbreviation Use short-ish labels like "sec" for "second" and "wk" for "week" if available
+ * @param extraShort Use extra-short labels like "s" for "second" and "w" for week
+ * @param absolute Convert numbers to absolute
+ * @param minimumUnit Smallest unit to consider while formatting. 55 seconds with a `minimumUnit` of `MINUTE` will return `"1 minute"` instead of `"55 seconds"`
+ * @returns Formatted string
+ */
 export default function getDuration(
   seconds: number,
   fixedDigits: number = 0,

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -61,10 +61,10 @@ const DURATION_LABELS = {
 /**
  *
  * @param seconds Duration in seconds
- * @param fixedDigits Number of digits after the decimal
+ * @param fixedDigits Number of digits after the decimal in output format
  * @param abbreviation Use short-ish labels like "sec" for "second" and "wk" for "week" if available
  * @param extraShort Use extra-short labels like "s" for "second" and "w" for week
- * @param absolute Convert numbers to absolute
+ * @param absolute Convert the number of second to absolute before formatting
  * @param minimumUnit Smallest unit to consider while formatting. 55 seconds with a `minimumUnit` of `MINUTE` will return `"1 minute"` instead of `"55 seconds"`
  * @returns Formatted string
  */


### PR DESCRIPTION
Measurements like span duration have microsecond precision, and it's useful to format that in some contexts (profiles, query durations, etc.) This PR adds microseconds as a possible unit _but_ preserves all current behaviour by setting the default minimum using to milliseconds. Also, as part of the PR adds the ability to set the minimum unit. This way, someone can force rendering "30 minutes" to "0.5 hours" if they want to.
