### PR TITLE
fix(trace-view): Add missing background colors to indicators

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -912,16 +912,19 @@ const TraceStylingWrapper = styled('div')`
     }
 
     &.Poor {
+      background-color: ${p => p.theme.red100};
       color: ${p => p.theme.red300};
       border: 1px solid ${p => p.theme.red300};
     }
 
     &.Meh {
+      background-color: ${p => p.theme.yellow100};
       color: ${p => p.theme.yellow400};
       border: 1px solid ${p => p.theme.yellow300};
     }
 
     &.Good {
+      background-color: ${p => p.theme.green100};
       color: ${p => p.theme.green300};
       border: 1px solid ${p => p.theme.green300};
     }


### PR DESCRIPTION
The web vitals indicators were missing their background colours, this PR adds them to conform to the design:

## Before
![image](https://github.com/user-attachments/assets/100b15d0-8a35-428b-9ac3-4863f7317647)
![image](https://github.com/user-attachments/assets/1c28971a-0e8a-459a-a67b-6dd075cf2208)


## After
![image](https://github.com/user-attachments/assets/ac034b3a-0388-4dfd-b80f-761107e43ef0)
![image](https://github.com/user-attachments/assets/74d26f4c-15b2-4f63-97bd-3be47185be95)
