### PR TITLE
feat(nav): Stop using config for primary navigation

### DIFF
--- a/static/app/components/nav/index.tsx
+++ b/static/app/components/nav/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {DeprecatedNavContextProvider} from 'sentry/components/nav/contextDeprecated';
 import MobileTopbar from 'sentry/components/nav/mobileTopbar';
-import Sidebar from 'sentry/components/nav/sidebar';
+import {Sidebar} from 'sentry/components/nav/sidebar';
 import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
 
 function Nav() {

--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 
-import {SidebarItems} from 'sentry/components/nav/sidebar';
+import {PrimaryNavigationItems} from 'sentry/components/nav/primary';
 import {IconClose, IconMenu, IconSentry} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import theme from 'sentry/utils/theme';
@@ -35,7 +35,7 @@ function MobileTopbar() {
       </button>
       {view !== 'closed' ? (
         <OverlayPortal>
-          <SidebarItems />
+          <PrimaryNavigationItems />
         </OverlayPortal>
       ) : null}
     </Topbar>

--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -243,7 +243,7 @@ export function PrimaryNavigationItems() {
             label: t('Settings'),
             icon: <IconSettings />,
             analyticsKey: 'settings',
-            to: `/${prefix}/settings/organization/`,
+            to: `${prefix}/settings/${organization.slug}/`,
           }}
         />
       </SidebarFooter>

--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -29,10 +29,8 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
 
 interface SidebarItemProps {
   item: NavSidebarItem;
@@ -143,29 +141,7 @@ export function PrimaryNavigationItems() {
             label: t('Issues'),
             icon: <IconIssues />,
             analyticsKey: 'issues',
-            submenu: [
-              {
-                label: t('All'),
-                to: `/${prefix}/issues/?query=is:unresolved`,
-              },
-              {
-                label: t('Error & Outage'),
-                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.ERROR_OUTAGE)}`,
-              },
-              {
-                label: t('Trend'),
-                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.TREND)}`,
-              },
-              {
-                label: t('Craftsmanship'),
-                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.CRAFTSMANSHIP)}`,
-              },
-              {
-                label: t('Security'),
-                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.SECURITY)}`,
-              },
-              {label: t('Feedback'), to: `/${prefix}/feedback/`},
-            ],
+            to: `/${prefix}/issues/`,
           }}
         />
         <SidebarItem
@@ -181,45 +157,7 @@ export function PrimaryNavigationItems() {
             label: t('Explore'),
             icon: <IconSearch />,
             analyticsKey: 'explore',
-            submenu: [
-              {
-                label: t('Traces'),
-                to: `/${prefix}/traces/`,
-                feature: {features: 'performance-trace-explorer'},
-              },
-              {
-                label: t('Metrics'),
-                to: `/${prefix}/metrics/`,
-                feature: {features: 'custom-metrics'},
-              },
-              {
-                label: t('Profiles'),
-                to: `/${prefix}/profiling/`,
-                feature: {
-                  features: 'profiling',
-                  hookName: 'feature-disabled:profiling-sidebar-item',
-                  requireAll: false,
-                },
-              },
-              {
-                label: t('Replays'),
-                to: `/${prefix}/replays/`,
-                feature: {
-                  features: 'session-replay-ui',
-                  hookName: 'feature-disabled:replay-sidebar-item',
-                },
-              },
-              {
-                label: t('Discover'),
-                to: getDiscoverLandingUrl(organization),
-                feature: {
-                  features: 'discover-basic',
-                  hookName: 'feature-disabled:discover2-sidebar-item',
-                },
-              },
-              {label: t('Releases'), to: `/${prefix}/releases/`},
-              {label: t('Crons'), to: `/${prefix}/crons/`},
-            ],
+            to: `/${prefix}/traces/`,
           }}
         />
         <Feature features={['performance-view']}>
