### PR TITLE
styles(explore): Fix spacing between explore toolbar visualize

### DIFF
--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -36,7 +36,11 @@ export const ToolbarFooterButton = styled(Button)<{disabled?: boolean}>`
   color: ${p => (p.disabled ? p.theme.gray300 : p.theme.linkColor)};
 `;
 
-export const ToolbarFooter = styled('div')<{disabled?: boolean}>``;
+export const ToolbarFooter = styled('div')<{disabled?: boolean}>`
+  :not(:last-child) {
+    margin-bottom: ${space(0.5)};
+  }
+`;
 
 export const ToolbarRow = styled('div')`
   display: flex;


### PR DESCRIPTION
The `+ Add Series` button was too close to the block below so it didn't look quite right. Add some spacing so it's closer to the block above where it adds the series to.