### PR TITLE
ref(dashboards): Push `SeriesConstructor` prop lower down

### DIFF
--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.tsx
@@ -3,11 +3,9 @@ import {
   type TimeSeriesWidgetProps,
 } from '../timeSeriesWidget/timeSeriesWidget';
 
-import {AreaChartWidgetSeries} from './areaChartWidgetSeries';
-
 export interface AreaChartWidgetProps
-  extends Omit<TimeSeriesWidgetProps, 'SeriesConstructor'> {}
+  extends Omit<TimeSeriesWidgetProps, 'visualizationType'> {}
 
 export function AreaChartWidget(props: AreaChartWidgetProps) {
-  return <TimeSeriesWidget {...props} SeriesConstructor={AreaChartWidgetSeries} />;
+  return <TimeSeriesWidget {...props} visualizationType="area" />;
 }

--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization.tsx
@@ -1,0 +1,15 @@
+import {
+  TimeSeriesWidgetVisualization,
+  type TimeSeriesWidgetVisualizationProps,
+} from '../timeSeriesWidget/timeSeriesWidgetVisualization';
+
+import {AreaChartWidgetSeries} from './areaChartWidgetSeries';
+
+export interface AreaChartWidgetVisualizationProps
+  extends Omit<TimeSeriesWidgetVisualizationProps, 'SeriesConstructor'> {}
+
+export function AreaChartWidgetVisualization(props: AreaChartWidgetVisualizationProps) {
+  return (
+    <TimeSeriesWidgetVisualization {...props} SeriesConstructor={AreaChartWidgetSeries} />
+  );
+}

--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization.tsx
@@ -3,13 +3,9 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from '../timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {AreaChartWidgetSeries} from './areaChartWidgetSeries';
-
 export interface AreaChartWidgetVisualizationProps
-  extends Omit<TimeSeriesWidgetVisualizationProps, 'SeriesConstructor'> {}
+  extends Omit<TimeSeriesWidgetVisualizationProps, 'visualizationType'> {}
 
 export function AreaChartWidgetVisualization(props: AreaChartWidgetVisualizationProps) {
-  return (
-    <TimeSeriesWidgetVisualization {...props} SeriesConstructor={AreaChartWidgetSeries} />
-  );
+  return <TimeSeriesWidgetVisualization {...props} visualizationType="area" />;
 }

--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.tsx
@@ -3,11 +3,9 @@ import {
   type TimeSeriesWidgetProps,
 } from '../timeSeriesWidget/timeSeriesWidget';
 
-import {BarChartWidgetSeries} from './barChartWidgetSeries';
-
 export interface BarChartWidgetProps
-  extends Omit<TimeSeriesWidgetProps, 'SeriesConstructor'> {}
+  extends Omit<TimeSeriesWidgetProps, 'visualizationType'> {}
 
 export function BarChartWidget(props: BarChartWidgetProps) {
-  return <TimeSeriesWidget {...props} SeriesConstructor={BarChartWidgetSeries} />;
+  return <TimeSeriesWidget {...props} visualizationType="bar" />;
 }

--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidgetVisualization.tsx
@@ -3,13 +3,9 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from '../timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {BarChartWidgetSeries} from './barChartWidgetSeries';
-
 export interface BarChartWidgetVisualizationProps
-  extends Omit<TimeSeriesWidgetVisualizationProps, 'SeriesConstructor'> {}
+  extends Omit<TimeSeriesWidgetVisualizationProps, 'visualizationType'> {}
 
 export function BarChartWidgetVisualization(props: BarChartWidgetVisualizationProps) {
-  return (
-    <TimeSeriesWidgetVisualization {...props} SeriesConstructor={BarChartWidgetSeries} />
-  );
+  return <TimeSeriesWidgetVisualization {...props} visualizationType="bar" />;
 }

