### PR TITLE
fix(widget-builder): Make slideout smaller and preview bigger

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -8,6 +8,7 @@ import {type AnimationProps, motion} from 'framer-motion';
 import {space} from 'sentry/styles/space';
 
 const PANEL_WIDTH = '50vw';
+const LEFT_SIDE_PANEL_WIDTH = '40vw';
 const PANEL_HEIGHT = '50vh';
 
 const OPEN_STYLES = {
@@ -138,8 +139,8 @@ const _SlideOverPanel = styled(motion.div, {
           : css`
               position: relative;
 
-              width: ${PANEL_WIDTH};
-              min-width: 500px;
+              width: ${LEFT_SIDE_PANEL_WIDTH};
+              min-width: 450px;
               height: 100%;
 
               top: 0;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -391,7 +391,7 @@ const SampleWidgetCard = styled(motion.div)`
   position: relative;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    width: 30vw;
+    width: 40vw;
     min-width: 300px;
     z-index: ${p => p.theme.zIndex.modal};
     cursor: auto;
@@ -399,9 +399,8 @@ const SampleWidgetCard = styled(motion.div)`
 
   @media (max-width: ${p => p.theme.breakpoints.large}) and (min-width: ${p =>
       p.theme.breakpoints.medium}) {
-    width: 25vw;
+    width: 30vw;
     min-width: 100px;
-    max-width: 300px;
   }
 `;
 


### PR DESCRIPTION
Got some requests to make the preview larger and the slideout smaller. I kept the slideout at a width that ensures all the subfields that are in the same line are still visible. It looks like this on larger and smaller screens (not mobile size):

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/76a49a63-e388-461a-9d51-c4d42ce9900a) | ![image](https://github.com/user-attachments/assets/e1f4bb84-f75b-4c50-af7e-4ff9309589f6) |
| ![image](https://github.com/user-attachments/assets/7774dab6-3575-4aaf-b351-f2c911f5c4cc) | ![image](https://github.com/user-attachments/assets/69c5d1c3-1f8d-4773-bd07-49ab1dd0b38f) | 
