### PR TITLE
chore(aci): comparison json schema for RegressionEventHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
@@ -8,6 +8,7 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionHand
 @condition_handler_registry.register(Condition.REGRESSION_EVENT)
 class RegressionEventConditionHandler(DataConditionHandler[WorkflowJob]):
     type = DataConditionHandlerType.WORKFLOW_TRIGGER
+    comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -1,3 +1,6 @@
+import pytest
+from jsonschema import ValidationError
+
 from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.regression_event import RegressionEventCondition
 from sentry.workflow_engine.models.data_condition import Condition
@@ -18,6 +21,24 @@ class TestRegressionEventCondition(ConditionTestCase):
         assert dc.comparison is True
         assert dc.condition_result is True
         assert dc.condition_group == dcg
+
+    def test_json_schema(self):
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison=True,
+            condition_result=True,
+        )
+
+        dc.comparison = False
+        dc.save()
+
+        dc.comparison = {"time": "asdf"}
+        with pytest.raises(ValidationError):
+            dc.save()
+
+        dc.comparison = "hello"
+        with pytest.raises(ValidationError):
+            dc.save()
 
     def test(self):
         job = WorkflowJob(


### PR DESCRIPTION
`comparison` for `RegressionEventHandler` should be a boolean