### PR TITLE
feat(symx): Add os as a tag

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -541,9 +541,15 @@ def emit_apple_symbol_stats(apple_symbol_stats, data):
             os_description = os_name + str(os_version)
             if os_description in options.get("symbolicate.symx-os-description-list"):
                 with sentry_sdk.isolation_scope() as scope:
+                    scope.set_tag("os", os_description)
                     scope.set_context(
                         "Event Info",
-                        {"id": data.get("event_id"), "modules": old, "os": os_description},
+                        {
+                            "project": data.get("project"),
+                            "id": data.get("event_id"),
+                            "modules": old,
+                            "os": os_description,
+                        },
                     )
                     sentry_sdk.capture_message("Failed to find symbols using symx")
 


### PR DESCRIPTION
Filtering by OS would be nice. Cardinality-wise this is no problem since we are only interested in a list of 4 values.

This also adds the project ID to the context so we can more easily find the event if we need to.