### PR TITLE
fix(alerts): Fix repeat span samples count query

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -254,18 +254,18 @@ class TriggersChart extends PureComponent<Props, State> {
       this.props;
     const {statsPeriod} = this.state;
     if (
-      showTotalCount &&
-      !isSessionAggregate(aggregate) &&
-      (!isEqual(prevProps.projects, projects) ||
-        prevProps.environment !== environment ||
-        prevProps.query !== query ||
-        !isEqual(prevProps.timeWindow, timeWindow) ||
-        !isEqual(prevState.statsPeriod, statsPeriod))
+      !isEqual(prevProps.projects, projects) ||
+      prevProps.environment !== environment ||
+      prevProps.query !== query ||
+      !isEqual(prevProps.timeWindow, timeWindow) ||
+      !isEqual(prevState.statsPeriod, statsPeriod)
     ) {
-      this.fetchTotalCount();
-    }
-    if (this.props.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
-      this.fetchExtrapolationSampleCount();
+      if (showTotalCount && !isSessionAggregate(aggregate)) {
+        this.fetchTotalCount();
+      }
+      if (this.props.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
+        this.fetchExtrapolationSampleCount();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes issue with span samples count query being fired redundantly due to not properly checking for change in query.