### PR TITLE
feat(tempest): relax permissions needed to add/delete tempest credentials

### DIFF
--- a/src/sentry/tempest/permissions.py
+++ b/src/sentry/tempest/permissions.py
@@ -11,6 +11,6 @@ class TempestCredentialsPermission(ProjectPermission):
             "org:write",
             "org:admin",
         ],
-        "POST": ["org:admin"],
-        "DELETE": ["org:admin"],
+        "POST": ["org:admin", "org:write", "project:admin", "project:write"],
+        "DELETE": ["org:admin", "org:write", "project:admin"],
     }

--- a/src/sentry/tempest/permissions.py
+++ b/src/sentry/tempest/permissions.py
@@ -12,5 +12,5 @@ class TempestCredentialsPermission(ProjectPermission):
             "org:admin",
         ],
         "POST": ["org:admin", "org:write", "project:admin", "project:write"],
-        "DELETE": ["org:admin", "org:write", "project:admin"],
+        "DELETE": ["org:admin", "org:write", "project:admin", "project:write"],
     }


### PR DESCRIPTION
Relaxes permissions and allows project admins and members with `project:write` permission to add/delete tempest credentials.

