### PR TITLE
refactor(aci): inline root path

### DIFF
--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -3,10 +3,9 @@ import {IndexRoute, Route} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/routes';
 
 export function AutomationRoutes() {
-  const root = `/automations/`;
   return (
     <Feature features="workflow-engine-ui">
-      <Route path={root} withOrgPath>
+      <Route path="/automations/" withOrgPath>
         <IndexRoute component={make(() => import('sentry/views/automations/list'))} />
         <Route
           path=":automationId/"

--- a/static/app/views/detectors/routes.tsx
+++ b/static/app/views/detectors/routes.tsx
@@ -3,10 +3,9 @@ import {IndexRoute, Route} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/routes';
 
 export function DetectorRoutes() {
-  const root = `/monitors/`;
   return (
     <Feature features="workflow-engine-ui">
-      <Route path={root} withOrgPath>
+      <Route path="/monitors/" withOrgPath>
         <IndexRoute component={make(() => import('sentry/views/detectors/list'))} />
         <Route
           path=":monitorId/"


### PR DESCRIPTION
Incredibly tiny nit, but the `root` variable was leftover from some older code. No longer needed!