### PR TITLE
ref(sentry apps): Use new error design for sentry app errors

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -128,9 +128,10 @@ class IntegrationPlatformEndpoint(Endpoint):
 
     def _handle_sentry_app_exception(self, exception: Exception):
         if isinstance(exception, SentryAppIntegratorError) or isinstance(exception, SentryAppError):
-            response_body = {"detail": exception.message}
+            response_body: dict[str, Any] = {"detail": exception.message}
             context = exception.extras.get("public_context", None)
-            response_body.update({"context": context}) if context else ""
+            if context is not None:
+                response_body.update({"context": context})
 
             response = Response(response_body, status=exception.status_code)
             response.exception = True

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -129,8 +129,8 @@ class IntegrationPlatformEndpoint(Endpoint):
     def _handle_sentry_app_exception(self, exception: Exception):
         if isinstance(exception, SentryAppIntegratorError) or isinstance(exception, SentryAppError):
             response_body: dict[str, Any] = {"detail": exception.message}
-            public_context = exception.public_context
-            if public_context:
+
+            if public_context := exception.public_context:
                 response_body.update({"context": public_context})
 
             response = Response(response_body, status=exception.status_code)

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -6,18 +6,16 @@ from functools import wraps
 from typing import Any
 
 import sentry_sdk
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser, superuser_has_permission
-from sentry.coreapi import APIError, APIUnauthorized
+from sentry.coreapi import APIError
 from sentry.integrations.api.bases.integration import PARANOID_GET
 from sentry.middleware.stats import add_request_metric_tags
 from sentry.models.organization import OrganizationStatus
@@ -103,10 +101,9 @@ class SentryAppsPermission(SentryPermission):
 
         # User must be a part of the Org they're trying to create the app in.
         if context.organization.status != OrganizationStatus.ACTIVE or not context.member:
-            raise SentryAppIntegratorError(
-                APIUnauthorized(
-                    "User must be a part of the Org they're trying to create the app in"
-                )
+            raise SentryAppError(
+                message="User must be a part of the Org they're trying to create the app in",
+                status_code=403,
             )
 
         assert request.method, "method must be present in request to get permissions"
@@ -131,7 +128,13 @@ class IntegrationPlatformEndpoint(Endpoint):
 
     def _handle_sentry_app_exception(self, exception: Exception):
         if isinstance(exception, SentryAppIntegratorError) or isinstance(exception, SentryAppError):
-            response = Response({"detail": str(exception)}, status=exception.status_code)
+            response = Response(
+                {
+                    "detail": exception.message,
+                    "context": exception.extras.get("public_context", {}),
+                },
+                status=exception.status_code,
+            )
             response.exception = True
             return response
 
@@ -154,7 +157,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
         organization_slug = request.data.get("organization")
         if not organization_slug or not isinstance(organization_slug, str):
             error_message = "Please provide a valid value for the 'organization' field."
-            raise SentryAppError(ResourceDoesNotExist(error_message))
+            raise SentryAppError(message=error_message)
         return organization_slug
 
     def _get_organization_for_superuser_or_staff(
@@ -166,7 +169,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
 
         if context is None:
             error_message = f"Organization '{organization_slug}' does not exist."
-            raise SentryAppError(ResourceDoesNotExist(error_message))
+            raise SentryAppError(message=error_message)
 
         return context
 
@@ -178,7 +181,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
         )
         if context is None or context.member is None:
             error_message = f"User does not belong to the '{organization_slug}' organization."
-            raise SentryAppIntegratorError(PermissionDenied(to_single_line_str(error_message)))
+            raise SentryAppError(message=to_single_line_str(error_message))
         return context
 
     def _get_org_context(self, request: Request) -> RpcUserOrganizationContext:
@@ -260,10 +263,15 @@ class SentryAppPermission(SentryPermission):
         # if app is unpublished, user must be in the Org who owns the app.
         if not sentry_app.is_published:
             if not any(sentry_app.owner_id == org.id for org in organizations):
-                raise SentryAppIntegratorError(
-                    APIUnauthorized(
-                        "User must be in the app owner's organization for unpublished apps"
-                    )
+                raise SentryAppError(
+                    message="User must be in the app owner's organization for unpublished apps",
+                    status_code=403,
+                    extras={
+                        "public_context": {
+                            "integration": sentry_app.slug,
+                            "user_organizations": [org.slug for org in organizations],
+                        }
+                    },
                 )
 
         # TODO(meredith): make a better way to allow for public
@@ -299,9 +307,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
         try:
             sentry_app = SentryApp.objects.get(slug__id_or_slug=sentry_app_id_or_slug)
         except SentryApp.DoesNotExist:
-            raise SentryAppIntegratorError(
-                ResourceDoesNotExist("Could not find the requested sentry app"), status_code=404
-            )
+            raise SentryAppError(message="Could not find the requested sentry app", status_code=404)
 
         self.check_object_permissions(request, sentry_app)
 
@@ -320,9 +326,7 @@ class RegionSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
         else:
             sentry_app = app_service.get_sentry_app_by_slug(slug=sentry_app_id_or_slug)
         if sentry_app is None:
-            raise SentryAppIntegratorError(
-                ResourceDoesNotExist("Could not find the requested sentry app"), status_code=404
-            )
+            raise SentryAppError(message="Could not find the requested sentry app", status_code=404)
 
         self.check_object_permissions(request, sentry_app)
 
@@ -353,8 +357,12 @@ class SentryAppInstallationsPermission(SentryPermission):
             else ()
         )
         if not any(organization.id == org.id for org in organizations):
-            raise SentryAppIntegratorError(
-                APIUnauthorized("User must belong to the given organization"), status_code=403
+            raise SentryAppError(
+                message="User must belong to the given organization",
+                status_code=403,
+                extras={
+                    "public_context": {"user_organizations": [org.slug for org in organizations]}
+                },
             )
         assert request.method, "method must be present in request to get permissions"
         return ensure_scoped_permission(request, self.scope_map.get(request.method))
@@ -379,9 +387,7 @@ class SentryAppInstallationsBaseEndpoint(IntegrationPlatformEndpoint):
             )
 
         if organization is None:
-            raise SentryAppIntegratorError(
-                ResourceDoesNotExist("Could not find requested organization"), status_code=404
-            )
+            raise SentryAppError(message="Could not find requested organization", status_code=404)
         self.check_object_permissions(request, organization)
 
         kwargs["organization"] = organization
@@ -437,9 +443,7 @@ class SentryAppInstallationPermission(SentryPermission):
             or not org_context.member
             or org_context.organization.status != OrganizationStatus.ACTIVE
         ):
