### PR TITLE
feat(streamline): Add an option to remove opt-out for new users

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -24,6 +24,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
 from sentry.hybridcloud.rpc import IDEMPOTENCY_KEY_LENGTH
+from sentry.issues.streamline import apply_streamline_rollout_group
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.projectplatform import ProjectPlatform
@@ -238,70 +239,74 @@ class OrganizationIndexEndpoint(Endpoint):
 
         serializer = OrganizationPostSerializer(data=request.data)
 
-        if serializer.is_valid():
-            result = serializer.validated_data
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-            try:
-                create_default_team = bool(result.get("defaultTeam"))
-                provision_args = OrganizationProvisioningOptions(
-                    provision_options=OrganizationOptions(
-                        name=result["name"],
-                        slug=result.get("slug") or result["name"],
-                        owning_user_id=request.user.id,
-                        create_default_team=create_default_team,
-                    ),
-                    post_provision_options=PostProvisionOptions(
-                        getsentry_options=None, sentry_options=None
-                    ),
-                )
+        result = serializer.validated_data
 
-                rpc_org = organization_provisioning_service.provision_organization_in_region(
-                    region_name=settings.SENTRY_REGION or settings.SENTRY_MONOLITH_REGION,
-                    provisioning_options=provision_args,
-                )
-                org = Organization.objects.get(id=rpc_org.id)
+        try:
+            create_default_team = bool(result.get("defaultTeam"))
+            provision_args = OrganizationProvisioningOptions(
+                provision_options=OrganizationOptions(
+                    name=result["name"],
+                    slug=result.get("slug") or result["name"],
+                    owning_user_id=request.user.id,
+                    create_default_team=create_default_team,
+                ),
+                post_provision_options=PostProvisionOptions(
+                    getsentry_options=None, sentry_options=None
+                ),
+            )
 
-                org_setup_complete.send_robust(
-                    instance=org, user=request.user, sender=self.__class__, referrer="in-app"
-                )
+            rpc_org = organization_provisioning_service.provision_organization_in_region(
+                region_name=settings.SENTRY_REGION or settings.SENTRY_MONOLITH_REGION,
+                provisioning_options=provision_args,
+            )
+            org = Organization.objects.get(id=rpc_org.id)
 
-                self.create_audit_entry(
-                    request=request,
-                    organization=org,
-                    target_object=org.id,
-                    event=audit_log.get_event_id("ORG_ADD"),
-                    data=org.get_audit_log_data(),
-                )
+            org_setup_complete.send_robust(
+                instance=org, user=request.user, sender=self.__class__, referrer="in-app"
+            )
 
-                analytics.record(
-                    "organization.created",
-                    org,
-                    actor_id=request.user.id if request.user.is_authenticated else None,
-                )
+            self.create_audit_entry(
+                request=request,
+                organization=org,
+                target_object=org.id,
+                event=audit_log.get_event_id("ORG_ADD"),
+                data=org.get_audit_log_data(),
+            )
 
-            # TODO(hybrid-cloud): We'll need to catch a more generic error
-            # when the internal RPC is implemented.
-            except IntegrityError:
-                return Response(
-                    {"detail": "An organization with this slug already exists."}, status=409
-                )
+            analytics.record(
+                "organization.created",
+                org,
+                actor_id=request.user.id if request.user.is_authenticated else None,
+            )
 
-            # failure on sending this signal is acceptable
-            if result.get("agreeTerms"):
-                terms_accepted.send_robust(
-                    user=request.user,
-                    organization_id=org.id,
-                    ip_address=request.META["REMOTE_ADDR"],
-                    sender=type(self),
-                )
+        # TODO(hybrid-cloud): We'll need to catch a more generic error
+        # when the internal RPC is implemented.
+        except IntegrityError:
+            return Response(
+                {"detail": "An organization with this slug already exists."}, status=409
+            )
 
-            if result.get("aggregatedDataConsent"):
-                org.update_option("sentry:aggregated_data_consent", True)
+        # failure on sending this signal is acceptable
+        if result.get("agreeTerms"):
+            terms_accepted.send_robust(
+                user=request.user,
+                organization_id=org.id,
+                ip_address=request.META["REMOTE_ADDR"],
+                sender=type(self),
+            )
 
-                analytics.record(
-                    "aggregated_data_consent.organization_created",
-                    organization_id=org.id,
-                )
+        if result.get("aggregatedDataConsent"):
+            org.update_option("sentry:aggregated_data_consent", True)
 
