### PR TITLE
ref(profiling): Type continuous profiles same as transaction profiles

### DIFF
--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -153,7 +153,7 @@ function getTransactionOffset(
 }
 
 function convertContinuousProfileMeasurementsToUIFrames(
-  measurement: ContinuousProfileGroup['measurements']['slow_frame_renders']
+  measurement: ProfileGroup['measurements']['slow_frame_renders']
 ): UIFrameMeasurements | undefined {
   if (!measurement) {
     return undefined;

--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -49,7 +49,7 @@ import {
   initializeFlamegraphRenderer,
   useResizeCanvasObserver,
 } from 'sentry/utils/profiling/gl/utils';
-import type {ContinuousProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import type {Profile} from 'sentry/utils/profiling/profile/profile';
 import {FlamegraphRenderer2D} from 'sentry/utils/profiling/renderers/flamegraphRenderer2D';
 import {FlamegraphRendererWebGL} from 'sentry/utils/profiling/renderers/flamegraphRendererWebGL';
@@ -70,7 +70,7 @@ import {
   useContinuousProfile,
   useContinuousProfileSegment,
 } from 'sentry/views/profiling/continuousProfileProvider';
-import {useContinuousProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
+import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
 import {FlamegraphDrawer} from './flamegraphDrawer/flamegraphDrawer';
 import {FlamegraphWarnings} from './flamegraphOverlays/FlamegraphWarnings';
@@ -101,7 +101,7 @@ function collectAllSpanEntriesFromTransaction(
 }
 
 function getMaxConfigSpace(
-  profileGroup: ContinuousProfileGroup,
+  profileGroup: ProfileGroup,
   transaction: EventTransaction | null,
   unit: ProfilingFormatterUnit | string,
   [start, end]: [number, number] | [null, null]
@@ -247,7 +247,7 @@ export function ContinuousFlamegraph(): ReactElement {
   const dispatch = useDispatchFlamegraphState();
 
   const profiles = useContinuousProfile();
-  const profileGroup = useContinuousProfileGroup();
+  const profileGroup = useProfileGroup();
   const segment = useContinuousProfileSegment();
 
   const configSpaceQueryParam = useMemo(() => decodeConfigSpace(), []);

--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -49,8 +49,8 @@ import {
   initializeFlamegraphRenderer,
   useResizeCanvasObserver,
 } from 'sentry/utils/profiling/gl/utils';
-import type {ContinuousProfile} from 'sentry/utils/profiling/profile/continuousProfile';
 import type {ContinuousProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
+import type {Profile} from 'sentry/utils/profiling/profile/profile';
 import {FlamegraphRenderer2D} from 'sentry/utils/profiling/renderers/flamegraphRenderer2D';
 import {FlamegraphRendererWebGL} from 'sentry/utils/profiling/renderers/flamegraphRendererWebGL';
 import type {SpanChartNode} from 'sentry/utils/profiling/spanChart';
@@ -131,7 +131,7 @@ function getMaxConfigSpace(
 }
 
 function getProfileOffset(
-  profile: ContinuousProfile | undefined,
+  profile: Profile | undefined,
   startedAtMs: number | null
 ): Rect {
   if (!profile || !startedAtMs) {
@@ -168,8 +168,10 @@ function convertContinuousProfileMeasurementsToUIFrames(
     const value = measurement.values[i]!;
     const next = measurement.values[i + 1] ?? value;
 
+    const elapsedNanoseconds = next.elapsed_since_start_ns - value.elapsed_since_start_ns;
+
     measurements.values.push({
-      elapsed: next!.timestamp - value.timestamp,
+      elapsed: elapsedNanoseconds / 1e9,
       value: value.value,
     });
   }
@@ -412,7 +414,7 @@ export function ContinuousFlamegraph(): ReactElement {
   ]);
 
   const batteryChart = useMemo(() => {
-    if (!hasCPUChart) {
+    if (!hasBatteryChart) {
       return LOADING_OR_FALLBACK_BATTERY_CHART;
     }
 
@@ -420,23 +422,15 @@ export function ContinuousFlamegraph(): ReactElement {
 
     for (const key in profileGroup.measurements) {
       if (key === 'cpu_energy_usage') {
-        const measurements = profileGroup.measurements[key]!;
-        const values: ProfileSeriesMeasurement['values'] = [];
-
-        let offset = 0;
-        for (let i = 0; i < measurements.values.length; i++) {
-          const value = measurements.values[i]!;
-          const next = measurements.values[i + 1]! ?? value;
-          offset += (next.timestamp - value.timestamp) * 1e3;
-
-          values.push({
-            value: fromNanoJoulesToWatts(value.value, 0.1),
-            elapsed: offset,
-          });
-        }
-
         // some versions of cocoa send byte so we need to correct it to watt
-        measures.push({name: 'CPU energy usage', unit: 'watt', values});
+        measures.push(
+          formatProfileSeriesMeasurement({
+            name: 'CPU energy usage',
+            unit: 'watt',
+            measurement: profileGroup.measurements[key]!,
+            valueFormatter: value => fromNanoJoulesToWatts(value, 0.1),
+          })
+        );
       }
     }
 
@@ -446,7 +440,12 @@ export function ContinuousFlamegraph(): ReactElement {
       flamegraphTheme.COLORS.BATTERY_CHART_COLORS,
       {timelineUnit: 'milliseconds'}
     );
-  }, [profileGroup.measurements, flamegraph.configSpace, flamegraphTheme, hasCPUChart]);
+  }, [
+    profileGroup.measurements,
+    flamegraph.configSpace,
+    flamegraphTheme,
+    hasBatteryChart,
+  ]);
 
   const CPUChart = useMemo(() => {
     if (!hasCPUChart) {
@@ -461,23 +460,12 @@ export function ContinuousFlamegraph(): ReactElement {
           key === 'cpu_usage'
             ? 'Average CPU usage'
             : `CPU Core ${key.replace('cpu_usage_', '')}`;
-
-        const measurements = profileGroup.measurements[key]!;
-        const values: ProfileSeriesMeasurement['values'] = [];
-
-        let offset = 0;
-        for (let i = 0; i < measurements.values.length; i++) {
-          const value = measurements.values[i]!;
-          const next = measurements.values[i + 1]! ?? value;
-          offset += (next.timestamp - value.timestamp) * 1e3;
-
-          values.push({
-            value: value.value,
-            elapsed: offset,
-          });
-        }
-
-        cpuMeasurements.push({name, unit: measurements?.unit, values});
+        cpuMeasurements.push(
+          formatProfileSeriesMeasurement({
+            name,
+            measurement: profileGroup.measurements[key]!,
+          })
+        );
       }
     }
 
@@ -498,48 +486,22 @@ export function ContinuousFlamegraph(): ReactElement {
 
     const memory_footprint = profileGroup.measurements?.memory_footprint;
     if (memory_footprint) {
-      const values: ProfileSeriesMeasurement['values'] = [];
-
-      let offset = 0;
-      for (let i = 0; i < memory_footprint.values.length; i++) {
-        const value = memory_footprint.values[i]!;
-        const next = memory_footprint.values[i + 1]! ?? value;
-        offset += (next.timestamp - value.timestamp) * 1e3;
-
-        values.push({
-          value: value.value,
-          elapsed: offset,
-        });
-      }
-
-      measures.push({
-        unit: memory_footprint.unit,
-        name: 'Heap Usage',
-        values,
-      });
+      measures.push(
+        formatProfileSeriesMeasurement({
+          name: 'Heap Usage',
+          measurement: memory_footprint,
+        })
+      );
     }
 
     const native_memory_footprint = profileGroup.measurements?.memory_native_footprint;
     if (native_memory_footprint) {
-      const values: ProfileSeriesMeasurement['values'] = [];
-
-      let offset = 0;
-      for (let i = 0; i < native_memory_footprint.values.length; i++) {
-        const value = native_memory_footprint.values[i]!;
-        const next = native_memory_footprint.values[i + 1]! ?? value;
-        offset += (next.timestamp - value.timestamp) * 1e3;
-
-        values.push({
-          value: value.value,
-          elapsed: offset,
-        });
-      }
-
-      measures.push({
-        unit: native_memory_footprint.unit,
-        name: 'Native Heap Usage',
-        values,
-      });
+      measures.push(
+        formatProfileSeriesMeasurement({
+          name: 'Native Heap Usage',
+          measurement: native_memory_footprint,
+        })
+      );
     }
 
     return new FlamegraphChartModel(
@@ -1623,4 +1585,35 @@ export function ContinuousFlamegraph(): ReactElement {
       />
     </Fragment>
   );
+}
+
+function formatProfileSeriesMeasurement({
+  measurement,
+  name,
+  unit,
+  valueFormatter,
+}: {
+  measurement: Profiling.Measurement;
+  name: string;
+  unit?: string;
+  valueFormatter?: (value: number) => number;
+}): ProfileSeriesMeasurement {
+  const values: ProfileSeriesMeasurement['values'] = [];
+  let offset = 0;
+  for (let i = 0; i < measurement.values.length; i++) {
+    const value = measurement.values[i]!;
+    const next = measurement.values[i + 1]! ?? value;
+    const offsetNanoseconds = next.elapsed_since_start_ns - value.elapsed_since_start_ns;
+    offset += offsetNanoseconds / 1e6;
+
+    values.push({
+      value: valueFormatter ? valueFormatter(value.value) : value.value,
+      elapsed: offset,
+    });
+  }
+  return {
+    name,
+    unit: unit ?? measurement?.unit,
+    values,
+  };
 }

--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -30,10 +30,7 @@ import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {isContinuousProfileReference} from 'sentry/utils/profiling/guards/profile';
 import type {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 import {useSourceCodeLink} from 'sentry/utils/profiling/hooks/useSourceLink';
-import type {
-  ContinuousProfileGroup,
-  ProfileGroup,
-} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {generateProfileRouteFromProfileReference} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -68,7 +65,7 @@ export interface FlamegraphContextMenuProps {
   onCopyFunctionNameClick: () => void;
   onCopyFunctionSource: () => void;
   onHighlightAllOccurrencesClick: () => void;
-  profileGroup: ProfileGroup | ContinuousProfileGroup | null;
+  profileGroup: ProfileGroup | null;
   disableCallOrderSort?: boolean;
   disableColorCoding?: boolean;
 }

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -18,10 +18,7 @@ import type {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flam
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
-import type {
-  ContinuousProfileGroup,
-  ProfileGroup,
-} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {invertCallTree} from 'sentry/utils/profiling/profile/utils';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -37,7 +34,7 @@ interface FlamegraphDrawerProps {
   flamegraph: Flamegraph;
   formatDuration: Flamegraph['formatter'];
   getFrameColor: (frame: FlamegraphFrame) => string;
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   profileTransaction: ReturnType<typeof useProfileTransaction> | null;
   referenceNode: FlamegraphFrame;
   rootNodes: FlamegraphFrame[];

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
@@ -18,10 +18,7 @@ import type {Project} from 'sentry/types/project';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import type {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
-import type {
-  ContinuousProfileGroup,
-  ProfileGroup,
-} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -37,7 +34,7 @@ import {ProfilingDetailsFrameTabs, ProfilingDetailsListItem} from './flamegraphD
 function renderValue(
   key: string,
   value: number | string | undefined,
-  profileGroup?: ProfileGroup | ContinuousProfileGroup
+  profileGroup?: ProfileGroup
 ) {
   if (key === 'threads' && value === undefined) {
     return profileGroup?.profiles.length;
@@ -53,7 +50,7 @@ function renderValue(
 }
 
 interface ProfileDetailsProps {
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   projectId: string;
   transaction: EventTransaction | null;
 }
@@ -188,7 +185,7 @@ function TransactionDeviceDetails({
   profileGroup,
   transaction,
 }: {
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   transaction: EventTransaction;
 }) {
   const deviceDetails = useMemo(() => {
@@ -257,7 +254,7 @@ function TransactionEventDetails({
   transaction,
 }: {
   organization: Organization;
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   project: Project | undefined;
   transaction: EventTransaction;
 }) {
@@ -352,11 +349,7 @@ function TransactionEventDetails({
   );
 }
 
-function ProfileEnvironmentDetails({
-  profileGroup,
-}: {
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
-}) {
+function ProfileEnvironmentDetails({profileGroup}: {profileGroup: ProfileGroup}) {
   return (
     <DetailsContainer>
       {Object.entries(ENVIRONMENT_DETAILS_KEY).map(([label, key]) => {
@@ -379,7 +372,7 @@ function ProfileEventDetails({
   transaction,
 }: {
   organization: Organization;
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   project: Project | undefined;
   transaction: EventTransaction | null;
 }) {

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
@@ -8,16 +8,13 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import type {FlamegraphState} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext';
-import type {
-  ContinuousProfileGroup,
-  ProfileGroup,
-} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import type {Profile} from 'sentry/utils/profiling/profile/profile';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 
 export interface FlamegraphThreadSelectorProps {
   onThreadIdChange: (threadId: Profile['threadId']) => void;
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   threadId: FlamegraphState['profiles']['threadId'];
 }
 

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -29,10 +29,7 @@ import {
 } from 'sentry/utils/profiling/gl/utils';
 import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 import {useInternalFlamegraphDebugMode} from 'sentry/utils/profiling/hooks/useInternalFlamegraphDebugMode';
-import type {
-  ContinuousProfileGroup,
-  ProfileGroup,
-} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import type {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {FlamegraphTextRenderer} from 'sentry/utils/profiling/renderers/flamegraphTextRenderer';
 import {GridRenderer} from 'sentry/utils/profiling/renderers/gridRenderer';
@@ -86,7 +83,7 @@ interface FlamegraphZoomViewProps {
   flamegraphOverlayCanvasRef: HTMLCanvasElement | null;
   flamegraphRenderer: FlamegraphRenderer | null;
   flamegraphView: CanvasView<Flamegraph> | null;
-  profileGroup: ProfileGroup | ContinuousProfileGroup;
+  profileGroup: ProfileGroup;
   scheduler: CanvasScheduler;
   setFlamegraphCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   setFlamegraphOverlayCanvasRef: React.Dispatch<

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -47,19 +47,7 @@ export interface ProfileGroup {
   profiles: Profile[];
   traceID: string;
   transactionID: string | null;
-  type: 'transaction' | 'loading';
-  images?: Image[];
-}
-
-export interface ContinuousProfileGroup {
-  activeProfileIndex: number;
-  measurements: Partial<Profiling.Measurements>;
-  metadata: Partial<Profiling.Schema['metadata']>;
-  name: string;
-  profiles: Profile[];
-  traceID: string;
-  transactionID: string | null;
-  type: 'continuous' | 'loading';
+  type: 'continuous' | 'transaction' | 'loading';
   images?: Image[];
 }
 
@@ -69,7 +57,7 @@ export function importProfile(
   activeThreadId: string | null,
   type: 'flamegraph' | 'flamechart',
   frameFilter?: (frame: Frame) => boolean
-): ProfileGroup | ContinuousProfileGroup {
+): ProfileGroup {
   return Sentry.withScope(scope => {
     const span = Sentry.startInactiveSpan({
       op: 'import',
@@ -258,7 +246,7 @@ export function importSentryContinuousProfileChunk(
   input: Readonly<Profiling.SentryContinousProfileChunk>,
   traceID: string,
   options: ImportOptions
-): ContinuousProfileGroup {
+): ProfileGroup {
   const frameIndex = createContinuousProfileFrameIndex(
     input.profile.frames,
     input.platform

--- a/static/app/views/profiling/profileGroupProvider.tsx
+++ b/static/app/views/profiling/profileGroupProvider.tsx
@@ -2,48 +2,17 @@ import {createContext, useContext, useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 
 import type {Frame} from 'sentry/utils/profiling/frame';
-import type {
-  ContinuousProfileGroup,
-  ProfileGroup,
-} from 'sentry/utils/profiling/profile/importProfile';
+import type {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {importProfile} from 'sentry/utils/profiling/profile/importProfile';
 
-type ProfileGroupContextValue = ContinuousProfileGroup | ProfileGroup;
+type ProfileGroupContextValue = ProfileGroup;
 const ProfileGroupContext = createContext<ProfileGroupContextValue | null>(null);
-
-function assertContinuousProfileGroup(
-  input: ProfileGroupContextValue | null
-): asserts input is ContinuousProfileGroup {
-  if (input && input.type !== 'loading' && input.type !== 'continuous') {
-    throw new Error('ProfileGroup is not of continuous profile type.');
-  }
-}
-
-function assertTransactionProfileGroup(
-  input: ProfileGroupContextValue | null
-): asserts input is ProfileGroup {
-  if (input && input.type !== 'loading' && input.type !== 'transaction') {
-    throw new Error('ProfileGroup is not of transaction profile type.');
-  }
-}
 
 export function useProfileGroup(): ProfileGroup {
   const context = useContext(ProfileGroupContext);
   if (!context) {
     throw new Error('useProfileGroup was called outside of ProfileGroupProvider');
   }
-  assertTransactionProfileGroup(context);
-  return context;
-}
-
-export function useContinuousProfileGroup(): ContinuousProfileGroup {
-  const context = useContext(ProfileGroupContext);
-  if (!context) {
-    throw new Error(
-      'useContinuousProfileGroup was called outside of ProfileGroupProvider'
-    );
-  }
-  assertContinuousProfileGroup(context);
   return context;
 }
 


### PR DESCRIPTION
In an effort to consolidate the 2 types of profiles, start by converting `ContinuousProfileGroup` to be typed the same way as `ProfileGroup`.