### PR TITLE
ref(quick-start): Remove prop "new_experience" from analytics

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -267,7 +267,6 @@ function Task({task, hidePanel, showWaitingIndicator}: TaskProps) {
         todo_id: task.task,
         todo_title: task.title,
         action: 'clickthrough',
-        new_experience: true,
       });
 
       e.stopPropagation();
@@ -305,7 +304,6 @@ function Task({task, hidePanel, showWaitingIndicator}: TaskProps) {
         todo_id: task.task,
         todo_title: task.title,
         action: 'skipped',
-        new_experience: true,
       });
       updateOnboardingTask(api, organization, {
         task: taskKey,

--- a/static/app/components/sidebar/newOnboardingStatus.tsx
+++ b/static/app/components/sidebar/newOnboardingStatus.tsx
@@ -79,7 +79,6 @@ export function NewOnboardingStatus({
     if (!walkthrough && !isActive === true) {
       trackAnalytics('quick_start.opened', {
         organization,
-        new_experience: true,
       });
     }
 
@@ -94,7 +93,6 @@ export function NewOnboardingStatus({
     trackAnalytics('quick_start.completed', {
       organization,
       referrer: 'onboarding_sidebar',
-      new_experience: true,
     });
 
     setQuickStartCompleted(true);

--- a/static/app/utils/analytics/quickStartAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/quickStartAnalyticsEvents.tsx
@@ -1,14 +1,10 @@
 export type QuickStartEventParameters = {
   'quick_start.completed': {
-    new_experience: boolean;
     referrer: string;
   };
-  'quick_start.opened': {
-    new_experience: boolean;
-  };
+  'quick_start.opened': {};
   'quick_start.task_card_clicked': {
     action: string;
-    new_experience: boolean;
     todo_id: string;
     todo_title: string;
   };


### PR DESCRIPTION
we already GAd, so everything is "new_experience"

closes https://github.com/getsentry/projects/issues/349