-            return Response(serialize(org, request.user), status=201)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            analytics.record(
+                "aggregated_data_consent.organization_created",
+                organization_id=org.id,
+            )
+
+        apply_streamline_rollout_group(organization=org)
+        # If unset, the organization's users can opt-in/out.
+        # If true, they only receive the Streamline UI. If false, they only receive the Legacy UI.
+        return Response(serialize(org, request.user), status=201)

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -307,6 +307,5 @@ class OrganizationIndexEndpoint(Endpoint):
             )
 
         apply_streamline_rollout_group(organization=org)
-        # If unset, the organization's users can opt-in/out.
-        # If true, they only receive the Streamline UI. If false, they only receive the Legacy UI.
+
         return Response(serialize(org, request.user), status=201)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -52,6 +52,7 @@ from sentry.constants import (
     SAMPLING_MODE_DEFAULT,
     SCRAPE_JAVASCRIPT_DEFAULT,
     SENSITIVE_FIELDS_DEFAULT,
+    STREAMLINE_UI_ONLY,
     TARGET_SAMPLE_RATE_DEFAULT,
     UPTIME_AUTODETECTION,
     ObjectStatus,
@@ -635,6 +636,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "rollbackEnabled": bool(
                     obj.get_option("sentry:rollback_enabled", ROLLBACK_ENABLED_DEFAULT)
                 ),
+                "streamlineOnly": obj.get_option("sentry:streamline_ui_only", STREAMLINE_UI_ONLY),
             }
         )
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -495,6 +495,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     metricsActivateLastForGauges: bool
     requiresSso: bool
     rollbackEnabled: bool
+    streamlineOnly: bool
 
 
 class DetailedOrganizationSerializer(OrganizationSerializer):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -495,7 +495,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     metricsActivateLastForGauges: bool
     requiresSso: bool
     rollbackEnabled: bool
-    streamlineOnly: bool
+    streamlineOnly: bool | None
 
 
 class DetailedOrganizationSerializer(OrganizationSerializer):
@@ -720,6 +720,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         "metricsActivateLastForGauges",
         "quota",
         "rollbackEnabled",
