### PR TITLE
fix(widget-builder): Clear sorting on field and y-axis changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -337,9 +337,30 @@ function useWidgetBuilderState(): {
               }
             }
           }
+
+          if (
+            displayType !== DisplayType.TABLE &&
+            displayType !== DisplayType.BIG_NUMBER &&
+            action.payload.length > 0
+          ) {
+            // Adding a grouping, so default the sort to the first aggregate if possible
+            setSort([
+              {
+                kind: 'desc',
+                field: generateFieldAsString(
+                  (yAxis?.[0] as QueryFieldValue) ??
+                    (action.payload[0] as QueryFieldValue)
+                ),
+              },
+            ]);
+          }
           break;
         case BuilderStateAction.SET_Y_AXIS:
           setYAxis(action.payload);
+          if (action.payload.length > 0 && fields?.length === 0) {
+            // Clear the sort if there is no grouping
+            setSort([]);
+          }
           break;
         case BuilderStateAction.SET_QUERY:
           setQuery(action.payload);


### PR DESCRIPTION
Sorting isn't necessary when you don't have a grouping, so update the state to set a default when a grouping is added (with priority for the yAxis if it exists) and clear the sort if a yAxis changes and a grouping is not applied.