### PR TITLE
fix(crons): correct broken link

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -92,7 +92,7 @@ export function CronTimelineSection({event, organization, project}: Props) {
         size="xs"
         icon={<IconOpen />}
         to={{
-          pathname: `/organizations/${organization.slug}/crons/${project.slug}/${monitorSlug}`,
+          pathname: `/organizations/${organization.slug}/alerts/rules/crons/${project.slug}/${monitorSlug}/details/`,
           query: {environment},
         }}
       >


### PR DESCRIPTION
Button would redirect users to the Crons page as opposed to the specific cron monitor's details page (although the correct page does flash for a second)

I think this was missed in #83247