### PR TITLE
chore(eslint): Set @emotion/syntax-preference to prefer string css= prop values

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -548,7 +548,7 @@ export default typescript.config([
       '@emotion/no-vanilla': 'error',
       '@emotion/pkg-renaming': 'off', // Not needed, we have migrated to v11 and the old package names cannot be used anymore
       '@emotion/styled-import': 'error',
-      '@emotion/syntax-preference': ['error', 'string'], // TODO(ryan953): Enable this so `css={css``}` is required
+      '@emotion/syntax-preference': ['error', 'string'],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -548,7 +548,7 @@ export default typescript.config([
       '@emotion/no-vanilla': 'error',
       '@emotion/pkg-renaming': 'off', // Not needed, we have migrated to v11 and the old package names cannot be used anymore
       '@emotion/styled-import': 'error',
-      '@emotion/syntax-preference': ['off', 'string'], // TODO(ryan953): Enable this so `css={css``}` is required
+      '@emotion/syntax-preference': ['error', 'string'], // TODO(ryan953): Enable this so `css={css``}` is required
     },
   },
   {

--- a/static/app/components/customCommitsResolutionModal.tsx
+++ b/static/app/components/customCommitsResolutionModal.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
@@ -75,7 +76,12 @@ function CustomCommitsResolutionModal({
         />
       </Body>
       <Footer>
-        <Button css={{marginRight: space(1.5)}} onClick={closeModal}>
+        <Button
+          css={css`
+            margin-right: ${space(1.5)};
+          `}
+          onClick={closeModal}
+        >
           {t('Cancel')}
         </Button>
         <Button type="submit" priority="primary">

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useState} from 'react';
+import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
@@ -83,7 +84,12 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
         />
       </Body>
       <Footer>
-        <Button css={{marginRight: space(1.5)}} onClick={props.closeModal}>
+        <Button
+          css={css`
+            margin-right: ${space(1.5)};
+          `}
+          onClick={props.closeModal}
+        >
           {t('Cancel')}
         </Button>
         <Button type="submit" priority="primary">

--- a/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
+++ b/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
@@ -98,16 +98,36 @@ function AlertListItem({item}: {item: Incident}) {
         `,
       ]}
     >
-      <div css={{gridArea: 'badge'}}>
+      <div
+        css={css`
+          grid-area: badge;
+        `}
+      >
         <AlertBadge status={item.status} isIssue={false} />
       </div>
 
-      <div css={[gridFlexEndCss, xSmallCss, {gridArea: 'time', color: 'var(--gray300)'}]}>
+      <div
+        css={[
+          gridFlexEndCss,
+          xSmallCss,
+          css`
+            grid-area: time;
+            color: var(--gray300);
+          `,
+        ]}
+      >
         <TimeSince date={item.dateStarted} unitStyle="extraShort" />
       </div>
 
       <AnalyticsProvider nameVal="item" keyVal="item">
-        <TextOverflow css={[smallCss, {gridArea: 'name'}]}>
+        <TextOverflow
+          css={[
+            smallCss,
+            css`
+              grid-area: name;
+            `,
+          ]}
+        >
           <SentryAppLink
             to={{
               url: alertDetailsLink({slug: organizationSlug} as Organization, item),

--- a/static/app/components/devtoolbar/components/app.tsx
+++ b/static/app/components/devtoolbar/components/app.tsx
@@ -1,5 +1,5 @@
 import {Fragment, Suspense} from 'react';
-import {Global} from '@emotion/react';
+import {css, Global} from '@emotion/react';
 
 import AnalyticsProvider from 'sentry/components/devtoolbar/components/analyticsProvider';
 import LoadingTriangle from 'sentry/components/loadingTriangle';
@@ -31,7 +31,15 @@ export default function App() {
       <Global styles={globalCss} />
       <Global styles={loadingIndicatorCss} />
       <Global styles={avatarCss} />
-      <div css={[fixedContainerBaseCss, placement.fixedContainer.css, {visibility}]}>
+      <div
+        css={[
+          fixedContainerBaseCss,
+          placement.fixedContainer.css,
+          css`
+            visibility: ${visibility};
+          `,
+        ]}
+      >
         {isDisabled ? null : (
           <Fragment>
             <AnalyticsProvider nameVal="nav" keyVal="nav">

--- a/static/app/components/devtoolbar/components/featureFlags/customOverride.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/customOverride.tsx
@@ -25,15 +25,13 @@ export default function CustomOverride({
 
   return (
     <form
-      css={[
-        {
-          display: 'grid',
-          gridTemplateColumns: 'auto max-content max-content',
-          alignItems: 'center',
-          justifyItems: 'space-between',
-          gap: 'var(--space100)',
-        },
-      ]}
+      css={css`
+        display: grid;
+        grid-template-columns: auto max-content max-content;
+        align-items: center;
+        justify-items: space-between;
+        gap: var(--space100);
+      `}
       onSubmit={e => {
         e.preventDefault();
         setOverride(name, isActive);
@@ -58,7 +56,9 @@ export default function CustomOverride({
         toggle={() => {
           setIsActive(!isActive);
         }}
-        css={{background: 'white'}}
+        css={css`
+          background: white;
+        `}
       />
       <button
         type="submit"

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagItem.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagItem.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useContext, useState} from 'react';
+import {css} from '@emotion/react';
 
 import AnalyticsProvider, {
   AnalyticsContext,
@@ -26,7 +27,10 @@ export default function FeatureFlagItem({flag}: {flag: FeatureFlag}) {
       <Cell
         css={[
           verticalPaddingCss,
-          {alignItems: 'flex-start', marginLeft: 'var(--space200)'},
+          css`
+            align-items: flex-start;
+            margin-left: var(--space200);
+          `,
         ]}
       >
         {featureFlags?.urlTemplate?.(flag.name) ? (
@@ -46,7 +50,12 @@ export default function FeatureFlagItem({flag}: {flag: FeatureFlag}) {
           <span>{flag.name}</span>
         )}
       </Cell>
-      <Cell css={{marginRight: 'var(--space200)', justifyContent: 'center'}}>
+      <Cell
+        css={css`
+          margin-right: var(--space200);
+          justify-content: center;
+        `}
+      >
         <FlagValueInput flag={flag} />
       </Cell>
     </Fragment>
@@ -85,12 +94,12 @@ function FlagValueBooleanInput({flag}: {flag: FeatureFlag}) {
   return (
     <label
       htmlFor={`toggle-${flag.name}`}
-      css={{
-        display: 'flex',
-        alignItems: 'flex-end',
-        alignSelf: 'flex-end',
-        gap: 'var(--space100)',
-      }}
+      css={css`
+        display: flex;
+        align-items: flex-end;
+        align-self: flex-end;
+        gap: var(--space100);
+      `}
     >
       <code>{String(isActive)}</code>
       <Switch

--- a/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
+++ b/static/app/components/devtoolbar/components/featureFlags/featureFlagsPanel.tsx
@@ -57,7 +57,10 @@ export default function FeatureFlagsPanel() {
               smallCss,
               panelSectionCss,
               panelInsetContentCss,
-              {background: 'var(--surface200)', padding: 'var(--space150)'},
+              css`
+                background: var(--surface200);
+                padding: var(--space150);
+              `,
             ]}
           >
             <AnalyticsProvider keyVal="custom-override" nameVal="Custom Override">
@@ -65,18 +68,24 @@ export default function FeatureFlagsPanel() {
             </AnalyticsProvider>
           </div>
         )}
-        <div css={{display: 'grid', gridTemplateRows: 'auto auto 1fr auto', flexGrow: 1}}>
+        <div
+          css={css`
+            display: grid;
+            grid-template-rows: auto auto 1fr auto;
+            flex-grow: 1;
+          `}
+        >
           <IsDirtyMessage />
           <div
             css={[
               smallCss,
               panelSectionCssNoBorder,
               panelInsetContentCss,
-              {
-                display: 'grid',
-                gridTemplateAreas: "'search segments'",
-                gap: 'var(--space100)',
-              },
+              css`
+                display: grid;
+                grid-template-areas: 'search segments';
+                gap: var(--space100);
+              `,
             ]}
           >
             <Filters
@@ -86,9 +95,17 @@ export default function FeatureFlagsPanel() {
             />
           </div>
           <div
-            css={[{contain: 'strict', flexDirection: 'column', alignItems: 'stretch'}]}
+            css={css`
+              contain: strict;
+              flex-direction: column;
+              align-items: stretch;
+            `}
           >
-            <div css={{overflow: 'auto'}}>
+            <div
+              css={css`
+                overflow: auto;
+              `}
+            >
               <AnalyticsProvider keyVal="flag-table" nameVal="Flag Table">
                 <FlagTable searchTerm={searchTerm} prefilter={prefilter} />
               </AnalyticsProvider>
@@ -105,7 +122,14 @@ function IsDirtyMessage() {
 
   return isDirty ? (
     <div
-      css={[smallCss, panelSectionCss, panelInsetContentCss, {color: 'var(--gray300)'}]}
+      css={[
+        smallCss,
+        panelSectionCss,
+        panelInsetContentCss,
+        css`
+          color: var(--gray300);
+        `,
+      ]}
     >
       <span>Reload to see changes</span>
     </div>
@@ -125,14 +149,20 @@ function Filters({
 }) {
   return (
     <Fragment>
-      <div css={{gridArea: 'segments'}}>
+      <div
+        css={css`
+          grid-area: segments;
+        `}
+      >
         <SegmentedControl<Prefilter> onChange={setPrefilter} size="xs" value={prefilter}>
           <SegmentedControl.Item key="all">All</SegmentedControl.Item>
           <SegmentedControl.Item key="overrides">Overrides</SegmentedControl.Item>
         </SegmentedControl>
       </div>
       <Input
-        css={{gridArea: 'search'}}
+        css={css`
+          grid-area: search;
+        `}
         onChange={e => setSearchTerm(e.target.value.toLowerCase())}
         placeholder="Search"
         size="xs"
@@ -161,18 +191,16 @@ function FlagTable({prefilter, searchTerm}: {prefilter: Prefilter; searchTerm: s
       <PanelTable
         disablePadding
         disableHeaders
-        css={[
-          {
-            flexGrow: 1,
-            margin: 0,
-            borderRadius: 0,
-            border: 'none',
-            padding: 0,
-            '& > :first-child': {
-              minHeight: 'unset',
-            },
-          },
-        ]}
+        css={css`
+          flex-grow: 1;
+          margin: 0;
+          border-radius: 0;
+          border: none;
+          padding: 0;
+          & > :first-child {
+            min-height: unset;
+          }
+        `}
         headers={[undefined, undefined]}
         stickyHeaders
       >
@@ -188,7 +216,11 @@ function FlagTable({prefilter, searchTerm}: {prefilter: Prefilter; searchTerm: s
             smallCss,
             panelSectionCssNoBorder,
             panelInsetContentCss,
-            {display: 'block', textAlign: 'center', color: 'var(--gray300)'},
+            css`
+              display: block;
+              text-align: center;
+              color: var(--gray300);
+            `,
           ]}
         >
           No flags to display
@@ -200,7 +232,10 @@ function FlagTable({prefilter, searchTerm}: {prefilter: Prefilter; searchTerm: s
             smallCss,
             panelSectionCssNoBorder,
             panelInsetContentCss,
-            {display: 'block', textAlign: 'center'},
+            css`
+              display: block;
+              text-align: center;
+            `,
           ]}
         >
           <button
@@ -217,11 +252,11 @@ function FlagTable({prefilter, searchTerm}: {prefilter: Prefilter; searchTerm: s
             <span
               css={[
                 resetFlexRowCss,
-                {
-                  gap: 'var(--space75)',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                },
+                css`
+                  gap: var(--space75);
+                  align-items: center;
+                  justify-content: center;
+                `,
               ]}
             >
               <IconClose isCircled size="xs" /> Remove All

--- a/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
+++ b/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
@@ -173,7 +173,11 @@ function FeedbackListItem({item}: {item: FeedbackIssueListItem}) {
         <div css={[badgeWithLabelCss, xSmallCss]} style={{gridArea: 'owner'}}>
           {item.project ? (
             <ProjectBadge
-              css={css({'&& img': {boxShadow: 'none'}})}
+              css={css`
+                && img {
+                  box-shadow: none;
+                }
+              `}
               project={item.project}
               avatarSize={16}
               hideName

--- a/static/app/components/devtoolbar/components/issueListItem.tsx
+++ b/static/app/components/devtoolbar/components/issueListItem.tsx
@@ -23,7 +23,13 @@ export default function IssueListItem({item}: {item: Group}) {
     <AnalyticsProvider keyVal="issue-list.item" nameVal="issue list item">
       <div css={listItemGridCss}>
         <TextOverflow
-          css={[badgeWithLabelCss, smallCss, 'display: block']}
+          css={[
+            badgeWithLabelCss,
+            smallCss,
+            css`
+              display: block;
+            `,
+          ]}
           style={{gridArea: 'name', fontWeight: item.hasSeen ? 'bold' : 400}}
         >
           <SentryAppLink
@@ -49,7 +55,11 @@ export default function IssueListItem({item}: {item: Group}) {
 
         <div css={[badgeWithLabelCss, xSmallCss]} style={{gridArea: 'owner'}}>
           <ProjectBadge
-            css={css({'&& img': {boxShadow: 'none'}})}
+            css={css`
+              && img {
+                box-shadow: none;
+              }
+            `}
             project={item.project}
             avatarSize={16}
             hideName

--- a/static/app/components/devtoolbar/components/panelLayout.tsx
+++ b/static/app/components/devtoolbar/components/panelLayout.tsx
@@ -45,7 +45,11 @@ export default function PanelLayout({
       <span
         css={[
           panelHeadingCss,
-          {display: 'flex', alignItems: 'center', gap: 'var(--space100)'},
+          css`
+            display: flex;
+            align-items: center;
+            gap: var(--space100);
+          `,
           noBorder
             ? css`
                 border-color: white;
@@ -55,7 +59,11 @@ export default function PanelLayout({
       >
         {showProjectBadge && (
           <ProjectBadge
-            css={css({'&& img': {boxShadow: 'none'}})}
+            css={css`
+              && img {
+                box-shadow: none;
+              }
+            `}
             project={{
               slug: projectSlug,
               id: projectId,
@@ -71,7 +79,10 @@ export default function PanelLayout({
             css={[
               panelSectionCss,
               resetFlexRowCss,
-              {alignItems: 'center', marginRight: 'var(--space100)'},
+              css`
+                align-items: center;
+                margin-right: var(--space100);
+              `,
             ]}
           >
             {link ? (

--- a/static/app/components/devtoolbar/components/releases/releaseIssues.tsx
+++ b/static/app/components/devtoolbar/components/releases/releaseIssues.tsx
@@ -40,7 +40,10 @@ export default function ReleaseIsssues({releaseVersion}: {releaseVersion: string
             smallCss,
             panelDescCss,
             panelSectionCssNoBorder,
-            {paddingTop: 'var(--space25)', paddingBottom: 0},
+            css`
+              padding-top: var(--space25);
+              padding-bottom: 0;
+            `,
           ]}
         >
           New Issues in This Release
@@ -74,13 +77,13 @@ export default function ReleaseIsssues({releaseVersion}: {releaseVersion: string
                     panelInsetContentCss,
                     releaseBoxCss,
                     resetFlexColumnCss,
-                    {
-                      padding: 'var(--space400)',
-                      alignItems: 'center',
-                      gap: 'var(--space150)',
-                      height: '212px',
-                      justifyContent: 'center',
-                    },
+                    css`
+                      padding: var(--space400);
+                      align-items: center;
+                      gap: var(--space150);
+                      height: 212px;
+                      justify-content: center;
+                    `,
                   ]}
                 >
                   <IconSearch size="lg" />

--- a/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
+++ b/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 
 import AnalyticsProvider from 'sentry/components/devtoolbar/components/analyticsProvider';
 import ReleaseIsssues from 'sentry/components/devtoolbar/components/releases/releaseIssues';
@@ -67,21 +68,31 @@ function getDiff(
       css={[
         releaseBoxCss,
         releaseNumbersCss,
-        {
-          backgroundColor: diffColor[1],
-          borderColor: diffColor[0],
-        },
+        css`
+          background-color: ${diffColor[1]};
+          border-color: ${diffColor[0]};
+        `,
       ]}
     >
-      <span css={[smallCss, {color: diffColor[0], fontWeight: 'bold'}]}>Change</span>
+      <span
+        css={[
+          smallCss,
+          css`
+            color: ${diffColor[0]};
+            font-weight: bold;
+          `,
+        ]}
+      >
+        Change
+      </span>
       <span
         css={[
           resetFlexRowCss,
-          {
-            alignItems: 'center',
-            gap: 'var(--space25)',
-            color: diffColor[0],
-          },
+          css`
+            align-items: center;
+            gap: var(--space25);
+            color: ${diffColor[0]};
+          `,
         ]}
       >
         {diff}
@@ -95,7 +106,15 @@ function getDiff(
 
 function ReleaseSummary({orgSlug, release}: {orgSlug: string; release: Release}) {
   return (
-    <PanelItem css={[releaseBoxCss, {width: '92%', alignItems: 'flex-start'}]}>
+    <PanelItem
+      css={[
+        releaseBoxCss,
+        css`
+          width: 92%;
+          align-items: flex-start;
+        `,
+      ]}
+    >
       <ReleaseInfoHeader css={infoHeaderCss}>
         <AnalyticsProvider nameVal="latest release" keyVal="latest-release">
           <SentryAppLink
@@ -112,9 +131,22 @@ function ReleaseSummary({orgSlug, release}: {orgSlug: string; release: Release})
         </AnalyticsProvider>
       </ReleaseInfoHeader>
       <ReleaseInfoSubheader
-        css={[resetFlexColumnCss, subtextCss, {alignItems: 'flex-start'}]}
+        css={[
+          resetFlexColumnCss,
+          subtextCss,
+          css`
+            align-items: flex-start;
+          `,
+        ]}
       >
-        <span css={[resetFlexRowCss, {gap: 'var(--space25)'}]}>
+        <span
+          css={[
+            resetFlexRowCss,
+            css`
+              gap: var(--space25);
+            `,
+          ]}
+        >
           <TimeSince date={release.lastDeploy?.dateFinished || release.dateCreated} />
           {release.lastDeploy?.dateFinished &&
             ` \u2022 ${release.lastDeploy.environment}`}
@@ -152,7 +184,12 @@ function CrashFreeRate({
 
   if (isCurrLoading || isPrevLoading) {
     return (
-      <PanelItem css={{width: '100%', padding: 'var(--space150)'}}>
+      <PanelItem
+        css={css`
+          width: 100%;
+          padding: var(--space150);
+        `}
+      >
         <Placeholder
           height={crashComparisonPlaceholderHeight}
           css={[
@@ -173,25 +210,50 @@ function CrashFreeRate({
 
   return (
     <div>
-      <span css={[smallCss, panelDescCss, panelSectionCssNoBorder, {paddingBottom: 0}]}>
+      <span
+        css={[
+          smallCss,
+          panelDescCss,
+          panelSectionCssNoBorder,
+          css`
+            padding-bottom: 0;
+          `,
+        ]}
+      >
         Crash Free Session Rate
       </span>
       <div
-        css={[
-          {
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr 1fr',
-            gap: 'var(--space100)',
-            padding: 'var(--space75) var(--space150) var(--space150) var(--space150)',
-          },
-        ]}
+        css={css`
+          display: grid;
+          grid-template-columns: 1fr 1fr 1fr;
+          gap: var(--space100);
+          padding: var(--space75) var(--space150) var(--space150) var(--space150);
+        `}
       >
         <div css={[releaseBoxCss, releaseNumbersCss]}>
-          <span css={[smallCss, {fontWeight: 'bold'}]}>Latest</span>
+          <span
+            css={[
+              smallCss,
+              css`
+                font-weight: bold;
+              `,
+            ]}
+          >
+            Latest
+          </span>
           {currCrashFreeRate}%
         </div>
         <div css={[releaseBoxCss, releaseNumbersCss]}>
-          <span css={[smallCss, {fontWeight: 'bold'}]}>Previous</span>
+          <span
+            css={[
+              smallCss,
+              css`
+                font-weight: bold;
+              `,
+            ]}
+          >
+            Previous
+          </span>
           {prevCrashFreeRate}%
         </div>
         {getDiff(
@@ -224,7 +286,16 @@ export default function ReleasesPanel() {
   return (
     <PanelLayout title="Latest Release" showProjectBadge link={{url: '/releases/'}}>
       <AnalyticsProvider nameVal="header" keyVal="header">
-        <span css={[smallCss, panelDescCss, panelSectionCssNoBorder, {paddingBottom: 0}]}>
+        <span
+          css={[
+            smallCss,
+            panelDescCss,
+            panelSectionCssNoBorder,
+            css`
+              padding-bottom: 0;
+            `,
+          ]}
+        >
           Latest Release
         </span>
       </AnalyticsProvider>

--- a/static/app/components/devtoolbar/components/replay/replayPanel.tsx
+++ b/static/app/components/devtoolbar/components/replay/replayPanel.tsx
@@ -62,7 +62,14 @@ export default function ReplayPanel() {
       </Button>
       <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
         {lastReplayId ? (
-          <span css={[resetFlexRowCss, {gap: 'var(--space50)'}]}>
+          <span
+            css={[
+              resetFlexRowCss,
+              css`
+                gap: var(--space50);
+              `,
+            ]}
+          >
             {isRecording ? 'Current replay: ' : 'Last recorded replay: '}
             <AnalyticsProvider keyVal="replay-details-link" nameVal="replay details link">
               <ReplayLink lastReplayId={lastReplayId} />
@@ -88,15 +95,19 @@ function ReplayLink({lastReplayId}: {lastReplayId: string}) {
       <div
         css={[
           resetFlexRowCss,
-          {
-            display: 'inline-flex',
-            gap: 'var(--space50)',
-            alignItems: 'center',
-          },
+          css`
+            display: inline-flex;
+            gap: var(--space50);
+            align-items: center;
+          `,
         ]}
       >
         <ProjectBadge
-          css={css({'&& img': {boxShadow: 'none'}})}
+          css={css`
+            && img {
+              box-shadow: none;
+            }
+          `}
           project={{
             slug: projectSlug,
             id: projectId,

--- a/static/app/components/modals/recoveryOptionsModal.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useState} from 'react';
+import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/alert';
@@ -100,7 +101,9 @@ function RecoveryOptionsModal({
             onClick={closeModal}
             to={`/settings/account/security/mfa/${sms.id}/enroll/`}
             name="addPhone"
-            css={{marginLeft: space(1)}}
+            css={css`
+              margin-left: ${space(1)};
+            `}
             autoFocus
           >
             {t('Add a Phone Number')}

--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {usePopper} from 'react-popper';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
@@ -603,7 +604,12 @@ function ProfileIdsSubMenu(props: {
       {isOpen &&
         props.subMenuPortalRef &&
         createPortal(
-          <ProfilingContextMenu style={popper.styles.popper} css={{maxHeight: 250}}>
+          <ProfilingContextMenu
+            style={popper.styles.popper}
+            css={css`
+              max-height: 250px;
+            `}
+          >
             <ProfilingContextMenuGroup>
               <ProfilingContextMenuHeading>{t('Profiles')}</ProfilingContextMenuHeading>
               {props.profileIds.map((profileId, i) => {
@@ -629,7 +635,12 @@ function ProfileIdsSubMenu(props: {
                     key={i}
                     {...props.contextMenu.getMenuItemProps({})}
                   >
-                    <Link to={to} css={{color: 'unset'}}>
+                    <Link
+                      to={to}
+                      css={css`
+                        color: unset;
+                      `}
+                    >
                       {getShortEventId(
                         typeof profileId === 'string'
                           ? profileId

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
@@ -122,7 +123,11 @@ function SwitchOrganization({canCreateOrganization}: Props) {
                 })}
               </OrganizationList>
               {organizations && !!organizations.length && canCreateOrganization && (
-                <Divider css={{marginTop: 0}} />
+                <Divider
+                  css={css`
+                    margin-top: 0;
+                  `}
+                />
               )}
               <CreateOrganization canCreateOrganization={canCreateOrganization} />
             </SwitchOrganizationMenu>

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -203,7 +204,9 @@ class PluginSettings<
     }
     return (
       <Form
-        css={{width: '100%'}}
+        css={css`
+          width: 100%;
+        `}
         onSubmit={this.onSubmit}
         submitDisabled={isSaving || !hasChanges}
       >

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -643,29 +643,30 @@ const generateUtils = (colors: BaseColors, aliases: Aliases) => ({
     textDecorationThickness: '0.75px',
     textUnderlineOffset: '1.25px',
   }),
-  overflowEllipsis: css({
-    display: 'block',
-    width: '100%',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  }),
+  overflowEllipsis: css`
+    display: block;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  `,
   // https://css-tricks.com/inclusively-hidden/
-  visuallyHidden: css({
-    clip: 'rect(0 0 0 0)',
-    clipPath: 'inset(50%)',
-    height: '1px',
-    overflow: 'hidden',
-    position: 'absolute',
-    whiteSpace: 'nowrap',
-    width: '1px',
-  }),
+  visuallyHidden: css`
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  `,
 });
 
 const generatePrismVariables = (
   prismColors: typeof prismLight,
   blockBackground: string
 ) =>
+  // eslint-disable-next-line @emotion/syntax-preference
   css({
     // block background differs based on light/dark mode
     '--prism-block-background': blockBackground,

--- a/static/app/views/monitors/components/monitorCreateForm.tsx
+++ b/static/app/views/monitors/components/monitorCreateForm.tsx
@@ -152,7 +152,11 @@ export default function MonitorCreateForm() {
                           name="config.schedule"
                           placeholder="* * * * *"
                           defaultValue={DEFAULT_SCHEDULE_CONFIG.cronSchedule}
-                          css={{input: {fontFamily: commonTheme.text.familyMono}}}
+                          css={css`
+                            input {
+                              font-family: ${commonTheme.text.familyMono};
+                            }
+                          `}
                           required={selectedCrontab}
                           stacked
                           inline={false}

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useRef} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
@@ -350,7 +351,11 @@ function MonitorForm({
                       hideLabel
                       placeholder="* * * * *"
                       defaultValue={DEFAULT_CRONTAB}
-                      css={{input: {fontFamily: commonTheme.text.familyMono}}}
+                      css={css`
+                        input {
+                          font-family: ${commonTheme.text.familyMono};
+                        }
+                      `}
                       required
                       stacked
                       inline={false}

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
@@ -168,16 +169,11 @@ function AccountClose() {
 
           {organizations?.map(({organization, singleOwner}) => (
             <PanelItem key={organization.slug}>
-              <label
-                css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
-              >
+              <PanelLabel>
                 <Checkbox
-                  css={{
-                    marginRight: 6,
-                  }}
+                  css={css`
+                    margin-right: 6px;
+                  `}
                   name="organizations"
                   checked={orgsToRemove.has(organization.slug)}
                   disabled={singleOwner}
@@ -187,7 +183,7 @@ function AccountClose() {
                   role="checkbox"
                 />
                 {organization.slug}
-              </label>
+              </PanelLabel>
             </PanelItem>
           ))}
         </PanelBody>
@@ -199,5 +195,10 @@ function AccountClose() {
     </div>
   );
 }
+
+const PanelLabel = styled('label')`
+  display: flex;
+  align-items: center;
+`;
 
 export default AccountClose;

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {QRCodeCanvas} from 'qrcode.react';
 
@@ -438,7 +439,9 @@ class AccountSecurityEnroll extends DeprecatedAsyncComponent<Props, State> {
                     : t('Authentication Method Inactive')
                 }
                 enabled={isActive}
-                css={{marginLeft: 6}}
+                css={css`
+                  margin-left: 6px;
+                `}
               />
             </Fragment>
           }

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
@@ -1,4 +1,5 @@
 import {useId} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {
@@ -150,7 +151,9 @@ function TargetRateInput({disabled}: {disabled?: boolean}) {
   return (
     <FieldGroup
       label={t('Global Target Sample Rate')}
-      css={{paddingBottom: space(0.5)}}
+      css={css`
+        padding-bottom: ${space(0.5)};
+      `}
       inline={false}
       showHelpInTooltip
       flexibleControlStateSize

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import AlertLink from 'sentry/components/alertLink';
@@ -106,7 +107,13 @@ function OrganizationApiKeysList({
                   message={t('Are you sure you want to remove this API key?')}
                   title={t('Remove API Key?')}
                 >
-                  <IconDelete size="xs" css={{position: 'relative', top: '2px'}} />
+                  <IconDelete
+                    size="xs"
+                    css={css`
+                      position: relative;
+                      top: 2px;
+                    `}
+                  />
                 </LinkWithConfirmation>
               </Cell>
             </Fragment>

--- a/static/app/views/settings/organizationRateLimits/organizationRateLimits.tsx
+++ b/static/app/views/settings/organizationRateLimits/organizationRateLimits.tsx
@@ -1,3 +1,5 @@
+import {css} from '@emotion/react';
+
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import RangeField from 'sentry/components/forms/fields/rangeField';
 import Form from 'sentry/components/forms/form';
@@ -91,7 +93,11 @@ function OrganizationRateLimit({organization}: OrganizationRateLimitProps) {
                   'The maximum number of events to accept across this entire organization.'
                 )}
               >
-                <TextBlock css={{marginBottom: 0}}>
+                <TextBlock
+                  css={css`
+                    margin-bottom: 0;
+                  `}
+                >
                   {tct(
                     'Your account is limited to a maximum of [maxRate] events per [maxRateInterval] seconds.',
                     {

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -1,4 +1,5 @@
 import {Component, Fragment, useCallback} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import iconAndroid from 'sentry-logos/logo-android.svg';
 import iconChrome from 'sentry-logos/logo-chrome.svg';
@@ -313,7 +314,10 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
                     aria-label={`${subfilter.title} ${subfilter.helpText}`}
                     isActive={this.state.subfilters.has(key)}
                     isDisabled={disabled}
-                    css={{flexShrink: 0, marginLeft: 6}}
+                    css={css`
+                      flex-shrink: 0;
+                      margin-left: 6;
+                    `}
                     toggle={this.handleToggleSubfilters.bind(this, key)}
                     size="lg"
                   />


### PR DESCRIPTION

This makes it easier to copy+paste styles into styled(*) blocks, and other css sources. Less quotes for things, and managing reacts css naming conventions
