### PR TITLE
fix(visibility): Omit irrelevant meta from response

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -614,16 +614,23 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             if is_equation(query_column):
                 equations += 1
             # `meta` contains meta for all columns. Only include field and unit
-            # information for the current column and time. Time just for safety
-            # no known UI uses it.
+            # information for the current column
             result[columns[index]]["meta"] = {
                 **meta,
                 "fields": {
-                    "time": meta["fields"]["time"],
                     axis_column: meta["fields"][axis_column],
                 },
                 "units": {"time": meta["units"]["time"], axis_column: meta["units"][axis_column]},
             }
+
+            # Time may be absent depending on dataset. If present, add it even though the
+            # frontend doesn't seem to use it
+            if meta["fields"].get("time", None):
+                result[columns[index]]["meta"]["fields"]["time"] = meta["fields"]["time"]
+
+            if meta["units"].get("time", None):
+                result[columns[index]]["meta"]["units"]["time"] = meta["units"]["time"]
+
         # Set order if multi-axis + top events
         if "order" in event_result.data:
             result["order"] = event_result.data["order"]

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -601,9 +601,12 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             dataset=dataset,
         )["meta"]
         for index, query_column in enumerate(query_columns):
+            axis_column = resolve_axis_column(
+                query_column, equations, transform_alias_to_input_format
+            )
             result[columns[index]] = serializer.serialize(
                 event_result,
-                resolve_axis_column(query_column, equations, transform_alias_to_input_format),
+                axis_column,
                 order=index,
                 allow_partial_buckets=allow_partial_buckets,
                 zerofill_results=zerofill_results,
@@ -617,9 +620,9 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 **meta,
                 "fields": {
                     "time": meta["fields"]["time"],
-                    query_column: meta["fields"][query_column],
+                    axis_column: meta["fields"][axis_column],
                 },
-                "units": {"time": meta["units"]["time"], query_column: meta["units"][query_column]},
+                "units": {"time": meta["units"]["time"], axis_column: meta["units"][axis_column]},
             }
         # Set order if multi-axis + top events
         if "order" in event_result.data:

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -610,7 +610,17 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             )
             if is_equation(query_column):
                 equations += 1
-            result[columns[index]]["meta"] = meta
+            # `meta` contains meta for all columns. Only include field and unit
+            # information for the current column and time. Time just for safety
+            # no known UI uses it.
+            result[columns[index]]["meta"] = {
+                **meta,
+                "fields": {
+                    "time": meta["fields"]["time"],
+                    query_column: meta["fields"][query_column],
+                },
+                "units": {"time": meta["units"]["time"], query_column: meta["units"][query_column]},
+            }
         # Set order if multi-axis + top events
         if "order" in event_result.data:
             result["order"] = event_result.data["order"]

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3138,29 +3138,29 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
             for y_axis in y_axes:
                 assert response.data[func]["p95(function.duration)"]["meta"]["fields"] == {
                     "time": "date",
-                    "p95_function_duration": "size",
+                    "p95_function_duration": "duration",
                 }
                 assert response.data[func]["p95(function.duration)"]["meta"]["units"] == {
                     "time": None,
-                    "p95_function_duration": "kibibyte",
+                    "p95_function_duration": "nanosecond",
                 }
 
                 assert response.data[func]["all_examples()"]["meta"]["fields"] == {
                     "time": "date",
-                    "all_examples": "size",
+                    "all_examples": "string",
                 }
                 assert response.data[func]["all_examples()"]["meta"]["units"] == {
                     "time": None,
-                    "all_examples": "kibibyte",
+                    "all_examples": None,
                 }
 
                 assert response.data[func]["cpm()"]["meta"]["fields"] == {
                     "time": "date",
-                    "cpm": "size",
+                    "cpm": "number",
                 }
                 assert response.data[func]["cpm()"]["meta"]["units"] == {
                     "time": None,
-                    "cpm": "kibibyte",
+                    "cpm": None,
                 }
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3029,19 +3029,28 @@ class OrganizationEventsStatsProfileFunctionDatasetEndpointTest(
             ],
         ]
 
