### PR TITLE
feat(ui): use signed urls for secondary email confirmation

### DIFF
--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {RequestOptions} from 'sentry/api';
 import AlertLink from 'sentry/components/alertLink';
 import Tag from 'sentry/components/badge/tag';
@@ -32,13 +32,24 @@ const ENDPOINT = '/users/me/emails/';
 function AccountEmails() {
   const queryClient = useQueryClient();
 
-  const handleSubmitSuccess: FormProps['onSubmitSuccess'] = (_change, model, id) => {
+  const handleSubmitSuccess: FormProps['onSubmitSuccess'] = (response, model, id) => {
     queryClient.invalidateQueries({queryKey: makeEmailsEndpointKey()});
 
-    if (id === undefined) {
-      return;
+    if (id !== undefined) {
+      model.setValue(id, '');
     }
-    model.setValue(id, '');
+
+    if (response?.detail) {
+      addSuccessMessage(response.detail);
+    }
+  };
+
+  const handleSubmitError: FormProps['onSubmitError'] = (error, _model, _id) => {
+    const errorMessage = error?.responseJSON?.detail;
+
+    if (errorMessage) {
+      addErrorMessage(errorMessage);
+    }
   };
 
   return (
@@ -52,6 +63,7 @@ function AccountEmails() {
         saveOnBlur
         allowUndo={false}
         onSubmitSuccess={handleSubmitSuccess}
+        onSubmitError={handleSubmitError}
       >
         <JsonForm forms={accountEmailsFields} />
       </Form>


### PR DESCRIPTION
Frontend changes to support #81044 

Here's what it will look like in the frontend after submitting the form with a new email:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/6f06e89b-a1d2-40eb-a4a4-1e860e07d57d" />

If you submit it with one that's already on your account:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/57daad3f-e129-4176-ba9a-fc36c73b11ea" />
