### PR TITLE
:recycle: ref(slos): change missing access errors to halts for discord

### DIFF
--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -63,7 +63,7 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
                 except ApiRateLimitedError as e:
                     # TODO(ecosystem): We should batch this on a per-organization basis
                     lifecycle.record_halt(e)
-                    # Errors that we recieve from the Discord API
+                # Errors that we recieve from the Discord API
                 except ApiError as error:
                     if error.code in DISCORD_HALT_ERROR_CODES:
                         lifecycle.record_halt(error)

--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -6,14 +6,14 @@ from sentry.integrations.discord.actions.issue_alert.form import DiscordNotifySe
 from sentry.integrations.discord.client import DiscordClient
 from sentry.integrations.discord.message_builder.issues import DiscordIssuesMessageBuilder
 from sentry.integrations.discord.spec import DiscordMessagingSpec
-from sentry.integrations.discord.utils.errors import DISCORD_HALT_ERROR_CODES
+from sentry.integrations.discord.utils.metrics import record_lifecycle_termination_level
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
 )
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
-from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
 
@@ -60,15 +60,9 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
                 try:
                     lifecycle.add_extras({"integration_id": integration.id, "channel": channel_id})
                     client.send_message(channel_id, message, notification_uuid=notification_uuid)
-                except ApiRateLimitedError as e:
-                    # TODO(ecosystem): We should batch this on a per-organization basis
-                    lifecycle.record_halt(e)
-                # Errors that we recieve from the Discord API
                 except ApiError as error:
-                    if error.code in DISCORD_HALT_ERROR_CODES:
-                        lifecycle.record_halt(error)
-                    else:
-                        lifecycle.record_failure(error)
+                    # Errors that we recieve from the Discord API
+                    record_lifecycle_termination_level(lifecycle, error)
                 except Exception as e:
                     lifecycle.add_extras(
                         {

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -11,12 +11,12 @@ from sentry.integrations.discord.message_builder.metric_alerts import (
     DiscordMetricAlertMessageBuilder,
 )
 from sentry.integrations.discord.spec import DiscordMessagingSpec
-from sentry.integrations.discord.utils.errors import DISCORD_HALT_ERROR_CODES
+from sentry.integrations.discord.utils.metrics import record_lifecycle_termination_level
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
 )
-from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import logger
 
@@ -64,18 +64,10 @@ def send_incident_alert_notification(
     ).capture() as lifecycle:
         try:
             client.send_message(channel, message)
-        except ApiRateLimitedError as error:
-            # TODO(ecosystem): We should batch this on a per-organization basis
-            lifecycle.record_halt(error)
-            return False
-        # Errors that we recieve from the Discord API
         except ApiError as error:
-            if error.code in DISCORD_HALT_ERROR_CODES:
-                lifecycle.record_halt(error)
-                return False
-            else:
-                lifecycle.record_failure(error)
-                return False
+            # Errors that we recieve from the Discord API
+            record_lifecycle_termination_level(lifecycle, error)
+            return False
         except Exception as error:
             lifecycle.add_extras(
                 {

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -11,11 +11,12 @@ from sentry.integrations.discord.message_builder.metric_alerts import (
     DiscordMetricAlertMessageBuilder,
 )
 from sentry.integrations.discord.spec import DiscordMessagingSpec
+from sentry.integrations.discord.utils.errors import DISCORD_HALT_ERROR_CODES
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
 )
-from sentry.shared_integrations.exceptions import ApiRateLimitedError
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 
 from ..utils import logger
 
@@ -67,6 +68,14 @@ def send_incident_alert_notification(
             # TODO(ecosystem): We should batch this on a per-organization basis
             lifecycle.record_halt(error)
             return False
+        # Errors that we recieve from the Discord API
+        except ApiError as error:
+            if error.code in DISCORD_HALT_ERROR_CODES:
+                lifecycle.record_halt(error)
+                return False
+            else:
+                lifecycle.record_failure(error)
+                return False
         except Exception as error:
             lifecycle.add_extras(
                 {

--- a/src/sentry/integrations/discord/utils/errors.py
+++ b/src/sentry/integrations/discord/utils/errors.py
@@ -1,8 +1,0 @@
-"""
-Errors that are user configuration errors and should be recorded as a halt for SLOs.
-"""
-
-# https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
-DISCORD_HALT_ERROR_CODES = [
-    50001,  # Missing access
-]

--- a/src/sentry/integrations/discord/utils/errors.py
+++ b/src/sentry/integrations/discord/utils/errors.py
@@ -1,0 +1,8 @@
+"""
+Errors that are user configuration errors and should be recorded as a halt for SLOs.
+"""
+
+# https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
+DISCORD_HALT_ERROR_CODES = [
+    50001,  # Missing access
+]

--- a/src/sentry/integrations/discord/utils/metrics.py
+++ b/src/sentry/integrations/discord/utils/metrics.py
@@ -1,0 +1,17 @@
+from sentry.integrations.utils.metrics import EventLifecycle
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+
+# https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
+DISCORD_HALT_ERROR_CODES = [
+    50001,  # Missing access
+]
+
+
+def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiError) -> None:
+    if isinstance(error, ApiRateLimitedError):
+        # TODO(ecosystem): We should batch this on a per-organization basis
+        lifecycle.record_halt(error)
+    elif error.code in DISCORD_HALT_ERROR_CODES:
+        lifecycle.record_halt(error)
+    else:
+        lifecycle.record_failure(error)

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -9,7 +9,7 @@ from sentry.integrations.discord.client import CHANNEL_URL, DISCORD_BASE_URL, ME
 from sentry.integrations.discord.spec import DiscordMessagingSpec
 from sentry.integrations.messaging.spec import MessagingActionHandler
 from sentry.integrations.types import EventLifecycleOutcome
-from sentry.shared_integrations.exceptions import ApiRateLimitedError
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -120,3 +120,33 @@ class DiscordActionHandlerTest(FireTest):
             handler.fire(metric_value, IncidentStatus.OPEN)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
+
+    @patch(
+        "sentry.integrations.discord.client.DiscordClient.send_message",
+        side_effect=ApiError(code=50001, text="Missing access"),
+    )
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_metric_alert_halt_for_missing_access(self, mock_record_event, mock_send_message):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus.OPEN)
+
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
+
+    @patch(
+        "sentry.integrations.discord.client.DiscordClient.send_message",
+        side_effect=ApiError(code=400, text="Bad request"),
+    )
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_metric_alert_halt_for_other_api_error(self, mock_record_event, mock_send_message):
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
+        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
+        metric_value = 1000
+        with self.tasks():
+            handler.fire(metric_value, IncidentStatus.OPEN)
+
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)


### PR DESCRIPTION
we should mark missing access errors from Discord (which means our bot's access was revoked) as halts instead of failures.

this is inline with what we do with slack here:

https://github.com/getsentry/sentry/blob/323c6fbcd454a9d7854da686c2207c62f2a42a9a/src/sentry/integrations/slack/utils/errors.py#L26-L27