-        for y_axis in y_axes:
-            assert response.data[y_axis]["meta"]["fields"] == {
-                "time": "date",
-                "cpm": "number",
-                "p95_function_duration": "duration",
-                "all_examples": "string",
-            }
-            assert response.data[y_axis]["meta"]["units"] == {
-                "time": None,
-                "cpm": None,
-                "p95_function_duration": "nanosecond",
-                "all_examples": None,
-            }
+        assert response.data["cpm()"]["meta"]["fields"] == {
+            "cpm": "number",
+            "time": "date",
+        }
+
+        assert response.data["cpm()"]["meta"]["units"] == {"cpm": None, "time": None}
+
+        assert response.data["p95(function.duration)"]["meta"]["fields"] == {
+            "p95_function_duration": "duration",
+            "time": "date",
+        }
+
+        assert response.data["p95(function.duration)"]["meta"]["units"] == {
+            "p95_function_duration": "nanosecond",
+        }
+
+        assert response.data["all_examples()"]["meta"]["fields"] == {
+            "all_examples": "string",
+            "time": "date",
+        }
+
+        assert response.data["all_examples()"]["meta"]["units"] == {"all_examples": None}
 
 
 class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
@@ -3130,6 +3139,33 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
                     "function": None,
                     "p95_function_duration": "nanosecond",
                     "all_examples": None,
