### PR TITLE
feat(widget-builder): Add selected aggregate to builder state

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
@@ -10,7 +10,7 @@ import {useUrlBatchContext} from '../contexts/urlParamBatchContext';
 interface UseQueryParamStateWithScalarDecoder<T> {
   fieldName: string;
   decoder?: typeof decodeScalar;
-  deserializer?: (value: ReturnType<typeof decodeScalar>) => T;
+  deserializer?: (value: ReturnType<typeof decodeScalar>) => T | undefined;
   serializer?: (value: T) => string;
 }
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -552,6 +552,27 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.query).toEqual(['event.type:test']);
     });
+
+    it('resets selectedAggregate when the display type is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({query: {selectedAggregate: '0'}})
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.selectedAggregate).toBe(0);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.TABLE,
+        });
+      });
+
+      expect(result.current.state.selectedAggregate).toBeUndefined();
+    });
   });
 
   describe('dataset', () => {
@@ -766,6 +787,27 @@ describe('useWidgetBuilderState', () => {
           kind: 'desc',
         },
       ]);
+    });
+
+    it('resets selectedAggregate when the dataset is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({query: {selectedAggregate: '0'}})
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.selectedAggregate).toBe(0);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.SPANS,
+        });
+      });
+
+      expect(result.current.state.selectedAggregate).toBeUndefined();
     });
   });
 
@@ -1022,6 +1064,55 @@ describe('useWidgetBuilderState', () => {
       });
 
       expect(result.current.state.legendAlias).toEqual(['test3', 'test4']);
