### PR TITLE
ref(explore): Lift explore table queries to parent component

### DIFF
--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -1,0 +1,93 @@
+import {useMemo} from 'react';
+
+import type {NewQuery} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  useExploreDataset,
+  useExploreGroupBys,
+  useExploreSortBys,
+  useExploreVisualizes,
+} from 'sentry/views/explore/contexts/pageParamsContext';
+import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+
+interface UseExploreAggregatesTableOptions {
+  enabled: boolean;
+  query: string;
+}
+
+export interface AggregatesTableResult {
+  eventView: EventView;
+  fields: string[];
+  result: ReturnType<typeof useSpansQuery<any[]>>;
+}
+
+export function useExploreAggregatesTable({
+  enabled,
+  query,
+}: UseExploreAggregatesTableOptions): AggregatesTableResult {
+  const {selection} = usePageFilters();
+
+  const dataset = useExploreDataset();
+  const groupBys = useExploreGroupBys();
+  const sorts = useExploreSortBys();
+  const visualizes = useExploreVisualizes();
+
+  const fields = useMemo(() => {
+    // When rendering the table, we want the group bys first
+    // then the aggregates.
+    const allFields: string[] = [];
+
+    for (const groupBy of groupBys) {
+      if (allFields.includes(groupBy)) {
+        continue;
+      }
+      allFields.push(groupBy);
+    }
+
+    for (const visualize of visualizes) {
+      for (const yAxis of visualize.yAxes) {
+        if (allFields.includes(yAxis)) {
+          continue;
+        }
+        allFields.push(yAxis);
+      }
+    }
+
+    return allFields.filter(Boolean);
+  }, [groupBys, visualizes]);
+
+  const eventView = useMemo(() => {
+    const search = new MutableSearch(query);
+
+    // Filtering out all spans with op like 'ui.interaction*' which aren't
+    // embedded under transactions. The trace view does not support rendering
+    // such spans yet.
+    search.addFilterValues('!transaction.span_id', ['00']);
+
+    const discoverQuery: NewQuery = {
+      id: undefined,
+      name: 'Explore - Span Aggregates',
+      fields,
+      orderby: sorts.map(formatSort),
+      query: search.formatString(),
+      version: 2,
+      dataset,
+    };
+
+    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
+  }, [dataset, fields, sorts, query, selection]);
+
+  const result = useSpansQuery({
+    enabled,
+    eventView,
+    initialData: [],
+    referrer: 'api.explore.spans-aggregates-table',
+  });
+
+  return useMemo(() => {
+    return {eventView, fields, result};
+  }, [eventView, fields, result]);
+}

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -1,0 +1,80 @@
+import {useMemo} from 'react';
+
+import type {NewQuery} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  useExploreDataset,
+  useExploreFields,
+  useExploreSortBys,
+} from 'sentry/views/explore/contexts/pageParamsContext';
+import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+
+interface UseExploreSpansTableOptions {
+  enabled: boolean;
+  query: string;
+}
+
+export interface SpansTableResult {
+  eventView: EventView;
+  result: ReturnType<typeof useSpansQuery<any[]>>;
+}
+
+export function useExploreSpansTable({
+  enabled,
+  query,
+}: UseExploreSpansTableOptions): SpansTableResult {
+  const {selection} = usePageFilters();
+
+  const dataset = useExploreDataset();
+  const fields = useExploreFields();
+  const sortBys = useExploreSortBys();
+
+  const visibleFields = useMemo(
+    () => (fields.includes('id') ? fields : ['id', ...fields]),
+    [fields]
+  );
+
+  const eventView = useMemo(() => {
+    const queryFields = [
+      ...visibleFields,
+      'project',
+      'trace',
+      'transaction.span_id',
+      'id',
+      'timestamp',
+    ];
+
+    const search = new MutableSearch(query);
+
+    // Filtering out all spans with op like 'ui.interaction*' which aren't
+    // embedded under transactions. The trace view does not support rendering
+    // such spans yet.
+    search.addFilterValues('!transaction.span_id', ['00']);
+
+    const discoverQuery: NewQuery = {
+      id: undefined,
+      name: 'Explore - Span Samples',
+      fields: queryFields,
+      orderby: sortBys.map(sort => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`),
+      query: search.formatString(),
+      version: 2,
+      dataset,
+    };
+
+    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
+  }, [dataset, sortBys, query, selection, visibleFields]);
+
+  const result = useSpansQuery({
+    enabled,
+    eventView,
+    initialData: [],
+    referrer: 'api.explore.spans-samples-table',
+    allowAggregateConditions: false,
+  });
+
+  return useMemo(() => {
+    return {eventView, result};
+  }, [eventView, result]);
+}

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from 'react';
+
+import {DEFAULT_PER_PAGE} from 'sentry/constants';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useExploreDataset} from 'sentry/views/explore/contexts/pageParamsContext';
+import {useTraces} from 'sentry/views/explore/hooks/useTraces';
+
+interface UseExploreTracesTableOptions {
+  enabled: boolean;
+  query: string;
+}
+
+export interface TracesTableResult {
+  result: ReturnType<typeof useTraces>;
+}
+
+export function useExploreTracesTable({
+  enabled,
+  query,
+}: UseExploreTracesTableOptions): TracesTableResult {
+  const location = useLocation();
+  const cursor = decodeScalar(location.query.cursor);
+  const dataset = useExploreDataset();
+
+  const result = useTraces({
+    enabled,
+    dataset,
+    query,
+    limit: DEFAULT_PER_PAGE,
+    sort: '-timestamp',
+    cursor,
+  });
+
+  return useMemo(() => {
+    return {result};
+  }, [result]);
+}

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -1,5 +1,4 @@
-import type {Dispatch, SetStateAction} from 'react';
-import {Fragment, useEffect, useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -10,17 +9,14 @@ import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
-import type {Confidence, NewQuery} from 'sentry/types/organization';
+import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import EventView from 'sentry/utils/discover/eventView';
 import {
   fieldAlignment,
   parseFunction,
   prettifyParsedFunction,
 } from 'sentry/utils/discover/fields';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   Table,
   TableBody,
@@ -41,21 +37,22 @@ import {
   useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
-import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
+import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import {TOP_EVENTS_LIMIT, useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
-import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 import {FieldRenderer} from './fieldRenderer';
 
 interface AggregatesTableProps {
+  aggregatesTableResult: AggregatesTableResult;
   confidences: Confidence[];
-  setError: Dispatch<SetStateAction<string>>;
 }
 
-export function AggregatesTable({confidences, setError}: AggregatesTableProps) {
-  const {selection} = usePageFilters();
+export function AggregatesTable({
+  aggregatesTableResult,
+  confidences,
+}: AggregatesTableProps) {
   const topEvents = useTopEvents();
   const organization = useOrganization();
   const title = useExploreTitle();
@@ -63,66 +60,13 @@ export function AggregatesTable({confidences, setError}: AggregatesTableProps) {
   const groupBys = useExploreGroupBys();
   const visualizes = useExploreVisualizes();
 
-  const fields = useMemo(() => {
-    // When rendering the table, we want the group bys first
-    // then the aggregates.
-    const allFields: string[] = [];
-
-    for (const groupBy of groupBys) {
-      if (allFields.includes(groupBy)) {
-        continue;
-      }
-      allFields.push(groupBy);
-    }
-
-    for (const visualize of visualizes) {
-      for (const yAxis of visualize.yAxes) {
-        if (allFields.includes(yAxis)) {
-          continue;
-        }
-        allFields.push(yAxis);
-      }
-    }
-
-    return allFields.filter(Boolean);
-  }, [groupBys, visualizes]);
+  const {result, eventView, fields} = aggregatesTableResult;
 
   const sorts = useExploreSortBys();
   const setSorts = useSetExploreSortBys();
   const query = useExploreQuery();
 
-  const eventView = useMemo(() => {
-    const search = new MutableSearch(query);
-
-    // Filtering out all spans with op like 'ui.interaction*' which aren't
-    // embedded under transactions. The trace view does not support rendering
-    // such spans yet.
-    search.addFilterValues('!transaction.span_id', ['00']);
-
-    const discoverQuery: NewQuery = {
-      id: undefined,
-      name: 'Explore - Span Aggregates',
-      fields,
-      orderby: sorts.map(formatSort),
-      query: search.formatString(),
-      version: 2,
-      dataset,
-    };
-
-    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [dataset, fields, sorts, query, selection]);
-
   const columns = useMemo(() => eventView.getColumns(), [eventView]);
-
-  const result = useSpansQuery({
-    eventView,
-    initialData: [],
-    referrer: 'api.explore.spans-aggregates-table',
-  });
-
-  useEffect(() => {
-    setError(result.error?.message ?? '');
-  }, [setError, result.error?.message]);
 
   useAnalytics({
     dataset,

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -1,4 +1,3 @@
-import type {Dispatch, SetStateAction} from 'react';
 import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 
@@ -16,15 +15,25 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
-import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
+import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
+import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
+import {Tab} from 'sentry/views/explore/hooks/useTab';
 import {AggregatesTable} from 'sentry/views/explore/tables/aggregatesTable';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {SpansTable} from 'sentry/views/explore/tables/spansTable';
 import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
-interface ExploreTablesProps {
+interface BaseExploreTablesProps {
   confidences: Confidence[];
-  setError: Dispatch<SetStateAction<string>>;
+  samplesTab: Tab;
+  setSamplesTab: (tab: Tab) => void;
+}
+
+interface ExploreTablesProps extends BaseExploreTablesProps {
+  aggregatesTableResult: AggregatesTableResult;
+  spansTableResult: SpansTableResult;
+  tracesTableResult: TracesTableResult;
 }
 
 export function ExploreTables(props: ExploreTablesProps) {
@@ -38,13 +47,20 @@ export function ExploreTables(props: ExploreTablesProps) {
   );
 }
 
-function ExploreAggregatesTable(props: ExploreTablesProps) {
+interface AggregatesExploreTablesProps extends BaseExploreTablesProps {
+  aggregatesTableResult: AggregatesTableResult;
+}
+
+function ExploreAggregatesTable(props: AggregatesExploreTablesProps) {
   return <AggregatesTable {...props} />;
 }
 
-function ExploreSamplesTable(props: ExploreTablesProps) {
-  const [tab, setTab] = useTab();
+interface SamplesExploreTablesProps extends BaseExploreTablesProps {
+  spansTableResult: SpansTableResult;
+  tracesTableResult: TracesTableResult;
+}
 
+function ExploreSamplesTable(props: SamplesExploreTablesProps) {
   const fields = useExploreFields();
   const setFields = useSetExploreFields();
 
@@ -69,22 +85,22 @@ function ExploreSamplesTable(props: ExploreTablesProps) {
   return (
     <Fragment>
       <SamplesTableHeader>
-        <Tabs value={tab} onChange={setTab}>
+        <Tabs value={props.samplesTab} onChange={props.setSamplesTab}>
           <TabList hideBorder>
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
             <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
           </TabList>
         </Tabs>
         <Button
-          disabled={tab !== Tab.SPAN}
+          disabled={props.samplesTab !== Tab.SPAN}
           onClick={openColumnEditor}
           icon={<IconTable />}
         >
           {t('Edit Table')}
         </Button>
       </SamplesTableHeader>
-      {tab === Tab.SPAN && <SpansTable {...props} />}
-      {tab === Tab.TRACE && <TracesTable {...props} />}
+      {props.samplesTab === Tab.SPAN && <SpansTable {...props} />}
+      {props.samplesTab === Tab.TRACE && <TracesTable {...props} />}
     </Fragment>
   );
 }

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -1,5 +1,4 @@
-import type {Dispatch, SetStateAction} from 'react';
-import {Fragment, useEffect, useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {GridResizer} from 'sentry/components/gridEditable/styles';
@@ -8,13 +7,10 @@ import Pagination from 'sentry/components/pagination';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
-import type {Confidence, NewQuery} from 'sentry/types/organization';
+import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import EventView from 'sentry/utils/discover/eventView';
 import {fieldAlignment, prettifyTagKey} from 'sentry/utils/discover/fields';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   Table,
   TableBody,
@@ -37,18 +33,16 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
-import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 
 import {FieldRenderer} from './fieldRenderer';
 
 interface SpansTableProps {
   confidences: Confidence[];
-  setError: Dispatch<SetStateAction<string>>;
+  spansTableResult: SpansTableResult;
 }
 
-export function SpansTable({confidences, setError}: SpansTableProps) {
-  const {selection} = usePageFilters();
-
+export function SpansTable({confidences, spansTableResult}: SpansTableProps) {
   const dataset = useExploreDataset();
   const title = useExploreTitle();
   const fields = useExploreFields();
@@ -63,48 +57,9 @@ export function SpansTable({confidences, setError}: SpansTableProps) {
     [fields]
   );
 
-  const eventView = useMemo(() => {
-    const queryFields = [
-      ...visibleFields,
-      'project',
-      'trace',
-      'transaction.span_id',
-      'id',
-      'timestamp',
-    ];
-
-    const search = new MutableSearch(query);
-
-    // Filtering out all spans with op like 'ui.interaction*' which aren't
-    // embedded under transactions. The trace view does not support rendering
-    // such spans yet.
-    search.addFilterValues('!transaction.span_id', ['00']);
-
-    const discoverQuery: NewQuery = {
-      id: undefined,
-      name: 'Explore - Span Samples',
-      fields: queryFields,
-      orderby: sortBys.map(sort => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`),
-      query: search.formatString(),
-      version: 2,
-      dataset,
-    };
-
-    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [dataset, sortBys, query, selection, visibleFields]);
+  const {result, eventView} = spansTableResult;
 
   const columnsFromEventView = useMemo(() => eventView.getColumns(), [eventView]);
-
-  const result = useSpansQuery({
-    eventView,
-    initialData: [],
-    referrer: 'api.explore.spans-samples-table',
-    allowAggregateConditions: false,
-  });
-
-  useEffect(() => {
-    setError(result.error?.message ?? '');
-  }, [setError, result.error?.message]);
 
   useAnalytics({
     dataset,

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -1,5 +1,4 @@
-import type {Dispatch, SetStateAction} from 'react';
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -11,7 +10,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Tooltip} from 'sentry/components/tooltip';
-import {DEFAULT_PER_PAGE, SPAN_PROPS_DOCS_URL} from 'sentry/constants';
+import {SPAN_PROPS_DOCS_URL} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tct} from 'sentry/locale';
@@ -19,7 +18,6 @@ import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -31,7 +29,8 @@ import {
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
-import {type TraceResult, useTraces} from 'sentry/views/explore/hooks/useTraces';
+import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
+import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
 import {
   Description,
   ProjectBadgeWrapper,
@@ -54,30 +53,17 @@ import {
 
 interface TracesTableProps {
   confidences: Confidence[];
-  setError: Dispatch<SetStateAction<string>>;
+  tracesTableResult: TracesTableResult;
 }
 
-export function TracesTable({confidences, setError}: TracesTableProps) {
+export function TracesTable({confidences, tracesTableResult}: TracesTableProps) {
   const title = useExploreTitle();
   const dataset = useExploreDataset();
   const query = useExploreQuery();
   const visualizes = useExploreVisualizes();
   const organization = useOrganization();
 
-  const location = useLocation();
-  const cursor = decodeScalar(location.query.cursor);
-
-  const result = useTraces({
-    dataset,
-    query,
-    limit: DEFAULT_PER_PAGE,
-    sort: '-timestamp',
-    cursor,
-  });
-
-  useEffect(() => {
-    setError(result.error?.message ?? '');
-  }, [setError, result.error?.message]);
+  const {result} = tracesTableResult;
 
   useAnalytics({
     dataset,


### PR DESCRIPTION
There's some dependencies between components that causes re-renders. Lift the table queries into the parent to avoid this.