+                }
+
+                assert response.data[func]["p95(function.duration)"]["meta"]["fields"] == {
+                    "time": "date",
+                    "p95_function_duration": "size",
+                }
+                assert response.data[func]["p95(function.duration)"]["meta"]["units"] == {
+                    "time": None,
+                    "p95_function_duration": "kibibyte",
+                }
+
+                assert response.data[func]["all_examples()"]["meta"]["fields"] == {
+                    "time": "date",
+                    "all_examples": "size",
+                }
+                assert response.data[func]["all_examples()"]["meta"]["units"] == {
+                    "time": None,
+                    "all_examples": "kibibyte",
+                }
+
+                assert response.data[func]["cpm()"]["meta"]["fields"] == {
+                    "time": "date",
+                    "cpm": "size",
+                }
+                assert response.data[func]["cpm()"]["meta"]["units"] == {
+                    "time": None,
+                    "cpm": "kibibyte",
                 }
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3043,6 +3043,7 @@ class OrganizationEventsStatsProfileFunctionDatasetEndpointTest(
 
         assert response.data["p95(function.duration)"]["meta"]["units"] == {
             "p95_function_duration": "nanosecond",
+            "time": None,
         }
 
         assert response.data["all_examples()"]["meta"]["fields"] == {
@@ -3050,7 +3051,10 @@ class OrganizationEventsStatsProfileFunctionDatasetEndpointTest(
             "time": "date",
         }
 
-        assert response.data["all_examples()"]["meta"]["units"] == {"all_examples": None}
+        assert response.data["all_examples()"]["meta"]["units"] == {
+            "all_examples": None,
+            "time": None,
+        }
 
 
 class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
@@ -3132,15 +3136,6 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
 
         for func in ["foo", "bar"]:
             for y_axis in y_axes:
-                assert response.data[func][y_axis]["meta"]["units"] == {
-                    "time": None,
-                    "count": None,
-                    "cpm": None,
-                    "function": None,
-                    "p95_function_duration": "nanosecond",
-                    "all_examples": None,
-                }
-
                 assert response.data[func]["p95(function.duration)"]["meta"]["fields"] == {
                     "time": "date",
                     "p95_function_duration": "size",

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -691,17 +691,32 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         )
 
         assert response.status_code == 200
-        meta = response.data["p95(measurements.custom)"]["meta"]
-        assert meta["fields"] == {
+        assert response.data["p95(measurements.custom)"]["meta"]["fields"] == {
             "time": "date",
             "p95_measurements_custom": "size",
         }
-        assert meta["units"] == {
+        assert response.data["p95(measurements.custom)"]["meta"]["units"] == {
             "time": None,
             "p95_measurements_custom": "kibibyte",
         }
-        assert meta == response.data["p99(measurements.custom)"]["meta"]
-        assert meta == response.data["p99(measurements.another.custom)"]["meta"]
+
+        assert response.data["p99(measurements.custom)"]["meta"]["fields"] == {
+            "time": "date",
+            "p99_measurements_custom": "size",
+        }
+        assert response.data["p99(measurements.custom)"]["meta"]["units"] == {
+            "time": None,
+            "p99_measurements_custom": "kibibyte",
+        }
+
+        assert response.data["p99(measurements.another.custom)"]["meta"]["fields"] == {
+            "time": "date",
+            "p99_measurements_another_custom": "size",
+        }
+        assert response.data["p95(measurements.another.custom)"]["meta"]["units"] == {
+            "time": None,
+            "p99_measurements_another_custom": "kibibyte",
+        }
 
     def test_no_top_events_with_project_field(self):
         project = self.create_project()

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -715,7 +715,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         }
         assert response.data["p99(measurements.another.custom)"]["meta"]["units"] == {
             "time": None,
-            "p99_measurements_another_custom": "kibibyte",
+            "p99_measurements_another_custom": "pebibyte",
         }
 
     def test_no_top_events_with_project_field(self):

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -713,7 +713,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             "time": "date",
             "p99_measurements_another_custom": "size",
         }
-        assert response.data["p95(measurements.another.custom)"]["meta"]["units"] == {
+        assert response.data["p99(measurements.another.custom)"]["meta"]["units"] == {
             "time": None,
             "p99_measurements_another_custom": "kibibyte",
         }

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -553,24 +553,20 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert sum_meta["fields"] == {
             "time": "date",
             "sum_measurements_datacenter_memory": "size",
-            "p50_measurements_datacenter_memory": "size",
         }
         assert sum_meta["units"] == {
             "time": None,
             "sum_measurements_datacenter_memory": "pebibyte",
-            "p50_measurements_datacenter_memory": "pebibyte",
         }
 
         p50_meta = p50_data["meta"]
         assert p50_meta["isMetricsData"] == p50_data["isMetricsData"]
         assert p50_meta["fields"] == {
             "time": "date",
-            "sum_measurements_datacenter_memory": "size",
             "p50_measurements_datacenter_memory": "size",
         }
         assert p50_meta["units"] == {
             "time": None,
-            "sum_measurements_datacenter_memory": "pebibyte",
             "p50_measurements_datacenter_memory": "pebibyte",
         }
 
@@ -699,14 +695,10 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert meta["fields"] == {
             "time": "date",
             "p95_measurements_custom": "size",
-            "p99_measurements_custom": "size",
-            "p99_measurements_another_custom": "size",
         }
         assert meta["units"] == {
             "time": None,
             "p95_measurements_custom": "kibibyte",
-            "p99_measurements_custom": "kibibyte",
-            "p99_measurements_another_custom": "pebibyte",
         }
         assert meta == response.data["p99(measurements.custom)"]["meta"]
         assert meta == response.data["p99(measurements.another.custom)"]["meta"]


### PR DESCRIPTION
If you request a multi-axis response, the response is keyed by the axis. e.g.,

```json
{
  "count()": {
    "data"..
    "meta"..
  },
  "epm()" {...
```

However, the `"meta"` key for each axis will have the _complete_ meta! e.g., `response.data["count()"]["meta"]` will be

```json
{
  "fields": {
    "count()": "integer",
    "epm()": "rate"
  },
  "units": {
    "count()": undefined,
    "epm()": "1/minute"
  }
}
```

`"epm()"` fields and units are in the `"count()"` meta.

This PR omits irrelevant keys from the response.
