### PR TITLE
fix(migration): make the index name smaller for notificationmessage

### DIFF
--- a/src/sentry/migrations/0817_update_notificationmessage_constraints_for_action_group_open_period.py
+++ b/src/sentry/migrations/0817_update_notificationmessage_constraints_for_action_group_open_period.py
@@ -74,7 +74,7 @@ class Migration(CheckedMigration):
                 condition=models.Q(
                     ("error_code__isnull", True), ("parent_notification_message__isnull", True)
                 ),
-                name="singular_parent_message_per_rule_fire_history_rule_action_open_period",
+                name="singular_parent_message_per_rule_fire_history_rule_action_open_",
             ),
         ),
         migrations.AddConstraint(

--- a/src/sentry/notifications/models/notificationmessage.py
+++ b/src/sentry/notifications/models/notificationmessage.py
@@ -122,7 +122,7 @@ class NotificationMessage(Model):
                     error_code__isnull=True,
                     parent_notification_message__isnull=True,
                 ),
-                name="singular_parent_message_per_rule_fire_history_rule_action_open_period",
+                name="singular_parent_message_per_rule_fire_history_rule_action_open_",
             ),
             # 1 parent message per action and group (open_period_start null not distinct)
             UniqueConstraint(


### PR DESCRIPTION
because the index name was longer than 63 chars, postgres was trimming the name, which led to the migration not being idempotent. this will update the index name so its below 63 charactors