### PR TITLE
feat(devservices): Add several new devservices modes

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -10,13 +10,6 @@ x-sentry-service-config:
         branch: master
         repo_link: https://github.com/getsentry/snuba.git
         mode: containerized
-    local-snuba:
-      description: Provides the ability to run snuba locally with sentry
-      remote:
-        repo_name: snuba
-        branch: master
-        repo_link: https://github.com/getsentry/snuba.git
-        mode: default
     relay:
       description: Service event forwarding and ingestion service
       remote:
@@ -39,6 +32,13 @@ x-sentry-service-config:
         branch: master
         repo_link: https://github.com/getsentry/symbolicator.git
         mode: default
+    vroom:
+      description: Sentry's profiling service, processing and deriving data about your profiles
+      remote:
+        repo_name: vroom
+        branch: main
+        repo_link: https://github.com/getsentry/vroom.git
+        mode: default
     bigtable:
       description: Bigtable emulator
     redis-cluster:
@@ -58,6 +58,9 @@ x-sentry-service-config:
         mode: containerized
     rabbitmq:
       description: Messaging and streaming broker
+    memcached:
+      description: Memcached used for caching
+
   modes:
     default: [snuba, postgres, relay]
     migrations: [postgres, redis]
@@ -66,8 +69,21 @@ x-sentry-service-config:
     backend-ci: [snuba, postgres, redis, bigtable, redis-cluster, symbolicator]
     rabbitmq: [postgres, snuba, rabbitmq]
     symbolicator: [postgres, snuba, symbolicator]
-    local-snuba: [postgres, local-snuba]
+    memcached: [postgres, snuba, memcached]
+    profiling: [postgres, snuba, vroom]
     minimal: [postgres, snuba]
+    full:
+      [
+        postgres,
+        snuba,
+        relay,
+        redis,
+        redis-cluster,
+        symbolicator,
+        taskbroker,
+        rabbitmq,
+        vroom,
+      ]
 
 services:
   postgres:
@@ -135,6 +151,14 @@ services:
       - host.docker.internal:host-gateway
     environment:
       - IP=0.0.0.0
+  memcached:
+    image: ghcr.io/getsentry/image-mirror-library-memcached:1.5-alpine
+    ports:
+      - '127.0.0.1:11211:11211'
+    networks:
+      - devservices
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
 networks:
   devservices:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -10,6 +10,13 @@ x-sentry-service-config:
         branch: master
         repo_link: https://github.com/getsentry/snuba.git
         mode: containerized
+    local-snuba:
+      description: Provides the ability to run snuba locally with sentry
+      remote:
+        repo_name: snuba
+        branch: master
+        repo_link: https://github.com/getsentry/snuba.git
+        mode: default
     relay:
       description: Service event forwarding and ingestion service
       remote:
@@ -58,6 +65,9 @@ x-sentry-service-config:
     taskbroker: [snuba, postgres, relay, taskbroker]
     backend-ci: [snuba, postgres, redis, bigtable, redis-cluster, symbolicator]
     rabbitmq: [postgres, snuba, rabbitmq]
+    symbolicator: [postgres, snuba, symbolicator]
+    local-snuba: [postgres, local-snuba]
+    minimal: [postgres, snuba]
 
 services:
   postgres:


### PR DESCRIPTION
These new modes will help support devservices for more use cases

**memcached**: This will allow users to run sentry whilst connecting when using the memcached backend
**symbolicator**: This brings up sentry with symbolicator running
**minimal**: These are the services that are the bare minimum for running sentry
**full**: This mode brings up pretty much most things needed for sentry development (symbolicator, vroom, relay, rabbitmq, taskbroker)