### PR TITLE
fix(dashboards): Improve Y axis rate formatting

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.spec.tsx
@@ -58,9 +58,16 @@ describe('formatYAxisValue', () => {
   describe('rate', () => {
     it.each([
       [0, '1/second', '0'],
+      [-3, '1/second', '-3/s'],
       [0.712, '1/second', '0.712/s'],
       [12712, '1/second', '12.7K/s'],
       [1231, '1/minute', '1.23K/min'],
+      [0.0003, '1/second', '0.0003/s'],
+      [0.35, '1/second', '0.35/s'],
+      [10, '1/second', '10/s'],
+      [10.0, '1/second', '10/s'],
+      [110000, '1/second', '110K/s'],
+      [1231, '1/minute', '1.2K/min'],
     ])('Formats %s as %s', (value, unit, formattedValue) => {
       expect(formatYAxisValue(value, 'rate', unit)).toEqual(formattedValue);
     });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.spec.tsx
@@ -62,12 +62,14 @@ describe('formatYAxisValue', () => {
       [0.712, '1/second', '0.712/s'],
       [12700, '1/second', '12.7K/s'],
       [0.0003, '1/second', '0.0003/s'],
+      [0.00000153, '1/second', '0.00000153/s'],
       [0.35, '1/second', '0.35/s'],
       [10, '1/second', '10/s'],
       [10.0, '1/second', '10/s'],
       [1231, '1/minute', '1.231K/min'],
       [110000, '1/second', '110K/s'],
       [110001, '1/second', '110.001K/s'],
+      [123456789, '1/second', '123.457M/s'],
     ])('Formats %s as %s', (value, unit, formattedValue) => {
       expect(formatYAxisValue(value, 'rate', unit)).toEqual(formattedValue);
     });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.spec.tsx
@@ -60,14 +60,14 @@ describe('formatYAxisValue', () => {
       [0, '1/second', '0'],
       [-3, '1/second', '-3/s'],
       [0.712, '1/second', '0.712/s'],
-      [12712, '1/second', '12.7K/s'],
-      [1231, '1/minute', '1.23K/min'],
+      [12700, '1/second', '12.7K/s'],
       [0.0003, '1/second', '0.0003/s'],
       [0.35, '1/second', '0.35/s'],
       [10, '1/second', '10/s'],
       [10.0, '1/second', '10/s'],
+      [1231, '1/minute', '1.231K/min'],
       [110000, '1/second', '110K/s'],
-      [1231, '1/minute', '1.2K/min'],
+      [110001, '1/second', '110.001K/s'],
     ])('Formats %s as %s', (value, unit, formattedValue) => {
       expect(formatYAxisValue(value, 'rate', unit)).toEqual(formattedValue);
     });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
@@ -23,10 +23,10 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
     case 'percentage':
       return formatPercentage(value, 3);
     case 'duration':
-      const inputUnit = isADurationUnit(unit) ? unit : DurationUnit.MILLISECOND;
+      const durationUnit = isADurationUnit(unit) ? unit : DurationUnit.MILLISECOND;
       const durationInMilliseconds = convertDuration(
         value,
-        inputUnit,
+        durationUnit,
         DurationUnit.MILLISECOND
       );
       return formatYAxisDuration(durationInMilliseconds);

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
@@ -42,7 +42,7 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
       const rateUnit = isARateUnit(unit) ? unit : RateUnit.PER_SECOND;
       return `${value.toLocaleString(undefined, {
         notation: 'compact',
-        maximumFractionDigits: 10,
+        maximumSignificantDigits: 6,
       })}${RATE_UNIT_LABELS[rateUnit]}`;
     default:
       return value.toString();

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
@@ -1,12 +1,12 @@
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {ABYTE_UNITS, SIZE_UNITS} from 'sentry/utils/discover/fieldRenderers';
-import {DurationUnit, type RateUnit} from 'sentry/utils/discover/fields';
-import {formatAbbreviatedNumber, formatRate} from 'sentry/utils/formatters';
+import {DurationUnit, RATE_UNIT_LABELS, RateUnit} from 'sentry/utils/discover/fields';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
 
-import {isADurationUnit} from '../common/typePredicates';
+import {isADurationUnit, isARateUnit} from '../common/typePredicates';
 
 import {formatYAxisDuration} from './formatYAxisDuration';
 
@@ -39,7 +39,10 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
 
       return formatter(bytes);
     case 'rate':
-      return formatRate(value, unit as RateUnit);
+      const rateUnit = isARateUnit(unit) ? unit : RateUnit.PER_SECOND;
+      return `${value.toLocaleString(undefined, {
+        notation: 'compact',
+      })}${RATE_UNIT_LABELS[rateUnit]}`;
     default:
       return value.toString();
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
@@ -42,6 +42,7 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
       const rateUnit = isARateUnit(unit) ? unit : RateUnit.PER_SECOND;
       return `${value.toLocaleString(undefined, {
         notation: 'compact',
+        maximumFractionDigits: 10,
       })}${RATE_UNIT_LABELS[rateUnit]}`;
     default:
       return value.toString();


### PR DESCRIPTION
A simpler formatter, using `.toLocaleString()`. This does a much better job of formatting values, and avoids having a lot of pointless trailing 0s than the previous approach.

**Before:**
![Screenshot 2025-01-14 at 5 07 19 PM](https://github.com/user-attachments/assets/09b6d0d2-045c-44c2-9c66-59338e221627)

**After:**
![Screenshot 2025-01-14 at 5 23 32 PM](https://github.com/user-attachments/assets/69053a37-8320-4354-993a-5f8709496bc9)
