### PR TITLE
feat(widget-builder): Allow selecting aggregate in big number

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -710,6 +710,68 @@ describe('Visualize', () => {
     expect(screen.queryByText('this field has an error')).not.toBeInTheDocument();
   });
 
+  it('shows radio buttons for big number widgets when there are multiple aggregates', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.BIG_NUMBER,
+              field: ['count_unique(user)'],
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(await screen.findByLabelText('Aggregate Selection')).toHaveTextContent(
+      'count_unique'
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Field'}));
+
+    // There are two radio buttons, one for each aggregate, and the last one is selected
+    expect(screen.getAllByLabelText('aggregate-selector')).toHaveLength(2);
+    expect(screen.getByRole('radio', {name: 'field1'})).toBeChecked();
+  });
+
+  it('shifts the selected aggregate up when it is the last one and removed', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.BIG_NUMBER,
+              field: ['count_unique(1)', 'count_unique(2)', 'count_unique(3)'],
+              selectedAggregate: '2',
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(await screen.findByRole('radio', {name: 'field2'})).toBeChecked();
+    await userEvent.click(screen.getAllByRole('button', {name: 'Remove field'})[2]!);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          selectedAggregate: 1,
+        }),
+      })
+    );
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -763,10 +763,13 @@ describe('Visualize', () => {
     expect(await screen.findByRole('radio', {name: 'field2'})).toBeChecked();
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove field'})[2]!);
 
+    // The second field is now selected, but the URL param for selectedAggregate
+    // is cleared, so the last field is selected
+    expect(await screen.findByRole('radio', {name: 'field1'})).toBeChecked();
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
-          selectedAggregate: 1,
+          selectedAggregate: undefined,
         }),
       })
     );

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -520,11 +520,13 @@ function Visualize({error, setError}: VisualizeProps) {
                         state.displayType === DisplayType.BIG_NUMBER &&
                         selectedAggregateSet
                       ) {
-                        // Only explicitly change the selected aggregate if it's the last one
+                        // Unset the selected aggregate if it's the last one
+                        // so the state will automatically choose the last aggregate
+                        // as new fields are added
                         if (state.selectedAggregate === fields.length - 1) {
                           dispatch({
                             type: BuilderStateAction.SET_SELECTED_AGGREGATE,
-                            payload: Math.max(0, state.selectedAggregate - 1),
+                            payload: undefined,
                           });
                         }
                       }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -4,9 +4,11 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {RadioLineItem} from 'sentry/components/forms/controls/radioGroup';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import Input from 'sentry/components/input';
