### PR TITLE
chore(llm-monitoring): remove old metric-based alerts in favor of EAP-based ones

### DIFF
--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -71,7 +71,6 @@ describe('AlertWizard', () => {
     expect(screen.getByText('Sessions')).toBeInTheDocument();
     expect(screen.getByText('Performance')).toBeInTheDocument();
     expect(screen.getByText('Uptime Monitoring')).toBeInTheDocument();
-    expect(screen.getByText('LLM Monitoring')).toBeInTheDocument();
     expect(screen.getByText('Custom')).toBeInTheDocument();
     const alertGroups = screen.getAllByRole('radiogroup');
     expect(alertGroups).toHaveLength(6);

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -73,7 +73,7 @@ describe('AlertWizard', () => {
     expect(screen.getByText('Uptime Monitoring')).toBeInTheDocument();
     expect(screen.getByText('Custom')).toBeInTheDocument();
     const alertGroups = screen.getAllByRole('radiogroup');
-    expect(alertGroups).toHaveLength(6);
+    expect(alertGroups).toHaveLength(5);
   });
 
   it('should only render alerts for errors in self-hosted errors only', () => {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -28,7 +28,6 @@ import {
   SessionsAggregate,
 } from 'sentry/views/alerts/rules/metric/types';
 import {hasEAPAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
-import {MODULE_TITLE as LLM_MONITORING_MODULE_TITLE} from 'sentry/views/insights/llmMonitoring/settings';
 
 export type AlertType =
   | 'issues'
@@ -45,8 +44,6 @@ export type AlertType =
   | 'crash_free_users'
   | 'custom_transactions'
   | 'custom_metrics'
-  | 'llm_tokens'
-  | 'llm_cost'
   | 'uptime_monitor'
   | 'eap_metrics';
 
@@ -90,8 +87,6 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   custom_transactions: t('Custom Measurement'),
   crash_free_sessions: t('Crash Free Session Rate'),
   crash_free_users: t('Crash Free User Rate'),
-  llm_cost: t('LLM cost'),
-  llm_tokens: t('LLM token usage'),
   uptime_monitor: t('Uptime Monitor'),
   eap_metrics: t('Spans'),
 };
@@ -143,12 +138,6 @@ export const getAlertWizardCategories = (org: Organization) => {
         ...(hasEAPAlerts(org) ? ['eap_metrics' as const] : []),
       ],
     });
-    if (org.features.includes('insights-addon-modules')) {
-      result.push({
-        categoryHeading: LLM_MONITORING_MODULE_TITLE,
-        options: ['llm_tokens', 'llm_cost'],
-      });
-    }
 
     result.push({
       categoryHeading: t('Uptime Monitoring'),
@@ -225,16 +214,6 @@ export const AlertWizardRuleTemplates: Record<
   },
   custom_metrics: {
     aggregate: DEFAULT_METRIC_ALERT_FIELD,
-    dataset: Dataset.GENERIC_METRICS,
-    eventTypes: EventTypes.TRANSACTION,
-  },
-  llm_tokens: {
-    aggregate: 'sum(ai.total_tokens.used)',
-    dataset: Dataset.GENERIC_METRICS,
-    eventTypes: EventTypes.TRANSACTION,
-  },
-  llm_cost: {
-    aggregate: 'sum(ai.total_cost)',
     dataset: Dataset.GENERIC_METRICS,
     eventTypes: EventTypes.TRANSACTION,
   },

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -143,20 +143,6 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCustomMetrics,
   },
-  llm_tokens: {
-    description: t(
-      'Receive an alert when the total number of tokens used by your LLMs reaches a limit.'
-    ),
-    examples: [t('When there are more than 100,000 tokens used within an hour')],
-    illustration: diagramCustomMetrics,
-  },
-  llm_cost: {
-    description: t(
-      'Receive an alert when the total cost of tokens used by your LLMs reaches a limit.'
-    ),
-    examples: [t('When there are more than $100 used by LLM  within an hour')],
-    illustration: diagramCustomMetrics,
-  },
   crash_free_sessions: {
     description: t(
       'A session begins when a user starts the application and ends when it’s closed or sent to the background. A crash is when a session ends due to an error and this type of alert lets you monitor when those crashed sessions exceed a threshold. This lets you get a better picture of the health of your app.'


### PR DESCRIPTION
Sentry has a new way of storing spans called the 'Events Analytics Platform' - in the coming months, you'll be able to make alerts on arbitrary data, not particular things like LLM tokens.