### PR TITLE
feat(symbolication): Pass org id to Symbolicator

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -498,6 +498,7 @@ def run_symbolicate(
     symbolicator = Symbolicator(
         task_kind=SymbolicatorTaskKind(platform=symbolicator_platform),
         on_request=on_symbolicator_request,
+        org=project.organization,
         project=project,
         event_id=get_event_id(profile),
     )
@@ -765,6 +766,7 @@ def _deobfuscate_using_symbolicator(project: Project, profile: Profile, debug_fi
     symbolicator = Symbolicator(
         task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.jvm),
         on_request=on_symbolicator_request,
+        org=project.organization,
         project=project,
         event_id=get_event_id(profile),
     )

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -148,6 +148,7 @@ def _do_symbolicate_event(
     symbolication_start_time = time()
 
     project = Project.objects.get_from_cache(id=project_id)
+    org = project.organization
     # needed for efficient featureflag checks in getsentry
     # NOTE: The `organization` is used for constructing the symbol sources.
     with sentry_sdk.start_span(op="lang.native.symbolicator.organization.get_from_cache"):
@@ -168,6 +169,7 @@ def _do_symbolicate_event(
     symbolicator = Symbolicator(
         task_kind=task_kind,
         on_request=on_symbolicator_request,
+        org=org,
         project=project,
         event_id=event_id,
     )


### PR DESCRIPTION
For metrics purposes. Currently Symbolicator only knows project ids. Without a corresponding Symbolicator change (to follow), this has no effect.