### PR TITLE
enha: use SentryWidget in Flutter onboarding

### DIFF
--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -48,7 +48,11 @@ Future<void> main() async {
           : ''
       }
     },
-    appRunner: () => runApp(const MyApp()),
+    appRunner: () => runApp(
+      SentryWidget(
+        child: MyApp(),
+      ),
+    ),
   );
 
   // or define SENTRY_DSN via Dart environment variable (--dart-define)
@@ -109,7 +113,11 @@ Future<void> main() async {
       options.dsn = '${params.dsn.public}';
       options.enableMetrics = true;
     },
-    appRunner: initApp, // Init your App.
+    appRunner: () => runApp(
+      SentryWidget(
+        child: MyApp(),
+      ),
+    ),
   );
 };`;
 
@@ -120,7 +128,11 @@ await SentryFlutter.init(
     options.experimental.replay.sessionSampleRate = 1.0;
     options.experimental.replay.onErrorSampleRate = 1.0;
   },
-  appRunner: () => runApp(MyApp()),
+  appRunner: () => runApp(
+      SentryWidget(
+        child: MyApp(),
+      ),
+    ),
 );
 `;
 


### PR DESCRIPTION
SentryWidget is necessary for some of the Flutter SDK features. People should be better guided to set them up when adding Sentry to their app.



Part of https://github.com/getsentry/sentry-dart/issues/2562
Related: https://github.com/getsentry/sentry-docs/pull/12390

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
