### PR TITLE
fix(eslint): Fix file pattern for *.stories.tsx files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -682,7 +682,7 @@ export default typescript.config([
   },
   {
     name: 'files/sentry-stories',
-    files: ['**/*.stories.{tsx}'],
+    files: ['**/*.stories.tsx'],
     rules: {
       'no-loss-of-precision': 'off', // Sometimes we have wild numbers hard-coded in stories
     },


### PR DESCRIPTION
`'**/*.stories.{tsx}'` matches nothing, while `'**/*.stories.tsx'` matches the files.