### PR TITLE
ref(workflow_engine): Update a couple of the top level response keys

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -227,7 +227,7 @@ class WorkflowSerializer(Serializer):
             attrs[item]["triggers"] = trigger_condition_map.get(
                 item.when_condition_group_id
             )  # when condition group
-            attrs[item]["actions"] = dcg_map.get(
+            attrs[item]["actionFilters"] = dcg_map.get(
                 item.id, []
             )  # The data condition groups for filtering actions
         return attrs
@@ -239,7 +239,7 @@ class WorkflowSerializer(Serializer):
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
             "triggers": attrs.get("triggers"),
-            "actions": attrs.get("actions"),
+            "actionFilters": attrs.get("actionFilters"),
             "environment": obj.environment.name if obj.environment else None,
             "config": obj.config,
         }

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -224,12 +224,12 @@ class WorkflowSerializer(Serializer):
             dcg_map[wdcg.workflow_id].append(serialized_condition_groups[wdcg.condition_group_id])
 
         for item in item_list:
-            attrs[item]["trigger_condition_group"] = trigger_condition_map.get(
+            attrs[item]["triggers"] = trigger_condition_map.get(
                 item.when_condition_group_id
             )  # when condition group
-            attrs[item]["data_condition_groups"] = dcg_map.get(
+            attrs[item]["actions"] = dcg_map.get(
                 item.id, []
-            )  # data condition groups associated with workflow via WorkflowDataConditionGroup lookup table
+            )  # The data condition groups for filtering actions
         return attrs
 
     def serialize(self, obj: Workflow, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
@@ -238,8 +238,8 @@ class WorkflowSerializer(Serializer):
             "organizationId": str(obj.organization_id),
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
-            "triggerConditionGroup": attrs.get("trigger_condition_group"),
-            "dataConditionGroups": attrs.get("data_condition_groups"),
+            "triggers": attrs.get("triggers"),
+            "actions": attrs.get("actions"),
             "environment": obj.environment.name if obj.environment else None,
             "config": obj.config,
         }

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -293,8 +293,8 @@ class TestWorkflowSerializer(TestCase):
             "config": {},
             "dateCreated": workflow.date_added,
             "dateUpdated": workflow.date_updated,
-            "triggerConditionGroup": None,
-            "dataConditionGroups": [],
+            "triggers": None,
+            "actions": [],
             "environment": None,
         }
 
@@ -343,7 +343,7 @@ class TestWorkflowSerializer(TestCase):
             "config": {},
             "dateCreated": workflow.date_added,
             "dateUpdated": workflow.date_updated,
-            "triggerConditionGroup": {
+            "triggers": {
                 "id": str(when_condition_group.id),
                 "organizationId": str(self.organization.id),
                 "logicType": DataConditionGroup.Type.ANY.value,
@@ -357,7 +357,7 @@ class TestWorkflowSerializer(TestCase):
                 ],
                 "actions": [],
             },
-            "dataConditionGroups": [
+            "actions": [
                 {
                     "id": str(condition_group.id),
                     "organizationId": str(self.organization.id),

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -294,7 +294,7 @@ class TestWorkflowSerializer(TestCase):
             "dateCreated": workflow.date_added,
             "dateUpdated": workflow.date_updated,
             "triggers": None,
-            "actions": [],
+            "actionFilters": [],
             "environment": None,
         }
 
@@ -357,7 +357,7 @@ class TestWorkflowSerializer(TestCase):
                 ],
                 "actions": [],
             },
-            "actions": [
+            "actionFilters": [
                 {
                     "id": str(condition_group.id),
                     "organizationId": str(self.organization.id),


### PR DESCRIPTION
# Description
- Change `triggerConditionGroup` to `triggers` - the way this would read from an API perspective is now: `workflow.triggers` which maps nicely to the UI concept
- Change `dataConditionGroups` to `actions` - this is to represent the idea of the "if x then trigger y"