### PR TITLE
ref(visibility): Unit conversions

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -179,6 +179,7 @@ export const ABYTE_UNITS = [
   'exabyte',
 ];
 
+// TODO: Remove this, use `DURATION_UNIT_MULTIPLIERS` instead
 export const DURATION_UNITS = {
   nanosecond: 1 / 1000 ** 2,
   microsecond: 1 / 1000,

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -153,6 +153,7 @@ export function nullableValue(value: string | null): string | React.ReactElement
   }
 }
 
+// TODO: Remove this, use `SIZE_UNIT_MULTIPLIERS` instead
 export const SIZE_UNITS = {
   bit: 1 / 8,
   byte: 1,

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -180,6 +180,24 @@ export enum SizeUnit {
   EXABYTE = 'exabyte',
 }
 
+// Sizes normalized to byte unit
+export const SIZE_UNIT_MULTIPLIERS: Record<SizeUnit, number> = {
+  bit: 1 / 8,
+  byte: 1,
+  kibibyte: 1024,
+  mebibyte: 1024 ** 2,
+  gibibyte: 1024 ** 3,
+  tebibyte: 1024 ** 4,
+  pebibyte: 1024 ** 5,
+  exbibyte: 1024 ** 6,
+  kilobyte: 1000,
+  megabyte: 1000 ** 2,
+  gigabyte: 1000 ** 3,
+  terabyte: 1000 ** 4,
+  petabyte: 1000 ** 5,
+  exabyte: 1000 ** 6,
+};
+
 export enum RateUnit {
   PER_SECOND = '1/second',
   PER_MINUTE = '1/minute',

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -149,6 +149,20 @@ export enum DurationUnit {
   YEAR = 'year',
 }
 
+// Durations normalized to millisecond unit
+export const DURATION_UNIT_MULTIPLIERS: Record<DurationUnit, number> = {
+  nanosecond: 1 / 1000 ** 2,
+  microsecond: 1 / 1000,
+  millisecond: 1,
+  second: 1000,
+  minute: 1000 * 60,
+  hour: 1000 * 60 * 60,
+  day: 1000 * 60 * 60 * 24,
+  week: 1000 * 60 * 60 * 24 * 7,
+  month: 1000 * 60 * 60 * 24 * 30,
+  year: 1000 * 60 * 60 * 24 * 365,
+};
+
 export enum SizeUnit {
   BIT = 'bit',
   BYTE = 'byte',

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -205,7 +205,6 @@ export enum RateUnit {
 }
 
 // Rates normalized to /second unit
-// TODO: For consistency these should scale UP not down
 export const RATE_UNIT_MULTIPLIERS: Record<RateUnit, number> = {
   [RateUnit.PER_SECOND]: 1,
   [RateUnit.PER_MINUTE]: 1 / 60,

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -187,7 +187,8 @@ export enum RateUnit {
 }
 
 // Rates normalized to /second unit
-export const RATE_UNIT_MULTIPLIERS = {
+// TODO: For consistency these should scale UP not down
+export const RATE_UNIT_MULTIPLIERS: Record<RateUnit, number> = {
   [RateUnit.PER_SECOND]: 1,
   [RateUnit.PER_MINUTE]: 1 / 60,
   [RateUnit.PER_HOUR]: 1 / (60 * 60),

--- a/static/app/utils/unitConversion/convertDuration.spec.tsx
+++ b/static/app/utils/unitConversion/convertDuration.spec.tsx
@@ -1,0 +1,15 @@
+import {DurationUnit} from '../discover/fields';
+
+import {convertDuration} from './convertDuration';
+
+describe('convertDuration', () => {
+  it.each([
+    [0, DurationUnit.MILLISECOND, DurationUnit.MILLISECOND, 0],
+    [1700, DurationUnit.MILLISECOND, DurationUnit.SECOND, 1.7],
+    [12, DurationUnit.MINUTE, DurationUnit.SECOND, 720],
+    [720, DurationUnit.SECOND, DurationUnit.MINUTE, 12],
+    [72, DurationUnit.MINUTE, DurationUnit.HOUR, 1.2],
+  ])('Converts %s %s to %s', (value, fromUnit, toUnit, result) => {
+    expect(convertDuration(value, fromUnit, toUnit)).toEqual(result);
+  });
+});

--- a/static/app/utils/unitConversion/convertDuration.tsx
+++ b/static/app/utils/unitConversion/convertDuration.tsx
@@ -1,0 +1,11 @@
+import {DURATION_UNIT_MULTIPLIERS, type DurationUnit} from '../discover/fields';
+
+export function convertDuration(
+  value: number,
+  fromUnit: DurationUnit,
+  toUnit: DurationUnit
+): number {
+  return (
+    (value * DURATION_UNIT_MULTIPLIERS[fromUnit]) / DURATION_UNIT_MULTIPLIERS[toUnit]
+  );
+}

--- a/static/app/utils/unitConversion/convertDuration.tsx
+++ b/static/app/utils/unitConversion/convertDuration.tsx
@@ -6,6 +6,6 @@ export function convertDuration(
   toUnit: DurationUnit
 ): number {
   return (
-    (value * DURATION_UNIT_MULTIPLIERS[fromUnit]) / DURATION_UNIT_MULTIPLIERS[toUnit]
+    value * (DURATION_UNIT_MULTIPLIERS[fromUnit] / DURATION_UNIT_MULTIPLIERS[toUnit])
   );
 }

--- a/static/app/utils/unitConversion/convertRate.spec.tsx
+++ b/static/app/utils/unitConversion/convertRate.spec.tsx
@@ -1,0 +1,15 @@
+import {RateUnit} from '../discover/fields';
+
+import {convertRate} from './convertRate';
+
+describe('convertRate', () => {
+  it.each([
+    [0, RateUnit.PER_MINUTE, RateUnit.PER_MINUTE, 0],
+    [17, RateUnit.PER_MINUTE, RateUnit.PER_SECOND, 1020],
+    [17, RateUnit.PER_MINUTE, RateUnit.PER_HOUR, 0.28333333],
+    [0.2, RateUnit.PER_HOUR, RateUnit.PER_MINUTE, 12],
+    [0.2, RateUnit.PER_HOUR, RateUnit.PER_SECOND, 720],
+  ])('Converts %s %s to %s', (value, fromUnit, toUnit, result) => {
+    expect(convertRate(value, fromUnit, toUnit)).toBeCloseTo(result, 5);
+  });
+});

--- a/static/app/utils/unitConversion/convertRate.tsx
+++ b/static/app/utils/unitConversion/convertRate.tsx
@@ -1,5 +1,5 @@
 import {RATE_UNIT_MULTIPLIERS, type RateUnit} from '../discover/fields';
 
 export function convertRate(value: number, fromUnit: RateUnit, toUnit: RateUnit): number {
-  return (value / RATE_UNIT_MULTIPLIERS[fromUnit]) * RATE_UNIT_MULTIPLIERS[toUnit];
+  return value * (RATE_UNIT_MULTIPLIERS[toUnit] / RATE_UNIT_MULTIPLIERS[fromUnit]);
 }

--- a/static/app/utils/unitConversion/convertRate.tsx
+++ b/static/app/utils/unitConversion/convertRate.tsx
@@ -1,0 +1,5 @@
+import {RATE_UNIT_MULTIPLIERS, type RateUnit} from '../discover/fields';
+
+export function convertRate(value: number, fromUnit: RateUnit, toUnit: RateUnit): number {
+  return (value / RATE_UNIT_MULTIPLIERS[fromUnit]) * RATE_UNIT_MULTIPLIERS[toUnit];
+}

--- a/static/app/utils/unitConversion/convertSize.spec.tsx
+++ b/static/app/utils/unitConversion/convertSize.spec.tsx
@@ -1,0 +1,15 @@
+import {SizeUnit} from '../discover/fields';
+
+import {convertSize} from './convertSize';
+
+describe('convertSize', () => {
+  it.each([
+    [0, SizeUnit.BYTE, SizeUnit.BYTE, 0],
+    [1, SizeUnit.BYTE, SizeUnit.BYTE, 1],
+    [1, SizeUnit.MEGABYTE, SizeUnit.KILOBYTE, 1000],
+    [500, SizeUnit.KILOBYTE, SizeUnit.MEGABYTE, 0.5],
+    [1, SizeUnit.MEBIBYTE, SizeUnit.MEGABYTE, 1.048576],
+  ])('Converts %s %s to %s', (value, fromUnit, toUnit, result) => {
+    expect(convertSize(value, fromUnit, toUnit)).toEqual(result);
+  });
+});

--- a/static/app/utils/unitConversion/convertSize.tsx
+++ b/static/app/utils/unitConversion/convertSize.tsx
@@ -1,0 +1,5 @@
+import {SIZE_UNIT_MULTIPLIERS, type SizeUnit} from '../discover/fields';
+
+export function convertSize(value: number, fromUnit: SizeUnit, toUnit: SizeUnit): number {
+  return (value * SIZE_UNIT_MULTIPLIERS[fromUnit]) / SIZE_UNIT_MULTIPLIERS[toUnit];
+}

--- a/static/app/utils/unitConversion/convertSize.tsx
+++ b/static/app/utils/unitConversion/convertSize.tsx
@@ -1,5 +1,5 @@
 import {SIZE_UNIT_MULTIPLIERS, type SizeUnit} from '../discover/fields';
 
 export function convertSize(value: number, fromUnit: SizeUnit, toUnit: SizeUnit): number {
-  return (value * SIZE_UNIT_MULTIPLIERS[fromUnit]) / SIZE_UNIT_MULTIPLIERS[toUnit];
+  return value * (SIZE_UNIT_MULTIPLIERS[fromUnit] / SIZE_UNIT_MULTIPLIERS[toUnit]);
 }


### PR DESCRIPTION
I was a little surprised that there aren't handy unit conversion functions, since we do a little bit of converting here and there.

There are already enums defined for types of interest that can be converted (sizes, rates, durations). This PR adds constants that hold the conversion rations, and small helper functions to do the conversions.