@@ -228,24 +166,7 @@ export function PrimaryNavigationItems() {
               label: t('Insights'),
               icon: <IconGraph />,
               analyticsKey: 'insights-domains',
-              submenu: [
-                {
-                  label: t('Frontend'),
-                  to: `/${prefix}/domain-views/frontend/`,
-                },
-                {
-                  label: t('Backend'),
-                  to: `/${prefix}/domain-views/backend/`,
-                },
-                {
-                  label: t('Mobile'),
-                  to: `/${prefix}/domain-views/mobile/`,
-                },
-                {
-                  label: t('AI'),
-                  to: `/${prefix}/domain-views/ai/`,
-                },
-              ],
+              to: `/${prefix}/insights/frontend/`,
             }}
           />
         </Feature>
@@ -322,7 +243,7 @@ export function PrimaryNavigationItems() {
             label: t('Settings'),
             icon: <IconSettings />,
             analyticsKey: 'settings',
-            to: `/settings/${organization.slug}/`,
+            to: `/${prefix}/settings/organization/`,
           }}
         />
       </SidebarFooter>

--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -1,0 +1,411 @@
+import {Fragment, type MouseEventHandler, useCallback} from 'react';
+import styled from '@emotion/styled';
+
+import {openHelpSearchModal} from 'sentry/actionCreators/modal';
+import Feature from 'sentry/components/acl/feature';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Link from 'sentry/components/links/link';
+import {linkStyles} from 'sentry/components/links/styles';
+import {
+  isNavItemActive,
+  isSubmenuItemActive,
+  makeLinkPropsFromTo,
+  type NavSidebarItem,
+  resolveNavItemTo,
+} from 'sentry/components/nav/utils';
+import {
+  IconDashboard,
+  IconGraph,
+  IconIssues,
+  IconLightning,
+  IconProject,
+  IconQuestion,
+  IconSearch,
+  IconSettings,
+  IconSiren,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
+
+interface SidebarItemProps {
+  item: NavSidebarItem;
+  children?: React.ReactNode;
+  onClick?: MouseEventHandler<HTMLElement>;
+}
+
+function SidebarBody({children}: {children: React.ReactNode}) {
+  return <SidebarItemList>{children}</SidebarItemList>;
+}
+
+function SidebarFooter({children}: {children: React.ReactNode}) {
+  return (
+    <SidebarFooterWrapper>
+      <SidebarItemList>{children}</SidebarItemList>
+    </SidebarFooterWrapper>
+  );
+}
+
+function SidebarItem({item}: SidebarItemProps) {
+  const to = resolveNavItemTo(item);
+  const SidebarChild = to ? SidebarLink : SidebarMenu;
+  const organization = useOrganization();
+
+  const FeatureGuard = item.feature ? Feature : Fragment;
+  const featureGuardProps: any = item.feature ?? {};
+
+  const recordAnalytics = useCallback(
+    () =>
+      trackAnalytics('growth.clicked_sidebar', {item: item.analyticsKey, organization}),
+    [organization, item.analyticsKey]
+  );
+
+  return (
+    <FeatureGuard {...featureGuardProps}>
+      <SidebarItemWrapper>
+        <SidebarChild item={item} key={item.label} onClick={recordAnalytics}>
+          {item.icon}
+          <span>{item.label}</span>
+        </SidebarChild>
+      </SidebarItemWrapper>
+    </FeatureGuard>
+  );
+}
+
+function SidebarMenu({item, children, onClick}: SidebarItemProps) {
+  if (!item.dropdown) {
+    throw new Error(
+      `Nav item "${item.label}" must have either a \`dropdown\` or \`to\` value!`
+    );
+  }
+  return (
+    <DropdownMenu
+      position="right-end"
+      trigger={(props, isOpen) => {
+        return (
+          <NavButton
+            {...props}
+            onClick={event => {
+              onClick?.(event);
+              props.onClick?.(event);
+            }}
+          >
+            <InteractionStateLayer hasSelectedBackground={isOpen} />
+            {children}
+          </NavButton>
+        );
+      }}
+      items={item.dropdown}
+    />
+  );
+}
+
+function SidebarLink({children, item, onClick}: SidebarItemProps) {
+  const location = useLocation();
+  const isActive = isNavItemActive(item, location);
+  const isSubmenuActive = isSubmenuItemActive(item, location);
+  const to = resolveNavItemTo(item);
+  if (!to) {
+    throw new Error(
+      `Nav item "${item.label}" must have either a \`dropdown\` or \`to\` value!`
+    );
+  }
+  const linkProps = makeLinkPropsFromTo(to);
+
+  return (
+    <NavLink
+      {...linkProps}
+      onClick={onClick}
+      className={isActive || isSubmenuActive ? 'active' : undefined}
+      aria-current={isActive ? 'page' : undefined}
+    >
+      <InteractionStateLayer hasSelectedBackground={isActive || isSubmenuActive} />
+      {children}
+    </NavLink>
+  );
+}
+
+export function PrimaryNavigationItems() {
+  const organization = useOrganization();
+  const prefix = `organizations/${organization.slug}`;
+
+  return (
+    <Fragment>
+      <SidebarBody>
+        <SidebarItem
+          item={{
+            label: t('Issues'),
+            icon: <IconIssues />,
+            analyticsKey: 'issues',
+            submenu: [
+              {
+                label: t('All'),
+                to: `/${prefix}/issues/?query=is:unresolved`,
+              },
+              {
+                label: t('Error & Outage'),
+                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.ERROR_OUTAGE)}`,
+              },
+              {
+                label: t('Trend'),
+                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.TREND)}`,
+              },
+              {
+                label: t('Craftsmanship'),
+                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.CRAFTSMANSHIP)}`,
+              },
+              {
+                label: t('Security'),
+                to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.SECURITY)}`,
+              },
+              {label: t('Feedback'), to: `/${prefix}/feedback/`},
+            ],
+          }}
+        />
+        <SidebarItem
+          item={{
+            label: t('Projects'),
+            icon: <IconProject />,
+            analyticsKey: 'projects',
+            to: `/${prefix}/projects/`,
+          }}
+        />
+        <SidebarItem
+          item={{
+            label: t('Explore'),
+            icon: <IconSearch />,
+            analyticsKey: 'explore',
+            submenu: [
+              {
+                label: t('Traces'),
+                to: `/${prefix}/traces/`,
+                feature: {features: 'performance-trace-explorer'},
+              },
+              {
+                label: t('Metrics'),
+                to: `/${prefix}/metrics/`,
+                feature: {features: 'custom-metrics'},
+              },
+              {
+                label: t('Profiles'),
+                to: `/${prefix}/profiling/`,
+                feature: {
+                  features: 'profiling',
+                  hookName: 'feature-disabled:profiling-sidebar-item',
+                  requireAll: false,
+                },
+              },
+              {
+                label: t('Replays'),
+                to: `/${prefix}/replays/`,
+                feature: {
+                  features: 'session-replay-ui',
+                  hookName: 'feature-disabled:replay-sidebar-item',
+                },
+              },
+              {
+                label: t('Discover'),
+                to: getDiscoverLandingUrl(organization),
+                feature: {
+                  features: 'discover-basic',
+                  hookName: 'feature-disabled:discover2-sidebar-item',
+                },
+              },
+              {label: t('Releases'), to: `/${prefix}/releases/`},
+              {label: t('Crons'), to: `/${prefix}/crons/`},
+            ],
+          }}
+        />
+        <Feature features={['performance-view']}>
+          <SidebarItem
+            item={{
+              label: t('Insights'),
+              icon: <IconGraph />,
+              analyticsKey: 'insights-domains',
+              submenu: [
+                {
+                  label: t('Frontend'),
+                  to: `/${prefix}/domain-views/frontend/`,
+                },
+                {
+                  label: t('Backend'),
+                  to: `/${prefix}/domain-views/backend/`,
+                },
+                {
+                  label: t('Mobile'),
+                  to: `/${prefix}/domain-views/mobile/`,
+                },
+                {
+                  label: t('AI'),
+                  to: `/${prefix}/domain-views/ai/`,
+                },
+              ],
+            }}
+          />
+        </Feature>
+        <Feature
+          features={['performance-view']}
+          hookName="feature-disabled:performance-sidebar-item"
+        >
+          <SidebarItem
+            item={{
+              label: t('Perf.'),
+              icon: <IconLightning />,
+              analyticsKey: 'performance',
+              to: `/${prefix}/performance/`,
+            }}
+          />
+        </Feature>
+        <Feature
+          features={['discover', 'discover-query', 'dashboards-basic', 'dashboards-edit']}
+          hookName="feature-disabled:dashboards-sidebar-item"
+          requireAll={false}
+        >
+          <SidebarItem
+            item={{
+              label: t('Boards'),
+              icon: <IconDashboard />,
+              analyticsKey: 'customizable-dashboards',
+              to: `/${prefix}/dashboards/`,
+            }}
+          />
+        </Feature>
+        <SidebarItem
+          item={{
+            label: t('Alerts'),
+            icon: <IconSiren />,
+            analyticsKey: 'alerts',
+            to: `/${prefix}/alerts/rules/`,
+          }}
+        />
+      </SidebarBody>
+      <SidebarFooter>
+        <SidebarItem
+          item={{
+            label: t('Help'),
+            icon: <IconQuestion />,
+            analyticsKey: 'help',
+            dropdown: [
+              {
+                key: 'search',
+                label: t('Search Support, Docs and More'),
+                onAction() {
+                  openHelpSearchModal({organization});
+                },
+              },
+              {
+                key: 'help',
+                label: t('Visit Help Center'),
+                to: 'https://sentry.zendesk.com/hc/en-us',
+              },
+              {
+                key: 'discord',
+                label: t('Join our Discord'),
+                to: 'https://discord.com/invite/sentry',
+              },
+              {
+                key: 'support',
+                label: t('Contact Support'),
+                to: `mailto:${ConfigStore.get('supportEmail')}`,
+              },
+            ],
+          }}
+        />
+        <SidebarItem
+          item={{
+            label: t('Settings'),
+            icon: <IconSettings />,
+            analyticsKey: 'settings',
+            to: `/settings/${organization.slug}/`,
+          }}
+        />
+      </SidebarFooter>
+    </Fragment>
+  );
+}
+
+const SidebarItemList = styled('ul')`
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  padding-top: ${space(1)};
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  color: rgba(255, 255, 255, 0.85);
+
+  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
+    gap: ${space(1)};
+  }
+`;
+
+const SidebarItemWrapper = styled('li')`
+  svg {
+    --size: 14px;
+    width: var(--size);
+    height: var(--size);
+
+    @media (min-width: ${p => p.theme.breakpoints.medium}) {
+      --size: 18px;
+      padding-top: ${space(0.5)};
+    }
+  }
+  > a,
+  button {
+    display: flex;
+    flex-direction: row;
+    height: 40px;
+    gap: ${space(1.5)};
+    align-items: center;
+    padding: auto ${space(1.5)};
+    color: var(--color, currentColor);
+    font-size: ${p => p.theme.fontSizeMedium};
+    font-weight: ${p => p.theme.fontWeightNormal};
+    line-height: 177.75%;
+
+    & > * {
+      pointer-events: none;
+    }
+
+    @media (min-width: ${p => p.theme.breakpoints.medium}) {
+      flex-direction: column;
+      justify-content: center;
+      height: 52px;
+      padding: ${space(0.5)} ${space(0.75)};
+      border-radius: ${p => p.theme.borderRadius};
+      font-size: ${p => p.theme.fontSizeExtraSmall};
+      margin-inline: ${space(1)};
+      gap: ${space(0.5)};
+    }
+  }
+`;
+
+const SidebarFooterWrapper = styled('div')`
+  position: relative;
+  border-top: 1px solid ${p => p.theme.translucentGray200};
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  padding-bottom: ${space(0.5)};
+  margin-top: auto;
+`;
+
+const NavLink = styled(Link)`
+  position: relative;
+`;
+
+const NavButton = styled('button')`
+  border: none;
+  position: relative;
+  background: transparent;
+  min-width: 58px;
+
+  ${linkStyles}
+`;

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -1,61 +1,21 @@
-import type {MouseEventHandler} from 'react';
-import {Fragment, useCallback} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import Link from 'sentry/components/links/link';
-import {linkStyles} from 'sentry/components/links/styles';
-import {useNavContextDeprecated} from 'sentry/components/nav/contextDeprecated';
+import {PrimaryNavigationItems} from 'sentry/components/nav/primary';
 import Submenu from 'sentry/components/nav/submenu';
