### PR TITLE
:bug: fix(threads): fix open period lookup to use regression

### DIFF
--- a/src/sentry/notifications/utils/open_period.py
+++ b/src/sentry/notifications/utils/open_period.py
@@ -16,7 +16,7 @@ def open_period_start_for_group(group: Group) -> datetime | None:
     latest_unresolved_activity: Activity | None = (
         Activity.objects.filter(
             group=group,
-            type=ActivityType.SET_UNRESOLVED.value,
+            type=ActivityType.SET_REGRESSION.value,
         )
         .order_by("-datetime")
         .first()

--- a/tests/sentry/notifications/utils/test_open_period.py
+++ b/tests/sentry/notifications/utils/test_open_period.py
@@ -36,7 +36,7 @@ class OpenPeriodTestCase(TestCase):
         unresolved_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
-            type=ActivityType.SET_UNRESOLVED.value,
+            type=ActivityType.SET_REGRESSION.value,
             datetime=unresolved_time,
         )
 
@@ -51,7 +51,7 @@ class OpenPeriodTestCase(TestCase):
         Activity.objects.create(
             group=self.group,
             project=self.group.project,
-            type=ActivityType.SET_UNRESOLVED.value,
+            type=ActivityType.SET_REGRESSION.value,
             datetime=first_unresolved,
         )
 
@@ -60,7 +60,7 @@ class OpenPeriodTestCase(TestCase):
         second_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
-            type=ActivityType.SET_UNRESOLVED.value,
+            type=ActivityType.SET_REGRESSION.value,
             datetime=second_unresolved,
         )
 


### PR DESCRIPTION
based on https://devsentry-ecosystem.sentry.io/api/0/issues/6238390205/activities/, it seems that the activity type i need to check for is `SET_REGRESSION` and not `SET_UNRESOLVED`

https://redash.getsentry.net/queries/8190/source verified we are just using first seen for that issue so its still threading.