### PR TITLE
fix(crons): Correct wording on cron alert row subtitle

### DIFF
--- a/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
+++ b/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
@@ -30,7 +30,7 @@ function LastUptimeIncident({rule}: {rule: UptimeAlert}) {
 function LastCronMonitorIncident({rule}: {rule: CronRule}) {
   // TODO(evanpurkhiser): Would probably be better if we had a way to get the
   // most recent incident.
-  return tct('Expected every [interval]', {
+  return tct('Expected [interval]', {
     interval: scheduleAsText(rule.config),
   });
 }


### PR DESCRIPTION
The "Every" was already part of the interval text