### PR TITLE
feat(crons): Redirect to cron insights when flag is enabled

### DIFF
--- a/static/app/views/monitors/index.tsx
+++ b/static/app/views/monitors/index.tsx
@@ -1,9 +1,23 @@
+import {useEffect} from 'react';
+
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 
 function MonitorsContainer({children}: {children?: React.ReactNode}) {
   const organization = useOrganization();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (organization.features.includes('insights-crons')) {
+      navigate(
+        normalizeUrl(`/organizations/${organization.slug}/insights/backend/crons/`),
+        {replace: true}
+      );
+    }
+  });
 
   return (
     <NoProjectMessage organization={organization}>


### PR DESCRIPTION
This redirects from the "old" `/crons` page to the
`/insights/backend/crons` route when the insights-crons flag is enabled.