### PR TITLE
fix(member-invite): invite modal only shows member's teams when open membership is disabled

### DIFF
--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.spec.tsx
@@ -1,5 +1,6 @@
 import {TeamFixture} from 'sentry-fixture/team';
 
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
@@ -17,11 +18,13 @@ describe('InviteRowControlNew', function () {
       id: '1',
       slug: 'moo-deng',
       name: "Moo Deng's Team",
+      isMember: true,
     },
     {
       id: '2',
       slug: 'moo-waan',
       name: "Moo Waan's Team",
+      isMember: false,
     },
   ];
   const teams: DetailedTeam[] = teamData.map(data => TeamFixture(data));
@@ -152,5 +155,37 @@ describe('InviteRowControlNew', function () {
     await userEvent.click(screen.getByRole('menuitemcheckbox', {name: '#moo-deng'}));
     await userEvent.click(screen.getByRole('menuitemcheckbox', {name: '#moo-waan'}));
     expect(mockSetTeams).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows all teams if Open Membership is enabled', async function () {
+    const {organization: orgWithInviteAccess} = initializeOrg({
+      organization: {
+        access: ['member:invite'],
+        allowMemberInvite: true,
+        openMembership: true,
+      },
+    });
+    render(getComponent(defaultInviteProps), {organization: orgWithInviteAccess});
+    const teamInput = screen.getByRole('textbox', {name: 'Add to Team'});
+    expect(teamInput).toBeEnabled();
+    await userEvent.click(teamInput);
+    expect(screen.getByText('#moo-deng')).toBeInTheDocument();
+    expect(screen.getByText('#moo-waan')).toBeInTheDocument();
+  });
+
+  it('only shows member teams if Open Membership is disabled', async function () {
+    const {organization: orgWithInviteAccess} = initializeOrg({
+      organization: {
+        access: ['member:invite'],
+        allowMemberInvite: true,
+        openMembership: false,
+      },
+    });
+    render(getComponent(defaultInviteProps), {organization: orgWithInviteAccess});
+    const teamInput = screen.getByRole('textbox', {name: 'Add to Team'});
+    expect(teamInput).toBeEnabled();
+    await userEvent.click(teamInput);
+    expect(screen.getByText('#moo-deng')).toBeInTheDocument();
+    expect(screen.queryByText('#moo-waan')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/teamSelector.spec.tsx
+++ b/static/app/components/teamSelector.spec.tsx
@@ -2,7 +2,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
@@ -210,16 +209,8 @@ describe('Team Selector', function () {
     expect(openCreateTeamModal).not.toHaveBeenCalled();
   });
 
-  it('shows all teams to members if Open Membership is enabled', async function () {
-    const {organization: orgWithInviteAccess} = initializeOrg({
-      organization: {
-        access: ['member:invite'],
-        allowMemberInvite: true,
-        openMembership: true,
-      },
-    });
-
-    createWrapper({isInviting: true, organization: orgWithInviteAccess});
+  it('shows all teams to members if filterByUserMembership is false', async function () {
+    createWrapper({filterByUserMembership: false});
     await userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
     expect(screen.getByText('#team1')).toBeInTheDocument();
@@ -227,16 +218,8 @@ describe('Team Selector', function () {
     expect(screen.getByText('#team3')).toBeInTheDocument();
   });
 
-  it('only shows member teams if Open Membership is disabled', async function () {
-    const {organization: orgWithInviteAccess} = initializeOrg({
-      organization: {
-        access: ['member:invite'],
-        allowMemberInvite: true,
-        openMembership: false,
-      },
-    });
-
-    createWrapper({isInviting: true, organization: orgWithInviteAccess});
+  it('only shows member teams if filterByUserMembership is true', async function () {
+    createWrapper({filterByUserMembership: true});
     await userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
     expect(screen.getByText('#team1')).toBeInTheDocument();

--- a/static/app/components/teamSelector.spec.tsx
+++ b/static/app/components/teamSelector.spec.tsx
@@ -219,7 +219,7 @@ describe('Team Selector', function () {
       },
     });
 
-    createWrapper({organization: orgWithInviteAccess});
+    createWrapper({isInviting: true, organization: orgWithInviteAccess});
     await userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
     expect(screen.getByText('#team1')).toBeInTheDocument();
@@ -236,7 +236,7 @@ describe('Team Selector', function () {
       },
     });
 
-    createWrapper({organization: orgWithInviteAccess});
+    createWrapper({isInviting: true, organization: orgWithInviteAccess});
     await userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
     expect(screen.getByText('#team1')).toBeInTheDocument();

--- a/static/app/components/teamSelector.tsx
+++ b/static/app/components/teamSelector.tsx
@@ -156,6 +156,14 @@ function TeamSelector(props: Props) {
   const api = useApi();
   const {teams, fetching, onSearch} = useTeams();
 
+  const isMemberInvite =
+    organization.access?.includes('member:invite') &&
+    !organization.access?.includes('member:admin');
+  const membersCanOnlyInviteMemberTeams =
+    organization.allowMemberInvite && !organization.openMembership;
+  // If Member Invites are enabled but Open Membership is disabled, only allow members to invite to teams they are a member of
+  const memberTeamsOnly = isMemberInvite && membersCanOnlyInviteMemberTeams;
+
   // TODO(ts) This type could be improved when react-select types are better.
   const selectRef = useRef<any>(null);
 
@@ -303,7 +311,13 @@ function TeamSelector(props: Props) {
   );
 
   function getOptions() {
-    const filteredTeams = teamFilter ? teams.filter(teamFilter) : teams;
+    const memberSettingsFilteredTeams = memberTeamsOnly
+      ? teams.filter((team: Team) => team.isMember)
+      : teams;
+    const filteredTeams = teamFilter
+      ? memberSettingsFilteredTeams.filter(teamFilter)
+      : memberSettingsFilteredTeams;
+
     const createOption = {
       value: CREATE_TEAM_VALUE,
       label: t('Create team'),
@@ -346,6 +360,7 @@ function TeamSelector(props: Props) {
     allowCreate,
     createTeamOption,
     includeUnassigned,
+    memberTeamsOnly,
     createTeamOutsideProjectOption,
   ]);
 

--- a/static/app/components/teamSelector.tsx
+++ b/static/app/components/teamSelector.tsx
@@ -114,6 +114,10 @@ type Props = {
   allowCreate?: boolean;
   includeUnassigned?: boolean;
   /**
+   * Flag that indicates whether the dropdown is being displayed on the invite member modal
+   */
+  isInviting?: boolean;
+  /**
    * Can be used to restrict teams to a certain project and allow for new teams to be add to that project
    */
   project?: Project;
@@ -146,6 +150,7 @@ function TeamSelector(props: Props) {
   const {
     allowCreate,
     includeUnassigned,
+    isInviting = false,
     styles: stylesProp,
     onChange,
     useTeamDefaultIfOnlyOne = false,
@@ -162,7 +167,7 @@ function TeamSelector(props: Props) {
   const membersCanOnlyInviteMemberTeams =
     organization.allowMemberInvite && !organization.openMembership;
   // If Member Invites are enabled but Open Membership is disabled, only allow members to invite to teams they are a member of
-  const memberTeamsOnly = isMemberInvite && membersCanOnlyInviteMemberTeams;
+  const memberTeamsOnly = isInviting && isMemberInvite && membersCanOnlyInviteMemberTeams;
 
   // TODO(ts) This type could be improved when react-select types are better.
   const selectRef = useRef<any>(null);


### PR DESCRIPTION
Frontend fix for https://github.com/getsentry/sentry/pull/83250

If Let Members Invite Others is turned ON but Open Team Membership is turned OFF, members are only able to send invites to teams that they are members of. Thus we should filter the team list to only show teams the member is in.

Recap of the expected behavior:

- If "Let Members Invite Others" is turned OFF (`allowMemberInvite` = false), members can never send invites
- If "Let Members Invite Others" is turned ON (`allowMemberInvite` = true), then there are 2 cases:
  - If "Open Team Membership" is turned ON (`openMembership` = true), then members can invite members to any team in the org
  - If "Open Team Membership is turned OFF (`openMembership` = false) then members can only invite members to teams that they are in (NEW BEHAVIOR)