### PR TITLE
chore(aci): comparison json schema for LatestReleaseHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -42,6 +42,7 @@ def get_latest_release_for_env(
 @condition_handler_registry.register(Condition.LATEST_RELEASE)
 class LatestReleaseConditionHandler(DataConditionHandler[WorkflowJob]):
     type = DataConditionHandlerType.ACTION_FILTER
+    comparison_json_schema = {"type": "boolean"}
 
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
+from jsonschema import ValidationError
 
 from sentry.models.release import Release
 from sentry.rules.filters.latest_release import LatestReleaseFilter, get_project_release_cache_key
@@ -43,6 +44,18 @@ class TestLatestReleaseCondition(ConditionTestCase):
         assert dc.comparison is True
         assert dc.condition_result is True
         assert dc.condition_group == dcg
+
+    def test_json_schema(self):
+        self.dc.comparison = False
+        self.dc.save()
+
+        self.dc.comparison = {"time": "asdf"}
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison = "hello"
+        with pytest.raises(ValidationError):
+            self.dc.save()
 
     def test_latest_release(self):
         old_release = Release.objects.create(


### PR DESCRIPTION
`comparison` for `LatestReleaseHandler` should be a `boolean`, we always set it to `True` because we only get the latest release