### PR TITLE
feat(forms): add segmented radio field

### DIFF
--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -45,9 +45,12 @@ export type RadioOption<C extends string = string> = [
 
 export interface RadioGroupProps<C extends string = string>
   extends BaseRadioGroupProps<C>,
-    Omit<ContainerProps, 'onChange'> {}
+    Omit<ContainerProps, 'onChange'> {
+  name?: string;
+}
 
 function RadioGroup<C extends string>({
+  name: groupName,
   value,
   disabled: groupDisabled,
   disabledChoices = [],
@@ -84,6 +87,7 @@ function RadioGroup<C extends string>({
           >
             <RadioLineItem index={index} aria-checked={value === id} disabled={disabled}>
               <Radio
+                name={groupName}
                 aria-label={name?.toString()}
                 disabled={disabled}
                 checked={value === id}

--- a/static/app/components/forms/fields/index.stories.tsx
+++ b/static/app/components/forms/fields/index.stories.tsx
@@ -14,6 +14,7 @@ import NumberField from './numberField';
 import RadioField from './radioField';
 import RangeField from './rangeField';
 import SecretField from './secretField';
+import SegmentedRadioField from './segmentedRadioField';
 import SelectField from './selectField';
 import SentryMemberTeamSelectorField from './sentryMemberTeamSelectorField';
 import SentryProjectSelectorField from './sentryProjectSelectorField';
@@ -78,6 +79,16 @@ export default storyBook(Form, story => {
           ]}
           help="This is a radio set field"
           name="myRadios"
+        />
+        <SegmentedRadioField
+          label="My Segmented Radio"
+          choices={[
+            ['thing_1', 'Thing 1', 'Thing 1 description'],
+            ['thing_2', 'Thing 2', 'Thing 2 description'],
+            ['thing_3', 'Thing 3', 'Thing 3 description'],
+          ]}
+          help="This is a segmented radio set field"
+          name="mySegmentedRadios"
         />
         <RangeField
           label="My Range Slider"

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -1,0 +1,179 @@
+import isPropValid from '@emotion/is-prop-valid';
+import styled from '@emotion/styled';
+
+import type {RadioGroupProps} from 'sentry/components/forms/controls/radioGroup';
+import type {InputFieldProps, OnEvent} from 'sentry/components/forms/fields/inputField';
+import FormField from 'sentry/components/forms/formField';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Radio from 'sentry/components/radio';
+import {Tooltip} from 'sentry/components/tooltip';
+import {space} from 'sentry/styles/space';
+
+export interface SegmentedRadioFieldProps extends Omit<InputFieldProps, 'type'> {
+  choices?: RadioGroupProps<any>['choices'];
+}
+
+function handleChange(
+  id: string,
+  onChange: OnEvent,
+  onBlur: OnEvent,
+  e: React.FormEvent<HTMLInputElement>
+) {
+  onChange(id, e);
+  onBlur(id, e);
+}
+
+function SegmentedRadioField(props: SegmentedRadioFieldProps) {
+  return (
+    <FormField {...props}>
+      {({id, onChange, onBlur, value, disabled, ...fieldProps}) => (
+        <ControlGroup
+          id={id}
+          name={props.name}
+          choices={fieldProps.choices}
+          disabled={disabled}
+          label={fieldProps.label}
+          value={value === '' ? null : value}
+          onChange={(v, e) => handleChange(v, onChange, onBlur, e)}
+        />
+      )}
+    </FormField>
+  );
+}
+
+function ControlGroup<C extends string>({
+  name: groupName,
+  value,
+  disabled: groupDisabled,
+  disabledChoices = [],
+  choices = [],
+  label,
+  onChange,
+  tooltipPosition,
+  ...props
+}: RadioGroupProps<C>) {
+  return (
+    <Container {...props} role="radiogroup" aria-label={label}>
+      {choices.map(([id, name, description], index) => {
+        const disabledChoice = disabledChoices.find(([choiceId]) => choiceId === id);
+        const disabledChoiceReason = disabledChoice?.[1];
+        const disabled = !!disabledChoice || groupDisabled;
+
+        return (
+          <Tooltip
+            key={index}
+            disabled={!disabledChoiceReason}
+            title={disabledChoiceReason}
+            position={tooltipPosition}
+          >
+            <RadioItem index={index} aria-checked={value === id} disabled={disabled}>
+              <InteractionStateLayer />
+              <Radio
+                name={groupName}
+                aria-label={name?.toString()}
+                disabled={disabled}
+                checked={value === id}
+                onChange={(e: React.FormEvent<HTMLInputElement>) =>
+                  !disabled && onChange(id, e)
+                }
+              />
+              <RadioLineText disabled={disabled}>{name}</RadioLineText>
+              {description && <Description>{description}</Description>}
+            </RadioItem>
+          </Tooltip>
+        );
+      })}
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  display: grid;
+  grid-auto-flow: row;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-rows: minmax(0, 1fr);
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-auto-flow: column;
+  }
+  overflow: hidden;
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const shouldForwardProp = (p: PropertyKey) =>
+  typeof p === 'string' && !['disabled', 'animate'].includes(p) && isPropValid(p);
+
+export const RadioItem = styled('label', {shouldForwardProp})<{
+  index: number;
+  disabled?: boolean;
+}>`
+  position: relative;
+  padding: ${space(1)} ${space(1.5)};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.25)};
+  cursor: ${p => (p.disabled ? 'default' : 'pointer')};
+  outline: none;
+  font-weight: ${p => p.theme.fontWeightNormal};
+  border: 1px solid ${p => p.theme.gray200};
+  margin: 0;
+
+  &[aria-checked='true'] {
+    border-color: ${p => p.theme.purple300} !important;
+    box-shadow: inset 0 0 0 1px ${p => p.theme.purple300};
+    z-index: ${p => p.theme.zIndex.initial};
+  }
+
+  &:first-child {
+    border-top-left-radius: ${p => p.theme.borderRadius};
+    border-top-right-radius: ${p => p.theme.borderRadius};
+  }
+  &:last-child {
+    border-bottom-left-radius: ${p => p.theme.borderRadius};
+    border-bottom-right-radius: ${p => p.theme.borderRadius};
+  }
+
+  &:nth-child(n + 2) {
+    border-top-color: transparent;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    &:nth-child(n + 2) {
+      border-top-color: ${p => p.theme.gray200};
+      border-left-color: transparent;
+    }
+    &:first-child {
+      border-top-right-radius: 0;
+      border-bottom-left-radius: ${p => p.theme.borderRadius};
+    }
+    &:last-child {
+      border-bottom-left-radius: 0;
+      border-top-right-radius: ${p => p.theme.borderRadius};
+    }
+  }
+
+  input {
+    /* visually hidden */
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+`;
+
+const RadioLineText = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
+  opacity: ${p => (p.disabled ? 0.4 : null)};
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+  color: ${p => p.theme.gray500};
+`;
+
+const Description = styled('div')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+  line-height: 1.4em;
+`;
+
+export default SegmentedRadioField;

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -9,8 +9,9 @@ import Radio from 'sentry/components/radio';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 
-export interface SegmentedRadioFieldProps extends Omit<InputFieldProps, 'type'> {
-  choices?: RadioGroupProps<any>['choices'];
+export interface SegmentedRadioFieldProps<Choices extends string = string>
+  extends Omit<InputFieldProps, 'type'> {
+  choices?: RadioGroupProps<Choices>['choices'];
 }
 
 function handleChange(
@@ -23,7 +24,9 @@ function handleChange(
   onBlur(id, e);
 }
 
-function SegmentedRadioField(props: SegmentedRadioFieldProps) {
+function SegmentedRadioField<Choices extends string = string>(
+  props: SegmentedRadioFieldProps<Choices>
+) {
   return (
     <FormField {...props}>
       {({id, onChange, onBlur, value, disabled, ...fieldProps}) => (

--- a/static/app/components/forms/fields/segmentedRadioField.tsx
+++ b/static/app/components/forms/fields/segmentedRadioField.tsx
@@ -27,7 +27,7 @@ function SegmentedRadioField(props: SegmentedRadioFieldProps) {
   return (
     <FormField {...props}>
       {({id, onChange, onBlur, value, disabled, ...fieldProps}) => (
-        <ControlGroup
+        <RadioControlGroup
           id={id}
           name={props.name}
           choices={fieldProps.choices}
@@ -41,7 +41,7 @@ function SegmentedRadioField(props: SegmentedRadioFieldProps) {
   );
 }
 
-function ControlGroup<C extends string>({
+function RadioControlGroup<C extends string>({
   name: groupName,
   value,
   disabled: groupDisabled,


### PR DESCRIPTION
Part of ACI M6.1.

- Introduces a new segmented radio field (mostly copied from the existing radio field, with some styling changes)
- fixes an accessibility issue with the existing radio field, which did not pass `name` down to the `input`. Without this change, keyboard navigation for multiple radio fields on the same page was broken.
- Adds to form field story

<img width="1170" alt="segmented-radio" src="https://github.com/user-attachments/assets/0e9f7a14-d6e3-4dc1-bbb3-7bd552f14e89" />

