### PR TITLE
feat(assemble): Implement batch assembling in the endpoint

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -15,7 +15,7 @@ from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
-from sentry import ratelimits
+from sentry import features, ratelimits
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -647,8 +647,11 @@ class DifAssembleEndpoint(ProjectEndpoint):
         except Exception:
             return Response({"error": "Invalid json body"}, status=400)
 
-        # TODO: implement feature flag check.
-        use_batch_assemble = True
+        use_batch_assemble = features.has(
+            "organizations:batch-assemble-debug-files",
+            project.organization,
+        )
+
         if use_batch_assemble:
             file_response = batch_assemble(project=project, files=files)
         else:

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -649,7 +649,8 @@ class DifAssembleEndpoint(ProjectEndpoint):
 
         use_batch_assemble = features.has(
             "organizations:batch-assemble-debug-files",
-            project.organization,
+            organization=project.organization,
+            actor=request.user,
         )
 
         if use_batch_assemble:

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -465,13 +465,13 @@ def batch_assemble(project, files):
         name, debug_id, chunks = file_info or (None, None, None)
 
         # If we don't have any chunks, this is likely a poll request
-        # checking for file status, so return NOT_FOUND
+        # checking for file status, so return NOT_FOUND.
         if not chunks:
             file_response[checksum] = {"state": ChunkFileState.NOT_FOUND, "missingChunks": []}
             checksums_without_chunks.add(checksum)
             continue
 
-        # Map each chunk back to its source file checksum
+        # Map each chunk back to its source file checksum.
         for chunk in chunks:
             chunks_to_check[chunk] = checksum
 
@@ -480,7 +480,7 @@ def batch_assemble(project, files):
     # 4. Find missing chunks and group them per checksum.
     all_missing_chunks = find_missing_chunks(project.organization.id, list(chunks_to_check.keys()))
 
-    missing_chunks_per_checksum = {}
+    missing_chunks_per_checksum: dict[str, set[str]] = {}
     for chunk in all_missing_chunks:
         # We access the chunk via `[]` since the chunk must be there since `all_missing_chunks` must be a subset of
         # `chunks_to_check.keys()`.

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -478,7 +478,7 @@ def batch_assemble(project, files):
     checksums_to_check -= checksums_without_chunks
 
     # 4. Find missing chunks and group them per checksum.
-    all_missing_chunks = find_missing_chunks(project.organization.id, chunks_to_check)
+    all_missing_chunks = find_missing_chunks(project.organization.id, list(chunks_to_check.keys()))
 
     missing_chunks_per_checksum = {}
     for chunk in all_missing_chunks:

--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -8,15 +8,16 @@ from sentry.models.files import FileBlob, FileBlobOwner
 
 def find_missing_chunks(organization_id: int, chunks: Sequence[str]):
     """Returns a list of chunks which are missing for an org."""
-    # refresh the timestamp of all files we are interested in,
-    # so they don't disappear from under us
+    # Refresh the timestamp of all files we are interested in, so they don't disappear from under us.
     now = timezone.now()
     threshold = now - timedelta(hours=12)
     FileBlob.objects.filter(checksum__in=chunks, timestamp__lte=threshold).update(timestamp=now)
 
+    # Compute the set of all existing chunks.
     owned = set(
         FileBlobOwner.objects.filter(
             blob__checksum__in=chunks, organization_id=organization_id
         ).values_list("blob__checksum", flat=True)
     )
+
     return list(set(chunks) - owned)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -548,6 +548,13 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable the new option to batch assemble debug files
+    manager.add(
+        "organizations:batch-assemble-debug-files",
+        OrganizationFeature,
+        FeatureHandlerStrategy.FLAGPOLE,
+        api_expose=False
+    )
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -20,6 +20,7 @@ from sentry.tasks.assemble import (
     set_assemble_status,
 )
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -36,6 +37,7 @@ class DifAssembleEndpoint(APITestCase):
             "sentry-api-0-assemble-dif-files", args=[self.organization.slug, self.project.slug]
         )
 
+    @with_feature("organizations:batch-assemble-debug-files")
     def test_assemble_json_schema(self):
         response = self.client.post(
             self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
@@ -63,6 +65,7 @@ class DifAssembleEndpoint(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data[checksum]["state"] == ChunkFileState.NOT_FOUND
 
+    @with_feature("organizations:batch-assemble-debug-files")
     def test_assemble_check(self):
         content = b"foo bar"
         fileobj = ContentFile(content)
@@ -138,6 +141,7 @@ class DifAssembleEndpoint(APITestCase):
         assert response.data[not_found_checksum]["state"] == ChunkFileState.NOT_FOUND
         assert set(response.data[not_found_checksum]["missingChunks"]) == {not_found_checksum}
 
+    @with_feature("organizations:batch-assemble-debug-files")
     @patch("sentry.tasks.assemble.assemble_dif")
     def test_assemble(self, mock_assemble_dif):
         content1 = b"foo"
@@ -209,6 +213,7 @@ class DifAssembleEndpoint(APITestCase):
         file_blob_index = FileBlobIndex.objects.all()
         assert len(file_blob_index) == 3
 
+    @with_feature("organizations:batch-assemble-debug-files")
     def test_dif_response(self):
         sym_file = self.load_fixture("crash.sym")
         blob1 = FileBlob.from_file(ContentFile(sym_file))
@@ -232,6 +237,7 @@ class DifAssembleEndpoint(APITestCase):
             response.data[total_checksum]["dif"]["uuid"] == "67e9247c-814e-392b-a027-dbde6748fcbf"
         )
 
+    @with_feature("organizations:batch-assemble-debug-files")
     def test_dif_error_response(self):
         sym_file = b"fail"
         blob1 = FileBlob.from_file(ContentFile(sym_file))


### PR DESCRIPTION
This PR is a first try at improving the performance of the debug files assembling endpoint which batches queries instead of issuing one query per file.

As a quick way to validate this improvement, we would like to try and turn on the new batch mechanism in production and see how it performs, after having validated the functional correctness with tests.

Closes: https://github.com/getsentry/sentry/issues/82804