### PR TITLE
chore(aci): Use factories to create models

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -69,14 +69,14 @@ class TestDetectorSerializer(TestCase):
         )
         type_name = data_source_type_registry.get_key(QuerySubscriptionDataSourceHandler)
         data_source = self.create_data_source(
-            organization_id=self.organization.id,
+            organization=self.organization,
             type=type_name,
             query_id=subscription.id,
         )
         data_source.detectors.set([detector])
 
         result = serialize(detector)
-
+        # print("result: ", result)
         assert result == {
             "id": str(detector.id),
             "organizationId": str(self.organization.id),
@@ -112,7 +112,7 @@ class TestDetectorSerializer(TestCase):
                 "conditions": [
                     {
                         "id": str(condition.id),
-                        "condition": Condition.GREATER,
+                        "condition": Condition.GREATER.value,
                         "comparison": 100,
                         "result": DetectorPriorityLevel.HIGH,
                     }
@@ -160,7 +160,7 @@ class TestDataSourceSerializer(TestCase):
             self.project, INCIDENTS_SNUBA_SUBSCRIPTION_TYPE, snuba_query
         )
         data_source = self.create_data_source(
-            organization_id=self.organization.id,
+            organization=self.organization,
             type=type_name,
             query_id=subscription.id,
         )

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -11,16 +11,8 @@ from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.workflow_engine.models import (
-    Action,
-    DataCondition,
-    DataConditionGroup,
-    DataSource,
-    Workflow,
-)
+from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.models.data_condition_group_action import DataConditionGroupAction
-from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -45,18 +37,18 @@ class TestDetectorSerializer(TestCase):
         }
 
     def test_serialize_full(self):
-        condition_group = DataConditionGroup.objects.create(
+        condition_group = self.create_data_condition_group(
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ANY,
         )
-        condition = DataCondition.objects.create(
+        condition = self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
             comparison=100,
             condition_result=DetectorPriorityLevel.HIGH,
         )
-        action = Action.objects.create(type=Action.Type.EMAIL, data={"foo": "bar"})
-        DataConditionGroupAction.objects.create(condition_group=condition_group, action=action)
+        action = self.create_action(type=Action.Type.EMAIL, data={"foo": "bar"})
+        self.create_data_condition_group_action(condition_group=condition_group, action=action)
         detector = self.create_detector(
             organization_id=self.organization.id,
             name="Test Detector",
@@ -76,7 +68,7 @@ class TestDetectorSerializer(TestCase):
             self.project, INCIDENTS_SNUBA_SUBSCRIPTION_TYPE, snuba_query
         )
         type_name = data_source_type_registry.get_key(QuerySubscriptionDataSourceHandler)
-        data_source = DataSource.objects.create(
+        data_source = self.create_data_source(
             organization_id=self.organization.id,
             type=type_name,
             query_id=subscription.id,
@@ -167,7 +159,7 @@ class TestDataSourceSerializer(TestCase):
         subscription = create_snuba_subscription(
             self.project, INCIDENTS_SNUBA_SUBSCRIPTION_TYPE, snuba_query
         )
-        data_source = DataSource.objects.create(
+        data_source = self.create_data_source(
             organization_id=self.organization.id,
             type=type_name,
             query_id=subscription.id,
@@ -198,7 +190,7 @@ class TestDataSourceSerializer(TestCase):
 
 class TestDataConditionGroupSerializer(TestCase):
     def test_serialize_simple(self):
-        condition_group = DataConditionGroup.objects.create(
+        condition_group = self.create_data_condition_group(
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ANY,
         )
@@ -214,20 +206,20 @@ class TestDataConditionGroupSerializer(TestCase):
         }
 
     def test_serialize_full(self):
-        condition_group = DataConditionGroup.objects.create(
+        condition_group = self.create_data_condition_group(
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ANY,
         )
-        condition = DataCondition.objects.create(
+        condition = self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
             comparison=100,
             condition_result=DetectorPriorityLevel.HIGH,
         )
 
-        action = Action.objects.create(type=Action.Type.EMAIL, data={"foo": "bar"})
+        action = self.create_action(type=Action.Type.EMAIL, data={"foo": "bar"})
 
-        DataConditionGroupAction.objects.create(condition_group=condition_group, action=action)
+        self.create_data_condition_group_action(condition_group=condition_group, action=action)
 
         result = serialize(condition_group)
 
@@ -255,7 +247,7 @@ class TestDataConditionGroupSerializer(TestCase):
 
 class TestActionSerializer(TestCase):
     def test_serialize_simple(self):
-        action = Action.objects.create(
+        action = self.create_action(
             type=Action.Type.EMAIL,
             data={"foo": "bar"},
         )
@@ -272,7 +264,7 @@ class TestActionSerializer(TestCase):
             integration = Integration.objects.create(
                 provider="slack", name="example-integration", external_id="123-id", metadata={}
             )
-        action = Action.objects.create(
+        action = self.create_action(
             type=Action.Type.SLACK,
             data={"foo": "bar"},
             integration_id=integration.id,
@@ -287,7 +279,7 @@ class TestActionSerializer(TestCase):
 
 class TestWorkflowSerializer(TestCase):
     def test_serialize_simple(self):
-        workflow = Workflow.objects.create(
+        workflow = self.create_workflow(
             name="hojicha",
             organization_id=self.organization.id,
             config={},
@@ -306,17 +298,17 @@ class TestWorkflowSerializer(TestCase):
         }
 
     def test_serialize_full(self):
-        when_condition_group = DataConditionGroup.objects.create(
+        when_condition_group = self.create_data_condition_group(
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ANY,
         )
-        trigger_condition = DataCondition.objects.create(
+        trigger_condition = self.create_data_condition(
             condition_group=when_condition_group,
             type=Condition.FIRST_SEEN_EVENT,
             comparison=True,
             condition_result=True,
         )
-        workflow = Workflow.objects.create(
+        workflow = self.create_workflow(
             name="hojicha",
             organization_id=self.organization.id,
             config={},
@@ -324,20 +316,20 @@ class TestWorkflowSerializer(TestCase):
             environment=self.environment,
         )
 
-        condition_group = DataConditionGroup.objects.create(
+        condition_group = self.create_data_condition_group(
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ALL,
         )
-        action = Action.objects.create(type=Action.Type.EMAIL, data={"foo": "bar"})
-        DataConditionGroupAction.objects.create(condition_group=condition_group, action=action)
-        condition = DataCondition.objects.create(
+        action = self.create_action(type=Action.Type.EMAIL, data={"foo": "bar"})
+        self.create_data_condition_group_action(condition_group=condition_group, action=action)
+        condition = self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
             comparison=100,
             condition_result=DetectorPriorityLevel.HIGH,
         )
 
-        WorkflowDataConditionGroup.objects.create(
+        self.create_workflow_data_condition_group(
             condition_group=condition_group,
             workflow=workflow,
         )


### PR DESCRIPTION
Update the serializer tests to use test factories instead of creating models directly