### PR TITLE
feat(metric-issues): Include the alert rule id in data

### DIFF
--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -70,7 +70,7 @@ def create_or_update_metric_issue(
         return None
 
     # collect the data from the incident to treat as an event
-    event_data: dict[str, str | int] = {
+    event_data: dict[str, Any] = {
         "event_id": uuid4().hex,
         "project_id": project.id,
         "timestamp": incident.date_started.isoformat(),

--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -56,7 +56,7 @@ def _build_occurrence_from_incident(
         culprit="",
         initial_issue_priority=initial_issue_priority,
         # TODO(snigdha): Add more data here as needed
-        evidence_data={"metric_value": metric_value},
+        evidence_data={"metric_value": metric_value, "alert_rule_id": incident.alert_rule.id},
         evidence_display=[],
     )
 
@@ -76,6 +76,7 @@ def create_or_update_metric_issue(
         "timestamp": incident.date_started.isoformat(),
         "platform": project.platform or "",
         "received": incident.date_started.isoformat(),
+        "contexts": {"metric_alert": {"alert_rule_id": incident.alert_rule.id}},
     }
 
     occurrence = _build_occurrence_from_incident(project, incident, event_data, metric_value)


### PR DESCRIPTION
The frontend relies on the alert rule ID to populate charts and tables and link to the alert rule/detector details.