### PR TITLE
feat(widget-builder): Big number thresholds

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
@@ -87,7 +87,7 @@ function ThresholdRow({
   );
 }
 
-function ThresholdsStep({
+export function Thresholds({
   thresholdsConfig,
   onThresholdChange,
   onUnitChange,
@@ -101,7 +101,6 @@ function ThresholdsStep({
   const unitOptions = ['duration', 'rate'].includes(dataType)
     ? getThresholdUnitSelectOptions(dataType)
     : [];
-
   const thresholdRowProps: ThresholdRowProp[] = [
     {
       maxKey: ThresholdMaxKeys.MAX_1,
@@ -167,6 +166,28 @@ function ThresholdsStep({
   ];
 
   return (
+    <ThresholdsContainer>
+      {thresholdRowProps.map((props, index) => (
+        <ThresholdRow
+          {...props}
+          onThresholdChange={onThresholdChange}
+          onUnitChange={onUnitChange}
+          key={index}
+        />
+      ))}
+    </ThresholdsContainer>
+  );
+}
+
+function ThresholdsStep({
+  thresholdsConfig,
+  onThresholdChange,
+  onUnitChange,
+  errors,
+  dataType = '',
+  dataUnit = '',
+}: ThresholdsStepProps) {
+  return (
     <BuildStep
       title={t('Set thresholds')}
       description={tct(
@@ -179,16 +200,14 @@ function ThresholdsStep({
         }
       )}
     >
-      <ThresholdsContainer>
-        {thresholdRowProps.map((props, index) => (
-          <ThresholdRow
-            {...props}
-            onThresholdChange={onThresholdChange}
-            onUnitChange={onUnitChange}
-            key={index}
-          />
-        ))}
-      </ThresholdsContainer>
+      <Thresholds
+        thresholdsConfig={thresholdsConfig}
+        onThresholdChange={onThresholdChange}
+        onUnitChange={onUnitChange}
+        errors={errors}
+        dataType={dataType}
+        dataUnit={dataUnit}
+      />
     </BuildStep>
   );
 }
@@ -219,7 +238,7 @@ const StyledSelectField = styled(SelectField)`
   min-width: 150px;
 `;
 
-const HighlightedText = styled('span')`
+export const HighlightedText = styled('span')`
   font-family: ${p => p.theme.text.familyMono};
   color: ${p => p.theme.pink300};
 `;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
@@ -18,12 +18,12 @@ type ThresholdErrors = {
 };
 
 type ThresholdsStepProps = {
-  errors: ThresholdErrors;
   onThresholdChange: (maxKey: ThresholdMaxKeys, value: string) => void;
   onUnitChange: (unit: string) => void;
   thresholdsConfig: ThresholdsConfig | null;
   dataType?: string;
   dataUnit?: string;
+  errors?: ThresholdErrors;
 };
 
 type ThresholdRowProp = {

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -1,0 +1,93 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {useNavigate} from 'sentry/utils/useNavigate';
+import Thresholds from 'sentry/views/dashboards/widgetBuilder/components/thresholds';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+
+jest.mock('sentry/utils/useNavigate');
+describe('Thresholds', () => {
+  let mockNavigate!: jest.Mock;
+
+  beforeEach(() => {
+    mockNavigate = jest.fn();
+    jest.mocked(useNavigate).mockReturnValue(mockNavigate);
+  });
+
+  it('sets thresholds to undefined if the thresholds are fully wiped', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Thresholds dataType="duration" dataUnit="millisecond" />
+      </WidgetBuilderProvider>,
+      {
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              thresholds: '{"max_values":{"max1":100},"unit":"millisecond"}',
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.clear(screen.getByLabelText('First Maximum'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          thresholds: undefined,
+        }),
+      })
+    );
+  });
+
+  it('sets a threshold when applied', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Thresholds dataType="duration" dataUnit="millisecond" />
+      </WidgetBuilderProvider>
+    );
+
+    await userEvent.type(screen.getByLabelText('First Maximum'), '100');
+    await userEvent.type(screen.getByLabelText('Second Maximum'), '200');
+    await userEvent.tab();
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          thresholds: '{"max_values":{"max1":100,"max2":200},"unit":null}',
+        }),
+      })
+    );
+  });
+
+  it('updates the unit when applied', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Thresholds dataType="duration" dataUnit="millisecond" />
+      </WidgetBuilderProvider>,
+      {
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"millisecond"}',
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getAllByText('millisecond')[0]!);
+    await userEvent.click(screen.getByText('second'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"second"}',
+        }),
+      })
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -71,6 +71,7 @@ function ThresholdsSection({dataType, dataUnit}: {dataType?: string; dataUnit?: 
         }}
         dataType={dataType}
         dataUnit={dataUnit}
+        // TODO: Add errors
         errors={{}}
       />
     </Fragment>

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -1,0 +1,80 @@
+import {Fragment} from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+
+import {t, tct} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {
+  HighlightedText,
+  Thresholds,
+} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
+import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+function ThresholdsSection({dataType, dataUnit}: {dataType?: string; dataUnit?: string}) {
+  const {state, dispatch} = useWidgetBuilderContext();
+  return (
+    <Fragment>
+      <SectionHeader
+        title={t('Thresholds')}
+        tooltipText={tct(
+          'Set thresholds to identify problematic widgets. For example: setting the max values, [thresholdValues] will display a green indicator for results in the range [greenRange], a yellow indicator for results in the range [yellowRange] and a red indicator for results above [redValue].',
+          {
+            thresholdValues: <HighlightedText>(green: 100, yellow: 200)</HighlightedText>,
+            greenRange: <HighlightedText>[0 - 100]</HighlightedText>,
+            yellowRange: <HighlightedText>(100 - 200]</HighlightedText>,
+            redValue: <HighlightedText>200</HighlightedText>,
+          }
+        )}
+        optional
+      />
+      <Thresholds
+        thresholdsConfig={state.thresholds ?? null}
+        onThresholdChange={(maxKey, value) => {
+          let newThresholds = cloneDeep(state.thresholds);
+
+          if (!defined(newThresholds) && value) {
+            newThresholds = {max_values: {}, unit: null};
+          }
+
+          if (newThresholds) {
+            if (value) {
+              newThresholds.max_values[maxKey] = parseInt(value, 10);
+            } else {
+              delete newThresholds.max_values[maxKey];
+            }
+          }
+
+          // Check if the value cleared all of the max values
+          if (
+            newThresholds &&
+            Object.values(newThresholds.max_values).every(
+              nextMaxValue => !defined(nextMaxValue)
+            )
+          ) {
+            newThresholds = undefined;
+          }
+
+          dispatch({
+            type: BuilderStateAction.SET_THRESHOLDS,
+            payload: newThresholds,
+          });
+        }}
+        onUnitChange={unit => {
+          dispatch({
+            type: BuilderStateAction.SET_THRESHOLDS,
+            payload: {
+              max_values: state.thresholds?.max_values ?? {},
+              unit,
+            },
+          });
+        }}
+        dataType={dataType}
+        dataUnit={dataUnit}
+        errors={{}}
+      />
+    </Fragment>
+  );
+}
+
+export default ThresholdsSection;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -345,4 +345,36 @@ describe('WidgetBuilderSlideout', () => {
 
     expect(await screen.findByPlaceholderText('Add Alias')).toHaveValue('');
   });
+
+  it('only renders thresholds for big number widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.BIG_NUMBER,
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Thresholds')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -9,6 +9,7 @@ import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -23,11 +24,15 @@ import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
-import {WidgetPreviewContainer} from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
+import {
+  type ThresholdMetaState,
+  WidgetPreviewContainer,
+} from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 import WidgetBuilderQueryFilterBuilder from 'sentry/views/dashboards/widgetBuilder/components/queryFilterBuilder';
 import RPCToggle from 'sentry/views/dashboards/widgetBuilder/components/rpcToggle';
 import SaveButton from 'sentry/views/dashboards/widgetBuilder/components/saveButton';
 import WidgetBuilderSortBySelector from 'sentry/views/dashboards/widgetBuilder/components/sortBySelector';
+import ThresholdsSection from 'sentry/views/dashboards/widgetBuilder/components/thresholds';
 import WidgetBuilderTypeSelector from 'sentry/views/dashboards/widgetBuilder/components/typeSelector';
 import Visualize from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import WidgetTemplatesList from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
@@ -44,6 +49,8 @@ type WidgetBuilderSlideoutProps = {
   openWidgetTemplates: boolean;
   setIsPreviewDraggable: (draggable: boolean) => void;
   setOpenWidgetTemplates: (openWidgetTemplates: boolean) => void;
+  onDataFetched?: (tableData: TableDataWithTitle[]) => void;
+  thresholdMetaState?: ThresholdMetaState;
 };
 
 function WidgetBuilderSlideout({
@@ -57,6 +64,8 @@ function WidgetBuilderSlideout({
   isWidgetInvalid,
   openWidgetTemplates,
   setOpenWidgetTemplates,
+  onDataFetched,
+  thresholdMetaState,
 }: WidgetBuilderSlideoutProps) {
   const organization = useOrganization();
   const {state} = useWidgetBuilderContext();
@@ -149,6 +158,7 @@ function WidgetBuilderSlideout({
                     dashboard={dashboard}
                     dashboardFilters={dashboardFilters}
                     isWidgetInvalid={isWidgetInvalid}
+                    onDataFetched={onDataFetched}
                   />
                 </Section>
               )}
@@ -161,6 +171,14 @@ function WidgetBuilderSlideout({
                 onQueryConditionChange={onQueryConditionChange}
               />
             </Section>
+            {state.displayType === DisplayType.BIG_NUMBER && (
+              <Section>
+                <ThresholdsSection
+                  dataType={thresholdMetaState?.dataType}
+                  dataUnit={thresholdMetaState?.dataUnit}
+                />
+              </Section>
+            )}
             {isChartWidget && (
               <Section>
                 <WidgetBuilderGroupBySelector />
@@ -185,6 +203,7 @@ function WidgetBuilderSlideout({
                     dashboard={dashboard}
                     dashboardFilters={dashboardFilters}
                     isWidgetInvalid={isWidgetInvalid}
+                    onDataFetched={onDataFetched}
                   />
                 </Section>
               )}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -1,4 +1,5 @@
 import PanelAlert from 'sentry/components/panels/panelAlert';
+import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -19,12 +20,14 @@ interface WidgetPreviewProps {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
   isWidgetInvalid?: boolean;
+  onDataFetched?: (tableData: TableDataWithTitle[]) => void;
 }
 
 function WidgetPreview({
   dashboard,
   dashboardFilters,
   isWidgetInvalid,
+  onDataFetched,
 }: WidgetPreviewProps) {
   const organization = useOrganization();
   const location = useLocation();
@@ -74,10 +77,7 @@ function WidgetPreview({
           : undefined
       }
       widgetLegendState={widgetLegendState}
-      // TODO: This will be filled in once we start supporting thresholds
-      onDataFetched={() => {}}
-      // onDataFetched={onDataFetched}
-
+      onDataFetched={onDataFetched}
       // TODO: This requires the current widget ID and a helper to update the
       // dashboard state to be added
       onWidgetSplitDecision={() => {}}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -573,6 +573,36 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.selectedAggregate).toBeUndefined();
     });
+
+    it('resets thresholds when the display type is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ERRORS,
+            displayType: DisplayType.BIG_NUMBER,
+            thresholds: '{"max_values":{"max1":200,"max2":300},"unit":"milliseconds"}',
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.thresholds).toEqual({
+        max_values: {max1: 200, max2: 300},
+        unit: 'milliseconds',
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.TABLE,
+        });
+      });
+
+      expect(result.current.state.thresholds).toBeUndefined();
+    });
   });
 
   describe('dataset', () => {
@@ -841,6 +871,36 @@ describe('useWidgetBuilderState', () => {
       });
 
       expect(result.current.state.sort).toEqual([]);
+    });
+
+    it('resets thresholds when the dataset is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ERRORS,
+            displayType: DisplayType.BIG_NUMBER,
+            thresholds: '{"max_values":{"max1":200,"max2":300},"unit":"milliseconds"}',
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.thresholds).toEqual({
+        max_values: {max1: 200, max2: 300},
+        unit: 'milliseconds',
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.TRANSACTIONS,
+        });
+      });
+
+      expect(result.current.state.thresholds).toBeUndefined();
     });
   });
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -246,6 +246,7 @@ function useWidgetBuilderState(): {
               ...(yAxisWithoutAlias?.slice(0, MAX_NUM_Y_AXES) ?? []),
             ]);
           }
+          setThresholds(undefined);
           setSelectedAggregate(undefined);
           break;
         case BuilderStateAction.SET_DATASET:
@@ -284,6 +285,8 @@ function useWidgetBuilderState(): {
             );
             setSort(decodeSorts(config.defaultWidgetQuery.orderby));
           }
+
+          setThresholds(undefined);
           setQuery([config.defaultWidgetQuery.conditions]);
           setSelectedAggregate(undefined);
           break;

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -120,4 +120,21 @@ describe('convertBuilderStateToWidget', function () {
 
     expect(widget.queries[0]!.selectedAggregate).toBeUndefined();
   });
+
+  it('applies the thresholds to the widget', () => {
+    const mockState: WidgetBuilderState = {
+      query: ['transaction.duration:>100'],
+      thresholds: {
+        max_values: {
+          max1: 200,
+          max2: 300,
+        },
+        unit: 'milliseconds',
+      },
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.thresholds).toEqual(mockState.thresholds);
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -64,6 +64,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     queries: widgetQueries,
     widgetType: state.dataset,
     limit: state.limit,
+    thresholds: state.thresholds,
   };
 }
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -98,4 +98,21 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(widget);
     expect(params.selectedAggregate).toBe(0);
   });
+
+  it('includes the thresholds in the builder params', () => {
+    const widget = {
+      ...getDefaultWidget(WidgetType.TRANSACTIONS),
+      thresholds: {
+        max_values: {
+          max1: 200,
+          max2: 300,
+        },
+        unit: 'milliseconds',
+      },
+    };
+    const params = convertWidgetToBuilderStateParams(widget);
+    expect(params.thresholds).toBe(
+      '{"max_values":{"max1":200,"max2":300},"unit":"milliseconds"}'
+    );
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -7,6 +7,7 @@ import {
 } from 'sentry/views/dashboards/types';
 import {
   serializeFields,
+  serializeThresholds,
   type WidgetBuilderStateQueryParams,
 } from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
@@ -59,5 +60,6 @@ export function convertWidgetToBuilderStateParams(
     sort,
     legendAlias,
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
+    thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
   };
 }


### PR DESCRIPTION
Adds thresholds for big numbers. Reuses some of the old widget builder UI. Generally this PR makes the following changes:

- Adds the thresholds to the builder state hook and resets it where necessary
- Creates a new field for the widget builder form to fill in the thresholds
- When the preview request is complete, parse the response and set the data type in one of the parent components to pass along as an override if data types change while widgets change.
- Updates to the thresholds do one of the following:
  - Updating the unit selector sets the new value as the unit
  - Updating the value pushes it to the URL params
  - If the value is cleared, remove it from the thresholds object
  - If all values are cleared, set the thresholds object to `undefined`
- The thresholds field is only visible for big number widgets
- Add thresholds to the corresponding helpers for builder state -> widget and widget -> builder state

I chose to do a simple thing and just use json parsing and stringify to serialize the formatting for this widget state. I also noticed that adding the marker in the big number preview would overflow the container. We should fix that but this PR was getting big enough. I will also follow it up with adding error support.

Closes [#82919](https://github.com/getsentry/sentry/issues/82919)
