### PR TITLE
ref(quick-start): Remove temp enum

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -177,10 +177,6 @@ class OrganizationOnboardingTask(AbstractOnboardingTask):
         ]
     )
 
-    # This enum will be removed soon.
-    # It has been temporarily added for backward and forward compatibility with getsentry.
-    NEW_REQUIRED_ONBOARDING_TASKS = frozenset(REQUIRED_ONBOARDING_TASKS)
-
     objects: ClassVar[OrganizationOnboardingTaskManager] = OrganizationOnboardingTaskManager()
 
     class Meta:


### PR DESCRIPTION
`NEW_REQUIRED_ONBOARDING_TASKS` is no longer used and we can remove it