### PR TITLE
chore(issue-details): Improve multiple suspect commits

### DIFF
--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -173,10 +173,16 @@ const StreamlinedPanel = styled(Panel)`
   overflow: hidden;
   margin-bottom: 0;
   width: 100%;
-  min-width: 85%;
+  min-width: 65%;
+  &:last-child {
+    margin-right: ${space(2)};
+  }
+  &:first-child {
+    margin-left: ${space(2)};
+  }
 `;
 
 const SuspectCommitWrapper = styled('div')`
-  margin-right: 0;
-  margin-left: 0;
+  margin-right: -${space(2)};
+  margin-left: -${space(2)};
 `;


### PR DESCRIPTION
this pr slightly updates how we show multiple suspect commits. the suspect commit component is shrunk a bit to show more of subsequent suspect commits. a regression to the scrolling on multiple suspect commits is also fixed so the suspect commits go to the edge instead of stopping early. 