### PR TITLE
feat(demo-mode): identify demo users via id

### DIFF
--- a/src/sentry/utils/demo_mode.py
+++ b/src/sentry/utils/demo_mode.py
@@ -22,9 +22,7 @@ def is_readonly_user(user: User | None) -> bool:
     if not user:
         return False
 
-    email = getattr(user, "email", None)
-
-    return email in options.get("demo-mode.users")
+    return user.id in options.get("demo-mode.users")
 
 
 def is_demo_org(organization: Organization | None):
@@ -41,8 +39,8 @@ def get_readonly_user():
     if not options.get("demo-mode.enabled"):
         return None
 
-    email = options.get("demo-mode.users")[0]
-    return User.objects.get(email=email)
+    user_id = options.get("demo-mode.users")[0]
+    return User.objects.get(id=user_id)
 
 
 def get_readonly_scopes() -> frozenset[str]:

--- a/tests/sentry/utils/test_demo_mode.py
+++ b/tests/sentry/utils/test_demo_mode.py
@@ -6,23 +6,23 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.demo_mode import get_readonly_user, is_demo_org, is_readonly_user
 
 
-@override_options({"demo-mode.enabled": True, "demo-mode.users": ["readonly@example.com"]})
+@override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
 def test_is_readonly_user_demo_mode_enabled_none():
     assert not is_readonly_user(None)
 
 
-@override_options({"demo-mode.enabled": True, "demo-mode.users": ["readonly@example.com"]})
+@override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
 def test_is_readonly_user_demo_mode_enabled_readonly_user():
-    user = Factories.create_user("readonly@example.com")
+    user = Factories.create_user(id=1)
     assert is_readonly_user(user)
 
 
-@override_options({"demo-mode.enabled": True, "demo-mode.users": ["readonly@example.com"]})
+@override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
 def test_is_readonly_user_demo_mode_enabled_non_readonly_user():
-    user = Factories.create_user("user@example.com")
+    user = Factories.create_user(id=2)
     assert not is_readonly_user(user)
 
 
@@ -35,14 +35,14 @@ def test_is_readonly_user_demo_mode_disabled_none():
 @override_options({"demo-mode.enabled": False})
 @django_db_all
 def test_is_readonly_user_demo_mode_disabled_readonly_user():
-    user = Factories.create_user("readonly@example.com")
+    user = Factories.create_user(id=1)
     assert not is_readonly_user(user)
 
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
 def test_is_readonly_user_demo_mode_disabled_non_readonly_user():
-    user = Factories.create_user("user@example.com")
+    user = Factories.create_user(id=2)
     assert not is_readonly_user(user)
 
 
@@ -79,10 +79,10 @@ def test_get_readonly_user_demo_mode_disabled():
     assert get_readonly_user() is None
 
 
-@override_options({"demo-mode.enabled": True, "demo-mode.users": ["readonly@example.com"]})
+@override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
 def test_get_readonly_user_demo_mode_enabled():
-    user = Factories.create_user("readonly@example.com")
+    user = Factories.create_user(id=1)
     with patch("sentry.utils.demo_mode.User.objects.get", return_value=user) as mock_user_get:
         assert get_readonly_user() == user
-        mock_user_get.assert_called_once_with(email="readonly@example.com")
+        mock_user_get.assert_called_once_with(id=1)


### PR DESCRIPTION
Switches from using email to id to identify readonly users 