### PR TITLE
ref(replay): add banner to mobile request/response network tab

### DIFF
--- a/static/app/views/replays/detail/network/details/components.tsx
+++ b/static/app/views/replays/detail/network/details/components.tsx
@@ -9,7 +9,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 export const Indent = styled('div')`
-  padding-left: ${space(4)};
+  padding-left: ${space(1)};
+  padding-right: ${space(1)};
 `;
 
 export const InspectorMargin = styled('div')`

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -74,7 +74,20 @@ export function Setup({
 
   const url = item.description || 'http://example.com';
 
-  return isVideoReplay ? null : (
+  return isVideoReplay ? (
+    visibleTab === 'request' || visibleTab === 'response' ? (
+      <StyledAlert type="info" showIcon>
+        {tct(
+          'Request and response headers or bodies are currently not available for mobile platforms. Track this [link:GitHub issue] to get progress on support for this feature.',
+          {
+            link: (
+              <ExternalLink href="https://github.com/getsentry/sentry-react-native/issues/4106" />
+            ),
+          }
+        )}
+      </StyledAlert>
+    ) : null
+  ) : (
     <SetupInstructions
       minVersion="7.53.1"
       sdkNeedsUpdate={sdkNeedsUpdate}
@@ -230,4 +243,8 @@ const StyledInstructions = styled('div')`
   p:last-child {
     margin-bottom: 0;
   }
+`;
+
+const StyledAlert = styled(Alert)`
+  margin: ${space(1)};
 `;


### PR DESCRIPTION
update the mobile replay network tab request & response tabs to show a blue banner:

https://github.com/user-attachments/assets/44583667-06bd-4eb9-abf2-ca9fa16468a6

also updated some margins for consistency

closes https://github.com/getsentry/sentry/issues/83739