### PR TITLE
fix(email): Use Sentry.io over `GetSentry` in gmail org name

### DIFF
--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -326,7 +326,7 @@
         <meta itemprop="name" content="View in Sentry"/>
       </div>
       <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-        <meta itemprop="name" content="GetSentry"/>
+        <meta itemprop="name" content="Sentry.io"/>
         <link itemprop="url" href="https://sentry.io/"/>
       </div>
     </div>


### PR DESCRIPTION
See https://developers.google.com/gmail/markup/reference/go-to-action#publisher_data

Seems more reasonable to have this set to `Sentry.io` which is a brand people know, not `GetSentry`