### PR TITLE
ref(profiling): Merge profile provider for both modes

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -80,7 +80,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
         <ProfilesProvider
           orgSlug={organization.slug}
           projectSlug={projectSlug}
-          profileId={profileId || ''}
+          profileMeta={profileId || ''}
         >
           <ProfileContext.Consumer>
             {profiles => (

--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -66,11 +66,11 @@ import {
 import {formatTo} from 'sentry/utils/profiling/units/units';
 import {useDevicePixelRatio} from 'sentry/utils/useDevicePixelRatio';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
-import {
-  useContinuousProfile,
-  useContinuousProfileSegment,
-} from 'sentry/views/profiling/continuousProfileProvider';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
+import {
+  useProfiles,
+  useProfileTransaction,
+} from 'sentry/views/profiling/profilesProvider';
 
 import {FlamegraphDrawer} from './flamegraphDrawer/flamegraphDrawer';
 import {FlamegraphWarnings} from './flamegraphOverlays/FlamegraphWarnings';
@@ -246,9 +246,9 @@ export function ContinuousFlamegraph(): ReactElement {
   const devicePixelRatio = useDevicePixelRatio();
   const dispatch = useDispatchFlamegraphState();
 
-  const profiles = useContinuousProfile();
+  const profiles = useProfiles();
   const profileGroup = useProfileGroup();
-  const segment = useContinuousProfileSegment();
+  const segment = useProfileTransaction();
 
   const configSpaceQueryParam = useMemo(() => decodeConfigSpace(), []);
 

--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -6,7 +6,7 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {useParams} from 'sentry/utils/useParams';
 import ProfileFlamegraph from 'sentry/views/profiling/profileFlamechart';
-import ProfilesAndTransactionProvider from 'sentry/views/profiling/profilesProvider';
+import ProfilesAndTransactionProvider from 'sentry/views/profiling/transactionProfileProvider';
 
 jest.mock('sentry/utils/useParams', () => ({
   useParams: jest.fn(),

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -68,7 +68,6 @@ import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 import {
   useProfiles,
   useProfileTransaction,
-  useSetProfiles,
 } from 'sentry/views/profiling/profilesProvider';
 
 import {FlamegraphDrawer} from './flamegraphDrawer/flamegraphDrawer';
@@ -219,7 +218,6 @@ function Flamegraph(): ReactElement {
   const dispatch = useDispatchFlamegraphState();
 
   const profiles = useProfiles();
-  const setProfiles = useSetProfiles();
   const profileGroup = useProfileGroup();
 
   const flamegraphTheme = useFlamegraphTheme();
@@ -1314,12 +1312,7 @@ function Flamegraph(): ReactElement {
     [dispatch]
   );
 
-  const onImport = useCallback(
-    (p: Profiling.ProfileInput) => {
-      setProfiles({type: 'resolved', data: p});
-    },
-    [setProfiles]
-  );
+  const onImport = useCallback(() => {}, []);
 
   useEffect(() => {
     if (defined(flamegraphProfiles.threadId)) {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2183,7 +2183,9 @@ function buildRoutes() {
       </Route>
       <Route
         path="profile/:projectId/:eventId/"
-        component={make(() => import('sentry/views/profiling/profilesProvider'))}
+        component={make(
+          () => import('sentry/views/profiling/transactionProfileProvider')
+        )}
       >
         <Route
           path="flamegraph/"

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -219,7 +219,7 @@ function EventDetailsContent(props: Props) {
                           <ProfilesProvider
                             orgSlug={organization.slug}
                             projectSlug={projectId}
-                            profileId={profileId || ''}
+                            profileMeta={profileId || ''}
                           >
                             <ProfileContext.Consumer>
                               {profiles => (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
@@ -73,7 +73,7 @@ export function MissingInstrumentationNodeDetails(
           <ProfilesProvider
             orgSlug={organization.slug}
             projectSlug={event?.projectSlug ?? ''}
-            profileId={profileId || ''}
+            profileMeta={profileId || ''}
           >
             <ProfileContext.Consumer>
               {profiles => (
@@ -191,7 +191,7 @@ function LegacyMissingInstrumentationNodeDetails({
           <ProfilesProvider
             orgSlug={organization.slug}
             projectSlug={node.event?.projectSlug ?? ''}
-            profileId={profileId || ''}
+            profileMeta={profileId || ''}
           >
             <ProfileContext.Consumer>
               {profiles => (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -253,7 +253,7 @@ export function SpanNodeDetails({
           <ProfilesProvider
             orgSlug={organization.slug}
             projectSlug={node.event?.projectSlug}
-            profileId={profileId || ''}
+            profileMeta={profileId || ''}
           >
             <ProfileContext.Consumer>
               {profiles => (

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -483,7 +483,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
             <ProfilesProvider
               orgSlug={organization.slug}
               projectSlug={embeddedChildren.projectSlug ?? ''}
-              profileId={profileId || ''}
+              profileMeta={profileId || ''}
             >
               <ProfileContext.Consumer>
                 {profiles => (

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -488,7 +488,7 @@ function SpanDetailsBody({
         <ProfilesProvider
           orgSlug={organization.slug}
           projectSlug={detail.event.projectSlug}
-          profileId={profileId || ''}
+          profileMeta={profileId || ''}
         >
           <ProfileContext.Consumer>
             {profiles => (

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -229,7 +229,7 @@ function EventDetailsContent(props: Props) {
                               <ProfilesProvider
                                 orgSlug={organization.slug}
                                 projectSlug={projectId}
-                                profileId={profileId || ''}
+                                profileMeta={profileId || ''}
                               >
                                 <ProfileContext.Consumer>
                                   {profiles => (

--- a/static/app/views/profiling/continuousProfileFlamegraph.tsx
+++ b/static/app/views/profiling/continuousProfileFlamegraph.tsx
@@ -25,11 +25,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 
-import {useContinuousProfile} from './continuousProfileProvider';
+import {useProfiles} from './profilesProvider';
 
 function ContinuousProfileFlamegraph(): React.ReactElement {
   const organization = useOrganization();
-  const profiles = useContinuousProfile();
+  const profiles = useProfiles();
   const params = useParams();
 
   const [storedPreferences] = useLocalStorageState<DeepPartial<FlamegraphState>>(

--- a/static/app/views/profiling/profilesProvider.tsx
+++ b/static/app/views/profiling/profilesProvider.tsx
@@ -2,17 +2,13 @@ import {createContext, useContext, useLayoutEffect, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import type {Client} from 'sentry/api';
-import {ProfileHeader} from 'sentry/components/profiling/profileHeader';
 import {t} from 'sentry/locale';
 import type {RequestState} from 'sentry/types/core';
 import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {isSchema, isSentrySampledProfile} from 'sentry/utils/profiling/guards/profile';
-import {useSentryEvent} from 'sentry/utils/profiling/hooks/useSentryEvent';
 import useApi from 'sentry/utils/useApi';
-import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
 
 function fetchFlamegraphs(
   api: Client,
@@ -31,39 +27,31 @@ function fetchFlamegraphs(
     .then(([data]) => data);
 }
 
-function getTransactionId(input: Profiling.ProfileInput): string | null {
-  if (isSchema(input)) {
-    return input.metadata.transactionID;
-  }
-  if (isSentrySampledProfile(input)) {
-    return input.transaction.id;
-  }
-  return null;
-}
-
-interface FlamegraphViewProps {
-  children: React.ReactNode;
+function fetchContinuousProfileFlamegraph(
+  api: Client,
+  query: ContinuousProfileQueryParams,
+  projectSlug: Project['slug'],
+  orgSlug: Organization['slug']
+): Promise<Profiling.ProfileInput> {
+  return api
+    .requestPromise(`/organizations/${orgSlug}/profiling/chunks/`, {
+      method: 'GET',
+      query: {
+        ...query,
+        project: projectSlug,
+      },
+      includeAllArgs: true,
+    })
+    .then(([data]) => data.chunk);
 }
 
 type ProfileProviderValue = RequestState<Profiling.ProfileInput>;
-type SetProfileProviderValue = React.Dispatch<
-  React.SetStateAction<RequestState<Profiling.ProfileInput>>
->;
 export const ProfileContext = createContext<ProfileProviderValue | null>(null);
-const SetProfileProvider = createContext<SetProfileProviderValue | null>(null);
 
 export function useProfiles() {
   const context = useContext(ProfileContext);
   if (!context) {
     throw new Error('useProfiles was called outside of ProfileProvider');
-  }
-  return context;
-}
-
-export function useSetProfiles() {
-  const context = useContext(SetProfileProvider);
-  if (!context) {
-    throw new Error('useSetProfiles was called outside of SetProfileProvider');
   }
   return context;
 }
@@ -81,77 +69,79 @@ export function useProfileTransaction() {
   return context;
 }
 
-function ProfilesAndTransactionProvider(props: FlamegraphViewProps): React.ReactElement {
-  const organization = useOrganization();
-  const params = useParams();
-
-  const projectSlug = params.projectId!;
-
-  const [profiles, setProfiles] = useState<RequestState<Profiling.ProfileInput>>({
-    type: 'initial',
-  });
-
-  const profileTransaction = useSentryEvent<EventTransaction>(
-    organization.slug,
-    projectSlug!,
-    profiles.type === 'resolved' ? getTransactionId(profiles.data) : null
-  );
-
-  return (
-    <ProfilesProvider
-      onUpdateProfiles={setProfiles}
-      orgSlug={organization.slug}
-      profileId={params.eventId!}
-      projectSlug={projectSlug}
-    >
-      <SetProfileProvider.Provider value={setProfiles}>
-        <ProfileTransactionContext.Provider value={profileTransaction}>
-          <ProfileHeader
-            eventId={params.eventId!}
-            projectId={projectSlug}
-            transaction={
-              profileTransaction.type === 'resolved' ? profileTransaction.data : null
-            }
-          />
-          {props.children}
-        </ProfileTransactionContext.Provider>
-      </SetProfileProvider.Provider>
-    </ProfilesProvider>
-  );
-}
-
 interface ProfilesProviderProps {
   children: React.ReactNode;
   orgSlug: Organization['slug'];
-  profileId: string;
+  profileMeta: string | ContinuousProfileQueryParams;
   projectSlug: Project['slug'];
-  onUpdateProfiles?: (profiles: RequestState<Profiling.ProfileInput>) => void;
 }
 
 export function ProfilesProvider({
   children,
-  onUpdateProfiles,
   orgSlug,
+  profileMeta,
   projectSlug,
-  profileId,
 }: ProfilesProviderProps) {
-  const api = useApi();
-
-  const [profiles, setProfiles] = useState<RequestState<Profiling.ProfileInput>>({
+  const [profile, setProfile] = useState<RequestState<Profiling.ProfileInput>>({
     type: 'initial',
   });
+
+  if (isContinuousProfileQueryParams(profileMeta)) {
+    return (
+      <ContinuousProfileProvider
+        orgSlug={orgSlug}
+        projectSlug={projectSlug}
+        profileMeta={profileMeta}
+        profile={profile}
+        setProfile={setProfile}
+      >
+        {children}
+      </ContinuousProfileProvider>
+    );
+  }
+
+  return (
+    <TransactionProfileProvider
+      orgSlug={orgSlug}
+      projectSlug={projectSlug}
+      profileId={profileMeta}
+      profile={profile}
+      setProfile={setProfile}
+    >
+      {children}
+    </TransactionProfileProvider>
+  );
+}
+
+interface TransactionProfileProviderProps {
+  children: React.ReactNode;
+  orgSlug: Organization['slug'];
+  profile: RequestState<Profiling.ProfileInput>;
+  profileId: string;
+  projectSlug: Project['slug'];
+  setProfile: (profiles: RequestState<Profiling.ProfileInput>) => void;
+}
+
+export function TransactionProfileProvider({
+  children,
+  orgSlug,
+  profile,
+  projectSlug,
+  profileId,
+  setProfile,
+}: TransactionProfileProviderProps) {
+  const api = useApi();
 
   useLayoutEffect(() => {
     if (!profileId || !projectSlug || !orgSlug) {
       return undefined;
     }
 
-    setProfiles({type: 'loading'});
+    setProfile({type: 'loading'});
 
     fetchFlamegraphs(api, profileId, projectSlug, orgSlug)
       .then(p => {
-        setProfiles({type: 'resolved', data: p});
-        onUpdateProfiles?.({type: 'resolved', data: p});
+        setProfile({type: 'resolved', data: p});
       })
       .catch(err => {
         // XXX: our API client mock implementation does not mimick the real
@@ -161,17 +151,80 @@ export function ProfilesProvider({
           ? t('Error: Unable to load profiles')
           : err.toString();
 
-        setProfiles({type: 'errored', error: message});
-        onUpdateProfiles?.({type: 'errored', error: message});
+        setProfile({type: 'errored', error: message});
         Sentry.captureException(err);
       });
 
     return () => {
       api.clear();
     };
-  }, [api, onUpdateProfiles, orgSlug, projectSlug, profileId]);
+  }, [api, orgSlug, projectSlug, profileId, setProfile]);
 
-  return <ProfileContext.Provider value={profiles}>{children}</ProfileContext.Provider>;
+  return <ProfileContext.Provider value={profile}>{children}</ProfileContext.Provider>;
 }
 
-export default ProfilesAndTransactionProvider;
+export interface ContinuousProfileQueryParams {
+  end: string;
+  profiler_id: string;
+  start: string;
+}
+
+function isContinuousProfileQueryParams(val: any): val is ContinuousProfileQueryParams {
+  return (
+    typeof val === 'object' &&
+    typeof val.start === 'string' &&
+    typeof val.end === 'string' &&
+    typeof val.profiler_id === 'string'
+  );
+}
+
+interface ContinuousProfileProviderProps {
+  children: React.ReactNode;
+  orgSlug: Organization['slug'];
+  profile: RequestState<Profiling.ProfileInput>;
+  profileMeta: ContinuousProfileQueryParams | null;
+  projectSlug: Project['slug'];
+  setProfile: (profile: RequestState<Profiling.ProfileInput>) => void;
+}
+
+export function ContinuousProfileProvider({
+  children,
+  orgSlug,
+  profile,
+  profileMeta,
+  projectSlug,
+  setProfile,
+}: ContinuousProfileProviderProps) {
+  const api = useApi();
+  const {projects} = useProjects();
+
+  useLayoutEffect(() => {
+    if (!profileMeta) {
+      Sentry.captureMessage(
+        'Failed to fetch continuous profile - invalid chunk parameters.'
+      );
+      return undefined;
+    }
+
+    const project = projects.find(p => p.slug === projectSlug);
+    if (!project) {
+      Sentry.captureMessage('Failed to fetch continuous profile - project not found.');
+      return undefined;
+    }
+
+    setProfile({type: 'loading'});
+
+    fetchContinuousProfileFlamegraph(api, profileMeta, project.id, orgSlug)
+      .then(p => {
+        setProfile({type: 'resolved', data: p});
+      })
+      .catch(err => {
+        setProfile({type: 'errored', error: 'Failed to fetch profiles'});
+        Sentry.captureException(err);
+      });
+
+    return () => api.clear();
+  }, [api, profileMeta, orgSlug, projectSlug, projects, setProfile]);
+
+  return <ProfileContext.Provider value={profile}>{children}</ProfileContext.Provider>;
+}


### PR DESCRIPTION
This merges the 2 providers for transaction and continuous type profiles into 1 so that we can pass either type of profile to it anywhere instead of having 2 different providers.