### PR TITLE
ref: ensure http requests in tests have .auth

### DIFF
--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -279,6 +279,7 @@ class BaseOrganizationEndpointTest(TestCase):
         if user is None:
             user = self.user
         request.user = user
+        request.auth = None
         request.access = from_request(request, self.org)
         return request
 
@@ -383,6 +384,7 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         request = RequestFactory().get("/")
         request.session = SessionBase()
         request.access = NoAccess()
+        request.auth = None
         result = self.endpoint.get_projects(request, self.org)
         assert [] == result
 

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -32,6 +32,7 @@ from sentry.utils.redis import clusters
 def _set_up_request():
     request = RequestFactory().post("/auth/sso/")
     request.user = AnonymousUser()
+    request.auth = None
     request.session = Client().session
     return request
 


### PR DESCRIPTION
this matches what our middleware sets

split out from my branch where I make the typing consistent

<!-- Describe your PR here. -->