### PR TITLE
ref(perf): Rename feature flag for OTEL support

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -272,8 +272,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-metrics-backed-transaction-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the UI for displaying mobile performance score
     manager.add("organizations:performance-mobile-perf-score-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use the new OTel-influenced span schema across the performance product
-    manager.add("organizations:performance-new-span-schema", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable OTel support for the core performance product
+    manager.add("organizations:performance-core-otel-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new trends
     manager.add("organizations:performance-new-trends", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable updated landing page widget designs


### PR DESCRIPTION
Renames the flag, since the old name is misleading after some discussions about the plan going forward. This flag will be to support the first phase of product changes for OTEL support rather than a span schema restructure.