-            raise SentryAppIntegratorError(
-                ResourceDoesNotExist("Given organization is not valid"), status_code=404
-            )
+            raise SentryAppError(message="Given organization is not valid", status_code=404)
 
         assert request.method, "method must be present in request to get permissions"
         return ensure_scoped_permission(request, self.scope_map.get(request.method))
@@ -452,8 +456,8 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
         installations = app_service.get_many(filter=dict(uuids=[uuid]))
         installation = installations[0] if installations else None
         if installation is None:
-            raise SentryAppIntegratorError(
-                ResourceDoesNotExist("Could not find given sentry app installation"),
+            raise SentryAppError(
+                message="Could not find given sentry app installation",
                 status_code=404,
             )
 

--- a/src/sentry/sentry_apps/external_issues/external_issue_creator.py
+++ b/src/sentry/sentry_apps/external_issues/external_issue_creator.py
@@ -48,5 +48,5 @@ class ExternalIssueCreator:
             )
             raise SentryAppSentryError(
                 message="Failed to create external issue obj",
-                extras={"webhook_context": {"error": str(e)}},
+                webhook_context={"error": str(e)},
             ) from e

--- a/src/sentry/sentry_apps/external_issues/external_issue_creator.py
+++ b/src/sentry/sentry_apps/external_issues/external_issue_creator.py
@@ -46,4 +46,7 @@ class ExternalIssueCreator:
                     "sentry_app_slug": self.install.sentry_app.slug,
                 },
             )
-            raise SentryAppSentryError(e) from e
+            raise SentryAppSentryError(
+                message="Failed to create external issue obj",
+                extras={"webhook_context": {"error": str(e)}},
+            ) from e

--- a/src/sentry/sentry_apps/external_issues/issue_link_creator.py
+++ b/src/sentry/sentry_apps/external_issues/issue_link_creator.py
@@ -32,7 +32,7 @@ class IssueLinkCreator:
 
     def _verify_action(self) -> None:
         if self.action not in VALID_ACTIONS:
