### PR TITLE
feat(hydration error): Remove confusing Before/After headings from the Mutation Tree view

### DIFF
--- a/static/app/components/replays/diff/replayMutationTree.tsx
+++ b/static/app/components/replays/diff/replayMutationTree.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
 import DiffFeedbackBanner from 'sentry/components/replays/diff/diffFeedbackBanner';
-import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import useExtractDiffMutations from 'sentry/utils/replays/hooks/useExtractDiffMutations';
 
@@ -29,10 +28,6 @@ export function ReplayMutationTree() {
 
   return (
     <Fragment>
-      <DiffHeader>
-        <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs} />
-        <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs} />
-      </DiffHeader>
       {!isLoading && Object.keys(timeIndexedMutations).length === 0 ? (
         <DiffFeedbackBanner />
       ) : null}


### PR DESCRIPTION
**Before:**
![before](https://github.com/user-attachments/assets/8a710d14-cebb-4268-a719-4a0b46cf7c24)


**After:**
![SCR-20250115-jjxs](https://github.com/user-attachments/assets/dc73783b-9dd5-4bc4-84dd-46be1bd58836)
