### PR TITLE
feat(ACI): Call alert rule trigger migration helpers

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -47,7 +47,10 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription,
 )
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
-from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    migrate_alert_rule,
+    migrate_resolve_threshold_data_conditions,
+)
 
 from ...snuba.metrics.naming_layer.mri import is_mri
 from . import (
@@ -516,6 +519,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                 "organizations:workflow-engine-metric-alert-processing", alert_rule.organization
             ):
                 migrate_alert_rule(alert_rule, user)
+                if alert_rule.resolve_threshold:
+                    migrate_resolve_threshold_data_conditions(alert_rule)
 
             self._handle_triggers(alert_rule, triggers)
             return alert_rule

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -511,13 +511,13 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                     extra={"details": str(e)},
                 )
                 raise BadRequest
-            self._handle_triggers(alert_rule, triggers)
 
             if features.has(
                 "organizations:workflow-engine-metric-alert-processing", alert_rule.organization
             ):
                 migrate_alert_rule(alert_rule, user)
 
+            self._handle_triggers(alert_rule, triggers)
             return alert_rule
 
     def update(self, instance, validated_data):

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -114,14 +114,15 @@ def migrate_metric_data_conditions(
         if alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value
         else Condition.LESS
     )
+    condition_result = (
+        DetectorPriorityLevel.MEDIUM
+        if alert_rule_trigger.label == "warning"
+        else DetectorPriorityLevel.HIGH
+    )
 
     detector_trigger = DataCondition.objects.create(
         comparison=alert_rule_trigger.alert_threshold,
-        condition_result=(
-            DetectorPriorityLevel.MEDIUM
-            if alert_rule_trigger.label == "warning"
-            else DetectorPriorityLevel.HIGH
-        ),
+        condition_result=condition_result,
         type=threshold_type,
         condition_group=detector_data_condition_group,
     )
@@ -139,11 +140,7 @@ def migrate_metric_data_conditions(
         workflow=alert_rule_workflow.workflow,
     )
     data_condition = DataCondition.objects.create(
-        comparison=(
-            DetectorPriorityLevel.MEDIUM
-            if alert_rule_trigger.label == "warning"
-            else DetectorPriorityLevel.HIGH
-        ),
+        comparison=condition_result,
         condition_result=True,
         type=Condition.ISSUE_PRIORITY_EQUALS,
         condition_group=data_condition_group,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -52,6 +52,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.workflow_engine.migration_helpers.test_migrate_alert_rule import (
     assert_alert_rule_migrated,
+    assert_alert_rule_resolve_trigger_migrated,
     assert_alert_rule_trigger_migrated,
 )
 
@@ -233,6 +234,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(["organizations:incidents", "organizations:performance-view"]),
         ):
