### PR TITLE
fix(crons): Minimal rollup resolution should be 1s

### DIFF
--- a/static/app/views/monitors/utils/useMonitorStats.tsx
+++ b/static/app/views/monitors/utils/useMonitorStats.tsx
@@ -22,7 +22,8 @@ interface Options {
 export function useMonitorStats({monitors, timeWindowConfig}: Options) {
   const {start, end, elapsedMinutes, timelineWidth} = timeWindowConfig;
 
-  const rollup = Math.floor((elapsedMinutes * 60) / timelineWidth);
+  // Minimum rollup is 1 second
+  const rollup = Math.floor((elapsedMinutes * 60) / timelineWidth) || 1;
 
   const selectionQuery = {
     since: Math.floor(start.getTime() / 1000),


### PR DESCRIPTION
Before this change there could be a `0s` resolution, which would default
to a rollup of 10s on the backend. So when you would zoom into a
check-in timeline you might have buckets down to 10s, causing a loss in
precision.