### PR TITLE
fix(issues): Remove duplicate clear assignee call

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -427,6 +427,9 @@ describe('AssigneeSelectorDropdown', () => {
         })
       )
     );
+    expect(assignMock).toHaveBeenCalledTimes(1);
+    assignMock.mockClear();
+
     rerender(
       <AssigneeSelectorDropdown
         group={assignedGroup}
@@ -442,13 +445,14 @@ describe('AssigneeSelectorDropdown', () => {
 
     // api was called with empty string, clearing assignment
     await waitFor(() =>
-      expect(assignMock).toHaveBeenLastCalledWith(
+      expect(assignMock).toHaveBeenCalledWith(
         '/organizations/org-slug/issues/1337/',
         expect.objectContaining({
           data: {assignedTo: '', assignedBy: 'assignee_selector'},
         })
       )
     );
+    expect(assignMock).toHaveBeenCalledTimes(1);
   });
 
   it('filters user by email and selects with keyboard', async () => {

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -572,7 +572,6 @@ export default function AssigneeSelectorDropdown({
             ? `${group.assignedTo?.type === 'user' ? 'user:' : 'team:'}${group.assignedTo.id}`
             : ''
         }
-        onClear={() => handleSelect(null)}
         menuTitle={t('Assignee')}
         searchPlaceholder="Search users or teams..."
         size="sm"


### PR DESCRIPTION
It seems onClear and handle change are both called creating a duplicate request.
