### PR TITLE
chore(aci): comparison json schema for IssueOccurrencesHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
@@ -10,6 +10,15 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionHand
 class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowJob]):
     type = DataConditionHandlerType.ACTION_FILTER
 
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "value": {"type": "integer", "minimum": 0},
+        },
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
         group: Group = job["event"].group

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -1,3 +1,6 @@
+import pytest
+from jsonschema import ValidationError
+
 from sentry.rules.filters.issue_occurrences import IssueOccurrencesFilter
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowJob
@@ -9,7 +12,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
     rule_cls = IssueOccurrencesFilter
     payload = {
         "id": IssueOccurrencesFilter.id,
-        "value": "10",
+        "value": 10,
     }
 
     def setUp(self):
@@ -23,7 +26,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={
-                "value": "10",
+                "value": 10,
             },
             condition_result=True,
         )
@@ -34,10 +37,26 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
 
         assert dc.type == self.condition
         assert dc.comparison == {
-            "value": "10",
+            "value": 10,
         }
         assert dc.condition_result is True
         assert dc.condition_group == dcg
+
+    def test_json_schema(self):
+        self.dc.comparison.update({"value": 2000})
+        self.dc.save()
+
+        self.dc.comparison.update({"value": -1})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"value": "2000"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"hello": "there"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
 
     def test_compares_correctly(self):
         self.group.update(times_seen=11)


### PR DESCRIPTION
`comparison` for `IssueOccurrencesHandler` should be a `dict` with `value: int` (>= 0)