### PR TITLE
IA-98: add rollout for sentry task latency

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2937,3 +2937,10 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# rollout option for task latency metrics
+register(
+    "sentry.tasks.record.timing.rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -86,15 +86,11 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=Fals
     def wrapped(func):
         @wraps(func)
         def _wrapped(*args, **kwargs):
-            record_timing_rollout = options.get("sentry.tasks.record.timing.rollout")
             do_record_timing_rollout = False
+            record_timing_rollout = options.get("sentry.tasks.record.timing.rollout")
             if record_timing_rollout and record_timing_rollout > random():
                 do_record_timing_rollout = True
-
             record_queue_wait_time = record_timing or do_record_timing_rollout
-
-            # Use a try/catch here to contain the blast radius of an exception being unhandled through the options lib
-            # Unhandled exception could cause all tasks to be effected and not work
 
             # TODO(dcramer): we want to tag a transaction ID, but overriding
             # the base on app.task seems to cause problems w/ Celery internals


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/71778 the option to allow latency metrics from a `SentryTask` was added, but defaulted to false and has since only been enabled on [3 tasks](https://github.com/search?q=repo%3Agetsentry%2Fsentry%20record_timing%3DTrue&type=code). 

This PR adds a rollout option to increase the rate at which all tasks in a region report latency metrics. This will allow us to configure monitors based off of task latency instead of backlog similar to what we have for kafka.