### PR TITLE
feat(widget-builder): Allow other functions in sort for spans

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -55,6 +55,7 @@ export function SortBySelectors({
   disableSortDirection,
   widgetQuery,
   displayType,
+  tags,
 }: Props) {
   const datasetConfig = getDatasetConfig(widgetType);
   const organization = useOrganization();
@@ -103,7 +104,7 @@ export function SortBySelectors({
         title={disableSortReason}
         disabled={!disableSort || (disableSortDirection && disableSort)}
       >
-        {displayType === DisplayType.TABLE || widgetType === WidgetType.SPANS ? (
+        {displayType === DisplayType.TABLE ? (
           <SelectControl
             name="sortBy"
             aria-label={t('Sort by')}
@@ -135,7 +136,8 @@ export function SortBySelectors({
             }
             fieldOptions={datasetConfig.getTimeseriesSortOptions!(
               organization,
-              widgetQuery
+              widgetQuery,
+              tags
             )}
             filterPrimaryOptions={
               datasetConfig.filterSeriesSortOptions

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -937,7 +937,7 @@ describe('WidgetBuilder', function () {
   });
 
   describe('spans dataset timeseries', function () {
-    it('returns only the selected aggregates and group by as options', async function () {
+    it('returns group by and aggregate as primary options', async function () {
       const widget: Widget = {
         id: '1',
         title: 'Test Widget',
@@ -967,16 +967,16 @@ describe('WidgetBuilder', function () {
       });
 
       await screen.findByText('Sort by a y-axis');
-      await selectEvent.openMenu(await screen.findByText('count(span.duration)'));
+      await selectEvent.openMenu(screen.getAllByText('count(\u2026)')[1]!);
 
-      // 3 options in the dropdown
-      expect(screen.queryAllByTestId('menu-list-item-label')).toHaveLength(3);
+      // 12 options in the dropdown
+      expect(screen.queryAllByTestId('menu-list-item-label')).toHaveLength(12);
 
-      // Appears once in the dropdown and once in the sort by field
-      expect(await screen.findAllByText('count(span.duration)')).toHaveLength(2);
+      // Appears once in the y-axis section, dropdown, and in the sort by field
+      expect(await screen.findAllByText('count(\u2026)')).toHaveLength(3);
 
-      // Appears once in the dropdown
-      expect(await screen.findAllByText('avg(span.duration)')).toHaveLength(1);
+      // Appears once in the y-axis section and in the dropdown
+      expect(await screen.findAllByText('avg(\u2026)')).toHaveLength(2);
 
       // Appears once in the dropdown and once in the group by field
       expect(await screen.findAllByText('transaction')).toHaveLength(2);

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -54,7 +54,9 @@ export function useAddToDashboard() {
           fields = sampleFields.filter(Boolean);
         }
       } else {
-        fields = [...groupBys, ...yAxes].filter(Boolean);
+        fields = [...groupBys, ...yAxes, ...sortBys.map(sort => sort.field)].filter(
+          Boolean
+        );
       }
 
       const search = new MutableSearch(query);

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -54,9 +54,9 @@ export function useAddToDashboard() {
           fields = sampleFields.filter(Boolean);
         }
       } else {
-        fields = [...groupBys, ...yAxes, ...sortBys.map(sort => sort.field)].filter(
-          Boolean
-        );
+        fields = [
+          ...new Set([...groupBys, ...yAxes, ...sortBys.map(sort => sort.field)]),
+        ].filter(Boolean);
       }
 
       const search = new MutableSearch(query);


### PR DESCRIPTION
A user can add a new series to the explore UI that sorts on a different field than it's showing. This allows us to transfer the query over to the dashboard by applying the sorting to the fields and then allowing the sort by selectors to show that option (i.e. unlike tables that need you to choose a column that's represented)

Going to add tests in later for this because it's just for spans and I'd like for us to turn on widget builder to internal soon