### PR TITLE
feat(ui): Allow generic decoders for `useLocationQuery`

### DIFF
--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -28,7 +28,7 @@ export function addQueryParamsToExistingUrl(
   return `${url.protocol}//${url.host}${url.pathname}?${qs.stringify(query)}`;
 }
 
-type QueryValue = string | string[] | undefined | null;
+export type QueryValue = string | string[] | undefined | null;
 
 /**
  * Append a tag key:value to a query string.

--- a/static/app/utils/url/useLocationQuery.spec.tsx
+++ b/static/app/utils/url/useLocationQuery.spec.tsx
@@ -2,7 +2,12 @@ import type {Location} from 'history';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
-import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {
+  decodeInteger,
+  decodeList,
+  decodeScalar,
+  type QueryValue,
+} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -80,7 +85,7 @@ describe('useLocationQuery', () => {
 
     type Title = 'Mr' | 'Ms' | 'Mx';
 
-    const titlesDecoder = (value): Title[] | undefined => {
+    const titlesDecoder = (value: QueryValue): Title[] | undefined => {
       const decodedValue = decodeList(value);
 
       const validTitles = decodedValue.filter(v => {

--- a/static/app/utils/url/useLocationQuery.spec.tsx
+++ b/static/app/utils/url/useLocationQuery.spec.tsx
@@ -70,6 +70,39 @@ describe('useLocationQuery', () => {
     });
   });
 
+  it('allows custom typed decoders', () => {
+    jest.mocked(useLocation).mockReturnValueOnce({
+      ...mockLocation,
+      query: {
+        titles: ['Mx', 'Dr'],
+      },
+    } as Location);
+
+    type Title = 'Mr' | 'Ms' | 'Mx';
+
+    const titlesDecoder = (value): Title[] | undefined => {
+      const decodedValue = decodeList(value);
+
+      const validTitles = decodedValue.filter(v => {
+        return ['Mr', 'Ms', 'Mx'].includes(v);
+      }) as Title[];
+
+      return validTitles.length > 0 ? validTitles : undefined;
+    };
+
+    const {result} = renderHook(useLocationQuery, {
+      initialProps: {
+        fields: {
+          titles: titlesDecoder,
+        },
+      },
+    });
+
+    expect(result.current).toStrictEqual({
+      titles: ['Mx'],
+    });
+  });
+
   it('should pass-through static values along with decoded ones', () => {
     jest.mocked(useLocation).mockReturnValueOnce({
       ...mockLocation,

--- a/static/app/utils/url/useLocationQuery.tsx
+++ b/static/app/utils/url/useLocationQuery.tsx
@@ -40,10 +40,7 @@ export type Decoder = KnownDecoder | GenericDecoder;
  * ```
  */
 export default function useLocationQuery<
-  InferredRequestShape extends Record<
-    string,
-    Scalar | Scalar[] | KnownDecoder | GenericDecoder
-  >,
+  InferredRequestShape extends Record<string, Scalar | Scalar[] | Decoder>,
   InferredResponseShape extends {
     readonly [Property in keyof InferredRequestShape]: InferredRequestShape[Property] extends Decoder
       ? ReturnType<InferredRequestShape[Property]>

--- a/static/app/utils/url/useLocationQuery.tsx
+++ b/static/app/utils/url/useLocationQuery.tsx
@@ -6,16 +6,22 @@ import {
   type decodeList,
   decodeScalar,
   type decodeSorts,
+  type QueryValue,
 } from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 
 type Scalar = string | boolean | number | undefined;
-export type Decoder =
+
+type KnownDecoder =
   | typeof decodeInteger
   | typeof decodeList
   | typeof decodeScalar
   | typeof decodeSorts
   | typeof decodeBoolean;
+
+type GenericDecoder<T = unknown> = (query: QueryValue) => T;
+
+export type Decoder = KnownDecoder | GenericDecoder;
 
 /**
  * Select and memoize query params from location.
@@ -34,7 +40,10 @@ export type Decoder =
  * ```
  */
 export default function useLocationQuery<
-  InferredRequestShape extends Record<string, Scalar | Scalar[] | Decoder>,
+  InferredRequestShape extends Record<
+    string,
+    Scalar | Scalar[] | KnownDecoder | GenericDecoder
+  >,
   InferredResponseShape extends {
     readonly [Property in keyof InferredRequestShape]: InferredRequestShape[Property] extends Decoder
       ? ReturnType<InferredRequestShape[Property]>


### PR DESCRIPTION
This updates the types in `useLocationQuery` to make it easier to use custom decoders. In Insights, a lot of the decoders do some fancy validation, and have return types like `FieldName[] | undefined`. The types in `useLocationQuery` only support "known" decoders, not generic ones. The type check there fails.

This PR adds a new, generic `CustomDecoder` type. This makes it possible for a decoder to return whatever it wants, and the types are preserved. The spec is funny because it always passed, but until this PR it wouldn't pass the type checks.

You can see in the screenshot the return value has correct custom types.

![Screenshot 2025-01-09 at 3 34 42 PM](https://github.com/user-attachments/assets/56374f13-fbe4-47c8-80e1-4398003a3e9c)

