### PR TITLE
fix: respect enhanced_privacy on emails

### DIFF
--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -129,10 +129,12 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
         should_add_url = provider is not None
         text_description = self.description_as_text(text_template, params, should_add_url, provider)
         html_description = self.description_as_html(html_template or text_template, params)
+        enhanced_privacy = self.organization.flags.enhanced_privacy
         return {
             **self.get_base_context(),
             "text_description": text_description,
             "html_description": html_description,
+            "enhanced_privacy": enhanced_privacy,
         }
 
     def get_group_context(self) -> MutableMapping[str, Any]:

--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -30,6 +30,11 @@
 
   {% if group and not enhanced_privacy %}
     {% include "sentry/emails/group_header.html" %}
+  {% else %}
+    <div class="notice">
+      Details about this issue are not shown in this notification since enhanced privacy controls are enabled.
+      For more details about this issue, <a href="{{ link }}">view this issue on Sentry</a>.
+    </div>
   {% endif %}
 
   {% if reason %}

--- a/src/sentry/templates/sentry/emails/activity/generic.txt
+++ b/src/sentry/templates/sentry/emails/activity/generic.txt
@@ -4,11 +4,14 @@
 
 {{ text_description }}
 
-
+{% if enhanced_privacy %}
+Details about this issue are not shown in this notification since enhanced privacy controls are enabled.
+For more details about this issue, view this issue on Sentry.
+{% else %}
 ## Issue Details
 
 {{ group.title }}
-
+{% endif %}
 {{ link }}
 {% if unsubscribe_link %}
 

--- a/src/sentry/web/frontend/debug/debug_generic_issue.py
+++ b/src/sentry/web/frontend/debug/debug_generic_issue.py
@@ -17,6 +17,7 @@ class DebugGenericIssueEmailView(View):
     def get(self, request):
         org = Organization(id=1, slug="example", name="Example")
         project = Project(id=1, slug="example", name="Example", organization=org)
+        enhanced_privacy = org.flags.enhanced_privacy
 
         event = make_generic_event(project)
         group = event.group
@@ -49,5 +50,6 @@ class DebugGenericIssueEmailView(View):
                 "issue_title": event.occurrence.issue_title,
                 "subtitle": event.occurrence.subtitle,
                 "culprit": event.occurrence.culprit,
+                "enhanced_privacy": enhanced_privacy,
             },
         ).render(request)

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -291,6 +291,7 @@ def get_shared_context(rule, org, project: Project, group, event):
         "tags": event.tags,
         "snooze_alert": snooze_alert,
         "snooze_alert_url": absolute_uri(snooze_alert_url),
+        "enhanced_privacy": org.flags.enhanced_privacy,
     }
 
 
@@ -457,7 +458,11 @@ def alert(request):
     group = event.group
 
     group.substatus = random.choice(
-        [GroupSubStatus.ESCALATING, GroupSubStatus.NEW, GroupSubStatus.REGRESSED]
+        [
+            GroupSubStatus.ESCALATING,
+            GroupSubStatus.NEW,
+            GroupSubStatus.REGRESSED,
+        ]
     )
 
     rule = Rule(id=1, label="An example rule")
@@ -485,6 +490,7 @@ def alert(request):
             "issue_type": group.issue_type.description,
             "replay_id": REPLAY_ID,
             "issue_replays_url": get_issue_replay_link(group, "?referrer=alert_email"),
+            "enhanced_privacy": org.flags.enhanced_privacy,
         },
     ).render(request)
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -324,7 +324,11 @@ class MailPreview:
     def render(self, request: HttpRequest):
         return render_to_response(
             "sentry/debug/mail/preview.html",
-            context={"preview": self, "format": request.GET.get("format")},
+            context={
+                "preview": self,
+                "format": request.GET.get("format"),
+                "enhanced_privacy": request.GET.get("enhanced_privacy", False),
+            },
         )
 
 
@@ -453,6 +457,8 @@ def alert(request):
     platform = request.GET.get("platform", "python")
     org = Organization(id=1, slug="example", name="Example")
     project = Project(id=1, slug="example", name="Example", organization=org)
+
+    org.flags.enhanced_privacy = request.GET.get("enhanced_privacy", False)
 
     event = make_error_event(request, project, platform)
     group = event.group


### PR DESCRIPTION
We did not always respect the "Enhanced Privacy" setting on outgoing emails. Primarily because the `enhanced_privacy` context value was not always present in the template rendering.

Regression email:
![image](https://github.com/user-attachments/assets/179ec506-9cee-40a5-9b4f-ac2238465d41)

Generic alert (regression):
![image](https://github.com/user-attachments/assets/c4af6f6c-3df4-43a7-a3c8-53db626621f5)
