### PR TITLE
feat(alerts): Replace total count in span alert chart with samples count

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -1,4 +1,5 @@
 import {type ComponentProps, Fragment, PureComponent} from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
@@ -487,22 +488,22 @@ class TriggersChart extends PureComponent<Props, State> {
           />
         )}
 
-        {dataset === Dataset.EVENTS_ANALYTICS_PLATFORM && (
-          <ChartFooter>
-            <ConfidenceFooter
-              sampleCount={extrapolationSampleCount ?? undefined}
-              confidence={confidence}
-            />
-          </ChartFooter>
-        )}
-
         <ChartControls>
           {showTotalCount ? (
             <InlineContainer data-test-id="alert-total-events">
-              <SectionHeading>{totalCountLabel}</SectionHeading>
-              <SectionValue>
-                {totalCount !== null ? totalCount.toLocaleString() : '\u2014'}
-              </SectionValue>
+              {dataset === Dataset.EVENTS_ANALYTICS_PLATFORM ? (
+                <ConfidenceFooter
+                  sampleCount={extrapolationSampleCount ?? undefined}
+                  confidence={confidence}
+                />
+              ) : (
+                <React.Fragment>
+                  <SectionHeading>{totalCountLabel}</SectionHeading>
+                  <SectionValue>
+                    {totalCount !== null ? totalCount.toLocaleString() : '\u2014'}
+                  </SectionValue>
+                </React.Fragment>
+              )}
             </InlineContainer>
           ) : (
             <InlineContainer />
@@ -817,7 +818,3 @@ export function ErrorChart({isAllowIndexed, isQueryValid, errorMessage, ...props
     </ChartErrorWrapper>
   );
 }
-
-const ChartFooter = styled('div')`
-  margin: 0 ${space(2)} ${space(2)} ${space(2)};
-`;


### PR DESCRIPTION
Replaces the `Total` count in span alerts charts with the extrapolation samples count. Having two separate numbers was confusing and the `Total` count wasn't particularly useful for span alerts
![image](https://github.com/user-attachments/assets/a782bde4-8ad6-4fb7-8b0d-fe3dd2a99935)
