### PR TITLE
feat(solutions): Allow solution section to be folded

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -179,8 +179,8 @@ export function GroupSummary({
     <div data-testid="group-summary">
       {isError ? <div>{t('Error loading summary')}</div> : null}
       <Content>
-        {data?.eventId && !isPending && (
-          <TooltipWrapper id="group-summary-tooltip-wrapper" preview={preview}>
+        {data?.eventId && !isPending && !preview && (
+          <TooltipWrapper id="group-summary-tooltip-wrapper">
             <DropdownMenu
               items={eventDetailsItems}
               triggerProps={{
@@ -314,9 +314,9 @@ const CardContent = styled('div')`
   flex: 1;
 `;
 
-const TooltipWrapper = styled('div')<{preview?: boolean}>`
+const TooltipWrapper = styled('div')`
   position: absolute;
-  top: ${p => (p.preview ? `-32px` : `-${space(0.5)}`)};
+  top: -${space(0.5)};
   right: 0;
 `;
 

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -264,9 +264,9 @@ export default function GroupSidebar({
         issueTypeConfig.issueSummary.enabled &&
         !organization.hideAiFeatures) ||
         issueTypeConfig.resources) && (
-        <SolutionsSectionContainer>
+        <ErrorBoundary mini>
           <SolutionsSection group={group} project={project} event={event} />
-        </SolutionsSectionContainer>
+        </ErrorBoundary>
       )}
 
       {hasStreamlinedUI && event && (
@@ -318,12 +318,6 @@ export default function GroupSidebar({
     </Container>
   );
 }
-
-const SolutionsSectionContainer = styled('div')`
-  margin-bottom: ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
-  padding-bottom: ${space(2)};
-`;
 
 const Container = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -15,6 +15,7 @@ export const enum SectionKey {
 
   USER_FEEDBACK = 'user-feedback',
   LLM_MONITORING = 'llm-monitoring',
+  SOLUTIONS_HUB = 'solutions-hub',
 
   UPTIME = 'uptime', // Only Uptime issues
   DOWNTIME = 'downtime',

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   Fragment,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -54,6 +55,7 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
     title,
     actions,
     sectionKey,
+    className,
     initialCollapse = false,
     preventCollapse = false,
   },
@@ -61,12 +63,18 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
 ) {
   const organization = useOrganization();
   const {sectionData, navScrollMargin, dispatch} = useIssueDetails();
-  // Does not control open/close state. Controls what state is persisted to local storage
   const [isCollapsed, setIsCollapsed] = useSyncedLocalStorageState(
     getFoldSectionKey(sectionKey),
     initialCollapse
   );
   const hasAttemptedScroll = useRef(false);
+
+  // If the section is prevented from collapsing, we need to update the local storage state and open
+  useEffect(() => {
+    if (preventCollapse) {
+      setIsCollapsed(false);
+    }
+  }, [preventCollapse, setIsCollapsed]);
 
   const scrollToSection = useCallback(
     (element: HTMLElement | null) => {
@@ -97,10 +105,11 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
       dispatch({
         type: 'UPDATE_EVENT_SECTION',
         key: sectionKey,
-        config: {initialCollapse},
+        // If the section is prevented from collapsing, we don't want to persist the initial collapse state
+        config: {initialCollapse: preventCollapse ? false : initialCollapse},
       });
     }
-  }, [sectionData, dispatch, sectionKey, initialCollapse]);
+  }, [sectionData, dispatch, sectionKey, initialCollapse, preventCollapse]);
 
   // This controls disabling the InteractionStateLayer when hovering over action items. We don't
   // want selecting an action to appear as though it'll fold/unfold the section.
@@ -130,6 +139,7 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
         id={sectionKey}
         scrollMargin={navScrollMargin ?? 0}
         role="region"
+        className={className}
       >
         <SectionExpander
           preventCollapse={preventCollapse}
@@ -142,7 +152,7 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
             hasSelectedBackground={false}
             hidden={preventCollapse ? preventCollapse : !isLayerEnabled}
           />
-          <TitleWithActions>
+          <TitleWithActions preventCollapse={preventCollapse}>
             <TitleWrapper>{title}</TitleWrapper>
             {!isCollapsed && (
               <div
@@ -205,13 +215,13 @@ const TitleWrapper = styled('div')`
 const IconWrapper = styled('div')<{preventCollapse: boolean}>`
   color: ${p => p.theme.subText};
   line-height: 0;
-  visibility: ${p => (p.preventCollapse ? 'hidden' : 'initial')};
+  display: ${p => (p.preventCollapse ? 'none' : 'block')};
 `;
 
-const TitleWithActions = styled('div')`
+const TitleWithActions = styled('div')<{preventCollapse: boolean}>`
   display: grid;
   grid-template-columns: 1fr auto;
-  margin-right: 8px;
+  margin-right: ${p => (p.preventCollapse ? 0 : space(1))};
   align-items: center;
   /* Usually the actions are buttons, this height allows actions appearing after opening the
   details section to not expand the summary */

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -57,10 +57,7 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
         issueTypeConfig.issueSummary.enabled &&
         !organization.hideAiFeatures) ||
         issueTypeConfig.resources) && (
-        <ErrorBoundary mini>
-          <SolutionsSection group={group} project={project} event={event} />
-          <StyledBreak />
-        </ErrorBoundary>
+        <SolutionsSection group={group} project={project} event={event} />
       )}
       {event && (
         <ErrorBoundary mini>

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
@@ -114,9 +114,7 @@ export default function SolutionsSection({
     if (aiConfig.needsGenAIConsent) {
       return (
         <Summary>
-          <HeadlineText>
-            {t('Explore potential root causes and solutions with Sentry AI.')}
-          </HeadlineText>
+          {t('Explore potential root causes and solutions with Sentry AI.')}
         </Summary>
       );
     }
@@ -213,12 +211,6 @@ const SolutionsSectionContainer = styled('div')`
 const Summary = styled('div')`
   margin-bottom: ${space(0.5)};
   position: relative;
-`;
-
-const HeadlineText = styled('span')`
-  margin-right: ${space(0.5)};
-  word-break: break-word;
-  padding: 0 ${space(0.5)};
 `;
 
 const ResourcesWrapper = styled('div')<{isExpanded: boolean}>`

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.tsx
@@ -7,18 +7,43 @@ import {Chevron} from 'sentry/components/chevron';
 import useDrawer from 'sentry/components/globalDrawer';
 import {GroupSummary} from 'sentry/components/group/groupSummary';
 import Placeholder from 'sentry/components/placeholder';
+import {IconMegaphone} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import {singleLineRenderer} from 'sentry/utils/marked';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 import Resources from 'sentry/views/issueDetails/streamline/sidebar/resources';
-import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 import {SolutionsHubDrawer} from 'sentry/views/issueDetails/streamline/sidebar/solutionsHubDrawer';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
+
+function SolutionsHubFeedbackButton({hidden}: {hidden: boolean}) {
+  const openFeedbackForm = useFeedbackForm();
+  if (hidden) {
+    return null;
+  }
+  return (
+    <Button
+      aria-label={t('Give feedback on the solutions hub')}
+      icon={<IconMegaphone />}
+      size="xs"
+      onClick={() =>
+        openFeedbackForm?.({
+          messagePlaceholder: t('How can we make Issue Summary better for you?'),
+          tags: {
+            ['feedback.source']: 'issue_details_ai_autofix',
+            ['feedback.owner']: 'ml-ai',
+          },
+        })
+      }
+    />
+  );
+}
 
 export default function SolutionsSection({
   group,
@@ -29,10 +54,11 @@ export default function SolutionsSection({
   group: Group;
   project: Project;
 }) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
+  // We don't use this on the streamlined UI, since the section folds.
   const [isExpanded, setIsExpanded] = useState(false);
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const {openDrawer} = useDrawer();
-  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const openSolutionsDrawer = () => {
     if (!event) {
@@ -63,7 +89,6 @@ export default function SolutionsSection({
   };
 
   const aiConfig = useAiConfig(group, event, project);
-
   const issueTypeConfig = getConfigForIssueType(group, project);
 
   const showCtaButton =
@@ -76,28 +101,22 @@ export default function SolutionsSection({
     if (aiConfig.needsGenAIConsent) {
       return t('Set up Sentry AI');
     }
-
-    if (aiConfig.hasAutofix) {
-      if (aiConfig.needsAutofixSetup) {
-        return t('Set up Autofix');
-      }
-      return aiConfig.hasResources ? t('Open Resources & Autofix') : t('Open Autofix');
+    if (!aiConfig.hasAutofix) {
+      return t('Open Resources');
     }
-
-    return t('Open Resources');
+    if (aiConfig.needsAutofixSetup) {
+      return t('Set up Autofix');
+    }
+    return aiConfig.hasResources ? t('Open Resources & Autofix') : t('Open Autofix');
   };
 
   const renderContent = () => {
     if (aiConfig.needsGenAIConsent) {
       return (
         <Summary>
-          <HeadlineText
-            dangerouslySetInnerHTML={{
-              __html: singleLineRenderer(
-                'Explore potential root causes and solutions with Sentry AI.'
-              ),
-            }}
-          />
+          <HeadlineText>
+            {t('Explore potential root causes and solutions with Sentry AI.')}
+          </HeadlineText>
         </Summary>
       );
     }
@@ -112,17 +131,19 @@ export default function SolutionsSection({
 
     if (!aiConfig.hasSummary && issueTypeConfig.resources) {
       return (
-        <ResourcesWrapper isExpanded={isExpanded}>
-          <ResourcesContent isExpanded={isExpanded}>
+        <ResourcesWrapper isExpanded={hasStreamlinedUI ? true : isExpanded}>
+          <ResourcesContent isExpanded={hasStreamlinedUI ? true : isExpanded}>
             <Resources
               configResources={issueTypeConfig.resources!}
               eventPlatform={event?.platform}
               group={group}
             />
           </ResourcesContent>
-          <ExpandButton onClick={() => setIsExpanded(!isExpanded)} size="zero">
-            {isExpanded ? t('SHOW LESS') : t('READ MORE')}
-          </ExpandButton>
+          {!hasStreamlinedUI && (
+            <ExpandButton onClick={() => setIsExpanded(!isExpanded)} size="zero">
+              {isExpanded ? t('SHOW LESS') : t('READ MORE')}
+            </ExpandButton>
+          )}
         </ResourcesWrapper>
       );
     }
@@ -130,46 +151,59 @@ export default function SolutionsSection({
     return null;
   };
 
-  return (
-    <SolutionsSectionContainer>
-      <SidebarSectionTitle style={{marginTop: 0}}>
-        <HeaderContainer>
-          {t('Solutions Hub')}
-          {aiConfig.hasSummary && (
-            <StyledFeatureBadge
-              type="beta"
-              title={tct(
-                'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
-                {
-                  email: <a href="mailto:autofix@sentry.io" />,
-                }
-              )}
-            />
+  const titleComponent = (
+    <HeaderContainer>
+      {t('Solutions Hub')}
+      {aiConfig.hasSummary && (
+        <FeatureBadge
+          type="beta"
+          title={tct(
+            'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
+            {
+              email: <a href="mailto:autofix@sentry.io" />,
+            }
           )}
-        </HeaderContainer>
-      </SidebarSectionTitle>
-      {renderContent()}
-      {isButtonLoading ? (
-        <ButtonPlaceholder />
-      ) : showCtaButton ? (
-        <StyledButton
-          ref={openButtonRef}
-          onClick={() => openSolutionsDrawer()}
-          analyticsEventKey="issue_details.solutions_hub_opened"
-          analyticsEventName="Issue Details: Solutions Hub Opened"
-          analyticsParams={{
-            has_streamlined_ui: hasStreamlinedUI,
-          }}
-        >
-          {getButtonText()}
-          <ChevronContainer>
-            <Chevron direction="right" size="large" />
-          </ChevronContainer>
-        </StyledButton>
-      ) : null}
-    </SolutionsSectionContainer>
+        />
+      )}
+    </HeaderContainer>
+  );
+
+  return (
+    <SidebarFoldSection
+      title={titleComponent}
+      sectionKey={SectionKey.SOLUTIONS_HUB}
+      actions={<SolutionsHubFeedbackButton hidden={!aiConfig.hasSummary} />}
+      preventCollapse={!hasStreamlinedUI}
+    >
+      <SolutionsSectionContainer>
+        {renderContent()}
+        {isButtonLoading ? (
+          <ButtonPlaceholder />
+        ) : showCtaButton ? (
+          <StyledButton
+            ref={openButtonRef}
+            onClick={() => openSolutionsDrawer()}
+            analyticsEventKey="issue_details.solutions_hub_opened"
+            analyticsEventName="Issue Details: Solutions Hub Opened"
+            analyticsParams={{
+              has_streamlined_ui: hasStreamlinedUI,
+            }}
+          >
+            {getButtonText()}
+            <ChevronContainer>
+              <Chevron direction="right" size="large" />
+            </ChevronContainer>
+          </StyledButton>
+        ) : null}
+      </SolutionsSectionContainer>
+    </SidebarFoldSection>
   );
 }
+
+const SidebarFoldSection = styled(FoldSection)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: -${space(1)};
+`;
 
 const SolutionsSectionContainer = styled('div')`
   display: flex;
@@ -184,6 +218,7 @@ const Summary = styled('div')`
 const HeadlineText = styled('span')`
   margin-right: ${space(0.5)};
   word-break: break-word;
+  padding: 0 ${space(0.5)};
 `;
 
 const ResourcesWrapper = styled('div')<{isExpanded: boolean}>`
@@ -241,14 +276,10 @@ const ChevronContainer = styled('div')`
 `;
 
 const HeaderContainer = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
   display: flex;
   align-items: center;
-  gap: ${space(0.5)};
-`;
-
-const StyledFeatureBadge = styled(FeatureBadge)`
-  margin-left: ${space(0.25)};
-  padding-bottom: 3px;
+  gap: ${space(0.25)};
 `;
 
 const ButtonPlaceholder = styled(Placeholder)`


### PR DESCRIPTION
Reimplements the existing folding section so we get it persisted to local storage and analytics. Needed to do a few roundabout things since this is a shared component across both the streamline and legacy interfaces. 

The three dot menu has just been removed from the sidebar. It was absolutely positioned which means any layout changes would definitely cause issues, and I don't think it was that useful being immediately accessible on the main page. I think letting the autofix drawer be the entry point works better Instead. 

I just pulled out the feedback button to the top level, but it's possible to refactor it so all the options are surfaced if we believe that to be necessary.

**Legacy UI (Non-Streamline)**

<img width="354" alt="image" src="https://github.com/user-attachments/assets/7ccd412a-1742-48da-8a02-8eb3e30548cd" />
<img width="332" alt="image" src="https://github.com/user-attachments/assets/af83e0ee-6c95-4e9b-9df5-03f426d3d1c5" />
<img width="355" alt="image" src="https://github.com/user-attachments/assets/a5735a9c-35ef-4014-a714-aae43882e9a8" />


**Streamline UI**

<img width="341" alt="image" src="https://github.com/user-attachments/assets/175ebc89-ac45-4b86-ba02-0fc317338890" />
<img width="336" alt="image" src="https://github.com/user-attachments/assets/f3d2c5fe-7ca8-48f3-9511-16a09e104048" />
<img width="325" alt="image" src="https://github.com/user-attachments/assets/337f4d5f-8fd1-4849-9fb1-991b2128016a" />

