### PR TITLE
feat(aci): schema validation for DataCondition.comparison

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -11,8 +11,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.AGE_COMPARISON)
 class AgeComparisonConditionHandler(DataConditionHandler[WorkflowJob]):
-    @staticmethod
-    def comparison_json_schema() -> dict[str, Any]:
+    @property
+    def comparison_json_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {

--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -11,21 +11,19 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 @condition_handler_registry.register(Condition.AGE_COMPARISON)
 class AgeComparisonConditionHandler(DataConditionHandler[WorkflowJob]):
-    @property
-    def comparison_json_schema(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "comparison_type": {
-                    "type": "string",
-                    "enum": [AgeComparisonType.OLDER, AgeComparisonType.NEWER],
-                },
-                "value": {"type": "integer", "minimum": 0},
-                "time": {"type": "string", "enum": list(timeranges.keys())},
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "comparison_type": {
+                "type": "string",
+                "enum": [AgeComparisonType.OLDER, AgeComparisonType.NEWER],
             },
-            "required": ["comparison_type", "value", "time"],
-            "additionalProperties": False,
-        }
+            "value": {"type": "integer", "minimum": 0},
+            "time": {"type": "string", "enum": list(timeranges.keys())},
+        },
+        "required": ["comparison_type", "value", "time"],
+        "additionalProperties": False,
+    }
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -165,10 +165,9 @@ def create_tagged_event_data_condition(
 def create_age_comparison_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    # TODO: Add comparison validation (error if not enough information)
     comparison = {
         "comparison_type": data["comparison_type"],
-        "value": data["value"],
+        "value": int(data["value"]),
         "time": data["time"],
     }
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -143,7 +143,7 @@ def enforce_comparison_schema(sender, instance: DataCondition, **kwargs):
         )
         return None
 
-    schema = handler().comparison_json_schema
+    schema = handler.comparison_json_schema
 
     try:
         validate(instance.comparison, schema)

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -43,7 +43,7 @@ class Condition(models.TextChoices):
     ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
 
 
-condition_ops = {
+CONDITION_OPS = {
     Condition.EQUAL: operator.eq,
     Condition.GREATER_OR_EQUAL: operator.ge,
     Condition.GREATER: operator.gt,
@@ -106,9 +106,9 @@ class DataCondition(DefaultFieldsModel):
             )
             return None
 
-        if condition_type in condition_ops:
+        if condition_type in CONDITION_OPS:
             # If the condition is a base type, handle it directly
-            op = condition_ops[Condition(self.type)]
+            op = CONDITION_OPS[Condition(self.type)]
             result = op(cast(Any, value), self.comparison)
             return self.get_condition_result() if result else None
 
@@ -130,7 +130,7 @@ class DataCondition(DefaultFieldsModel):
 def enforce_comparison_schema(sender, instance: DataCondition, **kwargs):
 
     condition_type = Condition(instance.type)
-    if condition_type in condition_ops:
+    if condition_type in CONDITION_OPS:
         # don't enforce schema for default ops, this can be any type
         return
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar
 
@@ -55,8 +56,9 @@ class DataSourceTypeHandler(Generic[T]):
 
 
 class DataConditionHandler(Generic[T]):
-    @staticmethod
-    def comparison_json_schema() -> dict[str, Any]:
+    @property
+    @abstractmethod
+    def comparison_json_schema(self) -> dict[str, Any]:
         # TODO(cathy): raise NotImplementedError
         return {}
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -56,5 +56,10 @@ class DataSourceTypeHandler(Generic[T]):
 
 class DataConditionHandler(Generic[T]):
     @staticmethod
+    def comparison_json_schema() -> dict[str, Any]:
+        # TODO(cathy): raise NotImplementedError
+        return {}
+
+    @staticmethod
     def evaluate_value(value: T, comparison: Any) -> DataConditionResult:
         raise NotImplementedError

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
 from sentry.types.group import PriorityLevel
 
@@ -56,11 +55,7 @@ class DataSourceTypeHandler(Generic[T]):
 
 
 class DataConditionHandler(Generic[T]):
-    @property
-    @abstractmethod
-    def comparison_json_schema(self) -> dict[str, Any]:
-        # TODO(cathy): raise NotImplementedError
-        return {}
+    comparison_json_schema: ClassVar[dict[str, Any]] = {}
 
     @staticmethod
     def evaluate_value(value: T, comparison: Any) -> DataConditionResult:

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+from jsonschema import ValidationError
+
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.testutils.helpers.datetime import freeze_time
@@ -36,7 +39,7 @@ class TestAgeComparisonCondition(ConditionTestCase):
         )
         self.dc = self.create_data_condition(
             type=self.condition,
-            comparison={"comparison_type": AgeComparisonType.OLDER, "value": "10", "time": "hour"},
+            comparison={"comparison_type": AgeComparisonType.OLDER, "value": 10, "time": "hour"},
             condition_result=True,
         )
 
