### PR TITLE
fix(widget-builder): Aggregates with no column not wiped

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -828,6 +828,36 @@ describe('Visualize', () => {
     );
   });
 
+  it('uses the provided value for a value parameter field', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              field: ['count_if(transaction.duration,equals,300)'],
+            },
+          }),
+        }),
+      }
+    );
+
+    // Simulate clearing and typing a new value from the user
+    await userEvent.type(
+      screen.getByDisplayValue('300'),
+      '{backspace}{backspace}{backspace}400'
+    );
+
+    // Unfocus the field
+    await userEvent.tab();
+
+    expect(await screen.findByDisplayValue('400')).toBeInTheDocument();
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -802,6 +802,32 @@ describe('Visualize', () => {
     expect(listbox[1]).toHaveTextContent('user');
   });
 
+  it('clears out the field when the selected aggregate has no parameters', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              field: ['transaction.duration'],
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'count'}));
+
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'None'
+    );
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -710,7 +710,7 @@ function AggregateParameterField({
     const inputProps = {
       required: parameter.required,
       value:
-        parameter.value ?? ('defaultValue' in parameter && parameter?.defaultValue) ?? '',
+        currentValue ?? ('defaultValue' in parameter && parameter?.defaultValue) ?? '',
       onUpdate: value => {
         onChange(value);
       },


### PR DESCRIPTION
Take the following scenario:
- Choose the transaction dataset
- select `transaction.duration` (i.e. set aggregate to None, set `transaction.duration` in the column field)
- update the aggregate to `count()`

The request is being made with `count(transaction_duration)` which shouldn't happen. I added a validate parameter helper that checks the parameter type, validates it, and if it's not valid then set it to the default value.