### PR TITLE
fix(trace-view): Padding issue

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -770,11 +770,9 @@ const TraceStylingWrapper = styled('div')`
   width: 100%;
   height: 100%;
   grid-area: trace;
-  padding-top: 26px;
+  padding-top: 38px;
 
   &.WithIndicators {
-    padding-top: 44px;
-
     &:before {
       background-color: ${p => p.theme.background};
       height: 38px;


### PR DESCRIPTION
Traces without web vitals were rendering strangely, due to the padding not accounting for the new dimensions of the header