### PR TITLE
fix(self-hosted): Fix default setting in the self hosted image

### DIFF
--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -186,7 +186,7 @@ SENTRY_QUOTAS = "sentry.quotas.redis.RedisQuota"
 # The TSDB is used for building charts as well as making things like per-rate
 # alerts possible.
 
-SENTRY_TSDB = "sentry.tsdb.redis.RedisSnubaTSDB"
+SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
 
 ###########
 # Digests #


### PR DESCRIPTION
This setting is not correct, and is causing the image of self hosted to not start when running with
default settings.