### PR TITLE
feat(deps): Upgrade `@sentry/status-page-list` to `0.6.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@sentry/node": "8.48.0",
     "@sentry/react": "8.48.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/status-page-list": "^0.3.0",
+    "@sentry/status-page-list": "^0.6.0",
     "@sentry/types": "8.48.0",
     "@sentry/utils": "8.48.0",
     "@sentry/webpack-plugin": "^2.22.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3482,10 +3482,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.1.tgz#0ab8be23fd494d80dd0e4ec8ae5f3d13f805b13d"
   integrity sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==
 
-"@sentry/status-page-list@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.3.0.tgz#d5520057007be1a021933aae26dfa6a4a3981c40"
-  integrity sha512-v/MkVOvs48QioXt7Ex8gmZEFGvjukWqx2DlIej+Ac4pVQJAfzF6/DFFVT3IK8/owIqv/IdEhY0XzHOcIB0yBIA==
+"@sentry/status-page-list@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.6.0.tgz#9ae1a2cf0fa5a89f0eefd81e6887c13f15ef6270"
+  integrity sha512-umFIGPsFo8wjT5xLSraUd69GDJhBv8a8YgpAt8zE23SlkFNiWZcDP+Wr6yif2EQvB6Z6i3TmnQcz3mBN1j1kNA==
 
 "@sentry/types@8.48.0":
   version "8.48.0"


### PR DESCRIPTION
https://github.com/getsentry/status-page-list/blob/main/CHANGELOG.md

Adds entries for Jotform, Paubox, SendGrid, Autodesk, Etsy, InfluxData, Loom, Miro, Monday.com, PlanetScale, Pleo, Ravelin, Render, Rippling, Squarespace, Twilio, and Vanta.

Improves entries for Atlassian and Vercel.