### PR TITLE
feat(symbolication): Add verbose symx log

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -9,6 +9,8 @@ import sentry_sdk
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import ParseDebugIdError
 
+from sentry import options
+from sentry.features.rollout import in_random_rollout
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.lang.native.utils import (
@@ -524,7 +526,7 @@ def emit_apple_symbol_stats(apple_symbol_stats, data):
     if old := apple_symbol_stats.get("old"):
         metrics.incr(
             "apple_symbol_availability_v2",
-            amount=old,
+            amount=len(old),
             tags={
                 "availability": "old",
                 "os_name": os_name,
@@ -533,6 +535,16 @@ def emit_apple_symbol_stats(apple_symbol_stats, data):
             },
             sample_rate=1.0,
         )
+
+        # This is done to temporally collect information about the events for which symx is not working correctly.
+        if in_random_rollout("symbolicate.symx-logging-rate"):
+            os_description = os_name + str(os_version)
+            if os_description in options.get("symbolicate.symx-os-description-list"):
+                with sentry_sdk.isolation_scope() as scope:
+                    scope.set_context(
+                        "Event Info", {"id": data.get("event_id"), "modules": str(old)}
+                    )
+                    sentry_sdk.capture_message("Failed to find symbols using symx")
 
     if symx := apple_symbol_stats.get("symx"):
         metrics.incr(

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -709,7 +709,8 @@ def collect_apple_symbol_stats(json):
     eligible_symbols = 0
     neither_has_symbol = 0
     both_have_symbol = 0
-    old_has_symbol = 0
+    # Done to temporally collect information about the events for which we don't find symbols in symx:
+    old_has_symbol = []
     symx_has_symbol = 0
 
     for module in json.get("modules") or ():
@@ -740,7 +741,7 @@ def collect_apple_symbol_stats(json):
             else:
                 symx_has_symbol += 1
         elif old_has_this_symbol:
-            old_has_symbol += 1
+            old_has_symbol.append(module)
         else:
             neither_has_symbol += 1
             # NOTE: It might be possible to apply a heuristic based on `code_file` here to figure out if this is

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1155,6 +1155,16 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# The ratio of events for which we emit verbose apple symbol stats.
+#
+# This is to allow collecting more information on why symx is not performing as it should.
+register("symbolicate.symx-logging-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+# The list of specific os_name+os_version for which we log extra infromation.
+#
+# This is done since SYMX is not performing bad across the board but rather only in specific case (what we are interested in).
+register("symbolicate.symx-os-description-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 


### PR DESCRIPTION
As can be seen [here](https://app.datadoghq.com/notebook/10270295/apple-symbol-investigation-optimised-for-exporting-to-m?notebookType=legacy&range=604800000&start=1736158053676&live=true) symx is not performing as it should, the reason as to why that is, is however unclear. To gain a better understanding of why symx performs as it does this adds logic to emit verbose info in the cases where symx is not working as it should.
