### PR TITLE
ref(quick-start): Remove 'New' prefix from components

### DIFF
--- a/static/app/components/onboardingWizard/sidebar.spec.tsx
+++ b/static/app/components/onboardingWizard/sidebar.spec.tsx
@@ -1,7 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {NewOnboardingSidebar} from 'sentry/components/onboardingWizard/newSidebar';
+import {OnboardingSidebar} from 'sentry/components/onboardingWizard/sidebar';
 import {type OnboardingTask, OnboardingTaskKey} from 'sentry/types/onboarding';
 
 const gettingStartedTasks: OnboardingTask[] = [
@@ -46,10 +46,10 @@ const beyondBasicsTasks: OnboardingTask[] = [
   },
 ];
 
-describe('NewSidebar', function () {
+describe('Sidebar', function () {
   it('should render the sidebar with the correct groups and tasks', async function () {
     render(
-      <NewOnboardingSidebar
+      <OnboardingSidebar
         onClose={jest.fn()}
         orientation="left"
         collapsed={false}
@@ -83,7 +83,7 @@ describe('NewSidebar', function () {
 
   it('if first group completed, second group should be expanded by default', function () {
     render(
-      <NewOnboardingSidebar
+      <OnboardingSidebar
         onClose={jest.fn()}
         orientation="left"
         collapsed={false}
@@ -114,7 +114,7 @@ describe('NewSidebar', function () {
     });
 
     render(
-      <NewOnboardingSidebar
+      <OnboardingSidebar
         onClose={jest.fn()}
         orientation="left"
         collapsed={false}

--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -557,7 +557,7 @@ function TaskGroup({
   );
 }
 
-interface NewSidebarProps
+interface SidebarProps
   extends Pick<CommonSidebarProps, 'orientation' | 'collapsed'>,
     Pick<
       ReturnType<typeof useOnboardingTasks>,
@@ -566,13 +566,13 @@ interface NewSidebarProps
   onClose: () => void;
 }
 
-export function NewOnboardingSidebar({
+export function OnboardingSidebar({
   onClose,
   orientation,
   collapsed,
   gettingStartedTasks,
   beyondBasicsTasks,
-}: NewSidebarProps) {
+}: SidebarProps) {
   const walkthrough = isDemoModeEnabled();
 
   const sortedGettingStartedTasks = gettingStartedTasks.sort(

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -17,7 +17,7 @@ import {
   ExpandedContext,
   ExpandedContextProvider,
 } from 'sentry/components/sidebar/expandedContextProvider';
-import {NewOnboardingStatus} from 'sentry/components/sidebar/newOnboardingStatus';
+import {OnboardingStatus} from 'sentry/components/sidebar/onboardingStatus';
 import {DismissableRollbackBanner} from 'sentry/components/sidebar/rollback/dismissableBanner';
 import {isDone} from 'sentry/components/sidebar/utils';
 import {
@@ -621,7 +621,7 @@ function Sidebar() {
               {...sidebarItemProps}
             />
             <SidebarSection hasNewNav={hasNewNav} noMargin noPadding>
-              <NewOnboardingStatus
+              <OnboardingStatus
                 currentPanel={activePanel}
                 onShowPanel={() => togglePanel(SidebarPanelKey.ONBOARDING_WIZARD)}
                 hidePanel={hidePanel}

--- a/static/app/components/sidebar/onboardingStatus.spec.tsx
+++ b/static/app/components/sidebar/onboardingStatus.spec.tsx
@@ -3,7 +3,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {NewOnboardingStatus} from 'sentry/components/sidebar/newOnboardingStatus';
+import {OnboardingStatus} from 'sentry/components/sidebar/onboardingStatus';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {OnboardingTaskKey} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
@@ -40,7 +40,7 @@ describe('Onboarding Status', function () {
     const handleShowPanel = jest.fn();
 
     render(
-      <NewOnboardingStatus
+      <OnboardingStatus
         currentPanel=""
         onShowPanel={handleShowPanel}
         hidePanel={jest.fn()}
@@ -84,7 +84,7 @@ describe('Onboarding Status', function () {
     const handleHidePanel = jest.fn();
 
     render(
-      <NewOnboardingStatus
+      <OnboardingStatus
         currentPanel={SidebarPanelKey.ONBOARDING_WIZARD}
         onShowPanel={jest.fn()}
         hidePanel={handleHidePanel}

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -4,7 +4,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
-import {NewOnboardingSidebar} from 'sentry/components/onboardingWizard/newSidebar';
+import {OnboardingSidebar} from 'sentry/components/onboardingWizard/sidebar';
 import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
 import {useOnboardingTasks} from 'sentry/components/onboardingWizard/useOnboardingTasks';
 import {findCompleteTasks} from 'sentry/components/onboardingWizard/utils';
@@ -26,15 +26,15 @@ import useProjects from 'sentry/utils/useProjects';
 import type {CommonSidebarProps} from './types';
 import {SidebarPanelKey} from './types';
 
-type NewOnboardingStatusProps = CommonSidebarProps;
+type OnboardingStatusProps = CommonSidebarProps;
 
-export function NewOnboardingStatus({
+export function OnboardingStatus({
   collapsed,
   currentPanel,
   orientation,
   hidePanel,
   onShowPanel,
-}: NewOnboardingStatusProps) {
+}: OnboardingStatusProps) {
   const organization = useOrganization();
   const onboardingContext = useContext(OnboardingContext);
   const {projects} = useProjects();
@@ -148,7 +148,7 @@ export function NewOnboardingStatus({
         )}
       </Container>
       {isActive && (
-        <NewOnboardingSidebar
+        <OnboardingSidebar
           orientation={orientation}
           collapsed={collapsed}
           onClose={hidePanel}


### PR DESCRIPTION
Contributes to https://github.com/getsentry/projects/issues/346