### PR TITLE
:sparkles: feat(thread): Support Opern Period for Workflow Notifications

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -251,7 +251,7 @@ class SlackService:
             sentry_sdk.capture_message(
                 f"slack.notify_all_threads_for_activity.multiple_parent_notifications_for_single_open_period Activity: {activity.id}, Group: {activity.group.id}, Project: {activity.project.id}, Integration: {integration.id}, Parent Notification Count: {parent_notification_count}"
             )
-            self._logger.info(
+            self._logger.error(
                 "multiple parent notifications found for single open period",
                 extra={
                     "activity_id": activity.id,


### PR DESCRIPTION
for an uptime issue, we should only notify a thread of the latest open period.

what this means is if i had 2 threads for a particular uptime alert, (old & new) - 

 i should get a notification when the issue is assigned or there a comment only on the new thread. the old thread should be "closed" once that instance of the open period is closed.

closes https://getsentry.atlassian.net/browse/ACI-90