### PR TITLE
fix(tasks) Set minute on tasks that were using jitter_minutes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1039,7 +1039,7 @@ CELERYBEAT_SCHEDULE_CONTROL = {
     "schedule-vsts-integration-subscription-check": {
         "task": "sentry.integrations.vsts.tasks.kickoff_vsts_subscription_check",
         # Run every 6 hours
-        "schedule": crontab(hour="*/6"),
+        "schedule": crontab(hour="*/6", minute="0"),
         "options": {"expires": 60 * 25, "queue": "integrations.control"},
     },
     "deliver-webhooks-control": {
@@ -1115,7 +1115,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     "collect-project-platforms": {
         "task": "sentry.tasks.collect_project_platforms",
         # 19:00 PDT, 22:00 EDT, 3:00 UTC
-        "schedule": crontab(hour="3"),
+        "schedule": crontab(hour="3", minute="0"),
         "options": {"expires": 3600 * 24},
     },
     "deliver-from-outbox": {


### PR DESCRIPTION
When removing the minute_jitter helper I neglected to set a minute on these schedules which has resulted in more tasks being spawned than we need.

Refs #83214
