### PR TITLE
feat(profiles): Set the correct outcome for UI profiles

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -987,7 +987,11 @@ def _track_duration_outcome(
         key_id=None,
         outcome=Outcome.ACCEPTED,
         timestamp=datetime.now(timezone.utc),
-        category=DataCategory.PROFILE_DURATION,
+        category=(
+            DataCategory.PROFILE_DURATION_UI
+            if profile["platform"] in {"cocoa", "android", "javascript"}
+            else DataCategory.PROFILE_DURATION
+        ),
         quantity=duration_ms,
     )
 


### PR DESCRIPTION
We're pricing continuous profiling for UI and backend differently so we need a different category for UI.