### PR TITLE
feat(widget-builder): Add text field for apdex and user misery thresholds

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -880,6 +880,57 @@ describe('Visualize', () => {
     expect(removeButtons[1]).toBeEnabled();
   });
 
+  it('shows a text box and removes the column selection for apdex', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              field: ['apdex(3000)'],
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toHaveTextContent('apdex');
+    expect(screen.getAllByRole('textbox')[0]).toHaveValue('3000');
+    expect(
+      screen.queryByRole('button', {name: 'Column Selection'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('resets the text box value when swapping between apdex and user_misery', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              field: ['apdex(9999)'],
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'user_misery'}));
+
+    expect(screen.getAllByRole('textbox')[0]).toHaveValue('300');
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -805,6 +805,11 @@ function AggregateParameterField({
       onUpdate: (value: any) => {
         onChange(value);
       },
+      onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+          onChange(e.currentTarget.value);
+        }
+      },
       placeholder: parameter.placeholder,
     };
     switch (parameter.dataType) {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -157,6 +157,9 @@ function validateParameter(
     return Boolean(columnOptions.find(option => option.value === value)?.value);
   }
   if (parameter.kind === 'value') {
+    if (parameter.dataType === 'number') {
+      return !isNaN(Number(value));
+    }
     return true;
   }
   return false;
@@ -422,7 +425,6 @@ function Visualize({error, setError}: VisualizeProps) {
                   ) : (
                     <Fragment>
                       <PrimarySelectRow hasColumnParameter={hasColumnParameter}>
-                        {/** TODO: Add support for the value parameter type for cases like user_misery, apdex */}
                         {hasColumnParameter && (
                           <ColumnCompactSelect
                             searchable
@@ -495,12 +497,17 @@ function Visualize({error, setError}: VisualizeProps) {
                                       // If no column filter method is provided, show all options
                                       columnFilterMethod ?? (() => true)
                                     );
-                                    const isValidColumn = Boolean(
-                                      newColumnOptions.find(
-                                        option =>
-                                          option.value === currentField.function[1]
-                                      )?.value
-                                    );
+                                    const newAggregateIsApdexOrUserMisery =
+                                      newAggregate?.value.meta.name === 'apdex' ||
+                                      newAggregate?.value.meta.name === 'user_misery';
+                                    const isValidColumn =
+                                      !newAggregateIsApdexOrUserMisery &&
+                                      Boolean(
+                                        newColumnOptions.find(
+                                          option =>
+                                            option.value === currentField.function[1]
+                                        )?.value
+                                      );
                                     currentField.function[1] =
                                       (isValidColumn
                                         ? currentField.function[1]
@@ -671,6 +678,25 @@ function Visualize({error, setError}: VisualizeProps) {
                             )}
                           </ParameterRefinements>
                         )}
+                      {isApdexOrUserMisery && field.kind === FieldValueKind.FUNCTION && (
+                        <AggregateParameterField
+                          parameter={matchingAggregate?.value.meta.parameters[0]}
+                          fieldValue={field}
+                          currentValue={field.function[1]}
+                          onChange={value => {
+                            const newFields = cloneDeep(fields);
+                            if (newFields[index]!.kind !== FieldValueKind.FUNCTION) {
+                              return;
+                            }
+                            newFields[index]!.function[1] = value;
+                            dispatch({
+                              type: updateAction,
+                              payload: newFields,
+                            });
+                            setError?.({...error, queries: []});
+                          }}
+                        />
+                      )}
                     </Fragment>
                   )}
                 </FieldBar>
@@ -786,7 +812,7 @@ function AggregateParameterField({
         return (
           <BufferedInput
             name="refinement"
-            key="parameter:number"
+            key={`parameter:number-${currentValue}`}
             type="text"
             inputMode="numeric"
             pattern="[0-9]*(\.[0-9]*)?"


### PR DESCRIPTION
Adds a new text field under the `apdex` and `user_misery` selections to update the threshold.

<img width="728" alt="Screenshot 2025-01-22 at 2 39 59 PM" src="https://github.com/user-attachments/assets/c7cf8925-bbd2-4c17-97c7-1a0385405277" />

I had to update the key for the buffered input because when the value changes as a side effect (i.e. going from `apdex(3000)` to `user_misery` should set the value to `user_misery(300)` automatically), it doesn't trigger a state change. Updating the key triggers this change for the field.

Closes #83372