### PR TITLE
fix(ui): Remove spread of key prop

### DIFF
--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -180,7 +180,7 @@ function Region<Value extends SelectKey>({
       label={label}
     >
       {(opt: SelectOption<Value>) => (
-        <Item key={opt.value} {...opt}>
+        <Item {...opt} key={opt.value}>
           {opt.label}
         </Item>
       )}

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -148,7 +148,11 @@ function CompactSelect<Value extends SelectKey>({
             );
           }
 
-          return <Item {...item}>{item.label}</Item>;
+          return (
+            <Item {...item} key={item.key}>
+              {item.label}
+            </Item>
+          );
         }}
       </List>
 

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -439,7 +439,7 @@ export function DraggableTabList({items, onAddView, ...props}: DraggableTabListP
       disabledKeys={disabledKeys}
       {...props}
     >
-      {item => <Item {...item} />}
+      {item => <Item {...item} key={item.key} />}
     </BaseDraggableTabList>
   );
 }

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -246,7 +246,7 @@ function DropdownMenu({
             );
           }
           return (
-            <Item size={size} {...item}>
+            <Item size={size} {...item} key={item.key}>
               {item.label}
             </Item>
           );

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -281,7 +281,7 @@ export function TabList({items, variant, ...props}: TabListProps) {
       variant={variant}
       {...props}
     >
-      {item => <Item {...item} />}
+      {item => <Item {...item} key={item.key} />}
     </BaseTabList>
   );
 }


### PR DESCRIPTION
part of https://github.com/getsentry/frontend-tsc/issues/68

in 19 we'll have to enforce that keys are not spread. Right now it's falling back to using `createElement()` instead of `jsx()`. More information here https://github.com/facebook/react/issues/20031#issuecomment-710346866
