### PR TITLE
fix(metrics): add organizations prefix to custom metric alerts & widg…

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -314,7 +314,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             )
             # required in order to correctly clean up the custom metric alert subscriptions
             or features.has(
-                "custom-metrics-alerts-widgets-removal-info",
+                "organizations:custom-metrics-alerts-widgets-removal-info",
                 Organization.objects.get_from_cache(id=self.org_id),
             )
         )


### PR DESCRIPTION
The flag is [defined on organizations](https://github.com/getsentry/sentry/blob/699ee6c2d93d4ad01b610e0124d27768f94b84af/src/sentry/features/temporary.py#L87) - the check for it needs to do that as well. 

Fixes [SENTRY-3EG4](https://sentry.sentry.io/issues/5808167117/)