### PR TITLE
feat(explore): Add new cell actions for explore

### DIFF
--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -48,6 +48,7 @@ export const ALLOWED_CELL_ACTIONS: Actions[] = [
   Actions.EXCLUDE,
   Actions.SHOW_GREATER_THAN,
   Actions.SHOW_LESS_THAN,
+  Actions.COPY,
 ];
 
 const MINIMUM_COLUMN_WIDTH = COL_WIDTH_MINIMUM;

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -268,8 +268,8 @@ export function useSetExploreMode() {
 export function useSetExploreQuery() {
   const setPageParams = useSetExplorePageParams();
   return useCallback(
-    (query: string) => {
-      setPageParams({query});
+    (query: string, mode?: Mode) => {
+      setPageParams({query, mode});
     },
     [setPageParams]
   );

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -268,6 +268,16 @@ export function useSetExploreMode() {
 export function useSetExploreQuery() {
   const setPageParams = useSetExplorePageParams();
   return useCallback(
+    (query: string) => {
+      setPageParams({query});
+    },
+    [setPageParams]
+  );
+}
+
+export function useSetExploreQueryWithMode() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
     (query: string, mode?: Mode) => {
       setPageParams({query, mode});
     },

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -37,6 +37,7 @@ import {
   useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
@@ -176,6 +177,7 @@ export function AggregatesTable({
                         data={row}
                         unit={meta?.units?.[field]}
                         meta={meta}
+                        mode={Mode.AGGREGATE}
                       />
                     </TableBodyCell>
                   );

--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -5,6 +5,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 
 import {FieldRenderer} from './fieldRenderer';
 
@@ -47,6 +48,7 @@ describe('FieldRenderer tests', function () {
         column={eventView.getColumns()[3]!}
         data={mockedEventData}
         meta={{}}
+        mode={Mode.SAMPLES}
       />,
       {organization}
     );
@@ -60,6 +62,7 @@ describe('FieldRenderer tests', function () {
         column={eventView.getColumns()[0]!}
         data={mockedEventData}
         meta={{}}
+        mode={Mode.SAMPLES}
       />,
       {organization}
     );
@@ -77,6 +80,7 @@ describe('FieldRenderer tests', function () {
         column={eventView.getColumns()[4]!}
         data={mockedEventData}
         meta={{}}
+        mode={Mode.SAMPLES}
       />,
       {organization}
     );
@@ -94,6 +98,7 @@ describe('FieldRenderer tests', function () {
         column={eventView.getColumns()[2]!}
         data={mockedEventData}
         meta={{}}
+        mode={Mode.SAMPLES}
       />,
       {organization}
     );
@@ -111,6 +116,7 @@ describe('FieldRenderer tests', function () {
         column={eventView.getColumns()[1]!}
         data={mockedEventData}
         meta={{}}
+        mode={Mode.SAMPLES}
       />,
       {organization}
     );

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -20,7 +20,7 @@ import type {TableColumn} from 'sentry/views/discover/table/types';
 import {ALLOWED_CELL_ACTIONS} from 'sentry/views/explore/components/table';
 import {
   useExploreQuery,
-  useSetExploreQuery,
+  useSetExploreQueryWithMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
@@ -38,7 +38,7 @@ export function FieldRenderer({data, meta, unit, column, mode}: FieldProps) {
   const location = useLocation();
   const organization = useOrganization();
   const userQuery = useExploreQuery();
-  const setUserQuery = useSetExploreQuery();
+  const setUserQueryWithMode = useSetExploreQueryWithMode();
   const dateSelection = EventView.fromLocation(location).normalizeDateSelection(location);
   const query = new MutableSearch(userQuery);
   const field = column.name;
@@ -118,7 +118,7 @@ export function FieldRenderer({data, meta, unit, column, mode}: FieldProps) {
             break;
           default:
             updateQuery(query, actions, column, value);
-            setUserQuery(
+            setUserQueryWithMode(
               query.formatString(),
               // samples action means we switch to samples mode
               // otherwise, don't do anything

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -31,6 +31,7 @@ import {
   useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
@@ -156,6 +157,7 @@ export function SpansTable({confidences, spansTableResult}: SpansTableProps) {
                         data={row}
                         unit={meta?.units?.[field]}
                         meta={meta}
+                        mode={Mode.SAMPLES}
                       />
                     </TableBodyCell>
                   );


### PR DESCRIPTION
This adds 2 new cell actions for explore
- view samples to add a filter to the query and switch to samples mode
- copy value to clipboard