### PR TITLE
fix(alerts): Enable transactions table for generic metrics

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -292,7 +292,7 @@ export default function MetricDetailsBody({
                   }
                 />
               )}
-              {dataset === Dataset.TRANSACTIONS && (
+              {[Dataset.TRANSACTIONS, Dataset.GENERIC_METRICS].includes(dataset) && (
                 <RelatedTransactions
                   organization={organization}
                   location={location}


### PR DESCRIPTION
We have this table for transactions, but not generic metrics which we use for very similar alerts. We should be able to turn it on for both

example alert https://sentry.sentry.io/alerts/rules/details/310864/