### PR TITLE
feat(workflow_engine): Endpoint for GET Organization Workflows

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2172,6 +2172,7 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         OrganizationUptimeAlertIndexEndpoint.as_view(),
         name="sentry-api-0-organization-uptime-alert-index",
     ),
+    *workflow_urls.organization_urlpatterns,
 ]
 
 PROJECT_URLS: list[URLPattern | URLResolver] = [
@@ -2763,7 +2764,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         TempestCredentialsDetailsEndpoint.as_view(),
         name="sentry-api-0-project-tempest-credentials-details",
     ),
-    *workflow_urls.urlpatterns,
+    *workflow_urls.project_urlpatterns,
 ]
 
 TEAM_URLS = [

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -25,7 +25,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ISSUES
 
     @extend_schema(
-        operation_id="Fetch a Workflows",
+        operation_id="Fetch Workflows",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
         ],

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -47,6 +47,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
+            order_by="id",
             on_results=lambda x: serialize(x, request.user),
         )
 

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -1,0 +1,57 @@
+from drf_spectacular.utils import extend_schema
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.workflow_engine.endpoints.serializers import WorkflowSerializer
+from sentry.workflow_engine.models import Workflow
+
+
+@region_silo_endpoint
+class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+
+    @extend_schema(
+        operation_id="Fetch a Workflows",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+        ],
+        responses={
+            201: WorkflowSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request, organization):
+        """
+        Returns a list of workflows for a given org
+        """
+        # TODO add additonal filters and ordering
+        queryset = Workflow.objects.filter(organization_id=organization.id).order_by("id")
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            on_results=lambda x: serialize(x, request.user),
+        )
+
+    def post(self, request, organization):
+        """
+        Creates a workflow for an organization
+        """
+        pass

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -198,7 +198,7 @@ class DetectorSerializer(Serializer):
 
 @register(Workflow)
 class WorkflowSerializer(Serializer):
