### PR TITLE
fix(insights): Close span samples panel when navigating to a trace view

### DIFF
--- a/static/app/views/insights/common/utils/useSamplesDrawer.tsx
+++ b/static/app/views/insights/common/utils/useSamplesDrawer.tsx
@@ -54,7 +54,15 @@ export function useSamplesDrawer({
 
   const shouldCloseOnLocationChange = useCallback(
     (newLocation: Location) => {
-      return !requiredParams.some(paramName => Boolean(newLocation.query[paramName]));
+      if (!requiredParams.every(paramName => Boolean(newLocation.query[paramName]))) {
+        return true;
+      }
+
+      if (newLocation.pathname.includes('/trace/')) {
+        return true;
+      }
+
+      return false;
     },
     [requiredParams]
   );


### PR DESCRIPTION
Right now, clicking on a span ID in the panel keeps the panel open, and navigates to the trace view. Closing the panel then calls the `onClose` callback, and sometimes clobbers the URL.

Navigating to the sample view should close the panel, this PR adds that check. This is a hotfix, the proper solution is to make the navigation behaviour more robust, probably by rendering the panel view at a `/samples/` sub-route, which is easier to detect on navigation.
