### PR TITLE
feat(aci): enqueue workflows for delayed processing

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -118,7 +118,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         filepath: file from the stacktrace (string)
         branch: commitsha or default_branch (string)
         """
-        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture() as lifecycle:
             filepath = filepath.lstrip("/")
             try:
                 client = self.get_client()
@@ -132,9 +132,12 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             except IdentityNotValid:
                 return None
             except ApiError as e:
-                if e.code != 404:
+                if e.code not in (404, 400):
                     sentry_sdk.capture_exception()
                     raise
+
+                else:
+                    lifecycle.record_halt(extra={"status_code": e.code})
 
                 return None
 

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -118,7 +118,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         filepath: file from the stacktrace (string)
         branch: commitsha or default_branch (string)
         """
-        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture() as lifecycle:
+        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture():
             filepath = filepath.lstrip("/")
             try:
                 client = self.get_client()
@@ -132,12 +132,9 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             except IdentityNotValid:
                 return None
             except ApiError as e:
-                if e.code not in (404, 400):
+                if e.code != 404:
                     sentry_sdk.capture_exception()
                     raise
-
-                else:
-                    lifecycle.record_halt(extra={"status_code": e.code})
 
                 return None
 

--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -1,5 +1,7 @@
 __all__ = [
     "EventCreatedByDetectorConditionHandler",
+    "EventFrequencyCountHandler",
+    "EventFrequencyPercentHandler",
     "EventSeenCountConditionHandler",
     "EveryEventConditionHandler",
     "ReappearedEventConditionHandler",
@@ -23,6 +25,7 @@ from .age_comparison_handler import AgeComparisonConditionHandler
 from .assigned_to_handler import AssignedToConditionHandler
 from .event_attribute_handler import EventAttributeConditionHandler
 from .event_created_by_detector_handler import EventCreatedByDetectorConditionHandler
+from .event_frequency_handlers import EventFrequencyCountHandler, EventFrequencyPercentHandler
 from .event_seen_count_handler import EventSeenCountConditionHandler
 from .every_event_handler import EveryEventConditionHandler
 from .existing_high_priority_issue_handler import ExistingHighPriorityIssueConditionHandler

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -156,19 +156,6 @@ def is_slow_condition(cond: DataCondition) -> bool:
     return Condition(cond.type) in SLOW_CONDITIONS
 
 
-def split_fast_slow_conditions(
-    conditions: list[DataCondition],
-) -> tuple[list[DataCondition], list[DataCondition]]:
-    fast_conditions = []
-    slow_conditions = []
-    for condition in conditions:
-        if is_slow_condition(condition):
-            slow_conditions.append(condition)
-        else:
-            fast_conditions.append(condition)
-    return fast_conditions, slow_conditions
-
-
 @receiver(pre_save, sender=DataCondition)
 def enforce_comparison_schema(sender, instance: DataCondition, **kwargs):
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -160,6 +160,19 @@ def is_slow_condition(cond: DataCondition) -> bool:
     return Condition(cond.type) in SLOW_CONDITIONS
 
 
+def split_fast_slow_conditions(
+    conditions: list[DataCondition],
+) -> tuple[list[DataCondition], list[DataCondition]]:
+    fast_conditions = []
+    slow_conditions = []
+    for condition in conditions:
+        if is_slow_condition(condition):
+            slow_conditions.append(condition)
+        else:
+            fast_conditions.append(condition)
+    return fast_conditions, slow_conditions
+
+
 @receiver(pre_save, sender=DataCondition)
 def enforce_comparison_schema(sender, instance: DataCondition, **kwargs):
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -123,10 +123,6 @@ class DataCondition(DefaultFieldsModel):
         return None
 
     def evaluate_value(self, value: T) -> DataConditionResult:
-        # slow conditions not evaluated here
-        if is_slow_condition(self):
-            return False
-
         try:
             condition_type = Condition(self.type)
         except ValueError:

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -66,6 +66,18 @@ CONDITION_OPS = {
     Condition.NOT_EQUAL: operator.ne,
 }
 
+SLOW_CONDITIONS = [
+    Condition.EVENT_FREQUENCY_COUNT,
+    Condition.EVENT_FREQUENCY_PERCENT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+    Condition.PERCENT_SESSIONS_COUNT,
+    Condition.PERCENT_SESSIONS_PERCENT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT,
+]
+
+
 T = TypeVar("T")
 
 
@@ -111,6 +123,10 @@ class DataCondition(DefaultFieldsModel):
         return None
 
     def evaluate_value(self, value: T) -> DataConditionResult:
+        # slow conditions not evaluated here
+        if is_slow_condition(self):
+            return False
+
         try:
             condition_type = Condition(self.type)
         except ValueError:
@@ -138,18 +154,6 @@ class DataCondition(DefaultFieldsModel):
 
         result = handler.evaluate_value(value, self.comparison)
         return self.get_condition_result() if result else None
-
-
-SLOW_CONDITIONS = [
-    Condition.EVENT_FREQUENCY_COUNT,
-    Condition.EVENT_FREQUENCY_PERCENT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
-    Condition.PERCENT_SESSIONS_COUNT,
-    Condition.PERCENT_SESSIONS_PERCENT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT,
-]
 
 
 def is_slow_condition(cond: DataCondition) -> bool:

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -84,7 +84,7 @@ def get_slow_conditions(workflow: Workflow) -> list[DataCondition]:
     slow_conditions = [
         condition
         for condition in workflow.when_condition_group.conditions.all()
-        if is_slow_condition(condition)
+        if workflow.when_condition_group and is_slow_condition(condition)
     ]
     return slow_conditions
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -3,7 +3,6 @@ from typing import Any, TypeVar
 
 from sentry.utils.function_cache import cache_func_for_models
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
-from sentry.workflow_engine.models.data_condition import split_fast_slow_conditions
 from sentry.workflow_engine.types import ProcessedDataConditionResult
 
 logger = logging.getLogger(__name__)
@@ -33,10 +32,7 @@ def evaluate_condition_group(
         # if we don't have any conditions, always return True
         return True, []
 
-    fast_conditions, slow_conditions = split_fast_slow_conditions(conditions)
-    has_slow_conditions = bool(slow_conditions)
-
-    for condition in fast_conditions:
+    for condition in conditions:
         evaluation_result = condition.evaluate_value(value)
         is_condition_triggered = evaluation_result is not None
 
@@ -51,8 +47,8 @@ def evaluate_condition_group(
         results.append((is_condition_triggered, evaluation_result))
 
     if data_condition_group.logic_type == data_condition_group.Type.NONE:
-        # if we get to this point + we don't have slow conditions, return True
-        return not has_slow_conditions, []
+        # if we get to this point, no conditions were met
+        return True, []
 
     elif data_condition_group.logic_type == data_condition_group.Type.ANY:
         is_any_condition_met = any([result[0] for result in results])
@@ -67,8 +63,7 @@ def evaluate_condition_group(
 
         if is_all_conditions_met:
             condition_results = [result[1] for result in results if result[0]]
-            # if all conditions are met so far + we don't have slow conditions, return True
-            return not has_slow_conditions, condition_results
+            return is_all_conditions_met, condition_results
 
     return False, []
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar
 
 from sentry.utils.function_cache import cache_func_for_models
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
+from sentry.workflow_engine.models.data_condition import split_fast_slow_conditions
 from sentry.workflow_engine.types import ProcessedDataConditionResult
 
 logger = logging.getLogger(__name__)
@@ -28,16 +29,13 @@ def evaluate_condition_group(
     results = []
     conditions = get_data_conditions_for_group(data_condition_group.id)
 
-    # TODO - @saponifi3d
-    # Split the conditions into fast and slow conditions
-    # Evaluate the fast conditions first, if any are met, return early
-    # Enqueue the slow conditions to be evaluated later
-
     if len(conditions) == 0:
         # if we don't have any conditions, always return True
         return True, []
 
-    for condition in conditions:
+    fast_conditions, slow_conditions = split_fast_slow_conditions(conditions)
+
+    for condition in fast_conditions:
         evaluation_result = condition.evaluate_value(value)
         is_condition_triggered = evaluation_result is not None
 
@@ -52,21 +50,23 @@ def evaluate_condition_group(
         results.append((is_condition_triggered, evaluation_result))
 
     if data_condition_group.logic_type == data_condition_group.Type.NONE:
-        # if we get to this point, no conditions were met
-        return True, []
+        # if we get to this point, no conditions were met, or we have slow conditions to check
+        return not bool(slow_conditions), []
+
     elif data_condition_group.logic_type == data_condition_group.Type.ANY:
         is_any_condition_met = any([result[0] for result in results])
 
         if is_any_condition_met:
             condition_results = [result[1] for result in results if result[0]]
             return is_any_condition_met, condition_results
+
     elif data_condition_group.logic_type == data_condition_group.Type.ALL:
         conditions_met = [result[0] for result in results]
         is_all_conditions_met = all(conditions_met)
 
         if is_all_conditions_met:
             condition_results = [result[1] for result in results if result[0]]
-            return is_all_conditions_met, condition_results
+            return is_all_conditions_met and not slow_conditions, condition_results
 
     return False, []
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -34,6 +34,7 @@ def evaluate_condition_group(
         return True, []
 
     fast_conditions, slow_conditions = split_fast_slow_conditions(conditions)
+    has_slow_conditions = bool(slow_conditions)
 
     for condition in fast_conditions:
         evaluation_result = condition.evaluate_value(value)
@@ -50,8 +51,8 @@ def evaluate_condition_group(
         results.append((is_condition_triggered, evaluation_result))
 
     if data_condition_group.logic_type == data_condition_group.Type.NONE:
-        # if we get to this point, no conditions were met, or we have slow conditions to check
-        return not bool(slow_conditions), []
+        # if we get to this point + we don't have slow conditions, return True
+        return not has_slow_conditions, []
 
     elif data_condition_group.logic_type == data_condition_group.Type.ANY:
         is_any_condition_met = any([result[0] for result in results])
@@ -66,7 +67,8 @@ def evaluate_condition_group(
 
         if is_all_conditions_met:
             condition_results = [result[1] for result in results if result[0]]
-            return is_all_conditions_met and not slow_conditions, condition_results
+            # if all conditions are met so far + we don't have slow conditions, return True
+            return not has_slow_conditions, condition_results
 
     return False, []
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -100,7 +100,6 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
     # Get the workflows, evaluate the when_condition_group, finally evaluate the actions for workflows that are triggered
     workflows = set(Workflow.objects.filter(detectorworkflow__detector_id=detector.id).distinct())
     triggered_workflows = evaluate_workflow_triggers(workflows, job)
-
     actions = evaluate_workflow_action_filters(triggered_workflows, job)
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 import sentry_sdk
 
 from sentry import buffer
-from sentry.models.project import Project
 from sentry.utils import json, metrics
 from sentry.workflow_engine.models import Detector, Workflow, WorkflowDataConditionGroup
 from sentry.workflow_engine.models.workflow import get_slow_conditions
@@ -64,7 +63,7 @@ def enqueue_workflows(
 
         value = json.dumps({"event_id": event.event_id, "occurrence_id": event.occurrence_id})
         buffer.backend.push_to_hash(
-            model=Project,
+            model=Workflow,
             filters={"project": project_id},
             field=f"{workflow.id}:{event.group.id}:{if_dcg_fields}",
             value=value,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,14 +1,47 @@
 import logging
+import random
 
 import sentry_sdk
 
-from sentry.utils import metrics
-from sentry.workflow_engine.models import Detector, Workflow
+from sentry import buffer
+from sentry.eventstore.models import GroupEvent
+from sentry.models.project import Project
+from sentry.utils import json, metrics
+from sentry.workflow_engine.models import DataCondition, Detector, Workflow
+from sentry.workflow_engine.models.workflow import get_slow_conditions
 from sentry.workflow_engine.processors.action import evaluate_workflow_action_filters
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.types import WorkflowJob
 
 logger = logging.getLogger(__name__)
+
+WORKFLOW_ENGINE_PROJECT_ID_BUFFER_LIST_KEY = "workflow_engine_project_id_buffer_list"
+
+
+def enqueue_workflow(
+    workflow: Workflow, event: GroupEvent, slow_conditions: list[DataCondition]
+) -> None:
+    project_id = event.group.project.id
+    if random.random() < 0.01:
+        logger.info(
+            "process_workflows.workflow_enqueued",
+            extra={"workflow": workflow.id, "group": event.group.id, "project": project_id},
+        )
+    buffer.backend.push_to_sorted_set(
+        WORKFLOW_ENGINE_PROJECT_ID_BUFFER_LIST_KEY, workflow.organization
+    )
+
+    slow_condition_ids = [condition.id for condition in slow_conditions]
+    slow_condition_fields = ":".join(map(str, slow_condition_ids))
+
+    value = json.dumps({"event_id": event.event_id, "occurrence_id": event.occurrence_id})
+    buffer.backend.push_to_hash(
+        model=Project,
+        filters={"project": project_id},
+        field=f"{workflow.id}:{event.group.id}:{slow_condition_fields}",
+        value=value,
+    )
+    metrics.incr("delayed_workflow.group_added")
 
 
 def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowJob) -> set[Workflow]:
@@ -17,6 +50,10 @@ def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowJob) -> se
     for workflow in workflows:
         if workflow.evaluate_trigger_conditions(job):
             triggered_workflows.add(workflow)
+        else:
+            if slow_conditions := get_slow_conditions(workflow):
+                # enqueue to be evaluated later
+                enqueue_workflow(workflow, job["event"], slow_conditions)
 
     return triggered_workflows
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import sentry_sdk
 
 from sentry import buffer
+from sentry.models.project import Project
 from sentry.utils import json, metrics
 from sentry.workflow_engine.models import Detector, Workflow, WorkflowDataConditionGroup
 from sentry.workflow_engine.models.workflow import get_slow_conditions
@@ -63,7 +64,7 @@ def enqueue_workflows(
 
         value = json.dumps({"event_id": event.event_id, "occurrence_id": event.occurrence_id})
         buffer.backend.push_to_hash(
-            model=Workflow,
+            model=Project,
             filters={"project": project_id},
             field=f"{workflow.id}:{event.group.id}:{if_dcg_fields}",
             value=value,

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -40,7 +40,7 @@ class WorkflowJob(EventJob, total=False):
     has_alert: bool
     has_escalated: bool
     workflow: Workflow
-    snuba_results: list[int]
+    snuba_results: list[int]  # TODO - @saponifi3 / TODO(cathy): audit this
 
 
 class ActionHandler:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -40,6 +40,7 @@ class WorkflowJob(EventJob, total=False):
     has_alert: bool
     has_escalated: bool
     workflow: Workflow
+    snuba_results: list[int]
 
 
 class ActionHandler:

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -46,13 +46,6 @@ class ConditionTestCase(BaseWorkflowTest):
     def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
-    # Slow conditions are evaluated in delayed processing and take in the results directly
-    def assert_slow_cond_passes(self, data_condition: DataCondition, value: Any) -> None:
-        assert data_condition.evaluate_value(value) == data_condition.get_condition_result()
-
-    def assert_slow_cond_does_not_pass(self, data_condition: DataCondition, value: Any) -> None:
-        assert data_condition.evaluate_value(value) != data_condition.get_condition_result()
-
     # TODO: activity
 
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
     EventFrequencyCountHandler,
 )
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.handlers.condition.test_base import (
     ConditionTestCase,
     EventFrequencyQueryTestBase,
@@ -27,6 +28,10 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         "comparisonType": ComparisonType.COUNT,
     }
 
+    def setUp(self):
+        super().setUp()
+        self.job = WorkflowJob({"event": self.group_event})
+
     def test_count(self):
         dc = self.create_data_condition(
             type=self.condition,
@@ -34,8 +39,11 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.assert_slow_cond_passes(dc, 1001)
-        self.assert_slow_cond_does_not_pass(dc, 999)
+        self.job["snuba_results"] = [1001]
+        self.assert_passes(dc, self.job)
+
+        self.job["snuba_results"] = [999]
+        self.assert_does_not_pass(dc, self.job)
 
     def test_dual_write_count(self):
         dcg = self.create_data_condition_group()
@@ -81,6 +89,10 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         "comparisonType": ComparisonType.PERCENT,
     }
 
+    def setUp(self):
+        super().setUp()
+        self.job = WorkflowJob({"event": self.group_event})
+
     def test_percent(self):
         dc = self.create_data_condition(
             type=self.condition,
@@ -92,8 +104,11 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.assert_slow_cond_passes(dc, [21, 10])
-        self.assert_slow_cond_does_not_pass(dc, [20, 10])
+        self.job["snuba_results"] = [21, 10]
+        self.assert_passes(dc, self.job)
+
+        self.job["snuba_results"] = [20, 10]
+        self.assert_does_not_pass(dc, self.job)
 
     def test_dual_write_percent(self):
         self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -136,3 +136,21 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         triggered_workflows = evaluate_workflow_triggers({self.workflow, workflow_two}, self.job)
 
         assert triggered_workflows == {self.workflow, workflow_two}
+
+    def test_enqueues_workflow_with_slow_conditions(self):
+        self.workflow.when_condition_group.update(logic_type=DataConditionGroup.Type.ALL)
+        self.create_data_condition(
+            condition_group=self.workflow.when_condition_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+                "comparison_interval": "1d",
+            },
+            condition_result=True,
+        )
+
+        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.job)
+        assert triggered_workflows == {}
+
+        # TODO: test buffer enqueue


### PR DESCRIPTION
Adds the following logic to account for delayed processing of slow conditions:

1. Process fast conditions in the WHEN `DataConditionGroup` (DCG), note the workflows that need to have their slow condition(s) checked before proceeding
2. For workflows that need their slow conditions checked, evaluate all their IF DCGs to determine which ones would fire if the slow condition(s) pass
3. For workflows that need their slow conditions checked + have passing IF DCGs, enqueue them in the buffer for delayed processing. We collect the IF DCGs so we know which actions to fire if the slow conditions pass via `DataConditionGroupAction`, this is so we can only evaluate slow conditions in delayed processing.