-            raise SentryAppSentryError(message=f"Invalid action: {self.action}")
+            raise SentryAppSentryError(message=f"Invalid action: {self.action}", status_code=401)
 
     def _make_external_request(self) -> dict[str, Any]:
         response = IssueLinkRequester(

--- a/src/sentry/sentry_apps/external_issues/issue_link_creator.py
+++ b/src/sentry/sentry_apps/external_issues/issue_link_creator.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from django.db import router, transaction
 
-from sentry.coreapi import APIUnauthorized
 from sentry.models.group import Group
 from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_requests.issue_link_requester import IssueLinkRequester
@@ -33,7 +32,7 @@ class IssueLinkCreator:
 
     def _verify_action(self) -> None:
         if self.action not in VALID_ACTIONS:
-            raise SentryAppSentryError(APIUnauthorized(f"Invalid action '{self.action}'"))
+            raise SentryAppSentryError(message=f"Invalid action: {self.action}")
 
     def _make_external_request(self) -> dict[str, Any]:
         response = IssueLinkRequester(

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,18 +1,11 @@
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any
 
 
 class SentryAppErrorType(Enum):
     CLIENT = "client"
     INTEGRATOR = "integrator"
     SENTRY = "sentry"
-
-
-class ErrorContext(TypedDict, total=False):
-    # Info that gets sent only to the integrator via webhook
-    webhook_context: dict[str, Any]
-    # Info that gets sent to the end user via endpoint Response AND sent to integrator
-    public_context: dict[str, Any]
 
 
 class SentryAppBaseError(Exception):
@@ -23,10 +16,14 @@ class SentryAppBaseError(Exception):
         self,
         message: str,
         status_code: int | None = None,
-        extras: ErrorContext | None = None,
+        public_context: dict[str, Any] | None = None,
+        webhook_context: dict[str, Any] | None = None,
     ) -> None:
         self.status_code = status_code or self.status_code
-        self.extras = extras or {}
+        # Info that gets sent only to the integrator via webhook
+        self.public_context = public_context or {}
+        # Info that gets sent to the end user via endpoint Response AND sent to integrator
+        self.webhook_context = webhook_context or {}
         self.message = message
 
 

--- a/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
+++ b/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
@@ -14,7 +14,7 @@ from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppPermission,
     add_integration_platform_metric_tag,
 )
-from sentry.sentry_apps.utils.errors import SentryAppIntegratorError
+from sentry.sentry_apps.utils.errors import SentryAppError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
@@ -43,7 +43,7 @@ class SentryAppPermissionTest(TestCase):
             request=self.make_request(user=non_owner, method="GET"), endpoint=self.endpoint
         )
 
-        with pytest.raises(SentryAppIntegratorError):
+        with pytest.raises(SentryAppError):
             self.permission.has_object_permission(self.request, None, self.sentry_app)
 
     def test_has_permission(self):
@@ -83,7 +83,7 @@ class SentryAppPermissionTest(TestCase):
 
         request._request.method = "POST"
 
-        with pytest.raises(SentryAppIntegratorError):
+        with pytest.raises(SentryAppError):
             self.permission.has_object_permission(request, None, self.sentry_app)
 
     @override_options({"superuser.read-write.ga-rollout": True})
@@ -143,7 +143,7 @@ class SentryAppBaseEndpointTest(TestCase):
         assert kwargs["sentry_app"].id == self.sentry_app.id
 
     def test_raises_when_sentry_app_not_found(self):
-        with pytest.raises(SentryAppIntegratorError):
+        with pytest.raises(SentryAppError):
             self.endpoint.convert_args(self.request, "notanapp")
 
 
@@ -181,7 +181,7 @@ class SentryAppInstallationPermissionTest(TestCase):
             self.make_request(user=user, method="GET"), endpoint=self.endpoint
         )
 
-        with pytest.raises(SentryAppIntegratorError):
+        with pytest.raises(SentryAppError):
             self.permission.has_object_permission(request, None, self.installation)
 
     def test_superuser_has_permission(self):
@@ -206,7 +206,7 @@ class SentryAppInstallationPermissionTest(TestCase):
         assert self.permission.has_object_permission(request, None, self.installation)
 
         request._request.method = "POST"
-        with pytest.raises(SentryAppIntegratorError):
+        with pytest.raises(SentryAppError):
             self.permission.has_object_permission(request, None, self.installation)
 
     @override_options({"superuser.read-write.ga-rollout": True})
@@ -242,7 +242,7 @@ class SentryAppInstallationBaseEndpointTest(TestCase):
         assert kwargs["installation"].id == self.installation.id
 
     def test_raises_when_sentry_app_not_found(self):
