### PR TITLE
feat(forms): Migrate to `react-textarea-autosize`

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "qrcode.react": "^3.1.0",
     "query-string": "7.0.1",
     "react": "18.2.0",
-    "react-autosize-textarea": "7.1.0",
+    "react-textarea-autosize": "8.5.7",
     "react-date-range": "^1.4.0",
     "react-dom": "18.2.0",
     "react-grid-layout": "^1.3.4",

--- a/static/app/components/events/autofix/autofixInstructionsModal.tsx
+++ b/static/app/components/events/autofix/autofixInstructionsModal.tsx
@@ -1,4 +1,4 @@
-import TextareaAutosize from 'react-autosize-textarea';
+import TextareaAutosize from 'react-textarea-autosize';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';

--- a/static/app/components/forms/controls/textarea.tsx
+++ b/static/app/components/forms/controls/textarea.tsx
@@ -1,5 +1,5 @@
 import {forwardRef} from 'react';
-import TextareaAutosize from 'react-autosize-textarea';
+import TextareaAutosize, {type TextareaAutosizeProps} from 'react-textarea-autosize';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -7,7 +7,10 @@ import type {InputStylesProps} from 'sentry/components/input';
 import {inputStyles} from 'sentry/components/input';
 
 export interface TextAreaProps
-  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'css' | 'onResize'>,
+  extends Omit<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      'css' | 'onResize' | 'height' | 'style'
+    >,
     InputStylesProps {
   /**
    * Enable autosizing of the textarea.
@@ -21,6 +24,7 @@ export interface TextAreaProps
    * Number of rows to default to.
    */
   rows?: number;
+  style?: TextareaAutosizeProps['style'];
 }
 
 const TextAreaControl = forwardRef(function TextAreaControl(
@@ -28,7 +32,7 @@ const TextAreaControl = forwardRef(function TextAreaControl(
   ref: React.Ref<HTMLTextAreaElement>
 ) {
   return autosize ? (
-    <TextareaAutosize {...p} async ref={ref} rows={rows ? rows : 2} maxRows={maxRows} />
+    <TextareaAutosize {...p} ref={ref} rows={rows ? rows : 2} maxRows={maxRows} />
   ) : (
     <textarea ref={ref} {...p} />
   );
@@ -43,7 +47,7 @@ const TextArea = styled(TextAreaControl, {
   ${inputStyles};
   line-height: ${p => p.theme.text.lineHeightBody};
 
-  /** Allow react-autosize-textarea to freely control height based on props. */
+  /** Allow react-textarea-autosize to freely control height based on props. */
   ${p =>
     p.autosize &&
     `

--- a/static/app/components/forms/controls/textarea.tsx
+++ b/static/app/components/forms/controls/textarea.tsx
@@ -9,7 +9,7 @@ import {inputStyles} from 'sentry/components/input';
 export interface TextAreaProps
   extends Omit<
       React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-      'css' | 'onResize' | 'height' | 'style'
+      'css' | 'onResize' | 'style'
     >,
     InputStylesProps {
   /**

--- a/static/app/utils/search/__mocks__/searchBoxTextArea.tsx
+++ b/static/app/utils/search/__mocks__/searchBoxTextArea.tsx
@@ -1,5 +1,0 @@
-/**
- * Mock of TextareaAutosize
- */
-const SearchBoxTextArea = 'textarea';
-export default SearchBoxTextArea;

--- a/static/app/utils/search/searchBoxTextArea.tsx
+++ b/static/app/utils/search/searchBoxTextArea.tsx
@@ -1,8 +1,0 @@
-import TextareaAutosize from 'react-autosize-textarea';
-
-const SearchBoxTextArea = TextareaAutosize;
-
-/**
- * Returns TextareaAutosize in prod, but is mocked with 'textarea' for unit tests.
- */
-export default SearchBoxTextArea;

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -69,7 +69,6 @@ jest
   .spyOn(performanceForSentry, 'VisuallyCompleteWithData')
   .mockImplementation(props => props.children as ReactElement);
 jest.mock('scroll-to-element', () => jest.fn());
-jest.mock('sentry/utils/search/searchBoxTextArea');
 
 DANGEROUS_SET_TEST_HISTORY({
   goBack: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,7 +1110,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.16.3":
+"@babel/runtime@^7.16.3", "@babel/runtime@^7.20.13":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -4886,11 +4886,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-autosize@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
-  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
-
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -5478,11 +5473,6 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
-
-computed-style@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
-  integrity sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -8965,13 +8955,6 @@ lilconfig@^3.1.2:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.2.tgz#e4a7c3cb549e3a606c8dcc32e5ae1005e62c05cb"
   integrity sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==
 
-line-height@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.3.1.tgz#4b1205edde182872a5efa3c8f620b3187a9c54c9"
-  integrity sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=
-  dependencies:
-    computed-style "~0.1.3"
-
 lines-and-columns@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.4.tgz#d00318855905d2660d8c0822e3f5a4715855fc42"
@@ -10321,7 +10304,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15, prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15, prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10423,15 +10406,6 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-react-autosize-textarea@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz#902c84fc395a689ca3a484dfb6bc2be9ba3694d1"
-  integrity sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==
-  dependencies:
-    autosize "^4.0.2"
-    line-height "^0.3.1"
-    prop-types "^15.5.6"
 
 react-date-range@^1.4.0:
   version "1.4.0"
@@ -10579,6 +10553,15 @@ react-sparklines@1.7.0:
   integrity sha512-bJFt9K4c5Z0k44G8KtxIhbG+iyxrKjBZhdW6afP+R7EnIq+iKjbWbEFISrf3WKNFsda+C46XAfnX0StS5fbDcg==
   dependencies:
     prop-types "^15.5.10"
+
+react-textarea-autosize@8.5.7:
+  version "8.5.7"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.7.tgz#b2bf1913383a05ffef7fbc89c2ea21ba8133b023"
+  integrity sha512-2MqJ3p0Jh69yt9ktFIaZmORHXw4c4bxSIhCeWiFwmJ9EYKgLmuNII3e9c9b2UO+ijl4StnpZdqpxNIhTdHvqtQ==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
 
 react-transition-group@^4.3.0:
   version "4.4.2"
@@ -12041,6 +12024,23 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-composed-ref@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.4.0.tgz#09e023bf798d005286ad85cd20674bdf5770653b"
+  integrity sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz#afb292eb284c39219e8cb8d3d62d71999361a21d"
+  integrity sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==
+
+use-latest@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.3.0.tgz#549b9b0d4c1761862072f0899c6f096eb379137a"
+  integrity sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==
+  dependencies:
+    use-isomorphic-layout-effect "^1.1.1"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
by the person that does emotion https://www.npmjs.com/package/react-textarea-autosize seems to work about the same. The previous package we were using is archived and last updated 4 years ago https://github.com/buildo/react-autosize-textarea

this new version drops the prop types package and has updated peer dependencies etc
