### PR TITLE
chore(settings): Remove early adopter banner on CSP settings page

### DIFF
--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -7,7 +7,6 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
-import PreviewFeature from 'sentry/components/previewFeature';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import formGroups from 'sentry/data/forms/cspReports';
 import {t, tct} from 'sentry/locale';
@@ -91,8 +90,6 @@ export default function ProjectCspReports() {
         title={routeTitleGen(t('Content Security Policy (CSP)'), projectId, false)}
       />
       <SettingsPageHeader title={t('Content Security Policy')} />
-
-      <PreviewFeature />
 
       <ReportUri keyList={keyList} orgId={organization.slug} projectId={projectId} />
 


### PR DESCRIPTION
This settings page has been here for years as far as I know and is not gated on EA:

![CleanShot 2025-01-21 at 12 55 12](https://github.com/user-attachments/assets/2c9caccd-39fb-49d7-8271-baf0686afb0f)
