### PR TITLE
fix(insights) Missing "Time Spent" value in Span Samples drawer

### DIFF
--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -79,10 +79,10 @@ function SampleInfo(props: Props) {
 
       <MetricReadout
         title={DataTitles.timeSpent}
-        value={spanMetrics?.[0]?.[`sum(${SpanMetricsField.SPAN_SELF_TIME}))`]}
+        value={spanMetrics?.[`sum(${SpanMetricsField.SPAN_SELF_TIME})`]}
         unit={DurationUnit.MILLISECOND}
         tooltip={getTimeSpentExplanation(
-          spanMetrics?.[0]?.['time_spent_percentage()'],
+          spanMetrics?.['time_spent_percentage()'],
           spanMetrics?.[SpanMetricsField.SPAN_OP]
         )}
         isLoading={isPending}


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/83297, just a bunch of typos.

**e.g.,**
![Screenshot 2025-01-14 at 12 22 16 PM](https://github.com/user-attachments/assets/2a40c478-a448-4d5a-b117-02a49e6572c7)
