### PR TITLE
fix(trace-view): Fix header height in Issues view

### DIFF
--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -353,7 +353,7 @@ const IssuesPointerDisabled = styled('div')`
 
 const ROW_HEIGHT = 24;
 const MIN_ROW_COUNT = 1;
-const HEADER_HEIGHT = 28;
+const HEADER_HEIGHT = 38;
 const MAX_HEIGHT = 12 * ROW_HEIGHT + HEADER_HEIGHT;
 const MAX_ROW_COUNT = Math.floor(MAX_HEIGHT / ROW_HEIGHT);
 


### PR DESCRIPTION
Recently, I've changed the header height for the trace view to better match the designs, but forgot to update the height for the trace view preview on Issue Details. This will stop the bottom of the preview from getting cut off early