### PR TITLE
feat(widget-builder): Aggregates without args take up the entire width

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -97,7 +97,7 @@ describe('Visualize', () => {
     expect(screen.queryAllByRole('button', {name: 'Remove field'})[0]).toBeDisabled();
   });
 
-  it('disables the column selection when the aggregate has no parameters', async () => {
+  it('removes the column selection when the aggregate has no parameters', async () => {
     render(
       <WidgetBuilderProvider>
         <Visualize />
@@ -120,10 +120,10 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'count'}));
 
-    expect(screen.getByRole('button', {name: 'Column Selection'})).toBeDisabled();
+    expect(
+      screen.queryByRole('button', {name: 'Column Selection'})
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toBeEnabled();
-
-    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveValue('');
   });
 
   it('adds the default value for the column selection when the aggregate has parameters', async () => {
@@ -144,8 +144,6 @@ describe('Visualize', () => {
         }),
       }
     );
-
-    expect(screen.getByRole('button', {name: 'Column Selection'})).toBeDisabled();
 
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'p95'}));
@@ -390,9 +388,9 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'count'}));
 
-    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
-      'None'
-    );
+    expect(
+      screen.queryByRole('button', {name: 'Column Selection'})
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
       'count'
     );
@@ -823,9 +821,9 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'count'}));
 
-    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
-      'None'
-    );
+    expect(
+      screen.queryByRole('button', {name: 'Column Selection'})
+    ).not.toBeInTheDocument();
   });
 
   it('uses the provided value for a value parameter field', async () => {


### PR DESCRIPTION
Aggregates that don't have an argument (e.g. `count()`) don't require you to select a column so we're going to not display the column selector. This enables the user so they can start selecting different values instead of seeing a disabled state.

<img width="716" alt="Screenshot 2025-01-21 at 2 18 53 PM" src="https://github.com/user-attachments/assets/6d2f8dd0-ebe1-4361-9a37-d3094ed65c72" />

Next, I'll add support for `apdex` and `user_misery` so they will show a text box below to adjust its parameter.