### PR TITLE
chore(analytics): Add experimental analytics for new streamlined orgs 

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -96,9 +96,18 @@ export type IssueEventParameters = {
   'issue.search_sidebar_clicked': {};
   'issue.share_from_icon': {};
   'issue.shared_publicly': {};
-  'issue_details.comment_created': {streamline: boolean};
-  'issue_details.comment_deleted': {streamline: boolean};
-  'issue_details.comment_updated': {streamline: boolean};
+  'issue_details.comment_created': {
+    org_streamline_only: boolean | undefined;
+    streamline: boolean;
+  };
+  'issue_details.comment_deleted': {
+    org_streamline_only: boolean | undefined;
+    streamline: boolean;
+  };
+  'issue_details.comment_updated': {
+    org_streamline_only: boolean | undefined;
+    streamline: boolean;
+  };
   'issue_details.copy_event_id_clicked': StreamlineGroupEventParams;
   'issue_details.copy_event_link_clicked': StreamlineGroupEventParams;
   'issue_details.escalating_feedback_received': {
@@ -130,6 +139,7 @@ export type IssueEventParameters = {
   };
   'issue_details.section_fold': {
     open: boolean;
+    org_streamline_only: boolean | undefined;
     sectionKey: string;
   };
   'issue_details.set_priority': SetPriorityParams;

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -98,11 +98,11 @@ export type TeamInsightsEventParameters = {
       | 'open_in_discover'
       | 'assign'
       | GroupStatus;
+    org_streamline_only: boolean | undefined;
     action_status_details?: string;
     action_substatus?: string;
     assigned_suggestion_reason?: string;
     assigned_type?: string;
-    org_streamline_only?: boolean | undefined;
   };
   'issue_details.attachment_tab.screenshot_modal_deleted': {};
   'issue_details.attachment_tab.screenshot_modal_download': {};

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -102,6 +102,7 @@ export type TeamInsightsEventParameters = {
     action_substatus?: string;
     assigned_suggestion_reason?: string;
     assigned_type?: string;
+    org_streamline_only?: boolean | undefined;
   };
   'issue_details.attachment_tab.screenshot_modal_deleted': {};
   'issue_details.attachment_tab.screenshot_modal_download': {};

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -158,6 +158,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
       ...getAnalyticsDataForGroup(group),
       ...getAnalyicsDataForProject(project),
+      org_streamline_only: organization?.streamlineOnly ?? undefined,
     });
   };
 

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -158,7 +158,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
       ...getAnalyticsDataForGroup(group),
       ...getAnalyicsDataForProject(project),
