### PR TITLE
fix(seer-api): Remove request url from signature

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -22,7 +22,7 @@ from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_m
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.profiles.utils import get_from_profiling_service
-from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.autofix import check_autofix_status
@@ -289,16 +289,13 @@ class GroupAutofixEndpoint(GroupEndpoint):
             option=orjson.OPT_NON_STR_KEYS,
         )
 
-        url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
             url,
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(
-                    salt,
-                    body=body,
-                ),
+                **sign_with_seer_secret(body=body, nonce=nonce),
             },
         )
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -22,7 +22,7 @@ from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_m
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.profiles.utils import get_from_profiling_service
-from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.autofix import check_autofix_status
@@ -289,13 +289,12 @@ class GroupAutofixEndpoint(GroupEndpoint):
             option=orjson.OPT_NON_STR_KEYS,
         )
 
-        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
-            url,
+            f"{settings.SEER_AUTOFIX_URL}{path}",
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body=body, nonce=nonce),
+                **sign_with_seer_secret(body),
             },
         )
 

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -22,7 +22,7 @@ from sentry.constants import ObjectStatus
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -129,16 +129,12 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
             option=orjson.OPT_NON_STR_KEYS,
         )
 
-        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
-            url,
+            f"{settings.SEER_AUTOFIX_URL}{path}",
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(
-                    body=body,
-                    nonce=nonce,
-                ),
+                **sign_with_seer_secret(body),
             },
         )
 

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -22,7 +22,7 @@ from sentry.constants import ObjectStatus
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -129,15 +129,15 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
             option=orjson.OPT_NON_STR_KEYS,
         )
 
-        url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
             url,
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
                 **sign_with_seer_secret(
-                    salt,
                     body=body,
+                    nonce=nonce,
                 ),
             },
         )

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -18,7 +18,7 @@ from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_m
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
 
 logger = logging.getLogger(__name__)
 
@@ -77,15 +77,15 @@ def get_repos_and_access(project: Project) -> list[dict]:
             }
         )
 
-        url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
             url,
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
                 **sign_with_seer_secret(
-                    salt,
                     body=body,
+                    nonce=nonce,
                 ),
             },
         )

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -18,7 +18,7 @@ from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_m
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import sign_with_seer_secret
 
 logger = logging.getLogger(__name__)
 
@@ -77,16 +77,12 @@ def get_repos_and_access(project: Project) -> list[dict]:
             }
         )
 
-        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
-            url,
+            f"{settings.SEER_AUTOFIX_URL}{path}",
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(
-                    body=body,
-                    nonce=nonce,
-                ),
+                **sign_with_seer_secret(body),
             },
         )
 

--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -13,7 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.models.group import Group
-from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import sign_with_seer_secret
 
 logger = logging.getLogger(__name__)
 
@@ -55,13 +55,12 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
             }
         )
 
-        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
-            url,
+            f"{settings.SEER_AUTOFIX_URL}{path}",
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body=body, nonce=nonce),
+                **sign_with_seer_secret(body),
             },
         )
 

--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -13,7 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.models.group import Group
-from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
 
 logger = logging.getLogger(__name__)
 
@@ -55,16 +55,13 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
             }
         )
 
-        url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+        url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
         response = requests.post(
             url,
             data=body,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(
-                    salt,
-                    body=body,
-                ),
+                **sign_with_seer_secret(body=body, nonce=nonce),
             },
         )
 

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.project import Project
 from sentry.models.repository import Repository
-from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
 from sentry.utils import json
 
 
@@ -81,15 +81,15 @@ def get_autofix_state(
         }
     )
 
-    url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+    url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
     response = requests.post(
         url,
         data=body,
         headers={
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(
-                salt,
                 body=body,
+                nonce=nonce,
             ),
         },
     )
@@ -119,15 +119,15 @@ def get_autofix_state_from_pr_id(provider: str, pr_id: int) -> AutofixState | No
         }
     ).encode("utf-8")
 
-    url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+    url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
     response = requests.post(
         url,
         data=body,
         headers={
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(
-                salt=salt,
                 body=body,
+                nonce=nonce,
             ),
         },
     )

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.project import Project
 from sentry.models.repository import Repository
-from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.utils import json
 
 
@@ -81,16 +81,12 @@ def get_autofix_state(
         }
     )
 
-    url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
     response = requests.post(
-        url,
+        f"{settings.SEER_AUTOFIX_URL}{path}",
         data=body,
         headers={
             "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(
-                body=body,
-                nonce=nonce,
-            ),
+            **sign_with_seer_secret(body),
         },
     )
 
