### PR TITLE
feat(autofix): UX improvements

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -35,16 +35,22 @@ type AutofixChangesProps = {
   groupId: string;
   runId: string;
   step: AutofixChangesStep;
+  previousDefaultStepIndex?: number;
+  previousInsightCount?: number;
 };
 
 function AutofixRepoChange({
   change,
   groupId,
   runId,
+  previousDefaultStepIndex,
+  previousInsightCount,
 }: {
   change: AutofixCodebaseChange;
   groupId: string;
   runId: string;
+  previousDefaultStepIndex?: number;
+  previousInsightCount?: number;
 }) {
   return (
     <Content>
@@ -60,6 +66,8 @@ function AutofixRepoChange({
         runId={runId}
         repoId={change.repo_external_id}
         editable={!change.pull_request}
+        previousDefaultStepIndex={previousDefaultStepIndex}
+        previousInsightCount={previousInsightCount}
       />
     </Content>
   );
@@ -305,7 +313,13 @@ function SetupAndCreatePRsButton({
   return <CreatePRsButton changes={changes} groupId={groupId} runId={runId} />;
 }
 
-export function AutofixChanges({step, groupId, runId}: AutofixChangesProps) {
+export function AutofixChanges({
+  step,
+  groupId,
+  runId,
+  previousDefaultStepIndex,
+  previousInsightCount,
+}: AutofixChangesProps) {
   const data = useAutofixData({groupId});
 
   const {mutate: sendFeedbackOnChanges} = useUpdateInsightCard({groupId, runId});
@@ -397,41 +411,65 @@ export function AutofixChanges({step, groupId, runId}: AutofixChangesProps) {
                   />
                 </ButtonBar>
               ) : prsMade ? (
-                <StyledScrollCarousel aria-label={t('View pull requests')}>
-                  {step.changes.map(
-                    change =>
-                      change.pull_request?.pr_url && (
-                        <LinkButton
-                          key={`${change.repo_external_id}-${Math.random()}`}
-                          size="xs"
-                          priority="primary"
-                          icon={<IconOpen size="xs" />}
-                          href={change.pull_request.pr_url}
-                          external
-                        >
-                          View PR in {change.repo_name}
-                        </LinkButton>
-                      )
-                  )}
-                </StyledScrollCarousel>
+                step.changes.length === 1 &&
+                step.changes[0] &&
+                step.changes[0].pull_request?.pr_url ? (
+                  <LinkButton
+                    size="xs"
+                    priority="primary"
+                    icon={<IconOpen size="xs" />}
+                    href={step.changes[0].pull_request.pr_url}
+                    external
+                  >
+                    View PR in {step.changes[0].repo_name}
+                  </LinkButton>
+                ) : (
+                  <StyledScrollCarousel aria-label={t('View pull requests')}>
+                    {step.changes.map(
+                      change =>
+                        change.pull_request?.pr_url && (
+                          <LinkButton
+                            key={`${change.repo_external_id}-${Math.random()}`}
+                            size="xs"
+                            priority="primary"
+                            icon={<IconOpen size="xs" />}
+                            href={change.pull_request.pr_url}
+                            external
+                          >
+                            View PR in {change.repo_name}
+                          </LinkButton>
+                        )
+                    )}
+                  </StyledScrollCarousel>
+                )
               ) : branchesMade ? (
-                <StyledScrollCarousel aria-label={t('Check out branches')}>
-                  {step.changes.map(
-                    change =>
-                      change.branch_name && (
-                        <BranchButton
-                          key={`${change.repo_external_id}-${Math.random()}`}
-                          change={change}
-                        />
-                      )
-                  )}
-                </StyledScrollCarousel>
+                step.changes.length === 1 && step.changes[0] ? (
+                  <BranchButton change={step.changes[0]} />
+                ) : (
+                  <StyledScrollCarousel aria-label={t('Check out branches')}>
+                    {step.changes.map(
+                      change =>
+                        change.branch_name && (
+                          <BranchButton
+                            key={`${change.repo_external_id}-${Math.random()}`}
+                            change={change}
+                          />
+                        )
+                    )}
+                  </StyledScrollCarousel>
+                )
               ) : null}
             </HeaderWrapper>
             {step.changes.map((change, i) => (
               <Fragment key={change.repo_external_id}>
                 {i > 0 && <Separator />}
-                <AutofixRepoChange change={change} groupId={groupId} runId={runId} />
+                <AutofixRepoChange
+                  change={change}
+                  groupId={groupId}
+                  runId={runId}
+                  previousDefaultStepIndex={previousDefaultStepIndex}
+                  previousInsightCount={previousInsightCount}
+                />
               </Fragment>
             ))}
           </ClippedBox>

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -4,12 +4,14 @@ import {type Change, diffWords} from 'diff';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
+import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
 import {
   type DiffLine,
   DiffLineType,
   type FilePatch,
 } from 'sentry/components/events/autofix/types';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
+import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
 import TextArea from 'sentry/components/forms/controls/textarea';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {IconChevron, IconClose, IconDelete, IconEdit} from 'sentry/icons';
@@ -23,6 +25,8 @@ type AutofixDiffProps = {
   editable: boolean;
   groupId: string;
   runId: string;
+  previousDefaultStepIndex?: number;
+  previousInsightCount?: number;
   repoId?: string;
 };
 
@@ -539,24 +543,53 @@ function FileDiff({
   );
 }
 
-export function AutofixDiff({diff, groupId, runId, repoId, editable}: AutofixDiffProps) {
+export function AutofixDiff({
+  diff,
+  groupId,
+  runId,
+  repoId,
+  editable,
+  previousDefaultStepIndex,
+  previousInsightCount,
+}: AutofixDiffProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selection = useTextSelection(containerRef);
+
   if (!diff || !diff.length) {
     return null;
   }
 
   return (
-    <DiffsColumn>
-      {diff.map(file => (
-        <FileDiff
-          key={file.path}
-          file={file}
+    <div>
+      {selection && (
+        <AutofixHighlightPopup
+          selectedText={selection.selectedText}
+          referenceElement={selection.referenceElement}
           groupId={groupId}
           runId={runId}
-          repoId={repoId}
-          editable={editable}
+          stepIndex={previousDefaultStepIndex ?? 0}
+          retainInsightCardIndex={
+            previousInsightCount !== undefined && previousInsightCount >= 0
+              ? previousInsightCount - 1
+              : -1
+          }
         />
-      ))}
-    </DiffsColumn>
+      )}
+      <div ref={containerRef}>
+        <DiffsColumn>
+          {diff.map(file => (
+            <FileDiff
+              key={file.path}
+              file={file}
+              groupId={groupId}
+              runId={runId}
+              repoId={repoId}
+              editable={editable}
+            />
+          ))}
+        </DiffsColumn>
+      </div>
+    </div>
   );
 }
 

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -158,7 +158,7 @@ const Container = styled(motion.div)`
   background: ${p => p.theme.background};
   border: 1px dashed ${p => p.theme.border};
   overflow: hidden;
-  box-shadow: ${p => p.theme.dropShadowMedium};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
 
   &:before {
     content: '';
@@ -225,14 +225,13 @@ const Arrow = styled('div')`
   position: absolute;
   width: 12px;
   height: 12px;
-  background: ${p => p.theme.active}10;
+  background: ${p => p.theme.active}01;
   border: 1px dashed ${p => p.theme.border};
   border-right: none;
   border-bottom: none;
   top: 20px;
   right: -6px;
   transform: rotate(135deg);
-  box-shadow: ${p => p.theme.dropShadowLight};
 `;
 
 function getScrollParents(element: HTMLElement): Element[] {

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -1,0 +1,253 @@
+import {useLayoutEffect, useRef, useState} from 'react';
+import {createPortal} from 'react-dom';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {SeerIcon} from 'sentry/components/ai/SeerIcon';
+import {Button} from 'sentry/components/button';
+import {useUpdateInsightCard} from 'sentry/components/events/autofix/autofixInsightCards';
+import Input from 'sentry/components/input';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import testableTransition from 'sentry/utils/testableTransition';
+
+interface Props {
+  groupId: string;
+  referenceElement: HTMLElement | null;
+  retainInsightCardIndex: number | null;
+  runId: string;
+  selectedText: string;
+  stepIndex: number;
+}
+
+function AutofixHighlightPopup({
+  selectedText,
+  groupId,
+  runId,
+  stepIndex,
+  retainInsightCardIndex,
+  referenceElement,
+}: Props) {
+  const {mutate: updateInsight} = useUpdateInsightCard({groupId, runId});
+  const [comment, setComment] = useState('');
+  const popupRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({left: 0, top: 0});
+
+  const truncatedText =
+    selectedText.length > 70
+      ? selectedText.slice(0, 35).split(' ').slice(0, -1).join(' ') +
+        '... ...' +
+        selectedText.slice(-35)
+      : selectedText;
+
+  useLayoutEffect(() => {
+    if (!referenceElement || !popupRef.current) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const rect = referenceElement.getBoundingClientRect();
+      setPosition({
+        left: rect.left - 320,
+        top: rect.top,
+      });
+    };
+
+    // Initial position
+    updatePosition();
+
+    // Create observer to track reference element changes
+    const resizeObserver = new ResizeObserver(updatePosition);
+    resizeObserver.observe(referenceElement);
+
+    // Track scroll events
+    const scrollElements = [window, ...getScrollParents(referenceElement)];
+    scrollElements.forEach(element => {
+      element.addEventListener('scroll', updatePosition, {passive: true});
+    });
+  }, [referenceElement]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!comment.trim()) {
+      return;
+    }
+    updateInsight({
+      message: comment,
+      step_index: stepIndex,
+      retain_insight_card_index: retainInsightCardIndex,
+    });
+    setComment('');
+  };
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return createPortal(
+    <Wrapper
+      ref={popupRef}
+      id="autofix-rethink-input"
+      data-popup="autofix-highlight"
+      initial={{opacity: 0, x: -10}}
+      animate={{opacity: 1, x: 0}}
+      exit={{opacity: 0, x: -10}}
+      transition={testableTransition({
+        duration: 0.2,
+      })}
+      style={{
+        left: `${position.left}px`,
+        top: `${position.top}px`,
+        transform: 'none',
+      }}
+      onClick={handleContainerClick}
+    >
+      <Arrow />
+      <ScaleContainer>
+        <Container onClick={handleContainerClick}>
+          <Header>
+            <StyledSeerIcon size="md" />
+            <SelectedText>
+              <span>"{truncatedText}"</span>
+            </SelectedText>
+          </Header>
+          <InputWrapper onSubmit={handleSubmit}>
+            <StyledInput
+              placeholder={t('Questions or comments?')}
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              size="sm"
+              autoFocus
+            />
+            <StyledButton size="sm" type="submit" borderless>
+              {t('>')}
+            </StyledButton>
+          </InputWrapper>
+        </Container>
+      </ScaleContainer>
+    </Wrapper>,
+    document.body
+  );
+}
+
+const Wrapper = styled(motion.div)`
+  z-index: ${p => p.theme.zIndex.tooltip};
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-right: ${space(1)};
+  gap: ${space(1)};
+  width: 300px;
+  position: fixed;
+  will-change: transform;
+`;
+
+const ScaleContainer = styled(motion.div)`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  transform-origin: top left;
+  padding-left: ${space(2)};
+`;
+
+const Container = styled(motion.div)`
+  position: relative;
+  width: 100%;
+  border-radius: ${p => p.theme.borderRadius};
+  background: ${p => p.theme.background};
+  border: 1px dashed ${p => p.theme.border};
+  overflow: hidden;
+  box-shadow: ${p => p.theme.dropShadowMedium};
+
+  &:before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      ${p => p.theme.active}20,
+      transparent
+    );
+    background-size: 2000px 100%;
+    pointer-events: none;
+  }
+`;
+
+const InputWrapper = styled('form')`
+  display: flex;
+  gap: ${space(0.25)};
+  padding: ${space(0.25)} ${space(0.25)};
+  background: ${p => p.theme.backgroundSecondary};
+`;
+
+const StyledInput = styled(Input)`
+  flex-grow: 1;
+  background: ${p => p.theme.background}
+    linear-gradient(to left, ${p => p.theme.background}, ${p => p.theme.pink400}20);
+  border-color: ${p => p.theme.innerBorder};
+
+  &:hover {
+    border-color: ${p => p.theme.border};
+  }
+`;
+
+const StyledButton = styled(Button)`
+  flex-shrink: 0;
+`;
+
+const Header = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  padding: ${space(1)};
+  background: ${p => p.theme.backgroundSecondary};
+`;
+
+const StyledSeerIcon = styled(SeerIcon)`
+  flex-shrink: 0;
+`;
+
+const SelectedText = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  display: flex;
+  align-items: center;
+
+  span {
+    overflow: wrap;
+    white-space: wrap;
+  }
+`;
+
+const Arrow = styled('div')`
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: ${p => p.theme.active}10;
+  border: 1px dashed ${p => p.theme.border};
+  border-right: none;
+  border-bottom: none;
+  top: 20px;
+  right: -6px;
+  transform: rotate(135deg);
+  box-shadow: ${p => p.theme.dropShadowLight};
+`;
+
+function getScrollParents(element: HTMLElement): Element[] {
+  const scrollParents: Element[] = [];
+  let currentElement = element.parentElement;
+
+  while (currentElement) {
+    const overflow = window.getComputedStyle(currentElement).overflow;
+    if (overflow.includes('scroll') || overflow.includes('auto')) {
+      scrollParents.push(currentElement);
+    }
+    currentElement = currentElement.parentElement;
+  }
+
+  return scrollParents;
+}
+
+export default AutofixHighlightPopup;

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -14,6 +14,7 @@ import {
 } from 'sentry/components/events/autofix/useAutofix';
 import Input from 'sentry/components/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
@@ -256,8 +257,13 @@ function AutofixHighlightPopup({
                 size="sm"
                 autoFocus
               />
-              <StyledButton size="sm" type="submit" borderless>
-                {t('>')}
+              <StyledButton
+                size="zero"
+                type="submit"
+                borderless
+                aria-label={t('Submit Comment')}
+              >
+                <IconChevron direction="right" />
               </StyledButton>
             </InputWrapper>
           )}

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -120,7 +120,7 @@ function AutofixHighlightPopup({
 
   useLayoutEffect(() => {
     if (!referenceElement || !popupRef.current) {
-      return;
+      return undefined;
     }
 
     const updatePosition = () => {
@@ -143,6 +143,13 @@ function AutofixHighlightPopup({
     scrollElements.forEach(element => {
       element.addEventListener('scroll', updatePosition, {passive: true});
     });
+
+    return () => {
+      resizeObserver.disconnect();
+      scrollElements.forEach(element => {
+        element.removeEventListener('scroll', updatePosition);
+      });
+    };
   }, [referenceElement]);
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -79,59 +79,58 @@ describe('AutofixInsightCards', () => {
     expect(screen.getByText('Another insight')).toBeInTheDocument();
   });
 
-  it('renders "Rethink from here" buttons', () => {
+  it('renders "Edit insight" buttons', () => {
     renderComponent();
-    const rethinkButtons = screen.getAllByRole('button', {name: 'Rethink from here'});
-    expect(rethinkButtons.length).toBeGreaterThan(0);
+    const editButtons = screen.getAllByRole('button', {name: 'Edit insight'});
+    expect(editButtons.length).toBeGreaterThan(0);
   });
 
-  it('shows rethink input overlay when "Rethink from here" is clicked', async () => {
+  it('shows edit input overlay when "Edit insight" is clicked', async () => {
     renderComponent();
-    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
-    await userEvent.click(rethinkButton);
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
+    if (!editButton) {
+      throw new Error('No edit button found');
+    }
+    await userEvent.click(editButton);
     expect(
-      screen.getByPlaceholderText(
-        'You should know X... Dive deeper into Y... Look at Z...'
-      )
+      screen.getByPlaceholderText('Share your own insight here...')
     ).toBeInTheDocument();
   });
 
-  it('hides rethink input overlay when clicked outside', async () => {
+  it('hides edit input when clicked cancel', async () => {
     renderComponent();
-    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
-    await userEvent.click(rethinkButton);
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
+    if (!editButton) {
+      throw new Error('No edit button found');
+    }
+    await userEvent.click(editButton);
     expect(
-      screen.getByPlaceholderText(
-        'You should know X... Dive deeper into Y... Look at Z...'
-      )
+      screen.getByPlaceholderText('Share your own insight here...')
     ).toBeInTheDocument();
 
-    await userEvent.click(document.body);
+    await userEvent.click(screen.getByLabelText('Cancel'));
     expect(
-      screen.queryByPlaceholderText(
-        'You should know X... Dive deeper into Y... Look at Z...'
-      )
+      screen.queryByPlaceholderText('Share your own insight here...')
     ).not.toBeInTheDocument();
   });
 
-  it('submits rethink request when form is submitted', async () => {
+  it('submits edit request when form is submitted', async () => {
     const mockApi = MockApiClient.addMockResponse({
       url: '/issues/1/autofix/update/',
       method: 'POST',
     });
 
     renderComponent();
-    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
-    await userEvent.click(rethinkButton);
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[1];
+    if (!editButton) {
+      throw new Error('No edit button found');
+    }
+    await userEvent.click(editButton);
 
-    const input = screen.getByPlaceholderText(
-      'You should know X... Dive deeper into Y... Look at Z...'
-    );
-    await userEvent.type(input, 'Rethink this part');
+    const input = screen.getByPlaceholderText('Share your own insight here...');
+    await userEvent.type(input, 'Here is my insight.');
 
-    const submitButton = screen.getByLabelText(
-      'Restart analysis from this point in the chain'
-    );
+    const submitButton = screen.getByLabelText('Rethink from here using your insight');
     await userEvent.click(submitButton);
 
     expect(mockApi).toHaveBeenCalledWith(
@@ -142,7 +141,7 @@ describe('AutofixInsightCards', () => {
           run_id: '1',
           payload: expect.objectContaining({
             type: 'restart_from_point_with_feedback',
-            message: 'Rethink this part',
+            message: 'Here is my insight.',
             step_index: 0,
             retain_insight_card_index: 0,
           }),
@@ -151,24 +150,23 @@ describe('AutofixInsightCards', () => {
     );
   });
 
-  it('shows success message after successful rethink submission', async () => {
+  it('shows success message after successful edit submission', async () => {
     MockApiClient.addMockResponse({
       url: '/issues/1/autofix/update/',
       method: 'POST',
     });
 
     renderComponent();
-    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
-    await userEvent.click(rethinkButton);
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
+    if (!editButton) {
+      throw new Error('No edit button found');
+    }
+    await userEvent.click(editButton);
 
-    const input = screen.getByPlaceholderText(
-      'You should know X... Dive deeper into Y... Look at Z...'
-    );
-    await userEvent.type(input, 'Rethink this part');
+    const input = screen.getByPlaceholderText('Share your own insight here...');
+    await userEvent.type(input, 'Here is my insight.');
 
-    const submitButton = screen.getByLabelText(
-      'Restart analysis from this point in the chain'
-    );
+    const submitButton = screen.getByLabelText('Rethink from here using your insight');
     await userEvent.click(submitButton);
 
     await waitFor(() => {
@@ -176,7 +174,7 @@ describe('AutofixInsightCards', () => {
     });
   });
 
-  it('shows error message after failed rethink submission', async () => {
+  it('shows error message after failed edit submission', async () => {
     MockApiClient.addMockResponse({
       url: '/issues/1/autofix/update/',
       method: 'POST',
@@ -184,17 +182,16 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
-    await userEvent.click(rethinkButton);
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
+    if (!editButton) {
+      throw new Error('No edit button found');
+    }
+    await userEvent.click(editButton);
 
-    const input = screen.getByPlaceholderText(
-      'You should know X... Dive deeper into Y... Look at Z...'
-    );
-    await userEvent.type(input, 'Rethink this part');
+    const input = screen.getByPlaceholderText('Share your own insight here...');
+    await userEvent.type(input, 'Here is my insight.');
 
-    const submitButton = screen.getByLabelText(
-      'Restart analysis from this point in the chain'
-    );
+    const submitButton = screen.getByLabelText('Rethink from here using your insight');
     await userEvent.click(submitButton);
 
     await waitFor(() => {

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -87,10 +87,7 @@ describe('AutofixInsightCards', () => {
 
   it('shows edit input overlay when "Edit insight" is clicked', async () => {
     renderComponent();
-    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
-    if (!editButton) {
-      throw new Error('No edit button found');
-    }
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0]!;
     await userEvent.click(editButton);
     expect(
       screen.getByPlaceholderText('Share your own insight here...')
@@ -99,10 +96,7 @@ describe('AutofixInsightCards', () => {
 
   it('hides edit input when clicked cancel', async () => {
     renderComponent();
-    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
-    if (!editButton) {
-      throw new Error('No edit button found');
-    }
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0]!;
     await userEvent.click(editButton);
     expect(
       screen.getByPlaceholderText('Share your own insight here...')
@@ -121,10 +115,7 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[1];
-    if (!editButton) {
-      throw new Error('No edit button found');
-    }
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[1]!;
     await userEvent.click(editButton);
 
     const input = screen.getByPlaceholderText('Share your own insight here...');
@@ -157,10 +148,7 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
-    if (!editButton) {
-      throw new Error('No edit button found');
-    }
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0]!;
     await userEvent.click(editButton);
 
     const input = screen.getByPlaceholderText('Share your own insight here...');
@@ -182,10 +170,7 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0];
-    if (!editButton) {
-      throw new Error('No edit button found');
-    }
+    const editButton = screen.getAllByRole('button', {name: 'Edit insight'})[0]!;
     await userEvent.click(editButton);
 
     const input = screen.getByPlaceholderText('Share your own insight here...');

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -198,6 +198,7 @@ function AutofixInsightCard({
                         size="sm"
                         onClick={handleCancel}
                         title={t('Cancel')}
+                        aria-label={t('Cancel')}
                       >
                         <IconClose size="sm" />
                       </Button>
@@ -206,6 +207,7 @@ function AutofixInsightCard({
                         priority="primary"
                         size="sm"
                         title={t('Rethink from here using your insight')}
+                        aria-label={t('Rethink from here using your insight')}
                       >
                         <IconRefresh size="sm" />
                       </Button>
@@ -243,9 +245,8 @@ function AutofixInsightCard({
                     size="zero"
                     borderless
                     onClick={handleEdit}
-                    icon={
-                      <StyledIconEdit size="sm" isHighlighted={shouldHighlightRethink} />
-                    }
+                    isHighlighted={shouldHighlightRethink ?? false}
+                    icon={<IconEdit size="sm" />}
                     aria-label={t('Edit insight')}
                     title={t('Replace insight and rethink')}
                   />
@@ -548,6 +549,7 @@ function ChainLink({
                       priority="primary"
                       size="sm"
                       title={t('Add insight and rethink')}
+                      aria-label={t('Add insight and rethink')}
                     >
                       <IconRefresh size="sm" />
                     </Button>
@@ -738,10 +740,6 @@ const StyledIconChevron = styled(IconChevron)`
   color: ${p => p.theme.pink400}90;
 `;
 
-const StyledIconEdit = styled(IconEdit)<{isHighlighted?: boolean}>`
-  color: ${p => (p.isHighlighted ? p.theme.pink400 : `${p.theme.pink400}90`)};
-`;
-
 const RightSection = styled('div')`
   display: flex;
   align-items: center;
@@ -764,10 +762,10 @@ const EditInput = styled(Input)`
   flex: 1;
 `;
 
-const EditButton = styled(Button)`
-  color: ${p => p.theme.subText};
+const EditButton = styled(Button)<{isHighlighted?: boolean}>`
+  color: ${p => (p.isHighlighted ? p.theme.pink400 : `${p.theme.pink400}90`)};
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.pink400};
   }
 `;
 

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -607,7 +607,7 @@ const VerticalLine = styled('div')`
   top: 0;
   bottom: 0;
   width: 2px;
-  background-color: ${p => p.theme.pink400}80;
+  background-color: ${p => p.theme.subText};
   grid-column: 2 / 3;
   transition: background-color 0.2s ease;
 `;
@@ -674,7 +674,7 @@ const ContextHeaderText = styled('p')`
 const ContextBody = styled('div')`
   padding: ${space(2)} ${space(2)} 0;
   background: ${p => p.theme.background}
-    linear-gradient(135deg, ${p => p.theme.background}, ${p => p.theme.pink400}20);
+    linear-gradient(135deg, ${p => p.theme.pink400}08, ${p => p.theme.pink400}20);
   border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
   overflow: hidden;
 `;

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -91,7 +91,6 @@ interface AutofixInsightCardProps {
   insightCount: number;
   runId: string;
   stepIndex: number;
-  shouldHighlightRethink?: boolean;
 }
 
 function AutofixInsightCard({
@@ -102,7 +101,6 @@ function AutofixInsightCard({
   stepIndex,
   groupId,
   runId,
-  shouldHighlightRethink,
   insightCount,
 }: AutofixInsightCardProps) {
   const isLastInsightInStep = index === insightCount - 1;
@@ -173,7 +171,6 @@ function AutofixInsightCard({
         <AnimationWrapper key="content" {...animationProps}>
           {hasCardAbove && (
             <ChainLink
-              isHighlighted={shouldHighlightRethink}
               stepIndex={stepIndex}
               groupId={groupId}
               runId={runId}
@@ -245,7 +242,6 @@ function AutofixInsightCard({
                     size="zero"
                     borderless
                     onClick={handleEdit}
-                    isHighlighted={shouldHighlightRethink ?? false}
                     icon={<IconEdit size="sm" />}
                     aria-label={t('Edit insight')}
                     title={t('Replace insight and rethink')}
@@ -281,7 +277,6 @@ function AutofixInsightCard({
 
           {hasCardBelow && (
             <ChainLink
-              isHighlighted={shouldHighlightRethink}
               isLastCard={isLastInsightInStep}
               stepIndex={stepIndex}
               groupId={groupId}
@@ -303,12 +298,9 @@ interface AutofixInsightCardsProps {
   runId: string;
   stepIndex: number;
   shouldCollapseByDefault?: boolean;
-  shouldHighlightRethink?: boolean;
 }
 
 function CollapsibleChainLink({
-  isHighlighted,
-  isLastCard,
   isEmpty,
   isCollapsed,
   onToggleCollapse,
@@ -317,8 +309,6 @@ function CollapsibleChainLink({
   insightCount?: number;
   isCollapsed?: boolean;
   isEmpty?: boolean;
-  isHighlighted?: boolean;
-  isLastCard?: boolean;
   onToggleCollapse?: () => void;
 }) {
   return (
@@ -347,20 +337,6 @@ function CollapsibleChainLink({
             />
           </CollapseButtonWrapper>
         )}
-        <AnimatePresence>
-          {isLastCard && isHighlighted && (
-            <RethinkMessage
-              initial={{opacity: 0, x: 20}}
-              animate={{opacity: 1, x: 0}}
-              exit={{opacity: 0, x: 20}}
-              transition={{duration: 0.4}}
-            >
-              {isEmpty
-                ? t('Not satisfied? Leave a comment.')
-                : t('Not satisfied? Leave a comment or edit something.')}
-            </RethinkMessage>
-          )}
-        </AnimatePresence>
       </RethinkButtonContainer>
     </VerticalLineContainer>
   );
@@ -373,7 +349,6 @@ function AutofixInsightCards({
   stepIndex,
   groupId,
   runId,
-  shouldHighlightRethink,
   shouldCollapseByDefault,
 }: AutofixInsightCardsProps) {
   const [isCollapsed, setIsCollapsed] = useState(!!shouldCollapseByDefault);
@@ -394,7 +369,6 @@ function AutofixInsightCards({
         <Fragment>
           {hasStepAbove && (
             <CollapsibleChainLink
-              isHighlighted={shouldHighlightRethink}
               isCollapsed={isCollapsed}
               onToggleCollapse={handleToggleCollapse}
               insightCount={validInsightCount}
@@ -420,7 +394,6 @@ function AutofixInsightCards({
                       groupId={groupId}
                       runId={runId}
                       insightCount={validInsightCount}
-                      shouldHighlightRethink={shouldHighlightRethink}
                     />
                   )
                 )}
@@ -433,7 +406,6 @@ function AutofixInsightCards({
       ) : hasStepBelow ? (
         <EmptyResultsContainer>
           <ChainLink
-            isHighlighted={shouldHighlightRethink}
             isLastCard
             isEmpty
             stepIndex={stepIndex}
@@ -486,12 +458,10 @@ interface ChainLinkProps {
   runId: string;
   stepIndex: number;
   isEmpty?: boolean;
-  isHighlighted?: boolean;
   isLastCard?: boolean;
 }
 
 function ChainLink({
-  isHighlighted,
   isLastCard,
   isEmpty,
   stepIndex,
@@ -565,7 +535,6 @@ function ChainLink({
               icon={<IconAdd size="sm" />}
               title={t('Add insight and rethink')}
               aria-label={t('Add insight and rethink')}
-              isHighlighted={isHighlighted}
             />
           ))}
       </RethinkButtonContainer>
@@ -650,15 +619,6 @@ const RethinkButtonContainer = styled('div')`
   width: calc(100% + ${space(1)});
 `;
 
-const RethinkMessage = styled(motion.div)`
-  color: ${p => p.theme.pink400};
-  font-size: ${p => p.theme.fontSizeSmall};
-  position: absolute;
-  right: 100%;
-  top: -${space(1)};
-  white-space: nowrap;
-`;
-
 const ContentWrapper = styled('div')``;
 
 const MiniHeader = styled('p')`
@@ -737,7 +697,10 @@ const AnimationWrapper = styled(motion.div)`
 `;
 
 const StyledIconChevron = styled(IconChevron)`
-  color: ${p => p.theme.pink400}90;
+  color: ${p => p.theme.textColor};
+  &:hover {
+    color: ${p => p.theme.pink400};
+  }
 `;
 
 const RightSection = styled('div')`
@@ -762,8 +725,8 @@ const EditInput = styled(Input)`
   flex: 1;
 `;
 
-const EditButton = styled(Button)<{isHighlighted?: boolean}>`
-  color: ${p => (p.isHighlighted ? p.theme.pink400 : `${p.theme.pink400}90`)};
+const EditButton = styled(Button)`
+  color: ${p => p.theme.textColor};
   &:hover {
     color: ${p => p.theme.pink400};
   }
@@ -790,8 +753,8 @@ const CollapsedCount = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-const AddButton = styled(Button)<{isHighlighted?: boolean}>`
-  color: ${p => (p.isHighlighted ? p.theme.pink400 : `${p.theme.pink400}90`)};
+const AddButton = styled(Button)`
+  color: ${p => p.theme.textColor};
   &:hover {
     color: ${p => p.theme.pink400};
   }

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -65,7 +65,7 @@ describe('AutofixOutputStream', () => {
     render(<AutofixOutputStream stream="Initial content" groupId="123" runId="456" />);
 
     const user = userEvent.setup();
-    await user.click(screen.getByText('Send'));
+    await user.click(screen.getByText('>'));
 
     expect(mockApi.requestPromise).not.toHaveBeenCalled();
   });
@@ -96,7 +96,7 @@ describe('AutofixOutputStream', () => {
     const input = screen.getByPlaceholderText('Interrupt me...');
 
     await user.type(input, 'Test message');
-    await user.click(screen.getByText('Send'));
+    await user.click(screen.getByText('>'));
 
     await waitFor(() => {
       expect(addSuccessMessage).toHaveBeenCalledWith('Thanks for the input.');
@@ -116,7 +116,7 @@ describe('AutofixOutputStream', () => {
     const input = screen.getByPlaceholderText('Interrupt me...');
 
     await user.type(input, 'Test message');
-    await user.click(screen.getByText('Send'));
+    await user.click(screen.getByText('>'));
 
     await waitFor(() => {
       expect(addErrorMessage).toHaveBeenCalledWith(

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -65,7 +65,7 @@ describe('AutofixOutputStream', () => {
     render(<AutofixOutputStream stream="Initial content" groupId="123" runId="456" />);
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', {name: '>'}));
+    await user.click(screen.getByRole('button', {name: 'Submit Comment'}));
 
     expect(mockApi.requestPromise).not.toHaveBeenCalled();
   });
@@ -96,7 +96,7 @@ describe('AutofixOutputStream', () => {
     const input = screen.getByPlaceholderText('Interrupt me...');
 
     await user.type(input, 'Test message');
-    await user.click(screen.getByRole('button', {name: '>'}));
+    await user.click(screen.getByRole('button', {name: 'Submit Comment'}));
 
     await waitFor(() => {
       expect(addSuccessMessage).toHaveBeenCalledWith('Thanks for the input.');
@@ -116,7 +116,7 @@ describe('AutofixOutputStream', () => {
     const input = screen.getByPlaceholderText('Interrupt me...');
 
     await user.type(input, 'Test message');
-    await user.click(screen.getByRole('button', {name: '>'}));
+    await user.click(screen.getByRole('button', {name: 'Submit Comment'}));
 
     await waitFor(() => {
       expect(addErrorMessage).toHaveBeenCalledWith(

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -65,7 +65,7 @@ describe('AutofixOutputStream', () => {
     render(<AutofixOutputStream stream="Initial content" groupId="123" runId="456" />);
 
     const user = userEvent.setup();
-    await user.click(screen.getByText('>'));
+    await user.click(screen.getByRole('button', {name: '>'}));
 
     expect(mockApi.requestPromise).not.toHaveBeenCalled();
   });
@@ -96,7 +96,7 @@ describe('AutofixOutputStream', () => {
     const input = screen.getByPlaceholderText('Interrupt me...');
 
     await user.type(input, 'Test message');
-    await user.click(screen.getByText('>'));
+    await user.click(screen.getByRole('button', {name: '>'}));
 
     await waitFor(() => {
       expect(addSuccessMessage).toHaveBeenCalledWith('Thanks for the input.');
@@ -116,7 +116,7 @@ describe('AutofixOutputStream', () => {
     const input = screen.getByPlaceholderText('Interrupt me...');
 
     await user.type(input, 'Test message');
-    await user.click(screen.getByText('>'));
+    await user.click(screen.getByRole('button', {name: '>'}));
 
     await waitFor(() => {
       expect(addErrorMessage).toHaveBeenCalledWith(

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -8,7 +8,6 @@ import {Button} from 'sentry/components/button';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Input from 'sentry/components/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {singleLineRenderer} from 'sentry/utils/marked';
@@ -159,7 +158,7 @@ export function AutofixOutputStream({
             },
           })}
         >
-          <StyledArrow direction="down" size="sm" />
+          <VerticalLine />
           <Container layout $required={responseRequired}>
             {activeLog && (
               <ActiveLogWrapper>
@@ -185,7 +184,7 @@ export function AutofixOutputStream({
                 required={responseRequired}
               />
               <StyledButton type="submit" borderless>
-                Send
+                {'>'}
               </StyledButton>
             </InputWrapper>
           </Container>
@@ -198,8 +197,9 @@ export function AutofixOutputStream({
 const Wrapper = styled(motion.div)`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  margin: ${space(1)} ${space(4)};
+  align-items: flex-start;
+  margin-bottom: ${space(1)};
+  margin-right: ${space(2)};
   gap: ${space(1)};
   overflow: hidden;
 `;
@@ -208,9 +208,9 @@ const ScaleContainer = styled(motion.div)`
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: ${space(1)};
-  transform-origin: top center;
+  align-items: flex-start;
+  transform-origin: top left;
+  padding-left: ${space(2)};
 `;
 
 const Container = styled(motion.div)<{$required: boolean}>`
@@ -262,9 +262,13 @@ const ActiveLog = styled('div')`
   flex-grow: 1;
 `;
 
-const StyledArrow = styled(IconArrow)`
-  color: ${p => p.theme.subText};
+const VerticalLine = styled('div')`
+  width: 0;
+  height: ${space(4)};
+  border-left: 2px dashed ${p => p.theme.pink400};
   opacity: 0.5;
+  margin-left: 17px;
+  margin-bottom: -1px;
 `;
 
 const InputWrapper = styled('form')`
@@ -290,5 +294,5 @@ const StyledButton = styled(Button)`
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  margin: 0;
+  margin: 0 0 0 ${space(0.5)};
 `;

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -147,12 +147,12 @@ export function AutofixOutputStream({
         })}
       >
         <ScaleContainer
-          initial={{scale: 0.8}}
-          animate={{scale: 1}}
-          exit={{scale: 0.8}}
+          initial={{scaleY: 0.8}}
+          animate={{scaleY: 1}}
+          exit={{scaleY: 0.8}}
           transition={testableTransition({
             duration: 0.2,
-            scale: {
+            scaleY: {
               type: 'spring',
               bounce: 0.2,
             },

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -271,8 +271,7 @@ const ActiveLog = styled('div')`
 const VerticalLine = styled('div')`
   width: 0;
   height: ${space(4)};
-  border-left: 2px dashed ${p => p.theme.pink400};
-  opacity: 0.5;
+  border-left: 2px dashed ${p => p.theme.subText};
   margin-left: 17px;
   margin-bottom: -1px;
 `;

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -168,7 +168,7 @@ export function AutofixOutputStream({
                     __html: singleLineRenderer(displayedActiveLog),
                   }}
                 />
-                {isProcessing && <StyledLoadingIndicator size={14} mini hideMessage />}
+                {isProcessing && <StyledLoadingIndicator mini size={14} />}
               </ActiveLogWrapper>
             )}
             {!responseRequired && stream && (
@@ -260,8 +260,10 @@ const ActiveLogWrapper = styled('div')`
   align-items: center;
   justify-content: space-between;
   padding: ${space(1)};
-  padding-right: ${space(3)};
+  padding-right: 0;
+  padding-left: ${space(2)};
   background: ${p => p.theme.backgroundSecondary};
+  gap: ${space(1)};
 `;
 
 const ActiveLog = styled('div')`
@@ -278,9 +280,8 @@ const VerticalLine = styled('div')`
 
 const InputWrapper = styled('form')`
   display: flex;
-  gap: ${space(0.25)};
-  padding: ${space(0.25)} ${space(0.25)};
-  background: ${p => p.theme.backgroundSecondary};
+  padding: ${space(0.5)};
+  position: relative;
 `;
 
 const StyledInput = styled(Input)`
@@ -288,6 +289,7 @@ const StyledInput = styled(Input)`
   background: ${p => p.theme.background}
     linear-gradient(to left, ${p => p.theme.background}, ${p => p.theme.pink400}20);
   border-color: ${p => p.theme.innerBorder};
+  padding-right: ${space(4)};
 
   &:hover {
     border-color: ${p => p.theme.border};
@@ -295,9 +297,17 @@ const StyledInput = styled(Input)`
 `;
 
 const StyledButton = styled(Button)`
-  flex-shrink: 0;
+  position: absolute;
+  right: ${space(1)};
+  top: 50%;
+  transform: translateY(-50%);
+  height: 24px;
+  width: 24px;
+  margin-right: 0;
+  z-index: 2;
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  margin: 0 0 0 ${space(0.5)};
+  position: relative;
+  top: ${space(0.5)};
 `;

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -159,7 +159,7 @@ export function AutofixOutputStream({
           })}
         >
           <VerticalLine />
-          <Container layout $required={responseRequired}>
+          <Container layout required={responseRequired}>
             {activeLog && (
               <ActiveLogWrapper>
                 <ActiveLog
@@ -213,7 +213,7 @@ const ScaleContainer = styled(motion.div)`
   padding-left: ${space(2)};
 `;
 
-const Container = styled(motion.div)<{$required: boolean}>`
+const Container = styled(motion.div)<{required: boolean}>`
   position: relative;
   width: 100%;
   border-radius: ${p => p.theme.borderRadius};
@@ -228,7 +228,7 @@ const Container = styled(motion.div)<{$required: boolean}>`
     background: linear-gradient(
       90deg,
       transparent,
-      ${p => (p.$required ? p.theme.pink400 : p.theme.active)}20,
+      ${p => (p.required ? p.theme.pink400 : p.theme.active)}20,
       transparent
     );
     background-size: 2000px 100%;

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -8,6 +8,7 @@ import {Button} from 'sentry/components/button';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Input from 'sentry/components/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {singleLineRenderer} from 'sentry/utils/marked';
@@ -183,8 +184,13 @@ export function AutofixOutputStream({
                 }
                 required={responseRequired}
               />
-              <StyledButton type="submit" borderless>
-                {'>'}
+              <StyledButton
+                type="submit"
+                borderless
+                aria-label={t('Submit Comment')}
+                size="zero"
+              >
+                <IconChevron direction="right" />
               </StyledButton>
             </InputWrapper>
           </Container>

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {AutofixRootCause} from 'sentry/components/events/autofix/autofixRootCause';
 
 describe('AutofixRootCause', function () {
-  let mockApi;
+  let mockApi: jest.Mock<any, any, any>;
 
   beforeEach(function () {
     mockApi = MockApiClient.addMockResponse({

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -13,6 +13,7 @@ import {
   type AutofixStep,
   AutofixStepType,
 } from 'sentry/components/events/autofix/types';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
 

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -30,7 +30,6 @@ interface StepProps {
   hasStepBelow: boolean;
   repos: AutofixRepository[];
   runId: string;
-  shouldHighlightRethink: boolean;
   step: AutofixStep;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
@@ -67,7 +66,6 @@ export function Step({
   hasStepBelow,
   hasStepAbove,
   hasErroredStepBefore,
-  shouldHighlightRethink,
   shouldCollapseByDefault,
   previousDefaultStepIndex,
   previousInsightCount,
@@ -91,7 +89,6 @@ export function Step({
                   stepIndex={step.index}
                   groupId={groupId}
                   runId={runId}
-                  shouldHighlightRethink={shouldHighlightRethink}
                   shouldCollapseByDefault={shouldCollapseByDefault}
                 />
               )}
@@ -171,14 +168,6 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
             nextStep?.status === 'PROCESSING' &&
             nextStep?.insights?.length === 0;
 
-          const isNextStepLastStep = index === steps.length - 2;
-          const shouldHighlightRethink =
-            (nextStep?.type === AutofixStepType.ROOT_CAUSE_ANALYSIS &&
-              isNextStepLastStep) ||
-            (nextStep?.type === AutofixStepType.CHANGES &&
-              nextStep.changes.length > 0 &&
-              !nextStep.changes.every(change => change.pull_request));
-
           return (
             <div ref={el => (stepsRef.current[index] = el)} key={step.id}>
               <Step
@@ -193,7 +182,6 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
                 runId={runId}
                 repos={repos}
                 hasErroredStepBefore={previousStepErrored}
-                shouldHighlightRethink={shouldHighlightRethink}
                 shouldCollapseByDefault={
                   step.type === AutofixStepType.DEFAULT &&
                   (step.status === 'ERROR' ||

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -86,8 +86,21 @@ interface BaseStep {
   status: AutofixStatus;
   title: string;
   type: AutofixStepType;
+  active_comment_thread?: CommentThread | null;
   completedMessage?: string;
   output_stream?: string | null;
+}
+
+export type CommentThread = {
+  id: string;
+  is_completed: boolean;
+  messages: CommentThreadMessage[];
+};
+
+export interface CommentThreadMessage {
+  content: string;
+  role: 'user' | 'assistant';
+  isLoading?: boolean;
 }
 
 export type CodeSnippetContext = {

--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -1,0 +1,75 @@
+import {useCallback, useEffect, useState} from 'react';
+
+interface TextSelection {
+  referenceElement: HTMLElement | null;
+  selectedText: string;
+}
+
+export function useTextSelection(containerRef: React.RefObject<HTMLElement>) {
+  const [selection, setSelection] = useState<TextSelection | null>(null);
+
+  const isClickInPopup = (target: HTMLElement) =>
+    target.closest('[data-popup="autofix-highlight"]');
+
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      // If clicking in popup, do nothing
+      if (isClickInPopup(target)) {
+        return;
+      }
+
+      // Check if the click is within our container
+      const isContainedWithin = containerRef.current?.contains(target);
+      if (!isContainedWithin) {
+        setSelection(null);
+        return;
+      }
+
+      // Get the text content of the clicked element
+      const clickedText = target.textContent?.trim() || '';
+      if (!clickedText) {
+        setSelection(null);
+        return;
+      }
+
+      setSelection({
+        selectedText: clickedText,
+        referenceElement: target,
+      });
+    },
+    [containerRef]
+  );
+
+  const clearSelection = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      // Don't clear if clicking within the popup
+      if (isClickInPopup(target)) {
+        return;
+      }
+
+      // Don't clear if clicking the original container that triggered the popup
+      if (containerRef.current?.contains(target)) {
+        return;
+      }
+
+      setSelection(null);
+    },
+    [containerRef]
+  );
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick);
+    document.addEventListener('mousedown', clearSelection);
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+      document.removeEventListener('mousedown', clearSelection);
+    };
+  }, [handleClick, clearSelection]);
+
+  return selection;
+}

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -304,7 +304,7 @@ const Container = styled('div')`
   width: 100%;
   border-radius: ${p => p.theme.borderRadius};
   background: ${p => p.theme.background}
-    linear-gradient(135deg, ${p => p.theme.background}, ${p => p.theme.pink400}20);
+    linear-gradient(135deg, ${p => p.theme.pink400}08, ${p => p.theme.pink400}20);
   overflow: hidden;
   padding: ${space(0.5)};
 `;


### PR DESCRIPTION
1. Collapsible insight cards. Can be collapsed manually, and also auto-collapses when a step is "completed" (root cause selected or PR/branch made).
2. Readability and saving vertical space by swapping arrows for a vertical line
3. Replace rethink on arrows with editing/adding insight cards. This is more expected for a document.
4. Support commenting on document. Click any text on an insight card, root cause, or diff, and ask questions or leave feedback, as expected for a document. Autofix responds, and if it detects that action is needed, it will automatically trigger a rethink.

This PR requires a backend change in Seer to go in first.

<img width="650" alt="Screenshot 2025-01-21 at 7 19 15 PM" src="https://github.com/user-attachments/assets/cada2f77-fe59-438c-a3ed-cbfbc8526ec7" />
<img width="820" alt="Screenshot 2025-01-21 at 7 19 26 PM" src="https://github.com/user-attachments/assets/ab4f43e6-bebb-44c2-a2fb-1b097753fd5c" />
<img width="806" alt="Screenshot 2025-01-21 at 7 20 24 PM" src="https://github.com/user-attachments/assets/ed44c3d8-6b46-4595-8b64-4fcd3bd57e6f" />
<img width="600" alt="Screenshot 2025-01-21 at 7 26 16 PM" src="https://github.com/user-attachments/assets/c0de04b7-26e2-4c10-bd69-f26a4067d98f" />