-      org_streamline_only: organization?.streamlineOnly ?? undefined,
+      org_streamline_only: organization.streamlineOnly ?? undefined,
     });
   };
 

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -49,7 +49,7 @@ function ActivitySection(props: Props) {
             onCreate(n, me);
             trackAnalytics('issue_details.comment_created', {
               organization,
-              org_streamline_only: organization?.streamlineOnly ?? undefined,
+              org_streamline_only: organization.streamlineOnly ?? undefined,
               streamline: false,
             });
             setInputId(uniqueId());
@@ -77,7 +77,7 @@ function ActivitySection(props: Props) {
                   trackAnalytics('issue_details.comment_deleted', {
                     organization,
                     streamline: false,
-                    org_streamline_only: organization?.streamlineOnly ?? undefined,
+                    org_streamline_only: organization.streamlineOnly ?? undefined,
                   });
                 }}
                 onUpdate={n => {
@@ -86,7 +86,7 @@ function ActivitySection(props: Props) {
                   trackAnalytics('issue_details.comment_updated', {
                     organization,
                     streamline: false,
-                    org_streamline_only: organization?.streamlineOnly ?? undefined,
+                    org_streamline_only: organization.streamlineOnly ?? undefined,
                   });
                 }}
                 {...noteProps}

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -49,6 +49,7 @@ function ActivitySection(props: Props) {
             onCreate(n, me);
             trackAnalytics('issue_details.comment_created', {
               organization,
+              org_streamline_only: organization?.streamlineOnly ?? undefined,
               streamline: false,
             });
             setInputId(uniqueId());
@@ -76,6 +77,7 @@ function ActivitySection(props: Props) {
                   trackAnalytics('issue_details.comment_deleted', {
                     organization,
                     streamline: false,
+                    org_streamline_only: organization?.streamlineOnly ?? undefined,
                   });
                 }}
                 onUpdate={n => {
@@ -84,6 +86,7 @@ function ActivitySection(props: Props) {
                   trackAnalytics('issue_details.comment_updated', {
                     organization,
                     streamline: false,
+                    org_streamline_only: organization?.streamlineOnly ?? undefined,
                   });
                 }}
                 {...noteProps}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -452,8 +452,8 @@ function useTrackView({
 }: {
   event: Event | null;
   group: Group | null;
+  organization: Organization;
   tab: Tab;
-  organization?: Organization;
   project?: Project;
 }) {
   const location = useLocation();
@@ -478,7 +478,7 @@ function useTrackView({
     ref_fallback,
     group_event_type: groupEventType,
     prefers_streamlined_ui: user?.options?.prefersIssueDetailsStreamlinedUI ?? false,
-    org_streamline_only: organization?.streamlineOnly ?? undefined,
+    org_streamline_only: organization.streamlineOnly ?? undefined,
   });
   // Set default values for properties that may be updated in subcomponents.
   // Must be separate from the above values, otherwise the actual values filled in

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -448,10 +448,12 @@ function useTrackView({
   event,
   project,
   tab,
+  organization,
 }: {
   event: Event | null;
   group: Group | null;
   tab: Tab;
+  organization?: Organization;
   project?: Project;
 }) {
   const location = useLocation();
@@ -476,6 +478,7 @@ function useTrackView({
     ref_fallback,
     group_event_type: groupEventType,
     prefers_streamlined_ui: user?.options?.prefersIssueDetailsStreamlinedUI ?? false,
+    org_streamline_only: organization?.streamlineOnly ?? undefined,
   });
   // Set default values for properties that may be updated in subcomponents.
   // Must be separate from the above values, otherwise the actual values filled in
@@ -613,7 +616,7 @@ function GroupDetailsContent({
     openIssueActivityDrawer,
   ]);
 
-  useTrackView({group, event, project, tab: currentTab});
+  useTrackView({group, event, project, tab: currentTab, organization});
 
   const isDisplayingEventDetails = [
     Tab.DETAILS,

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -104,6 +104,7 @@ export default function GroupSidebar({
         typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
+      org_streamline_only: organization.streamlineOnly ?? undefined,
       ...getAnalyticsDataForGroup(group),
       ...getAnalyicsDataForProject(project),
     });

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -191,7 +191,7 @@ export function EventSearch({
     ? 'new_org_issue_details_header'
     : 'new_org_issue_events_tab';
 
-  const searchSource = defined(organization?.streamlineOnly)
+  const searchSource = defined(organization.streamlineOnly)
     ? experimentSearchSource
     : hasStreamlinedUI
       ? 'issue_details_header'

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -11,6 +11,7 @@ import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils
 import {joinQuery, Token} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import type {Group, Tag, TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
 import {
   FieldKind,
   getFieldDefinition,
@@ -186,6 +187,16 @@ export function EventSearch({
 
   const filterKeySections = useMemo(() => getFilterKeySections(filterKeys), [filterKeys]);
 
+  const experimentSearchSource = hasStreamlinedUI
+    ? 'new_org_issue_details_header'
+    : 'new_org_issue_events_tab';
+
+  const searchSource = defined(organization?.streamlineOnly)
+    ? experimentSearchSource
+    : hasStreamlinedUI
+      ? 'issue_details_header'
+      : 'issue_events_tab';
+
   return (
     <SearchQueryBuilder
       initialQuery={query}
@@ -195,7 +206,7 @@ export function EventSearch({
       getTagValues={getTagValues}
       placeholder={hasStreamlinedUI ? t('Filter events\u2026') : t('Search events\u2026')}
       label={hasStreamlinedUI ? t('Filter events\u2026') : t('Search events')}
-      searchSource={hasStreamlinedUI ? 'issue_details_header' : 'issue_events_tab'}
+      searchSource={searchSource}
       className={className}
       showUnsubmittedIndicator
       {...queryBuilderProps}

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -114,6 +114,7 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
         sectionKey,
         organization,
         open: !isCollapsed,
+        org_streamline_only: organization?.streamlineOnly ?? undefined,
       });
       setIsCollapsed(!isCollapsed);
     },

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -114,7 +114,7 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
         sectionKey,
         organization,
         open: !isCollapsed,
-        org_streamline_only: organization?.streamlineOnly ?? undefined,
+        org_streamline_only: organization.streamlineOnly ?? undefined,
       });
       setIsCollapsed(!isCollapsed);
     },

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -166,6 +166,7 @@ export default function StreamlinedActivitySection({
             trackAnalytics('issue_details.comment_deleted', {
               organization,
               streamline: true,
+              org_streamline_only: organization?.streamlineOnly ?? undefined,
             });
             addSuccessMessage(t('Comment removed'));
           },
@@ -188,6 +189,7 @@ export default function StreamlinedActivitySection({
           trackAnalytics('issue_details.comment_updated', {
             organization,
             streamline: true,
+            org_streamline_only: organization?.streamlineOnly ?? undefined,
           });
         },
       });
@@ -209,6 +211,7 @@ export default function StreamlinedActivitySection({
           trackAnalytics('issue_details.comment_created', {
             organization,
             streamline: true,
+            org_streamline_only: organization?.streamlineOnly ?? undefined,
           });
           addSuccessMessage(t('Comment posted'));
         },

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -166,7 +166,7 @@ export default function StreamlinedActivitySection({
             trackAnalytics('issue_details.comment_deleted', {
               organization,
               streamline: true,
-              org_streamline_only: organization?.streamlineOnly ?? undefined,
+              org_streamline_only: organization.streamlineOnly ?? undefined,
             });
             addSuccessMessage(t('Comment removed'));
           },
@@ -189,7 +189,7 @@ export default function StreamlinedActivitySection({
           trackAnalytics('issue_details.comment_updated', {
             organization,
             streamline: true,
-            org_streamline_only: organization?.streamlineOnly ?? undefined,
+            org_streamline_only: organization.streamlineOnly ?? undefined,
           });
         },
       });
@@ -211,7 +211,7 @@ export default function StreamlinedActivitySection({
           trackAnalytics('issue_details.comment_created', {
             organization,
             streamline: true,
-            org_streamline_only: organization?.streamlineOnly ?? undefined,
+            org_streamline_only: organization.streamlineOnly ?? undefined,
           });
           addSuccessMessage(t('Comment posted'));
         },

--- a/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
@@ -4,9 +4,11 @@ import {Button} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 
 export function ToggleSidebar({size = 'lg'}: {size?: 'lg' | 'sm'}) {
+  const organization = useOrganization();
   const {isSidebarOpen, dispatch} = useIssueDetails();
   const direction = isSidebarOpen ? 'right' : 'left';
   return (
@@ -22,6 +24,7 @@ export function ToggleSidebar({size = 'lg'}: {size?: 'lg' | 'sm'}) {
         analyticsEventName="Issue Details: Sidebar Toggle"
         analyticsParams={{
           sidebar_open: !isSidebarOpen,
+          org_streamline_only: organization?.streamlineOnly ?? undefined,
         }}
       >
         <LeftChevron direction={direction} />

--- a/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
@@ -24,7 +24,7 @@ export function ToggleSidebar({size = 'lg'}: {size?: 'lg' | 'sm'}) {
         analyticsEventName="Issue Details: Sidebar Toggle"
         analyticsParams={{
           sidebar_open: !isSidebarOpen,
-          org_streamline_only: organization?.streamlineOnly ?? undefined,
+          org_streamline_only: organization.streamlineOnly ?? undefined,
         }}
       >
         <LeftChevron direction={direction} />


### PR DESCRIPTION
Adds a few analytics to measure for new orgs locked in to streamline/legacy UI:

- Issue details viewed
- Comments created/updated/removed
- Group Actions (archive, resolve, etc.)

Plus a few bonus ones I think might be interesting to see if the new streamline features are used by new organizations:

- Searches performed
- Sections folded
- Sidebar collapsing