### PR TITLE
chore(devservices): Stop running snuba workers in CI

### DIFF
--- a/.github/workflows/test_devservices_acceptance.yml
+++ b/.github/workflows/test_devservices_acceptance.yml
@@ -5,6 +5,7 @@ name: test-devservices-acceptance
 on:
   schedule:
     - cron: '0 * * * *'
+  pull_request:
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
@@ -19,6 +20,7 @@ env:
   USE_NEW_DEVSERVICES: 1
   IS_DEV: 1
   CHARTCUTERIE_CONFIG_PATH: ${{ github.workspace }}/config/chartcuterie
+  SNUBA_NO_WORKERS: 1
 
 jobs:
   devservices-acceptance:

--- a/.github/workflows/test_devservices_acceptance.yml
+++ b/.github/workflows/test_devservices_acceptance.yml
@@ -5,7 +5,6 @@ name: test-devservices-acceptance
 on:
   schedule:
     - cron: '0 * * * *'
-  pull_request:
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test_devservices_backend.yml
+++ b/.github/workflows/test_devservices_backend.yml
@@ -3,7 +3,6 @@ name: test-devservices-backend
 on:
   schedule:
     - cron: '0 * * * *'
-  pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:

--- a/.github/workflows/test_devservices_backend.yml
+++ b/.github/workflows/test_devservices_backend.yml
@@ -3,6 +3,7 @@ name: test-devservices-backend
 on:
   schedule:
     - cron: '0 * * * *'
+  pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -14,6 +15,7 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
   USE_NEW_DEVSERVICES: 1
   IS_DEV: 1
+  SNUBA_NO_WORKERS: 1
 
 jobs:
   devservices-api-docs:


### PR DESCRIPTION
The snuba devserver does not need to run with workers for CI purposes, and consumes some additional CPU which may result in a small time speedup for CI