@@ -119,16 +115,12 @@ def get_autofix_state_from_pr_id(provider: str, pr_id: int) -> AutofixState | No
         }
     ).encode("utf-8")
 
-    url, nonce = get_seer_url(f"{settings.SEER_AUTOFIX_URL}{path}")
     response = requests.post(
-        url,
+        f"{settings.SEER_AUTOFIX_URL}{path}",
         data=body,
         headers={
             "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(
-                body=body,
-                nonce=nonce,
-            ),
+            **sign_with_seer_secret(body),
         },
     )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2827,7 +2827,7 @@ register(
 # Controls the rate of using the sentry api shared secret for communicating to sentry.
 register(
     "seer.api.use-nonce-signature",
-    default=1.0,
+    default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2827,7 +2827,7 @@ register(
 # Controls the rate of using the sentry api shared secret for communicating to sentry.
 register(
     "seer.api.use-nonce-signature",
-    default=0.0,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2824,12 +2824,6 @@ register(
     "ecosystem:enable_integration_form_error_raise", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
-# Controls the rate of using the sentry api shared secret for communicating to sentry.
-register(
-    "seer.api.use-nonce-signature",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -4,7 +4,6 @@ import logging
 from random import random
 from typing import Any
 from urllib.parse import urlparse
-from uuid import uuid4
 
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
@@ -28,10 +27,7 @@ def make_signed_seer_api_request(
     url = f"{connection_pool.scheme}://{host}{path}"
     parsed = urlparse(url)
 
-    # Generate nonce based on option
-    path_with_nonce, nonce = get_seer_url(parsed.path)
-
-    auth_headers = sign_with_seer_secret(body, nonce)
+    auth_headers = sign_with_seer_secret(body)
 
     timeout_options: dict[str, Any] = {}
     if timeout:
@@ -44,26 +40,20 @@ def make_signed_seer_api_request(
     ):
         return connection_pool.urlopen(
             "POST",
-            path_with_nonce,
+            url,
             body=body,
             headers={"content-type": "application/json;charset=utf-8", **auth_headers},
             **timeout_options,
         )
 
 
-def get_seer_url(url: str) -> tuple[str, str | None]:
-    nonce = uuid4().hex if random() < options.get("seer.api.use-nonce-signature") else None
-
-    return f"{url}?nonce={nonce}" if nonce else url, nonce
-
-
-def sign_with_seer_secret(body: bytes, nonce: str | None = None) -> dict[str, str]:
+def sign_with_seer_secret(body: bytes) -> dict[str, str]:
     auth_headers: dict[str, str] = {}
     if random() < options.get("seer.api.use-shared-secret"):
         if settings.SEER_API_SHARED_SECRET:
             signature = hmac.new(
                 settings.SEER_API_SHARED_SECRET.encode("utf-8"),
-                b"%s:%s" % (nonce.encode(), body) if nonce else body,
+                body,
                 hashlib.sha256,
             ).hexdigest()
             auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -40,7 +40,7 @@ def make_signed_seer_api_request(
     ):
         return connection_pool.urlopen(
             "POST",
-            url,
+            parsed.path,
             body=body,
             headers={"content-type": "application/json;charset=utf-8", **auth_headers},
             **timeout_options,

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -20,7 +20,6 @@ def make_signed_seer_api_request(
     path: str,
     body: bytes,
     timeout: int | None = None,
-    use_nonce: bool = False,
 ) -> BaseHTTPResponse:
     host = connection_pool.host
     if connection_pool.port:
@@ -29,8 +28,8 @@ def make_signed_seer_api_request(
     url = f"{connection_pool.scheme}://{host}{path}"
     parsed = urlparse(url)
 
-    # Generate nonce but don't use it in signature yet
-    nonce = uuid4().hex if random() < use_nonce else None
+    # Generate nonce based on option
+    nonce = uuid4().hex if random() < options.get("seer.api.use-nonce-signature") else None
     path_with_nonce = f"{parsed.path}?nonce={nonce}" if nonce else parsed.path
 
     auth_headers = sign_with_seer_secret(body)

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -4,7 +4,7 @@ import orjson
 from django.conf import settings
 from rest_framework import status
 
-from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
 from sentry.testutils.cases import APITestCase
 
 
@@ -47,10 +47,10 @@ class TestGroupAutofixUpdate(APITestCase):
             }
         )
         expected_url = f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update"
-        expected_url, salt = get_seer_salted_url(expected_url)
+        expected_url, nonce = get_seer_url(expected_url)
         expected_headers = {
             "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(salt, body=expected_body),
+            **sign_with_seer_secret(body=expected_body, nonce=nonce),
         }
         mock_post.assert_called_once_with(
             expected_url,

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -4,7 +4,7 @@ import orjson
 from django.conf import settings
 from rest_framework import status
 
-from sentry.seer.signed_seer_api import get_seer_url, sign_with_seer_secret
+from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.testutils.cases import APITestCase
 
 
@@ -47,10 +47,9 @@ class TestGroupAutofixUpdate(APITestCase):
             }
         )
         expected_url = f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update"
-        expected_url, nonce = get_seer_url(expected_url)
         expected_headers = {
             "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body=expected_body, nonce=nonce),
+            **sign_with_seer_secret(expected_body),
         }
         mock_post.assert_called_once_with(
             expected_url,

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -67,7 +67,7 @@ class TestGetEventSeverity(TestCase):
 
         mock_urlopen.assert_called_with(
             "POST",
-            "/v0/issues/severity-score?",
+            "/v0/issues/severity-score",
             body=orjson.dumps(payload),
             headers={"content-type": "application/json;charset=utf-8"},
             timeout=0.2,
@@ -83,7 +83,7 @@ class TestGetEventSeverity(TestCase):
             _get_severity_score(event)
             mock_urlopen.assert_called_with(
                 "POST",
-                "/v0/issues/severity-score?",
+                "/v0/issues/severity-score",
                 body=orjson.dumps(payload),
                 headers={
                     "content-type": "application/json;charset=utf-8",
@@ -119,7 +119,7 @@ class TestGetEventSeverity(TestCase):
 
             mock_urlopen.assert_called_with(
                 "POST",
-                "/v0/issues/severity-score?",
+                "/v0/issues/severity-score",
                 body=orjson.dumps(payload),
                 headers={"content-type": "application/json;charset=utf-8"},
                 timeout=0.2,

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -87,7 +87,7 @@ class TestGetEventSeverity(TestCase):
                 body=orjson.dumps(payload),
                 headers={
                     "content-type": "application/json;charset=utf-8",
-                    "Authorization": "Rpcsignature rpc0:8d982376e4e49ffe845ed39853f6f2cb9bf38564d2a8a325dcd88abba8c58564",
+                    "Authorization": "Rpcsignature rpc0:b14214093c3e7c633e68ac90b01087e710fe2f96c0544b232b9ec9bc6ca971f4",
                 },
                 timeout=0.2,
             )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -111,7 +111,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         assert mock_seer_store_request.call_count == 1
         assert mock_seer_request.call_count == 1
         assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL + "?"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
         assert resp.data == seer_return_value["timeseries"]
 
     @with_feature("organizations:anomaly-detection-alerts")

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -464,7 +464,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = self.send_update(rule, 5, timedelta(minutes=-3))
 
         assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL + "?"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
         deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
         assert deserialized_body["organization_id"] == self.sub.project.organization.id
         assert deserialized_body["project_id"] == self.sub.project_id
@@ -505,7 +505,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = self.send_update(rule, 10, timedelta(minutes=-2))
 
         assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL + "?"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
         deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
         assert deserialized_body["organization_id"] == self.sub.project.organization.id
         assert deserialized_body["project_id"] == self.sub.project_id
@@ -543,7 +543,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = self.send_update(rule, 1, timedelta(minutes=-1))
 
         assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL + "?"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
         deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
         assert deserialized_body["organization_id"] == self.sub.project.organization.id
         assert deserialized_body["project_id"] == self.sub.project_id
@@ -592,7 +592,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = self.send_update(throughput_rule, 10, timedelta(minutes=-2))
 
         assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL + "?"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
         deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
         assert deserialized_body["organization_id"] == self.sub.project.organization.id
         assert deserialized_body["project_id"] == self.sub.project_id
@@ -633,7 +633,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = self.send_update(throughput_rule, 1, timedelta(minutes=-1))
 
         assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL + "?"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
         deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
         assert deserialized_body["organization_id"] == self.sub.project.organization.id
         assert deserialized_body["project_id"] == self.sub.project_id

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -181,7 +181,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            SEER_SIMILAR_ISSUES_URL + "?",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(expected_seer_request_params),
             headers={"content-type": "application/json;charset=utf-8"},
         )
@@ -602,7 +602,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            SEER_SIMILAR_ISSUES_URL + "?",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
@@ -628,7 +628,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            SEER_SIMILAR_ISSUES_URL + "?",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
                     "threshold": 0.01,
@@ -657,7 +657,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_seer_request.assert_called_with(
             "POST",
-            SEER_SIMILAR_ISSUES_URL + "?",
+            SEER_SIMILAR_ISSUES_URL,
             body=orjson.dumps(
                 {
                     "threshold": 0.01,

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -59,31 +59,6 @@ def test_uses_given_timeout():
 
 
 @pytest.mark.django_db
-@patch("sentry.seer.signed_seer_api.uuid4")
-def test_uses_shared_secret_nonce(uuid_mock):
-    new_mock = MagicMock()
-    new_mock.hex = "1234"
-    uuid_mock.return_value = new_mock
-
-    with override_options(
-        {
-            "seer.api.use-shared-secret": 1.0,
-            "seer.api.use-nonce-signature": 1.0,
-        }
-    ):
-        mock_url_open = run_test_case()
-        mock_url_open.assert_called_once_with(
-            "POST",
-            PATH + "?nonce=1234",
-            body=REQUEST_BODY,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                "Authorization": "Rpcsignature rpc0:487fb810a4e87faf306dc9637cec9aaea2be37247410391b372178ffc15af6a8",
-            },
-        )
-
-
-@pytest.mark.django_db
 def test_uses_shared_secret():
     with override_options({"seer.api.use-shared-secret": 1.0}):
         mock_url_open = run_test_case()

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -10,7 +10,11 @@ REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 PATH = "/v0/some/url"
 
 
-def run_test_case(path: str = PATH, timeout: int | None = None, shared_secret: str = "secret-one"):
+def run_test_case(
+    path: str = PATH,
+    timeout: int | None = None,
+    shared_secret: str = "secret-one",
+):
     """
     Make a mock connection pool, call `make_signed_seer_api_request` on it, and return the
     pool's `urlopen` method, so we can make assertions on how `make_signed_seer_api_request`
@@ -36,7 +40,7 @@ def test_simple():
     mock_url_open = run_test_case()
     mock_url_open.assert_called_once_with(
         "POST",
-        PATH + "?",
+        PATH,
         body=REQUEST_BODY,
         headers={"content-type": "application/json;charset=utf-8"},
     )
@@ -47,7 +51,7 @@ def test_uses_given_timeout():
     mock_url_open = run_test_case(timeout=5)
     mock_url_open.assert_called_once_with(
         "POST",
-        PATH + "?",
+        PATH,
         body=REQUEST_BODY,
         headers={"content-type": "application/json;charset=utf-8"},
         timeout=5,
@@ -61,7 +65,12 @@ def test_uses_shared_secret_nonce(uuid_mock):
     new_mock.hex = "1234"
     uuid_mock.return_value = new_mock
 
-    with override_options({"seer.api.use-shared-secret": 1.0, "seer.api.use-nonce-signature": 1.0}):
+    with override_options(
+        {
+            "seer.api.use-shared-secret": 1.0,
+            "seer.api.use-nonce-signature": 1.0,
+        }
+    ):
         mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(
             "POST",
@@ -69,7 +78,7 @@ def test_uses_shared_secret_nonce(uuid_mock):
             body=REQUEST_BODY,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                "Authorization": "Rpcsignature rpc0:487fb810a4e87faf306dc9637cec9aaea2be37247410391b372178ffc15af6a8",
+                "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
             },
         )
 
@@ -80,11 +89,11 @@ def test_uses_shared_secret():
         mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(
             "POST",
-            PATH + "?",
+            PATH,
             body=REQUEST_BODY,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                "Authorization": "Rpcsignature rpc0:96f23d5b3df807a9dc91f090078a46c00e17fe8b0bc7ef08c9391fa8b37a66b5",
+                "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
             },
         )
 
@@ -96,7 +105,7 @@ def test_uses_shared_secret_missing_secret():
 
         mock_url_open.assert_called_once_with(
             "POST",
-            PATH + "?",
+            PATH,
             body=REQUEST_BODY,
             headers={"content-type": "application/json;charset=utf-8"},
         )

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -78,7 +78,7 @@ def test_uses_shared_secret_nonce(uuid_mock):
             body=REQUEST_BODY,
             headers={
                 "content-type": "application/json;charset=utf-8",
-                "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+                "Authorization": "Rpcsignature rpc0:487fb810a4e87faf306dc9637cec9aaea2be37247410391b372178ffc15af6a8",
             },
         )
 


### PR DESCRIPTION
_Previously request signing was disabled due to a quirk in our networking setup that made the request url passed to the client signer not the same as the request seen on the server side._

This changes the request signing to match the seer side that no longer checks the request url but has an optional nonce.