-        with pytest.raises(SentryAppIntegratorError):
+        with pytest.raises(SentryAppError):
             self.endpoint.convert_args(self.request, "1234")
 
 

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -402,7 +402,7 @@ class SuperuserStaffPostSentryAppsTest(SentryAppsTest):
     def test_staff_cannot_create_app(self):
         """We do not allow staff to create Sentry Apps b/c this cannot be done in _admin."""
         self.login_as(self.staff_user, staff=True)
-        response = self.get_error_response(**self.get_data(), status_code=400)
+        response = self.get_error_response(**self.get_data(), status_code=403)
         assert (
             response.data["detail"]
             == "User must be a part of the Org they're trying to create the app in"
@@ -413,7 +413,10 @@ class SuperuserStaffPostSentryAppsTest(SentryAppsTest):
 
         data = self.get_data(name=sentry_app.name, organization="some-non-existent-org")
         response = self.get_error_response(**data, status_code=400)
-        assert response.data == {"detail": "Organization 'some-non-existent-org' does not exist."}
+        assert response.data == {
+            "detail": "Organization 'some-non-existent-org' does not exist.",
+            "context": {},
+        }
 
     def test_superuser_can_create_with_popularity(self):
         response = self.get_success_response(
@@ -546,6 +549,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self.get_error_response(**data, status_code=400)
         assert response.data == {
             "detail": "Please provide a valid value for the 'organization' field.",
+            "context": {},
         }
 
     def test_cannot_create_app_in_alien_organization(self):

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -402,7 +402,7 @@ class SuperuserStaffPostSentryAppsTest(SentryAppsTest):
     def test_staff_cannot_create_app(self):
         """We do not allow staff to create Sentry Apps b/c this cannot be done in _admin."""
         self.login_as(self.staff_user, staff=True)
-        response = self.get_error_response(**self.get_data(), status_code=403)
+        response = self.get_error_response(**self.get_data(), status_code=401)
         assert (
             response.data["detail"]
             == "User must be a part of the Org they're trying to create the app in"
@@ -412,10 +412,9 @@ class SuperuserStaffPostSentryAppsTest(SentryAppsTest):
         sentry_app = self.create_internal_integration(name="Foo Bar")
 
         data = self.get_data(name=sentry_app.name, organization="some-non-existent-org")
-        response = self.get_error_response(**data, status_code=400)
+        response = self.get_error_response(**data, status_code=404)
         assert response.data == {
             "detail": "Organization 'some-non-existent-org' does not exist.",
-            "context": {},
         }
 
     def test_superuser_can_create_with_popularity(self):
@@ -546,10 +545,9 @@ class PostSentryAppsTest(SentryAppsTest):
         sentry_app = self.create_internal_integration(name="Foo Bar")
 
         data = self.get_data(name=sentry_app.name, organization=None)
-        response = self.get_error_response(**data, status_code=400)
+        response = self.get_error_response(**data, status_code=404)
         assert response.data == {
             "detail": "Please provide a valid value for the 'organization' field.",
-            "context": {},
         }
 
     def test_cannot_create_app_in_alien_organization(self):
@@ -558,7 +556,7 @@ class PostSentryAppsTest(SentryAppsTest):
         sentry_app = self.create_internal_integration(name="Foo Bar")
 
         data = self.get_data(name=sentry_app.name, organization=other_organization.slug)
-        response = self.get_error_response(**data, status_code=400)
+        response = self.get_error_response(**data, status_code=403)
         assert response.data["detail"].startswith("User does not belong to")
 
     def test_user_cannot_create_app_in_nonexistent_organization(self):
@@ -566,7 +564,7 @@ class PostSentryAppsTest(SentryAppsTest):
         sentry_app = self.create_internal_integration(name="Foo Bar")
 
         data = self.get_data(name=sentry_app.name, organization="some-non-existent-org")
-        response = self.get_error_response(**data, status_code=400)
+        response = self.get_error_response(**data, status_code=403)
         assert response.data["detail"].startswith("User does not belong to")
 
     def test_nonsuperuser_cannot_create_with_popularity(self):


### PR DESCRIPTION
See this [notion doc ](https://www.notion.so/sentry/Sentry-App-Errors-1508b10e4b5d80babd74f7f0a3eada6c)for the design changes
tl:dr No wrapping errors, sentry app errors take in extras dictionary for additional context

Also a callout: If possible please give feedback if any data is sensitive and shouldn't be sent to one party or the other