### PR TITLE
:sparkles: feat(notification): add support for `open_period_start` for issue alert thread repo

### DIFF
--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from dataclasses import dataclass
+from datetime import datetime
 from logging import Logger, getLogger
 
 from django.db.models import Q
@@ -22,6 +23,7 @@ class IssueAlertNotificationMessage(BaseNotificationMessage):
     # TODO: https://github.com/getsentry/sentry/issues/66751
     rule_fire_history: RuleFireHistory | None = None
     rule_action_uuid: str | None = None
+    open_period_start: datetime | None = None
 
     @classmethod
     def from_model(cls, instance: NotificationMessage) -> IssueAlertNotificationMessage:
@@ -37,6 +39,7 @@ class IssueAlertNotificationMessage(BaseNotificationMessage):
             ),
             rule_fire_history=instance.rule_fire_history,
             rule_action_uuid=instance.rule_action_uuid,
+            open_period_start=instance.open_period_start,
             date_added=instance.date_added,
         )
 
@@ -55,6 +58,7 @@ class RuleFireHistoryAndRuleActionUuidActionValidationError(
 class NewIssueAlertNotificationMessage(BaseNewNotificationMessage):
     rule_fire_history_id: int | None = None
     rule_action_uuid: str | None = None
+    open_period_start: datetime | None = None
 
     def get_validation_error(self) -> Exception | None:
         error = super().get_validation_error()
@@ -100,7 +104,11 @@ class IssueAlertNotificationMessageRepository:
         return Q(parent_notification_message__isnull=True, error_code__isnull=True)
 
     def get_parent_notification_message(
-        self, rule_id: int, group_id: int, rule_action_uuid: str
+        self,
+        rule_id: int,
+        group_id: int,
+        rule_action_uuid: str,
+        open_period_start: datetime | None = None,
     ) -> IssueAlertNotificationMessage | None:
         """
         Returns the parent notification message for a metric rule if it exists, otherwise returns None.
@@ -114,6 +122,7 @@ class IssueAlertNotificationMessageRepository:
                     rule_fire_history__rule__id=rule_id,
                     rule_fire_history__group__id=group_id,
                     rule_action_uuid=rule_action_uuid,
+                    open_period_start=open_period_start,
                 )
                 .latest("date_added")
             )
@@ -146,6 +155,7 @@ class IssueAlertNotificationMessageRepository:
                 parent_notification_message_id=data.parent_notification_message_id,
                 rule_fire_history_id=data.rule_fire_history_id,
                 rule_action_uuid=data.rule_action_uuid,
+                open_period_start=data.open_period_start,
             )
             return IssueAlertNotificationMessage.from_model(instance=new_instance)
         except Exception as e:
@@ -157,7 +167,10 @@ class IssueAlertNotificationMessageRepository:
             raise
 
     def get_all_parent_notification_messages_by_filters(
-        self, group_ids: list[int] | None = None, project_ids: list[int] | None = None
+        self,
+        group_ids: list[int] | None = None,
+        project_ids: list[int] | None = None,
+        open_period_start: datetime | None = None,
     ) -> Generator[IssueAlertNotificationMessage]:
         """
         If no filters are passed, then all parent notification objects are returned.
@@ -168,10 +181,13 @@ class IssueAlertNotificationMessageRepository:
         """
         group_id_filter = Q(rule_fire_history__group__id__in=group_ids) if group_ids else Q()
         project_id_filter = Q(rule_fire_history__project_id__in=project_ids) if project_ids else Q()
-
-        query = self._model.objects.filter(group_id_filter & project_id_filter).filter(
-            self._parent_notification_message_base_filter()
+        open_period_start_filter = (
+            Q(open_period_start=open_period_start) if open_period_start else Q()
         )
+
+        query = self._model.objects.filter(
+            group_id_filter & project_id_filter & open_period_start_filter
+        ).filter(self._parent_notification_message_base_filter())
 
         try:
             for instance in query:

--- a/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
 from uuid import uuid4
+
+from django.utils import timezone
 
 from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessage,
@@ -8,6 +11,7 @@ from sentry.integrations.repository.issue_alert import (
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 
 
 class BaseIssueAlertNotificationMessageRepositoryTest(TestCase):
@@ -109,6 +113,26 @@ class TestGetParentNotificationMessage(BaseIssueAlertNotificationMessageReposito
         assert instance == IssueAlertNotificationMessage.from_model(
             self.parent_notification_message
         )
+
+    def test_returns_parent_notification_message_with_open_period_start(self) -> None:
+        open_period_start = timezone.now()
+        notification_with_period = NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="789xyz",
+            open_period_start=open_period_start,
+        )
+
+        instance = self.repository.get_parent_notification_message(
+            rule_id=self.rule.id,
+            group_id=self.group.id,
+            rule_action_uuid=self.action_uuid,
+            open_period_start=open_period_start,
+        )
+
+        assert instance is not None
+        assert instance == IssueAlertNotificationMessage.from_model(notification_with_period)
+        assert instance.open_period_start == open_period_start
 
 
 class TestCreateNotificationMessage(BaseIssueAlertNotificationMessageRepositoryTest):
@@ -230,3 +254,60 @@ class TestGetAllParentNotificationMessagesByFilters(
         assert len(result_ids) == 1
         assert result_ids[0] == self.parent_notification_message.id
         assert notification_message_that_should_not_be_returned.id not in result_ids
+
+    @freeze_time("2025-01-01 00:00:00")
+    def test_returns_correct_message_when_open_period_start_is_not_none(self) -> None:
+        n1 = NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=str(uuid4()),
+            message_identifier="period123",
+            open_period_start=timezone.now(),
+        )
+
+        NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=str(uuid4()),
+            message_identifier="period123",
+            open_period_start=timezone.now() + timedelta(days=1),
+        )
+
+        result = list(
+            self.repository.get_all_parent_notification_messages_by_filters(
+                project_ids=[self.project.id],
+                group_ids=[self.group.id],
+                open_period_start=timezone.now(),
+            )
+        )
+
+        result_ids = []
+        for parent_notification in result:
+            result_ids.append(parent_notification.id)
+
+        assert len(result_ids) == 1
+        assert result_ids[0] == n1.id
+
+    @freeze_time("2025-01-01 00:00:00")
+    def test_returns_none_when_open_period_start_does_not_match(self) -> None:
+        # Create notifications with different open periods
+        NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="period1",
+            open_period_start=timezone.now(),
+        )
+        NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="period2",
+            open_period_start=timezone.now() + timedelta(days=1),
+        )
+
+        # Query with a different open period
+        instance = self.repository.get_parent_notification_message(
+            rule_id=self.rule.id,
+            group_id=self.group.id,
+            rule_action_uuid=self.action_uuid,
+            open_period_start=timezone.now() + timedelta(seconds=1),
+        )
+
+        assert instance is None

--- a/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
@@ -123,16 +123,23 @@ class TestGetParentNotificationMessage(BaseIssueAlertNotificationMessageReposito
             open_period_start=open_period_start,
         )
 
+        notification_with_period = NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="789xyz",
+            open_period_start=open_period_start + timedelta(seconds=1),
+        )
+
         instance = self.repository.get_parent_notification_message(
             rule_id=self.rule.id,
             group_id=self.group.id,
             rule_action_uuid=self.action_uuid,
-            open_period_start=open_period_start,
+            open_period_start=open_period_start + timedelta(seconds=1),
         )
 
         assert instance is not None
         assert instance == IssueAlertNotificationMessage.from_model(notification_with_period)
-        assert instance.open_period_start == open_period_start
+        assert instance.open_period_start == open_period_start + timedelta(seconds=1)
 
 
 class TestCreateNotificationMessage(BaseIssueAlertNotificationMessageRepositoryTest):


### PR DESCRIPTION
this adds support for the `open_period_start` attribute that i just added to the notificationmessage model.

i will then follow this up by updating the issue alert metric handler to use this additional field. i probably do it via a registry based on group type.

context from a comment:
basically for metric issues and uptime issues, we want 1 thread per "open period" this tests creates 2 notifications, with the same rule & action, but with different open periods. this means the parent should return the latest notification (with the latest open period).

spec: https://www.notion.so/sentry/Slack-Threads-Refactor-1618b10e4b5d807db67ae6d4d85247b9
contributes to: https://getsentry.atlassian.net/browse/ACI-89