### PR TITLE
fix(storybook) special case index files for search

### DIFF
--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -183,7 +183,14 @@ function useStoryTree(query: string, files: string[]) {
     const lowerCaseQuery = query.toLowerCase();
 
     for (const {node, path} of root) {
-      const match = fzf(node.name, lowerCaseQuery, false);
+      // index files are useless when trying to match by name, so we'll special
+      // case them and match by their full path as it'll contain a more
+      // relevant path that we can match against.
+      const name = node.name.startsWith('index.')
+        ? [node.name, ...path.map(p => p.name)].join('.')
+        : node.name;
+
+      const match = fzf(name, lowerCaseQuery, false);
       node.result = match;
 
       if (match.score > 0) {


### PR DESCRIPTION
matching on index names is useless, and will never match anything besides when users search for index, so instead match on their path