### PR TITLE
ref(issue-views): Refactor type of unsavedChanges in a view

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -46,7 +46,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
     isError,
   } = useFetchIssueCounts({
     orgSlug: organization.slug,
-    query: [view.unsavedChanges ? view.unsavedChanges[0] : view.query],
+    query: [view.unsavedChanges?.query ?? view.query],
     project: pageFilters.selection.projects,
     environment: pageFilters.selection.environments,
     ...constructCountTimeFrame(pageFilters.selection.datetime),
@@ -62,7 +62,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
       : undefined;
   const count = isError
     ? 0
-    : queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ??
+    : queryCount?.[view.unsavedChanges?.query ?? view.query] ??
       queryCount?.[defaultQuery ?? ''] ??
       0;
 

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -346,7 +346,6 @@ describe('IssueViewsHeader', () => {
       // This test inexplicably fails on the lines below. which ensure the Medium Priority tab is selected when clicked
       // and the High Priority tab is unselected. This behavior exists in other tests and in browser, so idk why it fails here.
       // We still need to ensure the router works as expected, so I'm commenting these checks rather than skipping the whole test.
-
       // expect(screen.getByRole('tab', {name: 'High Priority'})).toHaveAttribute(
       //   'aria-selected',
       //   'false'

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -31,6 +31,7 @@ import {useUser} from 'sentry/utils/useUser';
 import {
   generateTempViewId,
   type IssueView,
+  type IssueViewParams,
   IssueViews,
   IssueViewsContext,
 } from 'sentry/views/issueList/issueViews/issueViews';
@@ -225,22 +226,28 @@ function IssueViewsIssueListHeaderTabsContent({
       tabListState?.setSelectedKey(views[0]!.key);
       return;
     }
-    // if a viewId is present, check if it exists in the existing views.
+    // if a viewId is present, check the frontend is aware of a view with that id.
     if (viewId) {
-      const selectedTab = views.find(tab => tab.id === viewId);
-      if (selectedTab) {
+      const selectedView = views.find(tab => tab.id === viewId);
+      if (selectedView) {
+        // If the frontend is aware of a view with that id, check if the query/sort is different
+        // from the view's original query/sort.
+        const {query: originalQuery, querySort: originalSort} = selectedView;
         const issueSortOption = Object.values(IssueSortOptions).includes(sort)
           ? sort
           : IssueSortOptions.DATE;
 
-        const newUnsavedChanges: [string, IssueSortOptions] | undefined =
-          query === selectedTab.query && sort === selectedTab.querySort
+        const newUnsavedChanges: IssueViewParams | undefined =
+          query === originalQuery && sort === originalSort
             ? undefined
-            : [query ?? selectedTab.query, issueSortOption];
+            : {
+                query,
+                querySort: issueSortOption,
+              };
         if (
-          (newUnsavedChanges && !selectedTab.unsavedChanges) ||
-          selectedTab.unsavedChanges?.[0] !== newUnsavedChanges?.[0] ||
-          selectedTab.unsavedChanges?.[1] !== newUnsavedChanges?.[1]
+          (newUnsavedChanges && !selectedView.unsavedChanges) ||
+          selectedView.unsavedChanges?.query !== newUnsavedChanges?.query ||
+          selectedView.unsavedChanges?.querySort !== newUnsavedChanges?.querySort
         ) {
           // If there were no unsaved changes before, or the existing unsaved changes
           // don't match the new query and/or sort, update the unsaved changes
@@ -248,24 +255,24 @@ function IssueViewsIssueListHeaderTabsContent({
             type: 'UPDATE_UNSAVED_CHANGES',
             unsavedChanges: newUnsavedChanges,
           });
-        } else if (!newUnsavedChanges && selectedTab.unsavedChanges) {
-          // If there are no longer unsaved changes but there were before, remove them
+        } else if (!newUnsavedChanges && selectedView.unsavedChanges) {
+          // If the query/sort are the same as the original query/sort, remove any unsaved changes
           dispatch({type: 'UPDATE_UNSAVED_CHANGES', unsavedChanges: undefined});
         }
-        if (!tabListState?.selectionManager.isSelected(selectedTab.key)) {
+        if (!tabListState?.selectionManager.isSelected(selectedView.key)) {
           navigate(
             normalizeUrl({
               ...location,
               query: {
                 ...queryParamsWithPageFilters,
-                query: newUnsavedChanges ? newUnsavedChanges[0] : selectedTab.query,
-                sort: newUnsavedChanges ? newUnsavedChanges[1] : selectedTab.querySort,
-                viewId: selectedTab.id,
+                query: newUnsavedChanges?.query ?? selectedView.query,
+                sort: newUnsavedChanges?.querySort ?? selectedView.querySort,
+                viewId: selectedView.id,
               },
             }),
             {replace: true}
           );
-          tabListState?.setSelectedKey(selectedTab.key);
+          tabListState?.setSelectedKey(selectedView.key);
         }
       } else {
         // if a viewId does not exist, remove it from the query
@@ -331,7 +338,7 @@ function IssueViewsIssueListHeaderTabsContent({
         setNewViewActive(false);
         dispatch({
           type: 'UPDATE_UNSAVED_CHANGES',
-          unsavedChanges: [query, sort ?? IssueSortOptions.DATE],
+          unsavedChanges: {query, querySort: sort ?? IssueSortOptions.DATE},
           isCommitted: true,
           syncViews: true,
         });
@@ -409,8 +416,8 @@ function IssueViewsIssueListHeaderTabsContent({
           to={normalizeUrl({
             query: {
               ...queryParams,
-              query: view.unsavedChanges?.[0] ?? view.query,
-              sort: view.unsavedChanges?.[1] ?? view.querySort,
+              query: view.unsavedChanges?.query ?? view.query,
+              sort: view.unsavedChanges?.querySort ?? view.querySort,
               viewId: view.id !== TEMPORARY_TAB_KEY ? view.id : undefined,
             },
             pathname: `/organizations/${organization.slug}/issues/`,


### PR DESCRIPTION
Refactors the type of `unsavedChanges` from a fixed-sized typed list to an interface, which is cleaner and more scalable. This will be helpful since we are planning to add new parameters (project, env, time) that would trigger unsaved changes.