### PR TITLE
ref(rules): refactor delayed processing batching logic to prepare for workflows

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -8,6 +8,8 @@ from sentry.signals import buffer_incr_complete
 from sentry.tasks.process_buffer import process_incr
 from sentry.utils.services import Service
 
+BufferField = models.Model | str | int
+
 
 class Buffer(Service):
     """
@@ -50,14 +52,10 @@ class Buffer(Service):
         """
         return {col: 0 for col in columns}
 
-    def get_hash(
-        self, model: type[models.Model], field: dict[str, models.Model | str | int]
-    ) -> dict[str, str]:
+    def get_hash(self, model: type[models.Model], field: dict[str, BufferField]) -> dict[str, str]:
         return {}
 
-    def get_hash_length(
-        self, model: type[models.Model], field: dict[str, models.Model | str | int]
-    ) -> int:
+    def get_hash_length(self, model: type[models.Model], field: dict[str, BufferField]) -> int:
         raise NotImplementedError
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
@@ -69,7 +67,7 @@ class Buffer(Service):
     def push_to_hash(
         self,
         model: type[models.Model],
-        filters: dict[str, models.Model | str | int],
+        filters: dict[str, BufferField],
         field: str,
         value: str,
     ) -> None:
@@ -78,7 +76,7 @@ class Buffer(Service):
     def push_to_hash_bulk(
         self,
         model: type[models.Model],
-        filters: dict[str, models.Model | str | int],
+        filters: dict[str, BufferField],
         data: dict[str, str],
     ) -> None:
         raise NotImplementedError
@@ -86,7 +84,7 @@ class Buffer(Service):
     def delete_hash(
         self,
         model: type[models.Model],
-        filters: dict[str, models.Model | str | int],
+        filters: dict[str, BufferField],
         fields: list[str],
     ) -> None:
         return None
@@ -98,7 +96,7 @@ class Buffer(Service):
         self,
         model: type[models.Model],
         columns: dict[str, int],
