### PR TITLE
ref(tempest): Rename fetch screenshots to include screenshots

### DIFF
--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -111,8 +111,8 @@ export default function TempestSettings({organization, project}: Props) {
                 {
                   name: 'tempestFetchScreenshots',
                   type: 'boolean',
-                  label: t('Fetch Screenshots'),
-                  help: t('Allow Tempest to fetch screenshots for the project.'),
+                  label: t('Include Screenshots'),
+                  help: t('Allow Tempest to include screenshots in issues.'),
                 },
               ],
             },

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -111,8 +111,8 @@ export default function TempestSettings({organization, project}: Props) {
                 {
                   name: 'tempestFetchScreenshots',
                   type: 'boolean',
-                  label: t('Include Screenshots'),
-                  help: t('Allow Tempest to include screenshots in issues.'),
+                  label: t('Attach Screenshots'),
+                  help: t('Attach screenshots to issues.'),
                 },
               ],
             },


### PR DESCRIPTION
Just some small naming update, tempest always has the screenshot, but the option toggles whether the screenshot is included in the issue.