### PR TITLE
fix(tests): Run jest tests in tests/js folder

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -234,7 +234,7 @@ const config: Config.InitialOptions = {
     '<rootDir>/tests/js/setup.ts',
     '<rootDir>/tests/js/setupFramework.ts',
   ],
-  testMatch: testMatch || ['<rootDir>/static/**/?(*.)+(spec|test).[jt]s?(x)'],
+  testMatch: testMatch || ['<rootDir>/(static|tests/js)/**/?(*.)+(spec|test).[jt]s?(x)'],
   testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],
 
   unmockedModulePathPatterns: [


### PR DESCRIPTION
There are some tests in the `tests/js` folder that we want to run, such as https://github.com/getsentry/sentry/blob/master/tests/js/sentry-test/reactTestingLibrary.spec.tsx