### PR TITLE
ref: Convert ContextPickerModal to an FC

### DIFF
--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -416,14 +416,14 @@ type ContainerProps = SharedProps & {
 };
 
 export default function ContextPickerModalContainer(props: ContainerProps) {
-  const {allowAllProjectsSelection, configUrl, projectSlugs} = props;
+  const {configUrl, projectSlugs, ...sharedProps} = props;
 
   const {organizations} = useLegacyStore(OrganizationsStore);
 
   const {organization} = useLegacyStore(OrganizationStore);
   const [selectedOrgSlug, setSelectedOrgSlug] = useState(organization?.slug);
 
-  const {data, isError, isLoading, refetch} = useApiQuery<Integration[]>(
+  const {data, isError, isPending, refetch} = useApiQuery<Integration[]>(
     [configUrl ?? ''],
     {
       enabled: Boolean(configUrl),
@@ -431,23 +431,22 @@ export default function ContextPickerModalContainer(props: ContainerProps) {
     }
   );
 
-  if (configUrl && isLoading) {
+  if (isPending) {
     return <LoadingIndicator />;
   }
-  if (configUrl && isError) {
+  if (isError) {
     return <LoadingError onRetry={refetch} />;
   }
-  if (data?.length) {
+  if (data.length) {
     return (
       <ContextPickerModal
-        {...props}
+        {...sharedProps}
         projects={[]}
-        loading={isLoading}
+        loading={isPending}
         organizations={organizations}
         organization={selectedOrgSlug!}
         onSelectOrganization={setSelectedOrgSlug}
         integrationConfigs={data}
-        allowAllProjectsSelection={allowAllProjectsSelection}
       />
     );
   }
@@ -460,14 +459,13 @@ export default function ContextPickerModalContainer(props: ContainerProps) {
       >
         {({projects, initiallyLoaded}) => (
           <ContextPickerModal
-            {...props}
+            {...sharedProps}
             projects={projects as Project[]}
             loading={!initiallyLoaded}
             organizations={organizations}
             organization={selectedOrgSlug}
             onSelectOrganization={setSelectedOrgSlug}
             integrationConfigs={[]}
-            allowAllProjectsSelection={allowAllProjectsSelection}
           />
         )}
       </Projects>
@@ -476,14 +474,13 @@ export default function ContextPickerModalContainer(props: ContainerProps) {
 
   return (
     <ContextPickerModal
-      {...props}
+      {...sharedProps}
       projects={[]}
       loading
       organizations={organizations}
       organization={selectedOrgSlug!}
       onSelectOrganization={setSelectedOrgSlug}
       integrationConfigs={[]}
-      allowAllProjectsSelection={allowAllProjectsSelection}
     />
   );
 }

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment, useEffect, useState} from 'react';
+import {Component, Fragment, useState} from 'react';
 import {components} from 'react-select';
 import styled from '@emotion/styled';
 import type {Query} from 'history';
@@ -14,6 +14,7 @@ import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import type {Integration} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
@@ -417,18 +418,10 @@ type ContainerProps = SharedProps & {
 export default function ContextPickerModalContainer(props: ContainerProps) {
   const {allowAllProjectsSelection, configUrl, projectSlugs} = props;
 
-  const [organizations, setOrganizations] = useState<Organization[]>(() =>
-    OrganizationsStore.getAll()
-  );
-  useEffect(() => {
-    const unsubscribe = OrganizationsStore.listen(setOrganizations, undefined);
-    return () => unsubscribe();
-  }, []);
+  const {organizations} = useLegacyStore(OrganizationsStore);
 
-  const selectedOrganization = OrganizationStore.get();
-  const [selectedOrgSlug, setSelectedOrgSlug] = useState(
-    selectedOrganization.organization?.slug
-  );
+  const {organization} = useLegacyStore(OrganizationStore);
+  const [selectedOrgSlug, setSelectedOrgSlug] = useState(organization?.slug);
 
   const {data, isError, isLoading, refetch} = useApiQuery<Integration[]>(
     [configUrl ?? ''],

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -418,7 +418,7 @@ export default function ContextPickerModalContainer(props: ContainerProps) {
   const {allowAllProjectsSelection, configUrl, projectSlugs} = props;
 
   const [organizations, setOrganizations] = useState<Organization[]>(
-    OrganizationsStore.getAll()
+    () => OrganizationsStore.getAll()
   );
   useEffect(() => {
     const unsubscribe = OrganizationsStore.listen(setOrganizations, undefined);

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -417,8 +417,8 @@ type ContainerProps = SharedProps & {
 export default function ContextPickerModalContainer(props: ContainerProps) {
   const {allowAllProjectsSelection, configUrl, projectSlugs} = props;
 
-  const [organizations, setOrganizations] = useState<Organization[]>(
-    () => OrganizationsStore.getAll()
+  const [organizations, setOrganizations] = useState<Organization[]>(() =>
+    OrganizationsStore.getAll()
   );
   useEffect(() => {
     const unsubscribe = OrganizationsStore.listen(setOrganizations, undefined);


### PR DESCRIPTION
Test Notes:

This modal is behind Settings Search, the cmd+K search, and Help Search in the sidebar. 

Search works as expected with one special case I discovered: Suggestions may include the `configUrl` field. In this case clicking on the suggestion will trigger that url to load and be rendered as a 2nd-level search list. To see this in action, go to Org Settings and search for something like "Github". One of the results will be the GitHub Integration, where you can connect to a github org. Clicking on that result will open the 2nd screen with a list of available github orgs to choose. 

| First search | list from `configUrl` |
| --- | --- |
| <img width="820" alt="SCR-20250117-iogq" src="https://github.com/user-attachments/assets/4b65213a-f90e-427b-96c7-e5387b992de3" /> | <img width="696" alt="SCR-20250117-iolm" src="https://github.com/user-attachments/assets/a6b9161c-b7db-4643-b67b-5795b6cd9c8d" />


Also before, if there was nothing returned from the `configUrl` url, only an empty array for example, we'd see an empty modal:
<img width="830" alt="SCR-20250117-jdyq" src="https://github.com/user-attachments/assets/ed8003f5-0099-48d7-aea8-1e59f3115293" />

This PR adds a call to `sharedProps.onFinish(sharedProps.nextPath);` which will redirect the user to the root of the config page instead of showing the blank modal. In my testing the root is something like `/settings/integrations/github/`.
When the modal is not blank, and there is a list of 2nd-level things to pick from, the url would've been constructed as `
`"/settings/integrations/github/" + pickedItem.value + "/"`. So redirecting just into the root is a little bit of a guess and might break in some cases. 