+    });
+  });
+
+  describe('selectedAggregate', () => {
+    it('can decode and update selectedAggregate', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({query: {selectedAggregate: '0'}})
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.selectedAggregate).toBe(0);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_SELECTED_AGGREGATE,
+          payload: 1,
+        });
+      });
+
+      expect(result.current.state.selectedAggregate).toBe(1);
+    });
+
+    it('can set selectedAggregate to undefined', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({query: {selectedAggregate: '0'}})
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.selectedAggregate).toBe(0);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_SELECTED_AGGREGATE,
+          payload: undefined,
+        });
+      });
+
+      expect(result.current.state.selectedAggregate).toBeUndefined();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {selectedAggregate: undefined},
+        })
+      );
     });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -29,6 +29,7 @@ export type WidgetBuilderStateQueryParams = {
   legendAlias?: string[];
   limit?: number;
   query?: string[];
+  selectedAggregate?: number;
   sort?: string[];
   title?: string;
   yAxis?: string[];
@@ -45,6 +46,7 @@ export const BuilderStateAction = {
   SET_SORT: 'SET_SORT',
   SET_LIMIT: 'SET_LIMIT',
   SET_LEGEND_ALIAS: 'SET_LEGEND_ALIAS',
+  SET_SELECTED_AGGREGATE: 'SET_SELECTED_AGGREGATE',
 } as const;
 
 type WidgetAction =
@@ -57,7 +59,8 @@ type WidgetAction =
   | {payload: string[]; type: typeof BuilderStateAction.SET_QUERY}
   | {payload: Sort[]; type: typeof BuilderStateAction.SET_SORT}
   | {payload: number; type: typeof BuilderStateAction.SET_LIMIT}
-  | {payload: string[]; type: typeof BuilderStateAction.SET_LEGEND_ALIAS};
+  | {payload: string[]; type: typeof BuilderStateAction.SET_LEGEND_ALIAS}
+  | {payload: number | undefined; type: typeof BuilderStateAction.SET_SELECTED_AGGREGATE};
 
 export interface WidgetBuilderState {
   dataset?: WidgetType;
@@ -67,6 +70,7 @@ export interface WidgetBuilderState {
   legendAlias?: string[];
   limit?: number;
   query?: string[];
+  selectedAggregate?: number;
   sort?: Sort[];
   title?: string;
   yAxis?: Column[];
@@ -119,6 +123,11 @@ function useWidgetBuilderState(): {
     fieldName: 'legendAlias',
     decoder: decodeList,
   });
+  const [selectedAggregate, setSelectedAggregate] = useQueryParamState<number>({
+    fieldName: 'selectedAggregate',
+    decoder: decodeScalar,
+    deserializer: deserializeSelectedAggregate,
+  });
 
   const state = useMemo(
     () => ({
@@ -132,6 +141,7 @@ function useWidgetBuilderState(): {
       sort,
       limit,
       legendAlias,
+      selectedAggregate,
     }),
     [
       title,
@@ -144,6 +154,7 @@ function useWidgetBuilderState(): {
       sort,
       limit,
       legendAlias,
+      selectedAggregate,
     ]
   );
 
@@ -197,6 +208,7 @@ function useWidgetBuilderState(): {
               ...(yAxis?.slice(0, MAX_NUM_Y_AXES) ?? []),
             ]);
           }
+          setSelectedAggregate(undefined);
           break;
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);
@@ -230,6 +242,7 @@ function useWidgetBuilderState(): {
           }
           setQuery([config.defaultWidgetQuery.conditions]);
           setSort(decodeSorts(config.defaultWidgetQuery.orderby));
+          setSelectedAggregate(undefined);
           break;
         case BuilderStateAction.SET_FIELDS:
           setFields(action.payload);
@@ -294,6 +307,9 @@ function useWidgetBuilderState(): {
         case BuilderStateAction.SET_LEGEND_ALIAS:
           setLegendAlias(action.payload);
           break;
+        case BuilderStateAction.SET_SELECTED_AGGREGATE:
+          setSelectedAggregate(action.payload);
+          break;
         default:
           break;
       }
@@ -309,6 +325,7 @@ function useWidgetBuilderState(): {
       setSort,
       setLimit,
       setLegendAlias,
+      setSelectedAggregate,
       fields,
       yAxis,
       displayType,
@@ -390,6 +407,10 @@ function serializeSorts(sorts: Sort[]): string[] {
  */
 function deserializeLimit(value: string): number {
   return decodeInteger(value, DEFAULT_RESULTS_LIMIT);
+}
+
+function deserializeSelectedAggregate(value: string): number | undefined {
+  return decodeInteger(value);
 }
 
 /**

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -99,4 +99,25 @@ describe('convertBuilderStateToWidget', function () {
     expect(widget.queries[1]!.name).toBe('test2');
     expect(widget.queries[1]!.conditions).toBe('transaction.duration:>50');
   });
+
+  it('propagates the selected aggregate to the widget query', () => {
+    const mockState: WidgetBuilderState = {
+      selectedAggregate: 0,
+      query: ['transaction.duration:>100'],
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.selectedAggregate).toBe(0);
+  });
+
+  it('sets selectedAggregate to undefined if not provided', () => {
+    const mockState: WidgetBuilderState = {
+      query: ['transaction.duration:>100'],
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.selectedAggregate).toBeUndefined();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -52,6 +52,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       orderby: sort,
       fieldAliases: fieldAliases ?? [],
       name: legendAlias[index] ?? '',
+      selectedAggregate: state.selectedAggregate,
     };
   });
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -80,4 +80,22 @@ describe('convertWidgetToBuilderStateParams', () => {
     expect(params.query).toEqual(['one condition', 'second condition']);
     expect(params.yAxis).toEqual(['count()']);
   });
+
+  it('exposes the selected aggregate in a widget query', () => {
+    const widget = {
+      ...getDefaultWidget(WidgetType.ERRORS),
+      queries: [
+        {
+          aggregates: ['count()'],
+          selectedAggregate: 0,
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+        },
+      ],
+    };
+    const params = convertWidgetToBuilderStateParams(widget);
+    expect(params.selectedAggregate).toBe(0);
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -58,5 +58,6 @@ export function convertWidgetToBuilderStateParams(
     query,
     sort,
     legendAlias,
+    selectedAggregate: firstWidgetQuery?.selectedAggregate,
   };
 }


### PR DESCRIPTION
To be used by the UI to render a radio button where a user can select the aggregate to visualize in big numbers

This is just the foundation, when working on the UI I'll probably have to update this so the dataset change resets to 0 when switching to a big number, or when we remove the field that is currently selected from the visualize section.

Contributes to #82370