### PR TITLE
ref(issue-views): Fix query count animation

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -58,7 +58,8 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
   // when the query changes and the new data is still being fetched.
   const count = isError
     ? 0
-    : Object.keys(queryCount ?? {}).length > 0
+    : Object.keys(queryCount ?? {}).length > 0 &&
+        queryCount?.[Object.keys(queryCount)[0]!]
       ? queryCount?.[Object.keys(queryCount)[0]!]
       : 0;
 

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -56,12 +56,15 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
   // But this component only ever sends one query, so we can just get the count of the first key.
   // This is a bit hacky, but it avoids having to use a state to store the previous query
   // when the query changes and the new data is still being fetched.
+  const defaultQuery =
+    Object.keys(queryCount ?? {}).length > 0
+      ? Object.keys(queryCount ?? {})[0]
+      : undefined;
   const count = isError
     ? 0
-    : Object.keys(queryCount ?? {}).length > 0 &&
-        queryCount?.[Object.keys(queryCount)[0]!]
-      ? queryCount?.[Object.keys(queryCount)[0]!] ?? 0
-      : 0;
+    : queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ??
+      queryCount?.[defaultQuery ?? ''] ??
+      0;
 
   return (
     <QueryCountBubble

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -60,7 +60,7 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
     ? 0
     : Object.keys(queryCount ?? {}).length > 0 &&
         queryCount?.[Object.keys(queryCount)[0]!]
-      ? queryCount?.[Object.keys(queryCount)[0]!]
+      ? queryCount?.[Object.keys(queryCount)[0]!] ?? 0
       : 0;
 
   return (

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
@@ -37,6 +38,8 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
   const pageFilters = usePageFilters();
   const theme = useTheme();
 
+  const [count, setCount] = useState<number>(0);
+
   // TODO(msun): Once page filters are saved to views, remember to use the view's specific
   // page filters here instead of the global pageFilters, if they exist.
   const {
@@ -52,9 +55,17 @@ export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
     ...constructCountTimeFrame(pageFilters.selection.datetime),
   });
 
-  const count = isError
-    ? 0
-    : queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ?? 0;
+  useEffect(() => {
+    // Only update the count once the query has finished fetching
+    // This preserves the previous count while the query is fetching a new one
+    if (queryCount && !isFetching) {
+      setCount(
+        queryCount?.[view.unsavedChanges ? view.unsavedChanges[0] : view.query] ?? 0
+      );
+    } else if (isError) {
+      setCount(0);
+    }
+  }, [queryCount, isFetching, isError, view.query, view.unsavedChanges]);
 
   return (
     <QueryCountBubble


### PR DESCRIPTION
~Reverts the latest commit in [this PR](https://github.com/getsentry/sentry/pull/83515) by adding back the use of and effect and state to achieve the desired animation behavior for issue counts.~

Implements the query count animation in a way that achieves the desired behavior without using state and effect

[Relevant discussion](https://github.com/getsentry/sentry/pull/82990#discussion_r1914598884)

This is currently in prod: 

https://github.com/user-attachments/assets/6c64d85c-6e39-41a5-b11e-6ceeaafa76e7

When you change the search query (not the page filters), the bubble flashes to 0 and shrinks before resizing once the response comes in. 

