### PR TITLE
chore(ingest): Remove metrics in `save_transaction_events`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2626,41 +2626,18 @@ def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> S
     set_measurement(measurement_name="jobs", value=len(jobs))
     set_measurement(measurement_name="projects", value=len(projects))
 
-    with metrics.timer("save_transaction_events.get_or_create_release_many"):
-        _get_or_create_release_many(jobs, projects)
-
-    with metrics.timer("save_transaction_events.get_event_user_many"):
-        _get_event_user_many(jobs, projects)
-
-    with metrics.timer("save_transaction_events.derive_plugin_tags_many"):
-        _derive_plugin_tags_many(jobs, projects)
-
-    with metrics.timer("save_transaction_events.derive_interface_tags_many"):
-        _derive_interface_tags_many(jobs)
-
-    with metrics.timer("save_transaction_events.calculate_span_grouping"):
-        _calculate_span_grouping(jobs, projects)
-
-    with metrics.timer("save_transaction_events.materialize_metadata_many"):
-        _materialize_metadata_many(jobs)
-
-    with metrics.timer("save_transaction_events.get_or_create_environment_many"):
-        _get_or_create_environment_many(jobs, projects)
-
-    with metrics.timer("save_transaction_events.get_or_create_release_associated_models"):
-        _get_or_create_release_associated_models(jobs, projects)
-
-    with metrics.timer("save_transaction_events.tsdb_record_all_metrics"):
-        _tsdb_record_all_metrics(jobs)
-
-    with metrics.timer("save_transaction_events.materialize_event_metrics"):
-        _materialize_event_metrics(jobs)
-
-    with metrics.timer("save_transaction_events.nodestore_save_many"):
-        _nodestore_save_many(jobs=jobs, app_feature="transactions")
-
-    with metrics.timer("save_transaction_events.eventstream_insert_many"):
-        _eventstream_insert_many(jobs)
+    _get_or_create_release_many(jobs, projects)
+    _get_event_user_many(jobs, projects)
+    _derive_plugin_tags_many(jobs, projects)
+    _derive_interface_tags_many(jobs)
+    _calculate_span_grouping(jobs, projects)
+    _materialize_metadata_many(jobs)
+    _get_or_create_environment_many(jobs, projects)
+    _get_or_create_release_associated_models(jobs, projects)
+    _tsdb_record_all_metrics(jobs)
+    _materialize_event_metrics(jobs)
+    _nodestore_save_many(jobs=jobs, app_feature="transactions")
+    _eventstream_insert_many(jobs)
 
     for job in jobs:
         track_sampled_event(
@@ -2669,17 +2646,10 @@ def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> S
             TransactionStageStatus.SNUBA_TOPIC_PUT,
         )
 
-    with metrics.timer("save_transaction_events.track_outcome_accepted_many"):
-        _track_outcome_accepted_many(jobs)
-
-    with metrics.timer("save_transaction_events.detect_performance_problems"):
-        _detect_performance_problems(jobs, projects)
-
-    with metrics.timer("save_transaction_events.send_occurrence_to_platform"):
-        _send_occurrence_to_platform(jobs, projects)
-
-    with metrics.timer("save_transaction_events.record_transaction_info"):
-        _record_transaction_info(jobs, projects)
+    _track_outcome_accepted_many(jobs)
+    _detect_performance_problems(jobs, projects)
+    _send_occurrence_to_platform(jobs, projects)
+    _record_transaction_info(jobs, projects)
 
     return jobs
 


### PR DESCRIPTION
These metrics were initially added in https://github.com/getsentry/sentry/pull/79724 in order to help analyze bottlenecks in the transaction ingestion pipeline, and to find initiatives to optimize the code in here. We're no longer looking at this now so we can remove the metrics