### PR TITLE
fix(charts): Multiline chart legend names

### DIFF
--- a/static/app/components/charts/components/legend.tsx
+++ b/static/app/components/charts/components/legend.tsx
@@ -15,7 +15,15 @@ export default function Legend(
   props: ChartProps['legend'] & {theme: Theme}
 ): LegendComponentOption {
   const {truncate, theme, ...rest} = props ?? {};
-  const formatter = (value: string) => truncationFormatter(value, truncate ?? 0);
+  const formatter = (value: string) =>
+    truncationFormatter(
+      value,
+      truncate ?? 0,
+      // Escaping the legend string will cause some special
+      // characters to render as their HTML equivalents.
+      // So disable it here.
+      false
+    );
 
   return merge(
     {

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -41,16 +41,34 @@ export type DateTimeObject = Partial<PageFilters['datetime']>;
 
 export function truncationFormatter(
   value: string,
-  truncate: number | boolean | undefined
+  truncate: number | boolean | undefined,
+  escaped: boolean = true
 ): string {
-  if (!truncate) {
-    return escape(value);
+  // Whitespace characters such as newlines and tabs can
+  // mess up the formatting in legends where it's part of
+  // the formatting as it's handled by ECharts.
+  //
+  // In places like tooltips, it's already ignored and
+  // rendered as a single space.
+  //
+  // So remove whitespace characters such as newlines,
+  // tabs in favor of a space.
+  value = value.replace(/\s+/g, ' ');
+
+  if (truncate) {
+    const truncationLength =
+      truncate && typeof truncate === 'number' ? truncate : DEFAULT_TRUNCATE_LENGTH;
+    value =
+      value.length > truncationLength
+        ? value.substring(0, truncationLength) + '…'
+        : value;
   }
-  const truncationLength =
-    truncate && typeof truncate === 'number' ? truncate : DEFAULT_TRUNCATE_LENGTH;
-  const truncated =
-    value.length > truncationLength ? value.substring(0, truncationLength) + '…' : value;
-  return escape(truncated);
+
+  if (escaped) {
+    value = escape(value);
+  }
+
+  return value;
 }
 
 /**

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -19,7 +19,6 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import usePrevious from 'sentry/utils/usePrevious';
-import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 import ChartContextMenu from 'sentry/views/explore/components/chartContextMenu';
 import {
@@ -233,7 +232,6 @@ export function ExploreCharts({
                   top: '32px', // make room to fit the legend above the chart
                   bottom: '0',
                 }}
-                legendFormatter={value => formatVersion(value)}
                 legendOptions={{
                   itemGap: 24,
                   top: '4px',

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -143,11 +143,7 @@ function Chart({
   onLegendSelectChanged,
   onDataZoom,
   legendOptions,
-  /**
-   * Setting a default formatter for some reason causes `>` to
-   * render correctly instead of rendering as `&gt;` in the legend.
-   */
-  legendFormatter = name => name,
+  legendFormatter,
 }: Props) {
   const theme = useTheme();
   const pageFilters = usePageFilters();
@@ -355,7 +351,13 @@ function Chart({
   };
 
   const legend = isLegendVisible
-    ? {top: 0, right: 10, formatter: legendFormatter, ...legendOptions}
+    ? {
+        top: 0,
+        right: 10,
+        truncate: true,
+        formatter: legendFormatter,
+        ...legendOptions,
+      }
     : undefined;
 
   const areaChartProps = {


### PR DESCRIPTION
When rendering series names that contain newline characters, make sure we format them nicely by replacing them with a single white space.

Also lifts the fix for escaped character names in the legend into the legend function directly instead of using an override in the insights chart component that loses the truncation formatter.