### PR TITLE
fix(feedback): Prevent empty api endpoint request

### DIFF
--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -15,7 +15,7 @@ export default function useFeedbackHasNewItems({listPrefetchQueryKey}: Props) {
   const {data} = useApiQuery<unknown[]>(listPrefetchQueryKey ?? [''], {
     refetchInterval: POLLING_INTERVAL_MS,
     staleTime: 0,
-    enabled: listPrefetchQueryKey && !foundData,
+    enabled: Boolean(listPrefetchQueryKey?.[0]) && !foundData,
   });
 
   useEffect(() => {

--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -20,7 +20,7 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
     issueQueryKey ?? [''],
     {
       staleTime: 0,
-      enabled: Boolean(issueQueryKey),
+      enabled: Boolean(issueQueryKey?.[0]),
     }
   );
 
@@ -28,7 +28,7 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
     eventQueryKey ?? [''],
     {
       staleTime: 0,
-      enabled: Boolean(eventQueryKey),
+      enabled: Boolean(eventQueryKey?.[0]),
     }
   );
 


### PR DESCRIPTION
`Boolean([''])` is true. Prevents subscribing to `/api/0`