### PR TITLE
:wrench: chore(discord): change rate limits to halt for SLOs

### DIFF
--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -12,6 +12,7 @@ from sentry.integrations.messaging.metrics import (
 )
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
+from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
 
@@ -59,7 +60,6 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
                     lifecycle.add_extras({"integration_id": integration.id, "channel": channel_id})
                     client.send_message(channel_id, message, notification_uuid=notification_uuid)
                 except Exception as e:
-                    # TODO(iamrajjoshi): Update some of these failures to halts
                     lifecycle.add_extras(
                         {
                             "project_id": event.project_id,
@@ -68,7 +68,10 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
                             "channel_id": channel_id,
                         }
                     )
-                    lifecycle.record_failure(e)
+                    if isinstance(e, ApiRateLimitedError):
+                        lifecycle.record_halt(e)
+                    else:
+                        lifecycle.record_failure(e)
 
             rule = rules[0] if rules else None
             self.record_notification_sent(event, channel_id, rule, notification_uuid)

--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -68,6 +68,7 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
                             "channel_id": channel_id,
                         }
                     )
+                    # TODO(ecosystem): We should batch this on a per-organization basis
                     if isinstance(e, ApiRateLimitedError):
                         lifecycle.record_halt(e)
                     else:

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -70,6 +70,7 @@ def send_incident_alert_notification(
                     "channel_id": channel,
                 }
             )
+            # TODO(ecosystem): We should batch this on a per-organization basis
             if isinstance(error, ApiRateLimitedError):
                 lifecycle.record_halt(error)
             else:

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -101,6 +101,6 @@ class DiscordActionHandlerTest(FireTest):
         handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.OPEN.value)
+            handler.fire(metric_value, IncidentStatus.OPEN)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+import orjson
+import responses
+
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.integrations.discord.client import CHANNEL_URL, DISCORD_BASE_URL, MESSAGE_URL
+from sentry.integrations.discord.spec import DiscordMessagingSpec
+from sentry.integrations.messaging.spec import MessagingActionHandler
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.testutils.asserts import assert_slo_metric
+from sentry.testutils.helpers.datetime import freeze_time
+
+from . import FireTest
+
+
+@freeze_time()
+class DiscordActionHandlerTest(FireTest):
+    @responses.activate
+    def setUp(self):
+        self.spec = DiscordMessagingSpec()
+
+        self.guild_id = "guild-id"
+        self.channel_id = "12345678910"
+        self.discord_user_id = "user1234"
+
+        responses.add(
+            method=responses.GET,
+            url=f"{DISCORD_BASE_URL}{CHANNEL_URL.format(channel_id=self.channel_id)}",
+            json={"type": 0, "guild_id": self.guild_id},
+            status=200,
+        )
+        self.discord_integration = self.create_integration(
+            provider="discord",
+            name="Cool server",
+            external_id=self.guild_id,
+            organization=self.organization,
+        )
+        self.provider = self.create_identity_provider(integration=self.discord_integration)
+        self.identity = self.create_identity(
+            user=self.user, identity_provider=self.provider, external_id=self.discord_user_id
+        )
+
+        self.action = self.create_alert_rule_trigger_action(
+            target_identifier=self.channel_id,
+            type=AlertRuleTriggerAction.Type.DISCORD,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=self.discord_integration,
+        )
+
+    @responses.activate
+    def run_test(self, incident, method):
+        responses.add(
+            method=responses.POST,
+            url=f"{DISCORD_BASE_URL}{MESSAGE_URL.format(channel_id=self.channel_id)}",
+            json={},
+            status=200,
+        )
+
+        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
+        metric_value = 1000
+        with self.tasks():
+            getattr(handler, method)(metric_value, IncidentStatus(incident.status))
+
+        data = orjson.loads(responses.calls[0].request.body)
+        return data
+
+    def test_fire_metric_alert(self):
+        self.run_fire_test()
+
+    def test_resolve_metric_alert(self):
+        self.run_fire_test("resolve")
+
+    @responses.activate
+    def test_rule_snoozed(self):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        self.snooze_rule(alert_rule=alert_rule)
+
+        responses.add(
+            method=responses.POST,
+            url=f"{DISCORD_BASE_URL}{MESSAGE_URL.format(channel_id=self.channel_id)}",
+            json={},
+            status=200,
+        )
+
+        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus(incident.status))
+
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    @patch("sentry.integrations.discord.client.DiscordClient.send_message", side_effect=Exception)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_metric_alert_failure(self, mock_record_event, mock_send_message):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus.OPEN.value)
+
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -9,6 +9,7 @@ from sentry.integrations.discord.client import CHANNEL_URL, DISCORD_BASE_URL, ME
 from sentry.integrations.discord.spec import DiscordMessagingSpec
 from sentry.integrations.messaging.spec import MessagingActionHandler
 from sentry.integrations.types import EventLifecycleOutcome
+from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -104,3 +105,18 @@ class DiscordActionHandlerTest(FireTest):
             handler.fire(metric_value, IncidentStatus.OPEN)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)
+
+    @patch(
+        "sentry.integrations.discord.client.DiscordClient.send_message",
+        side_effect=ApiRateLimitedError(text="Rate limited"),
+    )
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_metric_alert_halt_for_rate_limited(self, mock_record_event, mock_send_message):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus.OPEN)
+
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -81,6 +81,7 @@ class DiscordIssueAlertTest(RuleTestCase):
     )
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def assert_lifecycle_metrics_failure(self, mock_record_event, mock_send_message):
+        self.rule.after(self.event)
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)
 
     @mock.patch(
@@ -89,6 +90,7 @@ class DiscordIssueAlertTest(RuleTestCase):
     )
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def assert_lifecycle_metrics_halt_for_rate_limit(self, mock_record_event, mock_send_message):
+        self.rule.after(self.event)
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
 
     @responses.activate


### PR DESCRIPTION
one org has a extremely noisy alert (~4k fires in a single week) and its been severely ratelimited by discord. this however impacts our slos since we currently record rate limits as failures instead of halts.

also wrote some basic test cases for discord incident alert handler b/c we didn't have any 😬 