### PR TITLE
fix(cleanup): Fix silent flag on cleanup command during deletions

### DIFF
--- a/src/sentry/deletions/defaults/apigrant.py
+++ b/src/sentry/deletions/defaults/apigrant.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import Any
 
 from django.db import router
 
@@ -18,6 +19,6 @@ class ModelApiGrantDeletionTask(ModelDeletionTask[ApiGrant]):
         # no status to track
         pass
 
-    def delete_instance(self, instance: ApiGrant) -> None:
+    def delete_instance(self, instance: ApiGrant, **kwargs: Any) -> None:
         with unguarded_write(router.db_for_write(ApiGrant)):
             super().delete_instance(instance)

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -136,7 +136,7 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
 
     dataset = Dataset.Events
 
-    def chunk(self) -> bool:
+    def chunk(self, **kwargs: Any) -> bool:
         """This method is called to delete chunks of data. It returns a boolean to say
         if the deletion has completed and if it needs to be called again."""
         events = self.get_unfetched_events()
@@ -188,7 +188,7 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
     dataset = Dataset.IssuePlatform
     max_rows_to_delete = ISSUE_PLATFORM_MAX_ROWS_TO_DELETE
 
-    def chunk(self) -> bool:
+    def chunk(self, **kwargs: Any) -> bool:
         """This method is called to delete chunks of data. It returns a boolean to say
         if the deletion has completed and if it needs to be called again."""
         events = self.get_unfetched_events()
@@ -265,7 +265,7 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
     # balance the number of snuba replacements with memory limits.
     DEFAULT_CHUNK_SIZE = GROUP_CHUNK_SIZE
 
-    def delete_bulk(self, instance_list: Sequence[Group]) -> bool:
+    def delete_bulk(self, instance_list: Sequence[Group], **kwargs: Any) -> bool:
         """
         Group deletion operates as a quasi-bulk operation so that we don't flood
         snuba replacements with deletions per group.
@@ -291,7 +291,8 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
         self._delete_children(instance_list)
 
         # Remove group objects with children removed.
-        self.delete_instance_bulk(instance_list)
+        silent = kwargs.get("silent", False)
+        self.delete_instance_bulk(instance_list, silent=silent)
 
         return False
 
@@ -321,7 +322,7 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
 
         self.delete_children(child_relations)
 
-    def delete_instance(self, instance: Group) -> None:
+    def delete_instance(self, instance: Group, **kwargs: Any) -> None:
         from sentry import similarity
 
         if not self.skip_models or similarity not in self.skip_models:

--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry.deletions.base import ModelDeletionTask
 from sentry.models.grouphistory import GroupHistory
 
@@ -13,7 +15,7 @@ class GroupHistoryDeletionTask(ModelDeletionTask[GroupHistory]):
     span 10000 ID values.
     """
 
-    def chunk(self) -> bool:
+    def chunk(self, **kwargs: Any) -> bool:
         group_ids = self.query.get("group_id__in", [])
         if not group_ids:
             # If we don't have group_id conditions

--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry.constants import ObjectStatus
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -20,7 +22,7 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
 
         return relations
 
-    def delete_instance(self, instance: OrganizationIntegration) -> None:
+    def delete_instance(self, instance: OrganizationIntegration, **kwargs: Any) -> None:
         try:
             repository_service.disassociate_organization_integration(
                 organization_id=instance.organization_id,

--- a/src/sentry/deletions/defaults/querysubscription.py
+++ b/src/sentry/deletions/defaults/querysubscription.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.snuba.models import QuerySubscription
 
 
 class QuerySubscriptionDeletionTask(ModelDeletionTask[QuerySubscription]):
-    def delete_instance(self, instance: QuerySubscription) -> None:
+    def delete_instance(self, instance: QuerySubscription, **kwargs: Any) -> None:
         from sentry.incidents.models.incident import Incident
 
         # Clear the foreign key as the schema was created without a cascade clause

--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry.constants import ObjectStatus
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.models.repository import Repository
@@ -28,7 +30,7 @@ class RepositoryDeletionTask(ModelDeletionTask[Repository]):
     def get_child_relations(self, instance: Repository) -> list[BaseRelation]:
         return _get_repository_child_relations(instance)
 
-    def delete_instance(self, instance: Repository) -> None:
+    def delete_instance(self, instance: Repository, **kwargs: Any) -> None:
         # TODO: child_relations should also send pending_delete so we
         # don't have to do this here.
         pending_delete.send(sender=type(instance), instance=instance, actor=self.get_actor())

--- a/src/sentry/deletions/defaults/team.py
+++ b/src/sentry/deletions/defaults/team.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import Any
 
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.models.team import Team
@@ -19,7 +20,7 @@ class TeamDeletionTask(ModelDeletionTask[Team]):
             if instance.status != TeamStatus.DELETION_IN_PROGRESS:
                 instance.update(status=TeamStatus.DELETION_IN_PROGRESS)
 
-    def delete_instance(self, instance: Team) -> None:
+    def delete_instance(self, instance: Team, **kwargs: Any) -> None:
         from sentry.incidents.models.alert_rule import AlertRule
         from sentry.models.rule import Rule
         from sentry.monitors.models import Monitor

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -61,7 +61,7 @@ def debug_output(msg: str) -> None:
     click.echo(msg)
 
 
-def multiprocess_worker(task_queue: _WorkQueue) -> None:
+def multiprocess_worker(task_queue: _WorkQueue, silent: bool) -> None:
     # Configure within each Process
     import logging
 
@@ -104,7 +104,7 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             )
 
             while True:
-                if not task.chunk():
+                if not task.chunk(silent=silent):
                     break
         except Exception as e:
             logger.exception(e)
@@ -168,7 +168,7 @@ def cleanup(
     pool = []
     task_queue: _WorkQueue = Queue(1000)
     for _ in range(concurrency):
-        p = Process(target=multiprocess_worker, args=(task_queue,))
+        p = Process(target=multiprocess_worker, args=(task_queue, silent))
         p.daemon = True
         p.start()
         pool.append(p)


### PR DESCRIPTION
Fixes GH-7458

Hi!

I would like to try to fix this old issue but I would need some help/guidance: 1. Confirm if my approach is on the right way. 2. I've noticed that `cleanup` command doesn't have tests -> Should I add a test only for a deletion task with `chunk` with `silence` in `True` and test that there is no logging?

Thank you!