### PR TITLE
ref(alerts): Simplify combined alert rules endpoint test

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -13,70 +13,53 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.types.actor import Actor
 from sentry.uptime.models import ProjectUptimeSubscriptionMode, UptimeStatus
-from sentry.utils import json
 from tests.sentry.incidents.endpoints.serializers.test_alert_rule import BaseAlertRuleSerializerTest
 
 
 class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):
     endpoint = "sentry-api-0-organization-combined-rules"
 
-    def test_no_cron_monitor_rules(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        self.create_alert_rule()
-        Rule.objects.create(
-            project=self.project,
-            label="Generic rule",
-        )
-        cron_rule = Rule.objects.create(
-            project=self.project,
-            label="Cron Rule",
-            source=RuleSource.CRON_MONITOR,
-        )
+    def setUp(self) -> None:
+        super().setUp()
 
-        self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
-
-        # 3 because there is a default rule created
-        assert len(resp.data) == 3
-        assert cron_rule.id not in (r["id"] for r in resp.data), resp.data
-
-    def test_no_perf_alerts(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
-        self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
-            assert perf_alert_rule.id not in [x["id"] for x in list(resp.data)]
-
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_success_response(self.organization.slug)
-            assert perf_alert_rule.id in [int(x["id"]) for x in list(resp.data)]
-
-    def setup_project_and_rules(self):
-        self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(
-            organization=self.org, name="Mariachi Band", members=[self.user]
+            organization=self.organization,
+            name="Mariachi Band",
+            members=[self.user],
         )
-        self.team2 = self.create_team(organization=self.org, name="Folk Band", members=[self.user])
-        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
-        self.login_as(self.user)
+        self.team2 = self.create_team(
+            organization=self.organization,
+            name="Folk Band",
+            members=[self.user],
+        )
+        self.project = self.create_project(
+            organization=self.organization,
+            teams=[self.team],
+            name="Bengal",
+        )
         self.project2 = self.create_project(
-            organization=self.org, teams=[self.team], name="Elephant"
+            organization=self.organization,
+            teams=[self.team],
+            name="Elephant",
         )
+
         self.projects = [self.project, self.project2]
         self.project_ids = [str(self.project.id), str(self.project2.id)]
+
+        self.login_as(self.user)
+        self.combined_rules_url = f"/api/0/organizations/{self.organization.slug}/combined-rules/"
+
+    def setup_rules(self):
         self.alert_rule = self.create_alert_rule(
             name="alert rule",
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             date_added=before_now(minutes=6),
             owner=Actor.from_id(user_id=None, team_id=self.team.id),
         )
-        self.other_alert_rule = self.create_alert_rule(
+        self.alert_rule_2 = self.create_alert_rule(
             name="other alert rule",
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project2],
             date_added=before_now(minutes=5),
             owner=Actor.from_id(user_id=None, team_id=self.team.id),
@@ -91,36 +74,64 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "date_added": before_now(minutes=4),
             }
         )
-        self.yet_another_alert_rule = self.create_alert_rule(
+        self.alert_rule_team2 = self.create_alert_rule(
             name="yet another alert rule",
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             date_added=before_now(minutes=3),
             owner=Actor.from_id(user_id=None, team_id=self.team2.id),
         )
-        self.combined_rules_url = f"/api/0/organizations/{self.org.slug}/combined-rules/"
+
+    def test_no_cron_monitor_rules(self):
+        """
+        Tests that the shadow cron monitor rules are NOT returned as part of
+        the the list of alert rules.
+        """
+        self.create_alert_rule()
+        cron_rule = Rule.objects.create(
+            project=self.project,
+            label="Cron Rule",
+            source=RuleSource.CRON_MONITOR,
+        )
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_success_response(self.organization.slug)
+
+        assert len(resp.data) == 1
+        assert cron_rule.id not in (r["id"] for r in resp.data), resp.data
+
+    def test_no_perf_alerts(self):
+        self.create_alert_rule()
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
+        with self.feature("organizations:incidents"):
+            resp = self.get_success_response(self.organization.slug)
+            assert perf_alert_rule.id not in [x["id"] for x in list(resp.data)]
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_success_response(self.organization.slug)
+            assert perf_alert_rule.id in [int(x["id"]) for x in list(resp.data)]
 
     def test_simple(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {"per_page": "10", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 4
-        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_team2, result[0], skip_dates=True)
         assert result[1]["id"] == str(self.issue_rule.id)
         assert result[1]["type"] == "rule"
-        self.assert_alert_rule_serialized(self.other_alert_rule, result[2], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_2, result[2], skip_dates=True)
         self.assert_alert_rule_serialized(self.alert_rule, result[3], skip_dates=True)
 
     def test_snoozed_rules(self):
         """
         Test that we properly serialize snoozed rules with and without an owner
         """
-        self.setup_project_and_rules()
+        self.setup_rules()
         issue_rule2 = self.create_issue_alert_rule(
             data={
                 "project": self.project2,
@@ -135,7 +146,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.snooze_rule(user_id=self.user.id, rule=issue_rule2, owner_id=self.user.id)
         self.snooze_rule(user_id=self.user.id, alert_rule=self.alert_rule)
         self.snooze_rule(
-            user_id=self.user.id, alert_rule=self.yet_another_alert_rule, owner_id=self.user.id
+            user_id=self.user.id, alert_rule=self.alert_rule_team2, owner_id=self.user.id
         )
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -144,9 +155,9 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 5
-        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_team2, result[0], skip_dates=True)
         assert result[0]["snooze"]
 
         assert result[1]["id"] == str(issue_rule2.id)
@@ -157,14 +168,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert result[2]["type"] == "rule"
         assert result[2]["snooze"]
 
-        self.assert_alert_rule_serialized(self.other_alert_rule, result[3], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_2, result[3], skip_dates=True)
         assert not result[3].get("snooze")
 
         self.assert_alert_rule_serialized(self.alert_rule, result[4], skip_dates=True)
         assert result[4]["snooze"]
 
     def test_invalid_limit(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {"per_page": "notaninteger"}
             response = self.client.get(
@@ -173,7 +184,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert response.status_code == 400
 
     def test_limit_higher_than_results_no_cursor(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         # Test limit above result count (which is 4), no cursor.
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {"per_page": "5", "project": self.project_ids}
@@ -181,16 +192,16 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 4
-        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_team2, result[0], skip_dates=True)
         assert result[1]["id"] == str(self.issue_rule.id)
         assert result[1]["type"] == "rule"
-        self.assert_alert_rule_serialized(self.other_alert_rule, result[2], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_2, result[2], skip_dates=True)
         self.assert_alert_rule_serialized(self.alert_rule, result[3], skip_dates=True)
 
     def test_limit_as_1_with_paging_sort_name(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         # Test Limit as 1, no cursor:
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {
@@ -203,7 +214,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
         self.assert_alert_rule_serialized(self.alert_rule, result[0], skip_dates=True)
         links = requests.utils.parse_header_links(
@@ -223,7 +234,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
         assert result[0]["id"] == str(self.issue_rule.id)
         assert result[0]["type"] == "rule"
@@ -234,7 +245,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             organization=self.org, name="Mariachi Band", members=[self.user]
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
-        self.login_as(self.user)
         alert_rule = self.create_alert_rule(
             name="!1?",
             organization=self.org,
@@ -265,7 +275,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 content_type="application/json",
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
         self.assert_alert_rule_serialized(alert_rule, result[0], skip_dates=True)
         links = requests.utils.parse_header_links(
@@ -283,12 +293,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             }
             response = self.client.get(path=url, data=request_data, content_type="application/json")
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
         assert result[0]["id"] == str(alert_rule1.id)
 
     def test_limit_as_1_with_paging(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         # Test Limit as 1, no cursor:
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -298,9 +308,9 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
-        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_team2, result[0], skip_dates=True)
 
         links = requests.utils.parse_header_links(
             response.get("link", "").rstrip(">").replace(">,<", ",<")
@@ -314,13 +324,13 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
         assert result[0]["id"] == str(self.issue_rule.id)
         assert result[0]["type"] == "rule"
 
     def test_limit_as_2_with_paging(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         # Test Limit as 2, no cursor:
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -330,9 +340,9 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
-        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_team2, result[0], skip_dates=True)
         assert result[1]["id"] == str(self.issue_rule.id)
         assert result[1]["type"] == "rule"
 
@@ -348,9 +358,9 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
-        self.assert_alert_rule_serialized(self.other_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_2, result[0], skip_dates=True)
         self.assert_alert_rule_serialized(self.alert_rule, result[1], skip_dates=True)
 
         links = requests.utils.parse_header_links(
@@ -366,25 +376,25 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 0
 
     def test_offset_pagination(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         date_added = before_now(minutes=1)
-        self.one_alert_rule = self.create_alert_rule(
-            organization=self.org,
+        one_alert_rule = self.create_alert_rule(
+            organization=self.organization,
             projects=[self.project, self.project2],
             date_added=date_added,
         )
-        self.two_alert_rule = self.create_alert_rule(
-            organization=self.org,
+        two_alert_rule = self.create_alert_rule(
+            organization=self.organization,
             projects=[self.project2],
             date_added=date_added,
         )
-        self.three_alert_rule = self.create_alert_rule(
-            organization=self.org, projects=[self.project]
+        three_alert_rule = self.create_alert_rule(
+            organization=self.organization, projects=[self.project]
         )
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -394,10 +404,10 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
-        self.assert_alert_rule_serialized(self.three_alert_rule, result[0], skip_dates=True)
-        self.assert_alert_rule_serialized(self.one_alert_rule, result[1], skip_dates=True)
+        self.assert_alert_rule_serialized(three_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(one_alert_rule, result[1], skip_dates=True)
 
         links = requests.utils.parse_header_links(
             response.get("link", "").rstrip(">").replace(">,<", ",<")
@@ -412,28 +422,28 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
 
-        self.assert_alert_rule_serialized(self.two_alert_rule, result[0], skip_dates=True)
-        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[1], skip_dates=True)
+        self.assert_alert_rule_serialized(two_alert_rule, result[0], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule_team2, result[1], skip_dates=True)
 
     def test_filter_by_project(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         date_added = before_now(minutes=1)
-        self.one_alert_rule = self.create_alert_rule(
-            organization=self.org,
+        one_alert_rule = self.create_alert_rule(
+            organization=self.organization,
             projects=[self.project, self.project2],
             date_added=date_added,
         )
-        self.two_alert_rule = self.create_alert_rule(
-            organization=self.org,
+        two_alert_rule = self.create_alert_rule(
+            organization=self.organization,
             projects=[self.project],
             date_added=date_added,
         )
-        self.three_alert_rule = self.create_alert_rule(
-            organization=self.org, projects=[self.project2]
+        three_alert_rule = self.create_alert_rule(
+            organization=self.organization, projects=[self.project2]
         )
         proj_uptime_monitor = self.create_project_uptime_subscription(project=self.project)
         proj2_uptime_monitor = self.create_project_uptime_subscription(project=self.project2)
@@ -454,14 +464,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
 
         assert [r["id"] for r in result] == [
             f"{proj_cron_monitor.guid}",
             f"{proj_uptime_monitor.id}",
-            f"{self.one_alert_rule.id}",
-            f"{self.two_alert_rule.id}",
-            f"{self.yet_another_alert_rule.id}",
+            f"{one_alert_rule.id}",
+            f"{two_alert_rule.id}",
+            f"{self.alert_rule_team2.id}",
             f"{self.issue_rule.id}",
             f"{self.alert_rule.id}",
         ]
@@ -479,13 +489,13 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
         assert response.status_code == 200
 
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{proj2_cron_monitor.guid}",
             f"{proj2_uptime_monitor.id}",
-            f"{self.three_alert_rule.id}",
-            f"{self.one_alert_rule.id}",
-            f"{self.other_alert_rule.id}",
+            f"{three_alert_rule.id}",
+            f"{one_alert_rule.id}",
+            f"{self.alert_rule_2.id}",
         ]
 
         other_org = self.create_organization()
@@ -506,14 +516,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             assert response.data["detail"] == "You do not have permission to perform this action."
 
     def test_team_filter(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {"per_page": "10", "project": [self.project.id]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 3
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -526,7 +536,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -539,7 +549,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -552,7 +562,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 3
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -561,11 +571,11 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 1
 
-        self.an_unassigned_alert_rule = self.create_alert_rule(
-            organization=self.org,
+        an_unassigned_alert_rule = self.create_alert_rule(
+            organization=self.organization,
             projects=[self.project],
             date_added=before_now(minutes=3),
             owner=None,
@@ -576,7 +586,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -592,7 +602,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -605,10 +615,10 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 3
 
-        self.issue_rule2 = self.create_issue_alert_rule(
+        issue_rule2 = self.create_issue_alert_rule(
             data={
                 "project": self.project,
                 "name": "Issue Rule Test",
@@ -629,7 +639,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 2
 
         team_uptime_monitor = self.create_project_uptime_subscription(
@@ -666,11 +676,11 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
 
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{team_cron_monitor.guid}",
             f"{team_uptime_monitor.id}",
-            f"{self.issue_rule2.id}",
+            f"{issue_rule2.id}",
             f"{self.alert_rule.id}",
         ]
 
@@ -690,11 +700,11 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{unowned_cron_monitor.guid}",
             f"{unowned_uptime_monitor.id}",
-            f"{self.an_unassigned_alert_rule.id}",
+            f"{an_unassigned_alert_rule.id}",
             f"{self.issue_rule.id}",
         ]
 
@@ -752,7 +762,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert len(response.data) == 2  # We are not on this team, but we are a superuser.
 
     def test_team_filter_no_cross_org_access(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         another_org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         another_org_team = self.create_team(organization=another_org, name="Meow Band", members=[])
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -769,16 +779,16 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert response.data[0]["owner"] == f"team:{self.team.id}"
 
     def test_team_filter_no_access(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         # disable Open Membership
-        self.org.flags.allow_joinleave = False
-        self.org.save()
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
 
         user2 = self.create_user("bulldog@example.com")
-        team2 = self.create_team(organization=self.org, name="Barking Voices")
-        project2 = self.create_project(organization=self.org, teams=[team2], name="Bones")
-        self.create_member(user=user2, organization=self.org, role="member", teams=[team2])
+        team2 = self.create_team(organization=self.organization, name="Barking Voices")
+        project2 = self.create_project(organization=self.organization, teams=[team2], name="Bones")
+        self.create_member(user=user2, organization=self.organization, role="member", teams=[team2])
         self.login_as(user2)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -796,7 +806,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
 
     def test_name_filter(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         uptime_monitor = self.create_project_uptime_subscription(name="Uptime")
         another_uptime_monitor = self.create_project_uptime_subscription(name="yet another Uptime")
         cron_monitor = self.create_monitor(name="Cron")
@@ -818,11 +828,11 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{another_cron_monitor.guid}",
             f"{another_uptime_monitor.id}",
-            f"{self.yet_another_alert_rule.id}",
+            f"{self.alert_rule_team2.id}",
         ]
 
         with self.feature(
@@ -840,7 +850,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [f"{self.issue_rule.id}"]
 
         with self.feature(
@@ -858,7 +868,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 3
 
         with self.feature(
@@ -876,7 +886,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 0
 
         with self.feature(
@@ -894,7 +904,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 4
 
         with self.feature(
@@ -912,7 +922,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{another_uptime_monitor.id}",
             f"{uptime_monitor.id}",
@@ -934,17 +944,17 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{another_cron_monitor.guid}",
             f"{cron_monitor.guid}",
         ]
 
     def test_status_and_date_triggered_sort_order(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         alert_rule_critical = self.create_alert_rule(
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             name="some rule [crit]",
             query="",
@@ -955,7 +965,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             threshold_period=1,
         )
         another_alert_rule_warning = self.create_alert_rule(
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             name="another warning rule",
             query="",
@@ -966,7 +976,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             threshold_period=1,
         )
         alert_rule_warning = self.create_alert_rule(
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             name="warning rule",
             query="",
@@ -1044,7 +1054,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         # Assert failed uptime monitor is first, critical rule is next, then warnings (sorted by triggered date),
         # then issue rules and finally uptime monitors in ok status.
         assert [r["id"] for r in result] == [
@@ -1054,8 +1064,8 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             f"{another_alert_rule_warning.id}",
             f"{alert_rule_warning.id}",
             f"{self.alert_rule.id}",
-            f"{self.other_alert_rule.id}",
-            f"{self.yet_another_alert_rule.id}",
+            f"{self.alert_rule_2.id}",
+            f"{self.alert_rule_team2.id}",
             f"{self.issue_rule.id}",
             f"{uptime_monitor.id}",
             f"{ok_cron_monitor.guid}",
@@ -1078,7 +1088,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{failed_uptime_monitor.id}",
             f"{failed_cron_monitor.guid}",
@@ -1107,7 +1117,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{another_alert_rule_warning.id}",
             f"{alert_rule_warning.id}",
@@ -1115,7 +1125,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         ]
 
     def test_uptime_feature(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         uptime_monitor = self.create_project_uptime_subscription(name="Uptime Monitor")
         other_uptime_monitor = self.create_project_uptime_subscription(
             name="Other Uptime Monitor",
@@ -1130,14 +1140,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             path=self.combined_rules_url, data=request_data, content_type="application/json"
         )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert [r["id"] for r in result] == [
             f"{other_uptime_monitor.id}",
             f"{uptime_monitor.id}",
         ]
 
     def test_uptime_feature_name_sort(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         self.create_project_uptime_subscription(name="Uptime Monitor")
         self.create_project_uptime_subscription(
             name="Other Uptime Monitor",
@@ -1152,7 +1162,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             path=self.combined_rules_url, data=request_data, content_type="application/json"
         )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert [r["name"] for r in result] == [
             "yet another alert rule",
             "Uptime Monitor",
@@ -1162,10 +1172,10 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         ]
 
     def test_expand_latest_incident(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
 
         alert_rule_critical = self.create_alert_rule(
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             name="some rule [crit]",
             query="",
@@ -1192,16 +1202,16 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 200, response.content
-        result = json.loads(response.content)
+        result = response.data
         assert len(result) == 4
         assert result[0]["latestIncident"]["id"] == str(crit_incident.id)
 
     def test_non_existing_owner(self):
-        self.setup_project_and_rules()
+        self.setup_rules()
         team = self.create_team(organization=self.organization, members=[self.user])
         alert_rule = self.create_alert_rule(
             name="the best rule",
-            organization=self.org,
+            organization=self.organization,
             projects=[self.project],
             date_added=before_now(minutes=1),
             owner=Actor.from_id(user_id=None, team_id=team.id),
@@ -1230,8 +1240,16 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
     @freeze_time()
     def test_last_triggered(self):
-        self.login_as(user=self.user)
-        rule = Rule.objects.filter(project=self.project).get()
+        rule = self.create_issue_alert_rule(
+            data={
+                "project": self.project,
+                "name": "Issue Rule Test",
+                "conditions": [],
+                "actions": [],
+                "actionMatch": "all",
+                "date_added": before_now(minutes=4),
+            }
+        )
         resp = self.get_success_response(self.organization.slug, expand=["lastTriggered"])
         assert resp.data[0]["lastTriggered"] is None
         RuleFireHistory.objects.create(project=self.project, rule=rule, group=self.group)
@@ -1245,7 +1263,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         team = self.create_team(organization=org, name="Mariachi Band", members=[self.user])
         delete_project = self.create_project(organization=org, teams=[team], name="Bengal")
-        self.login_as(self.user)
         self.create_project_rule(project=delete_project)
 
         deletion = RegionScheduledDeletion.schedule(delete_project, days=0)
@@ -1258,7 +1275,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
     def test_active_and_disabled_rules(self):
         """Test that we return both active and disabled rules"""
-        self.setup_project_and_rules()
+        self.setup_rules()
         disabled_alert = self.create_project_rule(name="disabled rule")
         disabled_alert.status = ObjectStatus.DISABLED
         disabled_alert.save()
@@ -1272,11 +1289,9 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 assert data["status"] == "disabled"
 
     def test_dataset_filter(self):
-        self.create_team(organization=self.organization, members=[self.user])
         self.create_alert_rule(dataset=Dataset.Metrics)
         transaction_rule = self.create_alert_rule(dataset=Dataset.Transactions)
         events_rule = self.create_alert_rule(dataset=Dataset.Events)
-        self.login_as(self.user)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             transactions_res = self.get_success_response(


### PR DESCRIPTION
- splits the team / project setup into setUp
- Removes a bunch of self.* assignment when unnecessary