### PR TITLE
:sparkles: feat(aci): add pagerduty/opsegnie migration utils

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -23,7 +23,7 @@ class FieldMapping:
 
 class BaseActionTranslator(ABC):
     action_type: ClassVar[Action.Type]
-    # Updated field mappings to use FieldMapping class {target_field: FieldMapping}
+    # Represents the mapping of a target field to a source field {target_field: FieldMapping}
     field_mappings: ClassVar[dict[str, FieldMapping]] = {}
 
     def __init__(self, action: dict[str, Any]):
@@ -84,9 +84,11 @@ class BaseActionTranslator(ABC):
             mapped_data = {}
             for field in dataclasses.fields(self.blob_type):
                 mapping = self.field_mappings.get(field.name)
+                # If a mapping is specified, use the source field value or default value
                 if mapping:
                     source_field = mapping.source_field
                     value = self.action.get(source_field, mapping.default_value)
+                # Otherwise, use the field value
                 else:
                     value = self.action.get(field.name, "")
                 mapped_data[field.name] = value


### PR DESCRIPTION
continues https://github.com/getsentry/sentry/pull/83123, adding migration helper utils for oncall integrations.

continuing to iterate on ABCs, now have introduced something called a `FieldMapping` dataclass.

Why do we need it?  - Because we need Actions to work with Issue & Metric Alert registries, we need to consolidate the configuration for each integration for the API & UI.
More concretely, currently we use `severity` to mark priority in Issue Alert handlers and `priority` in Metric Alert. With this mapping we can change the key in the dict.

Another use this has is it will let us add sane defaults. Something we can improve is reducing the amount of optional fields in our code. For example, we have things such as `OPSGENIE_DEFAULT_PRIORITY` and `PAGERDUTY_DEFAULT_SEVERITY` defined which represent the default priority in the 3p if there is nothing configured. Here, I leverage this dataclass so we save the default value if nothing is configured. This should make the API and the UI much simpler and configurable.

closes https://getsentry.atlassian.net/browse/ACI-96
closes https://getsentry.atlassian.net/browse/ACI-97