### PR TITLE
fix(dashboards): Double padding in widgets

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -14,6 +14,8 @@ import {
   DEFAULT_FIELD,
   MISSING_DATA_MESSAGE,
   NON_FINITE_NUMBER_MESSAGE,
+  X_GUTTER,
+  Y_GUTTER,
 } from '../common/settings';
 import type {StateProps} from '../common/types';
 
@@ -91,4 +93,5 @@ const BigNumberResizeWrapper = styled('div')`
 const LoadingPlaceholder = styled('span')`
   color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
   font-size: ${p => p.theme.fontSizeLarge};
+  padding: ${Y_GUTTER} ${X_GUTTER};
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -15,6 +15,8 @@ import type {
   Thresholds,
 } from 'sentry/views/dashboards/widgets/common/types';
 
+import {X_GUTTER, Y_GUTTER} from '../common/settings';
+
 import {ThresholdsIndicator} from './thresholdsIndicator';
 
 export interface BigNumberWidgetVisualizationProps {
@@ -141,7 +143,7 @@ function Wrapper({children}: any) {
 
 const AutoResizeParent = styled('div')`
   position: absolute;
-  inset: 0;
+  inset: ${Y_GUTTER} ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
 
   color: ${p => p.theme.headingColor};
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -10,7 +10,7 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {MISSING_DATA_MESSAGE} from '../common/settings';
+import {MISSING_DATA_MESSAGE, X_GUTTER, Y_GUTTER} from '../common/settings';
 import type {StateProps} from '../common/types';
 import {LoadingPanel} from '../widgetLayout/loadingPanel';
 
@@ -72,4 +72,5 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
 
 const TimeSeriesWrapper = styled('div')`
   flex-grow: 1;
+  padding: 0 ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
 `;

--- a/static/app/views/dashboards/widgets/widgetLayout/loadingPanel.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/loadingPanel.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 
+import {X_GUTTER, Y_GUTTER} from '../common/settings';
+
 export function LoadingPanel() {
   return (
     <LoadingPlaceholder>
@@ -18,6 +20,8 @@ const LoadingPlaceholder = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  padding: ${Y_GUTTER} ${X_GUTTER};
 `;
 
 const LoadingMask = styled(TransparentLoadingMask)`

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -89,7 +89,7 @@ const VisualizationWrapper = styled('div')`
   flex-grow: 1;
   min-height: 0;
   position: relative;
-  padding: 0 ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
+  padding: 0;
 `;
 
 const CaptionWrapper = styled('div')`

--- a/static/app/views/projectDetail/projectScoreCards/actionWrapper.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/actionWrapper.tsx
@@ -3,5 +3,5 @@ import styled from '@emotion/styled';
 import {space} from 'sentry/styles/space';
 
 export const ActionWrapper = styled('div')`
-  padding: ${space(1)} 0 0 0;
+  padding: ${space(2)};
 `;


### PR DESCRIPTION
This is effectively a revert of https://github.com/getsentry/sentry/pull/83744 which ended up causing padding issues with tables. They're the only visualization type that ignores padding.
