### PR TITLE
fix(ui): Correct showCursor condition

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -159,7 +159,7 @@ export function GridLineOverlay({
   } = useTimelineZoom<HTMLDivElement>({enabled: !!allowZoom, onSelect: handleZoom});
 
   const {cursorContainerRef, timelineCursor} = useTimelineCursor<HTMLDivElement>({
-    enabled: showCursor && !selectionIsActive,
+    enabled: !!showCursor && !selectionIsActive,
     sticky: stickyCursor,
     labelText: makeCursorLabel,
   });


### PR DESCRIPTION
Before this change it would pass `undefined`, which would fall-through
to the default of `enabled=true` for displaying the cursor.