### PR TITLE
feat(rpc): Allow filtering when we can't use VirtualColumnContexts

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -102,6 +102,21 @@ class FunctionDefinition:
         return [arg for arg in self.arguments if arg.default_arg is None and not arg.ignored]
 
 
+@dataclass
+class VirtualColumnDefinition:
+    constructor: Callable[[SnubaParams], VirtualColumnContext]
+    # Allows additional processing to the term after its been resolved
+    term_resolver: (
+        Callable[
+            [str | list[str]],
+            int | str | list[int] | list[str],
+        ]
+        | None
+    ) = None
+    filter_column: str | None = None
+    default_value: str | None = None
+
+
 @dataclass(frozen=True, kw_only=True)
 class ResolvedFunction(ResolvedAttribute):
     # The internal rpc alias for this column
@@ -161,5 +176,5 @@ def datetime_processor(datetime_string: str) -> str:
 class ColumnDefinitions:
     functions: dict[str, FunctionDefinition]
     columns: dict[str, ResolvedColumn]
-    contexts: dict[str, Callable[[SnubaParams], VirtualColumnContext]]
+    contexts: dict[str, VirtualColumnDefinition]
     trace_item_type: TraceItemType.ValueType

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -48,6 +48,12 @@ STRING = AttributeKey.TYPE_STRING
 BOOLEAN = AttributeKey.TYPE_BOOLEAN
 DOUBLE = AttributeKey.TYPE_DOUBLE
 INT = AttributeKey.TYPE_INT
+TYPE_TO_STRING_MAP = {
+    STRING: "string",
+    BOOLEAN: "boolean",
+    FLOAT: "float",
+    INT: "integer",
+}
 
 # TODO: we need a datetime type
 # Maps search types back to types for the proto
@@ -105,3 +111,6 @@ VALID_GRANULARITIES = frozenset(
 TRUTHY_VALUES = {"1", "true"}
 FALSEY_VALUES = {"0", "false"}
 BOOLEAN_VALUES = TRUTHY_VALUES.union(FALSEY_VALUES)
+
+PROJECT_FIELDS = {"project", "project.slug", "project.name"}
+REVERSE_CONTEXT_ERROR = "Unknown value {} for filter {}, expecting one of: {}"

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -51,7 +51,7 @@ INT = AttributeKey.TYPE_INT
 TYPE_TO_STRING_MAP = {
     STRING: "string",
     BOOLEAN: "boolean",
-    FLOAT: "float",
+    DOUBLE: "double",
     INT: "integer",
 }
 

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -353,9 +353,9 @@ class SearchResolver:
         if term.key.name in constants.PROJECT_FIELDS:
             resolved_column, _ = self.resolve_attribute("project.id")
             if isinstance(final_raw_value, list):
-                final_raw_value = [int(val) for val in raw_value]
+                final_raw_value = [int(val) for val in final_raw_value]
             else:
-                final_raw_value = int(cast(str, raw_value))
+                final_raw_value = int(final_raw_value)
         elif term.key.name == "device.class":
             resolved_column, _ = self.resolve_attribute("sentry.device.class")
         return resolved_column, final_raw_value

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -32,7 +32,12 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from sentry.api import event_search
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
-from sentry.search.eap.columns import ColumnDefinitions, ResolvedColumn, ResolvedFunction
+from sentry.search.eap.columns import (
+    ColumnDefinitions,
+    ResolvedColumn,
+    ResolvedFunction,
+    VirtualColumnDefinition,
+)
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
@@ -50,10 +55,10 @@ class SearchResolver:
     params: SnubaParams
     config: SearchResolverConfig
     definitions: ColumnDefinitions
-    _resolved_attribute_cache: dict[str, tuple[ResolvedColumn, VirtualColumnContext | None]] = (
+    _resolved_attribute_cache: dict[str, tuple[ResolvedColumn, VirtualColumnDefinition | None]] = (
         field(default_factory=dict)
     )
-    _resolved_function_cache: dict[str, tuple[ResolvedFunction, VirtualColumnContext | None]] = (
+    _resolved_function_cache: dict[str, tuple[ResolvedFunction, VirtualColumnDefinition | None]] = (
         field(default_factory=dict)
     )
 
@@ -76,7 +81,9 @@ class SearchResolver:
     @sentry_sdk.trace
     def resolve_query(
         self, querystring: str | None
-    ) -> tuple[TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnContext | None]]:
+    ) -> tuple[
+        TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnDefinition | None]
+    ]:
         """Given a query string in the public search syntax eg. `span.description:foo` construct the TraceItemFilter"""
         environment_query = self.__resolve_environment_query()
         where, having, contexts = self.__resolve_query(querystring)
