### PR TITLE
fix(dashboards): Handle mismatched timeseries types in widgets

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -98,10 +98,28 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // show an error.
   const firstSeries = props.timeseries[0]!;
 
-  // TODO: Raise error if attempting to plot series of different types or units
+  let yAxisType: string;
+
+  const types = Array.from(
+    new Set(
+      props.timeseries
+        .map(timeserie => {
+          return timeserie?.meta?.fields[timeserie.field];
+        })
+        .filter(Boolean)
+    )
+  ) as string[];
+
+  if (types.length === 0 || types.length > 1) {
+    yAxisType = FALLBACK_TYPE;
+  } else {
+    yAxisType = types[0]!;
+  }
+
   const firstSeriesField = firstSeries?.field;
-  const type = firstSeries?.meta?.fields?.[firstSeriesField] ?? FALLBACK_TYPE;
-  const unit = firstSeries?.meta?.units?.[firstSeriesField] ?? undefined;
+
+  // TODO: It would be smart, here, to check the units and convert if necessary
+  const yAxisUnit = firstSeries?.meta?.units?.[firstSeriesField] ?? undefined;
 
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = (
     params,
@@ -227,7 +245,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         animation: false,
         axisLabel: {
           formatter(value: number) {
-            return formatYAxisValue(value, type, unit);
+            return formatYAxisValue(value, yAxisType, yAxisUnit);
           },
         },
         axisPointer: {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -100,7 +100,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   // TODO: Raise error if attempting to plot series of different types or units
   const firstSeriesField = firstSeries?.field;
-  const type = firstSeries?.meta?.fields?.[firstSeriesField] ?? 'number';
+  const type = firstSeries?.meta?.fields?.[firstSeriesField] ?? FALLBACK_TYPE;
   const unit = firstSeries?.meta?.units?.[firstSeriesField] ?? undefined;
 
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = (
@@ -140,8 +140,18 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     return getFormatter({
       isGroupedByDate: true,
       showTimeInTooltip: true,
-      valueFormatter: value => {
-        return formatTooltipValue(value, type, unit);
+      valueFormatter: (value, field) => {
+        if (!field) {
+          return formatTooltipValue(value, FALLBACK_TYPE);
+        }
+
+        const timeserie = props.timeseries.find(t => t.field === field);
+
+        return formatTooltipValue(
+          value,
+          timeserie?.meta?.fields?.[field] ?? FALLBACK_TYPE,
+          timeserie?.meta?.units?.[field] ?? undefined
+        );
       },
       nameFormatter: formatSeriesName,
       truncate: true,
@@ -242,3 +252,5 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     />
   );
 }
+
+const FALLBACK_TYPE = 'number';


### PR DESCRIPTION
Copies a bit of logic from Dashboards and adds it to `LineChartWidget` and `AreaChartWidget.

- Format tooltip value according to timeseries. This allows correct formatting in the tooltip if the series are mismatched
- Check for mismatched types. If the timeseries types are mismatched, fall back to a unitless Y axis

**e.g.,**
<img width="431" alt="Screenshot 2025-01-15 at 7 49 50 AM" src="https://github.com/user-attachments/assets/e2ddc564-a4fe-4eb5-9379-a6f001d07e34" />
