### PR TITLE
feat(aci): Call alert rule trigger action migration helpers

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule_trigger.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger.py
@@ -45,7 +45,6 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
             alert_rule_trigger = create_alert_rule_trigger(
                 alert_rule=self.context["alert_rule"], **validated_data
             )
-            self._handle_actions(alert_rule_trigger, actions)
 
         except forms.ValidationError as e:
             # if we fail in create_alert_rule_trigger, then only one message is ever returned
@@ -58,6 +57,7 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
             alert_rule_trigger.alert_rule.organization,
         ):
             migrate_metric_data_conditions(alert_rule_trigger)
+        self._handle_actions(alert_rule_trigger, actions)
         return alert_rule_trigger
 
     def update(self, instance, validated_data):

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -1,7 +1,7 @@
 from django.utils.encoding import force_str
 from rest_framework import serializers
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.auth.access import Access
 from sentry.incidents.logic import (
@@ -18,6 +18,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_metric_action
 
 
 class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
@@ -207,6 +208,12 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
             alert_rule_id=getattr(self.context["alert_rule"], "id"),
             organization_id=getattr(self.context["organization"], "id"),
         )
+        if features.has(
+            "organizations:workflow-engine-metric-alert-processing",
+            action.alert_rule_trigger.alert_rule.organization,
+        ):
+            migrate_metric_action(action)
+
         return action
 
     def update(self, instance, validated_data):

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -150,6 +150,9 @@ def migrate_metric_action(
         target_identifier=alert_rule_trigger_action.target_identifier,
         target_type=alert_rule_trigger_action.target_type,
     )
+    ActionAlertRuleTriggerAction.objects.create(
+        action=action, alert_rule_trigger_action=alert_rule_trigger_action
+    )
     data_condition_group_action = DataConditionGroupAction.objects.create(
         condition_group_id=action_filter.condition_group.id,
         action_id=action.id,

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -150,9 +150,6 @@ def migrate_metric_action(
         target_identifier=alert_rule_trigger_action.target_identifier,
         target_type=alert_rule_trigger_action.target_type,
     )
-    ActionAlertRuleTriggerAction.objects.create(
-        action=action, alert_rule_trigger_action=alert_rule_trigger_action
-    )
     data_condition_group_action = DataConditionGroupAction.objects.create(
         condition_group_id=action_filter.condition_group.id,
         action_id=action.id,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -50,9 +50,11 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import Action
 from tests.sentry.workflow_engine.migration_helpers.test_migrate_alert_rule import (
     assert_alert_rule_migrated,
     assert_alert_rule_resolve_trigger_migrated,
+    assert_alert_rule_trigger_action_migrated,
     assert_alert_rule_trigger_migrated,
 )
 
@@ -248,6 +250,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert_alert_rule_trigger_migrated(triggers[0])
         assert_alert_rule_trigger_migrated(triggers[1])
         assert_alert_rule_resolve_trigger_migrated(alert_rule)
+        assert_alert_rule_trigger_action_migrated(triggers[0], Action.Type.EMAIL)
+        assert_alert_rule_trigger_action_migrated(triggers[1], Action.Type.EMAIL)
 
     @with_feature("organizations:slack-metric-alert-description")
     @with_feature("organizations:incidents")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -245,13 +245,16 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         triggers = AlertRuleTrigger.objects.filter(alert_rule_id=alert_rule.id)
+        actions = AlertRuleTriggerAction.objects.filter(
+            alert_rule_trigger__in=[trigger.id for trigger in triggers]
+        )
         assert resp.data == serialize(alert_rule, self.user)
         assert_alert_rule_migrated(alert_rule, self.project.id)
         assert_alert_rule_trigger_migrated(triggers[0])
         assert_alert_rule_trigger_migrated(triggers[1])
         assert_alert_rule_resolve_trigger_migrated(alert_rule)
-        assert_alert_rule_trigger_action_migrated(triggers[0], Action.Type.EMAIL)
-        assert_alert_rule_trigger_action_migrated(triggers[1], Action.Type.EMAIL)
+        assert_alert_rule_trigger_action_migrated(actions[0], Action.Type.EMAIL)
+        assert_alert_rule_trigger_action_migrated(actions[1], Action.Type.EMAIL)
 
     @with_feature("organizations:slack-metric-alert-description")
     @with_feature("organizations:incidents")

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -148,7 +148,7 @@ def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_
     aarta = ActionAlertRuleTriggerAction.objects.get(
         alert_rule_trigger_action=alert_rule_trigger_action
     )
-    action = Action.objects.get(id=aarta.id, type=action_type)
+    action = Action.objects.get(id=aarta.action_id, type=action_type)
     assert DataConditionGroupAction.objects.filter(
         action_id=action.id,
     ).exists()

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -159,7 +159,6 @@ def assert_alert_rule_trigger_action_migrated(alert_rule_trigger, action_type):
     assert Action.objects.filter(
         id__in=[item.action.id for item in data_condition_group_actions], type=action_type
     ).exists()
-
     assert ActionAlertRuleTriggerAction.objects.filter(
         id__in=[item.action.id for item in data_condition_group_actions]
     )
@@ -367,13 +366,13 @@ class AlertRuleMigrationHelpersTest(APITestCase):
         migrate_metric_action(self.alert_rule_trigger_action_sentry_app)
 
         assert_alert_rule_trigger_action_migrated(
-            self.alert_rule_trigger_warning, Action.Type.EMAIL
+            self.alert_rule_trigger_action_email, Action.Type.EMAIL
         )
         assert_alert_rule_trigger_action_migrated(
-            self.alert_rule_trigger_critical, Action.Type.OPSGENIE
+            self.alert_rule_trigger_action_integration, Action.Type.OPSGENIE
         )
         assert_alert_rule_trigger_action_migrated(
-            self.alert_rule_trigger_critical, Action.Type.SENTRY_APP
+            self.alert_rule_trigger_action_sentry_app, Action.Type.SENTRY_APP
         )
 
     @mock.patch("sentry.workflow_engine.migration_helpers.alert_rule.logger")

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -144,24 +144,14 @@ def assert_alert_rule_trigger_migrated(alert_rule_trigger):
     ).exists()
 
 
-def assert_alert_rule_trigger_action_migrated(alert_rule_trigger, action_type):
-    action_filters = DataCondition.objects.filter(
-        comparison__in=[
-            DetectorPriorityLevel.MEDIUM,
-            DetectorPriorityLevel.HIGH,
-        ]
+def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_type):
+    aarta = ActionAlertRuleTriggerAction.objects.get(
+        alert_rule_trigger_action=alert_rule_trigger_action
     )
-    data_condition_group_actions = DataConditionGroupAction.objects.filter(
-        condition_group_id__in=[
-            action_filter.condition_group.id for action_filter in action_filters
-        ]
-    )
-    assert Action.objects.filter(
-        id__in=[item.action.id for item in data_condition_group_actions], type=action_type
+    action = Action.objects.get(id=aarta.id, type=action_type)
+    assert DataConditionGroupAction.objects.filter(
+        action_id=action.id,
     ).exists()
-    assert ActionAlertRuleTriggerAction.objects.filter(
-        id__in=[item.action.id for item in data_condition_group_actions]
-    )
 
 
 class AlertRuleMigrationHelpersTest(APITestCase):


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/83623 to call the alert rule trigger action creation migration helpers. 

Closes https://getsentry.atlassian.net/browse/ACI-76