### PR TITLE
feat(security): support for encrypted field in database

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -623,6 +623,10 @@ VISUALSTUDIO_APP_SECRET = ""
 VISUALSTUDIO_CLIENT_SECRET = ""
 VISUALSTUDIO_SCOPES = ["vso.work_write", "vso.project", "vso.code", "vso.release"]
 
+# Encryption key used for symmetric encryption of data in the database
+# Should not be used for anything else!!!
+SENTRY_DB_ENCRYPTION_KEY = os.getenv("SENTRY_DB_ENCRYPTION_KEY")
+
 SOCIAL_AUTH_PIPELINE = (
     "social_auth.backends.pipeline.user.get_username",
     "social_auth.backends.pipeline.social.social_auth_user",

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -1,0 +1,49 @@
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.db import models
+
+__all__ = ("EncryptedStringField",)
+
+
+def _get_encryption_key() -> bytes:
+    """
+    Returns a Fernet-compatible 32 byte url-safe base64-encoded key.
+    The input key from settings must be a 32-byte url-safe base64-encoded string.
+    """
+    key = settings.SENTRY_DB_ENCRYPTION_KEY
+    if isinstance(key, str):
+        # If the key is a string, encode it to bytes, as Fernet expects bytes
+        return key.encode("utf-8")
+
+    return key
+
+
+def _encrypt_value(value: str) -> bytes:
+    encryption_key = _get_encryption_key()
+    return Fernet(encryption_key).encrypt(value.encode("utf-8"))
+
+
+def _decrypt_value(value: bytes) -> str:
+    decryption_key = _get_encryption_key()
+    return Fernet(decryption_key).decrypt(value).decode("utf-8")
+
+
+class EncryptedStringField(models.BinaryField):
+    def get_prep_value(self, value):
+        if value is None:
+            return None
+
+        return _encrypt_value(value)
+
+    def from_db_value(self, value, *args, **kwargs):
+        return self.to_python(value)
+
+    def to_python(self, value):
+        if value is None:
+            return None
+
+        if isinstance(value, bytes):
+            return _decrypt_value(value)
+
+        value = bytes(value)
+        return _decrypt_value(value)

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -5,7 +5,7 @@ from django.db import models
 __all__ = ("EncryptedStringField",)
 
 
-def _get_encryption_key() -> bytes:
+def _get_encryption_key():
     """
     Returns a Fernet-compatible 32 byte url-safe base64-encoded key.
     The input key from settings must be a 32-byte url-safe base64-encoded string.

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -201,6 +201,8 @@ def pytest_configure(config: pytest.Config) -> None:
 
     settings.SENTRY_ISSUE_PLATFORM_FUTURES_MAX_LIMIT = 1
 
+    settings.SENTRY_DB_ENCRYPTION_KEY = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY="
+
     if not hasattr(settings, "SENTRY_OPTIONS"):
         settings.SENTRY_OPTIONS = {}
 

--- a/tests/sentry/db/models/fields/test_encryption.py
+++ b/tests/sentry/db/models/fields/test_encryption.py
@@ -1,0 +1,49 @@
+from django.db import models
+
+from sentry.db.models.fields.encryption import EncryptedStringField
+from sentry.testutils.cases import TestCase
+
+
+class EncryptedStringFieldTestModel(models.Model):
+    id = models.AutoField(primary_key=True)
+    encrypted_string = EncryptedStringField()
+
+    class Meta:
+        app_label = "fixtures"
+
+
+class EncryptedStringFieldNullableTestModel(models.Model):
+    id = models.AutoField(primary_key=True)
+    encrypted_string = EncryptedStringField(null=True)
+
+    class Meta:
+        app_label = "fixtures"
+
+
+class EncryptedStringFieldTest(TestCase):
+    def test_encrypted_string_field_save(self):
+        obj = EncryptedStringFieldTestModel.objects.create(encrypted_string="test")
+        self.assertEqual(obj.encrypted_string, "test")
+
+    def test_encrypted_string_field_empty(self):
+        obj = EncryptedStringFieldTestModel.objects.create(encrypted_string="")
+        self.assertEqual(obj.encrypted_string, "")
+
+    def test_encrypted_field_raw_value_is_encrypted(self):
+        field = EncryptedStringField()
+        raw_value = field.get_prep_value("test")
+        self.assertNotEqual(raw_value, "test")
+
+    def test_encrypt_and_decrypt_value(self):
+        obj = EncryptedStringFieldTestModel.objects.create(encrypted_string="test")
+        self.assertEqual(obj.encrypted_string, "test")
+
+        fetched_obj = EncryptedStringFieldTestModel.objects.get(id=obj.id)
+        self.assertEqual(fetched_obj.encrypted_string, "test")
+
+    def test_encrypted_field_support_for_null_values(self):
+        obj = EncryptedStringFieldNullableTestModel.objects.create(encrypted_string=None)
+        self.assertEqual(obj.encrypted_string, None)
+
+        fetched_obj = EncryptedStringFieldNullableTestModel.objects.get(id=obj.id)
+        self.assertEqual(fetched_obj.encrypted_string, None)

--- a/tests/sentry/db/models/fields/test_encryption.py
+++ b/tests/sentry/db/models/fields/test_encryption.py
@@ -29,10 +29,10 @@ class EncryptedStringFieldTest(TestCase):
         obj = EncryptedStringFieldTestModel.objects.create(encrypted_string="")
         self.assertEqual(obj.encrypted_string, "")
 
-    def test_encrypted_field_raw_value_is_encrypted(self):
+    def test_encrypted_field_raw_value_is_bytes(self):
         field = EncryptedStringField()
         raw_value = field.get_prep_value("test")
-        self.assertNotEqual(raw_value, "test")
+        self.assertTrue(type(raw_value) is bytes)
 
     def test_encrypt_and_decrypt_value(self):
         obj = EncryptedStringFieldTestModel.objects.create(encrypted_string="test")


### PR DESCRIPTION
PR adds support for having symmetric encrypted data in our database. This way, the data will always be encrypted in database level, but in application level, developers will be able to work with plain text strings.

First implementation of this will use a single encryption key, later the plan to improve from here and implement key rotations and use KMS.