### PR TITLE
fix(dashboards-eap): Remove explore from widget title

### DIFF
--- a/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
@@ -44,7 +44,7 @@ describe('AddToDashboardButton', () => {
       expect.objectContaining({
         // For Add + Stay on Page
         widget: {
-          title: 'Custom Explore Widget',
+          title: 'Custom Widget',
           displayType: DisplayType.LINE,
           interval: undefined,
           limit: undefined,
@@ -72,7 +72,7 @@ describe('AddToDashboardButton', () => {
             'span.duration',
             'timestamp',
           ],
-          defaultTitle: 'Custom Explore Widget',
+          defaultTitle: 'Custom Widget',
           defaultWidgetQuery:
             'name=&aggregates=avg(span.duration)&columns=&fields=avg(span.duration)&conditions=&orderby=-timestamp',
           displayType: DisplayType.LINE,
@@ -117,7 +117,7 @@ describe('AddToDashboardButton', () => {
       expect.objectContaining({
         // For Add + Stay on Page
         widget: {
-          title: 'Custom Explore Widget',
+          title: 'Custom Widget',
           displayType: DisplayType.LINE,
           interval: undefined,
           limit: undefined,
@@ -145,7 +145,7 @@ describe('AddToDashboardButton', () => {
             'span.duration',
             'timestamp',
           ],
-          defaultTitle: 'Custom Explore Widget',
+          defaultTitle: 'Custom Widget',
           defaultWidgetQuery:
             'name=&aggregates=max(span.duration)&columns=&fields=max(span.duration)&conditions=&orderby=-timestamp',
           displayType: DisplayType.LINE,
@@ -178,7 +178,7 @@ describe('AddToDashboardButton', () => {
       expect.objectContaining({
         // For Add + Stay on Page
         widget: {
-          title: 'Custom Explore Widget',
+          title: 'Custom Widget',
           displayType: DisplayType.LINE,
           interval: undefined,
           limit: undefined,
@@ -199,7 +199,7 @@ describe('AddToDashboardButton', () => {
         widgetAsQueryParams: expect.objectContaining({
           dataset: WidgetType.SPANS,
           defaultTableColumns: ['avg(span.duration)'],
-          defaultTitle: 'Custom Explore Widget',
+          defaultTitle: 'Custom Widget',
           defaultWidgetQuery:
             'name=&aggregates=avg(span.duration)&columns=&fields=avg(span.duration)&conditions=&orderby=-avg(span.duration)',
           displayType: DisplayType.LINE,
@@ -238,7 +238,7 @@ describe('AddToDashboardButton', () => {
       expect.objectContaining({
         // For Add + Stay on Page
         widget: {
-          title: 'Custom Explore Widget',
+          title: 'Custom Widget',
           displayType: DisplayType.LINE,
           interval: undefined,
           limit: undefined,
@@ -267,7 +267,7 @@ describe('AddToDashboardButton', () => {
             'max(span.duration)',
             'min(span.duration)',
           ],
-          defaultTitle: 'Custom Explore Widget',
+          defaultTitle: 'Custom Widget',
           defaultWidgetQuery:
             'name=&aggregates=avg(span.duration)%2Cmax(span.duration)%2Cmin(span.duration)&columns=&fields=avg(span.duration)%2Cmax(span.duration)%2Cmin(span.duration)&conditions=&orderby=-avg(span.duration)',
           displayType: DisplayType.LINE,

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -62,7 +62,7 @@ export function useAddToDashboard() {
       const search = new MutableSearch(query);
 
       const discoverQuery: NewQuery = {
-        name: t('Custom Explore Widget'),
+        name: t('Custom Widget'),
         fields,
         orderby: sortBys.map(formatSort),
         query: search.formatString(),


### PR DESCRIPTION
I don't think we want to expose the term `Explore` in the widget title anymore. I'm going to remove it for now.