### PR TITLE
fix(devservices): Use sentry as working directory when using setup-sentry action from external repos

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -214,13 +214,12 @@ runs:
       run: |
         sentry init
 
+        # This is necessary to bring up devservices with appropriate sentry config
+        cd "$WORKDIR"
+
         devservices up --mode ${{ inputs.mode }}
 
         # have tests listen on the docker gateway ip so loopback can occur
         echo "DJANGO_LIVE_TEST_SERVER_ADDRESS=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')" >> "$GITHUB_ENV"
 
         docker ps -a
-
-        # This is necessary when other repositories (e.g. relay) want to take advantage of this workflow
-        # without needing to fork it. The path needed is the one where tools are located
-        cd "$WORKDIR"


### PR DESCRIPTION
Other repos using the `setup-sentry` action with new devservices will encounter an error since they're not properly using the sentry devservices config as seen here: https://github.com/getsentry/symbolicator/actions/runs/12799224617/job/35684858244?pr=1591

This ensures that the action is being run in the correct directory