### PR TITLE
fix: do not return secondary emails in member listing/details

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -107,16 +107,23 @@ class OrganizationMemberSerializer(Serializer):
             # For invited members, use the invitation email
             email = obj.email
 
+        # helping mypy - we know email will never be None based on the model
+        assert email is not None
+        email = str(email)
+
         inviter_name = None
         if obj.inviter_id:
             inviter = attrs["inviter"]
             if inviter:
                 inviter_name = inviter.get_display_name()
 
+        # helping mypy - we know name will be a string since we fall back to email
+        name = str(serialized_user["name"] if serialized_user else email)
+
         data: OrganizationMemberResponse = {
             "id": str(obj.id),
             "email": email,
-            "name": serialized_user["name"] if serialized_user else email,
+            "name": name,
             "user": attrs["user"],
             "orgRole": obj.role,
             "pending": obj.is_pending,

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -45,8 +45,7 @@ class OrganizationMemberSerializer(Serializer):
         email_map: MutableMapping[str, str] = {}
         for u in user_service.serialize_many(filter={"user_ids": users_set}):
             # Filter out the emails from the user data
-            if "emails" in u:
-                del u["emails"]
+            u.pop("emails", None)
             users_by_id[u["id"]] = u
             email_map[u["id"]] = u["email"]
 
@@ -109,7 +108,6 @@ class OrganizationMemberSerializer(Serializer):
 
         # helping mypy - we know email will never be None based on the model
         assert email is not None
-        email = str(email)
 
         inviter_name = None
         if obj.inviter_id:
@@ -118,7 +116,7 @@ class OrganizationMemberSerializer(Serializer):
                 inviter_name = inviter.get_display_name()
 
         # helping mypy - we know name will be a string since we fall back to email
-        name = str(serialized_user["name"] if serialized_user else email)
+        name = serialized_user["name"] if serialized_user else email
 
         data: OrganizationMemberResponse = {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -100,13 +100,23 @@ class OrganizationMemberSerializer(Serializer):
     ) -> OrganizationMemberResponse:
         serialized_user = attrs["user"]
         if obj.user_id:
-            # Only use the user's primary email from the serialized user data
+            # if the OrganizationMember has a user_id, the user has an account
+            # `email` on the OrganizationMember will be null, so we need to pull
+            # the email address from the user's actual account
             email = serialized_user["email"] if serialized_user else obj.email
         else:
-            # For invited members, use the invitation email
+            # when there is no user_id, the OrganizationMember is an invited user
+            # and the email field on OrganizationMember will be populated, so we
+            # will use it directly
             email = obj.email
 
-        # helping mypy - we know email will never be None based on the model
+        # helping mypy - the email will always be populated at this point
+        # in the case that it is a user that has an account, we pull the email
+        # address above from the serialized_user. The email field on OrganizationMember
+        # is null in the case, so it is necessary.
+        #
+        # invited users do not yet have a full account and the email field
+        # on OrganizationMember will be populated in such cases
         assert email is not None
 
         inviter_name = None

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -102,7 +102,7 @@ class OrganizationMemberSerializer(Serializer):
         serialized_user = attrs["user"]
         if obj.user_id:
             # Only use the user's primary email from the serialized user data
-            email = serialized_user["email"] if serialized_user else None
+            email = serialized_user["email"] if serialized_user else obj.email
         else:
             # For invited members, use the invitation email
             email = obj.email

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -125,7 +125,6 @@ class OrganizationMemberSerializer(Serializer):
             if inviter:
                 inviter_name = inviter.get_display_name()
 
-        # helping mypy - we know name will be a string since we fall back to email
         name = serialized_user["name"] if serialized_user else email
 
         data: OrganizationMemberResponse = {

--- a/src/sentry/api/serializers/models/organization_member/expand/roles.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/roles.py
@@ -59,8 +59,7 @@ class OrganizationMemberWithRolesSerializer(OrganizationMemberWithTeamsSerialize
 
         # Filter out emails from the serialized user data
         for user_data in users_by_id.values():
-            if "emails" in user_data:
-                del user_data["emails"]
+            user_data.pop("emails", None)
 
         for item in item_list:
             result.setdefault(item, {})["serializedUser"] = users_by_id.get(str(item.user_id), {})

--- a/src/sentry/api/serializers/models/organization_member/expand/roles.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/roles.py
@@ -56,6 +56,12 @@ class OrganizationMemberWithRolesSerializer(OrganizationMemberWithTeamsSerialize
                 serializer=UserSerializeType.DETAILED,
             )
         }
+
+        # Filter out emails from the serialized user data
+        for user_data in users_by_id.values():
+            if "emails" in user_data:
+                del user_data["emails"]
+
         for item in item_list:
             result.setdefault(item, {})["serializedUser"] = users_by_id.get(str(item.user_id), {})
         return result


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/55234.

We only display the user's primary email address in the UI. There's no reason to send the secondary emails of the user in the API response.