### PR TITLE
fix(widgetDefinition) fix faulty conversion to bool

### DIFF
--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -75,7 +75,7 @@ export enum PerformanceWidgetSetting {
   HIGHEST_CACHE_MISS_RATE_TRANSACTIONS = 'highest_cache__miss_rate_transactions',
 }
 
-const WIDGET_PALETTE = !CHART_PALETTE[5];
+const WIDGET_PALETTE = CHART_PALETTE[5];
 export const WIDGET_DEFINITIONS: ({
   organization,
 }: {


### PR DESCRIPTION
This has wrongly been converted to a bool when I did the noUncheckedIndexedAccess migration. 

I've done a quick grep to see if there are other instances of this, and it seems like this is the only one. 

Thanks for catching this @TkDodo!