-    def get_attrs(self, item_list, user, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs) -> MutableMapping[Workflow, dict[str, Any]]:
         attrs: MutableMapping[Workflow, dict[str, Any]] = defaultdict(dict)
         trigger_conditions = list(
             DataConditionGroup.objects.filter(
@@ -233,7 +233,6 @@ class WorkflowSerializer(Serializer):
         return attrs
 
     def serialize(self, obj: Workflow, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
-        # WHAT TO DO ABOUT CONFIG?
         return {
             "id": str(obj.id),
             "organizationId": str(obj.organization_id),
@@ -242,4 +241,5 @@ class WorkflowSerializer(Serializer):
             "triggerConditionGroup": attrs.get("trigger_condition_group"),
             "dataConditionGroups": attrs.get("data_condition_groups"),
             "environment": obj.environment.name if obj.environment else None,
+            "config": json.loads(obj.config),
         }

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -241,5 +241,5 @@ class WorkflowSerializer(Serializer):
             "triggerConditionGroup": attrs.get("trigger_condition_group"),
             "dataConditionGroups": attrs.get("data_condition_groups"),
             "environment": obj.environment.name if obj.environment else None,
-            "config": json.loads(obj.config),
+            "config": obj.config,
         }

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -13,7 +13,6 @@ from .project_detector_index import ProjectDetectorIndexEndpoint
 
 # Remaining Workflows Endpoints
 # - GET /workflow w/ filters
-# - GET /workflow
 # - POST /workflow
 # - GET /workflow/:id
 # - PUT /workflow/:id

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -1,11 +1,36 @@
 from django.urls import re_path
 
+from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
 from .project_detector_index import ProjectDetectorIndexEndpoint
 
-urlpatterns = [
+# TODO @saponifi3d - Add the missing API endpoints
+
+# Remaining Detector Endpoints
+#   - GET /detector w/ filters
+#   - GET /detector/:id
+#   - PUT /detector/:id
+#   - DELETE /detector/:id
+
+# Remaining Workflows Endpoints
+# - GET /workflow w/ filters
+# - GET /workflow
+# - POST /workflow
+# - GET /workflow/:id
+# - PUT /workflow/:id
+# - DELETE /workflow/:id
+
+project_urlpatterns = [
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/detectors/$",
         ProjectDetectorIndexEndpoint.as_view(),
         name="sentry-api-0-project-detector-index",
+    ),
+]
+
+organization_urlpatterns = [
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/$",
+        OrganizationWorkflowIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-workflow-index",
     ),
 ]

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -3,7 +3,7 @@ from django.urls import re_path
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
 from .project_detector_index import ProjectDetectorIndexEndpoint
 
-# TODO @saponifi3d - Add the missing API endpoints
+# TODO @saponifi3d - Add the remaining API endpoints
 
 # Remaining Detector Endpoints
 #   - GET /detector w/ filters

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1,0 +1,35 @@
+import pytest
+
+from sentry.api.serializers import serialize
+from sentry.models.environment import Environment
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+class OrganizationWorkflowAPITestCase(APITestCase):
+    endpoint = "sentry-api-0-organization-workflow-index"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+
+@region_silo_test
+class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
+    def test_simple(self):
+        workflow = self.create_workflow(organization_id=self.organization.id, name="Test Workflow")
+
+        workflow_two = self.create_workflow(
+            organization_id=self.organization.id, name="Test Workflow 2"
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data == serialize([workflow, workflow_two])
+
+    @pytest.mark.skip(reason="DEBUGGING OTHER TEST")
+    def test_empty_result(self):
+        response = self.get_success_response(self.organization.slug)
+        assert response.data == []

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.api.serializers import serialize
 from sentry.models.environment import Environment
 from sentry.testutils.cases import APITestCase
@@ -29,7 +27,6 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
         response = self.get_success_response(self.organization.slug)
         assert response.data == serialize([workflow, workflow_two])
 
-    @pytest.mark.skip(reason="DEBUGGING OTHER TEST")
     def test_empty_result(self):
         response = self.get_success_response(self.organization.slug)
         assert response.data == []

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1,5 +1,4 @@
 from sentry.api.serializers import serialize
-from sentry.models.environment import Environment
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -10,9 +9,6 @@ class OrganizationWorkflowAPITestCase(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.environment = Environment.objects.create(
-            organization_id=self.organization.id, name="production"
-        )
 
 
 @region_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -290,6 +290,7 @@ class TestWorkflowSerializer(TestCase):
         assert result == {
             "id": str(workflow.id),
             "organizationId": str(self.organization.id),
+            "config": {},
             "dateCreated": workflow.date_added,
             "dateUpdated": workflow.date_updated,
             "triggerConditionGroup": None,
@@ -339,12 +340,13 @@ class TestWorkflowSerializer(TestCase):
         assert result == {
             "id": str(workflow.id),
             "organizationId": str(self.organization.id),
+            "config": {},
             "dateCreated": workflow.date_added,
             "dateUpdated": workflow.date_updated,
             "triggerConditionGroup": {
                 "id": str(when_condition_group.id),
                 "organizationId": str(self.organization.id),
-                "logicType": DataConditionGroup.Type.ANY,
+                "logicType": DataConditionGroup.Type.ANY.value,
                 "conditions": [
                     {
                         "id": str(trigger_condition.id),
@@ -359,13 +361,13 @@ class TestWorkflowSerializer(TestCase):
                 {
                     "id": str(condition_group.id),
                     "organizationId": str(self.organization.id),
-                    "logicType": DataConditionGroup.Type.ALL,
+                    "logicType": DataConditionGroup.Type.ALL.value,
                     "conditions": [
                         {
                             "id": str(condition.id),
                             "condition": "gt",
                             "comparison": 100,
-                            "result": DetectorPriorityLevel.HIGH,
+                            "result": DetectorPriorityLevel.HIGH.value,
                         }
                     ],
                     "actions": [


### PR DESCRIPTION
# Description
- Extends the `workflow_urls` pattern so we can have organization based urls as well
- Creates a basic GET request handler for `/organizations/:slug_or_id/workflows/` to get a list of workflows that an organization has created.
- Setup scaffolding for the POST handler