### PR TITLE
fix(storybook) ensure expanding always shows children

### DIFF
--- a/static/app/views/stories/storyTree.tsx
+++ b/static/app/views/stories/storyTree.tsx
@@ -100,6 +100,11 @@ function Folder(props: {node: StoryTreeNode}) {
       <FolderName
         onClick={() => {
           props.node.expanded = !props.node.expanded;
+          if (props.node.expanded) {
+            for (const child of Object.values(props.node.children)) {
+              child.visible = true;
+            }
+          }
           setExpanded(props.node.expanded);
         }}
       >


### PR DESCRIPTION
During search, non matching nodes are marked as not visible. Since it is possible for a folder to match a query, but not its children, expanding that folder needs to toggle that children as visible and render them