### PR TITLE
feat(widget-builder): Add validated widget response to filter

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -224,7 +224,7 @@ export function FilterResultsStep({
   );
 }
 
-function WidgetOnDemandQueryWarning(props: {
+export function WidgetOnDemandQueryWarning(props: {
   query: WidgetQuery;
   queryIndex: number;
   validatedWidgetResponse: Props['validatedWidgetResponse'];

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -27,7 +27,7 @@ describe('WidgetBuilderGroupBySelector', function () {
     render(
       <WidgetBuilderProvider>
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
-          <WidgetBuilderGroupBySelector />
+          <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
         </SpanTagsProvider>
       </WidgetBuilderProvider>
     );
@@ -41,7 +41,7 @@ describe('WidgetBuilderGroupBySelector', function () {
     render(
       <WidgetBuilderProvider>
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
-          <WidgetBuilderGroupBySelector />
+          <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
         </SpanTagsProvider>
       </WidgetBuilderProvider>
     );

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -3,19 +3,25 @@ import {Fragment} from 'react';
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {useValidateWidgetQuery} from 'sentry/views/dashboards/hooks/useValidateWidget';
-import {WidgetType} from 'sentry/views/dashboards/types';
+import {type ValidateWidgetResponse, WidgetType} from 'sentry/views/dashboards/types';
 import {GroupBySelector} from 'sentry/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
-function WidgetBuilderGroupBySelector() {
+interface WidgetBuilderGroupBySelectorProps {
+  validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
+}
+
+function WidgetBuilderGroupBySelector({
+  validatedWidgetResponse,
+}: WidgetBuilderGroupBySelectorProps) {
   const {state, dispatch} = useWidgetBuilderContext();
 
   const organization = useOrganization();
@@ -26,10 +32,6 @@ function WidgetBuilderGroupBySelector() {
   if (state.dataset === WidgetType.SPANS) {
     tags = {...numericSpanTags, ...stringSpanTags};
   }
-
-  const widget = convertBuilderStateToWidget(state);
-
-  const validatedWidgetResponse = useValidateWidgetQuery(widget);
 
   const datasetConfig = getDatasetConfig(state.dataset);
   const groupByOptions = datasetConfig.getGroupByFieldOptions

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -33,7 +33,10 @@ describe('QueryFilterBuilder', () => {
   it('renders a dataset-specific query filter bar', async () => {
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
+        <WidgetBuilderQueryFilterBuilder
+          onQueryConditionChange={() => {}}
+          validatedWidgetResponse={{} as any}
+        />
       </WidgetBuilderProvider>,
       {
         organization,
@@ -54,7 +57,10 @@ describe('QueryFilterBuilder', () => {
 
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
+        <WidgetBuilderQueryFilterBuilder
+          onQueryConditionChange={() => {}}
+          validatedWidgetResponse={{} as any}
+        />
       </WidgetBuilderProvider>,
       {
         organization,
@@ -77,7 +83,10 @@ describe('QueryFilterBuilder', () => {
   it('renders a legend alias input for charts', async () => {
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
+        <WidgetBuilderQueryFilterBuilder
+          onQueryConditionChange={() => {}}
+          validatedWidgetResponse={{} as any}
+        />
       </WidgetBuilderProvider>,
       {
         organization,
@@ -99,7 +108,10 @@ describe('QueryFilterBuilder', () => {
   it('limits number of filter queries to 3', async () => {
     render(
       <WidgetBuilderProvider>
-        <WidgetBuilderQueryFilterBuilder onQueryConditionChange={() => {}} />
+        <WidgetBuilderQueryFilterBuilder
+          onQueryConditionChange={() => {}}
+          validatedWidgetResponse={{} as any}
+        />
       </WidgetBuilderProvider>,
       {
         organization,

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -11,10 +11,17 @@ import {
   createOnDemandFilterWarning,
   shouldDisplayOnDemandWidgetWarning,
 } from 'sentry/utils/onDemandMetrics';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DisplayType,
+  type ValidateWidgetResponse,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
+import {WidgetOnDemandQueryWarning} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
@@ -23,15 +30,16 @@ import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder
 
 interface WidgetBuilderQueryFilterBuilderProps {
   onQueryConditionChange: (valid: boolean) => void;
+  validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
 }
 
 function WidgetBuilderQueryFilterBuilder({
   onQueryConditionChange,
+  validatedWidgetResponse,
 }: WidgetBuilderQueryFilterBuilderProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   const {selection} = usePageFilters();
   const organization = useOrganization();
-
   const [queryConditionValidity, setQueryConditionValidity] = useState<boolean[]>(() => {
     // Make a validity entry for each query condition initially
     return state.query?.map(() => true) ?? [];
@@ -152,6 +160,17 @@ function WidgetBuilderQueryFilterBuilder({
             widgetQuery={widget.queries[index]!}
             dataset={getDiscoverDatasetFromWidgetType(widgetType)}
           />
+          {shouldDisplayOnDemandWidgetWarning(
+            widget.queries[index]!,
+            widgetType,
+            organization
+          ) && (
+            <WidgetOnDemandQueryWarning
+              query={widget.queries[index]!}
+              validatedWidgetResponse={validatedWidgetResponse}
+              queryIndex={index}
+            />
+          )}
           {canHaveAlias && (
             <LegendAliasInput
               type="text"

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -160,17 +160,6 @@ function WidgetBuilderQueryFilterBuilder({
             widgetQuery={widget.queries[index]!}
             dataset={getDiscoverDatasetFromWidgetType(widgetType)}
           />
-          {shouldDisplayOnDemandWidgetWarning(
-            widget.queries[index]!,
-            widgetType,
-            organization
-          ) && (
-            <WidgetOnDemandQueryWarning
-              query={widget.queries[index]!}
-              validatedWidgetResponse={validatedWidgetResponse}
-              queryIndex={index}
-            />
-          )}
           {canHaveAlias && (
             <LegendAliasInput
               type="text"
@@ -185,6 +174,17 @@ function WidgetBuilderQueryFilterBuilder({
                     : [e.target.value],
                 });
               }}
+            />
+          )}
+          {shouldDisplayOnDemandWidgetWarning(
+            widget.queries[index]!,
+            widgetType,
+            organization
+          ) && (
+            <WidgetOnDemandQueryWarning
+              query={widget.queries[index]!}
+              validatedWidgetResponse={validatedWidgetResponse}
+              queryIndex={index}
             />
           )}
           {state.query && state.query?.length > 1 && (

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -13,6 +13,7 @@ import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {useValidateWidgetQuery} from 'sentry/views/dashboards/hooks/useValidateWidget';
 import {
   type DashboardDetails,
   type DashboardFilters,
@@ -37,6 +38,7 @@ import WidgetBuilderTypeSelector from 'sentry/views/dashboards/widgetBuilder/com
 import Visualize from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import WidgetTemplatesList from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 
 type WidgetBuilderSlideoutProps = {
   dashboard: DashboardDetails;
@@ -73,6 +75,10 @@ function WidgetBuilderSlideout({
   const [error, setError] = useState<Record<string, any>>({});
   const {widgetIndex} = useParams();
   const theme = useTheme();
+
+  const validatedWidgetResponse = useValidateWidgetQuery(
+    convertBuilderStateToWidget(state)
+  );
 
   const isEditing = widgetIndex !== undefined;
   const title = openWidgetTemplates
@@ -176,6 +182,7 @@ function WidgetBuilderSlideout({
             <Section>
               <WidgetBuilderQueryFilterBuilder
                 onQueryConditionChange={onQueryConditionChange}
+                validatedWidgetResponse={validatedWidgetResponse}
               />
             </Section>
             {state.displayType === DisplayType.BIG_NUMBER && (
@@ -188,7 +195,9 @@ function WidgetBuilderSlideout({
             )}
             {isChartWidget && (
               <Section>
-                <WidgetBuilderGroupBySelector />
+                <WidgetBuilderGroupBySelector
+                  validatedWidgetResponse={validatedWidgetResponse}
+                />
               </Section>
             )}
             {showSortByStep && (


### PR DESCRIPTION
Uses the `validateWidgetQuery` hook to get widget validation issues/warnings for ondemand. This seems to apply to the group by field and filter fields.

I'm mocking the object in the tests for now because we're not explicitly testing in there and it seemed complicated to properly mock.