### PR TITLE
fix: symx module logging

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -537,7 +537,7 @@ def emit_apple_symbol_stats(apple_symbol_stats, data):
         )
 
         # This is done to temporally collect information about the events for which symx is not working correctly.
-        if in_random_rollout("symbolicate.symx-logging-rate") and os_name:
+        if in_random_rollout("symbolicate.symx-logging-rate") and os_name and os_version:
             os_description = os_name + str(os_version)
             if os_description in options.get("symbolicate.symx-os-description-list"):
                 with sentry_sdk.isolation_scope() as scope:

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -537,7 +537,7 @@ def emit_apple_symbol_stats(apple_symbol_stats, data):
         )
 
         # This is done to temporally collect information about the events for which symx is not working correctly.
-        if in_random_rollout("symbolicate.symx-logging-rate"):
+        if in_random_rollout("symbolicate.symx-logging-rate") and os_name:
             os_description = os_name + str(os_version)
             if os_description in options.get("symbolicate.symx-os-description-list"):
                 with sentry_sdk.isolation_scope() as scope:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -725,7 +725,7 @@ def collect_apple_symbol_stats(json):
 
         eligible_symbols += 1
 
-        old_has_this_symbol = False
+        old_found_source = None
         symx_has_this_symbol = False
         for candidate in module.get("candidates") or ():
             if candidate["download"]["status"] == "ok":
@@ -733,21 +733,20 @@ def collect_apple_symbol_stats(json):
                 if source_id.startswith("sentry:symx"):
                     symx_has_this_symbol = True
                 elif source_id.startswith("sentry:") and source_id.endswith("os-source"):
-                    found_source = source_id
-                    old_has_this_symbol = True
+                    old_found_source = source_id
 
         if symx_has_this_symbol:
-            if old_has_this_symbol:
+            if old_found_source:
                 both_have_symbol += 1
             else:
                 symx_has_symbol += 1
-        elif old_has_this_symbol:
+        elif old_found_source:
             old_has_symbol.append(
                 {
                     "arch": module.get("arch"),
                     "code_file": module.get("code_file"),
                     "debug_id": module.get("debug_id"),
-                    "found_in": found_source,
+                    "found_in": old_found_source,
                 }
             )
         else:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -733,6 +733,7 @@ def collect_apple_symbol_stats(json):
                 if source_id.startswith("sentry:symx"):
                     symx_has_this_symbol = True
                 elif source_id.startswith("sentry:") and source_id.endswith("os-source"):
+                    found_source = source_id
                     old_has_this_symbol = True
 
         if symx_has_this_symbol:
@@ -741,7 +742,9 @@ def collect_apple_symbol_stats(json):
             else:
                 symx_has_symbol += 1
         elif old_has_this_symbol:
-            old_has_symbol.append(module)
+            old_has_symbol.append(
+                {"debug_id": module.get("debug_id", "unknown"), "found_in": found_source}
+            )
         else:
             neither_has_symbol += 1
             # NOTE: It might be possible to apply a heuristic based on `code_file` here to figure out if this is

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -743,7 +743,12 @@ def collect_apple_symbol_stats(json):
                 symx_has_symbol += 1
         elif old_has_this_symbol:
             old_has_symbol.append(
-                {"debug_id": module.get("debug_id", "unknown"), "found_in": found_source}
+                {
+                    "arch": module.get("arch"),
+                    "code_file": module.get("code_file"),
+                    "debug_id": module.get("debug_id"),
+                    "found_in": found_source,
+                }
             )
         else:
             neither_has_symbol += 1


### PR DESCRIPTION
Fixes up #83295.

1. Check if `os_name` and `os_version` exist
2. Only log relevant fields