### PR TITLE
Add Unreal Engine stack trace rules

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -429,3 +429,18 @@ module:io.netty.* -app
 module:newrelic -app -group
 path:**/*newrelic*/** -app -group
 path:**/*LogRocket*/** -app -group
+
+## Unreal Engine
+
+### Unreal Engine internal assertion handling
+family:native stack.function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group
+
+### Unreal Engine internal ensure handling
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group
+
+### UE SDK USentrySubsystem event capturing
+family:native stack.function:USentrySubsystem::CaptureMessage* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::CaptureEvent* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::CaptureEventWithScope* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group


### PR DESCRIPTION
This PR introduces stack trace rules specific to Unreal Engine. Having these set by default will allow us to merge https://github.com/getsentry/sentry-unreal/pull/744 and resolve https://github.com/getsentry/sentry-unreal/issues/669.

Essentially, the suggested set of rules addresses grouping issues we encountered with assertion/ensure events. It also takes care of cutting off redundant callstack frames for regular events sent via the UE SDK interface.