@@ -137,7 +144,9 @@ class SearchResolver:
 
     def __resolve_query(
         self, querystring: str | None
-    ) -> tuple[TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnContext | None]]:
+    ) -> tuple[
+        TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnDefinition | None]
+    ]:
         if querystring is None:
             return None, None, []
         try:
@@ -164,7 +173,9 @@ class SearchResolver:
 
     def _resolve_boolean_conditions(
         self, terms: event_filter.ParsedTerms
-    ) -> tuple[TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnContext | None]]:
+    ) -> tuple[
+        TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnDefinition | None]
+    ]:
         if len(terms) == 0:
             return None, None, []
         elif len(terms) == 1:
@@ -256,14 +267,16 @@ class SearchResolver:
 
     def _resolve_terms(
         self, terms: event_filter.ParsedTerms
-    ) -> tuple[TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnContext | None]]:
+    ) -> tuple[
+        TraceItemFilter | None, AggregationFilter | None, list[VirtualColumnDefinition | None]
+    ]:
         where, where_contexts = self._resolve_where(terms)
         having, having_contexts = self._resolve_having(terms)
         return where, having, where_contexts + having_contexts
 
     def _resolve_where(
         self, terms: event_filter.ParsedTerms
-    ) -> tuple[TraceItemFilter | None, list[VirtualColumnContext | None]]:
+    ) -> tuple[TraceItemFilter | None, list[VirtualColumnDefinition | None]]:
         parsed_terms = []
         resolved_contexts = []
         for item in terms:
@@ -282,7 +295,7 @@ class SearchResolver:
 
     def _resolve_having(
         self, terms: event_filter.ParsedTerms
-    ) -> tuple[AggregationFilter | None, list[VirtualColumnContext | None]]:
+    ) -> tuple[AggregationFilter | None, list[VirtualColumnDefinition | None]]:
         if not self.config.use_aggregate_conditions:
             return None, []
 
@@ -305,36 +318,33 @@ class SearchResolver:
             return parsed_terms[0], resolved_contexts
         return None, []
 
-    def _handle_virtual_column_terms(
+    def resolve_virtual_context_term(
         self,
-        term: event_search.SearchFilter,
+        term: str,
+        raw_value: str | list[str],
         resolved_column: ResolvedColumn,
-        context: VirtualColumnContext | None,
-    ) -> tuple[ResolvedColumn, float | datetime | Sequence[float] | Sequence[str]]:
-        raw_value = term.value.raw_value
-        if context is None:
-            return resolved_column, raw_value
-        raw_value = cast(str | int | list[str], raw_value)
-
+        context: VirtualColumnDefinition,
+    ) -> list[str] | str:
         # Convert the term to the expected values
-        final_raw_value: str | int | list[str] | list[int] = []
-        reversed_context = {v: k for k, v in context.value_map.items()}
-        if term.value.is_wildcard():
-            # Avoiding this for now, but we could theoretically do a wildcard search on the resolved contexts
-            raise InvalidSearchQuery(f"Cannot use wildcards with {term.key}")
-        elif isinstance(raw_value, list):
+        final_raw_value: str | list[str] = []
+        resolved_context = context.constructor(self.params)
+        reversed_context = {v: k for k, v in resolved_context.value_map.items()}
+        if isinstance(raw_value, list):
             new_value = []
             for raw_iterable in raw_value:
