### PR TITLE
ref(toolbar): add info banner to copy domain in settings

### DIFF
--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -62,7 +62,7 @@ function ProjectToolbarSettings({organization, project, params: {projectId}}: Pr
         {domain && (
           <Alert type="info" showIcon>
             {tct(
-              'Copy paste this domain into the text box next to Allowed Origins: [domain] ',
+              'Copy and paste this domain into the text box next to Allowed Origins: [domain] ',
               {domain: <strong>{domain}</strong>}
             )}
             <CopyToClipboardButton borderless iconSize="xs" size="zero" text={domain} />

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -62,7 +62,7 @@ function ProjectToolbarSettings({organization, project, params: {projectId}}: Pr
         {domain && (
           <Alert type="info" showIcon>
             {tct(
-              'Copy and paste this domain into the text box next to Allowed Origins: [domain] ',
+              'To enable the Dev Toolbar, copy and paste your domain into the Allowed Origins text box below: [domain] ',
               {domain: <strong>{domain}</strong>}
             )}
             <CopyToClipboardButton borderless iconSize="xs" size="zero" text={domain} />

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -1,14 +1,18 @@
 import Access from 'sentry/components/acl/access';
 import Feature from 'sentry/components/acl/feature';
+import Alert from 'sentry/components/alert';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {JsonFormObject} from 'sentry/components/forms/types';
 import {NoAccess} from 'sentry/components/noAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
@@ -21,6 +25,9 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 };
 
 function ProjectToolbarSettings({organization, project, params: {projectId}}: Props) {
+  const location = useLocation();
+  const domain = decodeScalar(location.query.domain);
+
   const formGroups: JsonFormObject[] = [
     {
       title: 'Settings',
@@ -52,6 +59,18 @@ function ProjectToolbarSettings({organization, project, params: {projectId}}: Pr
         renderDisabled={NoAccess}
       >
         <PermissionAlert project={project} />
+        <Alert type="info" showIcon>
+          {tct(
+            'Copy paste this domain into the text box next to Allowed Origins: [domain] ',
+            {domain: <strong>{domain}</strong>}
+          )}
+          <CopyToClipboardButton
+            borderless
+            iconSize="xs"
+            size="zero"
+            text={domain ?? ''}
+          />
+        </Alert>
 
         <Form
           apiMethod="PUT"

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -59,18 +59,15 @@ function ProjectToolbarSettings({organization, project, params: {projectId}}: Pr
         renderDisabled={NoAccess}
       >
         <PermissionAlert project={project} />
-        <Alert type="info" showIcon>
-          {tct(
-            'Copy paste this domain into the text box next to Allowed Origins: [domain] ',
-            {domain: <strong>{domain}</strong>}
-          )}
-          <CopyToClipboardButton
-            borderless
-            iconSize="xs"
-            size="zero"
-            text={domain ?? ''}
-          />
-        </Alert>
+        {domain && (
+          <Alert type="info" showIcon>
+            {tct(
+              'Copy paste this domain into the text box next to Allowed Origins: [domain] ',
+              {domain: <strong>{domain}</strong>}
+            )}
+            <CopyToClipboardButton borderless iconSize="xs" size="zero" text={domain} />
+          </Alert>
+        )}
 
         <Form
           apiMethod="PUT"


### PR DESCRIPTION
<img width="1445" alt="SCR-20250122-ntoj" src="https://github.com/user-attachments/assets/337e7045-66e7-4849-8ab6-ed2c9525ab26" />

followup to https://github.com/getsentry/sentry-toolbar/pull/193