+import Radio from 'sentry/components/radio';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -238,6 +240,24 @@ function Visualize({error, setError}: VisualizeProps) {
 
             return (
               <FieldRow key={index}>
+                {fields.length > 1 && state.displayType === DisplayType.BIG_NUMBER && (
+                  <RadioLineItem
+                    index={index}
+                    role="radio"
+                    aria-label="aggregate-selector"
+                  >
+                    <Radio
+                      checked={index === (state.selectedAggregate ?? fields.length - 1)}
+                      onChange={() => {
+                        dispatch({
+                          type: BuilderStateAction.SET_SELECTED_AGGREGATE,
+                          payload: index,
+                        });
+                      }}
+                      aria-label={'field' + index}
+                    />
+                  </RadioLineItem>
+                )}
                 <FieldBar data-testid={'field-bar'}>
                   {field.kind === FieldValueKind.EQUATION ? (
                     <StyledArithmeticInput
@@ -478,12 +498,22 @@ function Visualize({error, setError}: VisualizeProps) {
                     icon={<IconDelete />}
                     size="zero"
                     disabled={fields.length <= 1}
-                    onClick={() =>
+                    onClick={() => {
                       dispatch({
                         type: updateAction,
                         payload: fields?.filter((_field, i) => i !== index) ?? [],
-                      })
-                    }
+                      });
+
+                      if (state.displayType === DisplayType.BIG_NUMBER) {
+                        // Only change the selected aggregate if it's the last one
+                        if (state.selectedAggregate === fields.length - 1) {
+                          dispatch({
+                            type: BuilderStateAction.SET_SELECTED_AGGREGATE,
+                            payload: Math.max(0, state.selectedAggregate - 1),
+                          });
+                        }
+                      }
+                    }}
                     aria-label={t('Remove field')}
                   />
                 </FieldExtras>

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -64,6 +64,7 @@ function Visualize({error, setError}: VisualizeProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   let tags = useTags();
   const {customMeasurements} = useCustomMeasurements();
+  const [selectedAggregateSet, setSelectedAggregateSet] = useState(false);
 
   const isChartWidget =
     state.displayType !== DisplayType.TABLE &&
@@ -247,13 +248,14 @@ function Visualize({error, setError}: VisualizeProps) {
                     aria-label="aggregate-selector"
                   >
                     <Radio
-                      checked={index === (state.selectedAggregate ?? fields.length - 1)}
+                      checked={index === state.selectedAggregate}
                       onChange={() => {
                         dispatch({
                           type: BuilderStateAction.SET_SELECTED_AGGREGATE,
                           payload: index,
                         });
                       }}
+                      onClick={() => setSelectedAggregateSet(true)}
                       aria-label={'field' + index}
                     />
                   </RadioLineItem>
@@ -504,8 +506,11 @@ function Visualize({error, setError}: VisualizeProps) {
                         payload: fields?.filter((_field, i) => i !== index) ?? [],
                       });
 
-                      if (state.displayType === DisplayType.BIG_NUMBER) {
-                        // Only change the selected aggregate if it's the last one
+                      if (
+                        state.displayType === DisplayType.BIG_NUMBER &&
+                        selectedAggregateSet
+                      ) {
+                        // Only explicitly change the selected aggregate if it's the last one
                         if (state.selectedAggregate === fields.length - 1) {
                           dispatch({
                             type: BuilderStateAction.SET_SELECTED_AGGREGATE,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -12,6 +12,7 @@ import Radio from 'sentry/components/radio';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import {
   type AggregationKeyWithAlias,
   type AggregationRefinement,
@@ -22,6 +23,8 @@ import {
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import {FieldKind} from 'sentry/utils/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
@@ -64,7 +67,14 @@ function Visualize({error, setError}: VisualizeProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   let tags = useTags();
   const {customMeasurements} = useCustomMeasurements();
-  const [selectedAggregateSet, setSelectedAggregateSet] = useState(false);
+  const {selectedAggregate: queryParamSelectedAggregate} = useLocationQuery({
+    fields: {
+      selectedAggregate: decodeScalar,
+    },
+  });
+  const [selectedAggregateSet, setSelectedAggregateSet] = useState(
+    defined(queryParamSelectedAggregate)
+  );
 
   const isChartWidget =
     state.displayType !== DisplayType.TABLE &&

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -562,7 +562,7 @@ describe('useWidgetBuilderState', () => {
         wrapper: WidgetBuilderProvider,
       });
 
-      expect(result.current.state.selectedAggregate).toBe(0);
+      expect(result.current.state.selectedAggregate).toBeUndefined();
 
       act(() => {
         result.current.dispatch({
@@ -791,7 +791,13 @@ describe('useWidgetBuilderState', () => {
 
     it('resets selectedAggregate when the dataset is switched', () => {
       mockedUsedLocation.mockReturnValue(
-        LocationFixture({query: {selectedAggregate: '0'}})
+        LocationFixture({
+          query: {
+            selectedAggregate: '0',
+            displayType: DisplayType.BIG_NUMBER,
+            field: ['count_unique(1)', 'count_unique(2)'],
+          },
+        })
       );
 
       const {result} = renderHook(() => useWidgetBuilderState(), {
@@ -1139,7 +1145,13 @@ describe('useWidgetBuilderState', () => {
   describe('selectedAggregate', () => {
     it('can decode and update selectedAggregate', () => {
       mockedUsedLocation.mockReturnValue(
-        LocationFixture({query: {selectedAggregate: '0'}})
+        LocationFixture({
+          query: {
+            selectedAggregate: '0',
+            displayType: DisplayType.BIG_NUMBER,
+            field: ['count()', 'count_unique(user)'],
+          },
+        })
       );
 
       const {result} = renderHook(() => useWidgetBuilderState(), {
@@ -1158,9 +1170,15 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.selectedAggregate).toBe(1);
     });
 
-    it('can set selectedAggregate to undefined', () => {
+    it('can set selectedAggregate to undefined in the URL', () => {
       mockedUsedLocation.mockReturnValue(
-        LocationFixture({query: {selectedAggregate: '0'}})
+        LocationFixture({
+          query: {
+            selectedAggregate: '0',
+            displayType: DisplayType.BIG_NUMBER,
+            field: ['count()', 'count_unique(user)'],
+          },
+        })
       );
 
       const {result} = renderHook(() => useWidgetBuilderState(), {
@@ -1176,10 +1194,12 @@ describe('useWidgetBuilderState', () => {
         });
       });
 
-      expect(result.current.state.selectedAggregate).toBeUndefined();
+      // If selectedAggregate is undefined in the URL, then the widget builder state
+      // will set the selectedAggregate to the last aggregate
+      expect(result.current.state.selectedAggregate).toBe(1);
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {selectedAggregate: undefined},
+          query: expect.objectContaining({selectedAggregate: undefined}),
         })
       );
     });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -227,14 +227,7 @@ function useWidgetBuilderState(): {
               ...(yAxisWithoutAlias?.slice(0, MAX_NUM_Y_AXES) ?? []),
             ]);
           }
-          if (
-            action.payload === DisplayType.BIG_NUMBER &&
-            aggregatesWithoutAlias.length > 1
-          ) {
-            setSelectedAggregate(aggregatesWithoutAlias.length - 1);
-          } else {
-            setSelectedAggregate(undefined);
-          }
+          setSelectedAggregate(undefined);
           break;
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -220,7 +220,14 @@ function useWidgetBuilderState(): {
               ...(yAxisWithoutAlias?.slice(0, MAX_NUM_Y_AXES) ?? []),
             ]);
           }
-          setSelectedAggregate(undefined);
+          if (
+            action.payload === DisplayType.BIG_NUMBER &&
+            aggregatesWithoutAlias.length > 1
+          ) {
+            setSelectedAggregate(aggregatesWithoutAlias.length - 1);
+          } else {
+            setSelectedAggregate(undefined);
+          }
           break;
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo} from 'react';
 import partition from 'lodash/partition';
 
+import {defined} from 'sentry/utils';
 import {
   type Column,
   explodeField,
@@ -141,7 +142,13 @@ function useWidgetBuilderState(): {
       sort,
       limit,
       legendAlias,
-      selectedAggregate,
+
+      // The selected aggregate is the last aggregate for big number widgets
+      // if it hasn't been explicitly set
+      selectedAggregate:
+        displayType === DisplayType.BIG_NUMBER && defined(fields) && fields.length > 1
+          ? selectedAggregate ?? fields.length - 1
+          : undefined,
     }),
     [
       title,

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -42,6 +42,14 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       ? _formatSort(state.sort[0]!)
       : defaultSort;
 
+  // The selected aggregate is the last aggregate for big number widgets
+  // if it hasn't been explicitly set
+  const selectedAggregate =
+    state.displayType === DisplayType.BIG_NUMBER &&
+    defined(aggregates) &&
+    aggregates.length > 1
+      ? state.selectedAggregate ?? aggregates.length - 1
+      : undefined;
   const widgetQueries: WidgetQuery[] = queries.map((query, index) => {
     return {
       ...defaultQuery,
@@ -52,7 +60,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       orderby: sort,
       fieldAliases: fieldAliases ?? [],
       name: legendAlias[index] ?? '',
-      selectedAggregate: state.selectedAggregate,
+      selectedAggregate,
     };
   });
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -42,14 +42,6 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       ? _formatSort(state.sort[0]!)
       : defaultSort;
 
-  // The selected aggregate is the last aggregate for big number widgets
-  // if it hasn't been explicitly set
-  const selectedAggregate =
-    state.displayType === DisplayType.BIG_NUMBER &&
-    defined(aggregates) &&
-    aggregates.length > 1
-      ? state.selectedAggregate ?? aggregates.length - 1
-      : undefined;
   const widgetQueries: WidgetQuery[] = queries.map((query, index) => {
     return {
       ...defaultQuery,
@@ -60,7 +52,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       orderby: sort,
       fieldAliases: fieldAliases ?? [],
       name: legendAlias[index] ?? '',
-      selectedAggregate,
+      selectedAggregate: state.selectedAggregate,
     };
   });
 


### PR DESCRIPTION
This uses the `selectedAggregate` param in state to allow a user to choose an aggregate to display in big numbers. The following is the implemented behaviour

- If `selectedAggregate` is defined in the URL params, it is return or else we surface the index of the last element from `fields` (which would only be aggregates for big numbers)
- The last field should always be selected until the user makes an explicit selection and clicks a radio button, at which point adding/removing fields should not select a different field
- If the selected aggregate is the last field and that is removed, unset the URL param so we can continue the behaviour where new fields become automatically selected

I thought about making the `selectedAggregate` primarily managed by the visualize component, but I figured the widget builder state is supposed to be opinionated on maintaining that state, so I moved the logic for what I wanted as the default state (i.e. when `selectedAggregate` is undefined in the URL params) to there.