### PR TITLE
fix(widget-builder): Display visual confirmation when saving widget

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -22,13 +22,16 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
   const {widgetIndex} = useParams();
   const api = useApi();
   const organization = useOrganization();
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleSave = useCallback(async () => {
     const widget = convertBuilderStateToWidget(state);
+    setIsSaving(true);
     try {
       await validateWidget(api, organization.slug, widget);
       onSave({index: Number(widgetIndex), widget});
     } catch (error) {
+      setIsSaving(false);
       const errorDetails = error.responseJSON || error;
       setError(errorDetails);
       addErrorMessage(t('Unable to save widget'));
@@ -36,7 +39,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
   }, [api, onSave, organization.slug, state, widgetIndex, setError]);
 
   return (
-    <Button priority="primary" onClick={handleSave}>
+    <Button priority="primary" onClick={handleSave} busy={isSaving}>
       {isEditing ? t('Update Widget') : t('Add Widget')}
     </Button>
   );

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -1,7 +1,11 @@
 import {useCallback, useState} from 'react';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
-import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
@@ -33,6 +37,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
       onSave({index: Number(widgetIndex), widget});
     } catch (error) {
       setIsSaving(false);
+      clearIndicators();
       const errorDetails = error.responseJSON || error;
       setError(errorDetails);
       addErrorMessage(t('Unable to save widget'));

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useState} from 'react';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
@@ -29,6 +29,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
     setIsSaving(true);
     try {
       await validateWidget(api, organization.slug, widget);
+      addLoadingMessage(t('Saving widget'));
       onSave({index: Number(widgetIndex), widget});
     } catch (error) {
       setIsSaving(false);

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -11,7 +11,7 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
 import ModalStore from 'sentry/stores/modalStore';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -263,6 +263,52 @@ describe('WidgetBuilderSlideout', () => {
     });
 
     expect(screen.getByText('Create Custom Widget')).toBeInTheDocument();
+  });
+
+  it('should save the widget from the widget builder with loading messages if the widget is valid', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/widgets/',
+      method: 'POST',
+      body: {},
+      statusCode: 200,
+    });
+
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: [],
+              yAxis: ['count()'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.LINE,
+              title: 'Widget Title',
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByText('Add Widget'));
+
+    await waitFor(() => {
+      expect(addLoadingMessage).toHaveBeenCalledWith('Saving widget');
+    });
   });
 
   it('clears the alias when dataset changes', async () => {


### PR DESCRIPTION
Since widgets take some time to save and add to the dashboard, I've added some visual confirmation that a widget is being saved. When a widget has passed validation and is going through the saving process the button is busy/unclickable and a loading message will pop up to say that the widget is saving. 

Here it is in action:


https://github.com/user-attachments/assets/710418c4-7ec3-42f8-958c-36f7a8e4f3aa

