### PR TITLE
feat(setup-wizard): Allow project creation

### DIFF
--- a/static/app/views/setupWizard/utils/features.tsx
+++ b/static/app/views/setupWizard/utils/features.tsx
@@ -1,0 +1,5 @@
+import type {Organization} from 'sentry/types/organization';
+
+export function hasSetupWizardCreateProjectFeature(organization: Organization) {
+  return organization.features.includes('setup-wizard-create-project');
+}

--- a/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
+++ b/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
@@ -1,0 +1,28 @@
+import type {Project} from 'sentry/types/project';
+import {useMutation} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+
+export function useCreateProjectFromWizard() {
+  const api = useApi();
+  return useMutation({
+    mutationFn: (params: {
+      name: string;
+      organization: OrganizationWithRegion;
+      platform: string;
+      team: string;
+    }): Promise<Project> => {
+      const url = `/teams/${params.organization.slug}/${params.team}/projects/`;
+      return api.requestPromise(url, {
+        method: 'POST',
+        host: params.organization.region.url,
+        data: {
+          name: params.name,
+          platform: params.platform,
+          default_rules: true,
+          origin: 'ui',
+        },
+      });
+    },
+  });
+}

--- a/static/app/views/setupWizard/utils/useOrganizationDetails.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationDetails.tsx
@@ -1,0 +1,28 @@
+import type {Organization} from 'sentry/types/organization';
+import {useQuery} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+
+export function useOrganizationDetails({
+  organization,
+}: {
+  organization?: OrganizationWithRegion;
+}) {
+  const api = useApi();
+
+  return useQuery<Organization, RequestError>({
+    queryKey: [`/organizations/${organization?.slug}/`],
+    queryFn: () => {
+      return api.requestPromise(`/organizations/${organization?.slug}/`, {
+        host: organization?.region.url,
+        query: {
+          include_feature_flags: 1,
+        },
+      });
+    },
+    enabled: !!organization,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+}

--- a/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
@@ -1,0 +1,25 @@
+import type {Team} from 'sentry/types/organization';
+import {useQuery} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import type {OrganizationWithRegion} from 'sentry/views/setupWizard/types';
+
+export function useOrganizationTeams({
+  organization,
+}: {
+  organization?: OrganizationWithRegion;
+}) {
+  const api = useApi();
+
+  return useQuery<Team[], RequestError>({
+    queryKey: [`/organizations/${organization?.slug}/teams/`],
+    queryFn: () => {
+      return api.requestPromise(`/organizations/${organization?.slug}/teams/`, {
+        host: organization?.region.url,
+      });
+    },
+    enabled: !!organization,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+}


### PR DESCRIPTION
Allow creating Sentry projects in the setup wizard workflow.
It is only enabled if the wizard passes the `project_platform` URL param which is used to define the projects platform.


https://github.com/user-attachments/assets/b30fffd5-53ec-4360-a529-799d55984c06



Note: Sentry requires a team to be assigned to a project on creation. If there are no teams the current user is a member of, the project creation is disabled in this flow. We would need further work to also enable team creation in this view.

- part of https://github.com/getsentry/sentry-wizard/issues/549