### PR TITLE
feat(dashboards-eap): Add warning when over 30d range

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -19,10 +19,12 @@ import {defined} from 'sentry/utils';
 import {getFormattedDate} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -158,6 +160,7 @@ function WidgetCard(props: Props) {
   const onDemandWarning = useOnDemandWarning({widget});
   const discoverSplitAlert = useDiscoverSplitAlert({widget, onSetTransactionsDataset});
   const sessionDurationWarning = hasSessionDuration ? SESSION_DURATION_ALERT_TEXT : null;
+  const spanTimeRangeWarning = useTimeRangeWarning({widget});
 
   if (widget.widgetType === WidgetType.METRICS) {
     return (
@@ -220,9 +223,12 @@ function WidgetCard(props: Props) {
     Boolean
   ) as BadgeProps[];
 
-  const warnings = [onDemandWarning, discoverSplitAlert, sessionDurationWarning].filter(
-    Boolean
-  ) as string[];
+  const warnings = [
+    onDemandWarning,
+    discoverSplitAlert,
+    sessionDurationWarning,
+    spanTimeRangeWarning,
+  ].filter(Boolean) as string[];
 
   const actionsDisabled = Boolean(props.isPreview);
   const actionsMessage = actionsDisabled
@@ -382,6 +388,25 @@ function useOnDemandWarning(props: {widget: Widget}): string | null {
   if (widgetReachedSpecLimit) {
     return t(
       "This widget is using indexed data because you've reached your organization limit for dynamically extracted metrics."
+    );
+  }
+
+  return null;
+}
+
+function useTimeRangeWarning(props: {widget: Widget}) {
+  const {
+    selection: {datetime},
+  } = usePageFilters();
+
+  if (props.widget.widgetType !== WidgetType.SPANS) {
+    return null;
+  }
+
+  // Check if the requested time range is over the equivalent of 30days and then return a warning
+  if (statsPeriodToDays(datetime.period, datetime.start, datetime.end) > 30) {
+    return t(
+      "Spans-based widgets can only reliably visualize the last 30d of data at the moment. We're working on ramping this up."
     );
   }
 

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -403,10 +403,17 @@ function useTimeRangeWarning(props: {widget: Widget}) {
     return null;
   }
 
-  // Check if the requested time range is over the equivalent of 30days and then return a warning
+  const dataRetentionStart = new Date('2024-12-29');
+  if (datetime.start && new Date(datetime.start) < dataRetentionStart) {
+    // This message applies if the user has selected a time range that is before the data retention start date
+    return t('Spans-based widgets can only visualize the last 30d of data currently.');
+  }
+
   if (statsPeriodToDays(datetime.period, datetime.start, datetime.end) > 30) {
+    // This message applies if the user has selected a time range >30d because we can't guarantee
+    // the query will successfully run for a time range >30d at this time.
     return t(
-      "Spans-based widgets can only reliably visualize the last 30d of data at the moment. We're working on ramping this up."
+      "Spans-based widgets can only visualize the last 30d of data currently. We're working on ramping this up."
     );
   }
 

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -403,12 +403,6 @@ function useTimeRangeWarning(props: {widget: Widget}) {
     return null;
   }
 
-  const dataRetentionStart = new Date('2024-12-29');
-  if (datetime.start && new Date(datetime.start) < dataRetentionStart) {
-    // This message applies if the user has selected a time range that is before the data retention start date
-    return t('Spans-based widgets can only visualize the last 30d of data currently.');
-  }
-
   if (statsPeriodToDays(datetime.period, datetime.start, datetime.end) > 30) {
     // This message applies if the user has selected a time range >30d because we can't guarantee
     // the query will successfully run for a time range >30d at this time.


### PR DESCRIPTION
This adds a warning badge when a user tries change a dashboard to >30d, we can't guarantee the query will complete so we will inform the users that support for >30d will be coming.

<img width="624" alt="Screenshot 2025-01-23 at 10 18 02 AM" src="https://github.com/user-attachments/assets/874f3cfa-49b3-4207-8385-ad69f71b0737" />
