### PR TITLE
chore(aci): comparison json schema for AssignedToHandler

### DIFF
--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -218,7 +218,7 @@ FALLTHROUGH_CHOICES = [
 ]
 
 
-class AssigneeTargetType(Enum):
+class AssigneeTargetType(StrEnum):
     UNASSIGNED = "Unassigned"
     TEAM = "Team"
     MEMBER = "Member"

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -13,6 +13,15 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionHand
 @condition_handler_registry.register(Condition.ASSIGNED_TO)
 class AssignedToConditionHandler(DataConditionHandler[WorkflowJob]):
     type = DataConditionHandlerType.ACTION_FILTER
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "target_type": {"type": "string", "enum": [*AssigneeTargetType]},
+            "target_identifier": {"type": ["integer", "string"]},
+        },
+        "required": ["target_type", "target_identifier"],
+        "additionalProperties": False,
+    }
 
     @staticmethod
     def get_assignees(group: Group) -> Sequence[GroupAssignee]:

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -57,6 +57,10 @@ class TestAssignedToCondition(ConditionTestCase):
         with pytest.raises(ValidationError):
             self.dc.save()
 
+        self.dc.comparison.update({"hello": "there"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
     def test_assigned_to_member_passes(self):
         GroupAssignee.objects.create(user_id=self.user.id, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Member", "target_identifier": self.user.id})

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -1,3 +1,6 @@
+import pytest
+from jsonschema import ValidationError
+
 from sentry.models.groupassignee import GroupAssignee
 from sentry.rules.filters.assigned_to import AssignedToFilter
 from sentry.workflow_engine.models.data_condition import Condition
@@ -24,8 +27,8 @@ class TestAssignedToCondition(ConditionTestCase):
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
-                "targetType": "Member",
-                "targetIdentifier": 0,
+                "target_type": "Member",
+                "target_identifier": 0,
             },
             condition_result=True,
         )
@@ -41,6 +44,18 @@ class TestAssignedToCondition(ConditionTestCase):
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
+
+    def test_json_schema(self):
+        self.dc.comparison.update({"target_type": "Team"})
+        self.dc.save()
+
+        self.dc.comparison.update({"target_type": "asdf"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"target_identifier": False})
+        with pytest.raises(ValidationError):
+            self.dc.save()
 
     def test_assigned_to_member_passes(self):
         GroupAssignee.objects.create(user_id=self.user.id, group=self.group, project=self.project)


### PR DESCRIPTION
`comparison` for `RegressionEventHandler` should be a `dict` with `target_type: AssigneeTargetType` and `target_identifier: str | int`