### PR TITLE
fix(insights): non-mobile panels do not close when clicking close

### DIFF
--- a/static/app/views/insights/common/utils/useSamplesDrawer.tsx
+++ b/static/app/views/insights/common/utils/useSamplesDrawer.tsx
@@ -22,7 +22,7 @@ export function useSamplesDrawer({
   Component,
   moduleName,
   requiredParams,
-  onClose = () => undefined,
+  onClose = undefined,
 }: UseSamplesDrawerProps): void {
   const organization = useOrganization();
   const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();


### PR DESCRIPTION
non-mobile panels do not close when clicking close, this is just a quick fix which was introduced earlier in https://github.com/getsentry/sentry/pull/83571

Let me follow up on this with a proper test later.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
