### PR TITLE
fix(issues): Check project platform in icon summary

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -2,6 +2,7 @@ import {EventFixture} from 'sentry-fixture/event';
 import {EventAttachmentFixture} from 'sentry-fixture/eventAttachment';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -100,29 +101,37 @@ describe('HighlightsIconSummary', function () {
   });
 
   it('hides device for non mobile/native', function () {
+    const groupWithPlatform = GroupFixture({
+      project: ProjectFixture({
+        platform: 'javascript',
+      }),
+    });
     const eventWithDevice = EventFixture({
       contexts: {
         ...TEST_EVENT_CONTEXTS,
         device: iosDeviceContext,
       },
-      platform: 'javascript',
     });
 
-    render(<HighlightsIconSummary event={eventWithDevice} group={group} />);
+    render(<HighlightsIconSummary event={eventWithDevice} group={groupWithPlatform} />);
     expect(screen.queryByText('iPhone 13')).not.toBeInTheDocument();
     expect(screen.queryByText('x86')).not.toBeInTheDocument();
   });
 
   it('displays device for mobile/native event platforms', async function () {
+    const groupWithPlatform = GroupFixture({
+      project: ProjectFixture({
+        platform: 'android',
+      }),
+    });
     const eventWithDevice = EventFixture({
       contexts: {
         ...TEST_EVENT_CONTEXTS,
         device: iosDeviceContext,
       },
-      platform: 'android',
     });
 
-    render(<HighlightsIconSummary event={eventWithDevice} group={group} />);
+    render(<HighlightsIconSummary event={eventWithDevice} group={groupWithPlatform} />);
     expect(screen.getByText('iPhone 13')).toBeInTheDocument();
     expect(screen.getByText('x86')).toBeInTheDocument();
     await userEvent.hover(screen.getByText('x86'));

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -39,6 +39,7 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
   // Project slug and project id are pull out because group is not always available
   const projectSlug = group?.project.slug ?? event.projectSlug;
   const projectId = group?.project.id ?? event.projectID;
+  const projectPlatform = group?.project.platform;
 
   const {data: attachments = []} = useFetchEventAttachments({
     orgSlug: organization.slug,
@@ -48,7 +49,7 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
   const screenshot = attachments.find(({name}) => SCREENSHOT_NAMES.includes(name));
   // Hide device for non-native platforms since it's mostly duplicate of the client_os or os context
   const shouldDisplayDevice =
-    isMobilePlatform(event.platform) || isNativePlatform(event.platform);
+    isMobilePlatform(projectPlatform) || isNativePlatform(projectPlatform);
   // For now, highlight icons are only interpretted from context. We should extend this to tags
   // eventually, but for now, it'll match the previous expectations.
   const items = getOrderedContextItems(event)


### PR DESCRIPTION
The event.platform is not quite the same. In the case of react-native the event.platform is "javascript" and not 'react-native' 