### PR TITLE
ref(issue-details): Remove all query params from legacy UI when no event is found.

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -253,6 +253,10 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     refetch: refetchGroupCall,
   } = useGroup({groupId});
 
+  /**
+   * TODO(streamline-ui): Remove this whole hook once the legacy UI is removed. The streamlined UI exposes the
+   * filters on the page so the user is expected to clear it themselves, and the empty state is actually expected.
+   */
   useEffect(() => {
     const eventIdUrl = params.eventId ?? defaultIssueEvent;
     const isLatestOrRecommendedEvent =

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -261,7 +261,11 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     if (
       isLatestOrRecommendedEvent &&
       isEventError &&
-      router.location.query.query &&
+      // Expanding this list to ensure invalid date ranges get removed as well as queries
+      (router.location.query.query ||
+        router.location.query.start ||
+        router.location.query.end ||
+        router.location.query.statsPeriod) &&
       !hasStreamlinedUI
     ) {
       // If we get an error from the helpful event endpoint, it probably means
@@ -271,8 +275,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
         {
           ...router.location,
           query: {
-            ...router.location.query,
-            query: undefined,
+            project: router.location.query.project,
           },
         },
         {replace: true}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -258,6 +258,10 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
    * filters on the page so the user is expected to clear it themselves, and the empty state is actually expected.
    */
   useEffect(() => {
+    if (hasStreamlinedUI) {
+      return;
+    }
+
     const eventIdUrl = params.eventId ?? defaultIssueEvent;
     const isLatestOrRecommendedEvent =
       eventIdUrl === 'latest' || eventIdUrl === 'recommended';
@@ -269,8 +273,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
       (router.location.query.query ||
         router.location.query.start ||
         router.location.query.end ||
-        router.location.query.statsPeriod) &&
-      !hasStreamlinedUI
+        router.location.query.statsPeriod)
     ) {
       // If we get an error from the helpful event endpoint, it probably means
       // the query failed validation. We should remove the query to try again if

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -42,6 +42,7 @@ import useApi from 'sentry/utils/useApi';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
@@ -223,6 +224,9 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
   const organization = useOrganization();
   const router = useRouter();
   const params = router.params;
+  const navigate = useNavigate();
+  const defaultIssueEvent = useDefaultIssueEvent();
+  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const [allProjectChanged, setAllProjectChanged] = useState<boolean>(false);
 
@@ -234,6 +238,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
   const {
     data: event,
     isPending: loadingEvent,
+    isError: isEventError,
     refetch: refetchEvent,
   } = useGroupEvent({
     groupId,
@@ -247,6 +252,40 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
     error: groupError,
     refetch: refetchGroupCall,
   } = useGroup({groupId});
+
+  useEffect(() => {
+    const eventIdUrl = params.eventId ?? defaultIssueEvent;
+    const isLatestOrRecommendedEvent =
+      eventIdUrl === 'latest' || eventIdUrl === 'recommended';
+
+    if (
+      isLatestOrRecommendedEvent &&
+      isEventError &&
+      router.location.query.query &&
+      !hasStreamlinedUI
+    ) {
+      // If we get an error from the helpful event endpoint, it probably means
+      // the query failed validation. We should remove the query to try again if
+      // we are not using streamlined UI.
+      navigate(
+        {
+          ...router.location,
+          query: {
+            ...router.location.query,
+            query: undefined,
+          },
+        },
+        {replace: true}
+      );
+    }
+  }, [
+    defaultIssueEvent,
+    isEventError,
+    navigate,
+    router.location,
+    params.eventId,
+    hasStreamlinedUI,
+  ]);
 
   /**
    * Allows the GroupEventHeader to display the previous event while the new event is loading.


### PR DESCRIPTION
Adds back a portion removed in [this PR](https://github.com/getsentry/sentry/pull/82476/files#diff-a95c753ccf3abebbfb06333be0780c03f31de6cb0b8d178665b8ea24a02f00feL255-L275) that clears the query when it doesn't find an event, but only applies it when the UI is not streamlined.

Now though, instead of just removing `query`, we remove everything except `project`, since if we kept any `date` params, the endpoint would still return empty for recommend/latest events. It also searches for any of those qparams to be set before triggering so when they are all removed, it won't infinitely call `navigate` -- may add a test for this just in case though.