### PR TITLE
ci: make sure backend tests don't run unnecessarily

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -48,7 +48,7 @@ backend_build_changes: &backend_build_changes
   - 'pyproject.toml'
 
 # `backend_src` filters on files that are backend changes excluding
-# changes to the tests/ directory.
+# changes to the tests/ directory and changes to typescript related config files.
 # If you want to filter on *all* backend files, use the `backend_all` filter.
 backend_src: &backend_src
   - *backend_build_changes
@@ -59,7 +59,7 @@ backend_src: &backend_src
   - 'src/sentry/!(static)/**'
   - 'src/sentry_plugins/**/*.html'
   - 'migrations_lockfile.txt'
-  - 'config/**/*'
+  - 'config/**/!(tsconfig)*'
   - 'fixtures/search-syntax/**/*'
 
 backend_all: &backend_all


### PR DESCRIPTION
tsconfig files located inside the config/ directory should not trigger backend builds, as typescript is a frontend tool
