### PR TITLE
ref(aws-lambda-integration): Ensure correct node options for all layers

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -204,6 +204,35 @@ def get_dsn_for_project(organization_id, project_id):
     return enabled_dsn.dsn_public
 
 
+def get_node_options_for_layer(layer_name: str, layer_version: int | None) -> str:
+    """
+    Depending on the SDK major our Lambda Layer represents, a different SDK
+    package has to be used when setting `NODE_OPTIONS`.
+    This helper generates the correct options for all the layers we support.
+    """
+    # Lambda layers for v7 of our AWS SDK use the older `@sentry/serverless` SDK
+    #
+    # These are specifically
+    # - `SentryNodeServerlessSDKv7`
+    # - `SentryNodeServerlessSDK:235` and lower
+    if layer_name == "SentryNodeServerlessSDKv7" or (
+        layer_name == "SentryNodeServerlessSDK"
+        and layer_version is not None
+        and layer_version <= 235
+    ):
+        return "-r @sentry/serverless/dist/awslambda-auto"
+
+    # Lambda layers for v8 and above of our AWS SDK use
+    # the newer `@sentry/aws-serverless` SDK
+    #
+    # These are specifically
+    # - `SentryNodeServerlessSDK:236` and above
+    # - `SentryNodeServerlessSDKv8`
+    # - and any other layer with a version suffix above, e.g.
+    #   `SentryNodeServerlessSDKv9`
+    return "-r @sentry/aws-serverless/awslambda-auto"
+
+
 def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_left=3):
     # find the latest layer for this function
     layer_arn = get_latest_layer_for_function(function)
@@ -226,6 +255,7 @@ def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_le
 
     if runtime.startswith("nodejs"):
         # note the env variables would be different for non-Node runtimes
+        layer_name = get_option_value(function, OPTION_LAYER_NAME)
         version = get_option_value(function, OPTION_VERSION)
         try:
             parsed_version = int(version)
@@ -233,24 +263,12 @@ def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_le
             sentry_sdk.capture_message("Invariant: Unable to parse AWS lambda version")
             parsed_version = None
 
-        if (
-            # Lambda layer version 235 was the latest version using `@sentry/serverless` before we switched to `@sentry/aws-serverless`
-            parsed_version is not None
-            and parsed_version <= 235
-        ):
-            env_variables.update(
-                {
-                    "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
-                    **sentry_env_variables,
-                }
-            )
-        else:
-            env_variables.update(
-                {
-                    "NODE_OPTIONS": "-r @sentry/aws-serverless/awslambda-auto",
-                    **sentry_env_variables,
-                }
-            )
+        env_variables.update(
+            {
+                "NODE_OPTIONS": get_node_options_for_layer(layer_name, parsed_version),
+                **sentry_env_variables,
+            }
+        )
 
     elif runtime.startswith("python"):
         # Check if we are trying to re-enable an already enabled python, and if

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_serverless_functions.py
@@ -253,7 +253,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
             ],
             "Environment": {
                 "Variables": {
-                    "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                    "NODE_OPTIONS": "-r @sentry/aws-serverless/awslambda-auto",
                     "SENTRY_DSN": self.sentry_dsn,
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
@@ -286,7 +286,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
             ],
             Environment={
                 "Variables": {
-                    "NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto",
+                    "NODE_OPTIONS": "-r @sentry/aws-serverless/awslambda-auto",
                     "SENTRY_DSN": self.sentry_dsn,
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }


### PR DESCRIPTION
Previously, we only had one node lambda layer called `SentryNodeServerlessSDK`. With the `v8` major of the sentry-javascript SDKs a new layer for `v7` was published under `SentryNodeServerlessSDKv7` while the `v8` layer rolled over into `SentryNodeServerlessSDK`.

With `v8` the `@sentry/serverless` package was removed (see: #70137) and a version check was added to the integration to update `NODE_OPTIONS` for the integration accordingly. The version check assumes the `SentryNodeServerlessSDK` name and only checks the ARN version which is not enough to identify a `v7` layer since the introduction of `SentryNodeServerlessSDKv7`.

With `v9` we will stop updating the `SentryNodeServerlessSDK` and instead publish `SentryNodeServerlessSDKv9` exclusively, the integration has to ensure the correct `NODE_OPTIONS` are set depending on layer name and ARN version which this PR adds.

Closes: #82646