### PR TITLE
fix(insights): Stats for mobile insights are empty unless a release is selected a second time

### DIFF
--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -21,6 +21,7 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import {SamplesTables} from 'sentry/views/insights/mobile/appStarts/components/samples';
 import {
@@ -85,12 +86,12 @@ export function ScreenSummaryContentPage() {
   const location = useLocation<Query>();
 
   const {
-    primaryRelease,
-    secondaryRelease,
     transaction: transactionName,
     spanGroup,
     [SpanMetricsField.APP_START_TYPE]: appStartType,
   } = location.query;
+
+  const {primaryRelease, secondaryRelease} = useReleaseSelection();
 
   useEffect(() => {
     // Default the start type to cold start if not present

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -20,6 +20,7 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {SpanSamplesPanel} from 'sentry/views/insights/mobile/common/components/spanSamplesPanel';
@@ -82,12 +83,8 @@ export function ScreenLoadSpansContent() {
   const router = useRouter();
   const location = useLocation<Query>();
 
-  const {
-    spanGroup,
-    primaryRelease,
-    secondaryRelease,
-    transaction: transactionName,
-  } = location.query;
+  const {spanGroup, transaction: transactionName} = location.query;
+  const {primaryRelease, secondaryRelease} = useReleaseSelection();
 
   useSamplesDrawer({
     Component: (
@@ -172,21 +169,25 @@ export function ScreenLoadSpansContent() {
         />
         <SampleContainer>
           <SampleContainerItem>
-            <ScreenLoadEventSamples
-              release={primaryRelease}
-              sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-              cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-              transaction={transactionName}
-              showDeviceClassSelector
-            />
+            {primaryRelease && (
+              <ScreenLoadEventSamples
+                release={primaryRelease}
+                sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+                transaction={transactionName}
+                showDeviceClassSelector
+              />
+            )}
           </SampleContainerItem>
           <SampleContainerItem>
-            <ScreenLoadEventSamples
-              release={secondaryRelease}
-              sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-              cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-              transaction={transactionName}
-            />
+            {secondaryRelease && (
+              <ScreenLoadEventSamples
+                release={secondaryRelease}
+                sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
+                cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
+                transaction={transactionName}
+              />
+            )}
           </SampleContainerItem>
         </SampleContainer>
         <ScreenLoadSpansTable


### PR DESCRIPTION
Right now the top stats for mobile insights (e.g. Avg Cold Start R1) remain empty, unless a release is picked a second time:

https://github.com/user-attachments/assets/088e2945-c3b3-4d7a-8ecf-36b48aa417cb

