### PR TITLE
:bug: fix(azure devops): fix migration version on a fresh install

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -553,8 +553,8 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         # Assertion error happens when org_integration does not exist
         # KeyError happens when subscription is not found
-        except (IntegrationModel.DoesNotExist, AssertionError, KeyError) as e:
-            if isinstance(e, IntegrationModel.DoesNotExist) and features.has(
+        except (IntegrationModel.DoesNotExist, AssertionError, KeyError):
+            if features.has(
                 "organizations:migrate-azure-devops-integration", self.pipeline.organization
             ):
                 # If there is a new integration, we need to set the migration version to 1

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -164,6 +164,17 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         projects = installation.get_client().get_projects()
         assert len(projects) == 220
 
+    @with_feature("organizations:migrate-azure-devops-integration")
+    def test_metadata_is_correct(self):
+        self.assert_installation(new=True)
+        integration, installation = self._get_integration_and_install()
+        assert integration.metadata["domain_name"] == "https://MyVSTSAccount.visualstudio.com/"
+        assert set(integration.metadata["scopes"]) == set(VstsIntegrationProvider.NEW_SCOPES)
+        assert (
+            integration.metadata["integration_migration_version"]
+            == VstsIntegrationProvider.CURRENT_MIGRATION_VERSION
+        )
+
     @responses.activate
     def test_simple(self):
         responses.add(

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -617,6 +617,197 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
             installation.get_repositories()
 
 
+@control_silo_test
+@with_feature("organizations:migrate-azure-devops-integration")
+class NewVstsIntegrationTest(VstsIntegrationTestCase):
+    def test_get_organization_config(self):
+        self.assert_installation()
+        integration, installation = self._get_integration_and_install()
+
+        fields = installation.get_organization_config()
+
+        assert [field["name"] for field in fields] == [
+            "sync_status_forward",
+            "sync_forward_assignment",
+            "sync_comments",
+            "sync_status_reverse",
+            "sync_reverse_assignment",
+        ]
+
+    def test_get_organization_config_failure(self):
+        self.assert_installation()
+        integration, installation = self._get_integration_and_install()
+
+        # Set the `default_identity` property and force token expiration
+        installation.get_client()
+        assert installation.default_identity is not None
+        identity = Identity.objects.get(id=installation.default_identity.id)
+        identity.data["expires"] = 1566851050
+        identity.save()
+
+        responses.replace(
+            responses.POST,
+            "https://app.vssps.visualstudio.com/oauth2/token",
+            status=400,
+            json={"error": "invalid_grant", "message": "The provided authorization grant failed"},
+        )
+        fields = installation.get_organization_config()
+        assert fields[0]["disabled"], "Fields should be disabled"
+
+    def test_update_organization_config_remove_all(self):
+        self.assert_installation()
+
+        model = Integration.objects.get(provider="vsts")
+        integration = VstsIntegration(model, self.organization.id)
+
+        org_integration = OrganizationIntegration.objects.get(organization_id=self.organization.id)
+
+        data = {"sync_status_forward": {}, "other_option": "hello"}
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id=1,
+            resolved_status="ResolvedStatus1",
+            unresolved_status="UnresolvedStatus1",
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id=2,
+            resolved_status="ResolvedStatus2",
+            unresolved_status="UnresolvedStatus2",
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id=3,
+            resolved_status="ResolvedStatus3",
+            unresolved_status="UnresolvedStatus3",
+        )
+
+        integration.update_organization_config(data)
+
+        external_projects = IntegrationExternalProject.objects.all().values_list(
+            "external_id", flat=True
+        )
+
+        assert list(external_projects) == []
+
+        config = OrganizationIntegration.objects.get(
+            organization_id=org_integration.organization_id,
+            integration_id=org_integration.integration_id,
+        ).config
+
+        assert config == {"sync_status_forward": False, "other_option": "hello"}
+
+    def test_update_organization_config(self):
+        self.assert_installation()
+
+        org_integration = OrganizationIntegration.objects.get(organization_id=self.organization.id)
+
+        model = Integration.objects.get(provider="vsts")
+        integration = VstsIntegration(model, self.organization.id)
+
+        # test validation
+        data: dict[str, Any] = {
+            "sync_status_forward": {1: {"on_resolve": "", "on_unresolve": "UnresolvedStatus1"}}
+        }
+        with pytest.raises(IntegrationError):
+            integration.update_organization_config(data)
+
+        data = {
+            "sync_status_forward": {
+                1: {"on_resolve": "ResolvedStatus1", "on_unresolve": "UnresolvedStatus1"},
+                2: {"on_resolve": "ResolvedStatus2", "on_unresolve": "UnresolvedStatus2"},
+                4: {"on_resolve": "ResolvedStatus4", "on_unresolve": "UnresolvedStatus4"},
+            },
+            "other_option": "hello",
+        }
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id=1,
+            resolved_status="UpdateMe",
+            unresolved_status="UpdateMe",
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id=2,
+            resolved_status="ResolvedStatus2",
+            unresolved_status="UnresolvedStatus2",
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id=3,
+            resolved_status="ResolvedStatus3",
+            unresolved_status="UnresolvedStatus3",
+        )
+
+        integration.update_organization_config(data)
+
+        external_projects = IntegrationExternalProject.objects.all().order_by("external_id")
+
+        assert external_projects[0].external_id == "1"
+        assert external_projects[0].resolved_status == "ResolvedStatus1"
+        assert external_projects[0].unresolved_status == "UnresolvedStatus1"
+
+        assert external_projects[1].external_id == "2"
+        assert external_projects[1].resolved_status == "ResolvedStatus2"
+        assert external_projects[1].unresolved_status == "UnresolvedStatus2"
+
+        assert external_projects[2].external_id == "4"
+        assert external_projects[2].resolved_status == "ResolvedStatus4"
+        assert external_projects[2].unresolved_status == "UnresolvedStatus4"
+
+        config = OrganizationIntegration.objects.get(
+            organization_id=org_integration.organization_id,
+            integration_id=org_integration.integration_id,
+        ).config
+
+        assert config == {"sync_status_forward": True, "other_option": "hello"}
+
+    def test_update_domain_name(self):
+        account_name = "MyVSTSAccount.visualstudio.com"
+        account_uri = "https://MyVSTSAccount.visualstudio.com/"
+
+        self.assert_installation()
+
+        model = Integration.objects.get(provider="vsts")
+        model.metadata["domain_name"] = account_name
+        model.save()
+
+        integration = VstsIntegration(model, self.organization.id)
+        integration.get_client()
+
+        domain_name = integration.model.metadata["domain_name"]
+        assert domain_name == account_uri
+        assert Integration.objects.get(provider="vsts").metadata["domain_name"] == account_uri
+
+    def test_get_repositories(self):
+        self.assert_installation()
+        integration, installation = self._get_integration_and_install()
+
+        result = installation.get_repositories()
+        assert len(result) == 1
+        assert {"name": "ProjectA/cool-service", "identifier": self.repo_id} == result[0]
+
+    def test_get_repositories_identity_error(self):
+        self.assert_installation()
+        integration, installation = self._get_integration_and_install()
+
+        # Set the `default_identity` property and force token expiration
+        installation.get_client()
+        assert installation.default_identity is not None
+        identity = Identity.objects.get(id=installation.default_identity.id)
+        identity.data["expires"] = 1566851050
+        identity.save()
+
+        responses.replace(
+            responses.POST,
+            "https://app.vssps.visualstudio.com/oauth2/token",
+            status=400,
+            json={"error": "invalid_grant", "message": "The provided authorization grant failed"},
+        )
+        with pytest.raises(IntegrationError):
+            installation.get_repositories()
+
+
 class RegionVstsIntegrationTest(VstsIntegrationTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
when the integration is freshly installed, we need to make sure the migration version number is set to 1 as we use this metadata to determine what method we will use to refresh the tokens.

i wrote tests to make sure we refresh correctly when a new integration is installed as well.

to completely fix the bug, we need to do a backfill for all new integrations to update the metadata so we can grab the refresh correctly.