### PR TITLE
chore(metric-alerts): Remove `metric-alert-threshold-period` flag

### DIFF
--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.spec.tsx
@@ -12,7 +12,6 @@ describe('AnomalyDetectionFeedbackBanner', () => {
   const initialData = initializeOrg({
     organization: {
       features: [
-        'metric-alert-threshold-period',
         'change-alerts',
         'anomaly-detection-alerts',
         'anomaly-detection-rollout',

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -4,7 +4,6 @@ import {MetricRuleFixture} from 'sentry-fixture/metricRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
-import selectEvent from 'sentry-test/selectEvent';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type FormModel from 'sentry/components/forms/model';
@@ -48,7 +47,7 @@ describe('Incident Rules Form', () => {
 
   beforeEach(() => {
     const initialData = initializeOrg({
-      organization: {features: ['metric-alert-threshold-period', 'change-alerts']},
+      organization: {features: ['change-alerts']},
     });
     organization = initialData.organization;
     project = initialData.project;
@@ -201,9 +200,6 @@ describe('Incident Rules Form', () => {
         'Incident Rule'
       );
 
-      // Set thresholdPeriod
-      await selectEvent.select(screen.getAllByText('For 1 minute')[0]!, 'For 10 minutes');
-
       await userEvent.click(screen.getByLabelText('Save Rule'));
 
       expect(createRule).toHaveBeenCalledWith(
@@ -213,7 +209,6 @@ describe('Incident Rules Form', () => {
             name: 'Incident Rule',
             projects: ['project-slug'],
             eventTypes: ['default'],
-            thresholdPeriod: 10,
           }),
         })
       );
@@ -401,9 +396,6 @@ describe('Incident Rules Form', () => {
         'EAP Incident Rule'
       );
 
-      // Set thresholdPeriod
-      await selectEvent.select(screen.getAllByText('For 1 minute')[0]!, 'For 10 minutes');
-
       await userEvent.click(screen.getByLabelText('Save Rule'));
 
       expect(createRule).toHaveBeenCalledWith(
@@ -413,7 +405,6 @@ describe('Incident Rules Form', () => {
             name: 'EAP Incident Rule',
             projects: ['project-slug'],
             eventTypes: [],
-            thresholdPeriod: 10,
             alertType: 'eap_metrics',
             dataset: 'events_analytics_platform',
           }),
@@ -473,7 +464,6 @@ describe('Incident Rules Form', () => {
         name: 'Query Rule',
         projects: ['project-slug'],
         eventTypes: ['num_errors'],
-        thresholdPeriod: 10,
         query: 'is:unresolved',
         rule,
         ruleId: rule.id,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -147,7 +147,6 @@ type State = {
   query: string;
   resolveThreshold: UnsavedMetricRule['resolveThreshold'];
   sensitivity: UnsavedMetricRule['sensitivity'];
-  thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   timeWindow: number;
   triggerErrors: Map<number, {[fieldName: string]: string}>;
@@ -872,10 +871,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     );
   };
 
-  handleThresholdPeriodChange = (value: number) => {
-    this.setState({thresholdPeriod: value}, () => this.fetchAnomalies());
-  };
-
   handleResolveThresholdChange = (
     resolveThreshold: UnsavedMetricRule['resolveThreshold']
   ) => {
@@ -1234,7 +1229,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       triggers,
       aggregate,
       thresholdType,
-      thresholdPeriod,
       comparisonDelta,
       comparisonType,
       resolveThreshold,
@@ -1263,7 +1257,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         isMigration={isMigration}
         resolveThreshold={resolveThreshold}
         sensitivity={sensitivity}
-        thresholdPeriod={thresholdPeriod}
         thresholdType={thresholdType}
         comparisonType={comparisonType}
         currentProject={project.slug}
@@ -1271,7 +1264,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         availableActions={this.state.availableActions}
         onChange={this.handleChangeTriggers}
         onThresholdTypeChange={this.handleThresholdTypeChange}
-        onThresholdPeriodChange={this.handleThresholdPeriodChange}
         onResolveThresholdChange={this.handleResolveThresholdChange}
         onSensitivityChange={this.handleSensitivityChange}
       />

--- a/static/app/views/alerts/rules/metric/triggers/form.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/form.tsx
@@ -35,13 +35,11 @@ type Props = {
   fieldHelp: React.ReactNode;
   isCritical: boolean;
   onChange: (trigger: Trigger, changeObj: Partial<Trigger>) => void;
-  onThresholdPeriodChange: (value: number) => void;
   onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
   organization: Organization;
   placeholder: string;
   projects: Project[];
   resolveThreshold: UnsavedMetricRule['resolveThreshold'];
-  thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   trigger: Trigger;
 
@@ -79,14 +77,12 @@ class TriggerFormItem extends PureComponent<Props> {
       trigger,
       isCritical,
       thresholdType,
-      thresholdPeriod,
       hideControl,
       comparisonType,
       fieldHelp,
       triggerLabel,
       placeholder,
       onThresholdTypeChange,
-      onThresholdPeriodChange,
     } = this.props;
 
     return (
@@ -101,14 +97,12 @@ class TriggerFormItem extends PureComponent<Props> {
           disableThresholdType={!isCritical}
           type={trigger.label}
           thresholdType={thresholdType}
-          thresholdPeriod={thresholdPeriod}
           hideControl={hideControl}
           threshold={trigger.alertThreshold}
           comparisonType={comparisonType}
           placeholder={placeholder}
           onChange={this.handleChangeThreshold}
           onThresholdTypeChange={onThresholdTypeChange}
-          onThresholdPeriodChange={onThresholdPeriodChange}
         />
       </StyledField>
     );
@@ -193,13 +187,11 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
       organization,
       triggers,
       thresholdType,
-      thresholdPeriod,
       comparisonType,
       aggregate,
       resolveThreshold,
       projects,
       onThresholdTypeChange,
-      onThresholdPeriodChange,
     } = this.props;
 
     const resolveTrigger: UnsavedTrigger = {
@@ -223,7 +215,6 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
               disabled={disabled}
               error={errors?.get(index)}
               trigger={trigger}
-              thresholdPeriod={thresholdPeriod}
               thresholdType={thresholdType}
               comparisonType={comparisonType}
               aggregate={aggregate}
@@ -254,7 +245,6 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
               }
               onChange={this.handleChangeTrigger(index)}
               onThresholdTypeChange={onThresholdTypeChange}
-              onThresholdPeriodChange={onThresholdPeriodChange}
             />
           );
         })}
@@ -265,7 +255,6 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
           error={errors?.get(2)}
           trigger={resolveTrigger}
           // Flip rule thresholdType to opposite
-          thresholdPeriod={thresholdPeriod}
           thresholdType={+!thresholdType}
           comparisonType={comparisonType}
           aggregate={aggregate}
@@ -284,7 +273,6 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
           placeholder={t('Automatic')}
           onChange={this.handleChangeResolveTrigger}
           onThresholdTypeChange={onThresholdTypeChange}
-          onThresholdPeriodChange={onThresholdPeriodChange}
         />
       </Fragment>
     );

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -37,7 +37,6 @@ type Props = {
     resolveThreshold: UnsavedMetricRule['resolveThreshold']
   ) => void;
   onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
-  onThresholdPeriodChange: (value: number) => void;
   onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
   organization: Organization;
   projects: Project[];
@@ -45,7 +44,6 @@ type Props = {
 
   sensitivity: UnsavedMetricRule['sensitivity'];
 
-  thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   triggers: Trigger[];
   isMigration?: boolean;
@@ -108,14 +106,12 @@ class Triggers extends Component<Props> {
       disabled,
       aggregate,
       thresholdType,
-      thresholdPeriod,
       comparisonType,
       resolveThreshold,
       isMigration,
       onSensitivityChange,
       onThresholdTypeChange,
       onResolveThresholdChange,
-      onThresholdPeriodChange,
       sensitivity,
     } = this.props;
 
@@ -142,12 +138,10 @@ class Triggers extends Component<Props> {
                 aggregate={aggregate}
                 resolveThreshold={resolveThreshold}
                 thresholdType={thresholdType}
-                thresholdPeriod={thresholdPeriod}
                 comparisonType={comparisonType}
                 onChange={this.handleChangeTrigger}
                 onThresholdTypeChange={onThresholdTypeChange}
                 onResolveThresholdChange={onResolveThresholdChange}
-                onThresholdPeriodChange={onThresholdPeriodChange}
               />
             )}
           </PanelBody>

--- a/static/app/views/alerts/rules/metric/triggers/thresholdControl.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/thresholdControl.tsx
@@ -1,12 +1,11 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import Input from 'sentry/components/input';
 import NumberDragControl from 'sentry/components/numberDragControl';
 import {Tooltip} from 'sentry/components/tooltip';
-import {t, tct, tn} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ThresholdControlValue} from 'sentry/views/alerts/rules/metric/types';
 import {
@@ -19,10 +18,8 @@ type Props = ThresholdControlValue & {
   disableThresholdType: boolean;
   disabled: boolean;
   onChange: (value: ThresholdControlValue, e: React.FormEvent) => void;
-  onThresholdPeriodChange: (value: number) => void;
   onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
   placeholder: string;
-  thresholdPeriod: number | null;
   type: string;
   hideControl?: boolean;
 };
@@ -90,14 +87,9 @@ class ThresholdControl extends Component<Props, State> {
     onChange({thresholdType, threshold: currentValue + delta}, e);
   };
 
-  handleThresholdPeriodChange = ({value}) => {
-    this.props.onThresholdPeriodChange(value);
-  };
-
   render() {
     const {currentValue} = this.state;
     const {
-      thresholdPeriod,
       thresholdType,
       comparisonType,
       hideControl,
@@ -195,22 +187,6 @@ class ThresholdControl extends Component<Props, State> {
             </ThresholdContainer>
           )}
         </Container>
-        {!hideControl && (
-          <Feature features="metric-alert-threshold-period">
-            <SelectContainer>
-              <SelectControl
-                isDisabled={disabled}
-                name="thresholdPeriod"
-                value={thresholdPeriod}
-                options={[1, 2, 5, 10, 20].map(value => ({
-                  value,
-                  label: tn('For %s minute', 'For %s minutes', value),
-                }))}
-                onChange={this.handleThresholdPeriodChange}
-              />
-            </SelectContainer>
-          </Feature>
-        )}
       </Wrapper>
     );
   }


### PR DESCRIPTION
These changes were added in https://github.com/getsentry/sentry/pull/31378 but haven't been released beyond Sentry since then. 