### PR TITLE
fix(select): Use correct key in compact select region

### DIFF
--- a/static/app/components/compactSelect/composite.spec.tsx
+++ b/static/app/components/compactSelect/composite.spec.tsx
@@ -310,4 +310,29 @@ describe('CompactSelect', function () {
     await userEvent.keyboard('{ArrowDown>2}');
     expect(screen.getByRole('row', {name: 'Choice One'})).toHaveFocus();
   });
+
+  it('can use numbers as values', async function () {
+    const onChange = jest.fn();
+    render(
+      <CompositeSelect>
+        <CompositeSelect.Region
+          label="Region 1"
+          defaultValue={1}
+          onChange={onChange}
+          options={[
+            {value: 1, label: 'One'},
+            {value: 2, label: 'Two'},
+          ]}
+        />
+      </CompositeSelect>
+    );
+
+    // Open the menu
+    await userEvent.click(screen.getByRole('button'));
+
+    // Select 2
+    await userEvent.click(screen.getByRole('option', {name: 'Two'}));
+
+    expect(onChange).toHaveBeenCalledWith({value: 2, label: 'Two'});
+  });
 });

--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -179,8 +179,8 @@ function Region<Value extends SelectKey>({
       size={size}
       label={label}
     >
-      {(opt: SelectOption<Value>) => (
-        <Item {...opt} key={opt.value}>
+      {(opt: (typeof itemsWithKey)[number]) => (
+        <Item {...opt} key={opt.key}>
           {opt.label}
         </Item>
       )}


### PR DESCRIPTION
Using compact select regions with numbers as values was returning null because the change in  https://github.com/getsentry/sentry/pull/83345/files#diff-07cd789a0ce8846e516b16e697da51cccaa73d39b3423cbcb36869046b819f4aR183 was incorrectly setting the key.

fixes JAVASCRIPT-2XFB
fixes JAVASCRIPT-2XCT
