### PR TITLE
feat(issue-details): Display the resolution/archival reason on new UI

### DIFF
--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -12,76 +12,79 @@ interface ArchivedBoxProps {
   organization: Organization;
   statusDetails: IgnoredStatusDetails;
   substatus: Group['substatus'];
+  hasStreamlinedUI?: boolean;
 }
 
+export function renderArchiveReason({
+  substatus,
+  statusDetails,
+  organization,
+  hasStreamlinedUI = false,
+}: ArchivedBoxProps) {
+  const {ignoreUntil, ignoreCount, ignoreWindow, ignoreUserCount, ignoreUserWindow} =
+    statusDetails;
+
+  if (substatus === GroupSubstatus.ARCHIVED_UNTIL_ESCALATING) {
+    return hasStreamlinedUI
+      ? t('This issue has been archived until it escalates.')
+      : t(
+          "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
+          <ExternalLink
+            href="https://docs.sentry.io/product/issues/states-triage/#archive"
+            onClick={() =>
+              trackAnalytics('issue_details.issue_status_docs_clicked', {organization})
+            }
+          >
+            {t('read the docs')}
+          </ExternalLink>
+        );
+  }
+  if (ignoreUntil) {
+    return t(
+      'This issue has been archived until %s.',
+      <strong>
+        <DateTime date={ignoreUntil} />
+      </strong>
+    );
+  }
+  if (ignoreCount && ignoreWindow) {
+    return t(
+      'This issue has been archived until it occurs %s time(s) in %s.',
+      <strong>{ignoreCount.toLocaleString()}</strong>,
+      <strong>
+        <Duration seconds={ignoreWindow * 60} />
+      </strong>
+    );
+  }
+  if (ignoreCount) {
+    return t(
+      'This issue has been archived until it occurs %s more time(s).',
+      <strong>{ignoreCount.toLocaleString()}</strong>
+    );
+  }
+  if (ignoreUserCount && ignoreUserWindow) {
+    return t(
+      'This issue has been archived until it affects %s user(s) in %s.',
+      <strong>{ignoreUserCount.toLocaleString()}</strong>,
+      <strong>
+        <Duration seconds={ignoreUserWindow * 60} />
+      </strong>
+    );
+  }
+  if (ignoreUserCount) {
+    return t(
+      'This issue has been archived until it affects %s more user(s).',
+      <strong>{ignoreUserCount.toLocaleString()}</strong>
+    );
+  }
+
+  return t('This issue has been archived forever.');
+}
 function ArchivedBox({substatus, statusDetails, organization}: ArchivedBoxProps) {
-  function trackDocsClick() {
-    trackAnalytics('issue_details.issue_status_docs_clicked', {
-      organization,
-    });
-  }
-
-  function renderReason() {
-    const {ignoreUntil, ignoreCount, ignoreWindow, ignoreUserCount, ignoreUserWindow} =
-      statusDetails;
-
-    if (substatus === GroupSubstatus.ARCHIVED_UNTIL_ESCALATING) {
-      return t(
-        "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
-        <ExternalLink
-          href="https://docs.sentry.io/product/issues/states-triage/#archive"
-          onClick={trackDocsClick}
-        >
-          {t('read the docs')}
-        </ExternalLink>
-      );
-    }
-    if (ignoreUntil) {
-      return t(
-        'This issue has been archived until %s.',
-        <strong>
-          <DateTime date={ignoreUntil} />
-        </strong>
-      );
-    }
-    if (ignoreCount && ignoreWindow) {
-      return t(
-        'This issue has been archived until it occurs %s time(s) in %s.',
-        <strong>{ignoreCount.toLocaleString()}</strong>,
-        <strong>
-          <Duration seconds={ignoreWindow * 60} />
-        </strong>
-      );
-    }
-    if (ignoreCount) {
-      return t(
-        'This issue has been archived until it occurs %s more time(s).',
-        <strong>{ignoreCount.toLocaleString()}</strong>
-      );
-    }
-    if (ignoreUserCount && ignoreUserWindow) {
-      return t(
-        'This issue has been archived until it affects %s user(s) in %s.',
-        <strong>{ignoreUserCount.toLocaleString()}</strong>,
-        <strong>
-          <Duration seconds={ignoreUserWindow * 60} />
-        </strong>
-      );
-    }
-    if (ignoreUserCount) {
-      return t(
-        'This issue has been archived until it affects %s more user(s).',
-        <strong>{ignoreUserCount.toLocaleString()}</strong>
-      );
-    }
-
-    return t('This issue has been archived forever.');
-  }
-
   return (
     <BannerContainer priority="default">
       <BannerSummary>
-        <span>{renderReason()}</span>
+        <span>{renderArchiveReason({substatus, statusDetails, organization})}</span>
       </BannerSummary>
     </BannerContainer>
   );

--- a/static/app/components/resolutionBox.spec.tsx
+++ b/static/app/components/resolutionBox.spec.tsx
@@ -1,4 +1,5 @@
 import {CommitFixture} from 'sentry-fixture/commit';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -9,13 +10,22 @@ import {GroupActivityType} from 'sentry/types/group';
 import ResolutionBox from './resolutionBox';
 
 describe('ResolutionBox', function () {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
   it('handles default', function () {
-    const {container} = render(<ResolutionBox statusDetails={{}} projectId="1" />);
+    const {container} = render(
+      <ResolutionBox statusDetails={{}} project={project} organization={organization} />
+    );
     expect(container).toHaveTextContent('This issue has been marked as resolved.');
   });
   it('handles inNextRelease', function () {
     const {container} = render(
-      <ResolutionBox statusDetails={{inNextRelease: true}} projectId="1" />
+      <ResolutionBox
+        statusDetails={{inNextRelease: true}}
+        project={project}
+        organization={organization}
+      />
     );
     expect(container).toHaveTextContent(
       'This issue has been marked as resolved in the upcoming release.'
@@ -34,7 +44,8 @@ describe('ResolutionBox', function () {
             email: 'david@sentry.io',
           },
         }}
-        projectId="1"
+        project={project}
+        organization={organization}
       />
     );
     expect(container).toHaveTextContent(
@@ -48,7 +59,8 @@ describe('ResolutionBox', function () {
           inNextRelease: true,
           actor: UserFixture(),
         }}
-        projectId="1"
+        project={project}
+        organization={organization}
         activities={[
           {
             id: '1',
@@ -57,7 +69,7 @@ describe('ResolutionBox', function () {
               current_release_version: 'frontend@1.0.0',
             },
             dateCreated: new Date().toISOString(),
-            project: ProjectFixture(),
+            project,
           },
         ]}
       />
@@ -72,7 +84,8 @@ describe('ResolutionBox', function () {
         statusDetails={{
           inRelease: '1.0',
         }}
-        projectId="1"
+        project={project}
+        organization={organization}
       />
     );
     expect(container).toHaveTextContent(
@@ -92,7 +105,8 @@ describe('ResolutionBox', function () {
             email: 'david@sentry.io',
           },
         }}
-        projectId="1"
+        project={project}
+        organization={organization}
       />
     );
     expect(container).toHaveTextContent(
@@ -105,7 +119,8 @@ describe('ResolutionBox', function () {
         statusDetails={{
           inCommit: CommitFixture(),
         }}
-        projectId="1"
+        project={project}
+        organization={organization}
       />
     );
     expect(container).toHaveTextContent(
@@ -126,7 +141,8 @@ describe('ResolutionBox', function () {
             email: 'david@sentry.io',
           },
         }}
-        projectId="1"
+        project={project}
+        organization={organization}
       />
     );
     expect(container).toHaveTextContent(

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -25,15 +25,20 @@ type Props = {
   activities?: GroupActivity[];
 };
 
-function renderReason(
-  statusDetails: ResolvedStatusDetails,
-  projectId: string,
-  activities: GroupActivity[]
-) {
+export function renderResolutionReason({
+  statusDetails,
+  projectId,
+  activities = [],
+  hasStreamlinedUI = false,
+}: Props & {hasStreamlinedUI?: boolean}) {
   const actor = statusDetails.actor ? (
     <strong>
-      <UserAvatar user={statusDetails.actor} size={20} className="avatar" />
-      <span style={{marginLeft: 5}}>{statusDetails.actor.name}</span>
+      {!hasStreamlinedUI && (
+        <UserAvatar user={statusDetails.actor} size={20} className="avatar" />
+      )}
+      <span style={{marginLeft: hasStreamlinedUI ? 0 : 5}}>
+        {statusDetails.actor.name}
+      </span>
     </strong>
   ) : null;
 
@@ -115,7 +120,7 @@ function renderReason(
       ),
     });
   }
-  return t('This issue has been marked as resolved.');
+  return hasStreamlinedUI ? null : t('This issue has been marked as resolved.');
 }
 
 function ResolutionBox({statusDetails, projectId, activities = []}: Props) {
@@ -123,7 +128,7 @@ function ResolutionBox({statusDetails, projectId, activities = []}: Props) {
     <BannerContainer priority="default">
       <BannerSummary>
         <StyledIconCheckmark color="successText" />
-        <span>{renderReason(statusDetails, projectId, activities)}</span>
+        <span>{renderResolutionReason({statusDetails, projectId, activities})}</span>
       </BannerSummary>
     </BannerContainer>
   );

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -10,10 +10,13 @@ import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import ArchiveActions, {getArchiveActions} from 'sentry/components/actions/archive';
 import ResolveActions from 'sentry/components/actions/resolve';
+import {renderArchiveReason} from 'sentry/components/archivedBox';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button, LinkButton} from 'sentry/components/button';
+import {Flex} from 'sentry/components/container/flex';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import {renderResolutionReason} from 'sentry/components/resolutionBox';
 import {
   IconCheckmark,
   IconEllipsis,
@@ -367,9 +370,30 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
         (isResolved || isIgnored ? (
           <ResolvedActionWapper>
             <ResolvedWrapper>
-              <IconCheckmark />
-              {isResolved ? resolvedCopyCap || t('Resolved') : t('Archived')}
+              <IconCheckmark size="md" />
+              <Flex column>
+                {isResolved ? resolvedCopyCap || t('Resolved') : t('Archived')}
+                <ReasonBanner>
+                  {group.status === 'resolved'
+                    ? renderResolutionReason({
+                        statusDetails: group.statusDetails,
+                        projectId: project.id,
+                        activities: group.activity,
+                        hasStreamlinedUI,
+                      })
+                    : null}
+                  {group.status === 'ignored'
+                    ? renderArchiveReason({
+                        substatus: group.substatus,
+                        statusDetails: group.statusDetails,
+                        organization,
+                        hasStreamlinedUI,
+                      })
+                    : null}
+                </ReasonBanner>
+              </Flex>
             </ResolvedWrapper>
+
             <Divider />
             {resolveCap.enabled && (
               <Button
@@ -608,7 +632,7 @@ const ActionWrapper = styled('div')`
 
 const ResolvedWrapper = styled('div')`
   display: flex;
-  gap: ${space(0.5)};
+  gap: ${space(1.5)};
   align-items: center;
   color: ${p => p.theme.green400};
   font-weight: bold;
@@ -619,4 +643,10 @@ const ResolvedActionWapper = styled('div')`
   display: flex;
   gap: ${space(1)};
   align-items: center;
+`;
+
+const ReasonBanner = styled('div')`
+  font-weight: normal;
+  color: ${p => p.theme.green400};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -377,9 +377,10 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                   {group.status === 'resolved'
                     ? renderResolutionReason({
                         statusDetails: group.statusDetails,
-                        projectId: project.id,
                         activities: group.activity,
                         hasStreamlinedUI,
+                        project,
+                        organization,
                       })
                     : null}
                   {group.status === 'ignored'

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -152,7 +152,8 @@ function GroupEventDetails() {
           <ResolutionBox
             statusDetails={group.statusDetails}
             activities={group.activity}
-            projectId={project.id}
+            project={project}
+            organization={organization}
           />
         </GroupStatusBannerWrapper>
       );


### PR DESCRIPTION
Though the activity was still present, we stopped showing a banner for reasons associated with a resolution or archival. Those are brought back now alongside the new banner.

<img width="640" alt="image" src="https://github.com/user-attachments/assets/6840e069-c048-4e18-9e17-56ac7c235e14" />

<img width="535" alt="image" src="https://github.com/user-attachments/assets/6dc57b2b-8175-4942-9105-9608a774f323" />

