### PR TITLE
chore(relocation) Skip stuck outboxes for relocations

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -140,6 +140,10 @@ def process_relocation_reply_with_export(payload: Mapping[str, Any], **kwds):
     except Exception:
         raise FileNotFoundError("Could not open SaaS -> SaaS export in proxy relocation bucket.")
 
+    # TODO(mark) Remove this once stuck outboxes have cleared up.
+    if slug == "demo":
+        return
+
     with encrypted_bytes:
         region_relocation_export_service.reply_with_export(
             relocation_uuid=payload["relocation_uuid"],

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -92,6 +92,10 @@ def process_relocation_reply_with_export(payload: Any, **kwds):
             "Could not open SaaS -> SaaS export in export-side relocation bucket."
         )
 
+    # TODO(mark) Remove this once stuck outboxes have cleared up.
+    if slug == "demo":
+        return
+
     with encrypted_bytes:
         control_relocation_export_service.reply_with_export(
             relocation_uuid=uuid,


### PR DESCRIPTION
We have a few outboxes that are stuck for relocations that were started in DE. Both relocations with stuck outboxes have demo as the target org slug and both relocations have the status of completed.

A similar solution was temporarily deployed in #77787 to solve a similar issue.

Refs SENTRY-3KYV