### PR TITLE
lint(eslint): Enable no-unused-expressions rule and fix violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -425,7 +425,6 @@ export default typescript.config([
       '@typescript-eslint/no-require-imports': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/no-this-alias': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/no-unsafe-function-type': 'off', // TODO(ryan953): Fix violations and delete this line
-      '@typescript-eslint/no-unused-expressions': 'off', // TODO(ryan953): Fix violations and delete this line
 
       // Strict overrides
       '@typescript-eslint/no-dynamic-delete': 'off', // TODO(ryan953): Fix violations and delete this line

--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -214,7 +214,7 @@ class Client implements ApiNamespace.Client {
       this.request(path, {
         ...options,
         success: (data, ...args) => {
-          includeAllArgs ? resolve([data, ...args]) : resolve(data);
+          resolve(includeAllArgs ? [data, ...args] : data);
         },
         error: (error, ..._args) => {
           reject(error);

--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -73,7 +73,9 @@ function Alert({
     ) {
       return;
     }
-    showExpand && setIsExpanded(!isExpanded);
+    if (showExpand) {
+      setIsExpanded(!isExpanded);
+    }
   }
 
   return (

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -149,9 +149,11 @@ class AvatarChooser extends Component<Props, State> {
       },
       error: resp => {
         const avatarPhotoErrors = resp?.responseJSON?.avatar_photo || [];
-        avatarPhotoErrors.length
-          ? avatarPhotoErrors.map(this.handleError)
-          : this.handleError.bind(this, t('There was an error saving your preferences.'));
+        if (avatarPhotoErrors.length) {
+          avatarPhotoErrors.map(this.handleError);
+        } else {
+          this.handleError.bind(this, t('There was an error saving your preferences.'));
+        }
       },
     });
   };

--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -87,7 +87,9 @@ function GridList({
     e => {
       const continueCallback = keyDownHandler?.(e);
       // Prevent grid list from clearing value on Escape key press
-      continueCallback && e.key !== 'Escape' && gridProps.onKeyDown?.(e);
+      if (continueCallback && e.key !== 'Escape') {
+        gridProps.onKeyDown?.(e);
+      }
     },
     [keyDownHandler, gridProps]
   );

--- a/static/app/components/compactSelect/listBox/index.tsx
+++ b/static/app/components/compactSelect/listBox/index.tsx
@@ -135,7 +135,9 @@ const ListBox = forwardRef<HTMLUListElement, ListBoxProps>(function ListBox(
     e => {
       const continueCallback = keyDownHandler?.(e);
       // Prevent list box from clearing value on Escape key press
-      continueCallback && e.key !== 'Escape' && listBoxProps.onKeyDown?.(e);
+      if (continueCallback && e.key !== 'Escape') {
+        listBoxProps.onKeyDown?.(e);
+      }
     },
     [keyDownHandler, listBoxProps]
   );

--- a/static/app/components/devtoolbar/components/replay/replayPanel.tsx
+++ b/static/app/components/devtoolbar/components/replay/replayPanel.tsx
@@ -43,7 +43,11 @@ export default function ReplayPanel() {
         disabled={isDisabled || buttonLoading}
         onClick={async () => {
           setButtonLoading(true);
-          isRecordingSession ? await stopRecording() : await startRecordingSession();
+          if (isRecordingSession) {
+            await stopRecording();
+          } else {
+            await startRecordingSession();
+          }
           setButtonLoading(false);
           const type = isRecordingSession ? 'stop' : 'start';
           trackAnalytics?.({

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -222,7 +222,11 @@ export function EventFeatureFlagList({
               ref={viewAllButtonRef}
               title={t('View All Flags')}
               onClick={() => {
-                isDrawerOpen ? closeDrawer() : onViewAllFlags();
+                if (isDrawerOpen) {
+                  closeDrawer();
+                } else {
+                  onViewAllFlags();
+                }
               }}
             >
               {t('View All')}

--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -84,11 +84,12 @@ function Filter({
         toggleOperationNameFilter(opt.value);
 
         // Don't send individual analytics events if user clicked on the "Clear" button
-        selectedOpts.length !== 0 &&
+        if (selectedOpts.length !== 0) {
           trackAnalytics('performance_views.event_details.filter_by_op', {
             organization,
             operation: opt.label,
           });
+        }
       }
     });
   }

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
@@ -796,8 +796,9 @@ class NewTraceDetailsSpanTree extends Component<PropType> {
     }
 
     const limitExceededMessage = this.generateLimitExceededMessage();
-    limitExceededMessage &&
+    if (limitExceededMessage) {
       spanTree.push({type: SpanTreeNodeType.MESSAGE, element: limitExceededMessage});
+    }
 
     return (
       <TraceViewContainer>

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -275,9 +275,11 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
       () => {
         const {measure, span, addExpandedSpan, removeExpandedSpan} = this.props;
 
-        this.state.showDetail
-          ? addExpandedSpan(span, measure)
-          : removeExpandedSpan(span, measure);
+        if (this.state.showDetail) {
+          addExpandedSpan(span, measure);
+        } else {
+          removeExpandedSpan(span, measure);
+        }
       }
     );
   };

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -156,10 +156,11 @@ export default function SpanSiblingGroupBar(props: SpanSiblingGroupBarProps) {
       generateBounds={generateBounds}
       toggleSpanGroup={() => {
         toggleSiblingSpanGroup?.(spanGrouping[0]!.span, occurrence);
-        isEmbeddedSpanTree &&
+        if (isEmbeddedSpanTree) {
           trackAnalytics('issue_details.performance.autogrouped_siblings_toggle', {
             organization,
           });
+        }
       }}
       renderSpanTreeConnector={renderSpanTreeConnector}
       renderGroupSpansTitle={renderGroupSpansTitle}

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -759,8 +759,9 @@ class SpanTree extends Component<PropType> {
     }
 
     const limitExceededMessage = this.generateLimitExceededMessage();
-    limitExceededMessage &&
+    if (limitExceededMessage) {
       spanTree.push({type: SpanTreeNodeType.MESSAGE, element: limitExceededMessage});
+    }
 
     return (
       <TraceViewContainer ref={this.props.traceViewRef}>

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -495,14 +495,14 @@ class SpanTreeModel {
               acc.previousSiblingEndTimestamp = spanModel.span.timestamp;
 
               // It's possible that a section in the minimap is selected so some spans in this group may be out of view
-              if (bounds.isSpanVisibleInView) {
-                acc.descendants.push(enhancedSibling);
-              } else {
-                acc.descendants.push({
-                  type: 'filtered_out',
-                  span: spanModel.span,
-                });
-              }
+              acc.descendants.push(
+                bounds.isSpanVisibleInView
+                  ? enhancedSibling
+                  : {
+                      type: 'filtered_out',
+                      span: spanModel.span,
+                    }
+              );
             }
           });
 

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -495,12 +495,14 @@ class SpanTreeModel {
               acc.previousSiblingEndTimestamp = spanModel.span.timestamp;
 
               // It's possible that a section in the minimap is selected so some spans in this group may be out of view
-              bounds.isSpanVisibleInView
-                ? acc.descendants.push(enhancedSibling)
-                : acc.descendants.push({
-                    type: 'filtered_out',
-                    span: spanModel.span,
-                  });
+              if (bounds.isSpanVisibleInView) {
+                acc.descendants.push(enhancedSibling);
+              } else {
+                acc.descendants.push({
+                  type: 'filtered_out',
+                  span: spanModel.span,
+                });
+              }
             }
           });
 

--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -161,7 +161,9 @@ export function HybridFilter<Value extends SelectKey>({
   const onKeyUp = useCallback(() => setModifierKeyPressed(false), []);
   const onKeyDown = useCallback(
     (e: any) => {
-      e.key === 'Escape' && commitStagedChanges();
+      if (e.key === 'Escape') {
+        commitStagedChanges();
+      }
       setModifierKeyPressed(isModifierKeyPressed(e));
     },
     [commitStagedChanges]
@@ -323,7 +325,9 @@ export function HybridFilter<Value extends SelectKey>({
 
       // A modifier key is being pressed --> enter multiple selection mode
       if (multiple && modifierKeyPressed) {
-        !modifierTipSeen && setModifierTipSeen(true);
+        if (!modifierTipSeen) {
+          setModifierTipSeen(true);
+        }
         toggleOption(diff[0]!);
         return;
       }

--- a/static/app/components/projects/missingProjectMembership.tsx
+++ b/static/app/components/projects/missingProjectMembership.tsx
@@ -105,7 +105,11 @@ class MissingProjectMembership extends Component<Props, State> {
       if (!team) {
         return;
       }
-      team.isPending ? pending.push(team.slug) : request.push(team.slug);
+      if (team.isPending) {
+        pending.push(team.slug);
+      } else {
+        request.push(team.slug);
+      }
     });
 
     return [request, pending];

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -195,21 +195,21 @@ function WebVitalData({
       const elements: ReactNode[] = [];
       if ('nodeIds' in attr && Array.isArray(attr.nodeIds)) {
         attr.nodeIds.forEach(nodeId => {
-          selectors.get(nodeId)
-            ? elements.push(
-                <span
-                  key={nodeId}
-                  onMouseEnter={() => onMouseEnter(frame, nodeId)}
-                  onMouseLeave={() => onMouseLeave(frame, nodeId)}
-                >
-                  <ValueObjectKey>{t('element')}</ValueObjectKey>
-                  <span>{': '}</span>
-                  <span>
-                    <SelectorButton>{selectors.get(nodeId)}</SelectorButton>
-                  </span>
+          if (selectors.get(nodeId)) {
+            elements.push(
+              <span
+                key={nodeId}
+                onMouseEnter={() => onMouseEnter(frame, nodeId)}
+                onMouseLeave={() => onMouseLeave(frame, nodeId)}
+              >
+                <ValueObjectKey>{t('element')}</ValueObjectKey>
+                <span>{': '}</span>
+                <span>
+                  <SelectorButton>{selectors.get(nodeId)}</SelectorButton>
                 </span>
-              )
-            : null;
+              </span>
+            );
+          }
         });
       }
       // if we can't find the elements associated with the layout shift, we still show the score with element: unknown

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -22,7 +22,9 @@ export default function ReplayProcessingError({className, processingErrors}: Pro
     Sentry.withScope(scope => {
       scope.setLevel('warning');
       scope.setFingerprint(['replay-processing-error']);
-      sdk && scope.setTag('sdk.version', sdk.version);
+      if (sdk) {
+        scope.setTag('sdk.version', sdk.version);
+      }
       processingErrors.forEach(error => {
         Sentry.metrics.increment(`replay.processing-error`, 1, {
           tags: {

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -100,7 +100,9 @@ export function treeResultLocator<T>({
         break;
       case Token.KEY_AGGREGATE:
         nodeVisitor(token.name);
-        token.args && nodeVisitor(token.args);
+        if (token.args) {
+          nodeVisitor(token.args);
+        }
         nodeVisitor(token.argsSpaceBefore);
         nodeVisitor(token.argsSpaceAfter);
         break;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -207,10 +207,14 @@ function SidebarItem({
   const handleItemClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       setExpandedItemId(null);
-      !(to || href) && event.preventDefault();
+      if (!to && !href) {
+        event.preventDefault();
+      }
       recordAnalytics();
       onClick?.(id, event);
-      showIsNew && localStorage.setItem(isNewSeenKey, 'true');
+      if (showIsNew) {
+        localStorage.setItem(isNewSeenKey, 'true');
+      }
     },
     [href, to, id, onClick, recordAnalytics, showIsNew, isNewSeenKey, setExpandedItemId]
   );

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -247,7 +247,9 @@ export function TimeRangeSelector({
   );
 
   const commitChanges = useCallback(() => {
-    showRelative && setShowAbsoluteSelector(false);
+    if (showRelative) {
+      setShowAbsoluteSelector(false);
+    }
     setSearch('');
 
     if (!hasChanges) {

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -370,7 +370,6 @@ function getNpmPackage(siblingOption: string): string {
 }
 
 function getSiblingName(siblingOption: string): string {
-  siblingOption;
   switch (siblingOption) {
     case SiblingOption.ANGULARV10:
     case SiblingOption.ANGULARV12:
@@ -386,7 +385,6 @@ function getSiblingName(siblingOption: string): string {
 }
 
 function getSiblingImportName(siblingOption: string): string {
-  siblingOption;
   switch (siblingOption) {
     case SiblingOption.ANGULARV10:
     case SiblingOption.ANGULARV12:

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -167,11 +167,12 @@ const storeConfig: GuideStoreDefinition = {
     // map server guide state (i.e. seen status) with guide content
     const guides = guidesContent.reduce((acc: Guide[], content) => {
       const serverGuide = data.find(guide => guide.guide === content.guide);
-      serverGuide &&
+      if (serverGuide) {
         acc.push({
           ...content,
           ...serverGuide,
         });
+      }
       return acc;
     }, []);
 

--- a/static/app/utils/eventDispatcher.tsx
+++ b/static/app/utils/eventDispatcher.tsx
@@ -22,7 +22,11 @@ export default class EventDispatcher implements EventTarget {
   public dispatchEvent(event: Event): boolean {
     this.callbacks.get(event.type)?.forEach(cb => {
       try {
-        'handleEvent' in cb ? cb.handleEvent(event) : cb(event);
+        if ('handleEvent' in cb) {
+          cb.handleEvent(event);
+        } else {
+          cb(event);
+        }
       } catch (err) {
         // TODO: A callback failed, but we need to keep going
       }

--- a/static/app/utils/logging.tsx
+++ b/static/app/utils/logging.tsx
@@ -8,6 +8,10 @@ export function logException(ex: Error, context?: any): void {
 
     Sentry.captureException(ex);
   });
-  /* eslint no-console:0 */
-  window.console && console.error && console.error(ex);
+
+  // eslint-disable-next-line no-console
+  if (window.console && console.error) {
+    // eslint-disable-next-line no-console
+    console.error(ex);
+  }
 }

--- a/static/app/utils/performance/contexts/genericQueryBatcher.tsx
+++ b/static/app/utils/performance/contexts/genericQueryBatcher.tsx
@@ -199,12 +199,14 @@ export function GenericQueryBatcher({children}: {children: React.ReactNode}) {
   };
 
   // Cleanup timeout after component unmounts.
-  useEffect(
-    () => () => {
-      timeoutRef.current && window.clearTimeout(timeoutRef.current);
-    },
-    []
-  );
+  useEffect(() => {
+    const cleanup = () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+    return cleanup;
+  }, []);
 
   return (
     <GenericQueryBatcherProvider

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -246,7 +246,9 @@ export function useVirtualizedTree<T extends TreeLike>(
         return;
       }
       const scrollTop = Math.max(0, evt.target.scrollTop);
-      raf !== undefined && window.cancelAnimationFrame(raf);
+      if (raf !== undefined) {
+        window.cancelAnimationFrame(raf);
+      }
 
       raf = window.requestAnimationFrame(() => {
         dispatch({type: 'set scroll top', payload: scrollTop});

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -151,7 +151,9 @@ function useOverlay({
     isOpen,
     defaultOpen,
     onOpenChange: open => {
-      open && popperUpdate?.();
+      if (open) {
+        popperUpdate?.();
+      }
       onOpenChange?.(open);
     },
   });

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -309,9 +309,11 @@ class RuleNodeList extends Component<Props> {
           placeholder={placeholder}
           value={null}
           onChange={(obj: any) => {
-            additionalAction && obj === additionalAction.option
-              ? additionalAction.onClick()
-              : onAddRow(obj.value);
+            if (additionalAction && obj === additionalAction.option) {
+              additionalAction.onClick();
+            } else {
+              onAddRow(obj.value);
+            }
           }}
           options={options}
           disabled={disabled}

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -112,13 +112,15 @@ function EditAccessSelector({
     ) {
       newSelectedValues = ['_creator'];
     } else {
-      areAllTeamsSelected
-        ? // selecting all teams deselects 'all users'
-          (newSelectedValues = ['_creator', '_allUsers', ...teamIds])
-        : // deselecting any team deselects 'all users'
-          (newSelectedValues = newSelectedValues.filter(
-            (value: any) => value !== '_allUsers'
-          ));
+      if (areAllTeamsSelected) {
+        // selecting all teams deselects 'all users'
+        newSelectedValues = ['_creator', '_allUsers', ...teamIds];
+      } else {
+        // deselecting any team deselects 'all users'
+        newSelectedValues = newSelectedValues.filter(
+          (value: any) => value !== '_allUsers'
+        );
+      }
     }
 
     setSelectedOptions(newSelectedValues);

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -547,7 +547,7 @@ function WidgetBuilder({
   function handleDisplayTypeOrAnnotationChange<
     F extends keyof Pick<State, 'displayType' | 'title' | 'description'>,
   >(field: F, value: State[F]) {
-    value &&
+    if (value) {
       trackAnalytics('dashboards_views.widget_builder.change', {
         from: source,
         field,
@@ -556,7 +556,7 @@ function WidgetBuilder({
         organization,
         new_widget: !isEditing,
       });
-
+    }
     setState(prevState => {
       const newState = cloneDeep(prevState);
       set(newState, field, value);

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -171,7 +171,7 @@ function WidgetCardContextMenu({
               size="xs"
               icon={<IconExpand />}
               onClick={() => {
-                (seriesData || tableData) &&
+                if (seriesData || tableData) {
                   setData({
                     seriesData,
                     tableData,
@@ -179,6 +179,7 @@ function WidgetCardContextMenu({
                     totalIssuesCount,
                     seriesResultsType,
                   });
+                }
                 openWidgetViewerPath(index);
               }}
             />

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -77,24 +77,18 @@ class WidgetLegendSelectionState {
         return widgetLegend;
       });
 
-      if (isInQuery) {
-        router.replace({
-          query: {
-            ...location.query,
-            unselectedSeries: newLegendQuery,
-          },
-        });
-      } else {
-        router.replace({
-          query: {
-            ...location.query,
-            unselectedSeries: [
-              ...location.query.unselectedSeries,
-              this.encodeLegendQueryParam(widget, selected),
-            ],
-          },
-        });
-      }
+      const unselectedSeries = isInQuery
+        ? newLegendQuery
+        : [
+            ...location.query.unselectedSeries,
+            this.encodeLegendQueryParam(widget, selected),
+          ];
+      router.replace({
+        query: {
+          ...location.query,
+          unselectedSeries,
+        },
+      });
     } else {
       if (location.query.unselectedSeries?.includes(widget.id!)) {
         router.replace({

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -77,22 +77,24 @@ class WidgetLegendSelectionState {
         return widgetLegend;
       });
 
-      !isInQuery
-        ? router.replace({
-            query: {
-              ...location.query,
-              unselectedSeries: [
-                ...location.query.unselectedSeries,
-                this.encodeLegendQueryParam(widget, selected),
-              ],
-            },
-          })
-        : router.replace({
-            query: {
-              ...location.query,
-              unselectedSeries: newLegendQuery,
-            },
-          });
+      if (isInQuery) {
+        router.replace({
+          query: {
+            ...location.query,
+            unselectedSeries: newLegendQuery,
+          },
+        });
+      } else {
+        router.replace({
+          query: {
+            ...location.query,
+            unselectedSeries: [
+              ...location.query.unselectedSeries,
+              this.encodeLegendQueryParam(widget, selected),
+            ],
+          },
+        });
+      }
     } else {
       if (location.query.unselectedSeries?.includes(widget.id!)) {
         router.replace({

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -269,11 +269,11 @@ export function TraceBreakdownRenderer({
             offset={index}
             onMouseEnter={() => {
               setHoveredIndex(index);
-              breakdown.project
-                ? setHighlightedSliceName(
-                    getStylingSliceName(breakdown.project, breakdown.sdkName) ?? ''
-                  )
-                : null;
+              if (breakdown.project) {
+                setHighlightedSliceName(
+                  getStylingSliceName(breakdown.project, breakdown.sdkName) ?? ''
+                );
+              }
             }}
           />
         );

--- a/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
+++ b/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
@@ -44,9 +44,11 @@ export function formatMongoDBQuery(query: string, command: string) {
 
     // Push the bolded entry into tokens so it is the first entry displayed.
     // The other tokens will be pushed into tempTokens, and then copied into tokens afterwards
-    isBoldedEntry
-      ? tokens.push(jsonEntryToToken(key, val, true))
-      : tempTokens.push(jsonEntryToToken(key, val));
+    if (isBoldedEntry) {
+      tokens.push(jsonEntryToToken(key, val, true));
+    } else {
+      tempTokens.push(jsonEntryToToken(key, val));
+    }
   });
 
   if (tokens.length === 1 && tempTokens.length > 0) {

--- a/static/app/views/metrics/utils/index.tsx
+++ b/static/app/views/metrics/utils/index.tsx
@@ -97,9 +97,11 @@ export function updateQueryWithSeriesFilter(
     if (!defined(value)) {
       return;
     }
-    updateType === MetricSeriesFilterUpdateType.ADD
-      ? addToFilter(mutableSearch, key, value)
-      : excludeFromFilter(mutableSearch, key, value);
+    if (updateType === MetricSeriesFilterUpdateType.ADD) {
+      addToFilter(mutableSearch, key, value);
+    } else {
+      excludeFromFilter(mutableSearch, key, value);
+    }
   });
 
   const extendedQuery = mutableSearch.formatString();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -135,16 +135,18 @@ export function SpanDescription({
             projectID: node.event?.projectID,
           })}
           onClick={() => {
-            hasNewSpansUIFlag
-              ? trackAnalytics('trace.trace_layout.view_span_summary', {
-                  organization,
-                  module: resolvedModule,
-                })
-              : trackAnalytics('trace.trace_layout.view_similar_spans', {
-                  organization,
-                  module: resolvedModule,
-                  source: 'span_description',
-                });
+            if (hasNewSpansUIFlag) {
+              trackAnalytics('trace.trace_layout.view_span_summary', {
+                organization,
+                module: resolvedModule,
+              });
+            } else {
+              trackAnalytics('trace.trace_layout.view_similar_spans', {
+                organization,
+                module: resolvedModule,
+                source: 'span_description',
+              });
+            }
           }}
         >
           <StyledIconGraph type="scatter" size="xs" />
@@ -392,16 +394,18 @@ function LegacySpanDescription({
             projectID: node.event?.projectID,
           })}
           onClick={() => {
-            hasNewSpansUIFlag
-              ? trackAnalytics('trace.trace_layout.view_span_summary', {
-                  organization,
-                  module: resolvedModule,
-                })
-              : trackAnalytics('trace.trace_layout.view_similar_spans', {
-                  organization,
-                  module: resolvedModule,
-                  source: 'span_description',
-                });
+            if (hasNewSpansUIFlag) {
+              trackAnalytics('trace.trace_layout.view_span_summary', {
+                organization,
+                module: resolvedModule,
+              });
+            } else {
+              trackAnalytics('trace.trace_layout.view_similar_spans', {
+                organization,
+                module: resolvedModule,
+                source: 'span_description',
+              });
+            }
           }}
         >
           {hasNewSpansUIFlag ? t('More Samples') : t('View Similar Spans')}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -547,9 +547,11 @@ function TraceDrawerTab(props: TraceDrawerTabProps) {
         onClick={e => {
           e.stopPropagation();
           traceAnalytics.trackTabPin(organization);
-          props.pinned
-            ? props.traceDispatch({type: 'unpin tab', payload: props.index})
-            : props.traceDispatch({type: 'pin tab'});
+          if (props.pinned) {
+            props.traceDispatch({type: 'unpin tab', payload: props.index});
+          } else {
+            props.traceDispatch({type: 'pin tab'});
+          }
         }}
       />
     </Tab>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -547,11 +547,9 @@ function TraceDrawerTab(props: TraceDrawerTabProps) {
         onClick={e => {
           e.stopPropagation();
           traceAnalytics.trackTabPin(organization);
-          if (props.pinned) {
-            props.traceDispatch({type: 'unpin tab', payload: props.index});
-          } else {
-            props.traceDispatch({type: 'pin tab'});
-          }
+          props.traceDispatch(
+            props.pinned ? {type: 'unpin tab', payload: props.index} : {type: 'pin tab'}
+          );
         }}
       />
     </Tab>

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
@@ -125,8 +125,12 @@ export function collectTraceMeasurements(
       vitals.set(node, []);
     }
 
-    WEB_VITALS_LOOKUP.has(measurement) && vital_types.add('web');
-    MOBILE_VITALS_LOOKUP.has(measurement) && vital_types.add('mobile');
+    if (WEB_VITALS_LOOKUP.has(measurement)) {
+      vital_types.add('web');
+    }
+    if (MOBILE_VITALS_LOOKUP.has(measurement)) {
+      vital_types.add('mobile');
+    }
 
     const score = Math.round(
       (measurements[`score.${measurement}`]!?.value /

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1407,8 +1407,12 @@ export class VirtualizedViewManager {
   // DRAW METHODS
 
   hideSpanBar(span_bar: this['span_bars'][0], span_text: this['span_text'][0]) {
-    span_bar && (span_bar.ref.style.transform = 'translate(-10000px, -10000px)');
-    span_text && (span_text.ref.style.transform = 'translate(-10000px, -10000px)');
+    if (span_bar) {
+      span_bar.ref.style.transform = 'translate(-10000px, -10000px)';
+    }
+    if (span_text) {
+      span_text.ref.style.transform = 'translate(-10000px, -10000px)';
+    }
   }
 
   hideSpanArrow(span_arrow: this['span_arrows'][0]) {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -56,7 +56,11 @@ export function TraceTransactionRow(
                 expanded={props.node.expanded || props.node.zoomedIn}
                 onDoubleClick={props.onExpandDoubleClick}
                 onClick={e => {
-                  props.node.canFetch ? props.onZoomIn(e) : props.onExpand(e);
+                  if (props.node.canFetch) {
+                    props.onZoomIn(e);
+                  } else {
+                    props.onExpand(e);
+                  }
                 }}
               >
                 {props.node.children.length > 0

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -135,7 +135,9 @@ export function searchInTraceTreeTokens(
           bool = token;
           if (stack.length < 2) {
             Sentry.captureMessage('Unbalanced tree - missing left or right token');
-            typeof handle.id === 'number' && window.cancelAnimationFrame(handle.id);
+            if (typeof handle.id === 'number') {
+              window.cancelAnimationFrame(handle.id);
+            }
             cb([[], resultLookup, null]);
             return;
           }
@@ -154,7 +156,9 @@ export function searchInTraceTreeTokens(
       Sentry.captureMessage(
         'Invalid state in searchInTraceTreeTokens, missing boolean token'
       );
-      typeof handle.id === 'number' && window.cancelAnimationFrame(handle.id);
+      if (typeof handle.id === 'number') {
+        window.cancelAnimationFrame(handle.id);
+      }
       cb([[], resultLookup, null]);
       return;
     }
@@ -162,7 +166,9 @@ export function searchInTraceTreeTokens(
       Sentry.captureMessage(
         'Invalid state in searchInTraceTreeTokens, missing left or right token'
       );
-      typeof handle.id === 'number' && window.cancelAnimationFrame(handle.id);
+      if (typeof handle.id === 'number') {
+        window.cancelAnimationFrame(handle.id);
+      }
       cb([[], resultLookup, null]);
       return;
     }
@@ -337,7 +343,9 @@ function booleanResult(
   if (operator === BooleanOperator.AND) {
     const result = new Map();
     for (const [key, value] of left) {
-      right.has(key) && result.set(key, value);
+      if (right.has(key)) {
+        result.set(key, value);
+      }
     }
     return result;
   }

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -54,7 +54,11 @@ export default class Subscriptions extends Component<Props> {
 
   onChange = (resource: Resource, checked: boolean) => {
     const events = new Set(this.props.events);
-    checked ? events.add(resource) : events.delete(resource);
+    if (checked) {
+      events.add(resource);
+    } else {
+      events.delete(resource);
+    }
     this.save(Array.from(events));
   };
 

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -260,7 +260,9 @@ export class SentryAppExternalForm extends Component<Props, State> {
     );
 
     // If there is a default choice prepopulate the select with it
-    defaultValue ? this.model.setValue(field.name, defaultValue) : '';
+    if (defaultValue) {
+      this.model.setValue(field.name, defaultValue);
+    }
 
     return choices || [];
   };

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -61,8 +61,12 @@ function ProjectAlertSettings({canEditRule, params}: ProjectAlertSettingsProps) 
     return (
       <LoadingError
         onRetry={() => {
-          isProjectError && refetchProject();
-          isPluginListError && refetchPluginList();
+          if (isProjectError) {
+            refetchProject();
+          }
+          if (isPluginListError) {
+            refetchPluginList();
+          }
         }}
       />
     );

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -280,11 +280,11 @@ export function TraceBreakdownRenderer({
             offset={index}
             onMouseEnter={() => {
               setHoveredIndex(index);
-              breakdown.project
-                ? setHighlightedSliceName(
-                    getStylingSliceName(breakdown.project, breakdown.sdkName) ?? ''
-                  )
-                : null;
+              if (breakdown.project) {
+                setHighlightedSliceName(
+                  getStylingSliceName(breakdown.project, breakdown.sdkName) ?? ''
+                );
+              }
             }}
           />
         );


### PR DESCRIPTION
Lots of it is stuff like `isDrawerOpen ? closeDrawer() : onViewAllFlags();` becoming a proper if-statement

But there's also some nuggets in here that make me think this rule is worth enabling. Check the comments

Surprisingly everything was using curlies with their fat-arrows. I only saw `() => {...}` and never raw expressions returned like `() => ...`. So adding if-statements was easy enough, and i think readability is improved in each case.