### PR TITLE
spike(aci): evaluate workflow triggers in delayed processing

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -5,7 +5,7 @@ import uuid
 from collections.abc import MutableMapping, Sequence
 from datetime import datetime
 from time import time
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import sentry_sdk
 from django.conf import settings
@@ -947,7 +947,7 @@ def process_workflow_engine(job: PostProcessJob) -> None:
         return
 
     try:
-        workflow_job = WorkflowJob({**job})  # type: ignore[typeddict-item]
+        workflow_job = cast(WorkflowJob, job)
     except Exception:
         logger.exception("Could not create WorkflowJob", extra={"job": job})
         return

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.handlers.condition.event_frequency_base_handler impo
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult
+from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult, DataJob
 
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
@@ -59,7 +59,7 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
-class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHandler[list[int]]):
+class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHandler[DataJob]):
     comparison_json_schema = {
         "type": "object",
         "properties": {
@@ -71,14 +71,14 @@ class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHa
     }
 
     @staticmethod
-    def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
-        if not isinstance(value, list) or len(value) != 1:
+    def evaluate_value(value: DataJob, comparison: Any) -> DataConditionResult:
+        if not value.get("results") or len(value.get("results", [])) != 1:
             return False
-        return value[0] > comparison["value"]
+        return value["results"][0] > comparison["value"]
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
-class EventFrequencyPercentHandler(EventFrequencyConditionHandler, DataConditionHandler[list[int]]):
+class EventFrequencyPercentHandler(EventFrequencyConditionHandler, DataConditionHandler[DataJob]):
     comparison_json_schema = {
         "type": "object",
         "properties": {
@@ -91,7 +91,7 @@ class EventFrequencyPercentHandler(EventFrequencyConditionHandler, DataCondition
     }
 
     @staticmethod
-    def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
-        if not isinstance(value, list) or len(value) != 2:
+    def evaluate_value(value: DataJob, comparison: Any) -> DataConditionResult:
+        if not value.get("results") or len(value.get("results", [])) != 2:
             return False
-        return percent_increase(value[0], value[1]) > comparison["value"]
+        return percent_increase(value["results"][0], value["results"][1]) > comparison["value"]

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -78,7 +78,7 @@ class EventFrequencyCountHandler(
 
     @staticmethod
     def evaluate_value(value: WorkflowEvaluationData, comparison: Any) -> DataConditionResult:
-        if not ((data := value.get("data")) and isinstance(data, list) and len(data) == 1):
+        if not ((data := value["data"]) and isinstance(data, list) and len(data) == 1):
             return False
         return data[0] > comparison["value"]
 
@@ -100,6 +100,6 @@ class EventFrequencyPercentHandler(
 
     @staticmethod
     def evaluate_value(value: WorkflowEvaluationData, comparison: Any) -> DataConditionResult:
-        if not ((data := value.get("data")) and isinstance(data, list) and len(data) == 2):
+        if not ((data := value["data"]) and isinstance(data, list) and len(data) == 2):
             return False
         return percent_increase(data[0], data[1]) > comparison["value"]

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -78,9 +78,9 @@ class EventFrequencyCountHandler(
 
     @staticmethod
     def evaluate_value(value: WorkflowEvaluationData, comparison: Any) -> DataConditionResult:
-        if not isinstance(value.get("data"), list) or len(value["data"]) != 1:
+        if not ((data := value.get("data")) and isinstance(data, list) and len(data) == 1):
             return False
-        return value["data"][0] > comparison["value"]
+        return data[0] > comparison["value"]
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
@@ -100,6 +100,6 @@ class EventFrequencyPercentHandler(
 
     @staticmethod
     def evaluate_value(value: WorkflowEvaluationData, comparison: Any) -> DataConditionResult:
-        if not isinstance(value.get("data"), list) or len(value["data"]) != 2:
+        if not ((data := value.get("data")) and isinstance(data, list) and len(data) == 2):
             return False
-        return percent_increase(value["data"][0], value["data"][1]) > comparison["value"]
+        return percent_increase(data[0], data[1]) > comparison["value"]

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.handlers.condition.event_frequency_base_handler impo
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult, WorkflowJob
+from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult
 
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
@@ -59,7 +59,7 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
-class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHandler[WorkflowJob]):
+class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHandler[list[int]]):
     comparison_json_schema = {
         "type": "object",
         "properties": {
@@ -71,16 +71,14 @@ class EventFrequencyCountHandler(EventFrequencyConditionHandler, DataConditionHa
     }
 
     @staticmethod
-    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
-        if len(value.get("snuba_results", [])) != 1:
+    def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
+        if not isinstance(value, list) or len(value) != 1:
             return False
-        return value["snuba_results"][0] > comparison["value"]
+        return value[0] > comparison["value"]
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
-class EventFrequencyPercentHandler(
-    EventFrequencyConditionHandler, DataConditionHandler[WorkflowJob]
-):
+class EventFrequencyPercentHandler(EventFrequencyConditionHandler, DataConditionHandler[list[int]]):
     comparison_json_schema = {
         "type": "object",
         "properties": {
@@ -93,10 +91,7 @@ class EventFrequencyPercentHandler(
     }
 
     @staticmethod
-    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
-        if len(value.get("snuba_results", [])) != 2:
+    def evaluate_value(value: list[int], comparison: Any) -> DataConditionResult:
+        if not isinstance(value, list) or len(value) != 2:
             return False
-        return (
-            percent_increase(value["snuba_results"][0], value["snuba_results"][1])
-            > comparison["value"]
-        )
+        return percent_increase(value[0], value[1]) > comparison["value"]

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -156,6 +156,21 @@ def is_slow_condition(cond: DataCondition) -> bool:
     return Condition(cond.type) in SLOW_CONDITIONS
 
 
+def split_fast_slow_conditions(
+    conditions: list[DataCondition],
+) -> tuple[list[DataCondition], list[DataCondition]]:
+    fast_conditions = []
+    slow_conditions = []
+
+    for condition in conditions:
+        if is_slow_condition(condition):
+            slow_conditions.append(condition)
+        else:
+            fast_conditions.append(condition)
+
+    return fast_conditions, slow_conditions
+
+
 @receiver(pre_save, sender=DataCondition)
 def enforce_comparison_schema(sender, instance: DataCondition, **kwargs):
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -8,11 +8,10 @@ from django.dispatch import receiver
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
-from sentry.eventstore.models import GroupEvent
 from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
 from sentry.workflow_engine.processors.data_condition_group import evaluate_condition_group
-from sentry.workflow_engine.types import DataJob, WorkflowJob
+from sentry.workflow_engine.types import WorkflowEvaluationData, WorkflowJob
 
 from .json_config import JSONConfigBase
 
@@ -68,7 +67,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             )
         ]
 
-    def evaluate_trigger_conditions(self, job: DataJob) -> bool:
+    def evaluate_trigger_conditions(self, job: WorkflowEvaluationData) -> bool:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
         If there aren't any workflow trigger conditions, the workflow is considered triggered.
@@ -76,11 +75,11 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         if self.when_condition_group is None:
             return True
 
-        if evaluate_all_conditions := isinstance(job.get("event"), GroupEvent):
-            job["workflow"] = self
+        if evaluate_all_conditions := isinstance(job["data"], dict):
+            job["data"]["workflow"] = self
             evaluation, _ = evaluate_condition_group(
                 self.when_condition_group,
-                cast(WorkflowJob, job),
+                cast(WorkflowJob, job["data"]),
                 evaluate_slow_conditions=not evaluate_all_conditions,
             )
         else:

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -67,7 +67,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             )
         ]
 
-    def evaluate_trigger_conditions(self, job: WorkflowJob) -> bool:
+    def evaluate_trigger_conditions(self, job: WorkflowJob | list[int]) -> bool:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
         If there aren't any workflow trigger conditions, the workflow is considered triggered.
@@ -75,8 +75,12 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         if self.when_condition_group is None:
             return True
 
-        job["workflow"] = self
-        evaluation, _ = evaluate_condition_group(self.when_condition_group, job)
+        if evaluate_all_conditions := isinstance(job, dict):
+            job["workflow"] = self
+
+        evaluation, _ = evaluate_condition_group(
+            self.when_condition_group, job, evaluate_slow_conditions=not evaluate_all_conditions
+        )
         return evaluation
 
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,16 +1,18 @@
 import logging
 from collections import defaultdict
+from typing import cast
 
 import sentry_sdk
 
 from sentry import buffer
+from sentry.eventstore.models import GroupEvent
 from sentry.utils import json, metrics
 from sentry.workflow_engine.models import Detector, Workflow, WorkflowDataConditionGroup
 from sentry.workflow_engine.models.workflow import get_slow_conditions
 from sentry.workflow_engine.processors.action import evaluate_workflow_action_filters
 from sentry.workflow_engine.processors.data_condition_group import evaluate_condition_group
 from sentry.workflow_engine.processors.detector import get_detector_by_event
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import DataJob, WorkflowJob
 
 logger = logging.getLogger(__name__)
 
@@ -64,12 +66,10 @@ def enqueue_workflows(
         )
 
 
-def evaluate_workflow_triggers(
-    workflows: set[Workflow], job: WorkflowJob | list[int]
-) -> set[Workflow]:
+def evaluate_workflow_triggers(workflows: set[Workflow], job: DataJob) -> set[Workflow]:
     triggered_workflows: set[Workflow] = set()
     workflows_to_enqueue: set[Workflow] = set()
-    evaluate_all_conditions = isinstance(job, dict)
+    evaluate_all_conditions = isinstance(job.get("event"), GroupEvent)
 
     for workflow in workflows:
         if workflow.evaluate_trigger_conditions(job):
@@ -81,8 +81,9 @@ def evaluate_workflow_triggers(
                 # enqueue to be evaluated later
                 workflows_to_enqueue.add(workflow)
 
-    if workflows_to_enqueue and isinstance(job, dict):
-        enqueue_workflows(workflows_to_enqueue, job)
+    if workflows_to_enqueue and isinstance(job.get("event"), GroupEvent):
+        workflow_job = cast(WorkflowJob, job)
+        enqueue_workflows(workflows_to_enqueue, workflow_job)
 
     return triggered_workflows
 
@@ -105,7 +106,8 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
 
     # Get the workflows, evaluate the when_condition_group, finally evaluate the actions for workflows that are triggered
     workflows = set(Workflow.objects.filter(detectorworkflow__detector_id=detector.id).distinct())
-    triggered_workflows = evaluate_workflow_triggers(workflows, job)
+    data_job = cast(DataJob, job)
+    triggered_workflows = evaluate_workflow_triggers(workflows, data_job)
     actions = evaluate_workflow_action_filters(triggered_workflows, job)
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -64,19 +64,24 @@ def enqueue_workflows(
         )
 
 
-def evaluate_workflow_triggers(workflows: set[Workflow], job: WorkflowJob) -> set[Workflow]:
+def evaluate_workflow_triggers(
+    workflows: set[Workflow], job: WorkflowJob | list[int]
+) -> set[Workflow]:
     triggered_workflows: set[Workflow] = set()
     workflows_to_enqueue: set[Workflow] = set()
+    evaluate_all_conditions = isinstance(job, dict)
 
     for workflow in workflows:
         if workflow.evaluate_trigger_conditions(job):
             triggered_workflows.add(workflow)
+
+        # only collect slow conditions to enqueue if we are evaluating all conditions
         else:
-            if get_slow_conditions(workflow):
+            if evaluate_all_conditions and get_slow_conditions(workflow):
                 # enqueue to be evaluated later
                 workflows_to_enqueue.add(workflow)
 
-    if workflows_to_enqueue:
+    if workflows_to_enqueue and isinstance(job, dict):
         enqueue_workflows(workflows_to_enqueue, job)
 
     return triggered_workflows

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -39,14 +39,22 @@ class EventJob(TypedDict):
     event: GroupEvent
 
 
-class WorkflowJob(EventJob, total=False):
+class PostProcessJob(TypedDict, total=False):
     group_state: GroupState
     is_reprocessed: bool
     has_reappeared: bool
     has_alert: bool
     has_escalated: bool
     workflow: Workflow
-    snuba_results: list[int]  # TODO - @saponifi3 / TODO(cathy): audit this
+
+
+class WorkflowJob(EventJob, PostProcessJob):
+    pass
+
+
+class DataJob(PostProcessJob, total=False):
+    event: GroupEvent
+    results: list[int]
 
 
 class ActionHandler:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -39,7 +39,7 @@ class EventJob(TypedDict):
     event: GroupEvent
 
 
-class PostProcessJob(TypedDict, total=False):
+class WorkflowJob(EventJob, total=False):
     group_state: GroupState
     is_reprocessed: bool
     has_reappeared: bool
@@ -48,13 +48,8 @@ class PostProcessJob(TypedDict, total=False):
     workflow: Workflow
 
 
-class WorkflowJob(EventJob, PostProcessJob):
-    pass
-
-
-class DataJob(PostProcessJob, total=False):
-    event: GroupEvent
-    results: list[int]
+class WorkflowEvaluationData(TypedDict):
+    data: WorkflowJob | list[int]
 
 
 class ActionHandler:

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -13,7 +13,7 @@ from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
 )
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
-from sentry.workflow_engine.types import DataJob, WorkflowJob
+from sentry.workflow_engine.types import WorkflowEvaluationData, WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -46,11 +46,13 @@ class ConditionTestCase(BaseWorkflowTest):
     def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
-    def assert_slow_condition_passes(self, data_condition: DataCondition, job: DataJob) -> None:
+    def assert_slow_condition_passes(
+        self, data_condition: DataCondition, job: WorkflowEvaluationData
+    ) -> None:
         assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
 
     def assert_slow_condition_does_not_pass(
-        self, data_condition: DataCondition, job: DataJob
+        self, data_condition: DataCondition, job: WorkflowEvaluationData
     ) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -13,7 +13,7 @@ from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
 )
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import DataJob, WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -46,11 +46,11 @@ class ConditionTestCase(BaseWorkflowTest):
     def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
-    def assert_slow_condition_passes(self, data_condition: DataCondition, job: list[int]) -> None:
+    def assert_slow_condition_passes(self, data_condition: DataCondition, job: DataJob) -> None:
         assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
 
     def assert_slow_condition_does_not_pass(
-        self, data_condition: DataCondition, job: list[int]
+        self, data_condition: DataCondition, job: DataJob
     ) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -46,6 +46,14 @@ class ConditionTestCase(BaseWorkflowTest):
     def assert_does_not_pass(self, data_condition: DataCondition, job: WorkflowJob) -> None:
         assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
 
+    def assert_slow_condition_passes(self, data_condition: DataCondition, job: list[int]) -> None:
+        assert data_condition.evaluate_value(job) == data_condition.get_condition_result()
+
+    def assert_slow_condition_does_not_pass(
+        self, data_condition: DataCondition, job: list[int]
+    ) -> None:
+        assert data_condition.evaluate_value(job) != data_condition.get_condition_result()
+
     # TODO: activity
 
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
     EventFrequencyCountHandler,
 )
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DataJob
 from tests.sentry.workflow_engine.handlers.condition.test_base import (
     ConditionTestCase,
     EventFrequencyQueryTestBase,
@@ -27,6 +28,10 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         "comparisonType": ComparisonType.COUNT,
     }
 
+    def setUp(self):
+        super().setUp()
+        self.job = DataJob({"results": []})
+
     def test_count(self):
         dc = self.create_data_condition(
             type=self.condition,
@@ -34,8 +39,11 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.assert_slow_condition_passes(dc, [1001])
-        self.assert_slow_condition_does_not_pass(dc, [999])
+        self.job.update({"results": [1001]})
+        self.assert_slow_condition_passes(dc, self.job)
+
+        self.job.update({"results": [999]})
+        self.assert_slow_condition_does_not_pass(dc, self.job)
 
     def test_dual_write_count(self):
         dcg = self.create_data_condition_group()
@@ -81,6 +89,10 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         "comparisonType": ComparisonType.PERCENT,
     }
 
+    def setUp(self):
+        super().setUp()
+        self.job = DataJob({"results": []})
+
     def test_percent(self):
         dc = self.create_data_condition(
             type=self.condition,
@@ -92,8 +104,11 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.assert_slow_condition_passes(dc, [21, 10])
-        self.assert_slow_condition_does_not_pass(dc, [20, 10])
+        self.job.update({"results": [21, 10]})
+        self.assert_slow_condition_passes(dc, self.job)
+
+        self.job.update({"results": [20, 10]})
+        self.assert_slow_condition_does_not_pass(dc, self.job)
 
     def test_dual_write_percent(self):
         self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -9,7 +9,6 @@ from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
     EventFrequencyCountHandler,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.handlers.condition.test_base import (
     ConditionTestCase,
     EventFrequencyQueryTestBase,
@@ -28,10 +27,6 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         "comparisonType": ComparisonType.COUNT,
     }
 
-    def setUp(self):
-        super().setUp()
-        self.job = WorkflowJob({"event": self.group_event})
-
     def test_count(self):
         dc = self.create_data_condition(
             type=self.condition,
@@ -39,11 +34,8 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.job["snuba_results"] = [1001]
-        self.assert_passes(dc, self.job)
-
-        self.job["snuba_results"] = [999]
-        self.assert_does_not_pass(dc, self.job)
+        self.assert_slow_condition_passes(dc, [1001])
+        self.assert_slow_condition_does_not_pass(dc, [999])
 
     def test_dual_write_count(self):
         dcg = self.create_data_condition_group()
@@ -89,10 +81,6 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         "comparisonType": ComparisonType.PERCENT,
     }
 
-    def setUp(self):
-        super().setUp()
-        self.job = WorkflowJob({"event": self.group_event})
-
     def test_percent(self):
         dc = self.create_data_condition(
             type=self.condition,
@@ -104,11 +92,8 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.job["snuba_results"] = [21, 10]
-        self.assert_passes(dc, self.job)
-
-        self.job["snuba_results"] = [20, 10]
-        self.assert_does_not_pass(dc, self.job)
+        self.assert_slow_condition_passes(dc, [21, 10])
+        self.assert_slow_condition_does_not_pass(dc, [20, 10])
 
     def test_dual_write_percent(self):
         self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -9,7 +9,7 @@ from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
     EventFrequencyCountHandler,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DataJob
+from sentry.workflow_engine.types import WorkflowEvaluationData
 from tests.sentry.workflow_engine.handlers.condition.test_base import (
     ConditionTestCase,
     EventFrequencyQueryTestBase,
@@ -30,7 +30,7 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = DataJob({"results": []})
+        self.job = WorkflowEvaluationData({"data": []})
 
     def test_count(self):
         dc = self.create_data_condition(
@@ -39,10 +39,10 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.job.update({"results": [1001]})
+        self.job.update({"data": [1001]})
         self.assert_slow_condition_passes(dc, self.job)
 
-        self.job.update({"results": [999]})
+        self.job.update({"data": [999]})
         self.assert_slow_condition_does_not_pass(dc, self.job)
 
     def test_dual_write_count(self):
@@ -91,7 +91,7 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
 
     def setUp(self):
         super().setUp()
-        self.job = DataJob({"results": []})
+        self.job = WorkflowEvaluationData({"data": []})
 
     def test_percent(self):
         dc = self.create_data_condition(
@@ -104,10 +104,10 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        self.job.update({"results": [21, 10]})
+        self.job.update({"data": [21, 10]})
         self.assert_slow_condition_passes(dc, self.job)
 
-        self.job.update({"results": [20, 10]})
+        self.job.update({"data": [20, 10]})
         self.assert_slow_condition_does_not_pass(dc, self.job)
 
     def test_dual_write_percent(self):

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -1,4 +1,4 @@
-from sentry.workflow_engine.types import DataJob
+from sentry.workflow_engine.types import WorkflowEvaluationData, WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -9,7 +9,7 @@ class WorkflowTest(BaseWorkflowTest):
         )
         self.data_condition = self.data_condition_group.conditions.first()
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = DataJob({"event": self.group_event})
+        self.job = WorkflowEvaluationData({"data": WorkflowJob({"event": self.group_event})})
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self):
         evaluation = self.workflow.evaluate_trigger_conditions(self.job)

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -1,4 +1,4 @@
-from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.types import DataJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -9,7 +9,7 @@ class WorkflowTest(BaseWorkflowTest):
         )
         self.data_condition = self.data_condition_group.conditions.first()
         self.group, self.event, self.group_event = self.create_group_event()
-        self.job = WorkflowJob({"event": self.group_event})
+        self.job = DataJob({"event": self.group_event})
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self):
         evaluation = self.workflow.evaluate_trigger_conditions(self.job)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import cast
 from unittest import mock
 
 from sentry import buffer
@@ -14,7 +13,7 @@ from sentry.workflow_engine.processors.workflow import (
     evaluate_workflow_triggers,
     process_workflows,
 )
-from sentry.workflow_engine.types import DataJob, WorkflowJob
+from sentry.workflow_engine.types import WorkflowEvaluationData, WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
@@ -105,7 +104,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=occurrence,
         )
-        self.job = DataJob({"event": self.group_event})
+        self.job = WorkflowEvaluationData({"data": WorkflowJob({"event": self.group_event})})
 
     def test_workflow_trigger(self):
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.job)
@@ -174,7 +173,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=True,
         )
 
-        job = DataJob({"results": [101]})
+        job = WorkflowEvaluationData({"data": [101]})
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, job)
         assert triggered_workflows == {self.workflow}
 
