### PR TITLE
fix(dashboards): Fix timeseries widget loading background colour

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -27,7 +27,7 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
     return (
       <WidgetFrame title={props.title} description={props.description}>
         <LoadingPlaceholder>
-          <TransparentLoadingMask visible />
+          <LoadingMask visible />
           <LoadingIndicator mini />
         </LoadingPlaceholder>
       </WidgetFrame>
@@ -82,4 +82,8 @@ const LoadingPlaceholder = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;
+`;
+
+const LoadingMask = styled(TransparentLoadingMask)`
+  background: ${p => p.theme.background};
 `;


### PR DESCRIPTION
**Before:**
<img width="379" alt="Screenshot 2025-01-15 at 8 33 08 AM" src="https://github.com/user-attachments/assets/bd4d0acd-d1a6-4ce2-890c-2d70dade9194" />

**After:**
<img width="378" alt="Screenshot 2025-01-15 at 8 33 19 AM" src="https://github.com/user-attachments/assets/d63808b9-d35c-4a1b-b255-20b974f6a2ed" />
