### PR TITLE
ref: upgrade types-requests-oauthlib

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -230,7 +230,7 @@ types-pytz==2022.1.2
 types-pyyaml==6.0.11
 types-redis==3.5.18
 types-requests==2.32.0.20241016
-types-requests-oauthlib==2.0.0.20240417
+types-requests-oauthlib==2.0.0.20250119
 types-setuptools==69.0.0.0
 types-simplejson==3.17.7.2
 types-unidiff==0.7.0.20240505

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -58,7 +58,7 @@ types-pyyaml
 # make sure to match close-enough to redis==
 types-redis<4
 types-requests>=2.32.0.20241016
-types-requests-oauthlib
+types-requests-oauthlib>=2.0.0.20250119
 types-setuptools>=68
 types-simplejson>=3.17.7.2
 types-unidiff


### PR DESCRIPTION
fixes a handful of errors in ignored files

such as:

```
src/sentry_plugins/bitbucket/client.py:26: error: Argument "decoding" to "OAuth1" has incompatible type "None"; expected "str"  [arg-type]
```

<!-- Describe your PR here. -->