### PR TITLE
fix(widget-builder): Improve filtering for column options

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -428,7 +428,7 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('option', {name: 'count_miserable'}));
 
     expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
-      'transaction.duration'
+      'user'
     );
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
       'count_miserable'
@@ -437,7 +437,7 @@ describe('Visualize', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
-          field: ['count_miserable(transaction.duration,300)'],
+          field: ['count_miserable(user,300)'],
         }),
       })
     );
@@ -465,9 +465,8 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'count_miserable'}));
 
-    // TODO: This is supposed to only allow the user field
     expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
-      'transaction.duration'
+      'user'
     );
   });
 
@@ -773,6 +772,34 @@ describe('Visualize', () => {
         }),
       })
     );
+  });
+
+  it('only shows the relevant options for the release dataset', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.RELEASE,
+              field: ['crash_free_rate(session)'],
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Column Selection'})
+    ).toHaveTextContent('session');
+    await userEvent.click(screen.getByRole('button', {name: 'Column Selection'}));
+    const listbox = await screen.findAllByRole('option');
+    expect(listbox).toHaveLength(2);
+    expect(listbox[0]).toHaveTextContent('session');
+    expect(listbox[1]).toHaveTextContent('user');
   });
 
   describe('spans', () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -12,6 +12,7 @@ import Radio from 'sentry/components/radio';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {SelectValue} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
 import {
   type AggregationKeyWithAlias,
@@ -21,6 +22,7 @@ import {
   parseFunction,
   prettifyTagKey,
   type QueryFieldValue,
+  type ValidateColumnTypes,
 } from 'sentry/utils/discover/fields';
 import {FieldKind} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -37,8 +39,9 @@ import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
 import {
   BufferedInput,
   type ParameterDescription,
+  validateColumnTypes,
 } from 'sentry/views/discover/table/queryField';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {type FieldValue, FieldValueKind} from 'sentry/views/discover/table/types';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
@@ -56,6 +59,89 @@ const NONE_AGGREGATE = {
   label: t('None'),
   value: NONE,
 };
+
+function formatColumnOptions(
+  dataset: WidgetType,
+  options: SelectValue<FieldValue>[],
+  columnFilterMethod: (
+    option: SelectValue<FieldValue>,
+    field?: QueryFieldValue
+  ) => boolean
+) {
+  return options
+    .filter(option => {
+      // Don't show any aggregates under the columns, and if
+      // there isn't a filter method, just show the option
+      return (
+        option.value.kind !== FieldValueKind.FUNCTION &&
+        (columnFilterMethod?.(option) ?? true)
+      );
+    })
+    .map(option => ({
+      value: option.value.meta.name,
+      label:
+        dataset === WidgetType.SPANS
+          ? prettifyTagKey(option.value.meta.name)
+          : option.value.meta.name,
+
+      // For the spans dataset, all of the options are measurements,
+      // so we force the number badge to show
+      trailingItems:
+        dataset === WidgetType.SPANS ? <TypeBadge kind={FieldKind.MEASUREMENT} /> : null,
+    }));
+}
+
+function getColumnOptions(
+  dataset: WidgetType,
+  selectedField: QueryFieldValue,
+  fieldOptions: Record<string, SelectValue<FieldValue>>,
+  columnFilterMethod: (
+    option: SelectValue<FieldValue>,
+    field?: QueryFieldValue
+  ) => boolean
+) {
+  const fieldValues = Object.values(fieldOptions);
+  if (selectedField.kind !== FieldValueKind.FUNCTION || dataset === WidgetType.SPANS) {
+    return formatColumnOptions(dataset, fieldValues, columnFilterMethod);
+  }
+
+  const field = fieldValues.find(
+    option => option.value.meta.name === selectedField.function[0]
+  )?.value;
+
+  if (
+    field &&
+    field.kind === FieldValueKind.FUNCTION &&
+    field.meta.parameters.length > 0 &&
+    field.meta.parameters[0]
+  ) {
+    const parameter = field.meta.parameters[0];
+    if (parameter && parameter.kind === 'dropdown') {
+      // Parameters for dropdowns are already formatted in the correct manner
+      // for select fields
+      return parameter.options;
+    }
+
+    if (parameter && parameter.kind === 'column' && parameter.columnTypes) {
+      return formatColumnOptions(
+        dataset,
+        fieldValues.filter(
+          ({value}) =>
+            (value.kind === FieldValueKind.FIELD ||
+              value.kind === FieldValueKind.TAG ||
+              value.kind === FieldValueKind.MEASUREMENT ||
+              value.kind === FieldValueKind.CUSTOM_MEASUREMENT ||
+              value.kind === FieldValueKind.METRICS ||
+              value.kind === FieldValueKind.BREAKDOWN) &&
+            validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value)
+        ),
+        columnFilterMethod
+      );
+    }
+  }
+
+  return formatColumnOptions(dataset, fieldValues, columnFilterMethod);
+}
 
 interface VisualizeProps {
   error?: Record<string, any>;
@@ -199,29 +285,13 @@ function Visualize({error, setError}: VisualizeProps) {
               : field.kind === FieldValueKind.FUNCTION
                 ? datasetConfig.filterAggregateParams
                 : datasetConfig.filterTableOptions;
-            const columnOptions = Object.values(fieldOptions)
-              .filter(option => {
-                // Don't show any aggregates under the columns, and if
-                // there isn't a filter method, just show the option
-                return (
-                  option.value.kind !== FieldValueKind.FUNCTION &&
-                  (columnFilterMethod?.(option, field) ?? true)
-                );
-              })
-              .map(option => ({
-                value: option.value.meta.name,
-                label:
-                  state.dataset === WidgetType.SPANS
-                    ? prettifyTagKey(option.value.meta.name)
-                    : option.value.meta.name,
-
-                // For the spans dataset, all of the options are measurements,
-                // so we force the number badge to show
-                trailingItems:
-                  state.dataset === WidgetType.SPANS ? (
-                    <TypeBadge kind={FieldKind.MEASUREMENT} />
-                  ) : null,
-              }));
+            const columnOptions = getColumnOptions(
+              state.dataset ?? WidgetType.ERRORS,
+              field,
+              fieldOptions,
+              // If no column filter method is provided, show all options
+              columnFilterMethod ?? (() => true)
+            );
 
             let aggregateOptions = aggregates.map(option => ({
               value: option.value.meta.name,
@@ -294,6 +364,7 @@ function Visualize({error, setError}: VisualizeProps) {
                   ) : (
                     <Fragment>
                       <PrimarySelectRow>
+                        {/** TODO: Add support for the value parameter type for cases like user_misery, apdex */}
                         <ColumnCompactSelect
                           searchable
                           options={
@@ -359,11 +430,26 @@ function Visualize({error, setError}: VisualizeProps) {
                                   if (newAggregate.value.meta.parameters.length === 0) {
                                     currentField.function[1] = '';
                                   } else {
+                                    // Check if the column is a valid column for the new aggregate
+                                    const newColumnOptions = getColumnOptions(
+                                      state.dataset ?? WidgetType.ERRORS,
+                                      currentField,
+                                      fieldOptions,
+                                      // If no column filter method is provided, show all options
+                                      columnFilterMethod ?? (() => true)
+                                    );
+                                    const isValidColumn = Boolean(
+                                      newColumnOptions.find(
+                                        option =>
+                                          option.value === currentField.function[1]
+                                      )?.value
+                                    );
                                     currentField.function[1] =
-                                      (currentField.function[1] ||
-                                        newAggregate.value.meta.parameters[0]!
-                                          .defaultValue) ??
-                                      '';
+                                      (isValidColumn
+                                        ? currentField.function[1]
+                                        : newAggregate.value.meta.parameters[0]!
+                                            .defaultValue) ?? '';
+
                                     // Set the remaining parameters for the new aggregate
                                     for (
                                       let i = 1; // The first parameter is the column selection
@@ -415,10 +501,28 @@ function Visualize({error, setError}: VisualizeProps) {
                                 ) {
                                   newAggregate?.value.meta.parameters.forEach(
                                     (parameter, parameterIndex) => {
+                                      const newParameterOptions = getColumnOptions(
+                                        state.dataset ?? WidgetType.ERRORS,
+                                        {
+                                          kind: FieldValueKind.FUNCTION,
+                                          function: newFunction,
+                                        },
+                                        fieldOptions,
+                                        // If no column filter method is provided, show all options
+                                        columnFilterMethod ?? (() => true)
+                                      );
+                                      const isValidColumn = Boolean(
+                                        newParameterOptions.find(
+                                          option =>
+                                            option.value ===
+                                            newFunction[parameterIndex + 1]
+                                        )?.value
+                                      );
                                       // Increment by 1 to skip past the aggregate name
                                       newFunction[parameterIndex + 1] =
-                                        newFunction[parameterIndex + 1] ??
-                                        parameter.defaultValue;
+                                        (isValidColumn
+                                          ? newFunction[parameterIndex + 1]
+                                          : parameter.defaultValue) ?? '';
                                     }
                                   );
                                 }

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -698,7 +698,7 @@ class QueryField extends Component<Props> {
   }
 }
 
-function validateColumnTypes(
+export function validateColumnTypes(
   columnTypes: ValidateColumnTypes,
   input: FieldValueColumns
 ): boolean {


### PR DESCRIPTION
Some of the aggregates define stricter allowances for the available options. This adds support for the dropdown and column types so we can show the correct values.

To test this, you can look for aggregates such as any of the aggregates in the release health widget, they should only show `session` and `user` and not `session.duration` as it is doing now. Also, `count_miserable` in the Transactions dataset only accepts `user`, so it should automatically change to that when selected.

The code was slightly adapted from https://github.com/getsentry/sentry/blob/master/static/app/views/discover/table/queryField.tsx#L366

Closes [#83326](https://github.com/getsentry/sentry/issues/83326)