### PR TITLE
fix(stack-traces): Sorting for stack traces should affect frames, not exceptions

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -227,10 +227,6 @@ export function Content({
     );
   });
 
-  if (newestFirst) {
-    children.reverse();
-  }
-
   return <div>{children}</div>;
 }
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -308,7 +308,7 @@ function Content({
         hideIcon={hideIcon}
       >
         <StyledList data-test-id="frames">
-          {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
+          {!newestFirst ? convertedFrames : convertedFrames.toReversed()}
         </StyledList>
       </StackTraceContentPanel>
     </Wrapper>


### PR DESCRIPTION
When sorting stack traces, there's currently some odd behavior where the sort affects both the exceptions and ordering of the exceptions. Here's a good issue to demonstrate:

https://demo.sentry.io/issues/4188718841/

The raw stacktrace indicates the most deeply nested error, with this change, it will always be shown first, and sorting just affects the frames themselves.