### PR TITLE
feat(explore): Add view samples expansion to explore

### DIFF
--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -17,6 +17,7 @@ import {
   HeaderTitle,
 } from 'sentry/components/gridEditable/styles';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 
 interface TableProps extends React.ComponentProps<typeof _TableWrapper> {}
@@ -55,8 +56,17 @@ const MINIMUM_COLUMN_WIDTH = COL_WIDTH_MINIMUM;
 export function useTableStyles(
   fields: string[],
   tableRef: React.RefObject<HTMLDivElement>,
-  minimumColumnWidth = MINIMUM_COLUMN_WIDTH
+  options?: {
+    minimumColumnWidth?: number;
+    prefixColumnWidth?: 'min-content' | number;
+  }
 ) {
+  const minimumColumnWidth = options?.minimumColumnWidth ?? MINIMUM_COLUMN_WIDTH;
+  const prefixColumnWidth =
+    defined(options?.prefixColumnWidth) && typeof options.prefixColumnWidth === 'number'
+      ? `${options.prefixColumnWidth}px`
+      : options?.prefixColumnWidth;
+
   const resizingColumnIndex = useRef<number | null>(null);
   const columnWidthsRef = useRef<(number | null)[]>(fields.map(() => null));
 
@@ -66,14 +76,15 @@ export function useTableStyles(
     );
   }, [fields]);
 
-  const initialTableStyles = useMemo(
-    () => ({
-      gridTemplateColumns: fields
-        .map(() => `minmax(${minimumColumnWidth}px, auto)`)
-        .join(' '),
-    }),
-    [fields, minimumColumnWidth]
-  );
+  const initialTableStyles = useMemo(() => {
+    const gridTemplateColumns = fields.map(() => `minmax(${minimumColumnWidth}px, auto)`);
+    if (defined(prefixColumnWidth)) {
+      gridTemplateColumns.unshift(prefixColumnWidth);
+    }
+    return {
+      gridTemplateColumns: gridTemplateColumns.join(' '),
+    };
+  }, [fields, minimumColumnWidth, prefixColumnWidth]);
 
   const onResizeMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>, index: number) => {
@@ -105,13 +116,15 @@ export function useTableStyles(
         columnWidthsRef.current[index] = newWidth;
 
         // Updating the grid's `gridTemplateColumns` directly
-        gridElement.style.gridTemplateColumns = columnWidthsRef.current
-          .map(width => {
-            return typeof width === 'number'
-              ? `${width}px`
-              : `minmax(${minimumColumnWidth}px, auto)`;
-          })
-          .join(' ');
+        const gridTemplateColumns = columnWidthsRef.current.map(width => {
+          return typeof width === 'number'
+            ? `${width}px`
+            : `minmax(${minimumColumnWidth}px, auto)`;
+        });
+        if (defined(prefixColumnWidth)) {
+          gridTemplateColumns.unshift(prefixColumnWidth);
+        }
+        gridElement.style.gridTemplateColumns = gridTemplateColumns.join(' ');
       }
 
       function onMouseUp() {
@@ -125,7 +138,7 @@ export function useTableStyles(
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
     },
-    [tableRef, minimumColumnWidth]
+    [tableRef, minimumColumnWidth, prefixColumnWidth]
   );
 
   return {initialTableStyles, onResizeMouseDown};

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -1,0 +1,122 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {viewSamplesTarget} from 'sentry/views/explore/utils';
+
+describe('viewSamplesTarget', function () {
+  const project = ProjectFixture();
+  const extras = {projects: [project]};
+
+  it('simple drill down with no group bys', function () {
+    const location = LocationFixture();
+    const target = viewSamplesTarget(location, '', [], {}, extras);
+    expect(target).toMatchObject({
+      query: {
+        mode: 'samples',
+        query: '',
+      },
+    });
+  });
+
+  it('simple drill down with single group by', function () {
+    const location = LocationFixture();
+    const target = viewSamplesTarget(
+      location,
+      '',
+      ['foo'],
+      {foo: 'foo', 'count()': 10},
+      extras
+    );
+    expect(target).toMatchObject({
+      query: {
+        mode: 'samples',
+        query: 'foo:foo',
+      },
+    });
+  });
+
+  it('simple drill down with multiple group bys', function () {
+    const location = LocationFixture();
+    const target = viewSamplesTarget(
+      location,
+      '',
+      ['foo', 'bar', 'baz'],
+      {
+        foo: 'foo',
+        bar: 'bar',
+        baz: 'baz',
+        'count()': 10,
+      },
+      extras
+    );
+    expect(target).toMatchObject({
+      query: {
+        mode: 'samples',
+        query: 'foo:foo bar:bar baz:baz',
+      },
+    });
+  });
+
+  it('simple drill down with on environment', function () {
+    const location = LocationFixture();
+    const target = viewSamplesTarget(
+      location,
+      '',
+      ['environment'],
+      {
+        environment: 'prod',
+        'count()': 10,
+      },
+      extras
+    );
+    expect(target).toMatchObject({
+      query: {
+        mode: 'samples',
+        query: '',
+        environment: 'prod',
+      },
+    });
+  });
+
+  it('simple drill down with on project id', function () {
+    const location = LocationFixture();
+    const target = viewSamplesTarget(
+      location,
+      '',
+      ['project.id'],
+      {
+        'project.id': 1,
+        'count()': 10,
+      },
+      extras
+    );
+    expect(target).toMatchObject({
+      query: {
+        mode: 'samples',
+        query: '',
+        project: '1',
+      },
+    });
+  });
+
+  it('simple drill down with on project slug', function () {
+    const location = LocationFixture();
+    const target = viewSamplesTarget(
+      location,
+      '',
+      ['project'],
+      {
+        project: project.slug,
+        'count()': 10,
+      },
+      extras
+    );
+    expect(target).toMatchObject({
+      query: {
+        mode: 'samples',
+        query: '',
+        project: String(project.id),
+      },
+    });
+  });
+});

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -1,11 +1,16 @@
+import type {Location} from 'history';
 import * as qs from 'query-string';
 
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import type {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {newExploreTarget} from 'sentry/views/explore/contexts/pageParamsContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 
 export function getExploreUrl({
@@ -76,4 +81,38 @@ export function combineConfidenceForSeries(series: Series[]): Confidence {
   }
 
   return 'high';
+}
+
+export function viewSamplesTarget(
+  location: Location,
+  query: string,
+  groupBys: string[],
+  row: Record<string, any>,
+  extras: {
+    // needed to generate targets when `project` is in the group by
+    projects: Project[];
+  }
+) {
+  const search = new MutableSearch(query);
+
+  for (const groupBy of groupBys) {
+    const value = row[groupBy];
+    if (groupBy === 'project' && typeof value === 'string') {
+      const project = extras.projects.find(p => p.slug === value);
+      if (defined(project)) {
+        location.query.project = project.id;
+      }
+    } else if (groupBy === 'project.id' && typeof value === 'number') {
+      location.query.project = String(value);
+    } else if (groupBy === 'environment' && typeof value === 'string') {
+      location.query.environment = value;
+    } else if (typeof value === 'string') {
+      search.setFilterValues(groupBy, [value]);
+    }
+  }
+
+  return newExploreTarget(location, {
+    mode: Mode.SAMPLES,
+    query: search.formatString(),
+  });
 }


### PR DESCRIPTION
This adds a discover style expand stack button to the start of every row in the aggregation mode that can be used to drill down and view samples with the attributes of the row.