### PR TITLE
fix(streamline): Fix the logic for the experiment

### DIFF
--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -1,18 +1,22 @@
+from random import random
+
+from sentry import options
 from sentry.models.organization import Organization
-from sentry.utils.options import sample_modulo
 
 
 def apply_streamline_rollout_group(organization: Organization):
-    # If the rollout_result is false, the organization is not in the experiment.
-    rollout_result = sample_modulo(
-        "issues.details.streamline-experiment-rollout-rate", organization.id
-    )
+    # This shouldn't run multiple times, but if it does, don't resort the organization.
+    if organization.get_option("sentry:streamline_ui_only") is not None:
+        return
 
-    if rollout_result:
-        # If split_result is true, they only receive the Streamline UI.
-        # If split_result is false, they only receive the Legacy UI.
+    rollout_rate = options.get("issues.details.streamline-experiment-rollout-rate")
+
+    # If the rollout_rate is greater than a random number, the organization is in the experiment.
+    if rollout_rate > random():
+        split_rate = options.get("issues.details.streamline-experiment-split-rate")
+        # If the split_rate is greater than a random number, the split_result is true..
+        split_result = split_rate > random()
+        # When split_result is true, they only receive the Streamline UI.
+        # When split_result is false, they only receive the Legacy UI.
         # This behaviour is controlled on the frontend.
-        split_result = sample_modulo(
-            "issues.details.streamline-experiment-split-rate", organization.id
-        )
         organization.update_option("sentry:streamline_ui_only", split_result)

--- a/src/sentry/issues/streamline.py
+++ b/src/sentry/issues/streamline.py
@@ -5,17 +5,18 @@ from sentry.models.organization import Organization
 
 
 def apply_streamline_rollout_group(organization: Organization):
-    # This shouldn't run multiple times, but if it does, don't resort the organization.
+    # This shouldn't run multiple times, but if it does, don't re-sort the organization.
+    # If they're already in the experiment, we ignore them.
     if organization.get_option("sentry:streamline_ui_only") is not None:
         return
 
     rollout_rate = options.get("issues.details.streamline-experiment-rollout-rate")
 
-    # If the rollout_rate is greater than a random number, the organization is in the experiment.
-    if rollout_rate > random():
+    # If the random number is less than the rollout_rate, the organization is in the experiment.
+    if random() <= rollout_rate:
         split_rate = options.get("issues.details.streamline-experiment-split-rate")
-        # If the split_rate is greater than a random number, the split_result is true..
-        split_result = split_rate > random()
+        # If the random number is less than the split_rate, the split_result is true.
+        split_result = random() <= split_rate
         # When split_result is true, they only receive the Streamline UI.
         # When split_result is false, they only receive the Legacy UI.
         # This behaviour is controlled on the frontend.


### PR DESCRIPTION
Turns out the organization IDs that are generated from the snowflake ID formula did not produce truly random numbers, which meant organizations getting sorted incorrectly, and producing incorrect rates for the experiment. This should fix that by just using randomly generated numbers.