### PR TITLE
tests(trends): Fix flakey test due to call order

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
@@ -347,13 +347,12 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
 
     @mock.patch("sentry.api.endpoints.organization_events_trends_v2.detect_breakpoints")
     @mock.patch("sentry.api.endpoints.organization_events_trends_v2.EVENTS_PER_QUERY", 2)
-    @pytest.mark.skip(reason="Flaking 1/17/2025")
     def test_two_projects_same_transaction_split_queries(self, mock_detect_breakpoints):
         project1 = self.create_project(organization=self.org)
         project2 = self.create_project(organization=self.org)
 
         # force these 2 transactions from different projects
-        # to fall into the FIRST bucket when quering
+        # to fall into the FIRST bucket when querying
         for i in range(2):
             self.store_performance_metric(
                 name=TransactionMRI.DURATION.value,
@@ -372,7 +371,7 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
                 hours_before_now=2,
             )
         # force these 2 transactions from different projects
-        # to fall into the SECOND bucket when quering
+        # to fall into the SECOND bucket when querying
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
             tags={"transaction": "foo bar*"},
@@ -412,10 +411,20 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
         trends_call_args_data_1 = mock_detect_breakpoints.call_args_list[0][0][0]["data"]
         trends_call_args_data_2 = mock_detect_breakpoints.call_args_list[1][0][0]["data"]
 
-        assert len(trends_call_args_data_1[f"{project1.id},foo bar*"]) > 0
-        assert len(trends_call_args_data_1[f'{project2.id},foo bar\\\\"']) > 0
-        assert len(trends_call_args_data_2[f'{project1.id},foo bar\\\\"']) > 0
-        assert len(trends_call_args_data_2[f"{project2.id},foo bar*"]) > 0
+        # the order the calls happen in is non-deterministic because of the async
+        # nature making making the requests in a thread pool so check that 1 of
+        # the 2 possibilities happened
+        assert (
+            len(trends_call_args_data_1.get(f"{project1.id},foo bar*", {})) > 0
+            and len(trends_call_args_data_1.get(f'{project2.id},foo bar\\\\"', {})) > 0
+            and len(trends_call_args_data_2.get(f'{project1.id},foo bar\\\\"', {})) > 0
+            and len(trends_call_args_data_2.get(f"{project2.id},foo bar*", {})) > 0
+        ) or (
+            len(trends_call_args_data_1.get(f'{project1.id},foo bar\\\\"', {})) > 0
+            and len(trends_call_args_data_1.get(f"{project2.id},foo bar*", {})) > 0
+            and len(trends_call_args_data_2.get(f"{project1.id},foo bar*", {})) > 0
+            and len(trends_call_args_data_2.get(f'{project2.id},foo bar\\\\"', {})) > 0
+        )
 
         for trends_call_args_data in [trends_call_args_data_1, trends_call_args_data_2]:
             for k, v in trends_call_args_data.items():


### PR DESCRIPTION
The order the function is called is not guaranteed due to the thread pool. Assert both possibilities.