### PR TITLE
feat(dashboards): Add better series name formatting

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
@@ -20,6 +20,16 @@ describe('formatSeriesName', () => {
     });
   });
 
+  describe('versions', () => {
+    it.each([
+      ['frontend@31804d9a5f0b5e4f53055467cd258e1c', '31804d9a5f0b'],
+      ['android@5.3.1', '5.3.1'],
+      ['ios@5.3.1-rc1', '5.3.1-rc1'],
+    ])('Formats %s as %s', (name, result) => {
+      expect(formatSeriesName(name)).toEqual(result);
+    });
+  });
+
   describe('aggregates of measurements', () => {
     it.each([
       ['p75(measurements.lcp)', 'LCP'],

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
@@ -1,0 +1,40 @@
+import {formatSeriesName} from './formatSeriesname';
+
+describe('formatSeriesName', () => {
+  describe('releases', () => {
+    it.each([
+      ['p75(span.duration);11762', 'p75(span.duration)'],
+      ['Releases;', 'Releases'],
+    ])('Formats %s as %s', (name, result) => {
+      expect(formatSeriesName(name)).toEqual(result);
+    });
+  });
+
+  describe('aggregates', () => {
+    it.each([
+      ['user_misery()', 'user_misery()'],
+      ['apdex(200)', 'apdex(200)'],
+      ['p75(span.duration)', 'p75(span.duration)'],
+    ])('Formats %s as %s', (name, result) => {
+      expect(formatSeriesName(name)).toEqual(result);
+    });
+  });
+
+  describe('aggregates of measurements', () => {
+    it.each([
+      ['p75(measurements.lcp)', 'LCP'],
+      ['p50(measurements.lcp)', 'LCP'],
+    ])('Formats %s as %s', (name, result) => {
+      expect(formatSeriesName(name)).toEqual(result);
+    });
+  });
+
+  describe('equations', () => {
+    it.each([
+      ['equation|', ''],
+      ['equation|', ''],
+    ])('Formats %s as %s', (name, result) => {
+      expect(formatSeriesName(name)).toEqual(result);
+    });
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
@@ -31,8 +31,17 @@ describe('formatSeriesName', () => {
 
   describe('equations', () => {
     it.each([
-      ['equation|', ''],
-      ['equation|', ''],
+      ['equation|p75(measurements.cls) + 1', 'p75(measurements.cls) + 1'],
+      ['equation|p75(measurements.cls)', 'p75(measurements.cls)'],
+    ])('Formats %s as %s', (name, result) => {
+      expect(formatSeriesName(name)).toEqual(result);
+    });
+  });
+
+  describe('combinations', () => {
+    it.each([
+      ['equation|p75(measurements.cls) + 1;76123', 'p75(measurements.cls) + 1'],
+      ['equation|p75(measurements.cls);76123', 'p75(measurements.cls)'],
     ])('Formats %s as %s', (name, result) => {
       expect(formatSeriesName(name)).toEqual(result);
     });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.spec.tsx
@@ -1,4 +1,4 @@
-import {formatSeriesName} from './formatSeriesname';
+import {formatSeriesName} from './formatSeriesName';
 
 describe('formatSeriesName', () => {
   describe('releases', () => {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.tsx
@@ -4,12 +4,18 @@ import {
   maybeEquationAlias,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 
 import WidgetLegendNameEncoderDecoder from '../../widgetLegendNameEncoderDecoder';
 
 export function formatSeriesName(seriesName: string): string {
+  // Decode from series name disambiguation
   seriesName = WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(seriesName)!;
 
+  // Check if it's a release version
+  seriesName = formatVersion(seriesName);
+
+  // Check for special-case measurement formatting
   const arg = getAggregateArg(seriesName);
   if (arg) {
     const slug = getMeasurementSlug(arg);
@@ -19,6 +25,7 @@ export function formatSeriesName(seriesName: string): string {
     }
   }
 
+  // Strip equation prefix
   if (maybeEquationAlias(seriesName)) {
     seriesName = stripEquationPrefix(seriesName);
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatSeriesName.tsx
@@ -1,0 +1,27 @@
+import {
+  getAggregateArg,
+  getMeasurementSlug,
+  maybeEquationAlias,
+  stripEquationPrefix,
+} from 'sentry/utils/discover/fields';
+
+import WidgetLegendNameEncoderDecoder from '../../widgetLegendNameEncoderDecoder';
+
+export function formatSeriesName(seriesName: string): string {
+  seriesName = WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(seriesName)!;
+
+  const arg = getAggregateArg(seriesName);
+  if (arg) {
+    const slug = getMeasurementSlug(arg);
+
+    if (slug) {
+      seriesName = slug.toUpperCase();
+    }
+  }
+
+  if (maybeEquationAlias(seriesName)) {
+    seriesName = stripEquationPrefix(seriesName);
+  }
+
+  return seriesName;
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -193,7 +193,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
               top: 0,
               left: 0,
               formatter(name: string) {
-                return formatSeriesName(name);
+                return props.aliases?.[name] ?? formatSeriesName(name);
               },
             }
           : undefined


### PR DESCRIPTION
I took this logic out of `widgetCard/chart.tsx` and added specs, and put it into the timeseries widgets. EZ.
