### PR TITLE
chore(auto_source_code): Drop old queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -982,8 +982,6 @@ CELERY_QUEUES_REGION = [
     Queue("replays.delete_replay", routing_key="replays.delete_replay"),
     Queue("counters-0", routing_key="counters-0"),
     Queue("triggers-0", routing_key="triggers-0"),
-    # XXX: Temporarilty keep in place until we have migrated to the new queue
-    Queue("derive_code_mappings", routing_key="derive_code_mappings"),
     Queue("auto_source_code_config", routing_key="auto_source_code_config"),
     Queue("transactions.name_clusterer", routing_key="transactions.name_clusterer"),
     Queue("auto_enable_codecov", routing_key="auto_enable_codecov"),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -57,7 +57,6 @@ register(
     default=2**31,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register("system.new-auto-source-code-config-queue", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # URL configuration
 # Absolute URL to the sentry root directory. Should not include a trailing slash.

--- a/src/sentry/tasks/auto_source_code_config.py
+++ b/src/sentry/tasks/auto_source_code_config.py
@@ -79,17 +79,6 @@ def process_error(error: ApiError, extra: dict[str, str]) -> None:
     )
 
 
-# XXX: To be deleted after queue is empty
-@instrumented_task(
-    name="sentry.tasks.derive_code_mappings.derive_code_mappings",
-    queue="derive_code_mappings",
-    default_retry_delay=60 * 10,
-    max_retries=3,
-)
-def derive_code_mappings(project_id: int, event_id: str, **kwargs: Any) -> None:
-    auto_source_code_config(project_id, event_id=event_id, **kwargs)
-
-
 @instrumented_task(
     name="sentry.tasks.auto_source_code_config",
     queue="auto_source_code_config",

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -995,7 +995,7 @@ def process_code_mappings(job: PostProcessJob) -> None:
         return
 
     from sentry.issues.auto_source_code_config.code_mapping import SUPPORTED_LANGUAGES
-    from sentry.tasks.auto_source_code_config import auto_source_code_config, derive_code_mappings
+    from sentry.tasks.auto_source_code_config import auto_source_code_config
 
     try:
         event = job["event"]
@@ -1017,13 +1017,10 @@ def process_code_mappings(job: PostProcessJob) -> None:
         else:
             return
 
-        if options.get("system.new-auto-source-code-config-queue"):
-            auto_source_code_config.delay(project.id, event_id=event.event_id)
-        else:
-            derive_code_mappings.delay(project.id, event_id=event.event_id)
+        auto_source_code_config.delay(project.id, event_id=event.event_id)
 
     except Exception:
-        logger.exception("derive_code_mappings: Failed to process code mappings")
+        logger.exception("Failed to process automatic source code config")
 
 
 def process_commits(job: PostProcessJob) -> None:

--- a/tests/sentry/tasks/test_auto_source_code_config.py
+++ b/tests/sentry/tasks/test_auto_source_code_config.py
@@ -13,7 +13,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.auto_source_code_config import (
     DeriveCodeMappingsErrorReason,
-    derive_code_mappings,
+    auto_source_code_config,
     identify_stacktrace_paths,
 )
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
@@ -61,7 +61,7 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
             side_effect=error,
         ):
-            assert derive_code_mappings(self.project.id, event_id=self.event.event_id) is None
+            assert auto_source_code_config(self.project.id, event_id=self.event.event_id) is None
             assert_halt_metric(mock_record, error)
 
     @patch("sentry.tasks.auto_source_code_config.logger")
@@ -70,7 +70,7 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
             side_effect=ApiError("foo"),
         ):
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             assert mock_logger.error.call_count == 1
             assert_halt_metric(mock_record, ApiError("foo"))
 
@@ -80,7 +80,7 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
             side_effect=UnableToAcquireLock(),
         ):
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             assert not RepositoryProjectPathConfig.objects.exists()
             assert_failure_metric(mock_record, error)
 
