### PR TITLE
fix(new-trace): Adding back webvitals background colours

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -13,6 +13,7 @@ import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/tooltip';
 import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey, Project} from 'sentry/types/project';
@@ -136,6 +137,7 @@ export function Trace({
   const organization = useOrganization();
   const traceState = useTraceState();
   const traceDispatch = useTraceStateDispatch();
+  const {theme: colorMode} = useLegacyStore(ConfigStore);
 
   const rerenderRef = useRef<TraceProps['rerender']>(rerender);
   rerenderRef.current = rerender;
@@ -425,7 +427,7 @@ export function Trace({
                   <div
                     key={i}
                     ref={r => manager.registerIndicatorLabelRef(r, i, indicator)}
-                    className={`TraceIndicatorLabelContainer ${status}`}
+                    className={`TraceIndicatorLabelContainer ${status} ${colorMode}`}
                   >
                     <Tooltip
                       title={
@@ -922,16 +924,40 @@ const TraceStylingWrapper = styled('div')`
     &.Poor {
       color: ${p => p.theme.red300};
       border: 1px solid ${p => p.theme.red300};
+
+      &.light {
+        background-color: rgb(251 232 233);
+      }
+
+      &.dark {
+        background-color: rgb(63 17 20);
+      }
     }
 
     &.Meh {
       color: ${p => p.theme.yellow400};
       border: 1px solid ${p => p.theme.yellow300};
+
+      &.light {
+        background-color: rgb(249 244 224);
+      }
+
+      &.dark {
+        background-color: rgb(45 41 17);
+      }
     }
 
     &.Good {
       color: ${p => p.theme.green300};
       border: 1px solid ${p => p.theme.green300};
+
+      &.light {
+        background-color: rgb(232 241 239);
+      }
+
+      &.dark {
+        background-color: rgb(9 37 30);
+      }
     }
   }
 


### PR DESCRIPTION
Before: 
<img width="788" alt="Screenshot 2025-01-20 at 2 59 11 PM" src="https://github.com/user-attachments/assets/bdf9a2a4-e17e-4984-96e7-c4ac37400267" />

After:
<img width="897" alt="Screenshot 2025-01-20 at 2 58 50 PM" src="https://github.com/user-attachments/assets/c8e8cad1-5b55-4db8-8fb1-c26f44470f81" />
