### PR TITLE
chore(linting): Ignore false positive linting error

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -193,7 +193,7 @@ def save_issue_from_occurrence(
             granted_quota = issue_rate_limiter.check_and_use_quotas(
                 [
                     RequestedQuota(
-                        f"issue-platform-issues:{project.id}:{occurrence.type.slug}",
+                        f"issue-platform-issues:{project.id}:{occurrence.type.slug}",  # noqa E231 missing whitespace after ':'
                         1,
                         [occurrence.type.creation_quota],
                     )


### PR DESCRIPTION
An unrelated change I need to make to `ingest.py` is failing pre-commit hooks because of this error. This suppresses it, since it's a false positive. (It's treating a colon in a string as if it were the colon between a dictionary key and value.)