-        filters: dict[str, models.Model | str | int],
+        filters: dict[str, BufferField],
         extra: dict[str, Any] | None = None,
         signal_only: bool | None = None,
     ) -> None:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2821,6 +2821,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "delayed_processing.emit_logs",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "celery_split_queue_task_rollout",
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -1,0 +1,156 @@
+import logging
+import math
+import uuid
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from datetime import datetime, timezone
+from itertools import islice
+from typing import NotRequired, TypedDict
+
+from sentry import buffer, options
+from sentry.buffer.redis import BufferHookEvent, redis_buffer_registry
+from sentry.db import models
+from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
+from sentry.utils import metrics
+from sentry.utils.registry import NoRegistrationExistsError, Registry
+
+logger = logging.getLogger("sentry.delayed_processing")
+
+
+class FilterKeys(TypedDict):
+    project_id: int
+    batch_key: NotRequired[str]
+
+
+class BufferHashKeys(TypedDict):
+    model: type[models.Model]
+    filters: FilterKeys
+
+
+class DelayedProcessingBase(ABC):
+    def __init__(self, project_id: int):
+        self.project_id = project_id
+
+    @property
+    @abstractmethod
+    def hash_args(self) -> BufferHashKeys:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def processing_task(self) -> Callable[[int], None]:
+        raise NotImplementedError
+
+
+delayed_processing_registry = Registry[type[DelayedProcessingBase]]()
+
+
+def fetch_alertgroup_to_event_data(
+    project_id: int, model: type[models.Model], batch_key: str | None = None
+) -> dict[str, str]:
+    field: dict[str, models.Model | int | str] = {
+        "project_id": project_id,
+    }
+
+    if batch_key:
+        field["batch_key"] = batch_key
+
+    return buffer.backend.get_hash(model=model, field=field)
+
+
+def bucket_num_groups(num_groups: int) -> str:
+    if num_groups > 1:
+        magnitude = 10 ** int(math.log10(num_groups))
+        return f">{magnitude}"
+    return "1"
+
+
+def process_project_alerts_in_batches(project_id: int, processing_type: str) -> None:
+    """
+    This will check the number of alertgroup_to_event_data items in the Redis buffer for a project.
+
+    If the number is larger than the batch size, it will chunk the items and process them in batches.
+
+    The batches are replicated into a new redis hash with a unique filter (a uuid) to identify the batch.
+    We need to use a UUID because these batches can be created in multiple processes and we need to ensure
+    uniqueness across all of them for the centralized redis buffer. The batches are stored in redis because
+    we shouldn't pass objects that need to be pickled and 10k items could be problematic in the celery tasks
+    as arguments could be problematic. Finally, we can't use a pagination system on the data because
+    redis doesn't maintain the sort order of the hash keys.
+
+    `processing_task` will fetch the batch from redis and process the rules.
+    """
+    batch_size = options.get("delayed_processing.batch_size")
+    log_format = "{}.{}"
+
+    try:
+        processing_info = delayed_processing_registry.get(processing_type)(project_id)
+    except NoRegistrationExistsError:
+        logger.exception(log_format.format(processing_type, "no_registration"))
+        return
+
+    hash_args = processing_info.hash_args
+    task = processing_info.processing_task
+
+    event_count = buffer.backend.get_hash_length(
+        model=hash_args["model"], field=hash_args["filters"]
+    )
+    metrics.incr(
+        f"{processing_type}.num_groups", tags={"num_groups": bucket_num_groups(event_count)}
+    )
+
+    if event_count < batch_size:
+        return task.delay(project_id)
+
+    logger.info(
+        log_format.format(processing_type, "process_large_batch"),
+        extra={"project_id": project_id, "count": event_count},
+    )
+
+    # if the dictionary is large, get the items and chunk them.
+    alertgroup_to_event_data = fetch_alertgroup_to_event_data(project_id, hash_args["model"])
+
+    with metrics.timer(f"{processing_type}.process_batch.duration"):
+        items = iter(alertgroup_to_event_data.items())
+
+        while batch := dict(islice(items, batch_size)):
+            batch_key = str(uuid.uuid4())
+
+            buffer.backend.push_to_hash_bulk(
+                model=hash_args["model"],
+                filters={**hash_args["filters"], "batch_key": batch_key},
+                data=batch,
+            )
+
+            # remove the batched items from the project alertgroup_to_event_data
+            buffer.backend.delete_hash(**hash_args, fields=list(batch.keys()))
+
+            task.delay(project_id, batch_key)
+
+
+def process_project_ids(
+    fetch_time: datetime, buffer_list_key: str, processing_type: str
+) -> list[int]:
+    project_ids = buffer.backend.get_sorted_set(buffer_list_key, min=0, max=fetch_time.timestamp())
+    log_str = ", ".join(f"{project_id}: {timestamp}" for project_id, timestamp in project_ids)
+    log_name = f"{processing_type}.project_id_list"
+    logger.info(log_name, extra={"project_ids": log_str})
+
+    for project_id, _ in project_ids:
+        process_project_alerts_in_batches(project_id, processing_type)
+
+    buffer.backend.delete_key(buffer_list_key, min=0, max=fetch_time.timestamp())
+
+
+def process_delayed_alert_conditions() -> None:
+    fetch_time = datetime.now(tz=timezone.utc)
+
+    with metrics.timer("delayed_processing.process_all_conditions.duration"):
+        process_project_ids(fetch_time, PROJECT_ID_BUFFER_LIST_KEY, "delayed_processing")
+
+    # with metrics.timer("delayed_workflow.process_all_conditions.duration"):
+    #     process_project_ids(fetch_time, WORKFLOW_ENGINE_PROJECT_ID_BUFFER_LIST_KEY, "delayed_workflow")
+
+
+if not redis_buffer_registry.has(BufferHookEvent.FLUSH):
+    redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_delayed_alert_conditions)

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -34,6 +34,7 @@ from sentry.rules.processing.buffer_processing import (
     delayed_processing_registry,
 )
 from sentry.rules.processing.processor import (
+    PROJECT_ID_BUFFER_LIST_KEY,
     activate_downstream_actions,
     bulk_get_rule_status,
     is_condition_slow,
@@ -534,6 +535,8 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
 
 @delayed_processing_registry.register("delayed_processing")  # default delayed processing
 class DelayedRule(DelayedProcessingBase):
+    buffer_key = PROJECT_ID_BUFFER_LIST_KEY
+
     @property
     def hash_args(self) -> BufferHashKeys:
         return BufferHashKeys(model=Project, filters=FilterKeys(project_id=self.project_id))

--- a/tests/sentry/buffer/test_base.py
+++ b/tests/sentry/buffer/test_base.py
@@ -4,8 +4,7 @@ from unittest import mock
 from django.utils import timezone
 from pytest import raises
 
-from sentry.buffer.base import Buffer
-from sentry.db import models
+from sentry.buffer.base import Buffer, BufferField
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -25,7 +24,7 @@ class BufferTest(TestCase):
     def test_incr_delays_task(self, process_incr):
         model = mock.Mock()
         columns = {"times_seen": 1}
-        filters: dict[str, models.Model | str | int] = {"id": 1}
+        filters: dict[str, BufferField] = {"id": 1}
         self.buf.incr(model, columns, filters)
         kwargs = dict(model=model, columns=columns, filters=filters, extra=None, signal_only=None)
         process_incr.apply_async.assert_called_once_with(kwargs=kwargs, headers=mock.ANY)

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -18,7 +18,7 @@ from sentry.buffer.redis import (
 )
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.rules.processing.delayed_processing import process_delayed_alert_conditions
+from sentry.rules.processing.buffer_processing import process_delayed_alert_conditions
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -18,7 +18,7 @@ from sentry.buffer.redis import (
 )
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.rules.processing.buffer_processing import process_delayed_alert_conditions
+from sentry.rules.processing.buffer_processing import process_buffer
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -290,7 +290,7 @@ class TestRedisBuffer:
 
     @mock.patch("sentry.rules.processing.delayed_processing.metrics.timer")
     def test_callback(self, mock_metrics_timer):
-        redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_delayed_alert_conditions)
+        redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_buffer)
         self.buf.process_batch()
         assert mock_metrics_timer.call_count == 1
 

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -34,6 +34,7 @@ def _hgetall_decode_keys(client, key, is_redis_cluster):
         return ret
 
 
