### PR TITLE
chore(gitlab): emit halt for 400 and 404s when checking a file

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -133,7 +133,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                 return None
             except ApiError as e:
                 if e.code in (404, 400):
-                    lifecycle.record_halt(extra={"status_code": e.code})
+                    lifecycle.record_halt(e)
                     return None
                 else:
                     sentry_sdk.capture_exception()

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -118,7 +118,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         filepath: file from the stacktrace (string)
         branch: commitsha or default_branch (string)
         """
-        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture() as lifecycle:
             filepath = filepath.lstrip("/")
             try:
                 client = self.get_client()
@@ -132,11 +132,12 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             except IdentityNotValid:
                 return None
             except ApiError as e:
-                if e.code != 404:
+                if e.code in (404, 400):
+                    lifecycle.record_halt(extra={"status_code": e.code})
+                    return None
+                else:
                     sentry_sdk.capture_exception()
                     raise
-
-                return None
 
             return self.format_source_url(repo, filepath, branch)
 

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -365,7 +365,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             source_url == "https://gitlab.example.com/getsentry/example-repo/blob/master/README.md"
         )
 
-        mock_record_halt.assert_called_with(extra={"status_code": 404})
+        mock_record_halt.assert_called_once()
 
     @responses.activate
     def test_get_commit_context_all_frames(self):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -328,7 +328,8 @@ class GitlabIntegrationTest(IntegrationTestCase):
         assert excinfo.value.code == 401
 
     @responses.activate
-    def test_get_stacktrace_link_use_default_if_version_404(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_get_stacktrace_link_use_default_if_version_404(self, mock_record_halt):
         self.assert_setup_flow()
         external_id = 4
         integration = Integration.objects.get(provider=self.provider.key)
@@ -363,6 +364,8 @@ class GitlabIntegrationTest(IntegrationTestCase):
         assert (
             source_url == "https://gitlab.example.com/getsentry/example-repo/blob/master/README.md"
         )
+
+        mock_record_halt.assert_called_with(extra={"status_code": 404})
 
     @responses.activate
     def test_get_commit_context_all_frames(self):


### PR DESCRIPTION
We are seeing a lot of 400 responses from Gitlab which are causing failures in the SLO for getting a file (either to check codeowners or stacktrace paths).

We should be emitting a halt because a 400 comes from user misconfiguration; if the user typed in the incorrect path, it should not cause a failure metric.