### PR TITLE
fix(widget-builder): Combine columns and aggregates into fields for non-tables

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1223,7 +1223,7 @@ describe('Modals -> WidgetViewerModal', function () {
       conditions: '',
       fields: [`sum(session)`],
       columns: [],
-      aggregates: [],
+      aggregates: ['sum(session)'],
       id: '1',
       name: 'Query Name',
       orderby: '',

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -275,9 +275,10 @@ function WidgetViewerModal(props: Props) {
   const order = orderby.startsWith('-');
   const rawOrderby = trimStart(orderby, '-');
 
-  const fields = defined(tableWidget.queries[0]!.fields)
-    ? tableWidget.queries[0]!.fields
-    : [...columns, ...aggregates];
+  const fields =
+    widget.displayType === DisplayType.TABLE && defined(tableWidget.queries[0]!.fields)
+      ? tableWidget.queries[0]!.fields
+      : [...columns, ...aggregates];
 
   // Some Discover Widgets (Line, Area, Bar) allow the user to specify an orderby
   // that is not explicitly selected as an aggregate or column. We need to explicitly

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -9,20 +9,10 @@ describe('convertBuilderStateToWidget', function () {
       title: 'Test Widget',
       description: 'Test Description',
       dataset: WidgetType.ERRORS,
-      displayType: DisplayType.TABLE,
+      displayType: DisplayType.LINE,
       limit: 5,
-      fields: [
-        {kind: 'field', field: 'geo.country'},
-        {
-          function: ['count', '', undefined, undefined],
-          kind: 'function',
-        },
-        {
-          function: ['count_unique', 'user', undefined, undefined],
-          kind: 'function',
-        },
-      ],
-      yAxis: [{kind: 'field', field: 'count()'}],
+      fields: [{kind: 'field', field: 'geo.country'}],
+      yAxis: [{kind: 'function', function: ['count', '', undefined, undefined]}],
     };
 
     const widget = convertBuilderStateToWidget(mockState);
@@ -31,20 +21,22 @@ describe('convertBuilderStateToWidget', function () {
       title: 'Test Widget',
       description: 'Test Description',
       widgetType: WidgetType.ERRORS,
-      displayType: DisplayType.TABLE,
+      displayType: DisplayType.LINE,
       interval: '1h',
       limit: 5,
       queries: [
         {
-          fields: ['geo.country', 'count()', 'count_unique(user)'],
-          fieldAliases: ['', '', ''],
+          fields: ['geo.country', 'count()'],
+          fieldAliases: [''],
           aggregates: ['count()'],
           columns: ['geo.country'],
           conditions: '',
           name: '',
           orderby: 'geo.country',
+          selectedAggregate: undefined,
         },
       ],
+      thresholds: undefined,
     });
   });
 
@@ -136,5 +128,41 @@ describe('convertBuilderStateToWidget', function () {
     const widget = convertBuilderStateToWidget(mockState);
 
     expect(widget.thresholds).toEqual(mockState.thresholds);
+  });
+
+  it('uses the fields from widget state when displaying as a table', function () {
+    const mockState: WidgetBuilderState = {
+      fields: [
+        {field: 'geo.country', kind: FieldValueKind.FIELD},
+        {
+          function: ['count', '', undefined, undefined],
+          kind: FieldValueKind.FUNCTION,
+        },
+      ],
+      displayType: DisplayType.TABLE,
+      dataset: WidgetType.TRANSACTIONS,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.fields).toEqual(['geo.country', 'count()']);
+  });
+
+  it('combines columns and aggregates into fields when producing the widget when not displayed as a table', function () {
+    const mockState: WidgetBuilderState = {
+      fields: [{field: 'geo.country', kind: FieldValueKind.FIELD}],
+      yAxis: [
+        {
+          function: ['count', '', undefined, undefined],
+          kind: FieldValueKind.FUNCTION,
+        },
+      ],
+      displayType: DisplayType.LINE,
+      dataset: WidgetType.TRANSACTIONS,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.fields).toEqual(['geo.country', 'count()']);
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -37,7 +37,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
   const fields =
     state.displayType === DisplayType.TABLE
       ? state.fields?.map(generateFieldAsString)
-      : [...new Set([...(columns ?? []), ...(aggregates ?? [])])];
+      : [...(columns ?? []), ...(aggregates ?? [])];
 
   // If there's no sort, use the first field as the default sort
   const defaultSort = fields?.[0] ?? defaultQuery.orderby;

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -19,7 +19,6 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
   const legendAlias =
     defined(state.legendAlias) && state.legendAlias.length > 0 ? state.legendAlias : [];
 
-  const fields = state.fields?.map(generateFieldAsString);
   const fieldAliases = state.fields?.map(field => field.alias ?? '');
   const aggregates =
     (state.yAxis?.length ?? 0) > 0
@@ -34,6 +33,11 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
   const columns = state.fields
     ?.filter(field => field.kind === FieldValueKind.FIELD)
     .map(generateFieldAsString);
+
+  const fields =
+    state.displayType === DisplayType.TABLE
+      ? state.fields?.map(generateFieldAsString)
+      : [...new Set([...(columns ?? []), ...(aggregates ?? [])])];
 
   // If there's no sort, use the first field as the default sort
   const defaultSort = fields?.[0] ?? defaultQuery.orderby;


### PR DESCRIPTION
Widget viewer relies on `fields` when constructing its table query, and the way we had it before we would save only the columns as the fields, so the widget viewer would be missing the aggregate when expanding a timeseries chart. This only affects widgets created by the new widget builder, which is newly exposed internally so the impact should be low.

The solution is to check if the widget state is a table, if it is then we're safe to use the fields from the state directly. If it isn't a table, then we need to merge the columns and aggregates so they're available in table view. Big numbers are fine under this behaviour as well because they only ever define `aggregates` and not columns since they can't be grouped.

I also updated the widget viewer to fix cases where this is an issue because we will have some widgets that suffer from this data issue, but it can be handled in the frontend from the other parameters.