### PR TITLE
fix(widget-builder): Change default widget display type to line

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -259,8 +259,6 @@ function useWidgetBuilderState(): {
             nextDisplayType = DisplayType.TABLE;
           }
 
-          // should we be setting default display type for other datasets here (Line)?
-
           const config = getDatasetConfig(action.payload);
           setFields(
             config.defaultWidgetQuery.fields?.map(field => explodeField({field}))

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -259,6 +259,8 @@ function useWidgetBuilderState(): {
             nextDisplayType = DisplayType.TABLE;
           }
 
+          // should we be setting default display type for other datasets here (Line)?
+
           const config = getDatasetConfig(action.payload);
           setFields(
             config.defaultWidgetQuery.fields?.map(field => explodeField({field}))

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -4,7 +4,11 @@ import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getD
 
 describe('convertWidgetToBuilderStateParams', () => {
   it('should not pass along yAxis when converting a table to builder params', () => {
-    const widget = {...getDefaultWidget(WidgetType.ERRORS), aggregates: ['count()']};
+    const widget = {
+      ...getDefaultWidget(WidgetType.ERRORS),
+      displayType: DisplayType.TABLE,
+      aggregates: ['count()'],
+    };
     const params = convertWidgetToBuilderStateParams(widget);
     expect(params.yAxis).toEqual([]);
   });
@@ -12,6 +16,7 @@ describe('convertWidgetToBuilderStateParams', () => {
   it('stringifies the fields when converting a table to builder params', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
+      displayType: DisplayType.TABLE,
       queries: [
         {
           aggregates: [],

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.spec.tsx
@@ -6,7 +6,7 @@ describe('getDefaultWidget', () => {
   it('should return a default widget for errors', () => {
     const widget = getDefaultWidget(WidgetType.ERRORS);
     expect(widget).toEqual({
-      displayType: DisplayType.TABLE,
+      displayType: DisplayType.LINE,
       interval: '',
       title: 'Custom Widget',
       widgetType: WidgetType.ERRORS,
@@ -27,7 +27,7 @@ describe('getDefaultWidget', () => {
   it('should return a default widget for spans', () => {
     const widget = getDefaultWidget(WidgetType.SPANS);
     expect(widget).toEqual({
-      displayType: DisplayType.TABLE,
+      displayType: DisplayType.LINE,
       interval: '',
       title: 'Custom Widget',
       widgetType: WidgetType.SPANS,
@@ -69,7 +69,7 @@ describe('getDefaultWidget', () => {
   it('should return a default widget for releases', () => {
     const widget = getDefaultWidget(WidgetType.RELEASE);
     expect(widget).toEqual({
-      displayType: DisplayType.TABLE,
+      displayType: DisplayType.LINE,
       interval: '',
       title: 'Custom Widget',
       widgetType: WidgetType.RELEASE,

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
@@ -1,10 +1,10 @@
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {DisplayType, type Widget, type WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType, type Widget, WidgetType} from 'sentry/views/dashboards/types';
 
 export function getDefaultWidget(widgetType: WidgetType): Widget {
   const config = getDatasetConfig(widgetType);
   return {
-    displayType: DisplayType.TABLE,
+    displayType: widgetType === WidgetType.ISSUE ? DisplayType.TABLE : DisplayType.LINE,
     interval: '',
     title: 'Custom Widget',
     widgetType,


### PR DESCRIPTION
There were suggestions from the bug bash to change the default display type for widgets in the widget builder to be line charts. Now all datasets except for Issues will default to line charts. 