@@ -47,16 +50,30 @@ class TestAgeComparisonCondition(ConditionTestCase):
         assert dc.type == self.condition
         assert dc.comparison == {
             "comparison_type": AgeComparisonType.OLDER,
-            "value": "10",
+            "value": 10,
             "time": "hour",
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
+    def test_json_schema(self):
+        with pytest.raises(ValidationError):
+            self.dc.comparison.update({"time": "asdf"})
+            self.dc.save()
+
+        with pytest.raises(ValidationError):
+            self.dc.comparison.update({"value": "bad_value"})
+            self.dc.save()
+
+        with pytest.raises(ValidationError):
+            self.dc.comparison.update({"comparison_type": "bad_value"})
+            self.dc.save()
+
     def test_older_applies_correctly(self):
-        self.dc.update(
-            comparison={"comparison_type": AgeComparisonType.OLDER, "value": "10", "time": "hour"}
+        self.dc.comparison.update(
+            {"comparison_type": AgeComparisonType.OLDER, "value": 10, "time": "hour"}
         )
+        self.dc.save()
 
         self.group.update(first_seen=datetime.now(timezone.utc) - timedelta(hours=3))
         self.assert_does_not_pass(self.dc, self.job)
@@ -67,22 +84,13 @@ class TestAgeComparisonCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_newer_applies_correctly(self):
-        self.dc.update(
-            comparison={"comparison_type": AgeComparisonType.NEWER, "value": "10", "time": "hour"}
+        self.dc.comparison.update(
+            {"comparison_type": AgeComparisonType.NEWER, "value": 10, "time": "hour"}
         )
+        self.dc.save()
 
         self.group.update(first_seen=datetime.now(timezone.utc) - timedelta(hours=3))
         self.assert_passes(self.dc, self.job)
 
         self.group.update(first_seen=datetime.now(timezone.utc) - timedelta(hours=10))
-        self.assert_does_not_pass(self.dc, self.job)
-
-    def test_fails_on_insufficient_data(self):
-        self.dc.update(comparison={"time": "hour"})
-        self.assert_does_not_pass(self.dc, self.job)
-
-        self.dc.update(comparison={"value": "bad_value"})
-        self.assert_does_not_pass(self.dc, self.job)
-
-        self.dc.update(comparison={"comparison_type": "bad_value"})
         self.assert_does_not_pass(self.dc, self.job)

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -57,16 +57,16 @@ class TestAgeComparisonCondition(ConditionTestCase):
         assert dc.condition_group == dcg
 
     def test_json_schema(self):
+        self.dc.comparison.update({"time": "asdf"})
         with pytest.raises(ValidationError):
-            self.dc.comparison.update({"time": "asdf"})
             self.dc.save()
 
+        self.dc.comparison.update({"value": "bad_value"})
         with pytest.raises(ValidationError):
-            self.dc.comparison.update({"value": "bad_value"})
             self.dc.save()
 
+        self.dc.comparison.update({"comparison_type": "bad_value"})
         with pytest.raises(ValidationError):
-            self.dc.comparison.update({"comparison_type": "bad_value"})
             self.dc.save()
 
     def test_older_applies_correctly(self):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -84,7 +84,7 @@ class RuleMigrationHelpersTest(APITestCase):
             type=Condition.AGE_COMPARISON,
             comparison={
                 "comparison_type": AgeComparisonType.OLDER,
-                "value": "10",
+                "value": 10,
                 "time": "hour",
             },
             condition_result=True,

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -46,14 +46,11 @@ class EvaluateValueTest(TestCase):
         assert dc.evaluate_value(1) is None
 
     def test_bad_condition(self):
-
-        dc = self.create_data_condition(
-            type="invalid", comparison=1.0, condition_result=DetectorPriorityLevel.HIGH
-        )
-
-        with mock.patch("sentry.workflow_engine.models.data_condition.logger") as mock_logger:
-            assert dc.evaluate_value(2) is None
-            assert mock_logger.exception.call_args[0][0] == "Invalid condition type"
+        with pytest.raises(ValueError):
+            # Raises ValueError because the condition is invalid
+            self.create_data_condition(
+                type="invalid", comparison=1.0, condition_result=DetectorPriorityLevel.HIGH
+            )
 
     def test_bad_comparison(self):
         dc = self.create_data_condition(


### PR DESCRIPTION
Add schema validation for `DataCondition`'s `comparison` `JSONField`. We need this to be absolutely sure the comparison field contains the correct information to be able to evaluate the condition in processors.

This PR adds the schema validation for the `AgeComparison` condition as an example.