### PR TITLE
fix(rpc): Switch measurements to float

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -61,8 +61,7 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
     "week": FLOAT,
     "duration": FLOAT,
     "integer": INT,
-    # TODO:  need to update these to float once the proto supports float arrays
-    "number": INT,
+    "number": FLOAT,
     "percentage": FLOAT,
     "string": STRING,
 }

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -4,8 +4,8 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
     AttributeValue,
     ExtrapolationMode,
+    FloatArray,
     Function,
-    IntArray,
     StrArray,
     VirtualColumnContext,
 )
@@ -51,9 +51,9 @@ class SearchResolverQueryTest(TestCase):
         query, _ = self.resolver.resolve_query("ai.total_tokens.used:123")
         assert query == TraceItemFilter(
             comparison_filter=ComparisonFilter(
-                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_INT),
+                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_FLOAT),
                 op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(val_int=123),
+                value=AttributeValue(val_float=123),
             )
         )
 
@@ -95,9 +95,9 @@ class SearchResolverQueryTest(TestCase):
         query, _ = self.resolver.resolve_query("ai.total_tokens.used:[123,456,789]")
         assert query == TraceItemFilter(
             comparison_filter=ComparisonFilter(
-                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_INT),
+                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_FLOAT),
                 op=ComparisonFilter.OP_IN,
-                value=AttributeValue(val_int_array=IntArray(values=[123, 456, 789])),
+                value=AttributeValue(val_float_array=FloatArray(values=[123, 456, 789])),
             )
         )
 
@@ -105,9 +105,9 @@ class SearchResolverQueryTest(TestCase):
         query, _ = self.resolver.resolve_query("ai.total_tokens.used:>123")
         assert query == TraceItemFilter(
             comparison_filter=ComparisonFilter(
-                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_INT),
+                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_FLOAT),
                 op=ComparisonFilter.OP_GREATER_THAN,
-                value=AttributeValue(val_int=123),
+                value=AttributeValue(val_float=123),
             )
         )
 
@@ -281,7 +281,7 @@ class SearchResolverColumnTest(TestCase):
     def test_simple_number_tag(self):
         resolved_column, virtual_context = self.resolver.resolve_column("tags[foo, number]")
         assert resolved_column.proto_definition == AttributeKey(
-            name="foo", type=AttributeKey.Type.TYPE_INT
+            name="foo", type=AttributeKey.Type.TYPE_FLOAT
         )
         assert virtual_context is None
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1837,6 +1837,3 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     @pytest.mark.xfail(reason="wip: rate not implemented yet")
     def test_spm(self):
         super().test_spm()
-
-    def test_simple_measurements(self):
-        super().test_simple_measurements()

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -616,7 +616,6 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         assert response.status_code == 200, response.content
         assert response.data["data"] == [{"foo": "", "count()": 1}]
 
-    @pytest.mark.xfail
     def test_count_field_type(self):
         response = self.do_request(
             {
@@ -680,7 +679,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                         "sentry_tags": {"status": "success"},
                         "tags": {"bar": "bar2"},
                     },
-                    measurements={k: {"value": i + 1} for i, (k, _, _) in enumerate(keys)},
+                    measurements={k: {"value": (i + 1) / 10} for i, (k, _, _) in enumerate(keys)},
                     start_ts=self.ten_mins_ago,
                 ),
             ],
@@ -717,7 +716,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
             }
             assert response.data["data"] == [
                 {
-                    key: i + 1,
+                    key: pytest.approx((i + 1) / 10),
                     "id": mock.ANY,
                     "project.name": self.project.slug,
                 }
@@ -1664,7 +1663,6 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[0]["count()"] == 11
         assert confidence[0]["count()"] == "low"
 
-    @pytest.mark.xfail
     def test_aggregate_numeric_attr(self):
         self.store_spans(
             [
@@ -1839,3 +1837,6 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     @pytest.mark.xfail(reason="wip: rate not implemented yet")
     def test_spm(self):
         super().test_spm()
+
+    def test_simple_measurements(self):
+        super().test_simple_measurements()


### PR DESCRIPTION
- They always should've been floats, but at the initial implementation we didn't have float arrays yet, now that we do updating it