--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidgetVisualization.tsx
@@ -1,0 +1,15 @@
+import {
+  TimeSeriesWidgetVisualization,
+  type TimeSeriesWidgetVisualizationProps,
+} from '../timeSeriesWidget/timeSeriesWidgetVisualization';
+
+import {BarChartWidgetSeries} from './barChartWidgetSeries';
+
+export interface BarChartWidgetVisualizationProps
+  extends Omit<TimeSeriesWidgetVisualizationProps, 'SeriesConstructor'> {}
+
+export function BarChartWidgetVisualization(props: BarChartWidgetVisualizationProps) {
+  return (
+    <TimeSeriesWidgetVisualization {...props} SeriesConstructor={BarChartWidgetSeries} />
+  );
+}

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
@@ -3,11 +3,9 @@ import {
   type TimeSeriesWidgetProps,
 } from '../timeSeriesWidget/timeSeriesWidget';
 
-import {LineChartWidgetSeries} from './lineChartWidgetSeries';
-
 export interface LineChartWidgetProps
-  extends Omit<TimeSeriesWidgetProps, 'SeriesConstructor'> {}
+  extends Omit<TimeSeriesWidgetProps, 'visualizationType'> {}
 
 export function LineChartWidget(props: LineChartWidgetProps) {
-  return <TimeSeriesWidget {...props} SeriesConstructor={LineChartWidgetSeries} />;
+  return <TimeSeriesWidget {...props} visualizationType="line" />;
 }

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -1,0 +1,15 @@
+import {
+  TimeSeriesWidgetVisualization,
+  type TimeSeriesWidgetVisualizationProps,
+} from '../timeSeriesWidget/timeSeriesWidgetVisualization';
+
+import {LineChartWidgetSeries} from './lineChartWidgetSeries';
+
+export interface LineChartWidgetVisualizationProps
+  extends Omit<TimeSeriesWidgetVisualizationProps, 'SeriesConstructor'> {}
+
+export function LineChartWidgetVisualization(props: LineChartWidgetVisualizationProps) {
+  return (
+    <TimeSeriesWidgetVisualization {...props} SeriesConstructor={LineChartWidgetSeries} />
+  );
+}

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -3,13 +3,9 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from '../timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {LineChartWidgetSeries} from './lineChartWidgetSeries';
-
 export interface LineChartWidgetVisualizationProps
