### PR TITLE
ref(crons): Remove `type` from serialized monitor response

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -158,7 +158,6 @@ class MonitorSerializerResponse(MonitorSerializerResponseOptional):
     slug: str
     status: str
     isMuted: bool
-    type: Literal["cron_job", "unknown"]
     config: MonitorConfigSerializerResponse
     dateCreated: datetime
     project: ProjectSerializerResponse
@@ -245,7 +244,6 @@ class MonitorSerializer(Serializer):
             "id": str(obj.guid),
             "status": obj.get_status_display(),
             "isMuted": obj.is_muted,
-            "type": obj.get_type_display(),
             "name": obj.name,
             "slug": obj.slug,
             "config": config,


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/83604