@@ -196,7 +195,7 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
             occurrence=occurrence,
         )
         self.job = WorkflowJob({"event": self.group_event})
-        self.data_job = cast(DataJob, self.job)
+        self.data_job = WorkflowEvaluationData({"data": self.job})
         self.create_workflow_action(self.workflow)
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -172,6 +172,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             },
             condition_result=True,
         )
+        self.workflow.when_condition_group.update(logic_type=DataConditionGroup.Type.ALL)
 
         job = WorkflowEvaluationData({"data": [101]})
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, job)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -172,6 +172,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             },
             condition_result=True,
         )
+        assert self.workflow.when_condition_group
         self.workflow.when_condition_group.update(logic_type=DataConditionGroup.Type.ALL)
 
         job = WorkflowEvaluationData({"data": [101]})

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -162,6 +162,20 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.job)
         assert triggered_workflows == {self.workflow}
 
+    def test_evaluate_slow_conditions(self):
+        self.create_data_condition(
+            condition_group=self.workflow.when_condition_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+            },
+            condition_result=True,
+        )
+
+        triggered_workflows = evaluate_workflow_triggers({self.workflow}, [101])
+        assert triggered_workflows == {self.workflow}
+
 
 @freeze_time(FROZEN_TIME)
 class TestEnqueueWorkflow(BaseWorkflowTest):


### PR DESCRIPTION
We are able to reuse the `evaluate_workflow_triggers` function for delayed processing.

We need the `GroupEvent` in order to fire notifications if a workflow is triggered, but we don't need it to to evaluate slow conditions. However, it's not optimal for us to grab the `GroupEvent` BEFORE evaluation in delayed processing, since we may discard some after we find that some workflows don't need to be fired.

Requirements:
- Setup `evaluate_workflow_triggers` for delayed processing
- Continue passing `WorkflowJob` appropriately to fast condition handlers, because some of them expect a `GroupEvent` object
- Allow slow conditions to evaluate on results from a Snuba query (list[int])

This PR adds a `WorkflowEvaluationData` TypedDict that encapsulates the existing `WorkflowJob` TypedDict and can also contain results from Snuba. We can wrap `WorkflowJob` with `WorkflowEvaluationData` to use `evaluate_workflow_triggers`, and also pass in snuba results to the same function inside `WorkflowEvaluationData` for evaluating slow conditions.

When calling `DataCondition.evaluate_value`, we can pass a `WorkflowJob` instead of `WorkflowEvaluationData` if the type of `data` is `WorkflowJob`.