### PR TITLE
chore(eslint): Enable no-unescaped-entities and fix violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -337,7 +337,6 @@ export default typescript.config([
       ...react.configs.flat.recommended.rules,
       ...react.configs.flat['jsx-runtime'].rules,
       'react/display-name': 'off', // TODO(ryan953): Fix violations and delete this line
-      'react/no-unescaped-entities': 'off', // TODO(ryan953): Fix violations and delete this line
       'react/no-unknown-property': ['error', {ignore: ['css']}],
       'react/prop-types': 'off', // TODO(ryan953): Fix violations and delete this line
     },

--- a/static/app/components/alert.stories.tsx
+++ b/static/app/components/alert.stories.tsx
@@ -89,7 +89,7 @@ export default storyBook(Alert, story => {
     return (
       <Fragment>
         <p>
-          The <JSXProperty name="opaque" value /> prop is a boolean that's{' '}
+          The <JSXProperty name="opaque" value /> prop is a boolean that&apos;s{' '}
           <code>false</code> by default.
         </p>
         <SizingWindow display="block">

--- a/static/app/components/alertLink.stories.tsx
+++ b/static/app/components/alertLink.stories.tsx
@@ -77,7 +77,7 @@ export default storyBook(AlertLink, story => {
     return (
       <Fragment>
         <p>
-          The <JSXProperty name="system" value /> prop is a boolean that's{' '}
+          The <JSXProperty name="system" value /> prop is a boolean that&apos;s{' '}
           <code>false</code> by default.
         </p>
         <AlertLink>The default style.</AlertLink>
@@ -90,8 +90,8 @@ export default storyBook(AlertLink, story => {
     return (
       <Fragment>
         <p>
-          The <JSXProperty name="withoutMarginBottom" value /> prop is a boolean that's{' '}
-          <code>false</code> by default.
+          The <JSXProperty name="withoutMarginBottom" value /> prop is a boolean
+          that&apos;s <code>false</code> by default.
         </p>
         <AlertLink withoutMarginBottom>This one has no bottom margin.</AlertLink>
         <AlertLink>This one has bottom margin by default.</AlertLink>
@@ -104,8 +104,8 @@ export default storyBook(AlertLink, story => {
     return (
       <Fragment>
         <p>
-          The <JSXProperty name="size" value /> prop can be either <code>"small"</code> or{' '}
-          <code>"normal"</code>.{' '}
+          The prop can be either <JSXProperty name="size" value="small" />
+          or <JSXProperty name="size" value="normal" />.
         </p>
         <AlertLink priority="info" size="normal">
           Normal

--- a/static/app/components/alerts/pageBanner.stories.tsx
+++ b/static/app/components/alerts/pageBanner.stories.tsx
@@ -23,7 +23,7 @@ export default storyBook(PageBanner, story => {
 
   story('Example', () => (
     <Fragment>
-      <p>Here's an example Banner announcing this UI Component Library:</p>
+      <p>Here&apos;s an example Banner announcing this UI Component Library:</p>
       <PageBanner
         button={storiesButton}
         description="Build new products faster by exploring reusable the UI components available inside Sentry."
@@ -71,8 +71,8 @@ export default storyBook(PageBanner, story => {
     return (
       <Fragment>
         <p>
-          The banner will resize if it's shrunk really narrow. To make it expand inside a
-          flex parent set <kbd>flex-grow:1</kbd>.
+          The banner will resize if it&apos;s shrunk really narrow. To make it expand
+          inside a flex parent set <kbd>flex-grow:1</kbd>.
         </p>
         <p>
           <Button size="sm" onClick={() => setFlexGrow(!flexGrow)}>

--- a/static/app/components/avatar/avatarList.stories.tsx
+++ b/static/app/components/avatar/avatarList.stories.tsx
@@ -69,8 +69,9 @@ export default storyBook(AvatarList, story => {
       <Fragment>
         <p>
           You can set <JSXProperty name="typeAvatars" value={String} /> at any time, but
-          it's especially important when passing in teams or teams + users together. This
-          is rendered as the suffix to the tooltip on the summary avatar "10 other users"
+          it&apos;s especially important when passing in teams or teams + users together.
+          This is rendered as the suffix to the tooltip on the summary avatar &quot;10
+          other users&quot;
           <SizingWindow display="block" style={{width: '50%'}}>
             {isLoading ? (
               <Placeholder />

--- a/static/app/components/avatar/seenByList.stories.tsx
+++ b/static/app/components/avatar/seenByList.stories.tsx
@@ -61,11 +61,11 @@ export default storyBook(SeenByList, story => {
     return (
       <Fragment>
         <p>
-          In this example we've explicitly put `user` at the start of the list, that's
-          you! But it'll be filtered out. The idea is that that viewer is more interested
-          in who else has seen a resource. On the issue stream, for example, we indicate
-          if the viewer (you) has seen an issue by changing the font-weight to normal
-          after viewed.
+          In this example we&apos;ve explicitly put `user` at the start of the list,
+          that&apos;s you! But it&apos;ll be filtered out. The idea is that that viewer is
+          more interested in who else has seen a resource. On the issue stream, for
+          example, we indicate if the viewer (you) has seen an issue by changing the
+          font-weight to normal after viewed.
         </p>
         <SizingWindow display="block" style={{width: '50%'}}>
           {fetching ? <Placeholder /> : <SeenByList seenBy={[user, ...members]} />}

--- a/static/app/components/calendar/calendar.stories.tsx
+++ b/static/app/components/calendar/calendar.stories.tsx
@@ -17,7 +17,7 @@ export default storyBook('Calendar', story => {
           <JSXProperty name="onChange" value={Function} />.
         </p>
         <p>
-          Under the hook we're using{' '}
+          Under the hook we&apos;re using{' '}
           <ExternalLink href="https://github.com/hypeserver/react-date-range">
             react-date-range v1.4.x
           </ExternalLink>

--- a/static/app/components/checkInTimeline/checkInTimeline.stories.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.stories.tsx
@@ -95,11 +95,11 @@ export default storyBook(CheckInTimeline, story => {
       <PageFiltersContainer>
         <p>
           The <JSXNode name="CheckInTimeline" /> component may be used to render a
-          timeline of 'check-ins'.
+          timeline of &apos;check-ins&apos;.
         </p>
         <p>
-          The timeline is given a list of "Buckets" where each bucket contains a time
-          range of check-ins. Buckets are contiguous, so if there is a 5 second
+          The timeline is given a list of &quot;Buckets&quot; where each bucket contains a
+          time range of check-ins. Buckets are contiguous, so if there is a 5 second
           resolution, each bucket contains 5 seconds worth of check-in data. Buckets that
           are contiguously the same status will be merged together visually.
         </p>

--- a/static/app/components/codeSnippet.stories.tsx
+++ b/static/app/components/codeSnippet.stories.tsx
@@ -14,8 +14,8 @@ export default storyBook(CodeSnippet, story => {
         The <JSXNode name="CodeSnippet" /> component is useful when you want to render
         code instructions in onboarding or other setup situations. By default, the code
         snippet is able to be copied, selected, and has rounded corners and shows in light
-        mode. It'll also apply formatting automatically, if the language (passed in with
-        the <JSXProperty name="language" value={String} />
+        mode. It&apos;ll also apply formatting automatically, if the language (passed in
+        with the <JSXProperty name="language" value={String} />
         prop) is known.
       </p>
 

--- a/static/app/components/collapsible.stories.tsx
+++ b/static/app/components/collapsible.stories.tsx
@@ -31,8 +31,8 @@ export default storyBook(Collapsible, story => {
   story('Bugs', () => (
     <Fragment>
       <p>
-        It's possible to use <JSXNode name="ul" /> or <JSXNode name="ol" />, but beware
-        that the button will appear inside the list as well.
+        It&apos;s possible to use <JSXNode name="ul" /> or <JSXNode name="ol" />, but
+        beware that the button will appear inside the list as well.
       </p>
       <SideBySide>
         <ol>

--- a/static/app/components/compactSelect/index.stories.tsx
+++ b/static/app/components/compactSelect/index.stories.tsx
@@ -12,9 +12,9 @@ export default storyBook(CompactSelect, story => {
     return (
       <Fragment>
         <p>
-          <code>CompactSelect</code> is a general-purpose dropdown select component. It's
-          a capable alternative to <code>select</code> elements, and supports features
-          like sections, search, multi-select, loading states, and more.
+          <code>CompactSelect</code> is a general-purpose dropdown select component.
+          It&apos;s a capable alternative to <code>select</code> elements, and supports
+          features like sections, search, multi-select, loading states, and more.
         </p>
 
         <p>
@@ -47,8 +47,8 @@ export default storyBook(CompactSelect, story => {
       <Fragment>
         <p>
           In the most basic case, a <code>value</code>, <code>onChange</code> handler and
-          an array of <code>options</code> are all that's needed. The component does not
-          maintain its own selection state.
+          an array of <code>options</code> are all that&apos;s needed. The component does
+          not maintain its own selection state.
         </p>
 
         <CompactSelect value={value} onChange={handleValueChange} options={options} />
@@ -83,8 +83,8 @@ export default storyBook(CompactSelect, story => {
       <Fragment>
         <p>
           <code>CompactSelect</code> can also be made searchable, clearable,
-          multi-selectable, etc. It's also possible to group items into sections, and set
-          the props for the trigger.
+          multi-selectable, etc. It&apos;s also possible to group items into sections, and
+          set the props for the trigger.
         </p>
 
         <CompactSelect
@@ -125,12 +125,13 @@ export default storyBook(CompactSelect, story => {
     return (
       <Fragment>
         <p>
-          In some cases, it's useful to add caching to <code>CompactSelect</code>. If your
-          select is loading data asynchronously as the user types, a naive implementation
-          will interrupt the user flow. Consider the country selector below. Try typing
-          "c" then a second later "a", then "n". You'll notice that the loading state
-          interrupts the flow, because it clears the options list. This happens if the
-          data hook clears previous results while data is loading (very common).
+          In some cases, it&apos;s useful to add caching to <code>CompactSelect</code>. If
+          your select is loading data asynchronously as the user types, a naive
+          implementation will interrupt the user flow. Consider the country selector
+          below. Try typing <kbd>c</kbd> then a second later <kbd>a</kbd>, then{' '}
+          <kbd>n</kbd>. You&apos;ll notice that the loading state interrupts the flow,
+          because it clears the options list. This happens if the data hook clears
+          previous results while data is loading (very common).
         </p>
         <div>
           <CompactSelect

--- a/static/app/components/confirm.stories.tsx
+++ b/static/app/components/confirm.stories.tsx
@@ -22,7 +22,7 @@ export default storyBook(Confirm, story => {
           a trigger, or by calling <code>openConfirmModal()</code> in a callback.
         </p>
         <p>
-          It's recommended to call <code>openConfirmModal()</code>.
+          It&apos;s recommended to call <code>openConfirmModal()</code>.
         </p>
         <p>Current state is: {state}.</p>
         <SideBySide>
@@ -161,7 +161,7 @@ export default storyBook(Confirm, story => {
   story('<Confirm> child render func', () => (
     <Fragment>
       <p>
-        Here's an example where <JSXProperty name="children" value={Function} /> is a
+        Here&apos;s an example where <JSXProperty name="children" value={Function} /> is a
         render function:
       </p>
       <Confirm>{({open}) => <Button onClick={open}>Open the modal</Button>}</Confirm>

--- a/static/app/components/container/negativeSpaceContainer.stories.tsx
+++ b/static/app/components/container/negativeSpaceContainer.stories.tsx
@@ -12,11 +12,11 @@ export default storyBook(NegativeSpaceContainer, story => {
     <Fragment>
       <p>
         A <JSXNode name="NegativeSpaceContainer" /> is a container with a diagonal pattern
-        for a background. It will preserve the aspect ratio of whatever is inside it. It's
-        a flex element, so the children are free to expand/contract depending on whether
-        things like <kbd>flex-grow: 1</kbd> are set.
+        for a background. It will preserve the aspect ratio of whatever is inside it.
+        It&apos;s a flex element, so the children are free to expand/contract depending on
+        whether things like <kbd>flex-grow: 1</kbd> are set.
       </p>
-      <p>Here's one with nothing inside it:</p>
+      <p>Here&apos;s one with nothing inside it:</p>
       <NegativeSpaceContainer
         style={{width: '100%', height: '100px'}}
         data-test-id="empty-container"

--- a/static/app/components/copyToClipboardButton.stories.tsx
+++ b/static/app/components/copyToClipboardButton.stories.tsx
@@ -16,7 +16,7 @@ export default storyBook(CopyToClipboardButton, story => {
       <p>
         By default the button will stick the <JSXProperty name="text" value={String} />{' '}
         value onto your clipboard; as if you typed <kbd>CTRL+C</kbd> or <kbd>CMD+C</kbd>.
-        It'll show toast messages, and includes{' '}
+        It&apos;ll show toast messages, and includes{' '}
         <JSXProperty name="onCopy" value={Function} /> &
         <JSXProperty name="onError" value={Function} /> callbacks.
       </p>
@@ -37,10 +37,10 @@ export default storyBook(CopyToClipboardButton, story => {
     return (
       <Fragment>
         <p>
-          There's also a hook you can use to get the same behavior and apply it to any
-          other component.
+          There&apos;s also a hook you can use to get the same behavior and apply it to
+          any other component.
         </p>
-        <p>Here's an example where I've chosen a different icon:</p>
+        <p>Here&apos;s an example where I&apos;ve chosen a different icon:</p>
         <Button icon={<IconLink />} aria-label={label} onClick={onClick} />
       </Fragment>
     );
@@ -54,8 +54,8 @@ export default storyBook(CopyToClipboardButton, story => {
     <Fragment>
       <p>
         Try to keep the <JSXProperty name="size" value="" /> and{' '}
-        <JSXProperty name="iconSize" value="" /> props set to the same value. Here's a
-        grid of all the possible combinations.
+        <JSXProperty name="iconSize" value="" /> props set to the same value. Here&apos;s
+        a grid of all the possible combinations.
       </p>
       <Matrix
         render={CopyToClipboardButton}

--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -216,8 +216,8 @@ export function AutofixSetupContent({
       <Divider />
       <Header>Set up Autofix</Header>
       <p>
-        Sentry's AI-enabled Autofix uses all of the contextual data surrounding this error
-        to work with you to find the root cause and create a fix.
+        Sentry&apos;s AI-enabled Autofix uses all of the contextual data surrounding this
+        error to work with you to find the root cause and create a fix.
       </p>
       <p>To use Autofix, please follow the instructions below.</p>
       <AutofixSetupSteps autofixSetup={data} />

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -1135,7 +1135,7 @@ function ScrapingSourceFileAvailableChecklistItem({
           <Fragment>
             <p>{t('Sentry symbolification error message:')}</p>
             <ScrapingSymbolificationErrorMessage>
-              "{sourceResolutionResults.sourceFileScrapingStatus.details}"
+              &quot;{sourceResolutionResults.sourceFileScrapingStatus.details}&quot;
             </ScrapingSymbolificationErrorMessage>
           </Fragment>
         )}
@@ -1205,7 +1205,7 @@ function ScrapingSourceMapAvailableChecklistItem({
           <Fragment>
             <p>{t('Sentry symbolification error message:')}</p>
             <ScrapingSymbolificationErrorMessage>
-              "{sourceResolutionResults.sourceMapScrapingStatus.details}"
+              &quot;{sourceResolutionResults.sourceMapScrapingStatus.details}&quot;
             </ScrapingSymbolificationErrorMessage>
           </Fragment>
         )}

--- a/static/app/components/globalDrawer/index.stories.tsx
+++ b/static/app/components/globalDrawer/index.stories.tsx
@@ -15,15 +15,15 @@ export default storyBook('GlobalDrawer', story => {
     <Fragment>
       <p>
         <JSXNode name="GlobalDrawer" /> is a way to show a slide-out drawer on the right
-        side of the UI. It's an application-wide singleton component, which means that
-        only one drawer can be open at any given time and its position is always the same.
-        The drawer is opened and closed via React hooks. The contents of the drawer are
-        unstyled.
+        side of the UI. It&apos;s an application-wide singleton component, which means
+        that only one drawer can be open at any given time and its position is always the
+        same. The drawer is opened and closed via React hooks. The contents of the drawer
+        are unstyled.
       </p>
       <p>
-        By default the drawer can be closed with an "Escape" key press, with an outside
-        click, or on URL location change. This behavior can be changed by passing in
-        options to <code>openDrawer</code>. More on this below.
+        By default the drawer can be closed with an <kbd>Escape</kbd> key press, with an
+        outside click, or on URL location change. This behavior can be changed by passing
+        in options to <code>openDrawer</code>. More on this below.
       </p>
     </Fragment>
   ));
@@ -180,7 +180,7 @@ function MyDrawer({title}: {title: string}) {
         </LeftButton>
 
         <p>
-          Finally, "Escape" key press. You can control this with the{' '}
+          Finally, <kbd>Escape</kbd> key press. You can control this with the{' '}
           <code>closeOnEscapeKeypress</code> prop.
         </p>
 
@@ -192,7 +192,7 @@ function MyDrawer({title}: {title: string}) {
             })
           }
         >
-          Open Drawer. Does not close on "Escape".
+          Open Drawer. Does not close on <kbd>Escape</kbd>.
         </LeftButton>
       </Fragment>
     );
@@ -201,8 +201,8 @@ function MyDrawer({title}: {title: string}) {
   story('Automatically Opening Drawer on URLs', () => (
     <Fragment>
       <p>
-        It's good practice to represent the drawer state in the URL. If a page opens a
-        details drawer, that should update the URL. Opening that URL should open the
+        It&apos;s good practice to represent the drawer state in the URL. If a page opens
+        a details drawer, that should update the URL. Opening that URL should open the
         drawer. The simplest way to do this is via <code>useEffect</code> and checking the
         URL.
       </p>
@@ -239,10 +239,10 @@ function ModalContent() {
       </CodeSnippet>
 
       <p>
-        You don't need to worry about closing the drawer, since it'll close automatically
-        on URL change. If the drawer contents rely on the URL and change it, you'll need
-        to specify <code>shouldCloseOnLocationChange</code> to prevent the drawer from
-        closing (or re-triggering) unnecessarily.
+        You don&apos;t need to worry about closing the drawer, since it&apos;ll close
+        automatically on URL change. If the drawer contents rely on the URL and change it,
+        you&apos;ll need to specify <code>shouldCloseOnLocationChange</code> to prevent
+        the drawer from closing (or re-triggering) unnecessarily.
       </p>
     </Fragment>
   ));
@@ -254,9 +254,9 @@ function ModalContent() {
         <p>
           <JSXNode name="DrawerHeader" /> and <JSXNode name="DrawerBody" /> are helper
           components. You can use them to make your drawers look consistent with the rest
-          of the application. <JSXNode name="DrawerHeader" /> includes a "Close" button
-          and a spot to render a title. <JSXNode name="DrawerBody" /> specifies correct
-          padding, scrolling, and overflow.
+          of the application. <JSXNode name="DrawerHeader" /> includes a &quot;Close&quot;
+          button and a spot to render a title. <JSXNode name="DrawerBody" /> specifies
+          correct padding, scrolling, and overflow.
         </p>
 
         <CodeSnippet language="jsx">

--- a/static/app/components/guidedSteps/guidedSteps.stories.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.stories.tsx
@@ -95,13 +95,13 @@ export default storyBook(GuidedSteps, story => {
               <GuidedSteps.StepButtons />
             </GuidedSteps.Step>
             <GuidedSteps.Step title="Step 2 Title" stepKey="step-2" isCompleted={false}>
-              You haven't completed the second step yet, here's how you do it.
+              You haven&apos;t completed the second step yet, here&apos;s how you do it.
               <GuidedSteps.ButtonWrapper>
                 <GuidedSteps.BackButton />
               </GuidedSteps.ButtonWrapper>
             </GuidedSteps.Step>
             <GuidedSteps.Step title="Step 3 Title" stepKey="step-3" isCompleted={false}>
-              You haven't completed the third step yet, here's how you do it.
+              You haven&apos;t completed the third step yet, here&apos;s how you do it.
               <GuidedSteps.ButtonWrapper>
                 <GuidedSteps.BackButton />
               </GuidedSteps.ButtonWrapper>

--- a/static/app/components/keyValueData/index.stories.tsx
+++ b/static/app/components/keyValueData/index.stories.tsx
@@ -13,7 +13,7 @@ import theme from 'sentry/utils/theme';
 export default storyBook('KeyValueData', story => {
   story('Usage', () => (
     <CodeSnippet language="js">
-      import KeyValueData from 'sentry/components/keyValueData';
+      import KeyValueData from &apos;sentry/components/keyValueData&apos;;
     </CodeSnippet>
   ));
   story('<KeyValueData.Content />', () => (
@@ -115,10 +115,10 @@ export default storyBook('KeyValueData', story => {
     <Fragment>
       <p>
         <code>{'<KeyValueData.Container/>'}</code> can be used in combination with{' '}
-        <code>{'<KeyValueData.Card/>'}</code> components to create a 'masonry' style
-        layout for space efficiency. They leverage the{' '}
+        <code>{'<KeyValueData.Card/>'}</code> components to create a &apos;masonry&apos;
+        style layout for space efficiency. They leverage the{' '}
         <code>useIssueDetailsColumnCount</code> hook to distribute cards into the
-        available space evenly. They don't accept any props, and just require{' '}
+        available space evenly. They don&apos;t accept any props, and just require{' '}
         <code>children</code>.
       </p>
       <p>

--- a/static/app/components/loadingError.stories.tsx
+++ b/static/app/components/loadingError.stories.tsx
@@ -14,7 +14,7 @@ export default storyBook(LoadingError, story => {
         <p>
           You can use this <JSXNode name="LoadingError" /> to easily render an error
           message if a smaller component on your page fails to load. This is useful for
-          rendering a default error message if there's an error returned from a
+          rendering a default error message if there&apos;s an error returned from a
           <code>useApiQuery</code> call, for example.
         </p>
         <SizingWindow style={{height: '150px'}}>

--- a/static/app/components/onboardingPanel.stories.tsx
+++ b/static/app/components/onboardingPanel.stories.tsx
@@ -27,7 +27,7 @@ export default storyBook(OnboardingPanel, story => {
         <OnboardingPanel image={<img src={emptyStateImg} />}>
           <h3>What do users think?</h3>
           <p>
-            You can't read minds. At least we hope not. Ask users for feedback on the
+            You can&apos;t read minds. At least we hope not. Ask users for feedback on the
             impact of their crashes or bugs and you shall receive.
           </p>
           <ButtonList gap={1}>
@@ -45,8 +45,8 @@ export default storyBook(OnboardingPanel, story => {
           <OnboardingPanel image={<img src={emptyStateImg} />}>
             <h3>What do users think?</h3>
             <p>
-              You can't read minds. At least we hope not. Ask users for feedback on the
-              impact of their crashes or bugs and you shall receive.
+              You can&apos;t read minds. At least we hope not. Ask users for feedback on
+              the impact of their crashes or bugs and you shall receive.
             </p>
           </OnboardingPanel>
         </SizingWindow>
@@ -58,20 +58,20 @@ export default storyBook(OnboardingPanel, story => {
     return (
       <Fragment>
         <p>
-          You're not required to specify an <JSXProperty name="image" value /> with this
-          component, in which case your <JSXNode name="OnboardingPanel" /> might look
+          You&apos;re not required to specify an <JSXProperty name="image" value /> with
+          this component, in which case your <JSXNode name="OnboardingPanel" /> might look
           something like this.
         </p>
         <p>
-          Here, we've specified the optional property
+          Here, we&apos;ve specified the optional property
           <JSXProperty name="noCenter" value="true" />, which makes the content
           left-aligned. Note that the <JSXProperty name="noCenter" value /> prop is only
-          valid if there isn't an image specified!
+          valid if there isn&apos;t an image specified!
         </p>
         <OnboardingPanel noCenter>
           <h3>What do users think?</h3>
           <p>
-            You can't read minds. At least we hope not. Ask users for feedback on the
+            You can&apos;t read minds. At least we hope not. Ask users for feedback on the
             impact of their crashes or bugs and you shall receive.
           </p>
           <ButtonList gap={1}>

--- a/static/app/components/questionTooltip.stories.tsx
+++ b/static/app/components/questionTooltip.stories.tsx
@@ -15,8 +15,8 @@ export default storyBook(QuestionTooltip, story => {
           The <JSXNode name="QuestionTooltip" /> component is a small{' '}
           <JSXNode name="IconQuestion" /> where you can specify a tooltip to go with it.
           It is useful for placing after headers and titles to include additional
-          information. You'll see it often at the top of Sentry's pages, near the page
-          titles.
+          information. You&apos;ll see it often at the top of Sentry&apos;s pages, near
+          the page titles.
         </p>
         <p>
           An example <JSXNode name="QuestionTooltip" /> looks like this:
@@ -49,22 +49,28 @@ export default storyBook(QuestionTooltip, story => {
         </p>
         <IconExamples>
           <div>
-            "xs" <QuestionTooltip size="xs" title="xs" />
+            <JSXProperty name="size" value="xs" />{' '}
+            <QuestionTooltip size="xs" title="xs" />
           </div>
           <div>
-            "sm" <QuestionTooltip size="sm" title="sm" />
+            <JSXProperty name="size" value="sm" />{' '}
+            <QuestionTooltip size="sm" title="sm" />
           </div>
           <div>
-            "md" <QuestionTooltip size="md" title="md" />
+            <JSXProperty name="size" value="md" />{' '}
+            <QuestionTooltip size="md" title="md" />
           </div>
           <div>
-            "lg" <QuestionTooltip size="lg" title="lg" />
+            <JSXProperty name="size" value="lg" />{' '}
+            <QuestionTooltip size="lg" title="lg" />
           </div>
           <div>
-            "xl" <QuestionTooltip size="xl" title="xl" />
+            <JSXProperty name="size" value="xl" />{' '}
+            <QuestionTooltip size="xl" title="xl" />
           </div>
           <div>
-            "xxl" <QuestionTooltip size="xxl" title="xxl" />
+            <JSXProperty name="size" value="xxl" />{' '}
+            <QuestionTooltip size="xxl" title="xxl" />
           </div>
         </IconExamples>
       </Fragment>

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
@@ -20,7 +20,7 @@ export default storyBook(ReplayPreferenceDropdown, story => {
     return (
       <Fragment>
         <p>
-          Most often you'll want to save preferences into localStorage using the{' '}
+          Most often you&apos;ll want to save preferences into localStorage using the{' '}
           <code>LocalStorageReplayPreferences</code> strategy.
         </p>
         <p>
@@ -82,7 +82,7 @@ export default storyBook(ReplayPreferenceDropdown, story => {
     return (
       <Fragment>
         <p>
-          You can hide the fast-forward checkbox in case that's not supported or
+          You can hide the fast-forward checkbox in case that&apos;s not supported or
           desirable.
         </p>
         <ReplayPreferencesContextProvider prefsStrategy={StaticReplayPreferences}>

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -529,15 +529,15 @@ export default storyBook(SearchQueryBuilder, story => {
               parameter.
               <ul>
                 <li>
-                  <code>'value'</code>: If this parameter is a value it also requires a{' '}
-                  <code>dataType</code> and, optionally, a list of <code>options</code>{' '}
-                  that will be displayed as suggestions.
+                  <JSXProperty name="kind" value="value" />: If this parameter is a value
+                  it also requires a <code>dataType</code> and, optionally, a list of{' '}
+                  <code>options</code> that will be displayed as suggestions.
                 </li>
                 <li>
-                  <code>'column'</code>: Column parameters suggest other existing filter
-                  keys. This also requires <code>columnTypes</code> to be defined, which
-                  may be a list of data types that the column may be or a predicate
-                  function.
+                  <JSXProperty name="kind" value="column" />: Column parameters suggest
+                  other existing filter keys. This also requires <code>columnTypes</code>{' '}
+                  to be defined, which may be a list of data types that the column may be
+                  or a predicate function.
                 </li>
               </ul>
             </li>
@@ -581,24 +581,24 @@ export default storyBook(SearchQueryBuilder, story => {
     return (
       <Fragment>
         <p>
-          <code>onChange</code> is called whenever the search query changes. This can be
-          used to update the UI as the user updates the query.
+          <JSXProperty name="onChange" value={Function} /> is called whenever the search
+          query changes. This can be used to update the UI as the user updates the query.
         </p>
         <p>
-          <code>onSearch</code> is called when the user presses enter. This can be used to
-          submit the search query.
+          <JSXProperty name="onSearch" value={Function} /> is called when the user presses
+          enter. This can be used to submit the search query.
         </p>
         <p>
           <ul>
             <li>
               <strong>
-                Last <code>onChange</code> value
+                Last <JSXProperty name="onChange" value /> value
               </strong>
               : <code>{onChangeValue}</code>
             </li>
             <li>
               <strong>
-                Last <code>onSearch</code> value
+                Last <JSXProperty name="onSearch" value /> value
               </strong>
               : <code>{onSearchValue}</code>
             </li>

--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -106,8 +106,8 @@ export default storyBook(StructuredEventData, story => {
       <Fragment>
         <p>
           You can keep track of the expanded/collapsed state so the component looks the
-          same even if it's re-rendered on the screen at a later time (like in a virtual
-          scrolling list).
+          same even if it&apos;s re-rendered on the screen at a later time (like in a
+          virtual scrolling list).
         </p>
         <p>
           The <JSXProperty name="onToggleExpand" value={Function} /> callback is not

--- a/static/app/components/switchButton.stories.tsx
+++ b/static/app/components/switchButton.stories.tsx
@@ -16,9 +16,9 @@ export default storyBook('Switch', story => {
     return (
       <Fragment>
         <p>
-          The <JSXNode name="Switch" /> component is a toggle button. It doesn't have any
-          property to specify a text label, so you'll need to add your own accompanying
-          label if you need one.
+          The <JSXNode name="Switch" /> component is a toggle button. It doesn&apos;t have
+          any property to specify a text label, so you&apos;ll need to add your own
+          accompanying label if you need one.
         </p>
         <p>
           Here we are specifying the label with an HTML <code>label</code> element, which
@@ -44,8 +44,9 @@ export default storyBook('Switch', story => {
     return (
       <Fragment>
         <p>
-          The <JSXProperty name="size" value /> prop has two options: <code>"sm"</code>{' '}
-          and <code>"lg"</code>. The default value is <code>"sm"</code>.
+          The prop has two options: <JSXProperty name="size" value="sm" />
+          and <JSXProperty name="size" value="lg" />. The default value is{' '}
+          <JSXProperty name="size" value="sm" />.
         </p>
         <SwitchItem htmlFor="lg-switch">
           Large switch

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 import range from 'lodash/range';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
+import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix, {type PropMatrix} from 'sentry/components/stories/matrix';
 import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
@@ -197,10 +198,11 @@ export default storyBook(Tabs, story => {
     return (
       <div>
         <p>
-          Use the variant prop to control which tab design to use. The default, "flat", is
-          used in the above examples, but you can also use "filled" variant, as shown
-          below. Note that the "filled" variant does not work when the oritentation is
-          vertical
+          Use the variant prop to control which tab design to use. The default,{' '}
+          <JSXProperty name="variant" value="flat" />, is used in the above examples, but
+          you can also use <JSXProperty name="variant" value="filled" /> variant, as shown
+          below. Note that the <JSXProperty name="variant" value="filled" /> variant does
+          not work when the oritentation is vertical
         </p>
         <SizingWindow>
           <Tabs>
@@ -217,7 +219,10 @@ export default storyBook(Tabs, story => {
           </Tabs>
         </SizingWindow>
         <br />
-        <p>You can also use the "floating" variant, which is used below</p>
+        <p>
+          You can also use the <JSXProperty name="variant" value="foating" />
+          variant, which is used below
+        </p>
         <SizingWindow>
           <Tabs>
             <TabList variant="floating" hideBorder>

--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -18,7 +18,7 @@ import storyBook from 'sentry/stories/storyBook';
 export default storyBook('Timeline (Updated 06/17/24)', story => {
   story('Usage', () => (
     <CodeSnippet language="js">
-      import Timeline from 'sentry/components/timeline';
+      import Timeline from &apos;sentry/components/timeline&apos;;
     </CodeSnippet>
   ));
 
@@ -195,7 +195,7 @@ export default storyBook('Timeline (Updated 06/17/24)', story => {
       <p>
         <code>{'<Timeline.Container />'}</code> expects to contain{' '}
         <code>{'<Timeline.Item />'}</code> components. Adds a vertical line behind the
-        elements, even if the item is not marked 'isActive'.
+        elements, even if the item is not marked &apos;isActive&apos;.
       </p>
       <h6>Example</h6>
       <Timeline.Container>

--- a/static/app/components/workflowEngine/layout/index.stories.tsx
+++ b/static/app/components/workflowEngine/layout/index.stories.tsx
@@ -75,7 +75,7 @@ export default storyBook('Layout Components', story => {
         component.
       </p>
       <p>
-        The page's breadcrumbs are defined by the{' '}
+        The page&apos;s breadcrumbs are defined by the{' '}
         <JSXNode
           name="BreadcrumbsProvider"
           props={{crumb: {label: 'Automations', to: '/automations'}}}
@@ -83,7 +83,7 @@ export default storyBook('Layout Components', story => {
         component.
       </p>
       <p>
-        The page's action buttons are defined by the{' '}
+        The page&apos;s action buttons are defined by the{' '}
         <JSXNode name="ActionsProvider" props={{actions: <JSXNode name="Button" />}} />{' '}
         component.
       </p>

--- a/static/app/styles/colors.stories.tsx
+++ b/static/app/styles/colors.stories.tsx
@@ -121,8 +121,8 @@ export default function ColorStories() {
       <hr />
       <h4>Accent Colors</h4>
       <p>
-        Accent colors help shift the user's focus to certain interactive and high-priority
-        elements, like links, buttons, and warning banners.
+        Accent colors help shift the user&apos;s focus to certain interactive and
+        high-priority elements, like links, buttons, and warning banners.
       </p>
       <h5>Hues</h5>
       <p>There are 6 hues to choose from. Each has specific connotations:</p>
@@ -162,7 +162,7 @@ export default function ColorStories() {
           <strong>The 300 level</strong> has full opacity and serves well as text and icon
           colors (with the exception of Yellow 300, which does not meet{' '}
           <ExternalLink href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html">
-            WCAG's contrast standards
+            WCAG&apos;s contrast standards
           </ExternalLink>
           ).
         </li>
@@ -196,7 +196,7 @@ export default function ColorStories() {
         to confirm text contrast ratios.
       </p>
       <p>
-        In Sentry's color palette, only Gray 300 and above satisfy the contrast
+        In Sentry&apos;s color palette, only Gray 300 and above satisfy the contrast
         requirement for normal text. This applies to both light and dark mode.
       </p>
       <p>
@@ -345,7 +345,7 @@ const PositiveLabel = styled(({className}: {className?: string}) => (
 const NegativeLabel = styled(({className}: {className?: string}) => (
   <div className={className}>
     <IconClose color="red400" />
-    DON'T
+    DON&apos;T
   </div>
 ))`
   color: ${p => p.theme.red400};

--- a/static/app/styles/typography.stories.tsx
+++ b/static/app/styles/typography.stories.tsx
@@ -160,8 +160,8 @@ export default function TypographyStories() {
     <FixedWidth>
       <h3>Typography</h3>
       <p>
-        We've built Sentry's type system around Rubik - a playful open-source typeface.
-        For code and code-like elements, we use <code>Roboto Mono</code>.
+        We&apos;ve built Sentry&apos;s type system around Rubik - a playful open-source
+        typeface. For code and code-like elements, we use <code>Roboto Mono</code>.
       </p>
       <hr />
       <h4>Type scale</h4>
@@ -170,8 +170,8 @@ export default function TypographyStories() {
         common elements, such as Heading 1, Heading 2, Paragraph, and Button/Label.
       </p>
       <p>
-        Sentry's type scale is based on the Rubik typeface. The root font size is 16px
-        (1rem = 16px).
+        Sentry&apos;s type scale is based on the Rubik typeface. The root font size is
+        16px (1rem = 16px).
       </p>
       <PanelTable headers={['Scale', 'Weight', 'Size', 'Line Height', 'Letter Spacing']}>
         {TYPE_SCALE.map(({name, ...props}) => {
@@ -273,7 +273,8 @@ export default function TypographyStories() {
       <h4>External Links</h4>
       <p>
         External links lead users to pages outside the application. Examples include links
-        to Sentry's blog/marketing pages, terms of service, third-party documentation,…
+        to Sentry&apos;s blog/marketing pages, terms of service, third-party
+        documentation,…
       </p>
       <p>
         The following styling rules apply to external links only. Internal links, on the
@@ -293,8 +294,8 @@ export default function TypographyStories() {
           Add a solid underline in <ColorSwatch color="blue100" />
         </li>
         <li>
-          Don't include any preceding articles (a, the, this, our) in the linked text, for
-          example:
+          Don&apos;t include any preceding articles (a, the, this, our) in the linked
+          text, for example:
           <ul>
             <li>
               <Flex gap={space(1)} align="baseline">
@@ -333,8 +334,8 @@ export default function TypographyStories() {
       </p>
       <h5>Standalone</h5>
       <p>
-        When a link appears on its own and the user likely knows that it's a link given
-        the context, like in a footer:
+        When a link appears on its own and the user likely knows that it&apos;s a link
+        given the context, like in a footer:
       </p>
       <ExamplePanel>
         <Flex column>
@@ -347,7 +348,7 @@ export default function TypographyStories() {
           Use <ColorSwatch color="gray500" />, <ColorSwatch color="gray400" />, or{' '}
           <ColorSwatch color="gray300" />, depending on the context
         </li>
-        <li>Don't add any underline</li>
+        <li>Don&apos;t add any underline</li>
         <li>
           On hover:
           <ul>
@@ -395,7 +396,7 @@ export default function TypographyStories() {
       <p>
         <Flex gap={space(1)} align="flex-start">
           <PositiveLabel />
-          Don't add full stops (.) to the end of each item, unless the item contains
+          Don&apos;t add full stops (.) to the end of each item, unless the item contains
           multiple sentences.
         </Flex>
       </p>
@@ -619,7 +620,7 @@ const NegativeLabel = styled(
   ({className, style}: {className?: string; style?: CSSProperties}) => (
     <div className={className} style={style}>
       <IconClose color="red400" />
-      DON'T
+      DON&apos;T
     </div>
   )
 )`

--- a/static/app/views/dashboards/widgetCard/autoSizedText.stories.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.stories.tsx
@@ -19,13 +19,14 @@ export default storyBook(AutoSizedText, story => {
 
         <SmallSizingWindow>
           <AutoSizedText>
-            <OneLineSpan>NEWSFLASH, y'all!</OneLineSpan>
+            <OneLineSpan>NEWSFLASH, y&apos;all!</OneLineSpan>
           </AutoSizedText>
         </SmallSizingWindow>
 
         <p>
-          This was built for the "Big Number" widget in our Dashboards product. It's not
-          possible to <i>perfectly</i> size the text using only CSS and HTML!
+          This was built for the &quot;Big Number&quot; widget in our Dashboards product.
+          It&apos;s not possible to <i>perfectly</i> size the text using only CSS and
+          HTML!
         </p>
         <p>
           To use <JSXNode name="AutoSizedText" />, set it as the child of positioned

--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.stories.tsx
@@ -27,8 +27,8 @@ export default storyBook(AreaChartWidget, story => {
           Each timeseries is shown using a solid block of color. This chart is used to
           visualize multiple timeseries that represent parts of something. For example, a
           chart that shows time spent in the app broken down by component. In all other
-          ways, it behaves like <JSXNode name="LineChartWidget" />, though it doesn't
-          support features like "Previous Period Data".
+          ways, it behaves like <JSXNode name="LineChartWidget" />, though it doesn&apos;t
+          support features like &quot;Previous Period Data&quot;.
         </p>
         <p>
           <em>NOTE:</em> This chart is not appropriate for showing a single timeseries!
@@ -99,7 +99,7 @@ export default storyBook(AreaChartWidget, story => {
         <p>
           <JSXNode name="AreaChartWidget" /> supports the usual loading and error states.
           The loading state shows a spinner. The error state shows a message, and an
-          optional "Retry" button.
+          optional &quot;Retry&quot; button.
         </p>
 
         <SideBySide>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -33,8 +33,8 @@ export default storyBook(BigNumberWidget, story => {
 
         <p>
           <JSXNode name="BigNumberWidget" /> also supports string values. This is not
-          commonly used, but it's capable of rendering timestamps and in fact most fields
-          defined in our field renderer pipeline
+          commonly used, but it&apos;s capable of rendering timestamps and in fact most
+          fields defined in our field renderer pipeline
         </p>
 
         <SideBySide>
@@ -142,7 +142,7 @@ export default storyBook(BigNumberWidget, story => {
         <p>
           <JSXNode name="BigNumberWidget" /> supports the usual loading and error states.
           The loading state shows a simple placeholder. The error state also shows an
-          optional "Retry" button.
+          optional &quot;Retry&quot; button.
         </p>
 
         <SideBySide>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -14,8 +14,9 @@ export default storyBook(WidgetFrame, story => {
       <Fragment>
         <p>
           <JSXNode name="WidgetFrame" /> is a container element used for all widgets in
-          the Dashboards Widget Platform. It's mostly an under-the-hood component, but it
-          can be useful to emulate widget-like states, like widget cards with actions.
+          the Dashboards Widget Platform. It&apos;s mostly an under-the-hood component,
+          but it can be useful to emulate widget-like states, like widget cards with
+          actions.
         </p>
       </Fragment>
     );
@@ -31,7 +32,7 @@ export default storyBook(WidgetFrame, story => {
         </p>
 
         <p>
-          The description can be a React element, but don't go overboard. Stick to
+          The description can be a React element, but don&apos;t go overboard. Stick to
           strings, or <code>tct</code> output consisting of text and links.
         </p>
 

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -120,7 +120,7 @@ export default storyBook(LineChartWidget, story => {
         <p>
           <JSXNode name="LineChartWidget" /> supports the usual loading and error states.
           The loading state shows a spinner. The error state shows a message, and an
-          optional "Retry" button.
+          optional &quot;Retry&quot; button.
         </p>
 
         <SideBySide>

--- a/static/app/views/issueDetails/streamline/foldSection.stories.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.stories.tsx
@@ -21,7 +21,7 @@ import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
       </CodeSnippet>
       <p>
         The <code>SectionKey</code> required in props is used to create a local storage
-        state key to remember the user's previous state for the fold section.
+        state key to remember the users previous state for the fold section.
       </p>
     </Fragment>
   ));
@@ -101,7 +101,7 @@ import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
     return (
       <Fragment>
         <p>
-          Important Note: User's local storage preferences overwrite this prop, if they
+          Important Note: Users local storage preferences overwrite this prop, if they
           have manually opened this section before, it will stay open and ignore this
           prop.
         </p>

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -365,7 +365,9 @@ function MonitorForm({
                       stacked
                       inline={false}
                     />
-                    {parsedSchedule && <CronstrueText>"{parsedSchedule}"</CronstrueText>}
+                    {parsedSchedule && (
+                      <CronstrueText>&quot;{parsedSchedule}&quot;</CronstrueText>
+                    )}
                   </MultiColumnInput>
                 );
               }

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -100,7 +100,7 @@ function ReplaysList() {
               {t('Unindexed search field')}
               <EmptyStateSubheading>
                 {tct('Field [field] requires an [sdkPrompt]', {
-                  field: <strong>'click'</strong>,
+                  field: <strong>&apos;click&apos;</strong>,
                   sdkPrompt: <strong>{t('SDK version >= 7.44.0')}</strong>,
                 })}
               </EmptyStateSubheading>


### PR DESCRIPTION
This is a slightly more annoying rule to have enabled, seems like people like to put apos in their stories to this'll impact that.

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md

> This rule prevents characters that you may have meant as JSX escape characters from being accidentally injected as a text node in JSX statements.

I've seen this get into prod enough times over my tenure that we should know it's a problem; however usually it's found and fixed quickly. I was happy to see no issues in the codebase now, which might actually mean that our code-formatter is doing a good job and highlighting issues before they get deployed.

It's on the list to enable because it's part of the recommended ruleset, kind of like prettier is to formatting i'm thinking we aim to enable as much as reasonably possible. 


I replaced a bunch of places where we did the more manual work of writing `<code>"foo"</code>` to talk about a prop inside a story. The alternative is to bring in `<JSXProperty name="foo" value="sm" />` which does similar formatting but helps to show semantics in the jsx tree. 
I also exchanged some quotes with the `<kbd>` element to indicate that users will type something verbatim.