@@ -90,7 +90,7 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
             side_effect=Exception("foo"),
         ):
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             assert_failure_metric(mock_record, DeriveCodeMappingsErrorReason.UNEXPECTED_ERROR)
 
 
@@ -119,7 +119,7 @@ class TestBackSlashDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/mouse.py"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "\\"
             assert code_mapping.source_root == ""
@@ -134,7 +134,7 @@ class TestBackSlashDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/tasks.py"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "C:sentry\\"
             assert code_mapping.source_root == "sentry/"
@@ -149,7 +149,7 @@ class TestBackSlashDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["src/sentry/tasks.py"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "C:sentry\\"
             assert code_mapping.source_root == "src/sentry/"
@@ -164,7 +164,7 @@ class TestBackSlashDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/models/release.py"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "D:\\Users\\code\\"
             assert code_mapping.source_root == ""
@@ -223,7 +223,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
         assert stacktrace_paths == []
 
     @responses.activate
-    def test_derive_code_mappings_starts_with_period_slash(self):
+    def test_auto_source_code_config_starts_with_period_slash(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -234,7 +234,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
                     ["static/app/utils/handleXhrErrorResponse.tsx"],
                 )
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             # ./app/foo.tsx -> app/foo.tsx -> static/app/foo.tsx
             assert code_mapping.stack_root == "./"
@@ -242,7 +242,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_starts_with_period_slash_no_containing_directory(self):
+    def test_auto_source_code_config_starts_with_period_slash_no_containing_directory(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -253,7 +253,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
                     ["app/utils/handleXhrErrorResponse.tsx"],
                 )
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             # ./app/foo.tsx -> app/foo.tsx -> app/foo.tsx
             assert code_mapping.stack_root == "./"
@@ -261,7 +261,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_one_to_one_match(self):
+    def test_auto_source_code_config_one_to_one_match(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -269,7 +269,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["some/path/Test.tsx"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             # some/path/Test.tsx -> Test.tsx -> some/path/Test.tsx
             assert code_mapping.stack_root == ""
@@ -277,7 +277,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_same_trailing_substring(self):
+    def test_auto_source_code_config_same_trailing_substring(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -285,7 +285,7 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/app.tsx"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             assert not RepositoryProjectPathConfig.objects.exists()
 
 
@@ -311,7 +311,7 @@ class TestRubyDeriveCodeMappings(BaseDeriveCodeMappings):
         assert set(stacktrace_paths) == {"some/path/test.rb", "lib/tasks/crontask.rake"}
 
     @responses.activate
-    def test_derive_code_mappings_rb(self):
+    def test_auto_source_code_config_rb(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -319,14 +319,14 @@ class TestRubyDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["some/path/test.rb"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == ""
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_rake(self):
+    def test_auto_source_code_config_rake(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -334,7 +334,7 @@ class TestRubyDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["lib/tasks/crontask.rake"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == ""
             assert code_mapping.source_root == ""
@@ -371,7 +371,7 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
         }
 
     @responses.activate
-    def test_derive_code_mappings_starts_with_app(self):
+    def test_auto_source_code_config_starts_with_app(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -379,13 +379,13 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["utils/errors.js"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "app:///"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
-    def test_derive_code_mappings_starts_with_app_complex(self):
+    def test_auto_source_code_config_starts_with_app_complex(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -393,14 +393,14 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/utils/errors.js"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "app:///"
             assert code_mapping.source_root == "sentry/"
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_starts_with_multiple_dot_dot_slash(self):
+    def test_auto_source_code_config_starts_with_multiple_dot_dot_slash(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -408,14 +408,14 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["packages/api/src/response.ts"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "../../../../../../"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_starts_with_app_dot_dot_slash(self):
+    def test_auto_source_code_config_starts_with_app_dot_dot_slash(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -425,7 +425,7 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
                     Repo(repo_name, "master"), ["services/event/EventLifecycle/index.js"]
                 )
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "app:///../"
             assert code_mapping.source_root == ""
@@ -456,7 +456,7 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
         )
 
     @responses.activate
-    def test_derive_code_mappings_go_abs_filename(self):
+    def test_auto_source_code_config_go_abs_filename(self):
         repo_name = "go_repo"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -464,14 +464,14 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/capybara.go"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/Users/JohnDoe/code/"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_go_long_abs_filename(self):
+    def test_auto_source_code_config_go_long_abs_filename(self):
         repo_name = "go_repo"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -479,14 +479,14 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/kangaroo.go"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/Users/JohnDoe/Documents/code/"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_similar_but_incorrect_file(self):
+    def test_auto_source_code_config_similar_but_incorrect_file(self):
         repo_name = "go_repo"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -494,7 +494,7 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["notsentry/main.go"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             assert not RepositoryProjectPathConfig.objects.exists()
 
 
@@ -515,7 +515,7 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
         )
 
     @responses.activate
-    def test_derive_code_mappings_basic_php(self):
+    def test_auto_source_code_config_basic_php(self):
         repo_name = "php/place"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -523,14 +523,14 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/potato/kangaroo.php"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_different_roots_php(self):
+    def test_auto_source_code_config_different_roots_php(self):
         repo_name = "php/place"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -538,7 +538,7 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["src/sentry/potato/kangaroo.php"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/sentry/"
             assert code_mapping.source_root == "src/sentry/"
@@ -570,7 +570,7 @@ class TestCSharpDeriveCodeMappings(BaseDeriveCodeMappings):
         )
 
     @responses.activate
-    def test_derive_code_mappings_csharp_trivial(self):
+    def test_auto_source_code_config_csharp_trivial(self):
         repo_name = "csharp/repo"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -578,14 +578,14 @@ class TestCSharpDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/potato/kangaroo.cs"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_different_roots_csharp(self):
+    def test_auto_source_code_config_different_roots_csharp(self):
         repo_name = "csharp/repo"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -593,14 +593,14 @@ class TestCSharpDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["src/sentry/potato/kangaroo.cs"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/sentry/"
             assert code_mapping.source_root == "src/sentry/"
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    def test_derive_code_mappings_non_in_app_frame(self):
+    def test_auto_source_code_config_non_in_app_frame(self):
         repo_name = "csharp/repo"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -608,7 +608,7 @@ class TestCSharpDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/src/functions.cs"])
             }
-            derive_code_mappings(self.project.id, event_id=self.event.event_id)
+            auto_source_code_config(self.project.id, event_id=self.event.event_id)
             assert not RepositoryProjectPathConfig.objects.exists()
 
 
@@ -650,7 +650,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             )
         ],
     )
-    def test_derive_code_mappings_single_project(
+    def test_auto_source_code_config_single_project(
         self, mock_generate_code_mappings, mock_get_trees_for_org
     ):
         assert not RepositoryProjectPathConfig.objects.filter(project_id=self.project.id).exists()
@@ -662,7 +662,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             ) as mock_identify_stacktraces,
             self.tasks(),
         ):
-            derive_code_mappings(self.project.id, self.event.event_id)
+            auto_source_code_config(self.project.id, self.event.event_id)
 
         assert mock_identify_stacktraces.call_count == 1
         assert mock_get_trees_for_org.call_count == 1
@@ -672,7 +672,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
 
     def test_skips_not_supported_platforms(self):
         event = self.create_event([{}], platform="elixir")
-        assert derive_code_mappings(self.project.id, event.event_id) is None
+        assert auto_source_code_config(self.project.id, event.event_id) is None
         assert len(RepositoryProjectPathConfig.objects.filter(project_id=self.project.id)) == 0
 
     @patch("sentry.integrations.github.integration.GitHubIntegration.get_trees_for_org")
@@ -687,7 +687,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         ],
     )
     @patch("sentry.tasks.auto_source_code_config.logger")
-    def test_derive_code_mappings_duplicates(
+    def test_auto_source_code_config_duplicates(
         self, mock_logger, mock_generate_code_mappings, mock_get_trees_for_org
     ):
         with assume_test_silo_mode_of(OrganizationIntegration):
@@ -718,7 +718,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             ) as mock_identify_stacktraces,
             self.tasks(),
         ):
-            derive_code_mappings(self.project.id, self.event.event_id)
+            auto_source_code_config(self.project.id, self.event.event_id)
 
         assert mock_identify_stacktraces.call_count == 1
         assert mock_get_trees_for_org.call_count == 1
@@ -728,7 +728,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         assert mock_logger.info.call_count == 1
 
     @responses.activate
-    def test_derive_code_mappings_stack_and_source_root_do_not_match(self):
+    def test_auto_source_code_config_stack_and_source_root_do_not_match(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -736,14 +736,14 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["src/sentry/models/release.py"])
             }
-            derive_code_mappings(self.project.id, self.event.event_id)
+            auto_source_code_config(self.project.id, self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.get()
             # sentry/models/release.py -> models/release.py -> src/sentry/models/release.py
             assert code_mapping.stack_root == "sentry/"
             assert code_mapping.source_root == "src/sentry/"
 
     @responses.activate
-    def test_derive_code_mappings_no_normalization(self):
+    def test_auto_source_code_config_no_normalization(self):
         repo_name = "foo/bar"
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org"
@@ -751,7 +751,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             mock_get_trees_for_org.return_value = {
                 repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/models/release.py"])
             }
-            derive_code_mappings(self.project.id, self.event.event_id)
+            auto_source_code_config(self.project.id, self.event.event_id)
             code_mapping = RepositoryProjectPathConfig.objects.get()
 
             assert code_mapping.stack_root == ""

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -227,14 +227,14 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
+    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
     def test_derive_invalid_platform(self, mock_derive_code_mappings):
         event = self._create_event({"platform": "elixir"})
         self._call_post_process_group(event)
 
         assert mock_derive_code_mappings.delay.call_count == 0
 
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
+    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
     def test_derive_supported_languages(self, mock_derive_code_mappings):
         for platform in SUPPORTED_LANGUAGES:
             event = self._create_event({"platform": platform})
@@ -242,33 +242,13 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
 
             assert mock_derive_code_mappings.delay.call_count == 1
 
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
+    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
     def test_only_maps_a_given_project_once_per_hour(self, mock_derive_code_mappings):
         dogs_project = self.create_project()
-        maisey_event = self._create_event(
-            {
-                "fingerprint": ["themaiseymasieydog"],
-            },
-            dogs_project.id,
-        )
-        charlie_event = self._create_event(
-            {
-                "fingerprint": ["charliebear"],
-            },
-            dogs_project.id,
-        )
-        cory_event = self._create_event(
-            {
-                "fingerprint": ["thenudge"],
-            },
-            dogs_project.id,
-        )
-        bodhi_event = self._create_event(
-            {
-                "fingerprint": ["theescapeartist"],
-            },
-            dogs_project.id,
-        )
+        maisey_event = self._create_event({"fingerprint": ["themaiseymasieydog"]}, dogs_project.id)
+        charlie_event = self._create_event({"fingerprint": ["charliebear"]}, dogs_project.id)
+        cory_event = self._create_event({"fingerprint": ["thenudge"]}, dogs_project.id)
+        bodhi_event = self._create_event({"fingerprint": ["theescapeartist"]}, dogs_project.id)
 
         self._call_post_process_group(maisey_event)
         assert mock_derive_code_mappings.delay.call_count == 1
@@ -287,33 +267,13 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
             self._call_post_process_group(bodhi_event)
             assert mock_derive_code_mappings.delay.call_count == 2
 
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
+    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
     def test_only_maps_a_given_issue_once_per_day(self, mock_derive_code_mappings):
         dogs_project = self.create_project()
-        maisey_event1 = self._create_event(
-            {
-                "fingerprint": ["themaiseymaiseydog"],
-            },
-            dogs_project.id,
-        )
-        maisey_event2 = self._create_event(
-            {
-                "fingerprint": ["themaiseymaiseydog"],
-            },
-            dogs_project.id,
-        )
-        maisey_event3 = self._create_event(
-            {
-                "fingerprint": ["themaiseymaiseydog"],
-            },
-            dogs_project.id,
-        )
-        maisey_event4 = self._create_event(
-            {
-                "fingerprint": ["themaiseymaiseydog"],
-            },
-            dogs_project.id,
-        )
+        maisey_event1 = self._create_event({"fingerprint": ["themaiseymaiseydog"]}, dogs_project.id)
+        maisey_event2 = self._create_event({"fingerprint": ["themaiseymaiseydog"]}, dogs_project.id)
+        maisey_event3 = self._create_event({"fingerprint": ["themaiseymaiseydog"]}, dogs_project.id)
+        maisey_event4 = self._create_event({"fingerprint": ["themaiseymaiseydog"]}, dogs_project.id)
         # because of the fingerprint, the events should always end up in the same group,
         # but the rest of the test is bogus if they aren't, so let's be sure
         assert maisey_event1.group_id == maisey_event2.group_id
@@ -337,27 +297,12 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
             self._call_post_process_group(maisey_event4)
             assert mock_derive_code_mappings.delay.call_count == 2
 
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
+    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
     def test_skipping_an_issue_doesnt_mark_it_processed(self, mock_derive_code_mappings):
         dogs_project = self.create_project()
-        maisey_event = self._create_event(
-            {
-                "fingerprint": ["themaiseymasieydog"],
-            },
-            dogs_project.id,
-        )
-        charlie_event1 = self._create_event(
-            {
-                "fingerprint": ["charliebear"],
-            },
-            dogs_project.id,
-        )
-        charlie_event2 = self._create_event(
-            {
-                "fingerprint": ["charliebear"],
-            },
-            dogs_project.id,
-        )
+        maisey_event = self._create_event({"fingerprint": ["themaiseymasieydog"]}, dogs_project.id)
+        charlie_event1 = self._create_event({"fingerprint": ["charliebear"]}, dogs_project.id)
+        charlie_event2 = self._create_event({"fingerprint": ["charliebear"]}, dogs_project.id)
         # because of the fingerprint, the two Charlie events should always end up in the same group,
         # but the rest of the test is bogus if they aren't, so let's be sure
         assert charlie_event1.group_id == charlie_event2.group_id
@@ -374,28 +319,6 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
         with patch("time.time", return_value=time.time() + 60 * 61):
             self._call_post_process_group(charlie_event2)
             assert mock_derive_code_mappings.delay.call_count == 2
-
-    # XXX: Delete this test once we've migrated
-    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
-    def test_new_queue(self, mock_derive_code_mappings, mock_auto_source_code_config):
-        event = self._create_event(data={}, project_id=self.project.id)
-
-        with self.options({"system.new-auto-source-code-config-queue": False}):
-            self._call_post_process_group(event)
-            assert mock_derive_code_mappings.delay.call_count == 1
-            assert mock_auto_source_code_config.delay.call_count == 0
-
-    # XXX: Delete this test once we've migrated
-    @patch("sentry.tasks.auto_source_code_config.auto_source_code_config")
-    @patch("sentry.tasks.auto_source_code_config.derive_code_mappings")
-    def test_old_queue(self, mock_derive_code_mappings, mock_auto_source_code_config):
-        event = self._create_event(data={}, project_id=self.project.id)
-
-        with self.options({"system.new-auto-source-code-config-queue": True}):
-            self._call_post_process_group(event)
-            assert mock_derive_code_mappings.delay.call_count == 0
-            assert mock_auto_source_code_config.delay.call_count == 1
 
 
 class RuleProcessorTestMixin(BasePostProgressGroupMixin):


### PR DESCRIPTION
This reverts commit fae6fd34de212c67b311cd64704f5f39aea7f36d which got reverted in #83640.

It was reverted because I made the mistake of removing the option before this was fully out.