-import {
-  isNavItemActive,
-  isNonEmptyArray,
-  isSubmenuItemActive,
-  makeLinkPropsFromTo,
-  type NavSidebarItem,
-  resolveNavItemTo,
-} from 'sentry/components/nav/utils';
 import SidebarDropdown from 'sentry/components/sidebar/sidebarDropdown';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import theme from 'sentry/utils/theme';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 
-function Sidebar() {
+export function Sidebar() {
   return (
     <Fragment>
       <SidebarWrapper role="navigation" aria-label="Primary Navigation">
         <SidebarHeader>
           <SidebarDropdown orientation="left" collapsed />
         </SidebarHeader>
-        <SidebarItems />
+        <PrimaryNavigationItems />
       </SidebarWrapper>
       <Submenu />
-    </Fragment>
-  );
-}
-
-export default Sidebar;
-
-export function SidebarItems() {
-  const {config} = useNavContextDeprecated();
-  return (
-    <Fragment>
-      <SidebarBody>
-        {config.main.map(item => (
-          <SidebarItem key={item.label} item={item} />
-        ))}
-      </SidebarBody>
-      {isNonEmptyArray(config.footer) && (
-        <SidebarFooter>
-          {config.footer.map(item => (
-            <SidebarItem key={item.label} item={item} />
-          ))}
-        </SidebarFooter>
-      )}
     </Fragment>
   );
 }
@@ -64,183 +24,17 @@ const SidebarWrapper = styled('div')`
   height: 40px;
   width: 100vw;
   padding: ${space(2)} 0;
-  border-right: 1px solid ${theme.translucentGray100};
-  /* these colors should be moved to the "theme" object */
+  border-right: 1px solid ${p => p.theme.translucentGray100};
   background: #3e2648;
   background: linear-gradient(180deg, #3e2648 0%, #442c4e 100%);
   display: flex;
   flex-direction: column;
-  z-index: ${theme.zIndex.sidebar};
+  z-index: ${p => p.theme.zIndex.sidebar};
 
   @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
     height: unset;
     width: 74px;
   }
-`;
-
-const SidebarItemList = styled('ul')`
-  position: relative;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  padding-top: ${space(1)};
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  color: rgba(255, 255, 255, 0.85);
-
-  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
-    gap: ${space(1)};
-  }
-`;
-
-interface SidebarItemProps {
-  item: NavSidebarItem;
-  children?: React.ReactNode;
-  onClick?: MouseEventHandler<HTMLElement>;
-}
-
-function SidebarItem({item}: SidebarItemProps) {
-  const to = resolveNavItemTo(item);
-  const SidebarChild = to ? SidebarLink : SidebarMenu;
-  const organization = useOrganization();
-
-  const FeatureGuard = item.feature ? Feature : Fragment;
-  const featureGuardProps: any = item.feature ?? {};
-
-  const recordAnalytics = useCallback(
-    () =>
-      trackAnalytics('growth.clicked_sidebar', {item: item.analyticsKey, organization}),
-    [organization, item.analyticsKey]
-  );
-
-  return (
-    <FeatureGuard {...featureGuardProps}>
-      <SidebarItemWrapper>
-        <SidebarChild item={item} key={item.label} onClick={recordAnalytics}>
-          {item.icon}
-          <span>{item.label}</span>
-        </SidebarChild>
-      </SidebarItemWrapper>
-    </FeatureGuard>
-  );
-}
-
-const NavLink = styled(Link)`
-  position: relative;
-`;
-
-const NavButton = styled('button')`
-  border: none;
-  position: relative;
-  background: transparent;
-  min-width: 58px;
-
-  ${linkStyles}
-`;
-
-function SidebarLink({children, item, onClick}: SidebarItemProps) {
-  const location = useLocation();
-  const isActive = isNavItemActive(item, location);
-  const isSubmenuActive = isSubmenuItemActive(item, location);
-  const to = resolveNavItemTo(item);
-  if (!to) {
-    throw new Error(
-      `Nav item "${item.label}" must have either a \`dropdown\` or \`to\` value!`
-    );
-  }
-  const linkProps = makeLinkPropsFromTo(to);
-
-  return (
-    <NavLink
-      {...linkProps}
-      onClick={onClick}
-      className={isActive || isSubmenuActive ? 'active' : undefined}
-      aria-current={isActive ? 'page' : undefined}
-    >
-      <InteractionStateLayer hasSelectedBackground={isActive || isSubmenuActive} />
-      {children}
-    </NavLink>
-  );
-}
-
-function SidebarMenu({item, children, onClick}: SidebarItemProps) {
-  if (!item.dropdown) {
-    throw new Error(
-      `Nav item "${item.label}" must have either a \`dropdown\` or \`to\` value!`
-    );
-  }
-  return (
-    <DropdownMenu
-      position="right-end"
-      trigger={(props, isOpen) => {
-        return (
-          <NavButton
-            {...props}
-            onClick={event => {
-              onClick?.(event);
-              props.onClick?.(event);
-            }}
-          >
-            <InteractionStateLayer hasSelectedBackground={isOpen} />
-            {children}
-          </NavButton>
-        );
-      }}
-      items={item.dropdown}
-    />
-  );
-}
-
-const SidebarItemWrapper = styled('li')`
-  svg {
-    --size: 14px;
-    width: var(--size);
-    height: var(--size);
-
-    @media (min-width: ${p => p.theme.breakpoints.medium}) {
-      --size: 18px;
-      padding-top: ${space(0.5)};
-    }
-  }
-  > a,
-  button {
-    display: flex;
-    flex-direction: row;
-    height: 40px;
-    gap: ${space(1.5)};
-    align-items: center;
-    padding: auto ${space(1.5)};
-    color: var(--color, currentColor);
-    font-size: ${theme.fontSizeMedium};
-    font-weight: ${theme.fontWeightNormal};
-    line-height: 177.75%;
-
-    & > * {
-      pointer-events: none;
-    }
-
-    @media (min-width: ${p => p.theme.breakpoints.medium}) {
-      flex-direction: column;
-      justify-content: center;
-      height: 52px;
-      padding: ${space(0.5)} ${space(0.75)};
-      border-radius: ${theme.borderRadius};
-      font-size: ${theme.fontSizeExtraSmall};
-      margin-inline: ${space(1)};
-      gap: ${space(0.5)};
-    }
-  }
-`;
-
-const SidebarFooterWrapper = styled('div')`
-  position: relative;
-  border-top: 1px solid ${theme.translucentGray200};
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  padding-bottom: ${space(0.5)};
-  margin-top: auto;
 `;
 
 const SidebarHeader = styled('header')`
@@ -249,15 +43,3 @@ const SidebarHeader = styled('header')`
   justify-content: center;
   margin-bottom: ${space(1.5)};
 `;
-
-function SidebarBody({children}: any) {
-  return <SidebarItemList>{children}</SidebarItemList>;
-}
-
-function SidebarFooter({children}: any) {
-  return (
-    <SidebarFooterWrapper>
-      <SidebarItemList>{children}</SidebarItemList>
-    </SidebarFooterWrapper>
-  );
-}


### PR DESCRIPTION
The plan is to stop using the config and just render items as JSX. This moves all the primary items in the config over to JSX. No behavior changes.