### PR TITLE
fix(member-invite): prevent invites to teams that the inviter is not a member of when open team membership is off

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -223,8 +223,8 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 status=403,
             )
 
-        is_member = not (
-            request.access.has_scope("member:invite") and request.access.has_scope("member:admin")
+        is_member = not request.access.has_scope("member:admin") and request.access.has_scope(
+            "member:invite"
         )
         enable_member_invite = not organization.flags.disable_member_invite
         # Members can only resend invites
@@ -233,7 +233,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         is_invite_from_user = member.inviter_id == request.user.id
 
         if is_member:
-            if not enable_member_invite or not member.is_pending:
+            if not enable_member_invite or not member.is_pending or not reinvite_request_only:
                 raise PermissionDenied
             if not is_invite_from_user:
                 return Response({"detail": ERR_MEMBER_INVITE}, status=403)

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -223,17 +223,17 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 status=403,
             )
 
-        is_member = not request.access.has_scope("member:admin") and request.access.has_scope(
-            "member:invite"
+        is_member = not request.access.has_scope("member:admin") and (
+            request.access.has_scope("member:invite")
         )
-        enable_member_invite = not organization.flags.disable_member_invite
+        members_can_invite = not organization.flags.disable_member_invite
         # Members can only resend invites
-        reinvite_request_only = set(result.keys()).issubset({"reinvite", "regenerate"})
+        is_reinvite_request_only = set(result.keys()).issubset({"reinvite", "regenerate"})
         # Members can only resend invites that they sent
         is_invite_from_user = member.inviter_id == request.user.id
 
         if is_member:
-            if not enable_member_invite or not member.is_pending or not reinvite_request_only:
+            if not (members_can_invite and member.is_pending and is_reinvite_request_only):
                 raise PermissionDenied
             if not is_invite_from_user:
                 return Response({"detail": ERR_MEMBER_INVITE}, status=403)
@@ -241,7 +241,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         # XXX(dcramer): if/when this expands beyond reinvite we need to check
         # access level
         if result.get("reinvite"):
-            if not reinvite_request_only:
+            if not is_reinvite_request_only:
                 return Response({"detail": ERR_EDIT_WHEN_REINVITING}, status=403)
             if member.is_pending:
                 if ratelimits.for_organization_member_invite(

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -369,6 +369,31 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             )
             return Response({"detail": ERR_RATE_LIMITED}, status=429)
 
+        is_member = not request.access.has_scope("member:admin") and (
+            request.access.has_scope("member:invite")
+        )
+        disable_invites_to_other_teams = (
+            not organization.flags.allow_joinleave and not organization.flags.disable_member_invite
+        )
+        has_team_roles = "teamRoles" in result and bool(result["teamRoles"])
+
+        # members can only invite members to teams they are not in if
+        # disable_member_invite = False and allow_joinleave = True
+        if is_member and disable_invites_to_other_teams and has_team_roles:
+            requester_teams = set(
+                OrganizationMember.objects.filter(
+                    organization=organization,
+                    user_id=request.user.id,
+                    user_is_active=True,
+                ).values_list("teams__slug", flat=True)
+            )
+            team_slugs = [team.slug for team, _ in result.get("teamRoles")]
+            if not requester_teams.issuperset(team_slugs):
+                return Response(
+                    {"detail": "You cannot assign members to teams you are not a member of."},
+                    status=400,
+                )
+
         if (
             ("teamRoles" in result and result["teamRoles"])
             or ("teams" in result and result["teams"])

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -228,7 +228,6 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         response = self.get_error_response(
             self.organization.slug,
             self.curr_invite.id,
-            reinvite=1,
             teams=[foo.slug],
             status_code=403,
         )
@@ -240,14 +239,10 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         response = self.get_error_response(
             self.organization.slug,
             self.curr_invite.id,
-            reinvite=1,
             teams=[foo.slug],
             status_code=403,
         )
-        assert (
-            response.data.get("detail")
-            == "You cannot modify member details when resending an invitation. Separate requests are required."
-        )
+        assert response.data.get("detail") == "You do not have permission to perform this action."
         assert not mock_send_invite_email.mock_calls
 
     @patch("sentry.models.OrganizationMember.send_invite_email")


### PR DESCRIPTION
Fixing a bug with the "Let Members Invite Others" and "Open Team Membership" settings.

The new behavior is as follows:

- If "Let Members Invite Others" is turned OFF (`disable_member_invite = True`), members can never send invites
- If "Let Members Invite Others" is turned ON (`disable_member_invite = False`), then there are 2 cases:
  - If "Open Team Membership" is turned ON (`allow_joinleave = True`), then members can invite members to any team in the org
  - If "Open Team Membership is turned OFF (`allow_joinleave = False`) then members can only invite members to **teams that they are in (NEW BEHAVIOR)**