### PR TITLE
ref(project-stats): Expose 'hydration errors' and 'chunk errors' in chart

### DIFF
--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -42,8 +42,8 @@ const STAT_OPS = {
   'release-version': {title: t('Release'), color: theme.purple200},
   'web-crawlers': {title: t('Web Crawler'), color: theme.red300},
   'filtered-transaction': {title: t('Health Check'), color: theme.yellow400},
-  'react-hydration-errors': {title: t('Hydration Errors'), color: theme.purple300},
-  'chunk-load-error': {title: t('Chunk Load Errors'), color: theme.purple300},
+  'react-hydration-errors': {title: t('Hydration Errors'), color: theme.outcome.filtered},
+  'chunk-load-error': {title: t('Chunk Load Errors'), color: theme.outcome.filtered},
 };
 
 class ProjectFiltersChart extends Component<Props, State> {

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -42,6 +42,8 @@ const STAT_OPS = {
   'release-version': {title: t('Release'), color: theme.purple200},
   'web-crawlers': {title: t('Web Crawler'), color: theme.red300},
   'filtered-transaction': {title: t('Health Check'), color: theme.yellow400},
+  'react-hydration-errors': {title: t('Hydration Errors'), color: theme.purple300},
+  'chunk-load-error': {title: t('Chunk Load Errors'), color: theme.purple300},
 };
 
 class ProjectFiltersChart extends Component<Props, State> {


### PR DESCRIPTION
We would like to expose these 2 inbound filters in the projects stats chart.