-                if term.key.name == "device.class" and raw_iterable == "Unknown":
+                if context.default_value and context.default_value == raw_iterable:
                     # Avoiding this for now, while this could work with the Unknown:"" mapping
                     # But that won't work once we use the VirtualColumnContext.default_value
                     raise InvalidSearchQuery(
-                        "Using Unknown in an IN filter is not currently supported"
+                        f"Using {raw_iterable} in an IN filter is not currently supported"
                     )
                 elif raw_iterable not in reversed_context:
+                    valid_values = list(reversed_context.keys())[:5]
+                    if len(valid_values) > 5:
+                        valid_values.append("...")
                     raise InvalidSearchQuery(
                         constants.REVERSE_CONTEXT_ERROR.format(
-                            raw_value, term.key.name, ", ".join(reversed_context.keys())
+                            raw_value, term, ", ".join(valid_values)
                         )
                     )
                 else:
@@ -343,36 +353,47 @@ class SearchResolver:
         elif raw_value in reversed_context:
             final_raw_value = reversed_context[raw_value]
         else:
+            valid_values = list(reversed_context.keys())[:5]
+            if len(valid_values) > 5:
+                valid_values.append("...")
             raise InvalidSearchQuery(
                 constants.REVERSE_CONTEXT_ERROR.format(
-                    raw_value, term.key.name, ", ".join(reversed_context.keys())
+                    raw_value, term, ", ".join(list(reversed_context.keys())[:5])
                 )
             )
-
-        # Convert the resolved_column to the underlying column
-        if term.key.name in constants.PROJECT_FIELDS:
-            resolved_column, _ = self.resolve_attribute("project.id")
-            if isinstance(final_raw_value, list):
-                final_raw_value = [int(val) for val in final_raw_value]
-            else:
-                final_raw_value = int(final_raw_value)
-        elif term.key.name == "device.class":
-            resolved_column, _ = self.resolve_attribute("sentry.device.class")
-        return resolved_column, final_raw_value
+        return final_raw_value
 
     def resolve_term(
         self, term: event_search.SearchFilter
-    ) -> tuple[TraceItemFilter, VirtualColumnContext | None]:
-        resolved_column, context = self.resolve_column(term.key.name)
+    ) -> tuple[TraceItemFilter, VirtualColumnDefinition | None]:
+        resolved_column, context_definition = self.resolve_column(term.key.name)
 
         if not isinstance(resolved_column.proto_definition, AttributeKey):
             raise ValueError(f"{term.key.name} is not valid search term")
 
         raw_value = term.value.raw_value
 
-        resolved_column, raw_value = self._handle_virtual_column_terms(
-            term, resolved_column, context
-        )
+        if context_definition:
+            if term.value.is_wildcard():
+                # Avoiding this for now, but we could theoretically do a wildcard search on the resolved contexts
+                raise InvalidSearchQuery(f"Cannot use wildcards with {term.key.name}")
+            if (
+                isinstance(raw_value, str)
+                or isinstance(raw_value, list)
+                and all(isinstance(value, str) for value in raw_value)
+            ):
+                raw_value = self.resolve_virtual_context_term(
+                    term.key.name,
+                    raw_value,
+                    resolved_column,
+                    context_definition,
+                )
+            else:
+                raise InvalidSearchQuery(f"{raw_value} not a valid term for {term.key.name}")
+            if context_definition.term_resolver:
+                raw_value = context_definition.term_resolver(raw_value)
+            if context_definition.filter_column is not None:
+                resolved_column, _ = self.resolve_attribute(context_definition.filter_column)
 
         if term.value.is_wildcard():
             if term.operator == "=":
@@ -403,12 +424,12 @@ class SearchResolver:
                     value=self._resolve_search_value(resolved_column, term.operator, raw_value),
                 )
             ),
-            context,
+            context_definition,
         )
 
     def resolve_aggregate_term(
         self, term: event_search.AggregateFilter
-    ) -> tuple[AggregationFilter, VirtualColumnContext | None]:
+    ) -> tuple[AggregationFilter, VirtualColumnDefinition | None]:
         resolved_column, context = self.resolve_column(term.key.name)
 
         if not isinstance(resolved_column.proto_definition, AttributeAggregation):
