### PR TITLE
feat(widget-builder): UI for widget templates

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
@@ -30,6 +30,7 @@ import SaveButton from 'sentry/views/dashboards/widgetBuilder/components/saveBut
 import WidgetBuilderSortBySelector from 'sentry/views/dashboards/widgetBuilder/components/sortBySelector';
 import WidgetBuilderTypeSelector from 'sentry/views/dashboards/widgetBuilder/components/typeSelector';
 import Visualize from 'sentry/views/dashboards/widgetBuilder/components/visualize';
+import WidgetTemplatesList from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 
 type WidgetBuilderSlideoutProps = {
@@ -59,6 +60,9 @@ function WidgetBuilderSlideout({
   const [error, setError] = useState<Record<string, any>>({});
   const {widgetIndex} = useParams();
   const theme = useTheme();
+
+  // TODO: remove this once we have a proper way to handle templates
+  const showTemplates = localStorage.getItem('showTemplates') === 'true';
 
   const isEditing = widgetIndex !== undefined;
   const title = isEditing ? t('Edit Widget') : t('Create Custom Widget');
@@ -116,54 +120,73 @@ function WidgetBuilderSlideout({
         </CloseButton>
       </SlideoutHeaderWrapper>
       <SlideoutBodyWrapper>
-        <Section>
-          <WidgetBuilderFilterBar />
-        </Section>
-        <Section>
-          <WidgetBuilderDatasetSelector />
-        </Section>
-        {organization.features.includes('visibility-explore-dataset') &&
-          state.dataset === WidgetType.SPANS && (
+        {!showTemplates ? (
+          <Fragment>
             <Section>
-              <RPCToggle />
+              <WidgetBuilderFilterBar />
             </Section>
-          )}
-        <Section>
-          <WidgetBuilderTypeSelector error={error} setError={setError} />
-        </Section>
-        <div ref={previewRef}>
-          {isSmallScreen && (
             <Section>
-              <WidgetPreviewContainer
-                dashboard={dashboard}
-                dashboardFilters={dashboardFilters}
-                isWidgetInvalid={isWidgetInvalid}
+              <WidgetBuilderDatasetSelector />
+            </Section>
+            {organization.features.includes('visibility-explore-dataset') &&
+              state.dataset === WidgetType.SPANS && (
+                <Section>
+                  <RPCToggle />
+                </Section>
+              )}
+            <Section>
+              <WidgetBuilderTypeSelector error={error} setError={setError} />
+            </Section>
+            <div ref={previewRef}>
+              {isSmallScreen && (
+                <Section>
+                  <WidgetPreviewContainer
+                    dashboard={dashboard}
+                    dashboardFilters={dashboardFilters}
+                    isWidgetInvalid={isWidgetInvalid}
+                  />
+                </Section>
+              )}
+            </div>
+            <Section>
+              <Visualize error={error} setError={setError} />
+            </Section>
+            <Section>
+              <WidgetBuilderQueryFilterBuilder
+                onQueryConditionChange={onQueryConditionChange}
               />
             </Section>
-          )}
-        </div>
-        <Section>
-          <Visualize error={error} setError={setError} />
-        </Section>
-        <Section>
-          <WidgetBuilderQueryFilterBuilder
-            onQueryConditionChange={onQueryConditionChange}
-          />
-        </Section>
-        {isChartWidget && (
-          <Section>
-            <WidgetBuilderGroupBySelector />
-          </Section>
+            {isChartWidget && (
+              <Section>
+                <WidgetBuilderGroupBySelector />
+              </Section>
+            )}
+            {showSortByStep && (
+              <Section>
+                <WidgetBuilderSortBySelector />
+              </Section>
+            )}
+            <Section>
+              <WidgetBuilderNameAndDescription error={error} setError={setError} />
+            </Section>
+            <SaveButton isEditing={isEditing} onSave={onSave} setError={setError} />
+          </Fragment>
+        ) : (
+          <Fragment>
+            <div ref={previewRef}>
+              {isSmallScreen && (
+                <Section>
+                  <WidgetPreviewContainer
+                    dashboard={dashboard}
+                    dashboardFilters={dashboardFilters}
+                    isWidgetInvalid={isWidgetInvalid}
+                  />
+                </Section>
+              )}
+            </div>
+            <WidgetTemplatesList />
+          </Fragment>
         )}
-        {showSortByStep && (
-          <Section>
-            <WidgetBuilderSortBySelector />
-          </Section>
-        )}
-        <Section>
-          <WidgetBuilderNameAndDescription error={error} setError={setError} />
-        </Section>
-        <SaveButton isEditing={isEditing} onSave={onSave} setError={setError} />
       </SlideoutBodyWrapper>
     </SlideOverPanel>
   );

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -65,7 +65,11 @@ function WidgetBuilderSlideout({
   const showTemplates = localStorage.getItem('showTemplates') === 'true';
 
   const isEditing = widgetIndex !== undefined;
-  const title = isEditing ? t('Edit Widget') : t('Create Custom Widget');
+  const title = showTemplates
+    ? t('Add from Widget Library')
+    : isEditing
+      ? t('Edit Widget')
+      : t('Create Custom Widget');
   const isChartWidget =
     state.displayType !== DisplayType.BIG_NUMBER &&
     state.displayType !== DisplayType.TABLE;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -1,0 +1,30 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import WidgetTemplatesList from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
+
+describe('WidgetTemplatesList', () => {
+  it('should render the widget templates list', async () => {
+    render(<WidgetTemplatesList />);
+
+    expect(await screen.findByText('Duration Distribution')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Compare transaction durations across different percentiles.'
+      )
+    ).toBeInTheDocument();
+    expect(await screen.findByText('High Throughput Transactions')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Top 5 transactions with the largest volume.')
+    ).toBeInTheDocument();
+  });
+
+  it('should render buttons when the user clicks on a widget template', async () => {
+    render(<WidgetTemplatesList />);
+
+    const widgetTemplate = await screen.findByText('Duration Distribution');
+    await userEvent.click(widgetTemplate);
+
+    expect(await screen.findByText('Customize')).toBeInTheDocument();
+    expect(await screen.findByText('Add to dashboard')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -16,7 +16,7 @@ function WidgetTemplatesList() {
   const widgets = getTopNConvertedDefaultWidgets(organization);
 
   return (
-    <div>
+    <Fragment>
       {widgets.map((widget, index) => {
         const iconColor = theme.charts.getColorPalette(widgets.length - 2)?.[index]!;
 
@@ -31,7 +31,7 @@ function WidgetTemplatesList() {
               <IconWrapper backgroundColor={iconColor}>
                 <Icon color="white" />
               </IconWrapper>
-              <ContentWrapper>
+              <div>
                 <WidgetTitle>{widget.title}</WidgetTitle>
                 <WidgetDescription>{widget.description}</WidgetDescription>
                 {selectedWidget === index && (
@@ -40,12 +40,12 @@ function WidgetTemplatesList() {
                     <Button size="sm">{t('Add to dashboard')}</Button>
                   </ButtonsWrapper>
                 )}
-              </ContentWrapper>
+              </div>
             </TemplateCard>
           </TemplateContainer>
         );
       })}
-    </div>
+    </Fragment>
   );
 }
 
@@ -100,8 +100,6 @@ const IconWrapper = styled('div')<{backgroundColor: string}>`
   border-radius: ${p => p.theme.borderRadius};
   background: ${p => p.backgroundColor};
 `;
-
-const ContentWrapper = styled('div')``;
 
 const ButtonsWrapper = styled('div')`
   display: flex;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -1,0 +1,111 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import theme from 'sentry/utils/theme';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
+import {getWidgetIcon} from 'sentry/views/dashboards/widgetLibrary/widgetCard';
+
+function WidgetTemplatesList() {
+  const organization = useOrganization();
+  const [selectedWidget, setSelectedWidget] = useState<number | null>(null);
+
+  const widgets = getTopNConvertedDefaultWidgets(organization);
+
+  return (
+    <div>
+      {widgets.map((widget, index) => {
+        const iconColor = theme.charts.getColorPalette(widgets.length - 2)?.[index]!;
+
+        const Icon = getWidgetIcon(widget.displayType);
+        const lastWidget = index === widgets.length - 1;
+        return (
+          <TemplateContainer key={widget.id} lastWidget={lastWidget}>
+            <TemplateCard
+              selected={selectedWidget === index}
+              onClick={() => setSelectedWidget(index)}
+            >
+              <IconWrapper backgroundColor={iconColor}>
+                <Icon color="white" />
+              </IconWrapper>
+              <ContentWrapper>
+                <WidgetTitle>{widget.title}</WidgetTitle>
+                <WidgetDescription>{widget.description}</WidgetDescription>
+                {selectedWidget === index && (
+                  <ButtonsWrapper>
+                    <Button size="sm">{t('Customize')}</Button>
+                    <Button size="sm">{t('Add to dashboard')}</Button>
+                  </ButtonsWrapper>
+                )}
+              </ContentWrapper>
+            </TemplateCard>
+          </TemplateContainer>
+        );
+      })}
+    </div>
+  );
+}
+
+export default WidgetTemplatesList;
+
+const TemplateContainer = styled('div')<{lastWidget: boolean}>`
+  border-bottom: ${p => (p.lastWidget ? 'none' : `1px solid ${p.theme.border}`)};
+`;
+
+const TemplateCard = styled('div')<{selected: boolean}>`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(1.5)};
+  padding: ${space(2)};
+  border: none;
+  border-radius: ${p => p.theme.borderRadius};
+  background-color: ${p => (p.selected ? p.theme.purple100 : p.theme.background)};
+  margin: ${p => (p.selected ? space(2) : space(0.5))} 0px;
+
+  cursor: pointer;
+
+  &:focus,
+  &:hover {
+    background-color: ${p => p.theme.purple100};
+    outline: none;
+  }
+
+  &:active {
+    background-color: ${p => p.theme.purple100};
+  }
+`;
+
+const WidgetTitle = styled('h3')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  margin-bottom: ${space(0.25)};
+`;
+
+const WidgetDescription = styled('p')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray300};
+  margin-bottom: 0;
+`;
+
+const IconWrapper = styled('div')<{backgroundColor: string}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: ${space(1)};
+  min-width: 40px;
+  height: 40px;
+  border-radius: ${p => p.theme.borderRadius};
+  background: ${p => p.backgroundColor};
+`;
+
+const ContentWrapper = styled('div')``;
+
+const ButtonsWrapper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(3)};
+  margin-top: ${space(2)};
+`;


### PR DESCRIPTION
This PR is just for the UI of widget templates. None of the functionality works yet. It's not connected to the widget preview and the customize + add to dashboard buttons don't do anything. You are able to click on the templates and see the selected state.

I did some temporary hacky stuff to get the templates on the widget builder slideout; to see it set the `showTemplates` field in your local storage to `true`. Here's a quick video of it so far:


https://github.com/user-attachments/assets/c003244b-b0b4-4446-bc5a-53d935d0c641
