### PR TITLE
feat(dashboards): Add span extrapolation information to widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -7,6 +7,7 @@ import {
   type DashboardDetails,
   type DashboardFilters,
   DisplayType,
+  WidgetType,
 } from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
@@ -81,6 +82,8 @@ function WidgetPreview({
       // dashboard state to be added
       onWidgetSplitDecision={() => {}}
       // onWidgetSplitDecision={onWidgetSplitDecision}
+
+      showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
     />
   );
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -532,7 +532,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                       autoHeightResize={shouldResize ?? true}
                       noPadding={noPadding}
                     >
-                      <div style={{flex: 1}}>
+                      <RenderedChartContainer>
                         {getDynamicText({
                           value: this.chartComponent({
                             ...zoomRenderProps,
@@ -546,7 +546,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                           }),
                           fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                         })}
-                      </div>
+                      </RenderedChartContainer>
 
                       {showConfidenceWarning && confidence && (
                         <ConfidenceWarning
@@ -563,7 +563,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
             <TransitionChart loading={loading} reloading={loading}>
               <LoadingScreen loading={loading} />
               <ChartWrapper autoHeightResize={shouldResize ?? true} noPadding={noPadding}>
-                <div style={{flex: 1}}>
+                <RenderedChartContainer>
                   {getDynamicText({
                     value: this.chartComponent({
                       ...zoomRenderProps,
@@ -577,7 +577,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                     }),
                     fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                   })}
-                </div>
+                </RenderedChartContainer>
                 {showConfidenceWarning && confidence && (
                   <ConfidenceWarning
                     query={widget.queries[0]?.conditions ?? ''}
@@ -664,4 +664,8 @@ const StyledSimpleTableChart = styled(SimpleTableChart)`
 
 const StyledErrorPanel = styled(ErrorPanel)`
   padding: ${space(2)};
+`;
+
+const RenderedChartContainer = styled('div')`
+  flex: 1;
 `;

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -62,6 +62,7 @@ import type WidgetLegendSelectionState from '../widgetLegendSelectionState';
 import {BigNumberWidgetVisualization} from '../widgets/bigNumberWidget/bigNumberWidgetVisualization';
 
 import type {GenericWidgetQueriesChildrenProps} from './genericWidgetQueries';
+import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 
 const OTHER = 'Other';
 const PERCENTAGE_DECIMAL_POINTS = 3;
@@ -527,19 +528,23 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                       autoHeightResize={shouldResize ?? true}
                       noPadding={noPadding}
                     >
-                      {getDynamicText({
-                        value: this.chartComponent({
-                          ...zoomRenderProps,
-                          ...chartOptions,
-                          // Override default datazoom behaviour for updating Global Selection Header
-                          ...(onZoom ? {onDataZoom: onZoom} : {}),
-                          legend,
-                          series: [...series, ...(modifiedReleaseSeriesResults ?? [])],
-                          onLegendSelectChanged,
-                          forwardedRef,
-                        }),
-                        fixed: <Placeholder height="200px" testId="skeleton-ui" />,
-                      })}
+                      <div style={{flex: 1}}>
+                        {getDynamicText({
+                          value: this.chartComponent({
+                            ...zoomRenderProps,
+                            ...chartOptions,
+                            // Override default datazoom behaviour for updating Global Selection Header
+                            ...(onZoom ? {onDataZoom: onZoom} : {}),
+                            legend,
+                            series: [...series, ...(modifiedReleaseSeriesResults ?? [])],
+                            onLegendSelectChanged,
+                            forwardedRef,
+                          }),
+                          fixed: <Placeholder height="200px" testId="skeleton-ui" />,
+                        })}
+                      </div>
+
+                      <ConfidenceFooter sampleCount={500} confidence={'low'} />
                     </ChartWrapper>
                   </TransitionChart>
                 );
@@ -549,19 +554,22 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
             <TransitionChart loading={loading} reloading={loading}>
               <LoadingScreen loading={loading} />
               <ChartWrapper autoHeightResize={shouldResize ?? true} noPadding={noPadding}>
-                {getDynamicText({
-                  value: this.chartComponent({
-                    ...zoomRenderProps,
-                    ...chartOptions,
-                    // Override default datazoom behaviour for updating Global Selection Header
-                    ...(onZoom ? {onDataZoom: onZoom} : {}),
-                    legend,
-                    series,
-                    onLegendSelectChanged,
-                    forwardedRef,
-                  }),
-                  fixed: <Placeholder height="200px" testId="skeleton-ui" />,
-                })}
+                <div style={{flex: 1}}>
+                  {getDynamicText({
+                    value: this.chartComponent({
+                      ...zoomRenderProps,
+                      ...chartOptions,
+                      // Override default datazoom behaviour for updating Global Selection Header
+                      ...(onZoom ? {onDataZoom: onZoom} : {}),
+                      legend,
+                      series,
+                      onLegendSelectChanged,
+                      forwardedRef,
+                    }),
+                    fixed: <Placeholder height="200px" testId="skeleton-ui" />,
+                  })}
+                </div>
+                <ConfidenceFooter sampleCount={500} confidence={'low'} />
               </ChartWrapper>
             </TransitionChart>
           );
@@ -623,6 +631,9 @@ const ChartWrapper = styled('div')<{autoHeightResize: boolean; noPadding?: boole
   ${p => p.autoHeightResize && 'height: 100%;'}
   width: 100%;
   padding: ${p => (p.noPadding ? `0` : `0 ${space(2)} ${space(2)}`)};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
 `;
 
 const TableWrapper = styled('div')`

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -29,7 +29,7 @@ import type {
   EChartEventHandler,
   ReactEchartsRef,
 } from 'sentry/types/echarts';
-import type {Organization} from 'sentry/types/organization';
+import type {Confidence, Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {
   axisLabelFormatter,
@@ -51,6 +51,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
+import ConfidenceWarning from 'sentry/views/dashboards/widgetCard/confidenceWarning';
 import {getBucketSize} from 'sentry/views/dashboards/widgetCard/utils';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 
@@ -62,7 +63,6 @@ import type WidgetLegendSelectionState from '../widgetLegendSelectionState';
 import {BigNumberWidgetVisualization} from '../widgets/bigNumberWidget/bigNumberWidgetVisualization';
 
 import type {GenericWidgetQueriesChildrenProps} from './genericWidgetQueries';
-import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 
 const OTHER = 'Other';
 const PERCENTAGE_DECIMAL_POINTS = 3;
@@ -83,6 +83,7 @@ type WidgetCardChartProps = Pick<
   widget: Widget;
   widgetLegendState: WidgetLegendSelectionState;
   chartGroup?: string;
+  confidence?: Confidence;
   expandNumbers?: boolean;
   isMobile?: boolean;
   legendOptions?: LegendComponentOption;
@@ -94,6 +95,7 @@ type WidgetCardChartProps = Pick<
   }>;
   onZoom?: EChartDataZoomHandler;
   shouldResize?: boolean;
+  showConfidenceWarning?: boolean;
   timeseriesResultsTypes?: Record<string, AggregationOutputType>;
   windowWidth?: number;
 };
@@ -285,6 +287,8 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
       noPadding,
       timeseriesResultsTypes,
       shouldResize,
+      confidence,
+      showConfidenceWarning,
     } = this.props;
 
     if (widget.displayType === 'table') {
@@ -544,7 +548,12 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                         })}
                       </div>
 
-                      <ConfidenceFooter sampleCount={500} confidence={'low'} />
+                      {showConfidenceWarning && confidence && (
+                        <ConfidenceWarning
+                          query={widget.queries[0]?.conditions ?? ''}
+                          confidence={confidence}
+                        />
+                      )}
                     </ChartWrapper>
                   </TransitionChart>
                 );
@@ -569,7 +578,12 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                     fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                   })}
                 </div>
-                <ConfidenceFooter sampleCount={500} confidence={'low'} />
+                {showConfidenceWarning && confidence && (
+                  <ConfidenceWarning
+                    query={widget.queries[0]?.conditions ?? ''}
+                    confidence={confidence}
+                  />
+                )}
               </ChartWrapper>
             </TransitionChart>
           );

--- a/static/app/views/dashboards/widgetCard/confidenceWarning.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceWarning.tsx
@@ -1,0 +1,23 @@
+import type {Confidence} from 'sentry/types/organization';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useExtrapolationMeta} from 'sentry/views/explore/charts';
+import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
+
+interface ConfidenceWarningProps {
+  confidence: Confidence;
+  query: string;
+}
+
+export default function ConfidenceWarning({query, confidence}: ConfidenceWarningProps) {
+  const extrapolationMetaResults = useExtrapolationMeta({
+    dataset: DiscoverDatasets.SPANS_EAP_RPC,
+    query,
+  });
+
+  return (
+    <ConfidenceFooter
+      sampleCount={extrapolationMetaResults.data?.[0]?.['count_sample()']}
+      confidence={confidence}
+    />
+  );
+}

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -8,7 +8,7 @@ import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/util
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
-import type {Organization} from 'sentry/types/organization';
+import type {Confidence, Organization} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -43,6 +43,7 @@ export type OnDataFetchedProps = {
 
 export type GenericWidgetQueriesChildrenProps = {
   loading: boolean;
+  confidence?: Confidence;
   errorMessage?: string;
   pageLinks?: string;
   tableResults?: TableDataWithTitle[];

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -86,6 +86,7 @@ type Props = WithRouterProps & {
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   shouldResize?: boolean;
+  showConfidenceWarning?: boolean;
   showContextMenu?: boolean;
   showStoredAlert?: boolean;
   tableItemLimit?: number;
@@ -131,6 +132,7 @@ function WidgetCard(props: Props) {
     legendOptions,
     widgetLegendState,
     disableFullscreen,
+    showConfidenceWarning,
   } = props;
 
   if (widget.displayType === DisplayType.TOP_N) {
@@ -337,6 +339,7 @@ function WidgetCard(props: Props) {
               onLegendSelectChanged={onLegendSelectChanged}
               legendOptions={legendOptions}
               widgetLegendState={widgetLegendState}
+              showConfidenceWarning={showConfidenceWarning}
             />
           </WidgetFrame>
         )}

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -1,0 +1,97 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SpansWidgetQueries from './spansWidgetQueries';
+
+describe('spansWidgetQueries', () => {
+  const api = new MockApiClient();
+  const organization = OrganizationFixture();
+  let widget = WidgetFixture();
+  const selection = PageFiltersFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    widget = WidgetFixture();
+  });
+
+  it('calculates the confidence for a single series', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        confidence: [
+          [1, [{count: 'low'}]],
+          [2, [{count: 'low'}]],
+          [3, [{count: 'low'}]],
+        ],
+        data: [],
+      },
+    });
+
+    render(
+      <SpansWidgetQueries
+        api={api}
+        organization={organization}
+        widget={widget}
+        selection={selection}
+        dashboardFilters={{}}
+      >
+        {({confidence}) => <div>{confidence}</div>}
+      </SpansWidgetQueries>
+    );
+
+    expect(await screen.findByText('low')).toBeInTheDocument();
+  });
+
+  it('calculates the confidence for a multi series', async () => {
+    widget = WidgetFixture({
+      queries: [
+        {
+          name: '',
+          aggregates: ['a', 'b'],
+          fields: ['a', 'b'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        a: {
+          confidence: [
+            [1, [{count: 'high'}]],
+            [2, [{count: 'high'}]],
+            [3, [{count: 'high'}]],
+          ],
+          data: [],
+        },
+        b: {
+          confidence: [
+            [1, [{count: 'high'}]],
+            [2, [{count: 'high'}]],
+            [3, [{count: 'high'}]],
+          ],
+          data: [],
+        },
+      },
+    });
+
+    render(
+      <SpansWidgetQueries
+        api={api}
+        organization={organization}
+        widget={widget}
+        selection={selection}
+        dashboardFilters={{}}
+      >
+        {({confidence}) => <div>{confidence}</div>}
+      </SpansWidgetQueries>
+    );
+
+    expect(await screen.findByText('high')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -1,0 +1,98 @@
+import {useState} from 'react';
+
+import type {Client} from 'sentry/api';
+import {isMultiSeriesStats} from 'sentry/components/charts/utils';
+import type {PageFilters} from 'sentry/types/core';
+import type {
+  Confidence,
+  EventsStats,
+  MultiSeriesEventsStats,
+  Organization,
+} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {dedupeArray} from 'sentry/utils/dedupeArray';
+import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {determineSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
+import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {transformToSeriesMap} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+import type {DashboardFilters, Widget} from '../types';
+
+import type {
+  GenericWidgetQueriesChildrenProps,
+  OnDataFetchedProps,
+} from './genericWidgetQueries';
+import GenericWidgetQueries from './genericWidgetQueries';
+
+type SeriesResult = EventsStats | MultiSeriesEventsStats;
+type TableResult = TableData | EventsTableData;
+
+type Props = {
+  api: Client;
+  children: (props: GenericWidgetQueriesChildrenProps) => JSX.Element;
+  organization: Organization;
+  selection: PageFilters;
+  widget: Widget;
+  cursor?: string;
+  dashboardFilters?: DashboardFilters;
+  limit?: number;
+  onDataFetched?: (results: OnDataFetchedProps) => void;
+};
+
+function SpansWidgetQueries({
+  children,
+  api,
+  organization,
+  selection,
+  widget,
+  cursor,
+  limit,
+  dashboardFilters,
+  onDataFetched,
+}: Props) {
+  const config = SpansConfig;
+
+  const [confidence, setConfidence] = useState<Confidence | null>(null);
+
+  const afterFetchSeriesData = (result: SeriesResult) => {
+    if (isMultiSeriesStats(result)) {
+      const dedupedYAxes = dedupeArray(widget.queries[0]?.aggregates ?? []);
+      const seriesMap = transformToSeriesMap(result, dedupedYAxes);
+      const series = dedupedYAxes.flatMap(yAxis => seriesMap[yAxis]).filter(defined);
+      const seriesConfidence = combineConfidenceForSeries(series);
+      setConfidence(seriesConfidence);
+    } else {
+      const seriesConfidence = determineSeriesConfidence(result);
+      setConfidence(seriesConfidence);
+    }
+  };
+
+  return getDynamicText({
+    value: (
+      <GenericWidgetQueries<SeriesResult, TableResult>
+        config={config}
+        api={api}
+        organization={organization}
+        selection={selection}
+        widget={widget}
+        cursor={cursor}
+        limit={limit}
+        dashboardFilters={dashboardFilters}
+        onDataFetched={onDataFetched}
+        afterFetchSeriesData={afterFetchSeriesData}
+      >
+        {props =>
+          children({
+            ...props,
+            confidence,
+          })
+        }
+      </GenericWidgetQueries>
+    ),
+    fixed: <div />,
+  });
+}
+
+export default SpansWidgetQueries;

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -55,6 +55,7 @@ type Props = {
   onZoom?: EChartDataZoomHandler;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   shouldResize?: boolean;
+  showConfidenceWarning?: boolean;
   tableItemLimit?: number;
   windowWidth?: number;
 };
@@ -78,6 +79,7 @@ export function WidgetCardChartContainer({
   chartGroup,
   shouldResize,
   widgetLegendState,
+  showConfidenceWarning,
 }: Props) {
   const location = useLocation();
 
@@ -105,6 +107,7 @@ export function WidgetCardChartContainer({
         errorMessage,
         loading,
         timeseriesResultsTypes,
+        confidence,
       }) => {
         if (widget.widgetType === WidgetType.ISSUE) {
           return (
@@ -160,9 +163,9 @@ export function WidgetCardChartContainer({
                   : {selected: widgetLegendState.getWidgetSelectionState(widget)}
               }
               widgetLegendState={widgetLegendState}
+              showConfidenceWarning={confidence === 'low' || showConfidenceWarning}
+              confidence={confidence}
             />
-
-            {/* <ConfidenceFooter sampleCount={500} confidence={'low'} /> */}
           </Fragment>
         );
       }}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -163,7 +163,7 @@ export function WidgetCardChartContainer({
                   : {selected: widgetLegendState.getWidgetSelectionState(widget)}
               }
               widgetLegendState={widgetLegendState}
-              showConfidenceWarning={confidence === 'low' || showConfidenceWarning}
+              showConfidenceWarning={showConfidenceWarning}
               confidence={confidence}
             />
           </Fragment>

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -161,6 +161,8 @@ export function WidgetCardChartContainer({
               }
               widgetLegendState={widgetLegendState}
             />
+
+            {/* <ConfidenceFooter sampleCount={500} confidence={'low'} /> */}
           </Fragment>
         );
       }}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -2,10 +2,12 @@ import {Fragment} from 'react';
 
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
+import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import SpansWidgetQueries from 'sentry/views/dashboards/widgetCard/spansWidgetQueries';
 
 import type {DashboardFilters, Widget} from '../types';
 import {WidgetType} from '../types';
@@ -16,6 +18,7 @@ import WidgetQueries from './widgetQueries';
 
 type Results = {
   loading: boolean;
+  confidence?: Confidence;
   errorMessage?: string;
   pageLinks?: string;
   tableResults?: TableDataWithTitle[];
@@ -93,6 +96,22 @@ export function WidgetCardDataLoader({
     );
   }
 
+  if (widget.widgetType === WidgetType.SPANS) {
+    return (
+      <SpansWidgetQueries
+        api={api}
+        organization={organization}
+        widget={widget}
+        selection={selection}
+        limit={tableItemLimit}
+        onDataFetched={onDataFetched}
+        dashboardFilters={dashboardFilters}
+      >
+        {props => <Fragment>{children({...props})}</Fragment>}
+      </SpansWidgetQueries>
+    );
+  }
+
   return (
     <WidgetQueries
       api={api}
@@ -110,6 +129,7 @@ export function WidgetCardDataLoader({
         errorMessage,
         loading,
         timeseriesResultsTypes,
+        confidence,
       }) => (
         <Fragment>
           {children({
@@ -118,6 +138,7 @@ export function WidgetCardDataLoader({
             errorMessage,
             loading,
             timeseriesResultsTypes,
+            confidence,
           })}
         </Fragment>
       )}

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -268,7 +268,7 @@ export function ExploreCharts({
   );
 }
 
-function useExtrapolationMeta({
+export function useExtrapolationMeta({
   dataset,
   query,
 }: {

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -135,7 +135,7 @@ function isMultiSeriesEventsStats(
   return Object.values(obj).every(series => isEventsStats(series));
 }
 
-function transformToSeriesMap(
+export function transformToSeriesMap(
   result: MultiSeriesEventsStats | GroupedMultiSeriesEventsStats | undefined,
   yAxis: string[]
 ): SeriesMap {


### PR DESCRIPTION
Adds a message to span widgets with low confidence. The sample count and confidence message is only shown when editing the widget so far. We will also add it to the widget viewer.

To do this, I added another prop to our widget queries to pass along `confidence`, but it's only ever filled in for spans widgets.

<img width="1416" alt="Screenshot 2025-01-13 at 9 19 16 AM" src="https://github.com/user-attachments/assets/8b606dfa-5e2a-4ac0-a49d-e516405097f8" />
