### PR TITLE
fix(widget-builder): Put limit on filter conditions

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -2,7 +2,7 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
@@ -94,5 +94,35 @@ describe('QueryFilterBuilder', () => {
     );
 
     expect(await screen.findByPlaceholderText('Legend Alias')).toBeInTheDocument();
+  });
+
+  it('limits number of filter queries to 3', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              query: [],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(
+      screen.getByPlaceholderText('Search for events, users, tags, and more')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Add Filter')).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByText('Add Filter'));
+    await userEvent.click(await screen.findByText('Add Filter'));
+
+    expect(screen.queryByText('Add Filter')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -44,6 +44,13 @@ function WidgetBuilderQueryFilterBuilder({
 
   const canAddSearchConditions =
     state.displayType !== DisplayType.TABLE &&
+    state.displayType !== DisplayType.BIG_NUMBER &&
+    state.dataset !== WidgetType.SPANS &&
+    state.query &&
+    state.query.length < 3;
+
+  const canHaveAlias =
+    state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER;
 
   const onAddSearchConditions = () => {
@@ -145,8 +152,7 @@ function WidgetBuilderQueryFilterBuilder({
             widgetQuery={widget.queries[index]!}
             dataset={getDiscoverDatasetFromWidgetType(widgetType)}
           />
-          {canAddSearchConditions && (
-            // TODO: Hook up alias to query hook when it's implemented
+          {canHaveAlias && (
             <LegendAliasInput
               type="text"
               name="name"
@@ -162,7 +168,7 @@ function WidgetBuilderQueryFilterBuilder({
               }}
             />
           )}
-          {state.query && state.query?.length > 1 && canAddSearchConditions && (
+          {state.query && state.query?.length > 1 && (
             <DeleteButton onDelete={handleRemove(index)} />
           )}
         </QueryFieldRowWrapper>


### PR DESCRIPTION
There should only be max three filters on widgets. I've also added the spans dataset condition that's in the current widget builder as multiple filters are not doable on spans yet. 
