### PR TITLE
ref(alerts): Improve spacing between spot image and bullets

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -238,6 +238,7 @@ const WizardOptions = styled('div')`
 
 const WizardImage = styled('img')`
   max-height: 300px;
+  margin-bottom: ${space(2)};
 `;
 
 const WizardPanel = styled(Panel)<{visible?: boolean}>`


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="719" src="https://i.imgur.com/9klfDrw.png" />

After

<img alt="clipboard.png" width="734" src="https://i.imgur.com/Tg5wWja.png" />