### PR TITLE
fix(settings): Route to org settings forms correctly

### DIFF
--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -92,7 +92,7 @@ function Search({
   }, [entryPoint]);
 
   const handleSelectItem = useCallback(
-    (item: Result['item'], state?: AutoComplete<Result['item']>['state']) => {
+    (item: Readonly<Result['item']>, state?: AutoComplete<Result['item']>['state']) => {
       if (!item) {
         return;
       }
@@ -115,12 +115,14 @@ function Search({
         return;
       }
 
-      if (item.to.startsWith('http')) {
+      const pathname = typeof item.to === 'string' ? item.to : item.to.pathname;
+      if (pathname.startsWith('http')) {
         const open = window.open();
 
         if (open) {
           open.opener = null;
-          open.location.href = item.to;
+          // `to` is a full URL when starting with http
+          open.location.href = item.to as string;
           return;
         }
 
@@ -130,9 +132,14 @@ function Search({
         return;
       }
 
-      const nextPath = replaceRouterParams(item.to, params);
-
-      navigateTo(nextPath, router, item.configUrl);
+      const nextTo =
+        typeof item.to === 'string'
+          ? replaceRouterParams(item.to, params)
+          : {
+              ...item.to,
+              pathname: replaceRouterParams(item.to.pathname, params),
+            };
+      navigateTo(nextTo, router, item.configUrl);
     },
     [entryPoint, router, params]
   );

--- a/static/app/components/search/sources/formSource.spec.tsx
+++ b/static/app/components/search/sources/formSource.spec.tsx
@@ -62,7 +62,7 @@ describe('FormSource', function () {
                 route: '/route/',
                 resultType: 'field',
                 sourceType: 'field',
-                to: '/route/#test-field',
+                to: {pathname: '/route/', hash: '#test-field'},
               },
             }),
           ],

--- a/static/app/components/search/sources/formSource.tsx
+++ b/static/app/components/search/sources/formSource.tsx
@@ -6,7 +6,6 @@ import FormSearchStore from 'sentry/stores/formSearchStore';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import {createFuzzySearch} from 'sentry/utils/fuzzySearch';
-import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 
@@ -62,7 +61,7 @@ class FormSource extends Component<Props, State> {
   }
 
   render() {
-    const {searchMap, query, params, children} = this.props;
+    const {searchMap, query, children} = this.props;
     const {fuzzy} = this.state;
 
     const results =
@@ -73,9 +72,7 @@ class FormSource extends Component<Props, State> {
             ...item,
             sourceType: 'field',
             resultType: 'field',
-            to: `${replaceRouterParams(item.route, params)}#${encodeURIComponent(
-              item.field.name
-            )}`,
+            to: {pathname: item.route, hash: `#${encodeURIComponent(item.field.name)}`},
           } as ResultItem,
           ...rest,
         };

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -65,7 +65,7 @@ export type ResultItem = {
   /**
    * The path to visit when the result is clicked.
    */
-  to?: string;
+  to?: string | {hash: string; pathname: string};
 };
 
 /**


### PR DESCRIPTION
Splitting up the path and the query/hash and only calling replaceRouterParams once

Fixes an issue where routing to some settings like "Open Team Membership" would take you to the wrong page.