+@pytest.mark.django_db
 class TestRedisBuffer:
     @pytest.fixture(params=["cluster", "blaster"])
     def buffer(self, set_sentry_option, request):

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -19,11 +19,15 @@ from sentry.rules.conditions.event_frequency import (
     EventFrequencyCondition,
     EventFrequencyConditionData,
 )
+from sentry.rules.processing.buffer_processing import (
+    bucket_num_groups,
+    process_delayed_alert_conditions,
+    process_project_alerts_in_batches,
+)
 from sentry.rules.processing.delayed_processing import (
     DataAndGroups,
     UniqueConditionQuery,
     apply_delayed,
-    bucket_num_groups,
     bulk_fetch_events,
     cleanup_redis_buffer,
     generate_unique_queries,
@@ -34,8 +38,6 @@ from sentry.rules.processing.delayed_processing import (
     get_rules_to_groups,
     get_slow_conditions,
     parse_rulegroup_to_event_data,
-    process_delayed_alert_conditions,
-    process_rulegroups_in_batches,
 )
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY, RuleProcessor
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, TestCase
@@ -761,7 +763,7 @@ class ProcessDelayedAlertConditionsTest(CreateEventTestCase, PerformanceIssueTes
         self.push_to_hash(self.project_two.id, self.rule3.id, self.group3.id, self.event3.event_id)
         self.push_to_hash(self.project_two.id, self.rule4.id, self.group4.id, self.event4.event_id)
 
-    @patch("sentry.rules.processing.delayed_processing.process_rulegroups_in_batches")
+    @patch("sentry.rules.processing.buffer_processing.process_project_alerts_in_batches")
     def test_fetches_from_buffer_and_executes(self, mock_process_in_batches):
         self._push_base_events()
         # To get the correct mapping, we need to return the correct
@@ -1502,7 +1504,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed.delay")
     def test_no_redis_data(self, mock_apply_delayed):
-        process_rulegroups_in_batches(self.project.id)
+        process_project_alerts_in_batches(self.project.id, "delayed_processing")
         mock_apply_delayed.assert_called_once_with(self.project.id)
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed.delay")
@@ -1511,7 +1513,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        process_rulegroups_in_batches(self.project.id)
+        process_project_alerts_in_batches(self.project.id, "delayed_processing")
         mock_apply_delayed.assert_called_once_with(self.project.id)
 
     @override_options({"delayed_processing.batch_size": 2})
@@ -1521,7 +1523,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        process_rulegroups_in_batches(self.project.id)
+        process_project_alerts_in_batches(self.project.id, "delayed_processing")
         assert mock_apply_delayed.call_count == 2
 
         # Validate the batches are created correctly
@@ -1601,7 +1603,7 @@ class CleanupRedisBufferTest(CreateEventTestCase):
         rules_to_groups[self.rule.id].add(group_two.id)
         rules_to_groups[self.rule.id].add(group_three.id)
 
-        process_rulegroups_in_batches(self.project.id)
+        process_project_alerts_in_batches(self.project.id, "delayed_processing")
         batch_one_key = mock_apply_delayed.call_args_list[0][0][1]
         batch_two_key = mock_apply_delayed.call_args_list[1][0][1]
 

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -21,8 +21,8 @@ from sentry.rules.conditions.event_frequency import (
 )
 from sentry.rules.processing.buffer_processing import (
     bucket_num_groups,
-    process_delayed_alert_conditions,
-    process_project_alerts_in_batches,
+    process_buffer,
+    process_in_batches,
 )
 from sentry.rules.processing.delayed_processing import (
     DataAndGroups,
@@ -763,12 +763,12 @@ class ProcessDelayedAlertConditionsTest(CreateEventTestCase, PerformanceIssueTes
         self.push_to_hash(self.project_two.id, self.rule3.id, self.group3.id, self.event3.event_id)
         self.push_to_hash(self.project_two.id, self.rule4.id, self.group4.id, self.event4.event_id)
 
-    @patch("sentry.rules.processing.buffer_processing.process_project_alerts_in_batches")
+    @patch("sentry.rules.processing.buffer_processing.process_in_batches")
     def test_fetches_from_buffer_and_executes(self, mock_process_in_batches):
         self._push_base_events()
         # To get the correct mapping, we need to return the correct
         # rulegroup_event mapping based on the project_id input
-        process_delayed_alert_conditions()
+        process_buffer()
 
         for project, rule_group_event_mapping in (
             (self.project, self.rulegroup_event_mapping_one),
@@ -1504,7 +1504,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed.delay")
     def test_no_redis_data(self, mock_apply_delayed):
-        process_project_alerts_in_batches(self.project.id, "delayed_processing")
+        process_in_batches(self.project.id, "delayed_processing")
         mock_apply_delayed.assert_called_once_with(self.project.id)
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed.delay")
@@ -1513,7 +1513,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        process_project_alerts_in_batches(self.project.id, "delayed_processing")
+        process_in_batches(self.project.id, "delayed_processing")
         mock_apply_delayed.assert_called_once_with(self.project.id)
 
     @override_options({"delayed_processing.batch_size": 2})
@@ -1523,7 +1523,7 @@ class ProcessRuleGroupsInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        process_project_alerts_in_batches(self.project.id, "delayed_processing")
+        process_in_batches(self.project.id, "delayed_processing")
         assert mock_apply_delayed.call_count == 2
 
         # Validate the batches are created correctly
@@ -1603,7 +1603,7 @@ class CleanupRedisBufferTest(CreateEventTestCase):
         rules_to_groups[self.rule.id].add(group_two.id)
         rules_to_groups[self.rule.id].add(group_three.id)
 
-        process_project_alerts_in_batches(self.project.id, "delayed_processing")
+        process_in_batches(self.project.id, "delayed_processing")
         batch_one_key = mock_apply_delayed.call_args_list[0][0][1]
         batch_two_key = mock_apply_delayed.call_args_list[1][0][1]
 


### PR DESCRIPTION
Workflow engine will be using the same logic as delayed processing for rules to process slow conditions. This PR refactors the shared bit, **the batching logic**, to prepare for adding processing for workflows.

There are two differences the two kinds of delayed processing:
1. The exact task for processing
2. The information to get the hash from the buffer

To encapsulate the two differences, I've added a registry. Depending on which delayed processing we are doing, we fetch a handler that includes the information above and we use it in batching the task.