### PR TITLE
chore(dashboards): Add analytics for dashboards view and favourites

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -48,12 +48,9 @@ export type DashboardsEventParameters = {
   'dashboards_manage.change_view_type': {
     view_type: DashboardsLayout;
   };
-  // TODO(nikki): may not need this one
-  'dashboards_manage.count_favourites': {count: number; user_id: string};
   'dashboards_manage.create.start': {};
   'dashboards_manage.delete': {dashboard_id: number; view_type: DashboardsLayout};
   'dashboards_manage.duplicate': {dashboard_id: number; view_type: DashboardsLayout};
-  'dashboards_manage.favourite': {dashboard_id: string; favourited: boolean};
   'dashboards_manage.paginate': {};
   'dashboards_manage.search': {};
   'dashboards_manage.templates.add': {
@@ -67,6 +64,7 @@ export type DashboardsEventParameters = {
   'dashboards_manage.templates.toggle': {
     show_templates: boolean;
   };
+  'dashboards_manage.toggle_favorite': {dashboard_id: string; favorited: boolean};
   'dashboards_views.open_in_discover.opened': {
     widget_type: string;
   };
@@ -151,15 +149,14 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards_manage.search': 'Dashboards Manager: Search',
   'dashboards_manage.change_sort': 'Dashboards Manager: Sort By Changed',
   'dashboards_manage.change_view_type': 'Dashboards Manager: View Type Toggled',
-  'dashboards_manage.count_favourites': 'Dashboards Manager: Count Favourites',
   'dashboards_manage.create.start': 'Dashboards Manager: Dashboard Create Started',
   'dashboards_manage.delete': 'Dashboards Manager: Dashboard Deleted',
   'dashboards_manage.duplicate': 'Dashboards Manager: Dashboard Duplicated',
-  'dashboards_manage.favourite': 'Dashboards Manager: Dashboard Favourited',
   'dashboards_manage.paginate': 'Dashboards Manager: Paginate',
   'dashboards_manage.templates.toggle': 'Dashboards Manager: Template Toggle Changed',
   'dashboards_manage.templates.add': 'Dashboards Manager: Template Added',
   'dashboards_manage.templates.preview': 'Dashboards Manager: Template Previewed',
+  'dashboards_manage.toggle_favorite': 'Dashboards Manager: Dashboard Favorite Toggled',
   'dashboards_views.widget_viewer.edit': 'Widget Viewer: Edit Widget Modal Opened',
   'dashboards_views.widget_viewer.open': 'Widget Viewer: Opened',
   'dashboards_views.widget_viewer.open_source':

--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -45,9 +45,15 @@ export type DashboardsEventParameters = {
   'dashboards_manage.change_sort': {
     sort: string;
   };
+  'dashboards_manage.change_view_type': {
+    view_type: DashboardsLayout;
+  };
+  // TODO(nikki): may not need this one
+  'dashboards_manage.count_favourites': {count: number; user_id: string};
   'dashboards_manage.create.start': {};
   'dashboards_manage.delete': {dashboard_id: number; view_type: DashboardsLayout};
   'dashboards_manage.duplicate': {dashboard_id: number; view_type: DashboardsLayout};
+  'dashboards_manage.favourite': {dashboard_id: string; favourited: boolean};
   'dashboards_manage.paginate': {};
   'dashboards_manage.search': {};
   'dashboards_manage.templates.add': {
@@ -144,9 +150,12 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards_views.widget_library.opened': 'Dashboards2: Add Widget Library opened',
   'dashboards_manage.search': 'Dashboards Manager: Search',
   'dashboards_manage.change_sort': 'Dashboards Manager: Sort By Changed',
+  'dashboards_manage.change_view_type': 'Dashboards Manager: View Type Toggled',
+  'dashboards_manage.count_favourites': 'Dashboards Manager: Count Favourites',
   'dashboards_manage.create.start': 'Dashboards Manager: Dashboard Create Started',
   'dashboards_manage.delete': 'Dashboards Manager: Dashboard Deleted',
   'dashboards_manage.duplicate': 'Dashboards Manager: Dashboard Duplicated',
+  'dashboards_manage.favourite': 'Dashboards Manager: Dashboard Favourited',
   'dashboards_manage.paginate': 'Dashboards Manager: Paginate',
   'dashboards_manage.templates.toggle': 'Dashboards Manager: Template Toggle Changed',
   'dashboards_manage.templates.add': 'Dashboards Manager: Template Added',

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -220,6 +220,11 @@ function Controls({
                         dashboard.id,
                         !isFavorited
                       );
+                      trackAnalytics('dashboards_manage.favourite', {
+                        organization,
+                        dashboard_id: dashboard.id,
+                        favourited: !isFavorited,
+                      });
                     } catch (error) {
                       // If the api call fails, revert the state
                       setIsFavorited(isFavorited);

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -220,10 +220,10 @@ function Controls({
                         dashboard.id,
                         !isFavorited
                       );
-                      trackAnalytics('dashboards_manage.favourite', {
+                      trackAnalytics('dashboards_manage.toggle_favorite', {
                         organization,
                         dashboard_id: dashboard.id,
-                        favourited: !isFavorited,
+                        favorited: !isFavorited,
                       });
                     } catch (error) {
                       // If the api call fails, revert the state

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -106,10 +106,10 @@ function DashboardGrid({
     try {
       await updateDashboardFavorite(api, organization.slug, dashboard.id, isFavorited);
       onDashboardsChange();
-      trackAnalytics('dashboards_manage.favourite', {
+      trackAnalytics('dashboards_manage.toggle_favorite', {
         organization,
         dashboard_id: dashboard.id,
-        favourited: isFavorited,
+        favorited: isFavorited,
       });
     } catch (error) {
       throw error;

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -106,6 +106,11 @@ function DashboardGrid({
     try {
       await updateDashboardFavorite(api, organization.slug, dashboard.id, isFavorited);
       onDashboardsChange();
+      trackAnalytics('dashboards_manage.favourite', {
+        organization,
+        dashboard_id: dashboard.id,
+        favourited: isFavorited,
+      });
     } catch (error) {
       throw error;
     }

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -98,10 +98,10 @@ function FavoriteButton({
           setFavorited(!favorited);
           await updateDashboardFavorite(api, organization.slug, dashboardId, !favorited);
           onDashboardsChange();
-          trackAnalytics('dashboards_manage.favourite', {
+          trackAnalytics('dashboards_manage.toggle_favorite', {
             organization,
             dashboard_id: dashboardId,
-            favourited: !favorited,
+            favorited: !favorited,
           });
         } catch (error) {
           // If the api call fails, revert the state

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -98,6 +98,11 @@ function FavoriteButton({
           setFavorited(!favorited);
           await updateDashboardFavorite(api, organization.slug, dashboardId, !favorited);
           onDashboardsChange();
+          trackAnalytics('dashboards_manage.favourite', {
+            organization,
+            dashboard_id: dashboardId,
+            favourited: !favorited,
+          });
         } catch (error) {
           // If the api call fails, revert the state
           setFavorited(favorited);

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -264,7 +264,13 @@ function ManageDashboards() {
         />
         <Feature features={'organizations:dashboards-table-view'}>
           <SegmentedControl<DashboardsLayout>
-            onChange={setDashboardsLayout}
+            onChange={newValue => {
+              setDashboardsLayout(newValue);
+              trackAnalytics('dashboards_manage.change_view_type', {
+                organization,
+                view_type: newValue,
+              });
+            }}
             size="md"
             value={dashboardsLayout}
             aria-label={t('Layout Control')}


### PR DESCRIPTION
Adding analytics to:
- see if users toggle between table and grid view + see which view they switch to
- view interaction between the favourite button

Still need to figure out how to add analytics to view how many dashboards a user has favourited...

Contributes to https://github.com/getsentry/sentry/issues/83742