### PR TITLE
feat(new-trace): Adding project badge beside trace name in header

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -291,12 +291,14 @@ const HeaderLayout = styled(Layout.Header)`
 const HeaderRow = styled('div')`
   display: flex;
   justify-content: space-between;
+  gap: ${space(2)};
 
   &:not(:first-child) {
     margin: ${space(1)} 0;
   }
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
+    gap: ${space(1)};
     flex-direction: column;
   }
 `;

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -1,10 +1,12 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useProjects from 'sentry/utils/useProjects';
 
 import type {TraceTree} from '../traceModels/traceTree';
 
@@ -20,52 +22,71 @@ export function Title({traceSlug, representativeTransaction}: TitleProps) {
         transaction: representativeTransaction.transaction,
       }
     : null;
+  const {projects} = useProjects();
+  const project = projects.find(p => p.slug === representativeTransaction?.project_slug);
 
   return (
     <div>
-      <HeaderTitle>
-        {traceTitle ? (
-          traceTitle.transaction ? (
-            <Fragment>
+      {traceTitle ? (
+        traceTitle.transaction ? (
+          <TitleWrapper>
+            {project && (
+              <ProjectBadge
+                hideName
+                project={project}
+                avatarSize={20}
+                avatarProps={{
+                  hasTooltip: true,
+                  tooltip: representativeTransaction?.project_slug,
+                }}
+              />
+            )}
+            <TitleText>
               <strong>{traceTitle.op} - </strong>
               {traceTitle.transaction}
-            </Fragment>
-          ) : (
-            '\u2014'
-          )
+            </TitleText>
+          </TitleWrapper>
         ) : (
-          <Tooltip
-            title={tct(
-              'Might be due to sampling, ad blockers, permissions or more.[break][link:Read the docs]',
-              {
-                break: <br />,
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#troubleshooting" />
-                ),
-              }
-            )}
-            showUnderline
-            position="right"
-            isHoverable
-          >
-            <strong>{t('Missing Trace Root')}</strong>
-          </Tooltip>
-        )}
-      </HeaderTitle>
-      <HeaderSubtitle>
+          '\u2014'
+        )
+      ) : (
+        <Tooltip
+          title={tct(
+            'Might be due to sampling, ad blockers, permissions or more.[break][link:Read the docs]',
+            {
+              break: <br />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#troubleshooting" />
+              ),
+            }
+          )}
+          showUnderline
+          position="right"
+          isHoverable
+        >
+          <strong>{t('Missing Trace Root')}</strong>
+        </Tooltip>
+      )}
+      <SubtitleText>
         Trace ID: {traceSlug}
         <CopyToClipboardButton borderless size="zero" iconSize="xs" text={traceSlug} />
-      </HeaderSubtitle>
+      </SubtitleText>
     </div>
   );
 }
 
-const HeaderTitle = styled('div')`
+const TitleWrapper = styled('div')`
+  display: flex;
+  gap: ${space(0.5)};
+  align-items: center;
+`;
+
+const TitleText = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   ${p => p.theme.overflowEllipsis};
 `;
 
-const HeaderSubtitle = styled('div')`
+const SubtitleText = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.subText};
 `;


### PR DESCRIPTION
<img width="1088" alt="Screenshot 2025-01-20 at 3 59 39 PM" src="https://github.com/user-attachments/assets/4de166ae-43e1-4ceb-b202-2eff937e6d3d" />
