### PR TITLE
feat(eap): send trace_item_type with every request

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -68,7 +68,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.19.9
 sentry-kafka-schemas>=0.1.128
 sentry-ophio==1.0.0
-sentry-protos>=0.1.37
+sentry-protos>=0.1.49
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.4
 sentry-sdk[http2]>=2.19.2

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -189,7 +189,7 @@ sentry-forked-djangorestframework-stubs==3.15.2.post1
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==0.1.128
 sentry-ophio==1.0.0
-sentry-protos==0.1.39
+sentry-protos==0.1.49
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.4
 sentry-sdk==2.19.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -128,7 +128,7 @@ sentry-arroyo==2.19.9
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==0.1.128
 sentry-ophio==1.0.0
-sentry-protos==0.1.39
+sentry-protos==0.1.49
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.4
 sentry-sdk==2.19.2

--- a/src/sentry/search/eap/spans.py
+++ b/src/sentry/search/eap/spans.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import sentry_sdk
 from parsimonious.exceptions import ParseError
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
     AttributeValue,
@@ -68,6 +68,7 @@ class SearchResolver:
             project_ids=self.params.project_ids,
             start_timestamp=self.params.rpc_start_date,
             end_timestamp=self.params.rpc_end_date,
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
         )
 
     @sentry_sdk.trace

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -167,6 +167,7 @@ def rpc(
             project_ids=[project.id for project in projects],
             start_timestamp=start_time_proto,
             end_timestamp=end_time_proto,
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
         ),
         aggregate=AggregateBucketRequest.FUNCTION_SUM,
         filter=TraceItemFilter(


### PR DESCRIPTION
There's a way to tell EAP what 'type' of thing you are requesting now - it would make sense to make this field mandatory in snuba, so let's send it from sentry consistently.