### PR TITLE
ref(react19): Remove various styled defaultProps

### DIFF
--- a/static/app/components/alerts/toastIndicator.tsx
+++ b/static/app/components/alerts/toastIndicator.tsx
@@ -43,6 +43,14 @@ function ToastIndicator({indicator, onDismiss, className, ...props}: Props) {
       onClick={handleClick}
       data-test-id={type ? `toast-${type}` : 'toast'}
       className={classNames(className, 'ref-toast', `ref-${type}`)}
+      initial={{opacity: 0, y: 70}}
+      animate={{opacity: 1, y: 0}}
+      exit={{opacity: 0, y: 70}}
+      transition={testableTransition({
+        type: 'spring',
+        stiffness: 450,
+        damping: 25,
+      })}
       {...props}
     >
       {type === 'loading' ? (
@@ -73,26 +81,6 @@ const Toast = styled(motion.div)`
   box-shadow: ${p => p.theme.dropShadowHeavy};
   position: relative;
 `;
-
-Toast.defaultProps = {
-  initial: {
-    opacity: 0,
-    y: 70,
-  },
-  animate: {
-    opacity: 1,
-    y: 0,
-  },
-  exit: {
-    opacity: 0,
-    y: 70,
-  },
-  transition: testableTransition({
-    type: 'spring',
-    stiffness: 450,
-    damping: 25,
-  }),
-};
 
 const Icon = styled('div', {shouldForwardProp: p => p !== 'type'})<{type: string}>`
   margin-right: ${space(0.75)};

--- a/static/app/components/banner.tsx
+++ b/static/app/components/banner.tsx
@@ -59,7 +59,17 @@ function Banner({
   return (
     <BannerWrapper backgroundImg={backgroundImg} className={className}>
       {backgroundComponent}
-      {isDismissable ? <CloseButton onClick={dismiss} aria-label={t('Close')} /> : null}
+      {isDismissable ? (
+        <CloseButton
+          type="button"
+          borderless
+          size="xs"
+          priority="link"
+          icon={<IconClose />}
+          onClick={dismiss}
+          aria-label={t('Close')}
+        />
+      ) : null}
       <BannerContent>
         <BannerTitle>{title}</BannerTitle>
         <BannerSubtitle>{subtitle}</BannerSubtitle>
@@ -138,13 +148,5 @@ const CloseButton = styled(Button)`
   cursor: pointer;
   z-index: 1;
 `;
-
-CloseButton.defaultProps = {
-  icon: <IconClose />,
-  ['aria-label']: t('Close'),
-  priority: 'link',
-  borderless: true,
-  size: 'xs',
-};
 
 export default Banner;

--- a/static/app/components/charts/loadingPanel.tsx
+++ b/static/app/components/charts/loadingPanel.tsx
@@ -3,6 +3,9 @@ import styled from '@emotion/styled';
 import LoadingMask from 'sentry/components/loadingMask';
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * @default '200px'
+   */
   height?: string;
 }
 
@@ -14,14 +17,10 @@ const LoadingPanel = styled(({height: _height, ...props}: Props) => (
   flex: 1;
   flex-shrink: 0;
   overflow: hidden;
-  height: ${p => p.height};
+  height: ${p => p.height ?? '200px'};
   position: relative;
   border-color: transparent;
   margin-bottom: 0;
 `;
-
-LoadingPanel.defaultProps = {
-  height: '200px',
-};
 
 export default LoadingPanel;

--- a/static/app/components/checkInTimeline/timelineZoom.tsx
+++ b/static/app/components/checkInTimeline/timelineZoom.tsx
@@ -146,7 +146,22 @@ function useTimelineZoom<E extends HTMLElement>({enabled = true, onSelect}: Opti
   }, [enabled, handleMouseMove, handleMouseDown, handleMouseUp]);
 
   const timelineSelector = (
-    <AnimatePresence>{isActive && <Selection role="presentation" />}</AnimatePresence>
+    <AnimatePresence>
+      {isActive && (
+        <Selection
+          role="presentation"
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          transition={testableTransition({duration: 0.2})}
+          variants={{
+            initial: {opacity: 0},
+            animate: {opacity: 1},
+            exit: {opacity: 0},
+          }}
+        />
+      )}
+    </AnimatePresence>
   );
 
   return {selectionContainerRef: containerRef, isActive, timelineSelector};
@@ -164,17 +179,5 @@ const Selection = styled(motion.div)`
   width: var(--selectionWidth);
   z-index: 2;
 `;
-
-Selection.defaultProps = {
-  initial: 'initial',
-  animate: 'animate',
-  exit: 'exit',
-  transition: testableTransition({duration: 0.2}),
-  variants: {
-    initial: {opacity: 0},
-    animate: {opacity: 1},
-    exit: {opacity: 0},
-  },
-};
 
 export {useTimelineZoom};

--- a/static/app/components/circleIndicator.tsx
+++ b/static/app/components/circleIndicator.tsx
@@ -2,22 +2,29 @@ import styled from '@emotion/styled';
 
 type Props = {
   color?: string;
+  /**
+   * @default true
+   */
   enabled?: boolean;
+  /**
+   * @default 14
+   */
   size?: number;
+};
+
+const defaultProps = {
+  enabled: true,
+  size: 14,
 };
 
 const CircleIndicator = styled('div')<Props>`
   display: inline-block;
   position: relative;
   border-radius: 50%;
-  height: ${p => p.size}px;
-  width: ${p => p.size}px;
-  background: ${p => p.color ?? (p.enabled ? p.theme.success : p.theme.error)};
+  height: ${p => p.size ?? defaultProps.size}px;
+  width: ${p => p.size ?? defaultProps.size}px;
+  background: ${p =>
+    p.color ?? (p.enabled ?? defaultProps.enabled ? p.theme.success : p.theme.error)};
 `;
-
-CircleIndicator.defaultProps = {
-  enabled: true,
-  size: 14,
-};
 
 export default CircleIndicator;

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -233,7 +233,19 @@ function GlobalModal({onClose}: Props) {
         >
           <AnimatePresence>
             {visible && (
-              <Modal role="dialog" aria-modal css={options.modalCss}>
+              <Modal
+                role="dialog"
+                aria-modal
+                css={options.modalCss}
+                initial={{opacity: 0, y: -10}}
+                animate={{opacity: 1, y: 0}}
+                exit={{opacity: 0, y: 15}}
+                transition={testableTransition({
+                  type: 'spring',
+                  stiffness: 450,
+                  damping: 25,
+                })}
+              >
                 <Content role="document">{renderedChild}</Content>
               </Modal>
             )}
@@ -284,16 +296,6 @@ const Modal = styled(motion.div)`
     padding: ${space(4)} ${space(2)};
   }
 `;
-
-Modal.defaultProps = {
-  initial: {opacity: 0, y: -10},
-  animate: {opacity: 1, y: 0},
-  exit: {opacity: 0, y: 15},
-  transition: testableTransition({
-    opacity: {duration: 0.2},
-    y: {duration: 0.25},
-  }),
-};
 
 const Content = styled('div')`
   background: ${p => p.theme.background};

--- a/static/app/components/highlightModalContainer.tsx
+++ b/static/app/components/highlightModalContainer.tsx
@@ -5,14 +5,20 @@ import BottomLeft from 'sentry-images/pattern/highlight-bottom-left.svg';
 import TopRight from 'sentry-images/pattern/highlight-top-right.svg';
 
 type Props = {
-  bottomWidth: string;
   children: React.ReactNode;
-  topWidth: string;
+  /**
+   * @default '200px'
+   */
+  bottomWidth?: string;
+  /**
+   * @default '400px'
+   */
+  topWidth?: string;
 };
 
 export default function HighlightModalContainer({
-  topWidth,
-  bottomWidth,
+  topWidth = '400px',
+  bottomWidth = '200px',
   children,
 }: Props) {
   return (
@@ -41,8 +47,3 @@ const PositionBottomLeft = styled('img')<{width: string}>`
   pointer-events: none;
   border-radius: 0 0 0 ${p => p.theme.modalBorderRadius};
 `;
-
-HighlightModalContainer.defaultProps = {
-  topWidth: '400px',
-  bottomWidth: '200px',
-};

--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -10,12 +10,18 @@ interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
   /**
    * Controls if the opacity is increased when the element is in a
    * selected or expanded state (aria-selected='true' or aria-expanded='true')
+   *
+   * @default true
    */
   hasSelectedBackground?: boolean;
   higherOpacity?: boolean;
   isHovered?: boolean;
   isPressed?: boolean;
 }
+
+const defaultProps = {
+  hasSelectedBackground: true,
+};
 
 const InteractionStateLayer = styled(
   (props: StateLayerProps) => {
@@ -74,7 +80,7 @@ const InteractionStateLayer = styled(
           *:active > && {
             opacity: ${p.higherOpacity ? 0.12 : 0.09};
           }
-          ${p.hasSelectedBackground &&
+          ${(p.hasSelectedBackground ?? defaultProps.hasSelectedBackground) &&
           css`
             *[aria-expanded='true'] > &&,
             *[aria-selected='true'] > && {
@@ -89,9 +95,5 @@ const InteractionStateLayer = styled(
     opacity: 0;
   }
 `;
-
-InteractionStateLayer.defaultProps = {
-  hasSelectedBackground: true,
-};
 
 export default InteractionStateLayer;

--- a/static/app/components/letterAvatar.tsx
+++ b/static/app/components/letterAvatar.tsx
@@ -106,10 +106,6 @@ const LetterAvatar = styled(
   ${imageStyle};
 `;
 
-LetterAvatar.defaultProps = {
-  round: false,
-};
-
 export default forwardRef<SVGSVGElement, Props>((props, ref) => (
   <LetterAvatar forwardedRef={ref} {...props} />
 ));

--- a/static/app/components/pageOverlay.tsx
+++ b/static/app/components/pageOverlay.tsx
@@ -32,26 +32,20 @@ const subItemAnimation = {
   },
 };
 
-const Header = styled(motion.h2)`
+const Header = styled((props: React.ComponentProps<typeof motion.h2>) => (
+  <motion.h2 variants={subItemAnimation} transition={testableTransition()} {...props} />
+))`
   display: flex;
   align-items: center;
   font-weight: ${p => p.theme.fontWeightNormal};
   margin-bottom: ${space(1)};
 `;
 
-Header.defaultProps = {
-  variants: subItemAnimation,
-  transition: testableTransition(),
-};
-
-const Body = styled(motion.div)`
+const Body = styled((props: React.ComponentProps<typeof motion.div>) => (
+  <motion.div variants={subItemAnimation} transition={testableTransition()} {...props} />
+))`
   margin-bottom: ${space(2)};
 `;
-
-Body.defaultProps = {
-  variants: subItemAnimation,
-  transition: testableTransition(),
-};
 
 type ContentOpts = {
   Body: typeof Body;
@@ -206,7 +200,13 @@ function PageOverlay({
   return (
     <MaskedContent {...props}>
       {children}
-      <ContentWrapper ref={contentRef} transition={transition} variants={{animate: {}}}>
+      <ContentWrapper
+        initial="initial"
+        animate="animate"
+        ref={contentRef}
+        transition={transition}
+        variants={{animate: {}}}
+      >
         {BackgroundComponent && (
           <Background>
             <BackgroundComponent anchorRef={anchorRef} />
@@ -233,11 +233,6 @@ const ContentWrapper = styled(motion.div)`
   padding: 10%;
   z-index: 900;
 `;
-
-ContentWrapper.defaultProps = {
-  initial: 'initial',
-  animate: 'animate',
-};
 
 const Background = styled('div')`
   ${absoluteFull}

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -286,12 +286,6 @@ const ClearButton = styled(Button)`
   color: ${p => p.theme.textColor};
 `;
 
-ClearButton.defaultProps = {
-  icon: <IconClose isCircled />,
-  borderless: true,
-  size: 'xs',
-};
-
 const PlatformCard = styled(({platform, selected, onClear, ...props}) => (
   <div {...props}>
     <StyledPlatformIcon
@@ -302,7 +296,15 @@ const PlatformCard = styled(({platform, selected, onClear, ...props}) => (
       format="lg"
     />
     <h3>{platform.name}</h3>
-    {selected && <ClearButton onClick={onClear} aria-label={t('Clear')} />}
+    {selected && (
+      <ClearButton
+        icon={<IconClose isCircled />}
+        borderless
+        size="xs"
+        onClick={onClear}
+        aria-label={t('Clear')}
+      />
+    )}
   </div>
 ))`
   position: relative;

--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -19,7 +19,7 @@ const checkedCss = (p: CheckedProps, theme: Theme) => css`
   opacity: ${p.disabled ? 0.4 : null};
 `;
 
-const Radio = styled('input')<CheckedProps>`
+const Radio = styled((props: CheckedProps) => <input type="radio" {...props} />)`
   display: flex;
   padding: 0;
   width: ${p => (p.radioSize === 'small' ? '1rem' : '1.5rem')};
@@ -51,9 +51,5 @@ const Radio = styled('input')<CheckedProps>`
     ${p => checkedCss(p, p.theme)}
   }
 `;
-
-Radio.defaultProps = {
-  type: 'radio',
-};
 
 export default Radio;

--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -1,3 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid';
 import type {Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -19,7 +20,9 @@ const checkedCss = (p: CheckedProps, theme: Theme) => css`
   opacity: ${p.disabled ? 0.4 : null};
 `;
 
-const Radio = styled((props: CheckedProps) => <input type="radio" {...props} />)`
+const Radio = styled((props: CheckedProps) => <input type="radio" {...props} />, {
+  shouldForwardProp: isPropValid,
+})`
   display: flex;
   padding: 0;
   width: ${p => (p.radioSize === 'small' ? '1rem' : '1.5rem')};

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -111,7 +111,7 @@ function SidebarPanel({
       {title ? (
         <SidebarPanelHeader>
           <Title>{title}</Title>
-          <PanelClose onClick={hidePanel} aria-label={t('Close Panel')} />
+          <PanelClose size="lg" onClick={hidePanel} aria-label={t('Close Panel')} />
         </SidebarPanelHeader>
       ) : null}
       <SidebarPanelBody hasHeader={!!title}>{children}</SidebarPanelBody>
@@ -152,10 +152,6 @@ const PanelClose = styled(IconClose)`
     color: ${p => p.theme.textColor};
   }
 `;
-
-PanelClose.defaultProps = {
-  size: 'lg',
-};
 
 const Title = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};

--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -16,8 +16,13 @@ type Props = {
    * In Safari (July 2022) you will see this instead: `...https://example.co`.
    *
    * See: https://stackoverflow.com/a/24800788
+   *
+   * @default 'right'
    */
   ellipsisDirection?: 'left' | 'right';
+  /**
+   * @default false
+   */
   isParagraph?: boolean;
   style?: CSSProperties;
 };
@@ -26,8 +31,8 @@ const TextOverflow = styled(
   ({
     children,
     className,
-    ellipsisDirection,
-    isParagraph,
+    ellipsisDirection = 'right',
+    isParagraph = false,
     ['data-test-id']: dataTestId,
     style,
   }: Props) => {
@@ -56,10 +61,5 @@ const TextOverflow = styled(
   width: auto;
   line-height: 1.2;
 `;
-
-TextOverflow.defaultProps = {
-  ellipsisDirection: 'right',
-  isParagraph: false,
-};
 
 export default TextOverflow;

--- a/static/app/views/onboarding/components/createProjectsFooter.tsx
+++ b/static/app/views/onboarding/components/createProjectsFooter.tsx
@@ -186,7 +186,7 @@ export function CreateProjectsFooter({
   return (
     <GenericFooter>
       {genSkipOnboardingLink()}
-      <SelectionWrapper>
+      <SelectionWrapper transition={testableTransition({duration: 1.8})}>
         {selectedPlatform ? (
           <Fragment>
             <div>
@@ -204,7 +204,7 @@ export function CreateProjectsFooter({
           </Fragment>
         ) : null}
       </SelectionWrapper>
-      <ButtonWrapper>
+      <ButtonWrapper transition={testableTransition({duration: 1.3})}>
         <Button
           priority="primary"
           onClick={handleProjectCreation}
@@ -229,12 +229,6 @@ const SelectionWrapper = styled(motion.div)`
   }
 `;
 
-SelectionWrapper.defaultProps = {
-  transition: testableTransition({
-    duration: 1.8,
-  }),
-};
-
 const ButtonWrapper = styled(motion.div)`
   display: flex;
   height: 100%;
@@ -242,12 +236,6 @@ const ButtonWrapper = styled(motion.div)`
   margin-right: ${space(4)};
   margin-left: ${space(4)};
 `;
-
-ButtonWrapper.defaultProps = {
-  transition: testableTransition({
-    duration: 1.3,
-  }),
-};
 
 const SelectedPlatformIcon = styled(PlatformIcon)`
   margin-right: ${space(1)};

--- a/static/app/views/onboarding/components/genericFooter.tsx
+++ b/static/app/views/onboarding/components/genericFooter.tsx
@@ -3,7 +3,18 @@ import {motion} from 'framer-motion';
 
 import testableTransition from 'sentry/utils/testableTransition';
 
-const GenericFooter = styled(motion.div)`
+const GenericFooter = styled((props: React.ComponentProps<typeof motion.div>) => (
+  <motion.div
+    initial="initial"
+    animate="animate"
+    exit="exit"
+    variants={{animate: {}}}
+    transition={testableTransition({
+      staggerChildren: 0.2,
+    })}
+    {...props}
+  />
+))`
   width: 100%;
   position: fixed;
   bottom: 0;
@@ -15,15 +26,5 @@ const GenericFooter = styled(motion.div)`
   justify-content: space-between;
   box-shadow: ${p => p.theme.dropShadowHeavyTop};
 `;
-
-GenericFooter.defaultProps = {
-  initial: 'initial',
-  animate: 'animate',
-  exit: 'exit',
-  variants: {animate: {}},
-  transition: testableTransition({
-    staggerChildren: 0.2,
-  }),
-};
 
 export default GenericFooter;

--- a/static/app/views/onboarding/components/stepHeading.tsx
+++ b/static/app/views/onboarding/components/stepHeading.tsx
@@ -4,7 +4,21 @@ import {motion} from 'framer-motion';
 import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
 
-const StepHeading = styled(motion.h2)<{step: number}>`
+const StepHeading = styled(
+  (props: React.ComponentProps<typeof motion.h2> & {step: number}) => (
+    <motion.h2
+      variants={{
+        initial: {clipPath: 'inset(0% 100% 0% 0%)', opacity: 1},
+        animate: {clipPath: 'inset(0% 0% 0% 0%)', opacity: 1},
+        exit: {opacity: 0},
+      }}
+      transition={testableTransition({
+        duration: 0.3,
+      })}
+      {...props}
+    />
+  )
+)`
   margin-left: calc(-${space(2)} - 30px);
   position: relative;
   display: inline-grid;
@@ -25,16 +39,5 @@ const StepHeading = styled(motion.h2)<{step: number}>`
     font-size: 1rem;
   }
 `;
-
-StepHeading.defaultProps = {
-  variants: {
-    initial: {clipPath: 'inset(0% 100% 0% 0%)', opacity: 1},
-    animate: {clipPath: 'inset(0% 0% 0% 0%)', opacity: 1},
-    exit: {opacity: 0},
-  },
-  transition: testableTransition({
-    duration: 0.3,
-  }),
-};
 
 export default StepHeading;

--- a/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
@@ -68,23 +68,17 @@ function ChartRow(props: ChartRowProps) {
   );
 }
 
-export function TripleChartRow(props: ChartRowProps) {
-  return <ChartRow {...props} />;
+type DefaultProps = 'chartCount' | 'chartHeight';
+type ChartRowPropsWithDefaults = Omit<ChartRowProps, DefaultProps> &
+  Pick<Partial<ChartRowProps>, DefaultProps>;
+
+export function TripleChartRow(props: ChartRowPropsWithDefaults) {
+  return <ChartRow chartCount={3} chartHeight={100} {...props} />;
 }
 
-TripleChartRow.defaultProps = {
-  chartCount: 3,
-  chartHeight: 100,
-};
-
-export function DoubleChartRow(props: ChartRowProps) {
-  return <ChartRow {...props} />;
+export function DoubleChartRow(props: ChartRowPropsWithDefaults) {
+  return <ChartRow chartCount={2} chartHeight={150} {...props} />;
 }
-
-DoubleChartRow.defaultProps = {
-  chartCount: 2,
-  chartHeight: 150,
-};
 
 const StyledRow = styled(PerformanceLayoutBodyRow)`
   margin-bottom: ${space(2)};

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -634,15 +634,6 @@ const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
   margin: ${space(2)} ${space(3)};
 `;
 
-const MenuAction = styled('div')<{['data-test-id']?: string}>`
-  white-space: nowrap;
-  color: ${p => p.theme.textColor};
-`;
-
-MenuAction.defaultProps = {
-  'data-test-id': 'menu-action',
-};
-
 const StyledEmptyStateWarning = styled(EmptyStateWarning)`
   min-height: 300px;
   justify-content: center;

--- a/static/app/views/projectInstall/gettingStarted.tsx
+++ b/static/app/views/projectInstall/gettingStarted.tsx
@@ -8,8 +8,4 @@ const GettingStarted = styled(Layout.Page)`
   padding-top: ${space(3)};
 `;
 
-GettingStarted.defaultProps = {
-  withPadding: true,
-};
-
 export default GettingStarted;

--- a/static/app/views/projectInstall/platformOrIntegration.tsx
+++ b/static/app/views/projectInstall/platformOrIntegration.tsx
@@ -48,7 +48,7 @@ function PlatformOrIntegration({params}: Props) {
 
   return (
     <OnboardingContextProvider>
-      <GettingStarted>
+      <GettingStarted withPadding>
         <ProjectInstallPlatform
           project={project}
           loading={loadingProjects}

--- a/static/app/views/settings/components/identityIcon.tsx
+++ b/static/app/views/settings/components/identityIcon.tsx
@@ -47,27 +47,28 @@ export const ICON_PATHS: Record<string, string> = {
 };
 
 type Props = {
+  /**
+   * @default '_default'
+   */
   providerId?: string;
+  /**
+   * @default 36
+   */
   size?: number;
 };
 
 const IdentityIcon = styled('div')<Props>`
   position: relative;
-  height: ${p => p.size}px;
-  width: ${p => p.size}px;
+  height: ${p => p.size ?? 36}px;
+  width: ${p => p.size ?? 36}px;
   border-radius: 2px;
   border: 0;
   display: inline-block;
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;
-  background-image: url(${p =>
-    (p.providerId !== undefined && ICON_PATHS[p.providerId]) || DEFAULT_ICON});
+  background-image: url(${({providerId = '_default'}) =>
+    (providerId !== undefined && ICON_PATHS[providerId]) || DEFAULT_ICON});
 `;
-
-IdentityIcon.defaultProps = {
-  providerId: '_default',
-  size: 36,
-};
 
 export default IdentityIcon;


### PR DESCRIPTION
Part of https://github.com/getsentry/frontend-tsc/issues/68

defaultProps are removed in react 19 for functional components, we can usually pass props in another way or apply them in the one place they're used
