### PR TITLE
fix(flutter-web): hide unactionable source context errors

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
@@ -145,6 +145,20 @@ describe('Actionable Items', () => {
             'org-dartlang-sdk:///dart-sdk/lib/_internal/js_runtime/lib/js_helper.dart',
         },
       },
+      {
+        type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
+        data: {
+          source:
+            'org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart',
+        },
+      },
+      {
+        type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
+        data: {
+          source:
+            'org-dartlang-sdk:///dart-sdk/lib/async/zone.dart',
+        },
+      },
     ];
 
     MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
@@ -148,15 +148,13 @@ describe('Actionable Items', () => {
       {
         type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
         data: {
-          source:
-            'org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart',
+          source: 'org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart',
         },
       },
       {
         type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
         data: {
-          source:
-            'org-dartlang-sdk:///dart-sdk/lib/async/zone.dart',
+          source: 'org-dartlang-sdk:///dart-sdk/lib/async/zone.dart',
         },
       },
     ];

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
@@ -151,7 +151,7 @@ export function shouldErrorBeShown(error: EventErrorData, event: Event) {
     const source: string | undefined = error.data?.source;
     if (
       source &&
-      (source.includes('org-dartlang-sdk:///dart-sdk/lib/_internal') ||
+      (source.includes('org-dartlang-sdk:///dart-sdk/lib/') ||
         source.includes('flutter/packages/flutter/lib'))
     ) {
       return false;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-dart/issues/2450

Users often get source context errors regarding internal framework files but those aren't really relevant and are not actionable