### PR TITLE
feat(eap-alerts): Add support for dynamic thresholds

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -55,6 +55,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:alerts-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anomaly detection feature for rollout
     manager.add("organizations:anomaly-detection-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable anomaly detection feature for EAP spans
+    manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anomaly detection charts
     manager.add("organizations:anomaly-detection-alerts-charts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anr frame analysis

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -20,7 +20,6 @@ from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.metrics import AlertMetricsQueryBuilder
-from sentry.search.events.builder.spans_indexed import SpansEAPQueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key, resolve_tag_values
@@ -230,41 +229,6 @@ class EventsEntitySubscription(BaseEventsAndTransactionEntitySubscription):
 class PerformanceTransactionsEntitySubscription(BaseEventsAndTransactionEntitySubscription):
     query_type = SnubaQuery.Type.PERFORMANCE
     dataset = Dataset.Transactions
-
-
-class PerformanceSpansEAPSnqlEntitySubscription(BaseEventsAndTransactionEntitySubscription):
-    query_type = SnubaQuery.Type.PERFORMANCE
-    dataset = Dataset.EventsAnalyticsPlatform
-
-    def build_query_builder(
-        self,
-        query: str,
-        project_ids: list[int],
-        environment: Environment | None,
-        params: ParamsType | None = None,
-        skip_field_validation_for_entity_subscription_deletion: bool = False,
-    ) -> BaseQueryBuilder:
-        if params is None:
-            params = {}
-
-        params["project_id"] = project_ids
-
-        query = apply_dataset_query_conditions(self.query_type, query, self.event_types)
-        if environment:
-            params["environment"] = environment.name
-
-        return SpansEAPQueryBuilder(
-            dataset=Dataset(self.dataset.value),
-            query=query,
-            selected_columns=[self.aggregate],
-            params=params,
-            offset=None,
-            limit=None,
-            config=QueryBuilderConfig(
-                skip_time_conditions=True,
-                skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
-            ),
-        )
 
 
 class PerformanceSpansEAPRpcEntitySubscription(BaseEntitySubscription):


### PR DESCRIPTION
- adds EAP support for fetching historical data that is then sent to seer
- adds a flag to gate dynamic thresholds for eap in the FE
- [cleanup] removes PerformanceSpansEAPSnqlEntitySubscription, it's not used anywhere