### PR TITLE
feat(uptime): Add enable/disable project subscription methods

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -7,6 +7,7 @@ from django.db.models import TextField
 from django.db.models.expressions import Value
 from django.db.models.functions import MD5, Coalesce
 
+from sentry.constants import ObjectStatus
 from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.types.actor import Actor
@@ -262,6 +263,49 @@ def update_project_uptime_subscription(
     # uptime monitor. Check if the old subscription was orphaned due to this.
     if updated_subscription:
         remove_uptime_subscription_if_unused(cur_uptime_subscription)
+
+
+def disable_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscription):
+    """
+    Disables a project uptime subscription. If the uptime subscription no
+    longer has any active project subscriptions the subscription itself will
+    also be disabled.
+    """
+    if uptime_monitor.status == ObjectStatus.DISABLED:
+        return
+
+    uptime_monitor.update(status=ObjectStatus.DISABLED)
+    uptime_subscription = uptime_monitor.uptime_subscription
+
+    # Are there any other project subscriptions associated to the subscription
+    # that are NOT disabled?
+    has_active_subscription = uptime_subscription.projectuptimesubscription_set.exclude(
+        status=ObjectStatus.DISABLED
+    ).exists()
+
+    # All project subscriptions are disabled, we can disable the subscription
+    # and remove the remote subscription.
+    if not has_active_subscription:
+        uptime_subscription.update(status=UptimeSubscription.Status.DISABLED.value)
+        delete_remote_uptime_subscription.delay(uptime_subscription.id)
+
+
+def enable_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscription):
+    """
+    Re-enables a project uptime subscription. If the uptime subscription was
+    also disabled it will be re-activated and the remote subscription will be
+    published.
+    """
+    if uptime_monitor.status != ObjectStatus.DISABLED:
+        return
+
+    uptime_monitor.update(status=ObjectStatus.ACTIVE)
+    uptime_subscription = uptime_monitor.uptime_subscription
+
+    # The subscription was disabled, it can be re-activated now
+    if uptime_subscription.status == UptimeSubscription.Status.DISABLED.value:
+        uptime_subscription.update(status=UptimeSubscription.Status.CREATING.value)
+        create_remote_uptime_subscription.delay(uptime_subscription.id)
 
 
 def delete_uptime_subscriptions_for_project(

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -5,6 +5,7 @@ from django.test import override_settings
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.constants import ObjectStatus
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
@@ -19,6 +20,8 @@ from sentry.uptime.subscriptions.subscriptions import (
     delete_project_uptime_subscription,
     delete_uptime_subscription,
     delete_uptime_subscriptions_for_project,
+    disable_project_uptime_subscription,
+    enable_project_uptime_subscription,
     get_auto_monitored_subscriptions_for_project,
     get_or_create_project_uptime_subscription,
     get_or_create_uptime_subscription,
@@ -655,3 +658,92 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
         )
         assert get_auto_monitored_subscriptions_for_project(other_project) == []
+
+
+class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
+    def test(self):
+        proj_sub = get_or_create_project_uptime_subscription(
+            self.project,
+            self.environment,
+            url="https://sentry.io",
+            interval_seconds=3600,
+            timeout_ms=1000,
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )[0]
+
+        with self.tasks():
+            disable_project_uptime_subscription(proj_sub)
+
+        proj_sub.refresh_from_db()
+        assert proj_sub.status == ObjectStatus.DISABLED
+        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+
+    def test_multiple_project_subs(self):
+        project1 = self.project
+        project2 = self.create_project()
+
+        proj_sub1 = get_or_create_project_uptime_subscription(
+            project1,
+            self.environment,
+            url="https://sentry.io",
+            interval_seconds=3600,
+            timeout_ms=1000,
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )[0]
+        proj_sub2 = get_or_create_project_uptime_subscription(
+            project2,
+            self.environment,
+            url="https://sentry.io",
+            interval_seconds=3600,
+            timeout_ms=1000,
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )[0]
+
+        uptime_subscription = proj_sub1.uptime_subscription
+
+        # Disabling the first project subscription does NOT disable the
+        # subscription
+        with self.tasks():
+            disable_project_uptime_subscription(proj_sub1)
+
+        proj_sub1.refresh_from_db()
+        uptime_subscription.refresh_from_db()
+        assert proj_sub1.status == ObjectStatus.DISABLED
+        assert proj_sub2.status == ObjectStatus.ACTIVE
+        assert uptime_subscription.status != UptimeSubscription.Status.DISABLED.value
+
+        # Disabling the second project subscription DOES disable the
+        # subscription
+        with self.tasks():
+            disable_project_uptime_subscription(proj_sub2)
+
+        proj_sub2.refresh_from_db()
+        uptime_subscription.refresh_from_db()
+        assert proj_sub2.status == ObjectStatus.DISABLED
+        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+
+
+class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
+    def test(self):
+        proj_sub = get_or_create_project_uptime_subscription(
+            self.project,
+            self.environment,
+            url="https://sentry.io",
+            interval_seconds=3600,
+            timeout_ms=1000,
+            mode=ProjectUptimeSubscriptionMode.MANUAL,
+        )[0]
+
+        with self.tasks():
+            disable_project_uptime_subscription(proj_sub)
+
+        # Subscription is disabled
+        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+
+        # Enabling the subscription marks the suscription as active again
+        with self.tasks():
+            enable_project_uptime_subscription(proj_sub)
+
+        proj_sub.refresh_from_db()
+        assert proj_sub.status == ObjectStatus.ACTIVE
+        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value


### PR DESCRIPTION
We'll use these methods when enabling / disabling a uptime monitor for
seat quota reasons