### PR TITLE
feat(streamline): Allow the new UI to reflect the organization option

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -91,6 +91,7 @@ export interface Organization extends OrganizationSummary {
   scrubIPAddresses: boolean;
   sensitiveFields: string[];
   storeCrashReports: number;
+  streamlineOnly: boolean | null;
   targetSampleRate: number;
   teamRoleList: TeamRole[];
   trustedRelays: Relay[];

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -35,6 +35,36 @@ describe('NewIssueExperienceButton', function () {
     expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
   });
 
+  it('does not appear when an organization has the single interface option', function () {
+    const {unmount: unmountOptionTrue} = render(
+      <div data-test-id="test-id">
+        <NewIssueExperienceButton />
+      </div>,
+      {
+        organization: {
+          ...organization,
+          streamlineOnly: true,
+        },
+      }
+    );
+    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
+    unmountOptionTrue();
+
+    const {unmount: unmountOptionFalse} = render(
+      <div data-test-id="test-id">
+        <NewIssueExperienceButton />
+      </div>,
+      {
+        organization: {
+          ...organization,
+          streamlineOnly: false,
+        },
+      }
+    );
+    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
+    unmountOptionFalse();
+  });
+
   it('does not appear when an organization has the enforce flag', function () {
     render(
       <div data-test-id="test-id">

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -22,6 +22,8 @@ export function NewIssueExperienceButton() {
   const hasEnforceStreamlinedUIFlag = organization.features.includes(
     'issue-details-streamline-enforce'
   );
+  const hasOnlyOneUIOption = organization.streamlineOnly;
+
   const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();
   const {mutate} = useMutateUserOptions();
@@ -34,8 +36,15 @@ export function NewIssueExperienceButton() {
     });
   }, [mutate, organization, hasStreamlinedUI]);
 
-  // We hide the toggle if the org doesn't have the 'opt-in' flag, or has the 'remove opt-out' flag.
-  if (!hasStreamlinedUIFlag || hasEnforceStreamlinedUIFlag) {
+  // We hide the toggle if the org...
+  if (
+    // doesn't have the 'opt-in' flag,
+    !hasStreamlinedUIFlag ||
+    // has the 'remove opt-out' flag,
+    hasEnforceStreamlinedUIFlag ||
+    // has access to only one interface (via the organization option).
+    hasOnlyOneUIOption
+  ) {
     return null;
   }
 

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -22,7 +22,7 @@ export function NewIssueExperienceButton() {
   const hasEnforceStreamlinedUIFlag = organization.features.includes(
     'issue-details-streamline-enforce'
   );
-  const hasOnlyOneUIOption = organization.streamlineOnly;
+  const hasOnlyOneUIOption = defined(organization.streamlineOnly);
 
   const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -82,4 +82,43 @@ describe('useHasStreamlinedUI', () => {
     const {result} = renderHook(useHasStreamlinedUI);
     expect(result.current).toBe(true);
   });
+
+  it('ignores preferences if organization option is set', () => {
+    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+
+    const streamlineOrg = OrganizationFixture({streamlineOnly: true});
+    jest.mocked(useOrganization).mockReturnValue(streamlineOrg);
+
+    ConfigStore.init();
+    const user = UserFixture();
+    user.options.prefersIssueDetailsStreamlinedUI = false;
+    act(() => ConfigStore.set('user', user));
+
+    const {result: streamlineResult} = renderHook(useHasStreamlinedUI);
+    expect(streamlineResult.current).toBe(true);
+
+    const legacyOrg = OrganizationFixture({streamlineOnly: false});
+    jest.mocked(useOrganization).mockReturnValue(legacyOrg);
+
+    user.options.prefersIssueDetailsStreamlinedUI = true;
+    act(() => ConfigStore.set('user', user));
+
+    const {result: legacyResult} = renderHook(useHasStreamlinedUI);
+    expect(legacyResult.current).toBe(false);
+  });
+
+  it('ignores the option if unset', () => {
+    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+    jest
+      .mocked(useOrganization)
+      .mockReturnValue(OrganizationFixture({streamlineOnly: null}));
+
+    ConfigStore.init();
+    const user = UserFixture();
+    user.options.prefersIssueDetailsStreamlinedUI = true;
+    act(() => ConfigStore.set('user', user));
+
+    const {result: result} = renderHook(useHasStreamlinedUI);
+    expect(result.current).toBe(true);
+  });
 });

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -273,6 +273,11 @@ export function useHasStreamlinedUI() {
     return location.query.streamline === '1';
   }
 
+  // If the organzation option is set, it determines which interface is used.
+  if (defined(organization.streamlineOnly)) {
+    return organization.streamlineOnly;
+  }
+
   // If the enforce flag is set for the organization, ignore user preferences and enable the UI
   if (organization.features.includes('issue-details-streamline-enforce')) {
     return true;

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -80,6 +80,7 @@ export function OrganizationFixture( params: Partial<Organization> = {}): Organi
     relayPiiConfig: null,
     require2FA: false,
     requiresSso: false,
+    streamlineOnly: null,
     safeFields: [],
     samplingMode: 'organization',
     scrubIPAddresses: false,


### PR DESCRIPTION
Adds the organization option to be read from the changes in https://github.com/getsentry/sentry/pull/83205 and reflect them in the UI, along with tests.

This should be merged first, so that once the backend begins applying the flags, the frontend new orgs are served can already reflect the changes.