### PR TITLE
fix(symx): Moved log message

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -539,11 +539,16 @@ def emit_apple_symbol_stats(apple_symbol_stats, data):
         # This is done to temporally collect information about the events for which symx is not working correctly.
         if in_random_rollout("symbolicate.symx-logging-rate") and os_name and os_version:
             os_description = os_name + str(os_version)
+            logger.info(
+                "Failed to find symbols using symx",
+                extra={
+                    "id": data.get("event_id"),
+                    "modules": old,
+                    "os_description": os_description,
+                    "os_filter": options.get("symbolicate.symx-os-description-list"),
+                },
+            )
             if os_description in options.get("symbolicate.symx-os-description-list"):
-                logger.info(
-                    "Failed to find symbols using symx",
-                    extra={"id": data.get("event_id"), "modules": old},
-                )
                 with sentry_sdk.isolation_scope() as scope:
                     scope.set_context(
                         "Event Info", {"id": data.get("event_id"), "modules": str(old)}


### PR DESCRIPTION
Moved the logging introduced with (https://github.com/getsentry/sentry/pull/83381) to a different location since it still does not show in the logs.