### PR TITLE
fix(seer grouping): Hash project id before assigning to backfill worker

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -118,7 +118,10 @@ def create_project_cohort(
         query = query.exclude(projectoption__key=PROJECT_BACKFILL_COMPLETED)
     project_cohort_list = (
         query.values_list("id", flat=True)
-        .extra(where=["id %% %s = %s"], params=[total_worker_count, worker_number])
+        .extra(
+            where=["abs(hashtext(cast(id as varchar))) %% %s = %s"],
+            params=[total_worker_count, worker_number],
+        )
         .order_by("id")[:cohort_size]
     )
     return list(project_cohort_list)


### PR DESCRIPTION
When backfilling Seer grouping records, we split the projects up among our 4 workers by taking the project id mod 4 and assigning each project to the worker whose number matches the mod result. It turns out, though, that something about the way we generate project ids heavily skews the results to worker 0. (In other words, way more of our project ids mod out to 0 than 1, 2, or 3.) This means that we're not splitting the work up evenly, and the backfill is thus taking way longer than it needs to.

The solution to this problem is to hash the project ids before taking their mod, which this PR does. The table below shows the results of modding both raw and hashed project ids for 10,000 randomly selected projects, showing that hashing the ids first gives a much more even distribution.

| mod | raw id count | hashed id count |
|-----|--------------|-----------------|
|  0  |         7352 |            2545 |
|  1  |         1218 |            2496 |
|  2  |          805 |            2498 |
|  3  |          625 |            2461 |