### PR TITLE
ref(issue-views): Remove unnecessary state and effect from query count, fix apiquery typing 

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -1,4 +1,3 @@
-import {useEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
@@ -38,8 +37,6 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
   const pageFilters = usePageFilters();
   const theme = useTheme();
 
-  const [count, setCount] = useState<number>(0);
-
   // TODO(msun): Once page filters are saved to views, remember to use the view's specific
   // page filters here instead of the global pageFilters, if they exist.
   const {
@@ -55,17 +52,9 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
     ...constructCountTimeFrame(pageFilters.selection.datetime),
   });
 
-  useEffect(() => {
-    // Only update the count once the query has finished fetching
-    // This preserves the previous count while the query is fetching a new one
-    if (queryCount && !isFetching) {
-      setCount(
-        queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ?? 0
-      );
-    } else if (isError) {
-      setCount(0);
-    }
-  }, [queryCount, isFetching, isError, view.query, view.unsavedChanges]);
+  const count = isError
+    ? 0
+    : queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ?? 0;
 
   return (
     <QueryCountBubble

--- a/static/app/views/issueList/queries/useFetchIssueCounts.tsx
+++ b/static/app/views/issueList/queries/useFetchIssueCounts.tsx
@@ -1,6 +1,5 @@
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
-import type {QueryCount, QueryCounts} from 'sentry/views/issueList/utils';
 
 interface FetchIssueCountsParameters {
   environment: string[];
@@ -27,9 +26,9 @@ export const makeFetchIssueCounts = ({
 
 export const useFetchIssueCounts = (
   params: FetchIssueCountsParameters,
-  options: Partial<UseApiQueryOptions<Record<string, QueryCount>>> = {}
+  options: Partial<UseApiQueryOptions<Record<string, number>>> = {}
 ) => {
-  return useApiQuery<QueryCounts>(makeFetchIssueCounts(params), {
+  return useApiQuery<Record<string, number>>(makeFetchIssueCounts(params), {
     staleTime: 180000, // 3 minutes
     placeholderData: keepPreviousData,
     ...options,


### PR DESCRIPTION
Makes two minor, non-visual changes to the query count component: 

1. Removes the use of state and effect from the query count (as per [this conversation](https://github.com/getsentry/sentry/pull/82990#discussion_r1914598884) in the original PR). 
2. Fixes the typing of the apiQuery hook for issue counts