### PR TITLE
feat(ourlogs): Add tabs to explore page conditional on feature flag

### DIFF
--- a/static/app/utils/useOrganization.tsx
+++ b/static/app/utils/useOrganization.tsx
@@ -17,9 +17,9 @@ interface Options<AllowNull extends boolean = boolean> {
 // `allowNull` to true.
 
 function useOrganization(opts?: Options<false>): Organization;
-function useOrganization(opts?: Options<true>): Organization | null;
+function useOrganization(opts: Options<true>): Organization | null;
 
-function useOrganization({allowNull}: Options = {}) {
+function useOrganization({allowNull = false}: Options = {}) {
   const organization = useContext(OrganizationContext);
 
   if (allowNull) {

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -36,7 +36,10 @@ export function ExploreContent() {
     });
   }, [location, navigate]);
   const ourlogsEnabled = organization.features.includes('ourlogs-enabled');
-  const selectedTab = location.query.exploreTab || 'spans';
+  const selectedTab =
+    (Array.isArray(location.query.exploreTab)
+      ? location.query.exploreTab[0]
+      : location.query.exploreTab) ?? 'spans';
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -13,7 +13,9 @@ import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
+import TraceExplorerTabs from 'sentry/views/explore/tabBar';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 
 export function ExploreContent() {
@@ -33,6 +35,8 @@ export function ExploreContent() {
       },
     });
   }, [location, navigate]);
+  const ourlogsEnabled = organization.features.includes('ourlogs-enabled');
+  const selectedTab = location.query.exploreTab || 'spans';
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
@@ -67,12 +71,17 @@ export function ExploreContent() {
                 <FeedbackWidgetButton />
               </ButtonBar>
             </Layout.HeaderActions>
+            {ourlogsEnabled ? <TraceExplorerTabs selected={selectedTab} /> : null}
           </Layout.Header>
-          <SpansTabContent
-            defaultPeriod={defaultPeriod}
-            maxPickableDays={maxPickableDays}
-            relativeOptions={relativeOptions}
-          />
+          {ourlogsEnabled && selectedTab === 'logs' ? (
+            <LogsTabContent />
+          ) : (
+            <SpansTabContent
+              defaultPeriod={defaultPeriod}
+              maxPickableDays={maxPickableDays}
+              relativeOptions={relativeOptions}
+            />
+          )}
         </Layout.Page>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -10,6 +10,7 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -36,10 +37,7 @@ export function ExploreContent() {
     });
   }, [location, navigate]);
   const ourlogsEnabled = organization.features.includes('ourlogs-enabled');
-  const selectedTab =
-    (Array.isArray(location.query.exploreTab)
-      ? location.query.exploreTab[0]
-      : location.query.exploreTab) ?? 'spans';
+  const selectedTab = decodeScalar(location.query.exploreTab, 'spans');
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,0 +1,4 @@
+export function LogsTabContent() {
+  // TODO implement
+  return <div>logs!</div>;
+}

--- a/static/app/views/explore/tabBar.tsx
+++ b/static/app/views/explore/tabBar.tsx
@@ -1,0 +1,49 @@
+import {useMemo} from 'react';
+
+import * as Layout from 'sentry/components/layouts/thirds';
+import {TabList} from 'sentry/components/tabs';
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+
+export type TraceExplorerSelectedTab = 'spans' | 'ourlogs';
+interface Props {
+  selected: TraceExplorerSelectedTab;
+}
+
+export default function TraceExplorerTabs({selected}: Props) {
+  const location = useLocation();
+
+  const tabs = useMemo(
+    () => [
+      {
+        key: 'spans',
+        label: t('Spans'),
+        query: {...location.query, exploreTab: 'spans'},
+      },
+      {
+        key: 'logs',
+        label: t('Logs'),
+        query: {...location.query, exploreTab: 'logs'},
+      },
+    ],
+    [location.query]
+  );
+
+  return (
+    <Layout.HeaderTabs value={selected}>
+      <TabList hideBorder>
+        {tabs.map(tab => (
+          <TabList.Item
+            key={tab.key}
+            to={{
+              ...location,
+              query: tab.query,
+            }}
+          >
+            {tab.label}
+          </TabList.Item>
+        ))}
+      </TabList>
+    </Layout.HeaderTabs>
+  );
+}

--- a/static/app/views/explore/tabBar.tsx
+++ b/static/app/views/explore/tabBar.tsx
@@ -5,9 +5,8 @@ import {TabList} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 
-export type TraceExplorerSelectedTab = 'spans' | 'ourlogs';
 interface Props {
-  selected: TraceExplorerSelectedTab;
+  selected: string;
 }
 
 export default function TraceExplorerTabs({selected}: Props) {


### PR DESCRIPTION
This adds a tab bar to the new trace explorer if logging is enabled for your organization.

The content of the log tab will come later.

![Screenshot 2025-01-22 at 5 17 40 PM](https://github.com/user-attachments/assets/1c1c42ff-a1bc-4e58-86d9-f02df5958cbb)
