### PR TITLE
ref(test): Stop using wrapper: null in PipelineView test

### DIFF
--- a/static/app/views/integrationPipeline/pipelineView.spec.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.spec.tsx
@@ -1,4 +1,8 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+// The pipeline view renders a Router inside of it and
+// does not need the providers provided by our wrapped render function.
+// Use the original to avoid doubling up.
+// eslint-disable-next-line no-restricted-imports
+import {render, screen} from '@testing-library/react';
 
 import PipelineView from 'sentry/views/integrationPipeline/pipelineView';
 
@@ -17,12 +21,7 @@ describe('PipelineView', () => {
   });
 
   it('renders awsLambdaProjectSelect', () => {
-    render(<PipelineView pipelineName="awsLambdaProjectSelect" someField="someVal" />, {
-      // XXX(epurkhiser): The pipeline view renders a Router inside of it. Stop
-      // our test renderer from rendering it's Router by setting the wrapper to
-      // undefined.
-      wrapper: undefined,
-    });
+    render(<PipelineView pipelineName="awsLambdaProjectSelect" someField="someVal" />);
 
     expect(screen.getByText('mock_AwsLambdaProjectSelect')).toBeInTheDocument();
 
@@ -32,13 +31,8 @@ describe('PipelineView', () => {
   it('errros on invalid pipelineName', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(() =>
-      render(<PipelineView pipelineName="other" />, {
-        // XXX(epurkhiser): The pipeline view renders a Router inside of it. Stop
-        // our test renderer from rendering it's Router by setting the wrapper to
-        // undefined.
-        wrapper: undefined,
-      })
-    ).toThrow('Invalid pipeline name other');
+    expect(() => render(<PipelineView pipelineName="other" />)).toThrow(
+      'Invalid pipeline name other'
+    );
   });
 });


### PR DESCRIPTION
We need to stop overriding `wrapper` directly: https://github.com/getsentry/sentry/pull/83400/files#r1915302805