+        "streamlineOnly",
     ]
 )
 class DetailedOrganizationSerializerWithProjectsAndTeamsResponse(

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -717,6 +717,7 @@ UPTIME_AUTODETECTION = True
 TARGET_SAMPLE_RATE_DEFAULT = 1.0
 SAMPLING_MODE_DEFAULT = "organization"
 ROLLBACK_ENABLED_DEFAULT = True
+STREAMLINE_UI_ONLY = None
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
 EVENTS_MEMBER_ADMIN_DEFAULT = True

--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -7,16 +7,16 @@ def apply_streamline_rollout_group(organization: Organization):
     if organization.get_option("sentry:streamline_ui_only") is not None:
         return
 
-    # If the experiment is not enabled, the organization's users can opt-in/out.
+    # If the rollout_result is false, the organization is not in the experiment.
     rollout_result = sample_modulo(
         "issues.details.streamline-experiment-rollout-rate", organization.id
     )
 
     if rollout_result:
-        split_result = sample_modulo(
-            "issues.details.streamline-experiment-split-rate", organization.id
-        )
         # If split_result is true, they only receive the Streamline UI.
         # If split_result is false, they only receive the Legacy UI.
         # This behaviour is controlled on the frontend.
+        split_result = sample_modulo(
+            "issues.details.streamline-experiment-split-rate", organization.id
+        )
         organization.update_option("sentry:streamline_ui_only", split_result)

--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -1,0 +1,14 @@
+from sentry.models.group import Organization
+from sentry.utils.options import sample_modulo
+
+
+def apply_streamline_rollout_group(organization: Organization):
+    # If unset, the organization's users can opt-in/out.
+    if organization.get_option("sentry:streamline_ui_only") is not None:
+        return
+
+    result = sample_modulo("issues.details.streamline_rollout_rate", organization.id)
+    # If result is true, they only receive the Streamline UI.
+    # If result is false, they only receive the Legacy UI.
+    # This behaviour is controlled on the frontend.
+    organization.update_option("sentry:streamline_ui_only", result)

--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -1,4 +1,4 @@
-from sentry.models.group import Organization
+from sentry.models.organization import Organization
 from sentry.utils.options import sample_modulo
 
 

--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -7,8 +7,16 @@ def apply_streamline_rollout_group(organization: Organization):
     if organization.get_option("sentry:streamline_ui_only") is not None:
         return
 
-    result = sample_modulo("issues.details.streamline_rollout_rate", organization.id)
-    # If result is true, they only receive the Streamline UI.
-    # If result is false, they only receive the Legacy UI.
-    # This behaviour is controlled on the frontend.
-    organization.update_option("sentry:streamline_ui_only", result)
+    # If the experiment is not enabled, the organization's users can opt-in/out.
+    rollout_result = sample_modulo(
+        "issues.details.streamline-experiment-rollout-rate", organization.id
+    )
+
+    if rollout_result:
+        split_result = sample_modulo(
+            "issues.details.streamline-experiment-split-rate", organization.id
+        )
+        # If split_result is true, they only receive the Streamline UI.
+        # If split_result is false, they only receive the Legacy UI.
+        # This behaviour is controlled on the frontend.
+        organization.update_option("sentry:streamline_ui_only", split_result)

--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -3,10 +3,6 @@ from sentry.utils.options import sample_modulo
 
 
 def apply_streamline_rollout_group(organization: Organization):
-    # If unset, the organization's users can opt-in/out.
-    if organization.get_option("sentry:streamline_ui_only") is not None:
-        return
-
     # If the rollout_result is false, the organization is not in the experiment.
     rollout_result = sample_modulo(
         "issues.details.streamline-experiment-rollout-rate", organization.id

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -816,8 +816,17 @@ register(
 )
 
 
+#  Percentage of orgs that will be put into a bucket using the split rate below.
 register(
-    "issues.details.streamline_rollout_rate",
+    "issues.details.streamline-experiment-rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# 50% of orgs will only see the Streamline UI, 50% will only see the Legacy UI.
+register(
+    "issues.details.streamline-experiment-split-rate",
     type=Float,
     default=0.5,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -816,6 +816,14 @@ register(
 )
 
 
+register(
+    "issues.details.streamline_rollout_rate",
+    type=Float,
+    default=0.5,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
 # Killswitch for issue priority
 register(
     "issues.priority.enabled",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -733,6 +733,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "targetSampleRate": 0.1,
             "samplingMode": "organization",
             "rollbackEnabled": True,
+            "streamlineOnly": None,
         }
 
         # needed to set require2FA

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -317,15 +317,51 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         assert org.name == data["name"]
         assert OrganizationOption.objects.get_value(org, "sentry:aggregated_data_consent") is True
 
-    @override_options({"issues.details.streamline_rollout_rate": 1.0})
+    @override_options({"issues.details.streamline-experiment-rollout-rate": 0})
+    @override_options({"issues.details.streamline-experiment-split-rate": 1.0})
+    def test_streamline_only_is_unset_with_full_split_rate(self):
+        """
+        If the rollout rate is 0%, Ignore split rate, the organization should not be put into a bucket.
+        """
+        self.login_as(user=self.user)
+        response = self.get_success_response(name="acme")
+        organization = Organization.objects.get(id=response.data["id"])
+        assert (
+            OrganizationOption.objects.get_value(organization, "sentry:streamline_ui_only") is None
+        )
+
+    @override_options({"issues.details.streamline-experiment-rollout-rate": 0})
+    @override_options({"issues.details.streamline-experiment-split-rate": 0})
+    def test_streamline_only_is_unset_with_empty_split_rate(self):
+        """
+        If the rollout rate is 0%, Ignore split rate, the organization should not be put into a bucket.
+        """
+        self.login_as(user=self.user)
+        response = self.get_success_response(name="acme")
+        organization = Organization.objects.get(id=response.data["id"])
+        assert (
+            OrganizationOption.objects.get_value(organization, "sentry:streamline_ui_only") is None
+        )
+
+    @override_options({"issues.details.streamline-experiment-rollout-rate": 1.0})
+    @override_options({"issues.details.streamline-experiment-split-rate": 1.0})
     def test_streamline_only_is_true(self):
+        """
+        If the rollout rate is 100%, the split rate should be applied to all orgs.
+        In this case, with a split rate of 100%, all orgs should see the Streamline UI.
+        """
         self.login_as(user=self.user)
         response = self.get_success_response(name="acme")
         organization = Organization.objects.get(id=response.data["id"])
         assert OrganizationOption.objects.get_value(organization, "sentry:streamline_ui_only")
 
-    @override_options({"issues.details.streamline_rollout_rate": 0})
+    @override_options({"issues.details.streamline-experiment-rollout-rate": 1.0})
+    @override_options({"issues.details.streamline-experiment-split-rate": 0})
     def test_streamline_only_is_false(self):
+        """
+        If the rollout rate is 100%, the split rate should be applied to all orgs.
+        In this case, with a split rate of 0%, all orgs should see the Legacy UI.
+        """
         self.login_as(user=self.user)
         response = self.get_success_response(name="acme")
         organization = Organization.objects.get(id=response.data["id"])


### PR DESCRIPTION
Adds an option assigned to new organizations such that all members of the organization receive either the new UI or legacy UI without the ability to opt into one or the other.

This work doesn't actually do any of the UI enforcement, that will be in a correlated Frontend PR that needs to be merged first.

**todo**
- [x] Add some tests to ensure the options are set