### PR TITLE
fix(dashboards): Tooltip for all teams with access in access selector

### DIFF
--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -16,13 +16,11 @@ type UserAvatarProps = React.ComponentProps<typeof UserAvatar>;
 type Props = {
   avatarSize?: number;
   className?: string;
-  collapsedAvatarActions?: {
-    onMouseEnter: () => void;
-    onMouseLeave: () => void;
-  };
-  collapsedAvatarTooltip?: React.ReactNode;
-  collapsedAvatarTooltipStyle?: React.CSSProperties;
   maxVisibleAvatars?: number;
+  renderCollapsedAvatars?: (
+    avatarSize: number,
+    numCollapsedAvatars: number
+  ) => React.ReactNode;
   renderTooltip?: UserAvatarProps['renderTooltip'];
   renderUsersFirst?: boolean;
   teams?: Team[];
@@ -31,7 +29,7 @@ type Props = {
   users?: Array<Actor | AvatarUser>;
 };
 
-const CollapsedAvatars = forwardRef(function CollapsedAvatars(
+export const CollapsedAvatars = forwardRef(function CollapsedAvatars(
   {
     size,
     children,
@@ -82,9 +80,7 @@ function AvatarList({
   teams = [],
   renderUsersFirst = false,
   renderTooltip,
-  collapsedAvatarTooltip,
-  collapsedAvatarActions,
-  collapsedAvatarTooltipStyle,
+  renderCollapsedAvatars,
 }: Props) {
   const numTeams = teams.length;
   const numVisibleTeams = maxVisibleAvatars - numTeams > 0 ? numTeams : maxVisibleAvatars;
@@ -112,23 +108,20 @@ function AvatarList({
 
   return (
     <AvatarListWrapper className={className}>
-      {!!numCollapsedAvatars && (
-        <Tooltip
-          title={collapsedAvatarTooltip ?? `${numCollapsedAvatars} other ${typeAvatars}`}
-          skipWrapper={!collapsedAvatarTooltip}
-          isHoverable={!!collapsedAvatarTooltip}
-          overlayStyle={collapsedAvatarTooltipStyle}
-        >
-          <CollapsedAvatars
-            size={avatarSize}
-            data-test-id="avatarList-collapsedavatars"
-            collapsedAvatarActions={collapsedAvatarActions}
-          >
-            {numCollapsedAvatars < 99 && <Plus>+</Plus>}
-            {numCollapsedAvatars}
-          </CollapsedAvatars>
-        </Tooltip>
-      )}
+      {!!numCollapsedAvatars &&
+        (renderCollapsedAvatars ? (
+          renderCollapsedAvatars(avatarSize, numCollapsedAvatars)
+        ) : (
+          <Tooltip title={`${numCollapsedAvatars} other ${typeAvatars}`} skipWrapper>
+            <CollapsedAvatars
+              size={avatarSize}
+              data-test-id="avatarList-collapsedavatars"
+            >
+              {numCollapsedAvatars < 99 && <Plus>+</Plus>}
+              {numCollapsedAvatars}
+            </CollapsedAvatars>
+          </Tooltip>
+        ))}
 
       {renderUsersFirst
         ? visibleTeamAvatars.map(team => (

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -33,37 +33,22 @@ export const CollapsedAvatars = forwardRef(function CollapsedAvatars(
   {
     size,
     children,
-    collapsedAvatarActions,
   }: {
     children: React.ReactNode;
     size: number;
-    collapsedAvatarActions?: {
-      onMouseEnter: () => void;
-      onMouseLeave: () => void;
-    };
   },
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   if (hasStreamlinedUI) {
-    return (
-      <CollapsedAvatarPill
-        ref={ref}
-        onMouseEnter={() => collapsedAvatarActions?.onMouseEnter?.()}
-        onMouseLeave={() => collapsedAvatarActions?.onMouseLeave?.()}
-      >
-        {children}
-      </CollapsedAvatarPill>
-    );
+    return <CollapsedAvatarPill ref={ref}>{children}</CollapsedAvatarPill>;
   }
   return (
     <CollapsedAvatarsCicle
       ref={ref}
       size={size}
       data-test-id="avatarList-collapsedavatars"
-      onMouseEnter={() => collapsedAvatarActions?.onMouseEnter?.()}
-      onMouseLeave={() => collapsedAvatarActions?.onMouseLeave?.()}
     >
       {children}
     </CollapsedAvatarsCicle>

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -16,7 +16,12 @@ type UserAvatarProps = React.ComponentProps<typeof UserAvatar>;
 type Props = {
   avatarSize?: number;
   className?: string;
+  collapsedAvatarActions?: {
+    onMouseEnter: () => void;
+    onMouseLeave: () => void;
+  };
   collapsedAvatarTooltip?: React.ReactNode;
+  collapsedAvatarTooltipStyle?: React.CSSProperties;
   maxVisibleAvatars?: number;
   renderTooltip?: UserAvatarProps['renderTooltip'];
   renderUsersFirst?: boolean;
@@ -27,19 +32,40 @@ type Props = {
 };
 
 const CollapsedAvatars = forwardRef(function CollapsedAvatars(
-  {size, children}: {children: React.ReactNode; size: number},
+  {
+    size,
+    children,
+    collapsedAvatarActions,
+  }: {
+    children: React.ReactNode;
+    size: number;
+    collapsedAvatarActions?: {
+      onMouseEnter: () => void;
+      onMouseLeave: () => void;
+    };
+  },
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   if (hasStreamlinedUI) {
-    return <CollapsedAvatarPill ref={ref}>{children}</CollapsedAvatarPill>;
+    return (
+      <CollapsedAvatarPill
+        ref={ref}
+        onMouseEnter={() => collapsedAvatarActions?.onMouseEnter?.()}
+        onMouseLeave={() => collapsedAvatarActions?.onMouseLeave?.()}
+      >
+        {children}
+      </CollapsedAvatarPill>
+    );
   }
   return (
     <CollapsedAvatarsCicle
       ref={ref}
       size={size}
       data-test-id="avatarList-collapsedavatars"
+      onMouseEnter={() => collapsedAvatarActions?.onMouseEnter?.()}
+      onMouseLeave={() => collapsedAvatarActions?.onMouseLeave?.()}
     >
       {children}
     </CollapsedAvatarsCicle>
@@ -57,6 +83,8 @@ function AvatarList({
   renderUsersFirst = false,
   renderTooltip,
   collapsedAvatarTooltip,
+  collapsedAvatarActions,
+  collapsedAvatarTooltipStyle,
 }: Props) {
   const numTeams = teams.length;
   const numVisibleTeams = maxVisibleAvatars - numTeams > 0 ? numTeams : maxVisibleAvatars;
@@ -88,8 +116,14 @@ function AvatarList({
         <Tooltip
           title={collapsedAvatarTooltip ?? `${numCollapsedAvatars} other ${typeAvatars}`}
           skipWrapper={!collapsedAvatarTooltip}
+          isHoverable={!!collapsedAvatarTooltip}
+          overlayStyle={collapsedAvatarTooltipStyle}
         >
-          <CollapsedAvatars size={avatarSize} data-test-id="avatarList-collapsedavatars">
+          <CollapsedAvatars
+            size={avatarSize}
+            data-test-id="avatarList-collapsedavatars"
+            collapsedAvatarActions={collapsedAvatarActions}
+          >
             {numCollapsedAvatars < 99 && <Plus>+</Plus>}
             {numCollapsedAvatars}
           </CollapsedAvatars>

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -16,6 +16,7 @@ type UserAvatarProps = React.ComponentProps<typeof UserAvatar>;
 type Props = {
   avatarSize?: number;
   className?: string;
+  collapsedAvatarTooltip?: React.ReactNode;
   maxVisibleAvatars?: number;
   renderTooltip?: UserAvatarProps['renderTooltip'];
   renderUsersFirst?: boolean;
@@ -55,6 +56,7 @@ function AvatarList({
   teams = [],
   renderUsersFirst = false,
   renderTooltip,
+  collapsedAvatarTooltip,
 }: Props) {
   const numTeams = teams.length;
   const numVisibleTeams = maxVisibleAvatars - numTeams > 0 ? numTeams : maxVisibleAvatars;
@@ -83,7 +85,10 @@ function AvatarList({
   return (
     <AvatarListWrapper className={className}>
       {!!numCollapsedAvatars && (
-        <Tooltip title={`${numCollapsedAvatars} other ${typeAvatars}`} skipWrapper>
+        <Tooltip
+          title={collapsedAvatarTooltip ?? `${numCollapsedAvatars} other ${typeAvatars}`}
+          skipWrapper={!collapsedAvatarTooltip}
+        >
           <CollapsedAvatars size={avatarSize} data-test-id="avatarList-collapsedavatars">
             {numCollapsedAvatars < 99 && <Plus>+</Plus>}
             {numCollapsedAvatars}

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -1,10 +1,11 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
+import Avatar from 'sentry/components/avatar';
 import AvatarList from 'sentry/components/avatar/avatarList';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import Badge from 'sentry/components/badge/badge';
@@ -70,6 +71,9 @@ function EditAccessSelector({
         ? [selectedOptions[1]]
         : [],
   });
+  const {teams: allSelectedTeams} = useTeamsById({
+    ids: selectedOptions.filter(option => option !== '_allUsers'),
+  });
 
   // Gets selected options for the dropdown from dashboard object
   useEffect(() => {
@@ -129,6 +133,29 @@ function EditAccessSelector({
     };
   }
 
+  // Creates tooltip for the + bubble in avatar list
+  const renderCollapsedAvatarTooltip = () => {
+    const permissions = getDashboardPermissions();
+    if (permissions.teamsWithEditAccess.length > 1) {
+      return (
+        <Fragment>
+          {allSelectedTeams.map((team, index) => (
+            <CollapsedAvatarTooltipListItem
+              key={team.id}
+              style={{
+                marginBottom: index === allSelectedTeams.length - 1 ? 0 : space(1),
+              }}
+            >
+              <Avatar team={team} size={18} />
+              <div>#{team.name}</div>
+            </CollapsedAvatarTooltipListItem>
+          ))}
+        </Fragment>
+      );
+    }
+    return <div />;
+  };
+
   const makeCreatorOption = useCallback(
     () => ({
       value: '_creator',
@@ -187,6 +214,7 @@ function EditAccessSelector({
         maxVisibleAvatars={1}
         avatarSize={listOnly ? 30 : 25}
         tooltipOptions={{disabled: !userCanEditDashboardPermissions}}
+        collapsedAvatarTooltip={renderCollapsedAvatarTooltip()}
       />
     );
 
@@ -378,4 +406,10 @@ const FilterButtons = styled(ButtonBar)`
   margin-top: ${space(0.5)};
   margin-bottom: ${space(0.5)};
   justify-content: flex-end;
+`;
+
+const CollapsedAvatarTooltipListItem = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
 `;

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -168,21 +168,15 @@ function EditAccessSelector({
           zIndex: 1000,
         }}
       >
-        <CollapsedAvatars
-          size={avatarSize}
-          data-test-id="avatarList-collapsedavatars"
-          collapsedAvatarActions={{
-            onMouseEnter: () => {
-              setIsCollapsedAvatarTooltipOpen(true);
-            },
-            onMouseLeave: () => {
-              setIsCollapsedAvatarTooltipOpen(false);
-            },
-          }}
+        <div
+          onMouseEnter={() => setIsCollapsedAvatarTooltipOpen(true)}
+          onMouseLeave={() => setIsCollapsedAvatarTooltipOpen(false)}
         >
-          {numCollapsedAvatars < 99 && <Plus>+</Plus>}
-          {numCollapsedAvatars}
-        </CollapsedAvatars>
+          <CollapsedAvatars size={avatarSize}>
+            {numCollapsedAvatars < 99 && <Plus>+</Plus>}
+            {numCollapsedAvatars}
+          </CollapsedAvatars>
+        </div>
       </Tooltip>
     );
   };
@@ -443,7 +437,7 @@ const FilterButtons = styled(ButtonBar)`
 
 const CollapsedAvatarTooltip = styled('div')`
   max-height: 200px;
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
 const CollapsedAvatarTooltipListItem = styled('div')`

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
@@ -6,7 +6,7 @@ import sortBy from 'lodash/sortBy';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import Avatar from 'sentry/components/avatar';
-import AvatarList from 'sentry/components/avatar/avatarList';
+import AvatarList, {CollapsedAvatars} from 'sentry/components/avatar/avatarList';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import Badge from 'sentry/components/badge/badge';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
@@ -140,7 +140,7 @@ function EditAccessSelector({
     const permissions = getDashboardPermissions();
     if (permissions.teamsWithEditAccess.length > 1) {
       return (
-        <Fragment>
+        <CollapsedAvatarTooltip>
           {allSelectedTeams.map((team, index) => (
             <CollapsedAvatarTooltipListItem
               key={team.id}
@@ -152,10 +152,39 @@ function EditAccessSelector({
               <div>#{team.name}</div>
             </CollapsedAvatarTooltipListItem>
           ))}
-        </Fragment>
+        </CollapsedAvatarTooltip>
       );
     }
-    return <div />;
+    return null;
+  };
+
+  const renderCollapsedAvatars = (avatarSize: number, numCollapsedAvatars: number) => {
+    return (
+      <Tooltip
+        title={renderCollapsedAvatarTooltip()}
+        isHoverable
+        overlayStyle={{
+          pointerEvents: 'auto',
+          zIndex: 1000,
+        }}
+      >
+        <CollapsedAvatars
+          size={avatarSize}
+          data-test-id="avatarList-collapsedavatars"
+          collapsedAvatarActions={{
+            onMouseEnter: () => {
+              setIsCollapsedAvatarTooltipOpen(true);
+            },
+            onMouseLeave: () => {
+              setIsCollapsedAvatarTooltipOpen(false);
+            },
+          }}
+        >
+          {numCollapsedAvatars < 99 && <Plus>+</Plus>}
+          {numCollapsedAvatars}
+        </CollapsedAvatars>
+      </Tooltip>
+    );
   };
 
   const makeCreatorOption = useCallback(
@@ -216,21 +245,7 @@ function EditAccessSelector({
         maxVisibleAvatars={1}
         avatarSize={listOnly ? 30 : 25}
         tooltipOptions={{disabled: !userCanEditDashboardPermissions}}
-        collapsedAvatarTooltip={renderCollapsedAvatarTooltip()}
-        collapsedAvatarActions={{
-          onMouseEnter: () => {
-            setIsCollapsedAvatarTooltipOpen(true);
-          },
-          onMouseLeave: () => {
-            setIsCollapsedAvatarTooltipOpen(false);
-          },
-        }}
-        collapsedAvatarTooltipStyle={{
-          maxHeight: '200px',
-          overflowY: 'scroll',
-          pointerEvents: 'auto',
-          zIndex: 1000,
-        }}
+        renderCollapsedAvatars={renderCollapsedAvatars}
       />
     );
 
@@ -426,8 +441,19 @@ const FilterButtons = styled(ButtonBar)`
   justify-content: flex-end;
 `;
 
+const CollapsedAvatarTooltip = styled('div')`
+  max-height: 200px;
+  overflow-y: scroll;
+`;
+
 const CollapsedAvatarTooltipListItem = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
+`;
+
+const Plus = styled('span')`
+  font-size: 10px;
+  margin-left: 1px;
+  margin-right: -1px;
 `;

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -65,6 +65,8 @@ function EditAccessSelector({
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [stagedOptions, setStagedOptions] = useState<string[]>([]);
   const [isMenuOpen, setMenuOpen] = useState<boolean>(false);
+  const [isCollapsedAvatarTooltipOpen, setIsCollapsedAvatarTooltipOpen] =
+    useState<boolean>(false);
   const {teams: selectedTeam} = useTeamsById({
     ids:
       selectedOptions[1] && selectedOptions[1] !== '_allUsers'
@@ -215,6 +217,20 @@ function EditAccessSelector({
         avatarSize={listOnly ? 30 : 25}
         tooltipOptions={{disabled: !userCanEditDashboardPermissions}}
         collapsedAvatarTooltip={renderCollapsedAvatarTooltip()}
+        collapsedAvatarActions={{
+          onMouseEnter: () => {
+            setIsCollapsedAvatarTooltipOpen(true);
+          },
+          onMouseLeave: () => {
+            setIsCollapsedAvatarTooltipOpen(false);
+          },
+        }}
+        collapsedAvatarTooltipStyle={{
+          maxHeight: '200px',
+          overflowY: 'scroll',
+          pointerEvents: 'auto',
+          zIndex: 1000,
+        }}
       />
     );
 
@@ -346,7 +362,9 @@ function EditAccessSelector({
   return (
     <Tooltip
       title={t('Only the creator of the dashboard can edit permissions')}
-      disabled={userCanEditDashboardPermissions || isMenuOpen}
+      disabled={
+        userCanEditDashboardPermissions || isMenuOpen || isCollapsedAvatarTooltipOpen
+      }
     >
       {dropdownMenu}
     </Tooltip>


### PR DESCRIPTION
There was a request to have a tooltip displaying all teams that have access to a dashboard in [this slack thread](https://sentry.slack.com/archives/C072KUA8R1U/p1736457766301069). Now hovering over the +(a number) bubble in the avatar list will give a tooltip of all the teams (some of them are scrollable due to the large amount of teams). 

Here's what it looks like:
<img width="778" alt="image" src="https://github.com/user-attachments/assets/40086f9c-9562-40a6-ab11-a1195ebf6471" />