### PR TITLE
c

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -141,10 +141,11 @@ def run_table_query(
                 result_value = result.val_str
             elif resolved_column.proto_type == INT:
                 result_value = result.val_int
-            elif resolved_column.proto_type == FLOAT:
-                result_value = result.val_float
-            elif resolved_column.proto_type == DOUBLE:
-                result_value = result.val_double
+            elif resolved_column.proto_type == FLOAT or resolved_column.proto_type == DOUBLE:
+                if result.WhichOneof("value") == "val_float":
+                    result_value = result.val_float
+                if result.WhichOneof("value") == "val_double":
+                    result_value = result.val_double
             elif resolved_column.proto_type == BOOLEAN:
                 result_value = result.val_bool
             result_value = process_value(result_value)


### PR DESCRIPTION
Corrects https://github.com/getsentry/sentry/pull/83566

When Snuba sends back `AttributeValue` of `TYPE_DOUBLE` and `val_double`, Sentry uses `TYPE_MAP` to resolve the column into `TYPE_FLOAT` for doubles, and will try to read `val_float`. This is unintended behavior. 

There are 2 approaches:
1. this PR
2. https://github.com/getsentry/sentry/pull/83629