### PR TITLE
feat(metric-issues): Hide log level indicator for non-error issues

### DIFF
--- a/static/app/utils/issueTypeConfig/errorConfig.tsx
+++ b/static/app/utils/issueTypeConfig/errorConfig.tsx
@@ -23,6 +23,7 @@ export const errorConfig: IssueCategoryConfigMapping = {
     },
     attachments: {enabled: true},
     autofix: true,
+    logLevel: {enabled: true},
     mergedIssues: {enabled: true},
     replays: {enabled: true},
     similarIssues: {enabled: true},

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -44,6 +44,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   autofix: false,
   eventAndUserCounts: {enabled: true},
   events: {enabled: true},
+  logLevel: {enabled: false},
   mergedIssues: {enabled: false},
   filterAndSearchHeader: {enabled: true},
   performanceDurationRegression: {enabled: false},

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -65,6 +65,10 @@ export type IssueTypeConfig = {
    */
   issueSummary: DisabledWithReasonConfig;
   /**
+   * Is the Log Level icon shown for this issue
+   */
+  logLevel: DisabledWithReasonConfig;
+  /**
    * Is the Merged Issues tab shown for this issue
    */
   mergedIssues: DisabledWithReasonConfig;

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -195,11 +195,15 @@ export default function StreamlinedGroupHeader({
               ))}
           </StatTitle>
           <Flex gap={space(1)} align="center" justify="flex-start">
-            <ErrorLevel level={group.level} size={'10px'} />
-            {group.isUnhandled && <UnhandledTag />}
+            <Fragment>
+              {issueTypeConfig.logLevel.enabled && (
+                <ErrorLevel level={group.level} size={'10px'} />
+              )}
+              {group.isUnhandled && <UnhandledTag />}
+              {(issueTypeConfig.logLevel.enabled || group.isUnhandled) && <Divider />}
+            </Fragment>
             {statusProps?.status ? (
               <Fragment>
-                <Divider />
                 <Tooltip title={statusProps?.tooltip}>
                   <Subtext>{statusProps?.status}</Subtext>
                 </Tooltip>

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -72,6 +72,7 @@ describe('SolutionsSection', () => {
       events: {enabled: false},
       evidence: null,
       filterAndSearchHeader: {enabled: false},
+      logLevel: {enabled: true},
       mergedIssues: {enabled: false},
       performanceDurationRegression: {enabled: false},
       profilingDurationRegression: {enabled: false},


### PR DESCRIPTION

<img width="444" alt="image" src="https://github.com/user-attachments/assets/8a8e66fe-8efc-4110-ab1b-a6b733260986" />

<img width="444" alt="image" src="https://github.com/user-attachments/assets/e43f9279-0e6c-45ef-81dc-9d2ec74843e5" />