@@ -496,13 +517,16 @@ class SearchResolver:
         else:
             raise NotImplementedError("Aggregate Queries not implemented yet")
 
-    def clean_contexts(
-        self, resolved_contexts: list[VirtualColumnContext | None]
+    def resolve_contexts(
+        self, context_definitions: list[VirtualColumnDefinition | None]
     ) -> list[VirtualColumnContext]:
         """Given a list of contexts that may have None in them, remove the Nones and remove the dupes"""
         final_contexts = []
         existing_target_columns = set()
-        for context in resolved_contexts:
+        for context_definition in context_definitions:
+            if context_definition is None:
+                continue
+            context = context_definition.constructor(self.params)
             if context is None or context.to_column_name in existing_target_columns:
                 continue
             else:
@@ -513,7 +537,7 @@ class SearchResolver:
     @sentry_sdk.trace
     def resolve_columns(
         self, selected_columns: list[str]
-    ) -> tuple[list[ResolvedColumn | ResolvedFunction], list[VirtualColumnContext | None]]:
+    ) -> tuple[list[ResolvedColumn | ResolvedFunction], list[VirtualColumnDefinition | None]]:
         """Given a list of columns resolve them and get their context if applicable
 
         This function will also dedupe the virtual column contexts if necessary
@@ -548,7 +572,7 @@ class SearchResolver:
 
     def resolve_column(
         self, column: str, match: Match | None = None
-    ) -> tuple[ResolvedColumn | ResolvedFunction, VirtualColumnContext | None]:
+    ) -> tuple[ResolvedColumn | ResolvedFunction, VirtualColumnDefinition | None]:
         """Column is either an attribute or an aggregate, this function will determine which it is and call the relevant
         resolve function"""
         match = fields.is_function(column)
@@ -564,7 +588,7 @@ class SearchResolver:
     @sentry_sdk.trace
     def resolve_attributes(
         self, columns: list[str]
-    ) -> tuple[list[ResolvedColumn], list[VirtualColumnContext | None]]:
+    ) -> tuple[list[ResolvedColumn], list[VirtualColumnDefinition | None]]:
         """Helper function to resolve a list of attributes instead of 1 attribute at a time"""
         resolved_columns = []
         resolved_contexts = []
@@ -574,14 +598,16 @@ class SearchResolver:
             resolved_contexts.append(context)
         return resolved_columns, resolved_contexts
 
-    def resolve_attribute(self, column: str) -> tuple[ResolvedColumn, VirtualColumnContext | None]:
+    def resolve_attribute(
+        self, column: str
+    ) -> tuple[ResolvedColumn, VirtualColumnDefinition | None]:
         """Attributes are columns that aren't 'functions' or 'aggregates', usually this means string or numeric
         attributes (aka. tags), but can also refer to fields like span.description"""
         # If a virtual context is defined the column definition is always the same
         if column in self._resolved_attribute_cache:
             return self._resolved_attribute_cache[column]
         if column in self.definitions.contexts:
-            column_context = self.definitions.contexts[column](self.params)
+            column_context = self.definitions.contexts[column]
             column_definition = ResolvedColumn(
                 public_alias=column, internal_name=column, search_type="string"
             )
@@ -628,7 +654,7 @@ class SearchResolver:
     @sentry_sdk.trace
     def resolve_aggregates(
         self, columns: list[str]
-    ) -> tuple[list[ResolvedFunction], list[VirtualColumnContext | None]]:
+    ) -> tuple[list[ResolvedFunction], list[VirtualColumnDefinition | None]]:
         """Helper function to resolve a list of aggregates instead of 1 attribute at a time"""
         resolved_aggregates, resolved_contexts = [], []
         for column in columns:
@@ -639,7 +665,7 @@ class SearchResolver:
 
     def resolve_aggregate(
         self, column: str, match: Match | None = None
-    ) -> tuple[ResolvedFunction, VirtualColumnContext | None]:
+    ) -> tuple[ResolvedFunction, VirtualColumnDefinition | None]:
         if column in self._resolved_function_cache:
             return self._resolved_function_cache[column]
         # Check if this is a valid function, parse the function name and args out

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -352,6 +352,10 @@ class SearchResolver:
             final_raw_value = new_value
         elif raw_value in reversed_context:
             final_raw_value = reversed_context[raw_value]
+        elif context.default_value and context.default_value == raw_value:
+            # Avoiding this for now, while this could work with the Unknown:"" mapping
+            # But that won't work once we use the VirtualColumnContext.default_value
+            raise InvalidSearchQuery(f"Using {raw_value} is not currently supported")
         else:
             valid_values = list(reversed_context.keys())[:5]
             if len(valid_values) > 5:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -312,7 +312,7 @@ class SearchResolver:
         context: VirtualColumnContext | None,
     ) -> tuple[ResolvedColumn, float | datetime | Sequence[float] | Sequence[str]]:
         raw_value = term.value.raw_value
-        if context is None or isinstance(raw_value, datetime):
+        if context is None:
             return resolved_column, raw_value
         raw_value = cast(str | int | list[str], raw_value)
 
@@ -325,7 +325,7 @@ class SearchResolver:
         elif isinstance(raw_value, list):
             new_value = []
             for raw_iterable in raw_value:
-                if term.key.name not in constants.PROJECT_FIELDS and raw_iterable == "Unknown":
+                if term.key.name == "device.class" and raw_iterable == "Unknown":
                     # Avoiding this for now, while this could work with the Unknown:"" mapping
                     # But that won't work once we use the VirtualColumnContext.default_value
                     raise InvalidSearchQuery(

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -59,7 +59,7 @@ def run_table_query(
     meta = resolver.resolve_meta(referrer=referrer)
     where, having, query_contexts = resolver.resolve_query(query_string)
     columns, column_contexts = resolver.resolve_columns(selected_columns)
-    contexts = resolver.clean_contexts(query_contexts + column_contexts)
+    contexts = resolver.resolve_contexts(query_contexts + column_contexts)
     # We allow orderby function_aliases if they're a selected_column
     # eg. can orderby sum_span_self_time, assuming sum(span.self_time) is selected
     orderby_aliases = {
@@ -185,8 +185,6 @@ def get_timeseries_query(
             if isinstance(groupby.proto_definition, AttributeKey)
         ],
         granularity_secs=granularity_secs,
-        # TODO: need to add this once the RPC supports it
-        # virtual_column_contexts=[context for context in resolver.clean_contexts(query_contexts) if context is not None],
     )
 
 

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -548,7 +548,7 @@ class SearchResolverColumnTest(TestCase):
         assert resolved_column.proto_definition == AttributeKey(
             name="project", type=AttributeKey.Type.TYPE_STRING
         )
-        assert virtual_context == VirtualColumnContext(
+        assert virtual_context.constructor(self.resolver.params) == VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name="project",
             value_map={str(self.project.id): self.project.slug},
@@ -559,7 +559,7 @@ class SearchResolverColumnTest(TestCase):
         assert resolved_column.proto_definition == AttributeKey(
             name="project.slug", type=AttributeKey.Type.TYPE_STRING
         )
-        assert virtual_context == VirtualColumnContext(
+        assert virtual_context.constructor(self.resolver.params) == VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name="project.slug",
             value_map={str(self.project.id): self.project.slug},

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -548,6 +548,7 @@ class SearchResolverColumnTest(TestCase):
         assert resolved_column.proto_definition == AttributeKey(
             name="project", type=AttributeKey.Type.TYPE_STRING
         )
+        assert virtual_context is not None
         assert virtual_context.constructor(self.resolver.params) == VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name="project",
@@ -559,6 +560,7 @@ class SearchResolverColumnTest(TestCase):
         assert resolved_column.proto_definition == AttributeKey(
             name="project.slug", type=AttributeKey.Type.TYPE_STRING
         )
+        assert virtual_context is not None
         assert virtual_context.constructor(self.resolver.params) == VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name="project.slug",


### PR DESCRIPTION
- VirtualColumnContexts aren't available on timeseries, so if we filter by a vcc field (project, device.class) we need custom logic
- From a discussion in slack going to drop device.module support, will do that in a follow up PR