### PR TITLE
ref(feedback): add info logs to debug missing_context filter

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -217,6 +217,7 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
                     "has_feedback": feedback != {},
                     "event_type": event.get("type"),
                     "feedback_message": feedback_msg,
+                    "platform": project.platform,
                     "referrer": source.value,
                 },
             )
@@ -247,6 +248,7 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
             extra={
                 "project_id": project_id,
                 "organization_id": project.organization_id,
+                "platform": project.platform,
                 "referrer": source.value,
             },
         )

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, TypedDict
@@ -201,6 +202,24 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
                 "referrer": source.value,
             },
         )
+        # Temporary log for debugging.
+        if random.random() < 0.1:
+            project = Project.objects.get_from_cache(id=project_id)
+            contexts = event.get("contexts", {})
+            feedback = contexts.get("feedback", {})
+            feedback_msg = feedback.get("message")
+            logger.info(
+                "Filtered missing context or message.",
+                extra={
+                    "project_id": project_id,
+                    "organization_id": project.organization_id,
+                    "has_contexts": contexts != {},
+                    "has_feedback": feedback != {},
+                    "event_type": event.get("type"),
+                    "feedback_message": feedback_msg,
+                    "referrer": source.value,
+                },
+            )
         return True
 
     if event["contexts"]["feedback"]["message"] == UNREAL_FEEDBACK_UNATTENDED_MESSAGE:
@@ -218,6 +237,16 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
             "feedback.create_feedback_issue.filtered",
             tags={
                 "reason": "empty",
+                "referrer": source.value,
+            },
+        )
+        # Temporary log for debugging.
+        project = Project.objects.get_from_cache(id=project_id)
+        logger.info(
+            "Filtered empty feedback message.",
+            extra={
+                "project_id": project_id,
+                "organization_id": project.organization_id,
                 "referrer": source.value,
             },
         )


### PR DESCRIPTION
In the last month we saw 85% of new feedback envelopes filtered because they were missing a feedback context or message. 2% filtered because message was present, but empty. These logs will help us get some info on the specific orgs/projects this is happening for.

