### PR TITLE
ref(quick-start): Remove 'USER_CONTEXT' from onboarding tasks

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -103,7 +103,7 @@ from sentry.net.http import connection_from_url
 from sentry.plugins.base import plugins
 from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
-from sentry.receivers.onboarding import record_release_received, record_user_context_received
+from sentry.receivers.onboarding import record_release_received
 from sentry.reprocessing2 import is_reprocessed_event
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.signals import (
@@ -2538,7 +2538,6 @@ def _record_transaction_info(jobs: Sequence[Job], projects: ProjectsMapping) -> 
             # instead of sending a signal. we should consider potentially
             # deleting these
             record_event_processed(project, event)
-            record_user_context_received(project, event)
             record_release_received(project, event)
         except Exception:
             sentry_sdk.capture_exception()

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -60,7 +60,6 @@ class OnboardingTaskStatus:
 #   FIRST_EVENT:     User confirms that sdk has been installed
 #   INVITE_MEMBER:   Until the member has successfully joined org
 #   SECOND_PLATFORM: User confirms that sdk has been installed
-#   USER_CONTEXT:    User has added user context to sdk
 #   ISSUE_TRACKER:   Tracker added, issue not yet created
 
 
@@ -126,7 +125,6 @@ class OrganizationOnboardingTask(AbstractOnboardingTask):
         (OnboardingTask.FIRST_EVENT, "send_first_event"),
         (OnboardingTask.INVITE_MEMBER, "invite_member"),
         (OnboardingTask.SECOND_PLATFORM, "setup_second_platform"),
-        (OnboardingTask.USER_CONTEXT, "setup_user_context"),
         (OnboardingTask.RELEASE_TRACKING, "setup_release_tracking"),
         (OnboardingTask.SOURCEMAPS, "setup_sourcemaps"),
         (OnboardingTask.USER_REPORTS, "setup_user_reports"),

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -20,12 +20,13 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.db.models.manager.base import BaseManager
 
 
+# NOTE: There are gaps in the numberation because a
+# few tasks were removed as they are no longer used in the quick start sidebar
 class OnboardingTask:
     FIRST_PROJECT = 1
     FIRST_EVENT = 2
     INVITE_MEMBER = 3
     SECOND_PLATFORM = 4
-    USER_CONTEXT = 5
     RELEASE_TRACKING = 6
     SOURCEMAPS = 7
     USER_REPORTS = 8

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -480,44 +480,6 @@ event_processed.connect(record_release_received, weak=False)
 transaction_processed.connect(record_release_received, weak=False)
 
 
-def record_user_context_received(project, event, **kwargs):
-    user_context = event.data.get("user")
-    if not user_context:
-        return
-    # checking to see if only ip address is being sent (our js library does this automatically)
-    # testing for this in test_no_user_tracking_for_ip_address_only
-    # list(d.keys()) pattern is to make this python3 safe
-    elif list(user_context.keys()) != ["ip_address"]:
-        success = OrganizationOnboardingTask.objects.record(
-            organization_id=project.organization_id,
-            task=OnboardingTask.USER_CONTEXT,
-            status=OnboardingTaskStatus.COMPLETE,
-            project_id=project.id,
-        )
-        if success:
-            organization = Organization.objects.get_from_cache(id=project.organization_id)
-            try:
-                owner: RpcUser = organization.get_default_owner()
-            except IndexError:
-                logger.warning(
-                    "Cannot record user context received for organization (%s) due to missing owners",
-                    project.organization_id,
-                )
-                return
-
-            analytics.record(
-                "first_user_context.sent",
-                user_id=owner.id,
-                organization_id=project.organization_id,
-                project_id=project.id,
-            )
-
-            try_mark_onboarding_complete(project.organization_id, owner)
-
-
-event_processed.connect(record_user_context_received, weak=False)
-
-
 @first_event_with_minified_stack_trace_received.connect(weak=False)
 def record_event_with_first_minified_stack_trace_for_project(project, event, **kwargs):
     organization = Organization.objects.get_from_cache(id=project.organization_id)
@@ -551,9 +513,6 @@ def record_event_with_first_minified_stack_trace_for_project(project, event, **k
                 project_platform=project.platform,
                 url=dict(event.tags).get("url", None),
             )
-
-
-transaction_processed.connect(record_user_context_received, weak=False)
 
 
 @event_processed.connect(weak=False)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1584,7 +1584,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         self,
         mock_record_sample: mock.MagicMock,
         mock_record_release: mock.MagicMock,
-        mock_record_user: mock.MagicMock,
         mock_record_event: mock.MagicMock,
     ) -> None:
         manager = EventManager(
@@ -1644,7 +1643,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         event = manager.save(self.project.id)
 
         mock_record_event.assert_called_once_with(self.project, event)
-        mock_record_user.assert_called_once_with(self.project, event)
         mock_record_release.assert_called_once_with(self.project, event)
         assert mock_record_sample.mock_calls == [
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "wait")

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1578,7 +1578,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager.save(self.project.id)
 
     @patch("sentry.event_manager.record_event_processed")
-    @patch("sentry.event_manager.record_user_context_received")
     @patch("sentry.event_manager.record_release_received")
     @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
     def test_transaction_sampler_and_receive_mock_called(


### PR DESCRIPTION
Contributes to https://github.com/getsentry/projects/issues/352 and https://github.com/getsentry/projects/issues/346