### PR TITLE
ref(react19): Remove generic widget default props

### DIFF
--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -11,7 +11,9 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {MEPDataProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import useApi from 'sentry/utils/useApi';
-import getPerformanceWidgetContainer from 'sentry/views/performance/landing/widgets/components/performanceWidgetContainer';
+import getPerformanceWidgetContainer, {
+  type PerformanceWidgetContainerTypes,
+} from 'sentry/views/performance/landing/widgets/components/performanceWidgetContainer';
 
 import type {
   GenericPerformanceWidgetProps,
@@ -79,7 +81,13 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
           queries={queries}
           api={api}
         />
-        <DataDisplay<T> {...props} {...widgetProps} totalHeight={totalHeight} />
+        <DataDisplay<T>
+          chartHeight={200}
+          containerType="panel"
+          {...props}
+          {...widgetProps}
+          totalHeight={totalHeight}
+        />
       </MEPDataProvider>
     </Fragment>
   );
@@ -96,7 +104,11 @@ function trackDataComponentClicks(
 }
 
 export function DataDisplay<T extends WidgetDataConstraint>(
-  props: GenericPerformanceWidgetProps<T> & WidgetDataProps<T> & {totalHeight: number}
+  props: GenericPerformanceWidgetProps<T> &
+    WidgetDataProps<T> & {
+      containerType: PerformanceWidgetContainerTypes;
+      totalHeight: number;
+    }
 ) {
   const {Visualizations, chartHeight, totalHeight, containerType, EmptyComponent} = props;
 
@@ -203,8 +215,3 @@ const LoadingWrapper = styled('div')<{height?: number}>`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   margin: 0;
 `;
-
-GenericPerformanceWidget.defaultProps = {
-  containerType: 'panel',
-  chartHeight: 200,
-};

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -133,10 +133,7 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   Visualizations: Visualizations<T>;
 
   chartDefinition: ChartDefinition;
-  chartHeight: number;
-
   chartSetting: PerformanceWidgetSetting;
-  containerType: PerformanceWidgetContainerTypes;
   eventView: EventView;
 
   fields: string[];
@@ -151,6 +148,14 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
 
   InteractiveTitle?: InteractiveTitle<T> | null;
   Subtitle?: Subtitle<T>;
+  /**
+   * @default 200
+   */
+  chartHeight?: number;
+  /**
+   * @default 'panel'
+   */
+  containerType?: PerformanceWidgetContainerTypes;
 };
 
 export type GenericPerformanceWithData<T extends WidgetDataConstraint> =


### PR DESCRIPTION
Inlines them where they're used

part of https://github.com/getsentry/frontend-tsc/issues/68