### PR TITLE
fix(widget-builder): Reset sort for big numbers on dataset change

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -815,6 +815,33 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.selectedAggregate).toBeUndefined();
     });
+
+    it('resets the sort when the dataset is switched for big number widgets', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ERRORS,
+            displayType: DisplayType.BIG_NUMBER,
+            sort: ['-testField'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.sort).toEqual([{field: 'testField', kind: 'desc'}]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.TRANSACTIONS,
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([]);
+    });
   });
 
   describe('fields', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -253,6 +253,11 @@ function useWidgetBuilderState(): {
             setFields(
               config.defaultWidgetQuery.fields?.map(field => explodeField({field}))
             );
+            setSort(
+              nextDisplayType === DisplayType.BIG_NUMBER
+                ? []
+                : decodeSorts(config.defaultWidgetQuery.orderby)
+            );
           } else {
             setFields([]);
             setYAxis(
@@ -260,9 +265,9 @@ function useWidgetBuilderState(): {
                 explodeField({field: aggregate})
               )
             );
+            setSort(decodeSorts(config.defaultWidgetQuery.orderby));
           }
           setQuery([config.defaultWidgetQuery.conditions]);
-          setSort(decodeSorts(config.defaultWidgetQuery.orderby));
           setSelectedAggregate(undefined);
           break;
         case BuilderStateAction.SET_FIELDS:


### PR DESCRIPTION
Big numbers don't support sorting, so adding the field breaks the flow in this case because the user cannot remove it. The solution is to wipe the sort when changing datasets

Closes #83328