+            self.alert_rule_dict["resolveThreshold"] = 50
             resp = self.get_success_response(
                 self.organization.slug,
                 status_code=201,
@@ -246,7 +248,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert_alert_rule_trigger_migrated(triggers[0])
         assert_alert_rule_trigger_migrated(triggers[1])
         # TODO add the resolve threshold
-        # assert_alert_rule_resolve_trigger_migrated(alert_rule)
+        assert_alert_rule_resolve_trigger_migrated(alert_rule)
 
     @with_feature("organizations:slack-metric-alert-description")
     @with_feature("organizations:incidents")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -52,6 +52,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.workflow_engine.migration_helpers.test_migrate_alert_rule import (
     assert_alert_rule_migrated,
+    assert_alert_rule_trigger_migrated,
 )
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
@@ -239,8 +240,13 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
+        triggers = AlertRuleTrigger.objects.filter(alert_rule_id=alert_rule.id)
         assert resp.data == serialize(alert_rule, self.user)
         assert_alert_rule_migrated(alert_rule, self.project.id)
+        assert_alert_rule_trigger_migrated(triggers[0])
+        assert_alert_rule_trigger_migrated(triggers[1])
+        # TODO add the resolve threshold
+        # assert_alert_rule_resolve_trigger_migrated(alert_rule)
 
     @with_feature("organizations:slack-metric-alert-description")
     @with_feature("organizations:incidents")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -247,7 +247,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert_alert_rule_migrated(alert_rule, self.project.id)
         assert_alert_rule_trigger_migrated(triggers[0])
         assert_alert_rule_trigger_migrated(triggers[1])
-        # TODO add the resolve threshold
         assert_alert_rule_resolve_trigger_migrated(alert_rule)
 
     @with_feature("organizations:slack-metric-alert-description")

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -84,6 +84,53 @@ def assert_alert_rule_migrated(alert_rule, project_id):
     assert data_source_detector.detector == detector
 
 
+def assert_alert_rule_resolve_trigger_migrated(alert_rule):
+    detector_trigger = DataCondition.objects.get(comparison=alert_rule.resolve_threshold)
+    detector = AlertRuleDetector.objects.get(alert_rule=alert_rule).detector
+
+    assert detector_trigger.type == Condition.LESS_OR_EQUAL
+    assert detector_trigger.condition_result == DetectorPriorityLevel.OK
+    assert detector_trigger.condition_group == detector.workflow_condition_group
+
+    data_condition = DataCondition.objects.get(comparison=DetectorPriorityLevel.OK)
+
+    assert data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
+    assert data_condition.comparison == DetectorPriorityLevel.OK
+    assert data_condition.condition_result is True
+    assert WorkflowDataConditionGroup.objects.filter(
+        condition_group=data_condition.condition_group
+    ).exists()
+
+
+def assert_alert_rule_trigger_migrated(alert_rule_trigger):
+    assert AlertRuleTriggerDataCondition.objects.filter(
+        alert_rule_trigger=alert_rule_trigger
+    ).exists()
+
+    condition_result = (
+        DetectorPriorityLevel.MEDIUM
+        if alert_rule_trigger.label == "warning"
+        else DetectorPriorityLevel.HIGH
+    )
+    detector_trigger = DataCondition.objects.get(
+        comparison=alert_rule_trigger.alert_threshold,
+        condition_result=condition_result,
+    )
+    assert (
+        detector_trigger.type == Condition.GREATER
+        if alert_rule_trigger.alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value
+        else Condition.LESS
+    )
+    assert detector_trigger.condition_result == condition_result
+
+    data_condition = DataCondition.objects.get(comparison=condition_result)
+    assert data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
+    assert data_condition.condition_result is True
+    assert WorkflowDataConditionGroup.objects.filter(
+        condition_group=data_condition.condition_group
+    ).exists()
+
+
 class AlertRuleMigrationHelpersTest(APITestCase):
     def setUp(self):
         METADATA = {
@@ -205,77 +252,9 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         migrate_metric_data_conditions(self.alert_rule_trigger_critical)
         migrate_resolve_threshold_data_conditions(self.metric_alert)
 
-        assert (
-            AlertRuleTriggerDataCondition.objects.filter(
-                alert_rule_trigger__in=[
-                    self.alert_rule_trigger_critical,
-                    self.alert_rule_trigger_warning,
-                ]
-            ).count()
-            == 2
-        )
-        detector_triggers = DataCondition.objects.filter(
-            comparison__in=[
-                self.alert_rule_trigger_warning.alert_threshold,
-                self.alert_rule_trigger_critical.alert_threshold,
-                self.metric_alert.resolve_threshold,
-            ]
-        )
-
-        assert len(detector_triggers) == 3
-        detector = AlertRuleDetector.objects.get(alert_rule=self.metric_alert).detector
-
-        warning_detector_trigger = detector_triggers[0]
-        critical_detector_trigger = detector_triggers[1]
-        resolve_detector_trigger = detector_triggers[2]
-
-        assert warning_detector_trigger.type == Condition.GREATER
-        assert warning_detector_trigger.condition_result == DetectorPriorityLevel.MEDIUM
-        assert warning_detector_trigger.condition_group == detector.workflow_condition_group
-
-        assert critical_detector_trigger.type == Condition.GREATER
-        assert critical_detector_trigger.condition_result == DetectorPriorityLevel.HIGH
-        assert critical_detector_trigger.condition_group == detector.workflow_condition_group
-
-        assert resolve_detector_trigger.type == Condition.LESS_OR_EQUAL
-        assert resolve_detector_trigger.condition_result == DetectorPriorityLevel.OK
-        assert resolve_detector_trigger.condition_group == detector.workflow_condition_group
-
-        data_conditions = DataCondition.objects.filter(
-            comparison__in=[
-                DetectorPriorityLevel.MEDIUM,
-                DetectorPriorityLevel.HIGH,
-                DetectorPriorityLevel.OK,
-            ]
-        )
-        assert len(data_conditions) == 3
-        warning_data_condition = data_conditions[0]
-        critical_data_condition = data_conditions[1]
-        resolve_data_condition = data_conditions[2]
-
-        assert warning_data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
-        assert warning_data_condition.comparison == DetectorPriorityLevel.MEDIUM
-        assert warning_data_condition.condition_result is True
-        assert warning_data_condition.condition_group == warning_data_condition.condition_group
-        assert WorkflowDataConditionGroup.objects.filter(
-            condition_group=warning_data_condition.condition_group
-        ).exists()
-
-        assert critical_data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
-        assert critical_data_condition.comparison == DetectorPriorityLevel.HIGH
-        assert critical_data_condition.condition_result is True
-        assert critical_data_condition.condition_group == critical_data_condition.condition_group
-        assert WorkflowDataConditionGroup.objects.filter(
-            condition_group=critical_data_condition.condition_group
-        ).exists()
-
-        assert resolve_data_condition.type == Condition.ISSUE_PRIORITY_EQUALS
-        assert resolve_data_condition.comparison == DetectorPriorityLevel.OK
-        assert resolve_data_condition.condition_result is True
-        assert resolve_data_condition.condition_group == resolve_data_condition.condition_group
-        assert WorkflowDataConditionGroup.objects.filter(
-            condition_group=resolve_data_condition.condition_group
-        ).exists()
+        assert_alert_rule_trigger_migrated(self.alert_rule_trigger_warning)
+        assert_alert_rule_trigger_migrated(self.alert_rule_trigger_critical)
+        assert_alert_rule_resolve_trigger_migrated(self.metric_alert)
 
     def test_calculate_resolve_threshold_critical_only(self):
         migrate_alert_rule(self.metric_alert, self.rpc_user)


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/83562 to call the migration helpers for alert rule triggers. 

Addresses https://getsentry.atlassian.net/browse/ACI-76