### PR TITLE
feat(dashboards-eap): Wrap menu item with dashboards upsell

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -259,7 +259,6 @@ export type FeatureDisabledHooks = {
   'feature-disabled:codecov-integration-setting': FeatureDisabledHook;
   'feature-disabled:create-metrics-alert-tooltip': FeatureDisabledHook;
   'feature-disabled:custom-inbound-filters': FeatureDisabledHook;
-  'feature-disabled:dashboards-eap': FeatureDisabledHook;
   'feature-disabled:dashboards-edit': FeatureDisabledHook;
   'feature-disabled:dashboards-page': FeatureDisabledHook;
   'feature-disabled:dashboards-sidebar-item': FeatureDisabledHook;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -259,6 +259,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:codecov-integration-setting': FeatureDisabledHook;
   'feature-disabled:create-metrics-alert-tooltip': FeatureDisabledHook;
   'feature-disabled:custom-inbound-filters': FeatureDisabledHook;
+  'feature-disabled:dashboards-eap': FeatureDisabledHook;
   'feature-disabled:dashboards-edit': FeatureDisabledHook;
   'feature-disabled:dashboards-page': FeatureDisabledHook;
   'feature-disabled:dashboards-sidebar-item': FeatureDisabledHook;

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -1,3 +1,6 @@
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -63,30 +66,57 @@ function ChartContextMenu({
     });
   }
 
-  if (organization.features.includes('dashboards-eap')) {
-    items.push({
-      key: 'add-to-dashboard',
-      label: t('Add to Dashboard'),
-      onAction: () => addToDashboard(visualizeIndex),
-    });
-  }
-
   if (items.length === 0) {
     return null;
   }
 
   return (
-    <DropdownMenu
-      triggerProps={{
-        size: 'sm',
-        borderless: true,
-        showChevron: false,
-        icon: <IconEllipsis />,
+    <Feature features={['organizations:dashboards-edit', 'organizations:dashboards-eap']}>
+      {({hasFeature: hasDashboardsEap}) => {
+        items.push({
+          key: 'add-to-dashboard',
+          label: t('Add to Dashboard'),
+          textValue: t('Add to Dashboard'),
+          ...(hasDashboardsEap
+            ? {onAction: () => addToDashboard(visualizeIndex)}
+            : {
+                label: (
+                  <Feature
+                    hookName="feature-disabled:dashboards-edit"
+                    features={[
+                      'organizations:dashboards-edit',
+                      'organizations:dashboards-eap',
+                    ]}
+                    renderDisabled={() => (
+                      <DisabledText>{t('Add to Dashboard')}</DisabledText>
+                    )}
+                  >
+                    <DisabledText>{t('Add to Dashboard')}</DisabledText>
+                  </Feature>
+                ),
+                disabled: true,
+              }),
+        });
+
+        return (
+          <DropdownMenu
+            triggerProps={{
+              size: 'sm',
+              borderless: true,
+              showChevron: false,
+              icon: <IconEllipsis />,
+            }}
+            position="bottom-end"
+            items={items}
+          />
+        );
       }}
-      position="bottom-end"
-      items={items}
-    />
+    </Feature>
   );
 }
 
 export default ChartContextMenu;
+
+const DisabledText = styled('span')`
+  color: ${p => p.theme.disabled};
+`;

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -74,7 +74,7 @@ function ChartContextMenu({
       label: (
         <Feature
           hookName="feature-disabled:dashboards-edit"
-          features={['organizations:dashboards-edit']}
+          features="organizations:dashboards-edit"
           renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
         >
           {t('Add to Dashboard')}

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -66,52 +66,40 @@ function ChartContextMenu({
     });
   }
 
+  if (organization.features.includes('dashboards-eap')) {
+    const disableAddToDashboard = !organization.features.includes('dashboards-edit');
+    items.push({
+      key: 'add-to-dashboard',
+      textValue: t('Add to Dashboard'),
+      label: (
+        <Feature
+          hookName="feature-disabled:dashboards-edit"
+          features={['organizations:dashboards-edit']}
+          renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
+        >
+          {t('Add to Dashboard')}
+        </Feature>
+      ),
+      disabled: disableAddToDashboard,
+      onAction: !disableAddToDashboard ? () => addToDashboard(visualizeIndex) : undefined,
+    });
+  }
+
   if (items.length === 0) {
     return null;
   }
 
   return (
-    <Feature features={['organizations:dashboards-edit', 'organizations:dashboards-eap']}>
-      {({hasFeature: hasDashboardsEap}) => {
-        items.push({
-          key: 'add-to-dashboard',
-          label: t('Add to Dashboard'),
-          textValue: t('Add to Dashboard'),
-          ...(hasDashboardsEap
-            ? {onAction: () => addToDashboard(visualizeIndex)}
-            : {
-                label: (
-                  <Feature
-                    hookName="feature-disabled:dashboards-edit"
-                    features={[
-                      'organizations:dashboards-edit',
-                      'organizations:dashboards-eap',
-                    ]}
-                    renderDisabled={() => (
-                      <DisabledText>{t('Add to Dashboard')}</DisabledText>
-                    )}
-                  >
-                    <DisabledText>{t('Add to Dashboard')}</DisabledText>
-                  </Feature>
-                ),
-                disabled: true,
-              }),
-        });
-
-        return (
-          <DropdownMenu
-            triggerProps={{
-              size: 'sm',
-              borderless: true,
-              showChevron: false,
-              icon: <IconEllipsis />,
-            }}
-            position="bottom-end"
-            items={items}
-          />
-        );
+    <DropdownMenu
+      triggerProps={{
+        size: 'sm',
+        borderless: true,
+        showChevron: false,
+        icon: <IconEllipsis />,
       }}
-    </Feature>
+      position="bottom-end"
+      items={items}
+    />
   );
 }
 


### PR DESCRIPTION
Wraps the menu item for "Add to Dashboard" with a feature component to hook into for upselling. The implementation is a little wonky here because we don't typically flag menu items like this, but we need it to disable the Add to Dashboard button when a user clicks in. If the user doesn't have `dashboards-edit` access, we should disable the item. If they don't have `dashboards-eap` access, then we shouldn't show the menu item at all.

Ideally, if I went to see this on a team plan I would see the popover telling me I need the business plan when I hover.

![Screenshot 2025-01-20 at 2 08 19 PM](https://github.com/user-attachments/assets/c91b9366-eb8c-479c-9593-7a8c089d8e33)
