### PR TITLE
ref(issue-platform): replace process_occurrence function

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -69,12 +69,8 @@ def save_issue_occurrence(
     return occurrence, group_info
 
 
-def process_occurrence_data(data: dict[str, Any]) -> None:
-    if "fingerprint" not in data:
-        return
-
-    # Hash fingerprints to make sure they're a consistent length
-    data["fingerprint"] = [md5(part.encode("utf-8")).hexdigest() for part in data["fingerprint"]]
+def hash_fingerprint_parts(fingerprint: list[str]) -> list[str]:
+    return [md5(part.encode("utf-8")).hexdigest() for part in fingerprint]
 
 
 class IssueArgs(TypedDict):

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -22,7 +22,7 @@ from sentry import features, nodestore, options
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import get_group_type_by_type_id
-from sentry.issues.ingest import process_occurrence_data, save_issue_occurrence
+from sentry.issues.ingest import hash_fingerprint_parts, save_issue_occurrence
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA, LEGACY_EVENT_PAYLOAD_SCHEMA
 from sentry.issues.producer import PayloadType
@@ -206,7 +206,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
             occurrence_data = {
                 "id": UUID(payload["id"]).hex,
                 "project_id": payload["project_id"],
-                "fingerprint": payload["fingerprint"],
+                "fingerprint": hash_fingerprint_parts(payload["fingerprint"]),
                 "issue_title": payload["issue_title"],
                 "subtitle": payload["subtitle"],
                 "resource_id": payload.get("resource_id"),
@@ -217,8 +217,6 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 "level": payload.get("level", DEFAULT_LEVEL),
                 "assignee": assignee_identifier,
             }
-
-            process_occurrence_data(occurrence_data)
 
             if payload.get("event_id"):
                 occurrence_data["event_id"] = UUID(payload["event_id"]).hex

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -144,7 +144,7 @@ def bulk_get_groups_from_fingerprints(
     Returns a map of (project, fingerprint) to the group.
 
     Note that fingerprints for issue platform are expected to be
-    processed via `process_occurrence_data` prior to calling this function.
+    hashed prior to calling this function.
     """
     fingerprints_by_project: dict[int, list[str]] = defaultdict(list)
     for project_id, fingerprints in project_fingerprint_pairs:
@@ -179,16 +179,15 @@ def _get_status_change_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     """
     Processes the incoming message payload into a format we can use.
     """
-    from sentry.issues.ingest import process_occurrence_data
+    from sentry.issues.ingest import hash_fingerprint_parts
 
     data = {
-        "fingerprint": payload["fingerprint"],
+        "fingerprint": hash_fingerprint_parts(payload["fingerprint"]),
         "project_id": payload["project_id"],
         "new_status": payload["new_status"],
         "new_substatus": payload.get("new_substatus", None),
     }
 
-    process_occurrence_data(data)
     return {"status_change": data}
 
 

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -13,7 +13,7 @@ import sentry_sdk
 
 from sentry import options
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
-from sentry.issues.ingest import process_occurrence_data
+from sentry.issues.ingest import hash_fingerprint_parts
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_consumer import bulk_get_groups_from_fingerprints
 from sentry.issues.status_change_message import StatusChangeMessage
@@ -637,7 +637,6 @@ def generate_fingerprint(regression_type: RegressionType, name: str | int) -> st
 
 def generate_issue_group_key(project_id: int, fingerprint: str) -> tuple[int, str]:
     data = {
-        "fingerprint": [fingerprint],
+        "fingerprint": hash_fingerprint_parts([fingerprint]),
     }
-    process_occurrence_data(data)
     return project_id, data["fingerprint"][0]

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -7,7 +7,7 @@ from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload
 from django.test import override_settings
 
-from sentry.issues.ingest import process_occurrence_data
+from sentry.issues.ingest import hash_fingerprint_parts
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
@@ -315,8 +315,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
                 payload_type=PayloadType.STATUS_CHANGE,
                 status_change=bad_status_change,
             )
-            processed_fingerprint = {"fingerprint": ["group-1"]}
-            process_occurrence_data(processed_fingerprint)
+            processed_fingerprint = {"fingerprint": hash_fingerprint_parts(["group-1"])}
 
             self.group.refresh_from_db()
             mock_logger_error.assert_called_with(
@@ -346,8 +345,6 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
         assert group
         initial_status = group.status
         initial_substatus = group.substatus
-        wrong_fingerprint = {"fingerprint": ["wronghash"]}
-        process_occurrence_data(wrong_fingerprint)
 
         bad_status_change_resolve = StatusChangeMessage(
             fingerprint=["wronghash"],

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -11,7 +11,7 @@ from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.escalating import GroupsCountResponse
 from sentry.issues.grouptype import ProfileFileIOGroupType
-from sentry.issues.ingest import process_occurrence_data, save_issue_occurrence
+from sentry.issues.ingest import hash_fingerprint_parts, save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.issues.status_change_message import StatusChangeMessage, StatusChangeMessageData
@@ -42,7 +42,7 @@ class OccurrenceTestMixin:
             "id": uuid.uuid4().hex,
             "project_id": 1,
             "event_id": uuid.uuid4().hex,
-            "fingerprint": ["some-fingerprint"],
+            "fingerprint": hash_fingerprint_parts(["some-fingerprint"]),
             "issue_title": "something bad happened",
             "subtitle": "it was bad",
             "culprit": "api/123",
@@ -58,7 +58,6 @@ class OccurrenceTestMixin:
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 
-        process_occurrence_data(kwargs)
         return kwargs
 
     def build_occurrence(self, **overrides: Any) -> IssueOccurrence:
@@ -91,13 +90,12 @@ class StatusChangeTestMixin:
         kwargs: StatusChangeMessageData = {
             "id": uuid.uuid4().hex,
             "project_id": 1,
-            "fingerprint": ["some-fingerprint"],
+            "fingerprint": hash_fingerprint_parts(["some-fingerprint"]),
             "new_status": 1,
             "new_substatus": 1,
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 
-        process_occurrence_data(kwargs)
         return kwargs
 
     def build_statuschange(self, **overrides: Any) -> StatusChangeMessage:

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from django.utils import timezone
 
-from sentry.issues.ingest import process_occurrence_data
+from sentry.issues.ingest import hash_fingerprint_parts
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouphash import GroupHash
 from sentry.monitors.logic.mark_failed import mark_failed
@@ -430,8 +430,9 @@ class MarkFailedTestCase(TestCase):
         assert monitor_incident.starting_timestamp == checkin.date_added
         assert monitor_environment.active_incident is not None
         assert monitor_incident.grouphash == monitor_environment.active_incident.grouphash
-        occurrence_data = {"fingerprint": [monitor_environment.active_incident.grouphash]}
-        process_occurrence_data(occurrence_data)
+        occurrence_data = {
+            "fingerprint": hash_fingerprint_parts([monitor_environment.active_incident.grouphash])
+        }
         issue_platform_hash = occurrence_data["fingerprint"][0]
 
         grouphash = GroupHash.objects.get(hash=issue_platform_hash)


### PR DESCRIPTION
`process_occurrence_data` is somewhat confusing, as the naming implies it does more than it does. it also mutates data in a dictionary, which makes typing difficult and code confusing. replaces usages of it with simply calling `hash_fingerprint_parts` on the fingerprint of the occurrence data directly.