-  extends Omit<TimeSeriesWidgetVisualizationProps, 'SeriesConstructor'> {}
+  extends Omit<TimeSeriesWidgetVisualizationProps, 'visualizationType'> {}
 
 export function LineChartWidgetVisualization(props: LineChartWidgetVisualizationProps) {
-  return (
-    <TimeSeriesWidgetVisualization {...props} SeriesConstructor={LineChartWidgetSeries} />
-  );
+  return <TimeSeriesWidgetVisualization {...props} visualizationType="line" />;
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -7,28 +7,20 @@ import {
   WidgetFrame,
   type WidgetFrameProps,
 } from 'sentry/views/dashboards/widgets/common/widgetFrame';
-import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {
+  TimeSeriesWidgetVisualization,
+  type TimeSeriesWidgetVisualizationProps,
+} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {AreaChartWidgetVisualization} from '../areaChartWidget/areaChartWidgetVisualization';
-import {BarChartWidgetVisualization} from '../barChartWidget/barChartWidgetVisualization';
 import {MISSING_DATA_MESSAGE, X_GUTTER, Y_GUTTER} from '../common/settings';
 import type {StateProps} from '../common/types';
-import {LineChartWidgetVisualization} from '../lineChartWidget/lineChartWidgetVisualization';
-
-type VisualizationType = 'area' | 'line' | 'bar';
 
 export interface TimeSeriesWidgetProps
   extends StateProps,
     Omit<WidgetFrameProps, 'children'>,
     Partial<TimeSeriesWidgetVisualizationProps> {
-  visualizationType: VisualizationType;
+  visualizationType: TimeSeriesWidgetVisualizationProps['visualizationType'];
 }
-
-const VisualizationComponents: Record<VisualizationType, React.ComponentType<any>> = {
-  area: AreaChartWidgetVisualization,
-  line: LineChartWidgetVisualization,
-  bar: BarChartWidgetVisualization,
-};
 
 export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
   const {timeseries} = props;
@@ -52,8 +44,6 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
 
   const error = props.error ?? parsingError;
 
-  const Visualization = VisualizationComponents[props.visualizationType];
-
   return (
     <WidgetFrame
       title={props.title}
@@ -69,7 +59,8 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
     >
       {defined(timeseries) && (
         <TimeSeriesWrapper>
-          <Visualization
+          <TimeSeriesWidgetVisualization
+            visualizationType={props.visualizationType}
             timeseries={timeseries}
             releases={props.releases}
             aliases={props.aliases}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -7,18 +7,28 @@ import {
   WidgetFrame,
   type WidgetFrameProps,
 } from 'sentry/views/dashboards/widgets/common/widgetFrame';
-import {
-  TimeSeriesWidgetVisualization,
-  type TimeSeriesWidgetVisualizationProps,
-} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
+import {AreaChartWidgetVisualization} from '../areaChartWidget/areaChartWidgetVisualization';
+import {BarChartWidgetVisualization} from '../barChartWidget/barChartWidgetVisualization';
 import {MISSING_DATA_MESSAGE, X_GUTTER, Y_GUTTER} from '../common/settings';
 import type {StateProps} from '../common/types';
+import {LineChartWidgetVisualization} from '../lineChartWidget/lineChartWidgetVisualization';
+
+type VisualizationType = 'area' | 'line' | 'bar';
 
 export interface TimeSeriesWidgetProps
   extends StateProps,
     Omit<WidgetFrameProps, 'children'>,
-    Partial<TimeSeriesWidgetVisualizationProps> {}
+    Partial<TimeSeriesWidgetVisualizationProps> {
+  visualizationType: VisualizationType;
+}
+
+const VisualizationComponents: Record<VisualizationType, React.ComponentType<any>> = {
+  area: AreaChartWidgetVisualization,
+  line: LineChartWidgetVisualization,
+  bar: BarChartWidgetVisualization,
+};
 
 export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
   const {timeseries} = props;
@@ -42,6 +52,8 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
 
   const error = props.error ?? parsingError;
 
+  const Visualization = VisualizationComponents[props.visualizationType];
+
   return (
     <WidgetFrame
       title={props.title}
@@ -55,14 +67,13 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
       error={error}
       onRetry={props.onRetry}
     >
-      {defined(timeseries) && defined(props.SeriesConstructor) && (
+      {defined(timeseries) && (
         <TimeSeriesWrapper>
-          <TimeSeriesWidgetVisualization
+          <Visualization
             timeseries={timeseries}
             releases={props.releases}
             aliases={props.aliases}
             dataCompletenessDelay={props.dataCompletenessDelay}
-            SeriesConstructor={props.SeriesConstructor}
             timeseriesSelection={props.timeseriesSelection}
             onTimeseriesSelectionChange={props.onTimeseriesSelectionChange}
           />

--- a/static/app/views/insights/common/components/insightsAreaChartWidget.tsx
+++ b/static/app/views/insights/common/components/insightsAreaChartWidget.tsx
@@ -8,12 +8,11 @@ import {
   AreaChartWidget,
   type AreaChartWidgetProps,
 } from 'sentry/views/dashboards/widgets/areaChartWidget/areaChartWidget';
-import {AreaChartWidgetSeries} from 'sentry/views/dashboards/widgets/areaChartWidget/areaChartWidgetSeries';
-import type {Aliases} from 'sentry/views/dashboards/widgets/common/types';
 import {
-  TimeSeriesWidgetVisualization,
-  type TimeSeriesWidgetVisualizationProps,
-} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+  AreaChartWidgetVisualization,
+  type AreaChartWidgetVisualizationProps,
+} from 'sentry/views/dashboards/widgets/areaChartWidget/areaChartWidgetVisualization';
+import type {Aliases} from 'sentry/views/dashboards/widgets/common/types';
 
 import {THROUGHPUT_COLOR} from '../../colors';
 import type {DiscoverSeries} from '../queries/useDiscoverSeries';
@@ -31,8 +30,7 @@ export function InsightsAreaChartWidget(props: InsightsAreaChartWidgetProps) {
   const {start, end, period, utc} = pageFilters.selection.datetime;
   const {projects, environments} = pageFilters.selection;
 
-  const visualizationProps: TimeSeriesWidgetVisualizationProps = {
-    SeriesConstructor: AreaChartWidgetSeries,
+  const visualizationProps: AreaChartWidgetVisualizationProps = {
     timeseries: (props.series.filter(Boolean) ?? [])?.map(serie => {
       const timeserie = convertSeriesToTimeseries(serie);
 
@@ -67,7 +65,7 @@ export function InsightsAreaChartWidget(props: InsightsAreaChartWidgetProps) {
                 {({releases}) => {
                   return (
                     <ModalChartContainer>
-                      <TimeSeriesWidgetVisualization
+                      <AreaChartWidgetVisualization
                         {...visualizationProps}
                         releases={
                           releases

--- a/static/app/views/insights/common/components/insightsLineChartWidget.tsx
+++ b/static/app/views/insights/common/components/insightsLineChartWidget.tsx
@@ -8,11 +8,10 @@ import {
   LineChartWidget,
   type LineChartWidgetProps,
 } from 'sentry/views/dashboards/widgets/lineChartWidget/lineChartWidget';
-import {LineChartWidgetSeries} from 'sentry/views/dashboards/widgets/lineChartWidget/lineChartWidgetSeries';
 import {
-  TimeSeriesWidgetVisualization,
-  type TimeSeriesWidgetVisualizationProps,
-} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+  LineChartWidgetVisualization,
+  type LineChartWidgetVisualizationProps,
+} from 'sentry/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization';
 
 import {
   AVG_COLOR,
@@ -37,8 +36,7 @@ export function InsightsLineChartWidget(props: InsightsLineChartWidgetProps) {
   const {start, end, period, utc} = pageFilters.selection.datetime;
   const {projects, environments} = pageFilters.selection;
 
-  const visualizationProps: TimeSeriesWidgetVisualizationProps = {
-    SeriesConstructor: LineChartWidgetSeries,
+  const visualizationProps: LineChartWidgetVisualizationProps = {
     timeseries: (props.series.filter(Boolean) ?? [])?.map(serie => {
       const timeserie = convertSeriesToTimeseries(serie);
 
@@ -74,7 +72,7 @@ export function InsightsLineChartWidget(props: InsightsLineChartWidgetProps) {
                 {({releases}) => {
                   return (
                     <ModalChartContainer>
-                      <TimeSeriesWidgetVisualization
+                      <LineChartWidgetVisualization
                         {...visualizationProps}
                         aliases={props.aliases}
                         releases={


### PR DESCRIPTION
Right now, if you need to use `TimeseriesWidget`, it's a bit awkward. You need to import `TimeseriesWidget` _and_ a series constructor to do this:

```jsx
<TimeseriesWidget
  SeriesConstructor={LineChartWidgetSeries}
  ...
```

If the type is conditional (e.g., in Explore) this sucks, you have to import all three. This PR makes this suck a little less, and makes it less confusing.

`TimeseriesWidget` and `TimeseriesWidgetVisualization` now accept a simple `visualizationType` prop e.g., `visualizationType="area"` which is more intuitive.

Plus, I'm adding specific exports and props for:

- `LineChartWidgetVisualization`
- `AreaChartWidgetVisualization`
- `BarChartWidgetVisualization`

Makes its a little more straight-forward, if this is ever needed.
