### PR TITLE
fix(js): Recognize more paths as not-builtin for node

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -14,8 +14,9 @@ from sentry.utils.safe import get_path
 logger = logging.getLogger(__name__)
 
 # Matches "app:", "webpack:",
+# "http:", "https:",
 # "x:" where x is a single ASCII letter, or "/".
-NON_BUILTIN_PATH_REGEX = re.compile(r"^((app|webpack|[a-zA-Z]):|/)")
+NON_BUILTIN_PATH_REGEX = re.compile(r"^((app|webpack|[a-zA-Z]|https?):|/)")
 
 
 def _merge_frame_context(new_frame, symbolicated):


### PR DESCRIPTION
The PR that originally introduced the logic for skipping builtin Node frames was https://github.com/getsentry/sentry/pull/49174. Eventually we added Windows paths (`X:\…`). We have now seen customer events with `abs_path`s starting with `http(s)`, so we consider those non-builtin as well. 