### PR TITLE
feat(insights): Minor UI improvements

### DIFF
--- a/static/app/views/insights/mobile/screens/components/screensOverview.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.tsx
@@ -115,6 +115,7 @@ export function ScreensOverview() {
 
   const secondaryDataset = isSpanPrimary ? transactionMetricsDataset : spanMetricsDataset;
   const secondaryFields = isSpanPrimary ? transactionMetricsFields : spanMetricsFields;
+  const hasVisibleScreens = visibleScreens.length > 0;
 
   const {
     data: primaryData,
@@ -139,7 +140,7 @@ export function ScreensOverview() {
     selection,
     location,
     undefined,
-    visibleScreens.length > 0,
+    hasVisibleScreens,
     visibleScreens
   );
 
@@ -192,8 +193,7 @@ export function ScreensOverview() {
     return primaryData;
   }, [primaryData, secondaryData]);
 
-  const loading = primaryLoading || secondaryLoading;
-
+  const loading = primaryLoading || (hasVisibleScreens && secondaryLoading);
   return (
     <Container>
       <SearchBar

--- a/static/app/views/insights/mobile/screens/utils.ts
+++ b/static/app/views/insights/mobile/screens/utils.ts
@@ -4,6 +4,9 @@ import getDuration from 'sentry/utils/duration/getDuration';
 import {VitalState} from 'sentry/views/performance/vitalDetail/utils';
 
 const formatMetricValue = (metric: MetricValue): string => {
+  if (metric.value == null) {
+    return '-';
+  }
   if (typeof metric.value === 'number' && metric.type === 'duration' && metric.unit) {
     const seconds =
       (metric.value * ((metric.unit && DURATION_UNITS[metric.unit]) ?? 1)) / 1000;

--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -39,7 +39,7 @@ export function MobileHeader({
   const hasMobileUi = isModuleEnabled(ModuleName.MOBILE_UI, organization);
 
   const modules = hasMobileScreens
-    ? [ModuleName.MOBILE_SCREENS]
+    ? [ModuleName.MOBILE_SCREENS, ModuleName.HTTP]
     : [
         ModuleName.APP_START,
         ModuleName.SCREEN_LOAD,


### PR DESCRIPTION
A collection of a few small frontend related fixes: 
 * The mobile screens module was showing an endless spinner if no metric data was available
 * If the event stats endpoint returned a `null` value, it was rendered as `"null"`
 * The HTTP module tab wasn't shown if the mobile screens feature was enabled