### PR TITLE
fix: Fix actionCreator/organization promises and enable `no-async-promise-executor` eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -280,7 +280,6 @@ export default typescript.config([
       // https://github.com/eslint/eslint/blob/main/packages/js/src/configs/eslint-recommended.js
       ...eslint.configs.recommended.rules,
       'no-cond-assign': ['error', 'always'],
-      'no-async-promise-executor': 'off', // TODO(ryan953): Fix violations and delete this line
       'no-case-declarations': 'off', // TODO(ryan953): Fix violations and delete this line
       'no-constant-binary-expression': 'off', // TODO(ryan953): Fix violations and delete this line
       'no-dupe-class-members': 'off', // TODO(ryan953): Fix violations and delete this line


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-async-promise-executor#rule-details

This rule uncovered a case where an error inside of `loadOrganization()` could result in a stalled sudo auth page, and where `loadTeamsAndProjects()` would swallow errors.

**loadOrganization**
Before: if a `401` or `403` response was returned and `getErrorMessage()` couldn't read `.detail` or `.detail.message` then  we'd arrive at the lonely `return;` statement on line 178 without resolving or rejecting the parent promise. This would stall the promise forever.

Now: the promise always resolves or rejects, one way or another.

This was only a problem inside of:
- https://github.com/getsentry/sentry/blob/0944815865e35621323e0b40793648e29094b008/static/app/views/organizationContext.tsx#L182
Called by:
- https://github.com/getsentry/sentry/blob/0944815865e35621323e0b40793648e29094b008/static/app/components/modals/sudoModal.tsx#L87

All other callsites do no await the promise. 


**loadTeamsAndProjects**

The promise executor inside `loadTeamsAndProjects` had no try/catch blocks before. So any errors thrown from inside any of the function calls (including fetchProjectsAndTeams) would not be caught or re-thown by the `new Promise` class instance. They're just gone, and the promise returned by loadTeamsAndProjects() would never reject. 
This caused the same issue as `loadOrganization()` above and impacts the same callsites. Now the method always resolves or rejects.