### PR TITLE
feat(widget-builder): Use replace instead of push for URL changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
@@ -41,7 +41,8 @@ describe('DatasetSelector', function () {
       expect.objectContaining({
         ...router.location,
         query: expect.objectContaining({dataset: 'issue'}),
-      })
+      }),
+      {replace: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -1,16 +1,9 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
-
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: jest.fn(),
-}));
-
-const mockUseNavigate = jest.mocked(useNavigate);
 
 describe('WidgetBuilderGroupBySelector', function () {
   beforeEach(function () {
@@ -21,9 +14,6 @@ describe('WidgetBuilderGroupBySelector', function () {
   });
 
   it('renders', async function () {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
     render(
       <WidgetBuilderProvider>
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -46,7 +46,8 @@ describe('WidgetBuilder', () => {
       expect.objectContaining({
         ...router.location,
         query: expect.objectContaining({title: 'some name'}),
-      })
+      }),
+      {replace: true}
     );
 
     await userEvent.click(await screen.findByTestId('add-description'));
@@ -59,7 +60,8 @@ describe('WidgetBuilder', () => {
       expect.objectContaining({
         ...router.location,
         query: expect.objectContaining({description: 'some description'}),
-      })
+      }),
+      {replace: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -40,9 +40,6 @@ describe('WidgetBuilderSortBySelector', function () {
   });
 
   it('renders', async function () {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
     render(
       <WidgetBuilderProvider>
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
@@ -112,7 +109,8 @@ describe('WidgetBuilderSortBySelector', function () {
       expect.objectContaining({
         ...router.location,
         query: expect.objectContaining({sort: ['-count()']}),
-      })
+      }),
+      {replace: true}
     );
 
     await userEvent.click(sortDirectionSelector);
@@ -121,7 +119,8 @@ describe('WidgetBuilderSortBySelector', function () {
       expect.objectContaining({
         ...router.location,
         query: expect.objectContaining({sort: ['count()']}),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -180,7 +179,10 @@ describe('WidgetBuilderSortBySelector', function () {
     await userEvent.click(await screen.findByText('Limit to 3 results'));
 
     expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({query: expect.objectContaining({limit: 3})})
+      expect.objectContaining({
+        query: expect.objectContaining({limit: 3}),
+      }),
+      {replace: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -39,7 +39,8 @@ describe('Thresholds', () => {
         query: expect.objectContaining({
           thresholds: undefined,
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -59,7 +60,8 @@ describe('Thresholds', () => {
         query: expect.objectContaining({
           thresholds: '{"max_values":{"max1":100,"max2":200},"unit":null}',
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -87,7 +89,8 @@ describe('Thresholds', () => {
         query: expect.objectContaining({
           thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"second"}',
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -44,7 +44,8 @@ describe('TypeSelector', () => {
       expect.objectContaining({
         ...router.location,
         query: expect.objectContaining({displayType: 'bar'}),
-      })
+      }),
+      {replace: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -399,7 +399,8 @@ describe('Visualize', () => {
         query: expect.objectContaining({
           field: ['count()'],
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -437,7 +438,8 @@ describe('Visualize', () => {
         query: expect.objectContaining({
           field: ['count_miserable(user,300)'],
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -768,7 +770,8 @@ describe('Visualize', () => {
         query: expect.objectContaining({
           selectedAggregate: undefined,
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -112,7 +112,8 @@ describe('WidgetTemplatesList', () => {
           displayType: 'line',
           dataset: 'transactions-like',
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.spec.tsx
@@ -41,7 +41,10 @@ describe('UrlParamBatchProvider', () => {
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({query: {foo: 'bar', potato: 'test'}})
+      expect.objectContaining({
+        query: {foo: 'bar', potato: 'test'},
+      }),
+      {replace: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.tsx
@@ -37,13 +37,19 @@ export function UrlParamBatchProvider({children}: {children: React.ReactNode}) {
     if (Object.keys(pendingUpdates).length === 0) {
       return;
     }
-    navigate({
-      ...location,
-      query: {
-        ...location.query,
-        ...pendingUpdates,
+    navigate(
+      {
+        ...location,
+        query: {
+          ...location.query,
+          ...pendingUpdates,
+        },
       },
-    });
+
+      // TODO: Use replace until we can sync the state of the widget
+      // when the user navigates back
+      {replace: true}
+    );
     setPendingUpdates({});
   }, [location, navigate, pendingUpdates]);
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.spec.tsx
@@ -53,19 +53,25 @@ describe('useQueryParamState', () => {
     expect(result.current[0]).toBe('newValue');
 
     // The query param should not be updated yet
-    expect(mockedNavigate).not.toHaveBeenCalledWith({
-      ...LocationFixture(),
-      query: {testField: 'initial state'},
-    });
+    expect(mockedNavigate).not.toHaveBeenCalledWith(
+      {
+        ...LocationFixture(),
+        query: {testField: 'initial state'},
+      },
+      {replace: true}
+    );
 
     // Run the timers to trigger queued updates
     jest.runAllTimers();
 
     // The query param should be updated
-    expect(mockedNavigate).toHaveBeenCalledWith({
-      ...LocationFixture(),
-      query: {testField: 'newValue'},
-    });
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      {
+        ...LocationFixture(),
+        query: {testField: 'newValue'},
+      },
+      {replace: true}
+    );
 
     // The local state should be still reflect the new value
     expect(result.current[0]).toBe('newValue');
@@ -112,10 +118,13 @@ describe('useQueryParamState', () => {
       result.current[1]({value: 'newValue', count: 2, isActive: true});
     });
 
-    expect(mockedNavigate).toHaveBeenCalledWith({
-      ...LocationFixture(),
-      query: {testField: 'newValue - 2 - true'},
-    });
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      {
+        ...LocationFixture(),
+        query: {testField: 'newValue - 2 - true'},
+      },
+      {replace: true}
+    );
   });
 
   it('can decode and update sorts', () => {
@@ -142,9 +151,12 @@ describe('useQueryParamState', () => {
       result.current[1]([{field: 'testField', kind: 'asc'}]);
     });
 
-    expect(mockedNavigate).toHaveBeenCalledWith({
-      ...LocationFixture(),
-      query: {sort: ['testField']},
-    });
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      {
+        ...LocationFixture(),
+        query: {sort: ['testField']},
+      },
+      {replace: true}
+    );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -71,12 +71,16 @@ describe('useWidgetBuilderState', () => {
     jest.runAllTimers();
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({query: expect.objectContaining({title: 'new title'})})
+      expect.objectContaining({
+        query: expect.objectContaining({title: 'new title'}),
+      }),
+      {replace: true}
     );
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({description: 'new description'}),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -126,7 +130,8 @@ describe('useWidgetBuilderState', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({displayType: DisplayType.AREA}),
-        })
+        }),
+        {replace: true}
       );
     });
 
@@ -635,7 +640,8 @@ describe('useWidgetBuilderState', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({dataset: WidgetType.METRICS}),
-        })
+        }),
+        {replace: true}
       );
     });
 
@@ -1347,7 +1353,8 @@ describe('useWidgetBuilderState', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({selectedAggregate: undefined}),
-        })
+        }),
+        {replace: true}
       );
     });
   });


### PR DESCRIPTION
Since this hook maintains local state for now, clicking "back" doesn't update the state properly to reflect the new URL params. I want to just use `replace` to change the URL params but not overload the user's history stack in case they want to click "back" for now. For now, this requires us to add `{replace: true}` to any assertions we make against the mocked navigate function. Ideally we don't directly test this and instead we can just check that the right arguments are passed into the dispatch function.

I noticed if a user navigates backwards and gets out of the widget builder URL then we don't close it. I'll put up another PR to close that.