### PR TITLE
feat(issue-details): Update tag drawer to show only 3 values + other

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -57,6 +57,17 @@ export function TagPreviewDistribution({tag}: {tag: GroupTag}) {
 export function TagDistribution({tag}: {tag: GroupTag}) {
   const location = useLocation();
 
+  const visibleTagValues = tag.topValues.slice(0, 3);
+
+  const totalVisible = visibleTagValues.reduce((sum, value) => sum + value.count, 0);
+  const hasOther = totalVisible < tag.totalValues;
+
+  const otherPercentage = Math.round(
+    percent(tag.totalValues - totalVisible, tag.totalValues)
+  );
+  const otherDisplayPercentage =
+    otherPercentage < 1 ? '<1%' : `${otherPercentage.toFixed(0)}%`;
+
   return (
     <div>
       <TagPanel
@@ -71,7 +82,7 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
           </Tooltip>
         </TagHeader>
         <TagValueContent>
-          {tag.topValues.map((tagValue, tagValueIdx) => {
+          {visibleTagValues.map((tagValue, tagValueIdx) => {
             const percentage = percent(tagValue.count, tag.totalValues);
             const displayPercentage =
               percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
@@ -101,6 +112,23 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
               </TagValueRow>
             );
           })}
+          {hasOther && (
+            <TagValueRow>
+              <TagValue>{t('Other')}</TagValue>
+              <Tooltip
+                title={tct('[count] of [total] tagged events', {
+                  count: (tag.totalValues - totalVisible).toLocaleString(),
+                  total: tag.totalValues.toLocaleString(),
+                })}
+                skipWrapper
+              >
+                <TooltipContainer>
+                  <TagBarValue>{otherDisplayPercentage}</TagBarValue>
+                  <TagBar percentage={otherPercentage} />
+                </TooltipContainer>
+              </Tooltip>
+            </TagValueRow>
+          )}
         </TagValueContent>
       </TagPanel>
     </div>


### PR DESCRIPTION
this pr updates the tag drawer to limit how many values we showed (10 -> 3) while adding an "Other" category. this makes the drawer much easier to parse quickly. 

before: 
<img width="856" alt="Screenshot 2025-01-15 at 2 06 32 PM" src="https://github.com/user-attachments/assets/52b630c4-b840-40b0-b5a2-70fd46ec7ed7" />


after: 
<img width="855" alt="Screenshot 2025-01-15 at 2 05 37 PM" src="https://github.com/user-attachments/assets/77ed84a9-eff7-4079-94a3-64365bc77eff" />

