### PR TITLE
chore(eslint): Set array-type eslint rule to use the array-simple option

### DIFF
--- a/api-docs/paths/projects/dsyms.json
+++ b/api-docs/paths/projects/dsyms.json
@@ -110,9 +110,7 @@
         "auth_token": ["project:write"]
       }
     ],
-    "servers": [
-      {"url": "https://{region}.sentry.io"}
-    ]
+    "servers": [{ "url": "https://{region}.sentry.io" }]
   },
   "delete": {
     "tags": ["Projects"],

--- a/api-docs/paths/releases/project-release-files.json
+++ b/api-docs/paths/releases/project-release-files.json
@@ -172,8 +172,6 @@
         "auth_token": ["project:releases"]
       }
     ],
-    "servers": [
-      {"url": "https://{region}.sentry.io"}
-    ]
+    "servers": [{ "url": "https://{region}.sentry.io" }]
   }
 }

--- a/api-docs/paths/releases/release-files.json
+++ b/api-docs/paths/releases/release-files.json
@@ -136,8 +136,6 @@
         "auth_token": ["project:releases"]
       }
     ],
-    "servers": [
-      {"url": "https://{region}.sentry.io"}
-    ]
+    "servers": [{ "url": "https://{region}.sentry.io" }]
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -431,6 +431,7 @@ export default typescript.config([
       '@typescript-eslint/unified-signatures': 'off', // TODO(ryan953): Fix violations and delete this line
 
       // Stylistic overrides
+      '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
       '@typescript-eslint/class-literal-property-style': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/consistent-generic-constructors': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/consistent-indexed-object-style': 'off', // TODO(ryan953): Fix violations and delete this line

--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -121,16 +121,16 @@ type QueryArgs =
   | {
       query: string;
       environment?: string | string[];
-      project?: (number | string)[];
+      project?: Array<number | string>;
     }
   | {
       id: number[] | string[];
       environment?: string | string[];
-      project?: (number | string)[];
+      project?: Array<number | string>;
     }
   | {
       environment?: string | string[];
-      project?: (number | string)[];
+      project?: Array<number | string>;
     };
 
 /**
@@ -175,7 +175,7 @@ function getUpdateUrl({projectId, orgId}: UpdateParams) {
 }
 
 function chainUtil<Args extends any[]>(
-  ...funcs: (((...args: Args) => any) | undefined)[]
+  ...funcs: Array<((...args: Args) => any) | undefined>
 ) {
   const filteredFuncs = funcs.filter(
     (f): f is (...args: Args) => any => typeof f === 'function'

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -48,7 +48,7 @@ type EmailVerificationModalOptions = {
 };
 
 type InviteMembersModalOptions = {
-  initialData?: Partial<InviteRow>[];
+  initialData?: Array<Partial<InviteRow>>;
   onClose?: () => void;
   source?: string;
 };

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -125,8 +125,9 @@ const ALLOWED_ANON_PAGES = [
 /**
  * Return true if we should skip calling the normal error handler
  */
-const globalErrorHandlers: ((resp: ResponseMeta, options: RequestOptions) => boolean)[] =
-  [];
+const globalErrorHandlers: Array<
+  (resp: ResponseMeta, options: RequestOptions) => boolean
+> = [];
 
 export const initApiClientErrorHandling = () =>
   globalErrorHandlers.push((resp: ResponseMeta, options: RequestOptions) => {

--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -20,7 +20,7 @@ const discoverxAxis = XAxis({
   axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
 });
 
-export const discoverCharts: RenderDescriptor<ChartType>[] = [];
+export const discoverCharts: Array<RenderDescriptor<ChartType>> = [];
 
 discoverCharts.push({
   key: ChartType.SLACK_DISCOVER_TOTAL_PERIOD,
@@ -61,7 +61,7 @@ discoverCharts.push({
           name: s.key,
           stack: 'area',
           data: s.data.map(
-            ([timestamp, countsForTimestamp]: [number, {count: number}[]]) => [
+            ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => [
               timestamp * 1000,
               countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
             ]
@@ -124,7 +124,7 @@ discoverCharts.push({
           name: s.key,
           stack: 'area',
           data: s.data.map(
-            ([timestamp, countsForTimestamp]: [number, {count: number}[]]) => ({
+            ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => ({
               value: [
                 timestamp * 1000,
                 countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
@@ -187,7 +187,7 @@ discoverCharts.push({
         AreaSeries({
           stack: 'area',
           data: topSeries.data.map(
-            ([timestamp, countsForTimestamp]: [number, {count: number}[]]) => [
+            ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => [
               timestamp * 1000,
               countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
             ]
@@ -247,7 +247,7 @@ discoverCharts.push({
       .map((topSeries, i) =>
         LineSeries({
           data: topSeries.data.map(
-            ([timestamp, countsForTimestamp]: [number, {count: number}[]]) => [
+            ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => [
               timestamp * 1000,
               countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
             ]
@@ -308,7 +308,7 @@ discoverCharts.push({
         BarSeries({
           stack: 'area',
           data: topSeries.data.map(
-            ([timestamp, countsForTimestamp]: [number, {count: number}[]]) => [
+            ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => [
               timestamp * 1000,
               countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
             ]
@@ -389,10 +389,12 @@ discoverCharts.push({
             stack: 'area',
             data: s.data
               .slice(dataMiddleIndex)
-              .map(([timestamp, countsForTimestamp]: [number, {count: number}[]]) => [
-                timestamp * 1000,
-                countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
-              ]),
+              .map(
+                ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => [
+                  timestamp * 1000,
+                  countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
+                ]
+              ),
             lineStyle: {color: color?.[i], opacity: 1, width: 0.4},
             areaStyle: {color: color?.[i], opacity: 1},
           })
@@ -402,7 +404,10 @@ discoverCharts.push({
             name: t('previous %s', s.key),
             stack: 'previous',
             data: previous.map(
-              ([_, countsForTimestamp]: [number, {count: number}[]], index: number) => [
+              (
+                [_, countsForTimestamp]: [number, Array<{count: number}>],
+                index: number
+              ) => [
                 current[index][0] * 1000,
                 countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
               ]

--- a/static/app/chartcuterie/metricAlert.tsx
+++ b/static/app/chartcuterie/metricAlert.tsx
@@ -58,7 +58,7 @@ function transformAreaSeries(series: AreaChartSeries[]): LineSeriesOption[] {
   });
 }
 
-export const metricAlertCharts: RenderDescriptor<ChartType>[] = [];
+export const metricAlertCharts: Array<RenderDescriptor<ChartType>> = [];
 
 metricAlertCharts.push({
   key: ChartType.SLACK_METRIC_ALERT_EVENTS,

--- a/static/app/chartcuterie/performance.tsx
+++ b/static/app/chartcuterie/performance.tsx
@@ -13,7 +13,7 @@ import {DEFAULT_FONT_FAMILY, slackChartDefaults, slackChartSize} from './slack';
 import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
-export const performanceCharts: RenderDescriptor<ChartType>[] = [];
+export const performanceCharts: Array<RenderDescriptor<ChartType>> = [];
 
 export type FunctionRegressionPercentileData = {
   data: EventsStatsSeries<'p95()'>;

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -31,7 +31,7 @@ const IGNORE_DURATIONS = [
 
 const IGNORE_COUNTS = [1, 10, 100, 1000, 10000, 100000];
 
-const IGNORE_WINDOWS: SelectValue<number>[] = [
+const IGNORE_WINDOWS: Array<SelectValue<number>> = [
   {value: ONE_HOUR, label: t('per hour')},
   {value: ONE_HOUR * 24, label: t('per day')},
   {value: ONE_HOUR * 24 * 7, label: t('per week')},

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -97,7 +97,7 @@ export interface AssigneeSelectorDropdownProps {
   /**
    * Optional list of suggested owners of the group
    */
-  owners?: Omit<SuggestedAssignee, 'assignee'>[];
+  owners?: Array<Omit<SuggestedAssignee, 'assignee'>>;
   /**
    * Maximum number of teams/users to display in the dropdown
    */
@@ -414,8 +414,8 @@ export default function AssigneeSelectorDropdown({
     };
   };
 
-  const makeAllOptions = (): SelectOptionOrSection<string>[] => {
-    const options: SelectOptionOrSection<string>[] = [];
+  const makeAllOptions = (): Array<SelectOptionOrSection<string>> => {
+    const options: Array<SelectOptionOrSection<string>> = [];
 
     let memList = currentMemberList;
     let assignableTeamList = getAssignableTeams();

--- a/static/app/components/assistant/types.tsx
+++ b/static/app/components/assistant/types.tsx
@@ -68,7 +68,7 @@ export type Guide = BaseGuide & {
 
 export type GuidesContent = BaseGuide[];
 
-export type GuidesServerData = {
+export type GuidesServerData = Array<{
   /**
    * Guide key
    */
@@ -77,4 +77,4 @@ export type GuidesServerData = {
    * Has this guide already been seen?
    */
   seen: boolean;
-}[];
+}>;

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -26,7 +26,7 @@ type Props = {
   teams?: Team[];
   tooltipOptions?: UserAvatarProps['tooltipOptions'];
   typeAvatars?: string;
-  users?: (Actor | AvatarUser)[];
+  users?: Array<Actor | AvatarUser>;
 };
 
 export const CollapsedAvatars = forwardRef(function CollapsedAvatars(

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -198,7 +198,7 @@ class AvatarChooser extends Component<Props, State> {
     const isOrganization = type === 'organization';
     const isSentryApp = type?.startsWith('sentryApp');
 
-    const choices: [AvatarType, string][] = [];
+    const choices: Array<[AvatarType, string]> = [];
 
     if (allowDefault && preview) {
       choices.push(['default', defaultChoiceText ?? t('Use default avatar')]);

--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -63,7 +63,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Array of crumbs that will be rendered
    */
-  crumbs: (Crumb | CrumbDropdown)[];
+  crumbs: Array<Crumb | CrumbDropdown>;
 
   /**
    * As a general rule of thumb we don't want the last item to be link as it most likely

--- a/static/app/components/carousel.spec.tsx
+++ b/static/app/components/carousel.spec.tsx
@@ -3,8 +3,9 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import Carousel from 'sentry/components/carousel';
 
 describe('Carousel', function () {
-  let intersectionOnbserverCb: (entries: Partial<IntersectionObserverEntry>[]) => void =
-    jest.fn();
+  let intersectionOnbserverCb: (
+    entries: Array<Partial<IntersectionObserverEntry>>
+  ) => void = jest.fn();
 
   window.IntersectionObserver = class IntersectionObserver {
     root = null;

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -301,7 +301,7 @@ export interface BaseChartProps {
    * Pass `true` to have 2 x-axes with default properties.  Can pass an array
    * of multiple objects to customize xAxis properties
    */
-  xAxes?: true | BaseChartProps['xAxis'][];
+  xAxes?: true | Array<BaseChartProps['xAxis']>;
   /**
    * Must be explicitly `null` to disable xAxis
    *
@@ -313,7 +313,7 @@ export interface BaseChartProps {
    * Pass `true` to have 2 y-axes with default properties. Can pass an array of
    * objects to customize yAxis properties
    */
-  yAxes?: true | BaseChartProps['yAxis'][];
+  yAxes?: true | Array<BaseChartProps['yAxis']>;
 
   /**
    * Must be explicitly `null` to disable yAxis

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -396,7 +396,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
     data: EventsStatsData,
     getName: (
       timestamp: number,
-      countArray: {count: number}[],
+      countArray: Array<{count: number}>,
       i: number
     ) => number = timestamp => timestamp * 1000
   ): SeriesDataUnit[] {

--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -67,7 +67,7 @@ function OptionSelector({
         multiple,
         value: selected,
         defaultValue,
-        onChange: (sel: SelectOption<string>[]) => {
+        onChange: (sel: Array<SelectOption<string>>) => {
           onChange?.(sel.map(o => o.value));
         },
         closeOnSelect,

--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -42,7 +42,7 @@ export default class PercentageAreaChart extends Component<Props> {
   getSeries() {
     const {series, getDataItemName, getValue} = this.props;
 
-    const totalsArray: [string | number, number][] = series.length
+    const totalsArray: Array<[string | number, number]> = series.length
       ? series[0]!.data.map(({name}, i) => [
           name,
           series.reduce((sum, {data}) => sum + data[i]!.value, 0),

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -344,7 +344,7 @@ export const getPreviousSeriesName = (seriesName: string) => {
   return `previous ${seriesName}`;
 };
 
-function formatList(items: (string | number | undefined)[]) {
+function formatList(items: Array<string | number | undefined>) {
   const filteredItems = items.filter((item): item is string | number => !!item);
 
   return oxfordizeArray(filteredItems.map(item => item.toString()));

--- a/static/app/components/checkInTimeline/checkInTimeline.stories.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.stories.tsx
@@ -50,7 +50,7 @@ const statusPrecedent = [ExampleStatus.OK, ExampleStatus.TIMEOUT, ExampleStatus.
 function generateMockTickData(
   secondsGap: number,
   timeWindowConfig: TimeWindowConfig
-): CheckInBucket<ExampleStatus>[] {
+): Array<CheckInBucket<ExampleStatus>> {
   const buckets = timeWindowConfig.timelineWidth;
   const secondsPerBucket = (timeWindowConfig.elapsedMinutes * 60) / buckets;
 

--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -32,7 +32,7 @@ export interface CheckInTimelineProps<Status extends string>
   /**
    * Represents each check-in tick as bucketed check-in data.
    */
-  bucketedData: CheckInBucket<Status>[];
+  bucketedData: Array<CheckInBucket<Status>>;
 }
 
 function getBucketedCheckInsPosition(

--- a/static/app/components/checkInTimeline/checkInTooltip.tsx
+++ b/static/app/components/checkInTimeline/checkInTooltip.tsx
@@ -61,7 +61,7 @@ export function CheckInTooltip<Status extends string>({
           </tr>
         </HiddenHeader>
         <tbody>
-          {(Object.entries(stats) as [Status, number][]).map(
+          {(Object.entries(stats) as Array<[Status, number]>).map(
             ([status, count]) =>
               count > 0 && (
                 <tr key={status}>

--- a/static/app/components/checkInTimeline/utils/getAggregateStatusFromMultipleBuckets.tsx
+++ b/static/app/components/checkInTimeline/utils/getAggregateStatusFromMultipleBuckets.tsx
@@ -8,7 +8,7 @@ import {getAggregateStatus} from './getAggregateStatus';
  */
 export function getAggregateStatusFromMultipleBuckets<Status extends string>(
   statusPrecedent: Status[],
-  statsArr: StatsBucket<Status>[]
+  statsArr: Array<StatsBucket<Status>>
 ) {
   return statsArr
     .map(stats => getAggregateStatus(statusPrecedent, stats))

--- a/static/app/components/checkInTimeline/utils/mergeBuckets.spec.tsx
+++ b/static/app/components/checkInTimeline/utils/mergeBuckets.spec.tsx
@@ -12,7 +12,7 @@ function generateJobRunWithStats(jobStatus: string) {
 
 describe('mergeBucketsWithStats', function () {
   it('does not generate ticks less than 3px width', function () {
-    const bucketData: CheckInBucket<string>[] = [
+    const bucketData: Array<CheckInBucket<string>> = [
       [1, generateJobRunWithStats('ok')],
       [2, generateJobRunWithStats('ok')],
       [3, generateJobRunWithStats('ok')],
@@ -38,7 +38,7 @@ describe('mergeBucketsWithStats', function () {
   });
 
   it('generates adjacent ticks without border radius', function () {
-    const bucketData: CheckInBucket<string>[] = [
+    const bucketData: Array<CheckInBucket<string>> = [
       [1, generateJobRunWithStats('ok')],
       [2, generateJobRunWithStats('ok')],
       [3, generateJobRunWithStats('ok')],
@@ -72,7 +72,7 @@ describe('mergeBucketsWithStats', function () {
   });
 
   it('does not generate a separate tick if the next generated tick would be the same status', function () {
-    const bucketData: CheckInBucket<string>[] = [
+    const bucketData: Array<CheckInBucket<string>> = [
       [1, generateJobRunWithStats('timeout')],
       [2, generateJobRunWithStats('timeout')],
       [3, generateJobRunWithStats('timeout')],

--- a/static/app/components/checkInTimeline/utils/mergeBuckets.tsx
+++ b/static/app/components/checkInTimeline/utils/mergeBuckets.tsx
@@ -23,10 +23,10 @@ function generateJobTickFromBucketWithStats<Status extends string>(
 
 export function mergeBuckets<Status extends string>(
   statusPrecedent: Status[],
-  data: CheckInStats<Status>[]
-): JobTickData<Status>[] {
+  data: Array<CheckInStats<Status>>
+): Array<JobTickData<Status>> {
   const minTickWidth = 4;
-  const jobTicks: JobTickData<Status>[] = [];
+  const jobTicks: Array<JobTickData<Status>> = [];
 
   data.reduce<JobTickData<Status> | null>((currentJobTick, [timestamp, stats], i) => {
     const statsEmpty = isStatsBucketEmpty(stats);

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -58,10 +58,10 @@ interface CodeSnippetProps {
    */
   onTabClick?: (tab: string) => void;
   selectedTab?: string;
-  tabs?: {
+  tabs?: Array<{
     label: string;
     value: string;
-  }[];
+  }>;
 }
 
 export function CodeSnippet({

--- a/static/app/components/comboBox/comboBox.stories.tsx
+++ b/static/app/components/comboBox/comboBox.stories.tsx
@@ -16,7 +16,7 @@ const Divider = styled('hr')`
   border-top: 1px solid ${p => p.theme.innerBorder};
 `;
 
-const options: ComboBoxOptionOrSection<string>[] = [
+const options: Array<ComboBoxOptionOrSection<string>> = [
   {label: 'Option One', value: 'opt_one'},
   {label: 'Option Two', value: 'opt_two', details: 'This is a description'},
   {

--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -251,7 +251,7 @@ function ControlledComboBox<Value extends string>({
   ComboBoxProps<Value>,
   'items' | 'defaultItems' | 'children' | 'hasSearch' | 'hiddenOptions'
 > & {
-  options: ComboBoxOptionOrSection<Value>[];
+  options: Array<ComboBoxOptionOrSection<Value>>;
   defaultValue?: Value;
   filterOption?: (option: ComboBoxOption<Value>, inputValue: string) => boolean;
   onChange?: (value: ComboBoxOption<Value>) => void;
@@ -278,7 +278,7 @@ function ControlledComboBox<Value extends string>({
   }, [value, options]);
 
   const items = useMemo(() => {
-    return getItemsWithKeys(options) as ComboBoxOptionOrSectionWithKey<Value>[];
+    return getItemsWithKeys(options) as Array<ComboBoxOptionOrSectionWithKey<Value>>;
   }, [options]);
 
   const hiddenOptions = useMemo(

--- a/static/app/components/comboBox/types.tsx
+++ b/static/app/components/comboBox/types.tsx
@@ -14,7 +14,7 @@ export interface ComboBoxOption<Value extends SelectKey> extends SelectValue<Val
 }
 
 export interface ComboBoxSection<Value extends SelectKey> {
-  options: ComboBoxOption<Value>[];
+  options: Array<ComboBoxOption<Value>>;
   /**
    * When true, all options inside this section will be disabled.
    */
@@ -55,7 +55,7 @@ export interface ComboBoxSectionWithKey<Value extends SelectKey>
    * be used.
    */
   key: SelectKey;
-  options: ComboBoxOptionWithKey<Value>[];
+  options: Array<ComboBoxOptionWithKey<Value>>;
 }
 
 /**

--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -15,7 +15,7 @@ import type {SelectKey, SelectOption} from './types';
 import {getItemsWithKeys} from './utils';
 
 interface BaseCompositeSelectRegion<Value extends SelectKey> {
-  options: SelectOption<Value>[];
+  options: Array<SelectOption<Value>>;
   key?: SelectKey;
   label?: React.ReactNode;
 }

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -63,7 +63,7 @@ export interface SelectContextValue {
    */
   saveSelectedOptions: (
     index: number,
-    newSelectedOptions: SelectOption<SelectKey> | SelectOption<SelectKey>[]
+    newSelectedOptions: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>
   ) => void;
   /**
    * Search string to determine whether an option should be rendered in the select list.
@@ -256,7 +256,7 @@ export function Control({
   const wrapperRef = useRef<HTMLDivElement>(null);
   // Set up list states (in composite selects, each region has its own state, that way
   // selection values are contained within each region).
-  const [listStates, setListStates] = useState<ListState<any>[]>([]);
+  const [listStates, setListStates] = useState<Array<ListState<any>>>([]);
   const registerListState = useCallback<SelectContextValue['registerListState']>(
     (index, listState) => {
       setListStates(current => [
@@ -437,7 +437,7 @@ export function Control({
    * trigger label.
    */
   const [selectedOptions, setSelectedOptions] = useState<
-    (SelectOption<SelectKey> | SelectOption<SelectKey>[])[]
+    Array<SelectOption<SelectKey> | Array<SelectOption<SelectKey>>>
   >([]);
   const saveSelectedOptions = useCallback<SelectContextValue['saveSelectedOptions']>(
     (index, newSelectedOptions) => {

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -21,7 +21,7 @@ import {getItemsWithKeys} from './utils';
 export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 
 interface BaseSelectProps<Value extends SelectKey> extends ControlProps {
-  options: SelectOptionOrSection<Value>[];
+  options: Array<SelectOptionOrSection<Value>>;
 }
 
 export interface SingleSelectProps<Value extends SelectKey>

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -54,7 +54,7 @@ interface BaseListProps<Value extends SelectKey>
       | 'onSelectionChange'
       | 'autoFocus'
     > {
-  items: SelectOptionOrSectionWithKey<Value>[];
+  items: Array<SelectOptionOrSectionWithKey<Value>>;
   /**
    * This list's index number inside composite select menus.
    */
@@ -116,9 +116,9 @@ export interface MultipleListProps<Value extends SelectKey> extends BaseListProp
    * Whether to close the menu. Accepts either a boolean value or a callback function
    * that receives the newly selected options and returns whether to close the menu.
    */
-  closeOnSelect?: boolean | ((selectedOptions: SelectOption<Value>[]) => boolean);
+  closeOnSelect?: boolean | ((selectedOptions: Array<SelectOption<Value>>) => boolean);
   defaultValue?: Value[];
-  onChange?: (selectedOptions: SelectOption<Value>[]) => void;
+  onChange?: (selectedOptions: Array<SelectOption<Value>>) => void;
   value?: Value[];
 }
 

--- a/static/app/components/compactSelect/types.tsx
+++ b/static/app/components/compactSelect/types.tsx
@@ -13,7 +13,7 @@ export interface SelectOption<Value extends SelectKey> extends SelectValue<Value
 }
 
 export interface SelectSection<Value extends SelectKey> {
-  options: SelectOption<Value>[];
+  options: Array<SelectOption<Value>>;
   /**
    * When true, all options inside this section will be disabled.
    */
@@ -54,7 +54,7 @@ export interface SelectSectionWithKey<Value extends SelectKey>
    * be used.
    */
   key: SelectKey;
-  options: SelectOptionWithKey<Value>[];
+  options: Array<SelectOptionWithKey<Value>>;
 }
 
 /**

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -23,14 +23,14 @@ export function getEscapedKey<Value extends SelectKey | undefined>(value: Value)
 }
 
 export function getItemsWithKeys<Value extends SelectKey>(
-  options: SelectOption<Value>[]
-): SelectOptionWithKey<Value>[];
+  options: Array<SelectOption<Value>>
+): Array<SelectOptionWithKey<Value>>;
 export function getItemsWithKeys<Value extends SelectKey>(
-  options: SelectOptionOrSection<Value>[]
-): SelectOptionOrSectionWithKey<Value>[];
+  options: Array<SelectOptionOrSection<Value>>
+): Array<SelectOptionOrSectionWithKey<Value>>;
 export function getItemsWithKeys<Value extends SelectKey>(
-  options: SelectOptionOrSection<Value>[]
-): SelectOptionOrSectionWithKey<Value>[] {
+  options: Array<SelectOptionOrSection<Value>>
+): Array<SelectOptionOrSectionWithKey<Value>> {
   return options.map((item, i) => {
     if ('options' in item) {
       return {
@@ -52,10 +52,10 @@ export function getItemsWithKeys<Value extends SelectKey>(
  * non-flat arrays that contain sections (groups of options).
  */
 export function getSelectedOptions<Value extends SelectKey>(
-  items: SelectOptionOrSectionWithKey<Value>[],
+  items: Array<SelectOptionOrSectionWithKey<Value>>,
   selection: Selection
-): SelectOption<Value>[] {
-  return items.reduce<SelectOption<Value>[]>((acc, cur) => {
+): Array<SelectOption<Value>> {
+  return items.reduce<Array<SelectOption<Value>>>((acc, cur) => {
     // If this is a section
     if ('options' in cur) {
       return acc.concat(getSelectedOptions(cur.options, selection));
@@ -76,7 +76,7 @@ export function getSelectedOptions<Value extends SelectKey>(
  * were removed.
  */
 export function getDisabledOptions<Value extends SelectKey>(
-  items: SelectOptionOrSectionWithKey<Value>[],
+  items: Array<SelectOptionOrSectionWithKey<Value>>,
   isOptionDisabled?: (opt: SelectOptionWithKey<Value>) => boolean
 ): SelectKey[] {
   return items.reduce((acc: SelectKey[], cur) => {
@@ -102,7 +102,7 @@ export function getDisabledOptions<Value extends SelectKey>(
  * outside the list box's count limit.
  */
 export function getHiddenOptions<Value extends SelectKey>(
-  items: SelectOptionOrSectionWithKey<Value>[],
+  items: Array<SelectOptionOrSectionWithKey<Value>>,
   search: string,
   limit: number = Infinity,
   filterOption?: (opt: SelectOption<Value>, search: string) => boolean

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -128,8 +128,8 @@ class ContextPickerModal extends Component<Props> {
   // i.e. When there is only 1 org and no project is needed or
   // there is only 1 org and only 1 project (which should be rare)
   navigateIfFinish = (
-    organizations: {slug: string}[],
-    projects: {slug: string}[],
+    organizations: Array<{slug: string}>,
+    projects: Array<{slug: string}>,
     latestOrg = this.props.organization
   ) => {
     const {needProject, onFinish, nextPath, integrationConfigs} = this.props;

--- a/static/app/components/customIgnoreCountModal.tsx
+++ b/static/app/components/customIgnoreCountModal.tsx
@@ -18,7 +18,7 @@ type Props = ModalRenderProps & {
   label: string;
   onSelected: (statusDetails: IgnoredStatusDetails) => void;
   windowName: WindowNames;
-  windowOptions: SelectValue<number>[];
+  windowOptions: Array<SelectValue<number>>;
 };
 
 export default function CustomIgnoreCountModal(props: Props) {

--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -370,7 +370,7 @@ class DeprecatedAsyncComponent<
    *   ['stateKeyName', '/endpoint/', {optional: 'query params'}, {options}]
    * ]
    */
-  getEndpoints(): [string, string, any?, any?][] {
+  getEndpoints(): Array<[string, string, any?, any?]> {
     return [];
   }
 

--- a/static/app/components/deprecatedSmartSearchBar/index.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/index.tsx
@@ -644,7 +644,7 @@ class DeprecatedSmartSearchBar extends Component<DefaultProps & Props, State> {
     }
   }
 
-  moveToNextToken = (filterTokens: TokenResult<Token.FILTER>[]) => {
+  moveToNextToken = (filterTokens: Array<TokenResult<Token.FILTER>>) => {
     const token = this.cursorToken;
 
     if (this.searchInput.current && filterTokens.length > 0) {
@@ -1229,9 +1229,9 @@ class DeprecatedSmartSearchBar extends Component<DefaultProps & Props, State> {
     };
   }
 
-  get filterTokens(): TokenResult<Token.FILTER>[] {
+  get filterTokens(): Array<TokenResult<Token.FILTER>> {
     return (this.state.parsedQuery?.filter(tok => tok.type === Token.FILTER) ??
-      []) as TokenResult<Token.FILTER>[];
+      []) as Array<TokenResult<Token.FILTER>>;
   }
 
   /**

--- a/static/app/components/deprecatedSmartSearchBar/utils.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/utils.tsx
@@ -420,7 +420,7 @@ const getItemTitle = (key: string, kind: FieldKind) => {
  * The parent will become interactive if there exists a key "device".
  */
 export const getTagItemsFromKeys = (
-  tagKeys: readonly Readonly<string>[],
+  tagKeys: ReadonlyArray<Readonly<string>>,
   supportedTags: TagCollection,
   fieldDefinitionGetter: typeof getFieldDefinition = getFieldDefinition
 ) => {

--- a/static/app/components/deprecatedforms/genericField.tsx
+++ b/static/app/components/deprecatedforms/genericField.tsx
@@ -25,7 +25,7 @@ type FieldType =
 type SelectFieldType = 'select' | 'choice';
 
 type Config = {
-  choices: [number | string, number | string][];
+  choices: Array<[number | string, number | string]>;
   default: string;
   name: string;
   placeholder: string;

--- a/static/app/components/deprecatedforms/selectCreatableField.tsx
+++ b/static/app/components/deprecatedforms/selectCreatableField.tsx
@@ -17,7 +17,7 @@ import convertFromSelect2Choices from 'sentry/utils/convertFromSelect2Choices';
  * This is used in some integrations
  */
 export default class SelectCreatableField extends SelectField {
-  options: SelectValue<any>[] | undefined;
+  options: Array<SelectValue<any>> | undefined;
 
   constructor(props: any, context: any) {
     super(props, context);

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -54,7 +54,7 @@ export type DropdownOption = {
   /**
    * override the eventView query
    */
-  query?: [string, string][];
+  query?: Array<[string, string]>;
   /**
    * Included if the option is for a trend
    */

--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -29,7 +29,7 @@ import {GridCell, GridCellNumber} from 'sentry/views/performance/styles';
 import type {TrendsDataEvents} from 'sentry/views/performance/trends/types';
 
 type Props = {
-  columnOrder: TableColumn<React.ReactText>[];
+  columnOrder: Array<TableColumn<React.ReactText>>;
   eventView: EventView;
   isLoading: boolean;
   location: Location;
@@ -127,7 +127,7 @@ function TransactionsTable(props: Props) {
   const renderRow = (
     row: TableDataRow,
     rowIndex: number,
-    colOrder: TableColumn<React.ReactText>[],
+    colOrder: Array<TableColumn<React.ReactText>>,
     tableMeta: MetaType
   ): React.ReactNode[] => {
     const fields = eventView.getFields();

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -50,7 +50,7 @@ function useOverflowingTabs({state}: {state: TabListState<DraggableTabListItemPr
   );
   const outerRef = useRef<HTMLDivElement>(null);
   const addViewTempTabRef = useRef<HTMLDivElement>(null);
-  const [tabElements, setTabElements] = useState<(HTMLDivElement | null)[]>([]);
+  const [tabElements, setTabElements] = useState<Array<HTMLDivElement | null>>([]);
   const {width: outerWidth} = useDimensions({elementRef: outerRef});
   const {width: addViewTempTabWidth} = useDimensions({elementRef: addViewTempTabRef});
   const tabsDimensions = useDimensionsMultiple({elements: tabElements});
@@ -59,7 +59,7 @@ function useOverflowingTabs({state}: {state: TabListState<DraggableTabListItemPr
     const availableWidth = outerWidth - addViewTempTabWidth;
 
     let totalWidth = 0;
-    const overflowing: Node<DraggableTabListItemProps>[] = [];
+    const overflowing: Array<Node<DraggableTabListItemProps>> = [];
 
     for (let i = 0; i < tabsDimensions.length; i++) {
       totalWidth += (tabsDimensions[i]?.width ?? 0) + 1; // 1 extra pixel for the divider
@@ -87,7 +87,7 @@ function OverflowMenu({
   state,
   overflowTabs,
 }: {
-  overflowTabs: Node<DraggableTabListItemProps>[];
+  overflowTabs: Array<Node<DraggableTabListItemProps>>;
   state: TabListState<any>;
 }) {
   const options = useMemo(() => {
@@ -141,13 +141,13 @@ function Tabs({
 }: {
   ariaProps: AriaTabListOptions<DraggableTabListItemProps>;
   hoveringKey: Key | 'addView' | null;
-  onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void;
+  onReorder: (newOrder: Array<Node<DraggableTabListItemProps>>) => void;
   orientation: 'horizontal' | 'vertical';
-  overflowingTabs: Node<DraggableTabListItemProps>[];
+  overflowingTabs: Array<Node<DraggableTabListItemProps>>;
   setHoveringKey: (key: Key | 'addView' | null) => void;
-  setTabRefs: Dispatch<SetStateAction<(HTMLDivElement | null)[]>>;
+  setTabRefs: Dispatch<SetStateAction<Array<HTMLDivElement | null>>>;
   state: TabListState<DraggableTabListItemProps>;
-  tabs: Node<DraggableTabListItemProps>[];
+  tabs: Array<Node<DraggableTabListItemProps>>;
   tempTabActive: boolean;
   className?: string;
   disabled?: boolean;
@@ -405,7 +405,7 @@ const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nod
 export interface DraggableTabListProps
   extends AriaTabListOptions<DraggableTabListItemProps>,
     TabListStateOptions<DraggableTabListItemProps> {
-  onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void;
+  onReorder: (newOrder: Array<Node<DraggableTabListItemProps>>) => void;
   className?: string;
   editingTabKey?: string;
   hideBorder?: boolean;

--- a/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
+++ b/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
@@ -1,10 +1,12 @@
 import type {Item, ItemsAfterFilter, ItemsBeforeFilter} from './types';
 
 type Items = ItemsBeforeFilter;
-type ItemsWithChildren = (Omit<Item, 'index'> & {
-  items: Omit<Item, 'index'>[];
-  hideGroupLabel?: boolean;
-})[];
+type ItemsWithChildren = Array<
+  Omit<Item, 'index'> & {
+    items: Array<Omit<Item, 'index'>>;
+    hideGroupLabel?: boolean;
+  }
+>;
 
 function hasRootGroup(items: Items): items is ItemsWithChildren {
   return !!items[0]?.items;

--- a/static/app/components/dropdownAutoComplete/types.tsx
+++ b/static/app/components/dropdownAutoComplete/types.tsx
@@ -12,10 +12,12 @@ export type Item = {
   searchKey?: string;
 } & Record<string, any>;
 
-type Items<T> = (T & {
-  hideGroupLabel?: boolean;
-  items?: T[]; // Should hide group label
-})[];
+type Items<T> = Array<
+  T & {
+    hideGroupLabel?: boolean;
+    items?: T[]; // Should hide group label
+  }
+>;
 
 export type ItemsBeforeFilter = Items<Omit<Item, 'index'>>;
 

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -32,7 +32,7 @@ function removeHiddenItems(source: MenuItemProps[]): MenuItemProps[] {
 /**
  * Recursively finds and returns disabled items
  */
-function getDisabledKeys(source: MenuItemProps[]): MenuItemProps['key'][] {
+function getDisabledKeys(source: MenuItemProps[]): Array<MenuItemProps['key']> {
   return source.reduce<string[]>((acc, cur) => {
     if (cur.disabled) {
       // If an item is disabled, then its children will be inaccessible, so we

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -201,7 +201,7 @@ function DropdownMenuList({
   };
 
   // Render a collection of menu items
-  const renderCollection = (collection: Node<MenuItemProps>[]) =>
+  const renderCollection = (collection: Array<Node<MenuItemProps>>) =>
     collection.map((node, i) => {
       const isLastNode = collection.length - 1 === i;
       const showSeparator =

--- a/static/app/components/events/autofix/autofixActionSelector.tsx
+++ b/static/app/components/events/autofix/autofixActionSelector.tsx
@@ -18,7 +18,7 @@ interface Props<T extends string> {
   children: (selectedOption: Option<T>) => React.ReactNode;
   onBack: () => void;
   onSelect: (value: T) => void;
-  options: Option<T>[];
+  options: Array<Option<T>>;
   selected: T | null;
 }
 

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -179,7 +179,7 @@ function DiffHunkContent({
   }, []);
 
   const lineGroups = useMemo(() => {
-    const groups: {end: number; start: number; type: 'change' | DiffLineType}[] = [];
+    const groups: Array<{end: number; start: number; type: 'change' | DiffLineType}> = [];
     let currentGroup: (typeof groups)[number] | null = null;
 
     linesWithChanges.forEach((line, index) => {

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -121,7 +121,7 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
   const steps = data.steps;
   const repos = data.repositories;
 
-  const stepsRef = useRef<(HTMLDivElement | null)[]>([]);
+  const stepsRef = useRef<Array<HTMLDivElement | null>>([]);
   const containerRef = useRef<HTMLDivElement>(null);
   const [hasSeenBottom, setHasSeenBottom] = useState(false);
   const [isBottomVisible, setIsBottomVisible] = useState(false);

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -115,7 +115,7 @@ function getBreadcrumbLevelOptions(crumbs: EnhancedCrumb[]) {
 
 export function useBreadcrumbFilters(crumbs: EnhancedCrumb[]) {
   const filterOptions = useMemo(() => {
-    const options: SelectSection<string>[] = [];
+    const options: Array<SelectSection<string>> = [];
     const typeOptions = getBreadcrumbTypeOptions(crumbs);
     if (typeOptions.length) {
       options.push({
@@ -137,7 +137,7 @@ export function useBreadcrumbFilters(crumbs: EnhancedCrumb[]) {
   }, [crumbs]);
 
   const applyFilters = useCallback(
-    (crumbsToFilter: EnhancedCrumb[], options: SelectOption<string>['value'][]) => {
+    (crumbsToFilter: EnhancedCrumb[], options: Array<SelectOption<string>['value']>) => {
       const typeFilterSet = new Set<string>();
       const levelFilterSet = new Set<string>();
       options.forEach(optionValue => {

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -36,7 +36,7 @@ export function getOrderedContextItems(event: Event): ContextItem[] {
   // hide `flags` in the contexts section since we display this
   // info in the feature flag section below
   const {feedback, response, flags: _, ...otherContexts} = contexts ?? {};
-  const orderedContext: [ContextItem['alias'], ContextValue][] = [
+  const orderedContext: Array<[ContextItem['alias'], ContextValue]> = [
     ['response', response],
     ['feedback', feedback],
     ['user', {...userContext, ...(customUserData as any)}],

--- a/static/app/components/events/eventProcessingErrors.tsx
+++ b/static/app/components/events/eventProcessingErrors.tsx
@@ -33,7 +33,7 @@ export default function EventErrorCard({
   title,
   data,
 }: {
-  data: {key: string; subject: any; value: any}[];
+  data: Array<{key: string; subject: any; value: any}>;
   title: string;
 }) {
   const contentItems = data.map(datum => {

--- a/static/app/components/events/eventStatisticalDetector/eventRegressionTable.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventRegressionTable.tsx
@@ -30,8 +30,8 @@ type ThroughputDataRow<K extends string> = RawDataRow<K> & {
 
 interface EventRegressionTableProps<K extends string> {
   causeType: 'duration' | 'throughput';
-  columns: GridColumnOrder<K>[];
-  data: (DurationDataRow<K> | ThroughputDataRow<K>)[];
+  columns: Array<GridColumnOrder<K>>;
+  data: Array<DurationDataRow<K> | ThroughputDataRow<K>>;
   isError: boolean;
   isLoading: boolean;
   options: Record<

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -99,7 +99,7 @@ export function EventFeatureFlagList({
 
   const hasFlagContext = Boolean(event.contexts?.flags?.values);
 
-  const eventFlags: Required<FeatureFlag>[] = useMemo(() => {
+  const eventFlags: Array<Required<FeatureFlag>> = useMemo(() => {
     // At runtime there's no type guarantees on the event flags. So we have to
     // explicitly validate against SDK developer error or user-provided contexts.
     const rawFlags = event.contexts?.flags?.values ?? [];

--- a/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
@@ -53,7 +53,7 @@ function FeatureFlagOnboardingSidebar(props: CommonSidebarProps) {
   });
 
   const projectSelectOptions = useMemo(() => {
-    const supportedProjectItems: SelectValue<string>[] = supportedProjects.map(
+    const supportedProjectItems: Array<SelectValue<string>> = supportedProjects.map(
       project => {
         return {
           value: project.id,
@@ -65,7 +65,7 @@ function FeatureFlagOnboardingSidebar(props: CommonSidebarProps) {
       }
     );
 
-    const unsupportedProjectItems: SelectValue<string>[] = unsupportedProjects.map(
+    const unsupportedProjectItems: Array<SelectValue<string>> = unsupportedProjects.map(
       project => {
         return {
           value: project.id,

--- a/static/app/components/events/featureFlags/testUtils.tsx
+++ b/static/app/components/events/featureFlags/testUtils.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import type {FeatureFlag} from 'sentry/types/event';
 
-export const MOCK_FLAGS: Required<FeatureFlag>[] = [
+export const MOCK_FLAGS: Array<Required<FeatureFlag>> = [
   {
     flag: 'mobile-replay-ui',
     result: false,

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -27,7 +27,7 @@ interface GroupingVariantProps {
   variant: EventGroupVariant;
 }
 
-type VariantData = [string, React.ReactNode][];
+type VariantData = Array<[string, React.ReactNode]>;
 
 function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
   if ('matched_rule' in variant) {

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -154,7 +154,7 @@ export function getHighlightTagData({
 }: {
   event: Event;
   highlightTags: HighlightTags;
-}): Required<TagTreeContent>[] {
+}): Array<Required<TagTreeContent>> {
   const tagMap: Record<string, {meta: Record<string, any>; tag: EventTag}> =
     event.tags.reduce((tm, tag, i) => {
       // @ts-ignore TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/components/events/interfaces/analyzeFrames.tsx
+++ b/static/app/components/events/interfaces/analyzeFrames.tsx
@@ -15,7 +15,7 @@ type SuspectFrame = {
   module: string | RegExp;
   resources: React.ReactNode;
   exceptionMessage?: string;
-  functions?: (string | RegExp)[];
+  functions?: Array<string | RegExp>;
   offendingThreadStates?: ThreadStates[];
 };
 

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -90,7 +90,9 @@ export function applyBreadcrumbSearch<T extends BreadcrumbListType>(
 
 function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Props) {
   const [searchTerm, setSearchTerm] = useState('');
-  const [filterSelections, setFilterSelections] = useState<SelectOption<string>[]>([]);
+  const [filterSelections, setFilterSelections] = useState<Array<SelectOption<string>>>(
+    []
+  );
   const [displayRelativeTime, setDisplayRelativeTime] = useState(false);
   const [sort, setSort] = useLocalStorageState<BreadcrumbSort>(
     BREADCRUMB_SORT_LOCALSTORAGE_KEY,
@@ -122,7 +124,7 @@ function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Pr
     const typeOptions = getFilterTypes(initialBreadcrumbs);
     const levels = getFilterLevels(typeOptions);
 
-    const options: SelectSection<string>[] = [];
+    const options: Array<SelectSection<string>> = [];
 
     if (typeOptions.length) {
       options.push({
@@ -174,7 +176,7 @@ function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Pr
   }
 
   function getFilterLevels(types: SelectOptionWithLevels[]) {
-    const filterLevels: SelectOption<string>[] = [];
+    const filterLevels: Array<SelectOption<string>> = [];
 
     for (const indexType in types) {
       for (const indexLevel in types[indexType]!.levels) {
@@ -202,7 +204,7 @@ function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Pr
 
   function applySelectedFilters(
     breadcrumbs: BreadcrumbWithMeta[],
-    selectedFilterOptions: SelectOption<string>[]
+    selectedFilterOptions: Array<SelectOption<string>>
   ) {
     const checkedTypeOptions = new Set(
       selectedFilterOptions

--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -35,14 +35,14 @@ const sentryInit = <code>Sentry.init</code>;
 function getErrorMessage(
   error: SourceMapDebugError,
   sdkName?: string
-): {
+): Array<{
   title: string;
   /**
    * Expandable description
    */
   desc?: React.ReactNode;
   docsLink?: string;
-}[] {
+}> {
   const docPlatform = (sdkName && sourceMapSdkDocsMap[sdkName]) ?? 'javascript';
   const useShortPath = shortPathPlatforms.includes(docPlatform);
 
@@ -213,7 +213,7 @@ function ExpandableErrorList({
 }
 
 function combineErrors(
-  response: (SourceMapDebugResponse | undefined | null)[],
+  response: Array<SourceMapDebugResponse | undefined | null>,
   sdkName?: string
 ) {
   const combinedErrors = uniqBy(

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
@@ -33,9 +33,9 @@ interface SourceMapDebugBlueThunderResponseFrame {
 
 interface SourceMapDebugBlueThunderResponse {
   dist: string | null;
-  exceptions: {
+  exceptions: Array<{
     frames: SourceMapDebugBlueThunderResponseFrame[];
-  }[];
+  }>;
   has_debug_ids: boolean;
   has_uploaded_some_artifact_with_a_debug_id: boolean;
   project_has_some_artifact_bundle: boolean;

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidates.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidates.tsx
@@ -43,8 +43,8 @@ type Props = {
 };
 
 type State = {
-  filterOptions: SelectSection<string>[];
-  filterSelections: SelectOption<string>[];
+  filterOptions: Array<SelectSection<string>>;
+  filterSelections: Array<SelectOption<string>>;
   filteredCandidatesByFilter: ImageCandidates;
   filteredCandidatesBySearch: ImageCandidates;
   searchTerm: string;
@@ -156,7 +156,7 @@ class Candidates extends Component<Props, State> {
   }
 
   getFilterOptions(candidates: ImageCandidates) {
-    const filterOptions: SelectSection<string>[] = [];
+    const filterOptions: Array<SelectSection<string>> = [];
 
     const candidateStatus = [
       ...new Set(candidates.map(candidate => candidate.download.status)),
@@ -194,7 +194,7 @@ class Candidates extends Component<Props, State> {
 
   getFilteredCandidatedByFilter(
     candidates: ImageCandidates,
-    filterOptions: SelectOption<string>[]
+    filterOptions: Array<SelectOption<string>>
   ) {
     const checkedStatusOptions = new Set(
       filterOptions
@@ -264,7 +264,7 @@ class Candidates extends Component<Props, State> {
     this.setState({searchTerm});
   };
 
-  handleChangeFilter = (filterSelections: SelectOption<string>[]) => {
+  handleChangeFilter = (filterSelections: Array<SelectOption<string>>) => {
     const {filteredCandidatesBySearch} = this.state;
     const filteredCandidatesByFilter = this.getFilteredCandidatedByFilter(
       filteredCandidatesBySearch,

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -42,7 +42,7 @@ import {
 
 interface DebugMetaProps {
   data: {
-    images: (Image | null)[];
+    images: Array<Image | null>;
   };
   event: Event;
   projectSlug: Project['slug'];
@@ -51,8 +51,8 @@ interface DebugMetaProps {
 
 interface FilterState {
   allImages: ImageWithCombinedStatus[];
-  filterOptions: SelectSection<string>[];
-  filterSelections: SelectOption<string>[];
+  filterOptions: Array<SelectSection<string>>;
+  filterSelections: Array<SelectOption<string>>;
 }
 
 const cache = new CellMeasurerCache({
@@ -62,7 +62,7 @@ const cache = new CellMeasurerCache({
 
 function applyImageFilters(
   images: ImageWithCombinedStatus[],
-  filterSelections: SelectOption<string>[],
+  filterSelections: Array<SelectOption<string>>,
   searchTerm: string
 ) {
   const selections = new Set(filterSelections.map(option => option.value));

--- a/static/app/components/events/interfaces/debugMeta/utils.tsx
+++ b/static/app/components/events/interfaces/debugMeta/utils.tsx
@@ -44,7 +44,7 @@ export function normalizeId(id?: string) {
   return id?.trim().toLowerCase().replace(/[- ]/g, '') ?? '';
 }
 
-export function shouldSkipSection(filteredImages: Image[], images: (Image | null)[]) {
+export function shouldSkipSection(filteredImages: Image[], images: Array<Image | null>) {
   if (filteredImages.length) {
     return false;
   }

--- a/static/app/components/events/interfaces/frame/context.spec.tsx
+++ b/static/app/components/events/interfaces/frame/context.spec.tsx
@@ -22,7 +22,7 @@ describe('Frame - Context', function () {
     ProjectsStore.loadInitialData([project]);
   });
 
-  const lines: [number, string][] = [
+  const lines: Array<[number, string]> = [
     [231, 'this is line 231'],
     [232, 'this is line 232'],
     [233, 'this is line 233'],

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -30,7 +30,7 @@ import {usePrismTokensSourceContext} from './usePrismTokensSourceContext';
 import {useStacktraceCoverage} from './useStacktraceCoverage';
 
 type Props = {
-  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
+  components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>>;
   event: Event;
   frame: Frame;
   registers: {[key: string]: string};
@@ -48,9 +48,9 @@ type Props = {
 };
 
 export function getLineCoverage(
-  lines: [number, string][],
+  lines: Array<[number, string]>,
   lineCov: LineCoverage[]
-): [(Coverage | undefined)[], boolean] {
+): [Array<Coverage | undefined>, boolean] {
   const keyedCoverage = keyBy(lineCov, 0);
   const lineCoverage = lines.map<Coverage | undefined>(
     ([lineNo]) => keyedCoverage[lineNo]?.[1]

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -100,7 +100,7 @@ export interface DeprecatedLineProps {
 }
 
 interface Props extends DeprecatedLineProps {
-  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
+  components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>>;
 }
 
 type State = {

--- a/static/app/components/events/interfaces/frame/openInContextLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.spec.tsx
@@ -14,7 +14,7 @@ describe('OpenInContextLine', function () {
   const filename = '/sentry/app.py';
   const group = GroupFixture();
   const install = SentryAppInstallationFixture();
-  const components: SentryAppComponent<SentryAppSchemaStacktraceLink>[] = [
+  const components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>> = [
     {
       uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',
       type: 'stacktrace-link',

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -13,7 +13,7 @@ import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
 import {recordInteraction} from 'sentry/utils/recordSentryAppInteraction';
 
 type Props = {
-  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
+  components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>>;
   filename: string;
   lineNo: number | null;
 };

--- a/static/app/components/events/interfaces/frame/usePrismTokensSourceContext.spec.tsx
+++ b/static/app/components/events/interfaces/frame/usePrismTokensSourceContext.spec.tsx
@@ -10,7 +10,7 @@ const defaultProps = {
     [10, 'function foo() {'],
     [11, "  return 'bar';"],
     [12, '}'],
-  ] as [number, string][],
+  ] as Array<[number, string]>,
   lineNo: 11,
   fileExtension: 'js',
 };
@@ -63,7 +63,7 @@ describe('usePrismTokensSourceContext', function () {
           [10, 'function foo() {'],
           [11, "  return 'bar';"],
           [12, '}'],
-        ] as [number, string][],
+        ] as Array<[number, string]>,
         lineNo: 11,
       },
     });
@@ -106,7 +106,7 @@ describe('usePrismTokensSourceContext', function () {
           [12, '}'],
           [13, '/*'],
           [12, 'some comment text'],
-        ] as [number, string][],
+        ] as Array<[number, string]>,
         lineNo: 11,
       },
     });
@@ -151,7 +151,7 @@ describe('usePrismTokensSourceContext', function () {
           [12, '}'],
           [13, '/*'],
           [12, 'some comment text'],
-        ] as [number, string][],
+        ] as Array<[number, string]>,
         lineNo: 11,
       },
     });
@@ -199,7 +199,7 @@ describe('usePrismTokensSourceContext', function () {
           [10, 'function foo() {'],
           [11, "  return 'bar';"],
           [12, '}'],
-        ] as [number, string][],
+        ] as Array<[number, string]>,
         lineNo: 11,
       },
     });
@@ -250,7 +250,7 @@ describe('usePrismTokensSourceContext', function () {
           [10, 'function foo() {'],
           [11, "  return 'bar';"],
           [12, '}'],
-        ] as [number, string][],
+        ] as Array<[number, string]>,
         lineNo: 11,
       },
     });
@@ -300,7 +300,7 @@ describe('usePrismTokensSourceContext', function () {
             [12, 'b = "20"'],
             [13, "'''"],
             [14, 'some comment text'],
-          ] as [number, string][],
+          ] as Array<[number, string]>,
           lineNo: 11,
           fileExtension: 'py',
         },
@@ -345,7 +345,7 @@ describe('usePrismTokensSourceContext', function () {
             [12, '$b = 20;'],
             [13, '=comment'],
             [14, 'some comment text'],
-          ] as [number, string][],
+          ] as Array<[number, string]>,
           lineNo: 11,
           fileExtension: 'pl',
         },

--- a/static/app/components/events/interfaces/frame/usePrismTokensSourceContext.tsx
+++ b/static/app/components/events/interfaces/frame/usePrismTokensSourceContext.tsx
@@ -208,7 +208,7 @@ const normalizeLineEndings = (line?: string) => {
 };
 
 const convertContextLines = (
-  contextLines: [number, string][],
+  contextLines: Array<[number, string]>,
   executedLineNo: number | null
 ) => {
   if (!executedLineNo) {
@@ -249,7 +249,7 @@ export const usePrismTokensSourceContext = ({
 }: {
   fileExtension: string;
   lineNo: number | null;
-  contextLines?: [number, string][];
+  contextLines?: Array<[number, string]>;
 }) => {
   const organization = useOrganization({allowNull: true});
 

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -49,7 +49,7 @@ import Context from './frame/context';
 import {SymbolicatorStatus} from './types';
 
 type Props = {
-  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
+  components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>>;
   event: Event;
   frame: Frame;
   isUsedForGrouping: boolean;

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -40,7 +40,7 @@ export function getSpanInfoFromTransactionEvent(
     return entry.type === EntryType.SPANS;
   });
 
-  const spans: (RawSpanType | TraceContextSpanProxy)[] = spanEntry?.data
+  const spans: Array<RawSpanType | TraceContextSpanProxy> = spanEntry?.data
     ? [...spanEntry.data]
     : [];
 

--- a/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
+++ b/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
@@ -16,7 +16,7 @@ import {loadPrismLanguage} from 'sentry/utils/prism';
 type GraphQlBodyProps = {data: EntryRequestDataGraphQl['data']; event: Event};
 
 type GraphQlError = {
-  locations?: {column: number; line: number}[];
+  locations?: Array<{column: number; line: number}>;
   message?: string;
   path?: string[];
 };

--- a/static/app/components/events/interfaces/searchBarAction.tsx
+++ b/static/app/components/events/interfaces/searchBarAction.tsx
@@ -11,9 +11,9 @@ type Props = {
   placeholder: string;
   query: string;
   className?: string;
-  filterOptions?: SelectOptionOrSection<string>[];
-  filterSelections?: SelectOption<string>[];
-  onFilterChange?: (options: SelectOption<string>[]) => void;
+  filterOptions?: Array<SelectOptionOrSection<string>>;
+  filterSelections?: Array<SelectOption<string>>;
+  onFilterChange?: (options: Array<SelectOption<string>>) => void;
 };
 
 function SearchBarAction({

--- a/static/app/components/events/interfaces/spans/aggregateSpans.tsx
+++ b/static/app/components/events/interfaces/spans/aggregateSpans.tsx
@@ -18,7 +18,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-type SpanSamples = [string, string][];
+type SpanSamples = Array<[string, string]>;
 
 type AggregateSpanRow = {
   'avg(absolute_offset)': number;
@@ -60,7 +60,7 @@ export function useAggregateSpans({
   };
 
   return useApiQuery<{
-    data: {[fingerprint: string]: AggregateSpanRow}[];
+    data: Array<{[fingerprint: string]: AggregateSpanRow}>;
     meta: any;
   }>(
     [

--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -10,7 +10,7 @@ import {setBodyUserSelect} from 'sentry/utils/userselect';
 const DEFAULT_DIVIDER_POSITION = 0.4;
 
 const selectRefs = (
-  refs: React.RefObject<HTMLDivElement>[],
+  refs: Array<React.RefObject<HTMLDivElement>>,
   transform: (dividerDOM: HTMLDivElement) => void
 ) => {
   refs.forEach(ref => {
@@ -60,8 +60,8 @@ export class Provider extends Component<PropType, StateType> {
   previousUserSelect: UserSelectValues | null = null;
   dividerHandlePosition: number = DEFAULT_DIVIDER_POSITION;
   isDragging: boolean = false;
-  dividerLineRefs: React.RefObject<HTMLDivElement>[] = [];
-  ghostDividerLineRefs: React.RefObject<HTMLDivElement>[] = [];
+  dividerLineRefs: Array<React.RefObject<HTMLDivElement>> = [];
+  ghostDividerLineRefs: Array<React.RefObject<HTMLDivElement>> = [];
 
   hasInteractiveLayer = (): boolean => !!this.props.interactiveLayerRef.current;
 

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -48,7 +48,7 @@ function TraceErrorAlerts({
     return null;
   }
 
-  const traceErrors: (TraceError | TracePerformanceIssue)[] = [];
+  const traceErrors: Array<TraceError | TracePerformanceIssue> = [];
   if (errors && errors.length > 0) {
     traceErrors.push(...errors);
   }

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -108,7 +108,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
   );
 
   const childTransactions = useMemo(() => {
-    const transactions: TraceTreeNode<TraceTree.Transaction>[] = [];
+    const transactions: Array<TraceTreeNode<TraceTree.Transaction>> = [];
     TraceTree.ForEachChild(props.node, c => {
       if (isTransactionNode(c)) {
         transactions.push(c);

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -124,7 +124,7 @@ export class Provider extends Component<Props, State> {
   wheelTimeout: NodeJS.Timeout | null = null;
   animationTimeout: NodeJS.Timeout | null = null;
   previousUserSelect: UserSelectValues | null = null;
-  spanBars: (SpanBar | NewTraceDetailsSpanBar)[] = [];
+  spanBars: Array<SpanBar | NewTraceDetailsSpanBar> = [];
   currentLeftPos = 0;
 
   getReferenceSpanBar() {

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -69,12 +69,12 @@ export type RawSpanType = {
 export type AggregateSpanType = RawSpanType & {
   count: number;
   frequency: number;
-  samples: {
+  samples: Array<{
     span: string;
     timestamp: number;
     trace: string;
     transaction: string;
-  }[];
+  }>;
   total: number;
   type: 'aggregate';
 };
@@ -248,7 +248,7 @@ export type IndexedFusedSpan = {
 };
 
 export type FilterSpans = {
-  results: Fuse.FuseResult<IndexedFusedSpan>[];
+  results: Array<Fuse.FuseResult<IndexedFusedSpan>>;
   spanIDs: Set<string>;
 };
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -470,7 +470,7 @@ export function parseTrace(
     }
   );
 
-  const spans: (RawSpanType | AggregateSpanType)[] = spanEntry?.data ?? [];
+  const spans: Array<RawSpanType | AggregateSpanType> = spanEntry?.data ?? [];
 
   const traceContext = getTraceContext(event);
   const traceID = traceContext?.trace_id || '';
@@ -1001,7 +1001,7 @@ export function getSpanGroupBounds(
 }
 
 export function getCumulativeAlertLevelFromErrors(
-  errors?: Pick<TraceError, 'level' | 'type'>[]
+  errors?: Array<Pick<TraceError, 'level' | 'type'>>
 ): keyof Theme['alert'] | undefined {
   const highestErrorLevel = maxBy(
     errors || [],

--- a/static/app/components/events/interfaces/utils.spec.tsx
+++ b/static/app/components/events/interfaces/utils.spec.tsx
@@ -233,7 +233,7 @@ describe('components/interfaces/utils', function () {
           ['Content-Type', 'application/json'],
           ['Referer', 'http://example.com'],
           ['Accept-Encoding', 'gzip'],
-        ] as [string, string][],
+        ] as Array<[string, string]>,
         url: 'https://www.sentry.io',
         query: [],
         data: null,

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -174,7 +174,7 @@ export function getCurlCommand(data: EntryRequest['data']) {
 }
 
 export function stringifyQueryList(
-  query: string | ([key: string, value: string] | null)[]
+  query: string | Array<[key: string, value: string] | null>
 ) {
   if (typeof query === 'string') {
     return query;
@@ -225,12 +225,12 @@ export function getFullUrl(data: EntryRequest['data']): string | undefined {
  */
 export function objectToSortedTupleArray(obj: Record<string, string | string[]>) {
   return Object.keys(obj)
-    .reduce<[string, string][]>((out, k) => {
+    .reduce<Array<[string, string]>>((out, k) => {
       const val = obj[k];
       return out.concat(
         Array.isArray(val)
           ? val.map(v => [k, v]) // key has multiple values (array)
-          : ([[k, val]] as [string, string][]) // key has single value
+          : ([[k, val]] as Array<[string, string]>) // key has single value
       );
     }, [])
     .sort(function ([keyA, valA], [keyB, valB]) {

--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -194,7 +194,7 @@ function SearchBar(props: SearchBarProps) {
   // with data when ready
   const getEventFieldValues = memoize(
     (tag, query, endpointParams): Promise<string[]> => {
-      const projectIdStrings = (projectIds as Readonly<number>[])?.map(String);
+      const projectIdStrings = (projectIds as Array<Readonly<number>>)?.map(String);
 
       if (isAggregateField(tag.key) || isMeasurement(tag.key)) {
         // We can't really auto suggest values for aggregate fields

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -38,7 +38,7 @@ type State = {
 };
 
 type ChildProps = Omit<State, 'sortBy'> & {
-  display: (keyof typeof displayOptions)[];
+  display: Array<keyof typeof displayOptions>;
   recentFirst: boolean;
 };
 
@@ -92,7 +92,7 @@ export function TraceEventDataSection({
     fullStackTrace: !hasAppOnlyFrames ? true : fullStackTrace,
   });
 
-  const [display, setDisplay] = useLocalStorageState<(keyof typeof displayOptions)[]>(
+  const [display, setDisplay] = useLocalStorageState<Array<keyof typeof displayOptions>>(
     `issue-details-stracktrace-display-${organization.slug}-${projectSlug}`,
     []
   );
@@ -142,7 +142,7 @@ export function TraceEventDataSection({
   );
 
   const handleDisplayChange = useCallback(
-    (vals: (keyof typeof displayOptions)[]) => {
+    (vals: Array<keyof typeof displayOptions>) => {
       if (vals.includes('raw-stack-trace')) {
         trackAnalytics('stack-trace.display_option_raw_stack_trace_clicked', {
           organization,
@@ -248,12 +248,12 @@ export function TraceEventDataSection({
     [organization, platform, projectSlug, isMobile, display, setDisplay]
   );
 
-  function getDisplayOptions(): {
+  function getDisplayOptions(): Array<{
     label: string;
     value: keyof typeof displayOptions;
     disabled?: boolean;
     tooltip?: string;
-  }[] {
+  }> {
     if (
       platform === 'objc' ||
       platform === 'native' ||

--- a/static/app/components/events/viewHierarchy/utils.tsx
+++ b/static/app/components/events/viewHierarchy/utils.tsx
@@ -7,7 +7,7 @@ import {defined} from 'sentry/utils';
 import {watchForResize} from 'sentry/utils/profiling/gl/utils';
 import {Rect} from 'sentry/utils/profiling/speedscope';
 
-export function useResizeCanvasObserver(canvases: (HTMLCanvasElement | null)[]): Rect {
+export function useResizeCanvasObserver(canvases: Array<HTMLCanvasElement | null>): Rect {
   const [bounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
 
   useLayoutEffect(() => {
@@ -50,7 +50,7 @@ export function getHierarchyDimensions(
   nodes: ViewNode[];
 } {
   const nodes: ViewNode[] = [];
-  const queue: [Rect | null, ViewHierarchyWindow][] = [];
+  const queue: Array<[Rect | null, ViewHierarchyWindow]> = [];
   for (let i = hierarchies.length - 1; i >= 0; i--) {
     queue.push([null, hierarchies[i]!]);
   }

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -148,7 +148,7 @@ export default class AbstractExternalIssueForm<
    */
   updateFetchedFieldOptionsCache = (
     field: IssueConfigField,
-    result: SelectValue<string | number>[]
+    result: Array<SelectValue<string | number>>
   ): void => {
     const {fetchedFieldOptionsCache} = this.state;
     this.setState({
@@ -169,8 +169,8 @@ export default class AbstractExternalIssueForm<
    */
   ensureCurrentOption = (
     field: IssueConfigField,
-    result: SelectValue<string | number>[]
-  ): SelectValue<string | number>[] => {
+    result: Array<SelectValue<string | number>>
+  ): Array<SelectValue<string | number>> => {
     const currentOption = this.getDefaultOptions(field).find(
       option => option.value === this.model.getValue(field.name)
     );
@@ -257,7 +257,8 @@ export default class AbstractExternalIssueForm<
 
   getDefaultOptions = (field: IssueConfigField) => {
     const choices =
-      (field.choices as [number | string, number | string | React.ReactElement][]) || [];
+      (field.choices as Array<[number | string, number | string | React.ReactElement]>) ||
+      [];
     return choices.map(([value, label]) => ({value, label}));
   };
 

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -55,7 +55,7 @@ function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
   });
 
   const projectSelectOptions = useMemo(() => {
-    const supportedProjectItems: SelectValue<string>[] = allProjects
+    const supportedProjectItems: Array<SelectValue<string>> = allProjects
       .sort((aProject, bProject) => {
         // if we're comparing two projects w/ or w/o feedback alphabetical sort
         if (aProject.hasNewFeedbacks === bProject.hasNewFeedbacks) {

--- a/static/app/components/feedback/useFeedbackCache.tsx
+++ b/static/app/components/feedback/useFeedbackCache.tsx
@@ -11,7 +11,7 @@ type TFeedbackIds = 'all' | string[];
 
 export type ListCache = {
   pageParams: unknown[];
-  pages: ApiResult<FeedbackIssueListItem[]>[];
+  pages: Array<ApiResult<FeedbackIssueListItem[]>>;
 };
 
 const issueApiEndpointRegexp = /^\/organizations\/\w+\/issues\/\d+\/$/;

--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -15,7 +15,7 @@ interface BaseRadioGroupProps<C extends string> {
   /**
    * The choices availiable in the group
    */
-  choices: RadioOption<C>[];
+  choices: Array<RadioOption<C>>;
   /**
    * Labels the radio group.
    */
@@ -26,7 +26,7 @@ interface BaseRadioGroupProps<C extends string> {
   /**
    * An array of [choice id, disabled reason]
    */
-  disabledChoices?: [C, React.ReactNode?][];
+  disabledChoices?: Array<[C, React.ReactNode?]>;
   /**
    * Switch the radio items to flow left to right, instead of vertically.
    */

--- a/static/app/components/forms/fields/projectMapperField.tsx
+++ b/static/app/components/forms/fields/projectMapperField.tsx
@@ -85,7 +85,7 @@ export class RenderField extends Component<RenderProps, State> {
       id: formElementId,
     } = this.props;
 
-    const existingValues: [number, MappedValue][] = incomingValues || [];
+    const existingValues: Array<[number, MappedValue]> = incomingValues || [];
     const nextUrlOrArray = safeGetQsParam('next');
     let nextUrl = Array.isArray(nextUrlOrArray) ? nextUrlOrArray[0] : nextUrlOrArray;
 

--- a/static/app/components/forms/fields/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.tsx
@@ -23,7 +23,7 @@ export interface RenderFieldProps extends InputFieldProps {
    * When using groupProjects you must specify the labels of the groups as a
    * list of key and label. The ordering determines the order of the groups.
    */
-  groups?: {key: string; label: React.ReactNode}[];
+  groups?: Array<{key: string; label: React.ReactNode}>;
   projects?: Project[];
   /**
    * Use the slug as the select field value. Without setting this the numeric id

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -54,7 +54,7 @@ const propsToObserve = [
   'visible',
   'disabled',
   'disabledReason',
-] satisfies (keyof FormFieldProps)[];
+] satisfies Array<keyof FormFieldProps>;
 
 interface FormFieldPropModel extends FormFieldProps {
   model: FormModel;

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -43,7 +43,7 @@ interface BaseField {
   autosize?: boolean;
   choices?:
     | ((props: {[key: string]: any}) => void)
-    | readonly Readonly<[number | string, React.ReactNode]>[];
+    | ReadonlyArray<Readonly<[number | string, React.ReactNode]>>;
   confirm?: {[key: string]: React.ReactNode};
   defaultValue?: FieldValue;
   disabled?: boolean | ((props: any) => boolean);
@@ -119,11 +119,11 @@ type InputType = {type: 'string' | 'secret'} & {
 type SelectControlType = {type: 'choice' | 'select'} & {
   allowClear?: boolean;
   // for new select
-  defaultOptions?: {label: string; value: any}[] | boolean;
+  defaultOptions?: Array<{label: string; value: any}> | boolean;
   filterOption?: ReturnType<typeof createFilter>;
   multiple?: boolean;
   noOptionsMessage?: () => string;
-  options?: SelectValue<any>[];
+  options?: Array<SelectValue<any>>;
 };
 
 type TextareaType = {type: 'textarea'} & {
@@ -167,7 +167,7 @@ export interface TableType {
 export type ProjectMapperType = {
   iconType: string;
   mappedDropdown: {
-    items: {label: string; url: string; value: string | number}[];
+    items: Array<{label: string; url: string; value: string | number}>;
     placeholder: string;
   };
   nextButton: {
@@ -176,7 +176,7 @@ export type ProjectMapperType = {
     // url comes from the `next` parameter in the QS
     description?: string;
   };
-  sentryProjects: (AvatarProject & {id: number; name: string})[];
+  sentryProjects: Array<AvatarProject & {id: number; name: string}>;
   type: 'project_mapper';
 };
 

--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -18,7 +18,7 @@ interface ExampleDataItem {
 }
 
 export default storyBook(GridEditable, story => {
-  const columns: GridColumnOrder<keyof ExampleDataItem>[] = [
+  const columns: Array<GridColumnOrder<keyof ExampleDataItem>> = [
     {key: 'category', name: 'Platform Category'},
     {key: 'name', name: 'Platform Name'},
   ];
@@ -32,7 +32,7 @@ export default storyBook(GridEditable, story => {
     return <GridEditable data={[]} columnOrder={columns} columnSortBy={[]} grid={{}} />;
   });
 
-  const columnsWithWidth: GridColumnOrder<keyof ExampleDataItem | 'other'>[] =
+  const columnsWithWidth: Array<GridColumnOrder<keyof ExampleDataItem | 'other'>> =
     columns.map(col => {
       col.width = 200;
       return col;
@@ -136,7 +136,7 @@ export default storyBook(GridEditable, story => {
 
   function useStatefulColumnWidths() {
     const [columnsWithDynamicWidths, setColumns] =
-      useState<GridColumnOrder<keyof ExampleDataItem | 'other'>[]>(columnsWithWidth);
+      useState<Array<GridColumnOrder<keyof ExampleDataItem | 'other'>>>(columnsWithWidth);
 
     const handleResizeColumn = useCallback(
       (

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -63,8 +63,8 @@ export type ColResizeMetadata = {
 };
 
 type GridEditableProps<DataRow, ColumnKey> = {
-  columnOrder: GridColumnOrder<ColumnKey>[];
-  columnSortBy: GridColumnSortBy<ColumnKey>[];
+  columnOrder: Array<GridColumnOrder<ColumnKey>>;
+  columnSortBy: Array<GridColumnSortBy<ColumnKey>>;
   data: DataRow[];
 
   /**

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -51,7 +51,7 @@ type Rule = [RuleDefinition, RuleOwner[]];
 function findMatchedRules(
   rules: EventOwners['rules'],
   owner: Actor
-): Rule[0][] | undefined {
+): Array<Rule[0]> | undefined {
   if (!rules) {
     return undefined;
   }
@@ -79,7 +79,7 @@ type IssueOwner = {
   actor: Actor;
   source: 'codeowners' | 'projectOwnership' | 'suspectCommit';
   commits?: Commit[];
-  rules?: [string, string][] | null;
+  rules?: Array<[string, string]> | null;
 };
 export interface EventOwners {
   owners: Actor[];
@@ -141,7 +141,7 @@ export function getOwnerList(
   committers: Committer[],
   eventOwners: EventOwners | undefined,
   assignedTo: Actor | null
-): Omit<SuggestedAssignee, 'assignee'>[] {
+): Array<Omit<SuggestedAssignee, 'assignee'>> {
   const owners: IssueOwner[] = committers.map(commiter => ({
     actor: {...commiter.author, type: 'user'},
     commits: commiter.commits,

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -21,7 +21,7 @@ interface AssigneeSelectorProps {
   handleAssigneeChange: (assignedActor: AssignableEntity | null) => void;
   additionalMenuFooterItems?: React.ReactNode;
   memberList?: User[];
-  owners?: Omit<SuggestedAssignee, 'assignee'>[];
+  owners?: Array<Omit<SuggestedAssignee, 'assignee'>>;
 }
 
 export type OnAssignCallback = (

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -12,11 +12,11 @@ type Props<H extends HookName> = {
    * If children are provided as a function to the Hook, the hooks will be
    * passed down as a render prop.
    */
-  children?: (opts: {hooks: Hooks[H][]}) => React.ReactNode;
+  children?: (opts: {hooks: Array<Hooks[H]>}) => React.ReactNode;
 } & Omit<Parameters<Hooks[H]>[0], 'name'>;
 
 type HookState<H extends HookName> = {
-  hooks: Hooks[H][];
+  hooks: Array<Hooks[H]>;
 };
 
 /**
@@ -45,7 +45,7 @@ function Hook<H extends HookName>({name, ...props}: Props<H>) {
       this.unsubscribe();
     }
 
-    handleHooks(hookName: HookName, hooks: Hooks[H][]) {
+    handleHooks(hookName: HookName, hooks: Array<Hooks[H]>) {
       // Make sure that the incoming hook update matches this component's hook name
       if (hookName !== name) {
         return;
@@ -55,7 +55,7 @@ function Hook<H extends HookName>({name, ...props}: Props<H>) {
     }
 
     unsubscribe = HookStore.listen(
-      (hookName: HookName, hooks: Hooks[H][]) => this.handleHooks(hookName, hooks),
+      (hookName: HookName, hooks: Array<Hooks[H]>) => this.handleHooks(hookName, hooks),
       undefined
     );
 

--- a/static/app/components/hookOrDefault.tsx
+++ b/static/app/components/hookOrDefault.tsx
@@ -70,10 +70,10 @@ function HookOrDefault<H extends HookName>({
   }
 
   function HookOrDefaultComponent(props: Props) {
-    const [hooks, setHooks] = useState<Hooks[H][]>(HookStore.get(hookName));
+    const [hooks, setHooks] = useState<Array<Hooks[H]>>(HookStore.get(hookName));
 
     useEffect(() => {
-      const unsubscribe = HookStore.listen((name: string, newHooks: Hooks[H][]) => {
+      const unsubscribe = HookStore.listen((name: string, newHooks: Array<Hooks[H]>) => {
         if (name === hookName) {
           setHooks(newHooks);
         }

--- a/static/app/components/internalStatChart.tsx
+++ b/static/app/components/internalStatChart.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 type State = {
-  data: [number, number][] | null;
+  data: Array<[number, number]> | null;
   error: boolean;
   loading: boolean;
 };

--- a/static/app/components/metrics/chart/types.tsx
+++ b/static/app/components/metrics/chart/types.tsx
@@ -8,7 +8,7 @@ import type {MetricDisplayType} from 'sentry/utils/metrics/types';
 export type Series = {
   aggregate: MetricAggregation;
   color: string;
-  data: {name: number; value: number}[];
+  data: Array<{name: number; value: number}>;
   id: string;
   seriesName: string;
   total: number;

--- a/static/app/components/metrics/equationInput/syntax/formatter.tsx
+++ b/static/app/components/metrics/equationInput/syntax/formatter.tsx
@@ -16,11 +16,11 @@ const operatorTokens = new Set([
 
 interface EquationFormatterProps {
   equation: string;
-  errors?: {
+  errors?: Array<{
     message: string;
     start: number;
     end?: number;
-  }[];
+  }>;
 }
 
 export function EquationFormatter({equation: formula, errors}: EquationFormatterProps) {

--- a/static/app/components/metrics/equationInput/syntax/parser.ts
+++ b/static/app/components/metrics/equationInput/syntax/parser.ts
@@ -5,7 +5,7 @@ import type {
 
 import grammar from './equation.pegjs';
 
-type TokenTree = (Token | TokenTree)[];
+type TokenTree = Array<Token | TokenTree>;
 
 export function parseFormula(formula: string): TokenList {
   const tree = grammar.parse(formula) as TokenTree;

--- a/static/app/components/metrics/metricSamplesTable.tsx
+++ b/static/app/components/metrics/metricSamplesTable.tsx
@@ -375,8 +375,8 @@ function getColumnForMRI(mri?: MRI): GridColumnOrder<ResultField> {
         };
 }
 
-function getColumnOrder(mri?: MRI): GridColumnOrder<ResultField>[] {
-  const orders: (GridColumnOrder<ResultField> | undefined)[] = [
+function getColumnOrder(mri?: MRI): Array<GridColumnOrder<ResultField>> {
+  const orders: Array<GridColumnOrder<ResultField> | undefined> = [
     {key: 'id', width: COL_WIDTH_UNDEFINED, name: 'Span ID'},
     {key: 'span.description', width: COL_WIDTH_UNDEFINED, name: 'Description'},
     {key: 'span.op', width: COL_WIDTH_UNDEFINED, name: 'Operation'},

--- a/static/app/components/metrics/queryBuilder.tsx
+++ b/static/app/components/metrics/queryBuilder.tsx
@@ -133,7 +133,7 @@ export const QueryBuilder = memo(function QueryBuilder({
   );
 
   const handleGroupByChange = useCallback(
-    (options: SelectOption<string>[]) => {
+    (options: Array<SelectOption<string>>) => {
       trackAnalytics('ddm.widget.group', {organization});
       incrementQueryMetric('ddm.widget.group', {
         groupBy: options.map(o => o.value),

--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -83,7 +83,7 @@ function CreateNewIntegrationModal({
         )}
       </RadioChoiceDescription>,
     ],
-  ] as [string, ReactNode, ReactNode][];
+  ] as Array<[string, ReactNode, ReactNode]>;
 
   return (
     <Fragment>

--- a/static/app/components/modals/debugFileCustomRepository/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/utils.tsx
@@ -11,7 +11,9 @@ import {t, tct} from 'sentry/locale';
 import {CustomRepoType} from 'sentry/types/debugFiles';
 import {uniqueId} from 'sentry/utils/guid';
 
-function objectToChoices(obj: Record<string, string>): [key: string, value: string][] {
+function objectToChoices(
+  obj: Record<string, string>
+): Array<[key: string, value: string]> {
   return Object.entries(obj).map(([key, value]) => [key, value]);
 }
 

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -22,7 +22,7 @@ import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface InviteMembersModalProps extends ModalRenderProps {
-  initialData?: Partial<InviteRow>[];
+  initialData?: Array<Partial<InviteRow>>;
   source?: string;
 }
 

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -14,7 +14,7 @@ import useApi from 'sentry/utils/useApi';
 
 interface Props {
   organization: Organization;
-  initialData?: Partial<InviteRow>[];
+  initialData?: Array<Partial<InviteRow>>;
   source?: string;
 }
 

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -72,7 +72,7 @@ export default class SentryAppDetailsModal extends DeprecatedAsyncComponent<
     return [['featureData', `/sentry-apps/${sentryApp.slug}/features/`]];
   }
 
-  featureTags(features: Pick<IntegrationFeature, 'featureGate'>[]) {
+  featureTags(features: Array<Pick<IntegrationFeature, 'featureGate'>>) {
     return features.map(feature => {
       const feat = feature.featureGate.replace(/integrations/g, '');
       return <StyledTag key={feat}>{feat.replace(/-/g, ' ')}</StyledTag>;

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -240,7 +240,7 @@ function AddToDashboardModal({
           }),
         tooltipOptions: {position: 'right'},
       })),
-    ].filter(Boolean) as SelectValue<string>[];
+    ].filter(Boolean) as Array<SelectValue<string>>;
   }, [allowCreateNewDashboard, dashboards]);
 
   const widgetLegendState = new WidgetLegendSelectionState({

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -48,7 +48,7 @@ function NotificationActionManager({
   disabled = false,
 }: NotificationActionManagerProps) {
   const [notificationActions, setNotificationActions] =
-    useState<Partial<NotificationAction>[]>(actions);
+    useState<Array<Partial<NotificationAction>>>(actions);
 
   useEffect(() => {
     setNotificationActions(actions);
@@ -96,11 +96,11 @@ function NotificationActionManager({
   // Will render the notif actions in the order the keys are listed in
   const actionsMap: Record<
     NotificationActionService,
-    {action: NotificationAction; index: number}[]
+    Array<{action: NotificationAction; index: number}>
   > = useMemo(() => {
     const notificationActionsMap: Record<
       NotificationActionService,
-      {action: NotificationAction; index: number}[]
+      Array<{action: NotificationAction; index: number}>
     > = {
       [NotificationActionService.SENTRY_NOTIFICATION]: [],
       [NotificationActionService.EMAIL]: [],

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -13,10 +13,10 @@ export interface PlatformOption<Value extends string = string> {
   /**
    * Array of items for the option. Each one representing a selectable value.
    */
-  items: {
+  items: Array<{
     label: string;
     value: Value;
-  }[];
+  }>;
   /**
    * The name of the option
    */
@@ -100,7 +100,7 @@ export interface OnboardingConfig<
       install: StepProps[];
       verify: StepProps[];
       introduction?: React.ReactNode | React.ReactNode[];
-      nextSteps?: (NextStep | null)[];
+      nextSteps?: Array<NextStep | null>;
       onPageLoad?: () => void;
       onPlatformOptionsChange?: (
         platformOptions: SelectedPlatformOptions<PlatformOptions>

--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -169,7 +169,7 @@ export function HybridFilter<Value extends SelectKey>({
     [commitStagedChanges]
   );
 
-  const mappedOptions = useMemo<SelectOptionOrSection<Value>[]>(() => {
+  const mappedOptions = useMemo<Array<SelectOptionOrSection<Value>>>(() => {
     const mapOption = (option: SelectOption<Value>): SelectOption<Value> => ({
       ...option,
       hideCheck: true,
@@ -301,7 +301,7 @@ export function HybridFilter<Value extends SelectKey>({
   );
 
   const handleChange = useCallback(
-    (selectedOptions: SelectOption<Value>[]) => {
+    (selectedOptions: Array<SelectOption<Value>>) => {
       const oldValue = stagedValue;
       const newValue = selectedOptions.map(op => op.value);
       const oldValueSet = new Set(oldValue);

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -251,7 +251,7 @@ export function ProjectPageFilter({
     });
   }, [onReset, routes, organization]);
 
-  const options = useMemo<SelectOptionOrSection<number>[]>(() => {
+  const options = useMemo<Array<SelectOptionOrSection<number>>>(() => {
     const hasProjects = !!memberProjects.length || !!nonMemberProjects.length;
     if (!hasProjects) {
       return [];
@@ -332,7 +332,7 @@ export function ProjectPageFilter({
 
   const desynced = desyncedFilters.has('projects');
   const defaultMenuWidth = useMemo(() => {
-    const flatOptions: SelectOption<number>[] = options.flatMap(item =>
+    const flatOptions: Array<SelectOption<number>> = options.flatMap(item =>
       'options' in item ? item.options : [item]
     );
 

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -61,7 +61,7 @@ function SearchBar(props: SearchBarProps) {
 
   const url = `/organizations/${organization.slug}/events/`;
 
-  const projectIdStrings = (eventView.project as Readonly<number>[])?.map(String);
+  const projectIdStrings = (eventView.project as Array<Readonly<number>>)?.map(String);
 
   const handleSearchChange = (query: any) => {
     setSearchString(query);

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
@@ -193,11 +193,11 @@ function TransactionDeviceDetails({
     const deviceContext = transaction.contexts.device;
     const osContext = transaction.contexts.os;
 
-    const details: {
+    const details: Array<{
       key: string;
       label: string;
       value: React.ReactNode;
-    }[] = [
+    }> = [
       {
         key: 'model',
         label: t('Model'),
@@ -276,11 +276,11 @@ function TransactionEventDetails({
           })
         : null;
 
-    const details: {
+    const details: Array<{
       key: string;
       label: string;
       value: React.ReactNode;
-    }[] = [
+    }> = [
       {
         key: 'transaction',
         label: t('Transaction'),

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
@@ -52,7 +52,7 @@ function FlamegraphOptionsMenu({
   );
 }
 
-const colorCodingOptions: SelectOption<FlamegraphPreferences['colorCoding']>[] = [
+const colorCodingOptions: Array<SelectOption<FlamegraphPreferences['colorCoding']>> = [
   {value: 'by system vs application frame', label: t('By System vs Application Frame')},
   {value: 'by symbol name', label: t('By Symbol Name')},
   {value: 'by library', label: t('By Package')},

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -221,11 +221,11 @@ function sortByDepthAndStart(
 
 function sortFrameResults(
   results: FlamegraphSearchResults['results']
-): (FlamegraphFrame | SpanChartNode)[] {
+): Array<FlamegraphFrame | SpanChartNode> {
   // If frames have the same start times, move frames with lower stack depth first.
   // This results in top down and left to right iteration
   let sid = -1;
-  const spans: (SpanChartNode | FlamegraphFrame)[] = new Array(results.frames.size);
+  const spans: Array<SpanChartNode | FlamegraphFrame> = new Array(results.frames.size);
   for (const n of results.spans.values()) {
     spans[++sid] = n.span;
   }

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
@@ -24,11 +24,11 @@ function FlamegraphThreadSelector({
   profileGroup,
 }: FlamegraphThreadSelectorProps) {
   const [profileOptions, emptyProfileOptions]: [
-    SelectOption<number>[],
-    SelectOption<number>[],
+    Array<SelectOption<number>>,
+    Array<SelectOption<number>>,
   ] = useMemo(() => {
-    const profiles: SelectOption<number>[] = [];
-    const emptyProfiles: SelectOption<number>[] = [];
+    const profiles: Array<SelectOption<number>> = [];
+    const emptyProfiles: Array<SelectOption<number>> = [];
     const activeThreadId =
       typeof profileGroup.activeProfileIndex === 'number'
         ? profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId

--- a/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
@@ -37,7 +37,7 @@ export function FlamegraphUIFramesTooltip({
   hoveredNode,
 }: FlamegraphUIFramesTooltipProps) {
   const uiFramesInConfigSpace = useMemo<
-    {rect: Rect; type: UIFrames['frames'][0]['type']}[]
+    Array<{rect: Rect; type: UIFrames['frames'][0]['type']}>
   >(() => {
     const framesInConfigSpace = hoveredNode.map(frame => {
       return {

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -122,7 +122,7 @@ function ProfilingOnboarding(props: CommonSidebarProps) {
   ]);
 
   const projectSelectOptions = useMemo(() => {
-    const supportedProjectItems: SelectValue<string>[] = supportedProjects.map(
+    const supportedProjectItems: Array<SelectValue<string>> = supportedProjects.map(
       project => {
         return {
           value: project.id,
@@ -134,7 +134,7 @@ function ProfilingOnboarding(props: CommonSidebarProps) {
       }
     );
 
-    const unsupportedProjectItems: SelectValue<string>[] = unsupportedProjects.map(
+    const unsupportedProjectItems: Array<SelectValue<string>> = unsupportedProjects.map(
       project => {
         return {
           value: project.id,

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -190,7 +190,7 @@ function WebVitalData({
 }) {
   const webVitalData = {value: frame.data.value};
   if (isCLSFrame(frame) && frame.data.attributions && selectors) {
-    const layoutShifts: {[x: string]: ReactNode[]}[] = [];
+    const layoutShifts: Array<{[x: string]: ReactNode[]}> = [];
     for (const attr of frame.data.attributions) {
       const elements: ReactNode[] = [];
       if ('nodeIds' in attr && Array.isArray(attr.nodeIds)) {

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -18,7 +18,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
   const organization = useOrganization();
 
   const gaps = useMemo(() => {
-    const ranges: {left: string; width: string}[] = [];
+    const ranges: Array<{left: string; width: string}> = [];
     let previousVideoEnd = startTimestampMs;
 
     // create gap in timeline when there is a gap between video events larger than 1.1s

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -5,7 +5,7 @@ import {t} from 'sentry/locale';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
-const timestampOptions: ('relative' | 'absolute')[] = ['relative', 'absolute'];
+const timestampOptions: Array<'relative' | 'absolute'> = ['relative', 'absolute'];
 
 export default function ReplayPreferenceDropdown({
   speedOptions,

--- a/static/app/components/replays/renderSortableHeaderCell.tsx
+++ b/static/app/components/replays/renderSortableHeaderCell.tsx
@@ -9,8 +9,8 @@ interface Props<Key extends string> {
   currentSort: Sort;
   makeSortLinkGenerator: (column: GridColumnOrder<Key>) => () => LocationDescriptorObject;
   onClick(column: GridColumnOrder<Key>, e: MouseEvent<HTMLAnchorElement>): void;
-  rightAlignedColumns: GridColumnOrder<string>[];
-  sortableColumns: GridColumnOrder<string>[];
+  rightAlignedColumns: Array<GridColumnOrder<string>>;
+  sortableColumns: Array<GridColumnOrder<string>>;
 }
 
 export default function renderSortableHeaderCell<Key extends string>({

--- a/static/app/components/replays/useQueryBasedColumnResize.tsx
+++ b/static/app/components/replays/useQueryBasedColumnResize.tsx
@@ -8,7 +8,7 @@ import {decodeInteger, decodeList} from 'sentry/utils/queryString';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 interface Props<K extends string> {
-  columns: GridColumnOrder<K>[];
+  columns: Array<GridColumnOrder<K>>;
   location: Location;
   paramName?: string;
 }

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -159,7 +159,7 @@ export function flattenFrames(frames: SpanFrame[]): FlattenedSpanRange[] {
  * Finds the index of the mobile replay segment that is nearest
  */
 export function findVideoSegmentIndex(
-  trackList: [ts: number, index: number][],
+  trackList: Array<[ts: number, index: number]>,
   segments: VideoEvent[],
   targetTimestamp: number,
   optionalStart?: number,

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -45,7 +45,7 @@ export class VideoReplayer {
   private _currentIndex: number | undefined;
   private _startTimestamp: number;
   private _timer = new Timer();
-  private _trackList: [ts: number, index: number][];
+  private _trackList: Array<[ts: number, index: number]>;
   private _isPlaying: boolean = false;
   private _listeners: RemoveListener[] = [];
   /**

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -58,7 +58,7 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
   });
 
   const projectSelectOptions = useMemo(() => {
-    const supportedProjectItems: SelectValue<string>[] = supportedProjects
+    const supportedProjectItems: Array<SelectValue<string>> = supportedProjects
       .sort((aProject, bProject) => {
         // if we're comparing two projects w/ or w/o replays alphabetical sort
         if (aProject.hasReplays === bProject.hasReplays) {
@@ -77,7 +77,7 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
         };
       });
 
-    const unsupportedProjectItems: SelectValue<string>[] = unsupportedProjects.map(
+    const unsupportedProjectItems: Array<SelectValue<string>> = unsupportedProjects.map(
       project => {
         return {
           value: project.id,

--- a/static/app/components/scrollCarousel.spec.tsx
+++ b/static/app/components/scrollCarousel.spec.tsx
@@ -3,8 +3,9 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 
 describe('ScrollCarousel', function () {
-  let intersectionOnbserverCb: (entries: Partial<IntersectionObserverEntry>[]) => void =
-    jest.fn();
+  let intersectionOnbserverCb: (
+    entries: Array<Partial<IntersectionObserverEntry>>
+  ) => void = jest.fn();
 
   window.IntersectionObserver = class IntersectionObserver {
     root = null;

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -67,7 +67,7 @@ interface SearchProps {
    * The sources to query
    */
   // TODO(ts): Improve any type here
-  sources?: React.ComponentType<any>[];
+  sources?: Array<React.ComponentType<any>>;
 }
 
 function Search({

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -326,7 +326,7 @@ class ApiSource extends Component<Props, State> {
     const orgId = organization?.slug;
 
     let searchUrls: string[] = [];
-    let directUrls: (string | null)[] = [];
+    let directUrls: Array<string | null> = [];
 
     // Only run these queries when we have an org in context
     if (orgId) {
@@ -401,8 +401,8 @@ class ApiSource extends Component<Props, State> {
 
   // Handles a list of search request promises, and then updates state with response objects
   async handleSearchRequest(
-    searchRequests: Promise<ResultItem[]>[],
-    directRequests: Promise<Result | null>[]
+    searchRequests: Array<Promise<ResultItem[]>>,
+    directRequests: Array<Promise<Result | null>>
   ) {
     const {searchOptions} = this.props;
 
@@ -453,7 +453,7 @@ class ApiSource extends Component<Props, State> {
   }
 
   // Process API requests that create result objects that should be searchable
-  async getSearchableResults(requests: Promise<any>[]) {
+  async getSearchableResults(requests: Array<Promise<any>>) {
     const {organization} = this.props;
     const orgId = organization?.slug;
 
@@ -483,7 +483,7 @@ class ApiSource extends Component<Props, State> {
 
   // Create result objects from API requests that do not require fuzzy search
   // i.e. these responses only return 1 object or they should always be displayed regardless of query input
-  async getDirectResults(requests: Promise<any>[]): Promise<Result[]> {
+  async getDirectResults(requests: Array<Promise<any>>): Promise<Result[]> {
     const [shortIdLookup, eventIdLookup] = requests;
 
     const directResults = (

--- a/static/app/components/search/sources/index.tsx
+++ b/static/app/components/search/sources/index.tsx
@@ -14,7 +14,7 @@ type Props = {
   children: (props: ChildProps) => React.ReactElement;
   params: {orgId: string};
   query: string;
-  sources: React.ComponentType<any>[];
+  sources: Array<React.ComponentType<any>>;
   searchOptions?: Fuse.IFuseOptions<any>;
 };
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -122,7 +122,10 @@ function removeQueryToken(query: string, token: TokenResult<Token>): string {
   );
 }
 
-function removeQueryTokensFromQuery(query: string, tokens: TokenResult<Token>[]): string {
+function removeQueryTokensFromQuery(
+  query: string,
+  tokens: Array<TokenResult<Token>>
+): string {
   if (!tokens.length) {
     return query;
   }
@@ -233,7 +236,7 @@ function modifyFilterValueDate(
 // Uses the token's location to replace a sequence of tokens with the new text value
 function replaceQueryTokens(
   query: string,
-  tokens: TokenResult<Token>[],
+  tokens: Array<TokenResult<Token>>,
   value: string
 ): string {
   if (tokens.length === 0) {
@@ -258,7 +261,7 @@ function replaceQueryToken(
 // Takes a list of token replacements and applies them to the query
 function multipleReplaceQueryToken(
   query: string,
-  replacements: {replacement: string; token: TokenResult<Token>}[]
+  replacements: Array<{replacement: string; token: TokenResult<Token>}>
 ) {
   // Because replacements to earlier tokens can affect the offsets of later tokens,
   // we need to apply the replacements in order from rightmost to leftmost
@@ -286,7 +289,7 @@ function removeExcessWhitespaceFromParts(...parts: string[]): string {
 // and cleans up any extra whitespace
 export function replaceTokensWithPadding(
   query: string,
-  tokens: TokenResult<Token>[],
+  tokens: Array<TokenResult<Token>>,
   value: string
 ): string {
   if (tokens.length === 0) {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -112,7 +112,7 @@ function FilterKeyOperatorLabel({
 export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
   label: ReactNode;
   operator: TermOperator;
-  options: SelectOption<TermOperator>[];
+  options: Array<SelectOption<TermOperator>>;
 } {
   if (isDateToken(token)) {
     const operator = getOperatorFromDateToken(token);

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -93,7 +93,7 @@ function useParameterSuggestions({
 }: {
   parameterIndex: number;
   token: AggregateFilter;
-}): SelectOptionWithKey<string>[] {
+}): Array<SelectOptionWithKey<string>> {
   const {getFieldDefinition, filterKeys} = useSearchQueryBuilder();
   const fieldDefinition = getFieldDefinition(token.key.name.text);
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
@@ -14,6 +14,6 @@ export type SuggestionSection = {
 };
 
 export type SuggestionSectionItem = {
-  items: SelectOptionWithKey<string>[];
+  items: Array<SelectOptionWithKey<string>>;
   sectionText: string;
 };

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -89,7 +89,7 @@ function getFilterSearchValues(
 // This will suggest a maximum of 3 options and will display them
 // at the top only if the score is better than any of the keys.
 function getValueSuggestionsFromSearchResult(
-  results: Fuse.FuseResult<FilterKeySearchItem>[]
+  results: Array<Fuse.FuseResult<FilterKeySearchItem>>
 ) {
   const suggestions = results
     .filter(result => result.item.type === 'value')

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -130,7 +130,7 @@ export function getInitialFilterText(
   }
 }
 
-export function mergeSets<T>(...sets: Set<T>[]) {
+export function mergeSets<T>(...sets: Array<Set<T>>) {
   const combinedSet = new Set<T>();
   for (const set of sets) {
     for (const value of set) {

--- a/static/app/components/searchSyntax/evaluator.spec.tsx
+++ b/static/app/components/searchSyntax/evaluator.spec.tsx
@@ -70,8 +70,8 @@ const tokensToString = (tokens: ProcessedTokenResult[]): string => {
 };
 
 function assertTokens(
-  tokens: TokenResult<Token>[] | null
-): asserts tokens is TokenResult<Token>[] {
+  tokens: Array<TokenResult<Token>> | null
+): asserts tokens is Array<TokenResult<Token>> {
   if (tokens === null) {
     throw new Error('Expected tokens to be an array');
   }

--- a/static/app/components/searchSyntax/evaluator.tsx
+++ b/static/app/components/searchSyntax/evaluator.tsx
@@ -14,7 +14,7 @@ export type ProcessedTokenResult =
   | {type: 'L_PAREN'}
   | {type: 'R_PAREN'};
 
-export function toFlattened(tokens: TokenResult<Token>[]): ProcessedTokenResult[] {
+export function toFlattened(tokens: Array<TokenResult<Token>>): ProcessedTokenResult[] {
   const flattened_result: ProcessedTokenResult[] = [];
 
   function flatten(token: TokenResult<Token>): void {
@@ -91,7 +91,7 @@ export function insertImplicitAND(
   return with_implicit_and;
 }
 
-function processTokenResults(tokens: TokenResult<Token>[]): ProcessedTokenResult[] {
+function processTokenResults(tokens: Array<TokenResult<Token>>): ProcessedTokenResult[] {
   const flattened = toFlattened(tokens);
   const withImplicitAnd = insertImplicitAND(flattened);
 
@@ -103,7 +103,7 @@ function isBooleanAND(token: ProcessedTokenResult): boolean {
 }
 
 // https://en.wikipedia.org/wiki/Shunting_yard_algorithm
-export function toPostFix(tokens: TokenResult<Token>[]): ProcessedTokenResult[] {
+export function toPostFix(tokens: Array<TokenResult<Token>>): ProcessedTokenResult[] {
   const processed = processTokenResults(tokens);
 
   const result: ProcessedTokenResult[] = [];

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -37,7 +37,7 @@ type TestCase = {
 /**
  * Normalize results to match the json test cases
  */
-const normalizeResult = (tokens: TokenResult<Token>[]) =>
+const normalizeResult = (tokens: Array<TokenResult<Token>>) =>
   treeTransformer({
     tree: tokens,
     transform: token => {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -457,11 +457,11 @@ export class TokenConverter {
   });
 
   tokenLogicGroup = (
-    inner: (
+    inner: Array<
       | ReturnType<TokenConverter['tokenLogicBoolean']>
       | ReturnType<TokenConverter['tokenFilter']>
       | ReturnType<TokenConverter['tokenFreeText']>
-    )[]
+    >
   ) => ({
     ...this.defaultTokenFields,
     type: Token.LOGIC_GROUP as const,
@@ -535,7 +535,7 @@ export class TokenConverter {
 
   tokenKeyAggregateArgs = (
     arg1: ReturnType<TokenConverter['tokenKeyAggregateParam']>,
-    args: ListItem<ReturnType<TokenConverter['tokenKeyAggregateParam']>>[]
+    args: Array<ListItem<ReturnType<TokenConverter['tokenKeyAggregateParam']>>>
   ) => {
     return {
       ...this.defaultTokenFields,
@@ -546,9 +546,9 @@ export class TokenConverter {
 
   tokenValueIso8601Date = (
     value: string,
-    date: (string | string[])[],
-    time?: (string | string[] | string[][])[],
-    tz?: (string | string[])[]
+    date: Array<string | string[]>,
+    time?: Array<string | string[] | string[][]>,
+    tz?: Array<string | string[]>
   ) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_ISO_8601_DATE as const,
@@ -643,7 +643,7 @@ export class TokenConverter {
 
   tokenValueNumberList = (
     item1: ReturnType<TokenConverter['tokenValueNumber']>,
-    items: ListItem<ReturnType<TokenConverter['tokenValueNumber']>>[]
+    items: Array<ListItem<ReturnType<TokenConverter['tokenValueNumber']>>>
   ) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_NUMBER_LIST as const,
@@ -652,7 +652,7 @@ export class TokenConverter {
 
   tokenValueTextList = (
     item1: ReturnType<TokenConverter['tokenValueText']>,
-    items: ListItem<ReturnType<TokenConverter['tokenValueText']>>[]
+    items: Array<ListItem<ReturnType<TokenConverter['tokenValueText']>>>
   ) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_TEXT_LIST as const,

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -45,7 +45,7 @@ type TreeResultLocatorOpts = {
   /**
    * The tree to visit
    */
-  tree: TokenResult<Token>[];
+  tree: Array<TokenResult<Token>>;
   /**
    * A function used to check if we've found the result in the node we're
    * visiting. May also indicate that we want to skip any further traversal of
@@ -147,7 +147,7 @@ type TreeTransformerOpts = {
   /**
    * The tree to transform
    */
-  tree: TokenResult<Token>[];
+  tree: Array<TokenResult<Token>>;
 };
 
 /**

--- a/static/app/components/similarScoreCard.tsx
+++ b/static/app/components/similarScoreCard.tsx
@@ -23,7 +23,7 @@ type Props = {
   // we treat the score list keys as opaque as we wish to be able to extend the
   // backend without having to fix UI. Keys not in scoreComponents are grouped
   // into Other anyway
-  scoreList?: [string, ScoreValue][];
+  scoreList?: Array<[string, ScoreValue]>;
 };
 
 function SimilarScoreCard({scoreList = []}: Props) {

--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -9,7 +9,7 @@ import {space} from 'sentry/styles/space';
 type RenderProps = {};
 
 export type PropMatrix<P extends RenderProps> = Partial<{
-  [Prop in keyof P]: P[Prop][];
+  [Prop in keyof P]: Array<P[Prop]>;
 }>;
 
 interface Props<P extends RenderProps> {

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -40,7 +40,7 @@ export function useOverflowTabs({
   tabItemsRef: React.RefObject<Record<string | number, HTMLLIElement | null>>;
   tabListRef: React.RefObject<HTMLUListElement>;
 }) {
-  const [overflowTabs, setOverflowTabs] = useState<(string | number)[]>([]);
+  const [overflowTabs, setOverflowTabs] = useState<Array<string | number>>([]);
 
   useEffect(() => {
     if (disabled) {

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -187,7 +187,7 @@ export function TimeRangeSelector({
   });
 
   const getOptions = useCallback(
-    (items: Item[]): SelectOption<string>[] => {
+    (items: Item[]): Array<SelectOption<string>> => {
       // Return the default options if there's nothing in search
       if (!search) {
         return items.map(item => {

--- a/static/app/components/timeRangeSelector/utils.tsx
+++ b/static/app/components/timeRangeSelector/utils.tsx
@@ -219,7 +219,7 @@ export const _timeRangeAutoCompleteFilter = function <T extends RelativeUnitsMap
     maxDateRange,
   }: {
     supportedPeriods: T;
-    supportedUnits: (keyof T & string)[];
+    supportedUnits: Array<keyof T & string>;
     maxDateRange?: number;
     maxDays?: number;
   }

--- a/static/app/components/workflowEngine/layout/breadcrumbs.tsx
+++ b/static/app/components/workflowEngine/layout/breadcrumbs.tsx
@@ -5,7 +5,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 
 export interface BreadcrumbsContextValue {
-  crumbs: (Crumb | CrumbDropdown)[];
+  crumbs: Array<Crumb | CrumbDropdown>;
 }
 export const BreadcrumbsContext = createContext<BreadcrumbsContextValue>({
   crumbs: [],

--- a/static/app/data/timezones.tsx
+++ b/static/app/data/timezones.tsx
@@ -19,7 +19,7 @@ type TimezoneGroup =
   | 'Antarctica'
   | 'Arctic';
 
-const timezones: [group: TimezoneGroup, value: string, label: string][] = [
+const timezones: Array<[group: TimezoneGroup, value: string, label: string]> = [
   ['Other', 'UTC', 'UTC'],
   ['Other', 'GMT', 'GMT'],
 
@@ -476,17 +476,19 @@ const OffsetLabel = styled('div')`
 const groupedTimezones = Object.entries(groupBy(timezones, ([group]) => group));
 
 // @ts-ignore TS(2322): Type '{ label: string; options: { value: string; t... Remove this comment to see the full error message
-const timezoneOptions: SelectValue<string>[] = groupedTimezones.map(([group, zones]) => ({
-  label: group,
-  options: zones.map(([_, value, label]) => {
-    const offsetLabel = moment.tz(value).format('Z');
-    return {
-      value,
-      trailingItems: <OffsetLabel>UTC {offsetLabel}</OffsetLabel>,
-      label,
-      textValue: `${group} ${label} ${offsetLabel}`,
-    };
-  }),
-}));
+const timezoneOptions: Array<SelectValue<string>> = groupedTimezones.map(
+  ([group, zones]) => ({
+    label: group,
+    options: zones.map(([_, value, label]) => {
+      const offsetLabel = moment.tz(value).format('Z');
+      return {
+        value,
+        trailingItems: <OffsetLabel>UTC {offsetLabel}</OffsetLabel>,
+        label,
+        textValue: `${group} ${label} ${offsetLabel}`,
+      };
+    }),
+  })
+);
 
 export {timezones, timezoneOptions};

--- a/static/app/routes.spec.tsx
+++ b/static/app/routes.spec.tsx
@@ -83,7 +83,7 @@ describe('buildRoutes()', function () {
 
     // All routes that exist under orgId path slugs should
     // have a sibling under customer-domains.
-    const mismatch: {domain: string; slug: string}[] = [];
+    const mismatch: Array<{domain: string; slug: string}> = [];
     for (const path of routes) {
       // Normalize the URLs so that we know the path we're looking for.
       const domainPath = normalizeUrl(path, {forceCustomerDomain: true});

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -97,9 +97,9 @@ export type SimilarItem = {
   };
   score?: Record<string, number | null>;
   scoresByInterface?: {
-    exception: [string, number | null][];
-    message: [string, any | null][];
-    shouldBeGrouped?: [string, string | null][];
+    exception: Array<[string, number | null]>;
+    message: Array<[string, any | null]>;
+    shouldBeGrouped?: Array<[string, string | null]>;
   };
 };
 
@@ -110,7 +110,7 @@ type ResponseProcessors = {
     isBelowThreshold: boolean;
     issue: Group;
     score: ScoreMap;
-    scoresByInterface: Record<string, [string, number | null][]>;
+    scoresByInterface: Record<string, Array<[string, number | null]>>;
   };
 };
 
@@ -118,13 +118,13 @@ type DataKey = keyof ResponseProcessors;
 
 type ResultsAsArrayDataMerged = Parameters<ResponseProcessors['merged']>[0];
 
-type ResultsAsArrayDataSimilar = Parameters<ResponseProcessors['similar']>[0][];
+type ResultsAsArrayDataSimilar = Array<Parameters<ResponseProcessors['similar']>[0]>;
 
-type ResultsAsArray = {
+type ResultsAsArray = Array<{
   data: ResultsAsArrayDataMerged | ResultsAsArrayDataSimilar;
   dataKey: DataKey;
   links: string | null;
-}[];
+}>;
 
 type IdState = {
   busy?: boolean;
@@ -147,11 +147,11 @@ interface GroupingStoreDefinition extends StrictStoreDefinition<State> {
   init(): void;
   isAllUnmergedSelected(): boolean;
   onFetch(
-    toFetchArray: {
+    toFetchArray: Array<{
       dataKey: DataKey;
       endpoint: string;
       queryParams?: Record<string, any>;
-    }[]
+    }>
   ): Promise<any>;
   onMerge(props: {
     projectId: Project['id'];

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -14,7 +14,7 @@ type HookCallback = (...args: any[]) => void;
 
 interface HookStoreDefinition extends StoreDefinition, Internals {
   add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
-  get<H extends HookName>(hookName: H): Hooks[H][];
+  get<H extends HookName>(hookName: H): Array<Hooks[H]>;
   getCallback<H extends HookName>(hookName: H, key: string): HookCallback | undefined;
   init(): void;
   persistCallback<H extends HookName>(

--- a/static/app/stories/storyBook.tsx
+++ b/static/app/stories/storyBook.tsx
@@ -13,7 +13,7 @@ export default function storyBook(
   bookContext: string | React.ComponentType<any>,
   setup: SetupFunction
 ): StoryRenderFunction {
-  const contexts: {name: string; render: StoryRenderFunction}[] = [];
+  const contexts: Array<{name: string; render: StoryRenderFunction}> = [];
 
   const storyFn: StoryFunction = (name: string, render: StoryRenderFunction) => {
     contexts.push({name, render});

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -58,7 +58,7 @@ export const enum IssueAlertFilterType {
 
 interface IssueAlertFormFieldChoice {
   type: 'choice';
-  choices?: [key: string | number, name: string][];
+  choices?: Array<[key: string | number, name: string]>;
   initial?: string;
   placeholder?: string;
 }
@@ -263,7 +263,7 @@ export interface IssueAlertRule extends UnsavedIssueAlertRule {
    */
   disableDate?: string;
   disableReason?: 'noisy';
-  errors?: {detail: string}[];
+  errors?: Array<{detail: string}>;
   lastTriggered?: string;
   /**
    * Set to true to opt out of the rule being automatically disabled

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -122,10 +122,10 @@ export type EChartFinishedHandler = EChartEventHandler<{}>;
 
 export type EChartRenderedHandler = EChartEventHandler<{}>;
 
-type EchartBrushAreas = {
+type EchartBrushAreas = Array<{
   coordRange: number[][];
   range: number[][];
-}[];
+}>;
 
 export type EChartBrushStartHandler = EChartEventHandler<{
   areas: EchartBrushAreas;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -186,7 +186,7 @@ export enum LockType {
 export type Frame = {
   absPath: string | null;
   colNo: number | null;
-  context: [number, string][];
+  context: Array<[number, string]>;
   filename: string | null;
   function: string | null;
   inApp: boolean;
@@ -284,7 +284,7 @@ export enum EntryType {
 
 export type EntryDebugMeta = {
   data: {
-    images: (Image | null)[];
+    images: Array<Image | null>;
   };
   type: EntryType.DEBUGMETA;
 };
@@ -335,17 +335,17 @@ export interface EntryRequestDataDefault {
   apiTarget: null;
   method: string;
   url: string;
-  cookies?: ([key: string, value: string] | null)[];
-  data?: string | null | Record<string, any> | [key: string, value: any][];
+  cookies?: Array<[key: string, value: string] | null>;
+  data?: string | null | Record<string, any> | Array<[key: string, value: any]>;
   env?: Record<string, string>;
   fragment?: string | null;
-  headers?: ([key: string, value: string] | null)[];
+  headers?: Array<[key: string, value: string] | null>;
   inferredContentType?:
     | null
     | 'application/json'
     | 'application/x-www-form-urlencoded'
     | 'multipart/form-data';
-  query?: ([key: string, value: string] | null)[] | string;
+  query?: Array<[key: string, value: string] | null> | string;
 }
 
 export interface EntryRequestDataGraphQl
@@ -810,13 +810,9 @@ export interface EventTransaction
   endTimestamp: number;
   // EntryDebugMeta is required for profiles to render in the span
   // waterfall with the correct symbolication statuses
-  entries: (
-    | EntrySpans
-    | EntryRequest
-    | EntryDebugMeta
-    | AggregateEntrySpans
-    | EntryBreadcrumbs
-  )[];
+  entries: Array<
+    EntrySpans | EntryRequest | EntryDebugMeta | AggregateEntrySpans | EntryBreadcrumbs
+  >;
   startTimestamp: number;
   type: EventOrGroupType.TRANSACTION;
   perfProblem?: PerformanceDetectorData;
@@ -851,13 +847,9 @@ export interface AggregateEventTransaction
 }
 
 export interface EventError extends Omit<EventBase, 'entries' | 'type'> {
-  entries: (
-    | EntryException
-    | EntryStacktrace
-    | EntryRequest
-    | EntryThreads
-    | EntryDebugMeta
-  )[];
+  entries: Array<
+    EntryException | EntryStacktrace | EntryRequest | EntryThreads | EntryDebugMeta
+  >;
   type: EventOrGroupType.ERROR;
 }
 

--- a/static/app/types/experiments.tsx
+++ b/static/app/types/experiments.tsx
@@ -16,7 +16,7 @@ export type ExperimentConfig = {
   /**
    * Possible assignment values of the experiment
    */
-  assignments: readonly (string | number | typeof unassignedValue)[];
+  assignments: ReadonlyArray<string | number | typeof unassignedValue>;
   /**
    * The name of the organization. This maps to the key exposed by the
    * organization manager on the backend.

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -816,7 +816,7 @@ export interface BaseGroup {
   logger: string | null;
   metadata: EventMetadata;
   numComments: number;
-  participants: (UserParticipant | TeamParticipant)[];
+  participants: Array<UserParticipant | TeamParticipant>;
   permalink: string;
   platform: PlatformKey;
   pluginActions: TitledPlugin[];
@@ -897,7 +897,7 @@ export type Meta = {
 };
 
 export type MetaError = string | [string, any];
-export type MetaRemark = (string | number)[];
+export type MetaRemark = Array<string | number>;
 
 export type ChunkType = {
   rule_id: string | number;
@@ -960,7 +960,7 @@ export type Note = {
   /**
    * Array of [id, display string] tuples used for @-mentions
    */
-  mentions: [string, string][];
+  mentions: Array<[string, string]>;
 
   /**
    * Note contents (markdown allowed)

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -313,11 +313,11 @@ export type DocIntegration = {
   url: string;
   avatar?: Avatar;
   features?: IntegrationFeature[];
-  resources?: {title: string; url: string}[];
+  resources?: Array<{title: string; url: string}>;
 };
 
 type IntegrationAspects = {
-  alerts?: (AlertProps & {text: string; icon?: string | React.ReactNode})[];
+  alerts?: Array<AlertProps & {text: string; icon?: string | React.ReactNode}>;
   configure_integration?: {
     title: string;
   };
@@ -486,7 +486,7 @@ export type PluginNoProject = {
     label: string | any;
     url: string;
   };
-  resourceLinks?: {title: string; url: string}[];
+  resourceLinks?: Array<{title: string; url: string}>;
   version?: string;
 };
 

--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -67,18 +67,22 @@ export type MetricsApiResponse = {
 };
 
 export interface MetricsQueryApiResponse {
-  data: {
-    by: Record<string, string>;
-    series: (number | null)[];
-    totals: number;
-  }[][];
+  data: Array<
+    Array<{
+      by: Record<string, string>;
+      series: Array<number | null>;
+      totals: number;
+    }>
+  >;
   end: string;
   intervals: string[];
-  meta: [
-    ...{name: string; type: string}[],
-    // The last entry in meta has a different shape
-    MetricsQueryApiResponseLastMeta,
-  ][];
+  meta: Array<
+    [
+      ...Array<{name: string; type: string}>,
+      // The last entry in meta has a different shape
+      MetricsQueryApiResponseLastMeta,
+    ]
+  >;
   start: string;
 }
 
@@ -94,7 +98,7 @@ export interface MetricsQueryApiResponseLastMeta {
 
 export type MetricsGroup = {
   by: Record<string, string>;
-  series: Record<string, (number | null)[]>;
+  series: Record<string, Array<number | null>>;
   totals: Record<string, number | null>;
 };
 

--- a/static/app/types/notificationActions.tsx
+++ b/static/app/types/notificationActions.tsx
@@ -32,5 +32,5 @@ export type AvailableNotificationAction = {
     targetDisplay?: string;
     targetIdentifier?: string;
   };
-  requires: {description: string; name: string}[];
+  requires: Array<{description: string; name: string}>;
 };

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -58,7 +58,7 @@ export interface Organization extends OrganizationSummary {
   allowSuperuserAccess: boolean;
   attachmentsRole: string;
   /** @deprecated use orgRoleList instead. */
-  availableRoles: {id: string; name: string}[];
+  availableRoles: Array<{id: string; name: string}>;
   dataScrubber: boolean;
   dataScrubberDefaults: boolean;
   debugFilesRole: string;
@@ -185,10 +185,10 @@ export interface Member {
   teamRoleList: TeamRole[];
 
   // TODO: Move to global store
-  teamRoles: {
+  teamRoles: Array<{
     role: string | null;
     teamSlug: string;
-  }[];
+  }>;
   /**
    * @deprecated use teamRoles
    */
@@ -275,7 +275,7 @@ export interface NewQuery {
   queryDataset?: SavedQueryDatasets;
   range?: string;
   start?: string | Date;
-  teams?: readonly ('myteams' | number)[];
+  teams?: ReadonlyArray<'myteams' | number>;
   topEvents?: string;
   utc?: boolean | string;
   widths?: readonly string[];
@@ -296,9 +296,11 @@ export type SavedQueryState = {
 
 export type Confidence = 'high' | 'low' | null;
 
-export type EventsStatsData = [number, {count: number; comparisonCount?: number}[]][];
+export type EventsStatsData = Array<
+  [number, Array<{count: number; comparisonCount?: number}>]
+>;
 
-export type ConfidenceStatsData = [number, {count: Confidence}[]][];
+export type ConfidenceStatsData = Array<[number, Array<{count: Confidence}>]>;
 
 // API response format for a single series
 export type EventsStats = {
@@ -331,11 +333,11 @@ export type GroupedMultiSeriesEventsStats = {
 };
 
 export type EventsStatsSeries<F extends string> = {
-  data: {
+  data: Array<{
     axis: F;
     values: number[];
     label?: string;
-  }[];
+  }>;
   meta: {
     dataset: string;
     end: number;
@@ -349,11 +351,11 @@ export type EventsStatsSeries<F extends string> = {
  */
 // Base type for series style API response
 export interface SeriesApi {
-  groups: {
+  groups: Array<{
     by: Record<string, string | number>;
     series: Record<string, number[]>;
     totals: Record<string, number>;
-  }[];
+  }>;
   intervals: string[];
 }
 

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -98,7 +98,7 @@ export type MinimalProject = Pick<Project, 'id' | 'slug' | 'platform'>;
 // Response from project_keys endpoints.
 export type ProjectKey = {
   browserSdk: {
-    choices: [key: string, value: string][];
+    choices: Array<[key: string, value: string]>;
   };
   browserSdkVersion: ProjectKey['browserSdk']['choices'][number][0];
   dateCreated: string;

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -72,11 +72,11 @@ export interface Release extends BaseRelease, ReleaseData {
 }
 
 export interface ReleaseWithHealth extends BaseRelease, ReleaseData {
-  projects: Required<ReleaseProject>[];
+  projects: Array<Required<ReleaseProject>>;
 }
 
 interface ReleaseData {
-  authors: (User | {email: string; name: string})[];
+  authors: Array<User | {email: string; name: string}>;
   commitCount: number;
   currentProjectMeta: {
     firstReleaseVersion: string | null;
@@ -191,10 +191,10 @@ export enum HealthStatsPeriodOption {
   TWENTY_FOUR_HOURS = '24h',
 }
 
-export type CrashFreeTimeBreakdown = {
+export type CrashFreeTimeBreakdown = Array<{
   crashFreeSessions: number | null;
   crashFreeUsers: number | null;
   date: string;
   totalSessions: number;
   totalUsers: number;
-}[];
+}>;

--- a/static/app/types/sourceMaps.tsx
+++ b/static/app/types/sourceMaps.tsx
@@ -17,12 +17,12 @@ export type DebugIdBundleArtifact = {
   date: string;
   dateModified: string;
   fileCount: number;
-  files: {
+  files: Array<{
     debugId: string;
     filePath: string;
     fileSize: number;
     fileType: number;
     id: string;
     sourcemap: string | null;
-  }[];
+  }>;
 };

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -173,7 +173,7 @@ export interface Config {
   /**
    * This comes from django (django.contrib.messages)
    */
-  messages: {level: keyof Theme['alert']; message: string}[];
+  messages: Array<{level: keyof Theme['alert']; message: string}>;
   needsUpgrade: boolean;
   privacyUrl: string | null;
   // The list of regions the user has has access to.

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -25,11 +25,11 @@ export type AvatarUser = {
 export interface User extends Omit<AvatarUser, 'options'> {
   canReset2fa: boolean;
   dateJoined: string;
-  emails: {
+  emails: Array<{
     email: string;
     id: string;
     is_verified: boolean;
-  }[];
+  }>;
   experiments: Partial<UserExperiments>;
   flags: {newsletter_consent_prompt: boolean};
   has2fa: boolean;

--- a/static/app/utils/browserHistory.tsx
+++ b/static/app/utils/browserHistory.tsx
@@ -7,7 +7,7 @@ import {
   locationDescriptorToTo,
 } from './reactRouter6Compat/location';
 
-const historyMethods: (keyof History)[] = [
+const historyMethods: Array<keyof History> = [
   'listenBefore',
   'listen',
   'transitionTo',

--- a/static/app/utils/convertFromSelect2Choices.tsx
+++ b/static/app/utils/convertFromSelect2Choices.tsx
@@ -11,7 +11,9 @@ function isStringList(maybe: string[] | Choices): maybe is string[] {
  * This contains some any hacks as this is creates type errors with the generics
  * used in SelectControl as the generics conflict with the concrete types here.
  */
-const convertFromSelect2Choices = (choices: Input): SelectValue<any>[] | undefined => {
+const convertFromSelect2Choices = (
+  choices: Input
+): Array<SelectValue<any>> | undefined => {
   // TODO(ts): This is to make sure that this function is backwards compatible, ideally,
   // this function only accepts arrays
   if (!Array.isArray(choices)) {

--- a/static/app/utils/crashReports.tsx
+++ b/static/app/utils/crashReports.tsx
@@ -27,7 +27,7 @@ export enum SettingScope {
   PROJECT = 1,
 }
 export function getStoreCrashReportsValues(settingScope: SettingScope) {
-  const values: (number | null)[] = [
+  const values: Array<number | null> = [
     0, // disabled
     1, // limited per issue
     5,

--- a/static/app/utils/discover/arrayValue.tsx
+++ b/static/app/utils/discover/arrayValue.tsx
@@ -7,7 +7,7 @@ import {space} from 'sentry/styles/space';
 import {nullableValue} from './fieldRenderers';
 
 type Props = {
-  value: (string | null)[];
+  value: Array<string | null>;
 };
 
 function ArrayValue(props: Props) {

--- a/static/app/utils/discover/charts.spec.tsx
+++ b/static/app/utils/discover/charts.spec.tsx
@@ -16,7 +16,7 @@ import {categorizeDuration} from './categorizeDuration';
 
 describe('tooltipFormatter()', () => {
   it('formats values', () => {
-    const cases: [string, number, string][] = [
+    const cases: Array<[string, number, string]> = [
       // function, input, expected
       ['count()', 0.1, '0.1'],
       ['avg(thing)', 0.125126, '0.125'],
@@ -36,7 +36,7 @@ describe('tooltipFormatter()', () => {
 
 describe('tooltipFormatterUsingAggregateOutputType()', () => {
   it('formats values', () => {
-    const cases: [string, number, string][] = [
+    const cases: Array<[string, number, string]> = [
       // function, input, expected
       ['number', 0.1, '0.1'],
       ['integer', 0.125, '0.125'],
@@ -55,7 +55,7 @@ describe('tooltipFormatterUsingAggregateOutputType()', () => {
 
 describe('axisLabelFormatter()', () => {
   it('formats values', () => {
-    const cases: [string, number, string][] = [
+    const cases: Array<[string, number, string]> = [
       // type, input, expected
       ['count()', 0.1, '0.1'],
       ['avg(thing)', 0.125126, '0.125'],
@@ -106,7 +106,7 @@ describe('axisLabelFormatter()', () => {
 
 describe('axisLabelFormatterUsingAggregateOutputType()', () => {
   it('formats values', () => {
-    const cases: [string, number, string][] = [
+    const cases: Array<[string, number, string]> = [
       // type, input, expected
       ['number', 0.1, '0.1'],
       ['integer', 0.125, '0.125'],

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -83,7 +83,7 @@ export type LocationQuery = {
 
 const DATETIME_QUERY_STRING_KEYS = ['start', 'end', 'utc', 'statsPeriod'] as const;
 
-const EXTERNAL_QUERY_STRING_KEYS: readonly (keyof LocationQuery)[] = [
+const EXTERNAL_QUERY_STRING_KEYS: ReadonlyArray<keyof LocationQuery> = [
   ...DATETIME_QUERY_STRING_KEYS,
   'cursor',
 ];
@@ -234,7 +234,7 @@ const decodeTeam = (value: string): 'myteams' | number => {
   return parseInt(value, 10);
 };
 
-const decodeTeams = (location: Location): ('myteams' | number)[] => {
+const decodeTeams = (location: Location): Array<'myteams' | number> => {
   if (!location.query || !location.query.team) {
     return [];
   }
@@ -277,7 +277,7 @@ export type EventViewOptions = {
   sorts: readonly Sort[];
   start: string | undefined;
   statsPeriod: string | undefined;
-  team: readonly ('myteams' | number)[];
+  team: ReadonlyArray<'myteams' | number>;
   topEvents: string | undefined;
   additionalConditions?: MutableSearch;
   dataset?: DiscoverDatasets;
@@ -293,7 +293,7 @@ class EventView {
   fields: readonly Field[];
   sorts: readonly Sort[];
   query: string;
-  team: readonly ('myteams' | number)[];
+  team: ReadonlyArray<'myteams' | number>;
   project: readonly number[];
   start: string | undefined;
   end: string | undefined;
@@ -778,7 +778,7 @@ class EventView {
     return this.fields.length;
   }
 
-  getColumns(): TableColumn<React.ReactText>[] {
+  getColumns(): Array<TableColumn<React.ReactText>> {
     return decodeColumnOrder(this.fields);
   }
 
@@ -1069,13 +1069,13 @@ class EventView {
     return newEventView;
   }
 
-  withTeams(teams: ('myteams' | number)[]): EventView {
+  withTeams(teams: Array<'myteams' | number>): EventView {
     const newEventView = this.clone();
     newEventView.team = teams;
     return newEventView;
   }
 
-  getSorts(): TableColumnSort<React.ReactText>[] {
+  getSorts(): Array<TableColumnSort<React.ReactText>> {
     return this.sorts.map(
       sort =>
         ({
@@ -1357,7 +1357,7 @@ class EventView {
     return newEventView;
   }
 
-  getYAxisOptions(): SelectValue<string>[] {
+  getYAxisOptions(): Array<SelectValue<string>> {
     // Make option set and add the default options in.
     return uniqBy(
       this.getAggregateFields()
@@ -1398,7 +1398,7 @@ class EventView {
     return defaultOption;
   }
 
-  getDisplayOptions(): SelectValue<string>[] {
+  getDisplayOptions(): Array<SelectValue<string>> {
     return DISPLAY_MODE_OPTIONS.map(item => {
       if (item.value === DisplayModes.PREVIOUS) {
         if (this.start || this.end) {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -457,7 +457,7 @@ const SPECIAL_FIELDS: SpecialFields = {
   minidump: {
     sortField: null,
     renderFunc: (data, {organization, projectSlug}) => {
-      const attachments: (IssueAttachment & {url: string})[] = data.attachments;
+      const attachments: Array<IssueAttachment & {url: string}> = data.attachments;
 
       const minidump = attachments.find(
         attachment => attachment.type === 'event.minidump'

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -81,7 +81,7 @@ export type AggregateParameter =
   | {
       dataType: string;
       kind: 'dropdown';
-      options: SelectValue<string>[];
+      options: Array<SelectValue<string>>;
       required: boolean;
       defaultValue?: string;
       placeholder?: string;
@@ -794,7 +794,7 @@ export const TRACING_FIELDS = [
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 ];
 
-export const TRANSACTION_ONLY_FIELDS: (FieldKey | SpanOpBreakdown)[] = [
+export const TRANSACTION_ONLY_FIELDS: Array<FieldKey | SpanOpBreakdown> = [
   FieldKey.TRANSACTION_DURATION,
   FieldKey.TRANSACTION_OP,
   FieldKey.TRANSACTION_STATUS,
@@ -810,7 +810,7 @@ export const ERROR_FIELDS = DISCOVER_FIELDS.filter(
   f => !TRANSACTION_ONLY_FIELDS.includes(f)
 );
 
-export const ERROR_ONLY_FIELDS: (FieldKey | SpanOpBreakdown)[] = [
+export const ERROR_ONLY_FIELDS: Array<FieldKey | SpanOpBreakdown> = [
   FieldKey.LOCATION,
   FieldKey.EVENT_TYPE,
   FieldKey.ERROR_TYPE,

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -54,7 +54,7 @@ export const INTERVAL_DISPLAY_MODES: string[] = [
   DisplayModes.BAR,
 ];
 
-export const DISPLAY_MODE_OPTIONS: SelectValue<string>[] = [
+export const DISPLAY_MODE_OPTIONS: Array<SelectValue<string>> = [
   {value: DisplayModes.DEFAULT, label: t('Total Period')},
   {value: DisplayModes.PREVIOUS, label: t('Previous Period')},
   {value: DisplayModes.TOP5, label: t('Top 5 Period')},
@@ -92,7 +92,7 @@ export const MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES = [
   DisplayModes.BAR,
 ];
 
-export const CONDITIONS_ARGUMENTS: {value: string; label?: string}[] = [
+export const CONDITIONS_ARGUMENTS: Array<{value: string; label?: string}> = [
   {
     label: 'is equal to',
     value: 'equals',
@@ -119,7 +119,7 @@ export const CONDITIONS_ARGUMENTS: {value: string; label?: string}[] = [
   },
 ];
 
-export const WEB_VITALS_QUALITY: {value: string; label?: string}[] = [
+export const WEB_VITALS_QUALITY: Array<{value: string; label?: string}> = [
   {
     label: 'good',
     value: 'good',

--- a/static/app/utils/displayReprocessEventAction.tsx
+++ b/static/app/utils/displayReprocessEventAction.tsx
@@ -127,7 +127,7 @@ function addFramePlatforms(
  */
 function addPlatforms(
   platforms: Set<PlatformKey>,
-  iter: {platform?: PlatformKey | null}[]
+  iter: Array<{platform?: PlatformKey | null}>
 ) {
   for (const o of iter) {
     if (o.platform) {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -266,14 +266,14 @@ export type AggregateValueParameter = {
   name: string;
   required: boolean;
   defaultValue?: string;
-  options?: {value: string; label?: string}[];
+  options?: Array<{value: string; label?: string}>;
   placeholder?: string;
 };
 
 export type AggregateParameter = AggregateColumnParameter | AggregateValueParameter;
 
 export type ParameterDependentValueType = (
-  parameters: (string | null)[]
+  parameters: Array<string | null>
 ) => FieldValueType;
 
 export interface FieldDefinition {
@@ -349,7 +349,7 @@ function validateForNumericAggregate(
   };
 }
 
-function getDynamicFieldValueType(parameters: (string | null)[]): FieldValueType {
+function getDynamicFieldValueType(parameters: Array<string | null>): FieldValueType {
   const column = parameters[0];
   const fieldDef = column ? getFieldDefinition(column) : null;
   return fieldDef?.valueType ?? FieldValueType.NUMBER;

--- a/static/app/utils/mergeRefs.tsx
+++ b/static/app/utils/mergeRefs.tsx
@@ -2,7 +2,7 @@
  * Combine refs to allow assignment to all passed refs
  */
 export default function mergeRefs<T = any>(
-  refs: (React.MutableRefObject<T> | React.LegacyRef<T> | undefined)[]
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T> | undefined>
 ): React.RefCallback<T> {
   return value => {
     refs.forEach(ref => {

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -18,7 +18,7 @@ interface EquationParams {
 }
 
 export function convertToDashboardWidget(
-  metricQueries: (QueryParams | EquationParams)[],
+  metricQueries: Array<QueryParams | EquationParams>,
   displayType?: MetricDisplayType,
   title = ''
 ): Widget {

--- a/static/app/utils/metrics/dashboardImport.tsx
+++ b/static/app/utils/metrics/dashboardImport.tsx
@@ -24,18 +24,18 @@ type WidgetDefinition = {
   title: string;
   type: string;
   widgets: ImportWidget[];
-  legend_columns?: ('avg' | 'max' | 'min' | 'sum' | 'value')[];
+  legend_columns?: Array<'avg' | 'max' | 'min' | 'sum' | 'value'>;
   requests?: Request[];
 };
 
 type Request = {
   display_type: 'area' | 'bars' | 'line';
   formulas: Formula[];
-  queries: {
+  queries: Array<{
     data_source: string;
     name: string;
     query: string;
-  }[];
+  }>;
   response_format: 'note' | 'timeseries';
   style?: {
     line_type: 'dotted' | 'solid';
@@ -47,12 +47,12 @@ type Formula = {
   alias?: string;
 };
 
-type MetricWidgetReport = {
+type MetricWidgetReport = Array<{
   errors: string[];
   id: number;
   outcome: ImportOutcome;
   title: string;
-}[];
+}>;
 
 type ImportOutcome = 'success' | 'warning' | 'error';
 
@@ -443,7 +443,7 @@ export class WidgetParser {
   }
 
   private constructMetricQueryFilter(
-    filters: {key: string; value: string}[],
+    filters: Array<{key: string; value: string}>,
     availableTags: string[]
   ) {
     const queryFilters = filters.map(filter => {

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -78,8 +78,8 @@ export function getMetricsUrl(
     project,
     ...otherParams
   }: Omit<MetricsQueryParams, 'project' | 'widgets'> & {
-    widgets: Partial<MetricsWidget>[];
-    project?: (string | number)[];
+    widgets: Array<Partial<MetricsWidget>>;
+    project?: Array<string | number>;
   }
 ) {
   const urlParams: Partial<MetricsQueryParams> = {

--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -128,18 +128,18 @@ export type MetricCorrelation = {
   profileId: string;
   projectId: number;
   segmentName: string;
-  spansDetails: {
+  spansDetails: Array<{
     spanDuration: number;
     spanId: string;
     spanTimestamp: string;
-  }[];
+  }>;
   spansNumber: number;
   timestamp: string;
   traceId: string;
   transactionId: string;
   transactionSpanId: string;
-  spansSummary?: {
+  spansSummary?: Array<{
     spanDuration: number;
     spanOp: string;
-  }[];
+  }>;
 };

--- a/static/app/utils/metrics/useCardinalityLimitedMetricVolume.tsx
+++ b/static/app/utils/metrics/useCardinalityLimitedMetricVolume.tsx
@@ -4,7 +4,7 @@ import {
 } from 'sentry/utils/metrics/useMetricsQuery';
 
 type Props = {
-  projects: (number | string)[];
+  projects: Array<number | string>;
 };
 
 const CARDINALITY_QUERIES = [

--- a/static/app/utils/metrics/useMetricsQuery.tsx
+++ b/static/app/utils/metrics/useMetricsQuery.tsx
@@ -81,7 +81,7 @@ export function isMetricFormula(
 }
 
 export function getMetricsQueryApiRequestPayload(
-  queries: (MetricsQueryApiRequestQuery | MetricsQueryApiRequestFormula)[],
+  queries: Array<MetricsQueryApiRequestQuery | MetricsQueryApiRequestFormula>,
   {
     projects,
     environments,
@@ -89,7 +89,7 @@ export function getMetricsQueryApiRequestPayload(
   }: {
     datetime: PageFilters['datetime'];
     environments: PageFilters['environments'];
-    projects: (number | string)[];
+    projects: Array<number | string>;
   },
   {
     intervalLadder,
@@ -114,13 +114,13 @@ export function getMetricsQueryApiRequestPayload(
         '1m'
       );
 
-  const requestQueries: {mql: string; name: string}[] = [];
-  const requestFormulas: {
+  const requestQueries: Array<{mql: string; name: string}> = [];
+  const requestFormulas: Array<{
     mql: string;
     limit?: number;
     name?: string;
     order?: 'asc' | 'desc';
-  }[] = [];
+  }> = [];
 
   queries.forEach((query, index) => {
     if (isMetricFormula(query)) {
@@ -187,7 +187,7 @@ export function useMetricsQuery(
   }: {
     datetime: PageFilters['datetime'];
     environments: PageFilters['environments'];
-    projects: (number | string)[];
+    projects: Array<number | string>;
   },
   overrides: {
     includeSeries?: boolean;

--- a/static/app/utils/metrics/useMetricsSamples.tsx
+++ b/static/app/utils/metrics/useMetricsSamples.tsx
@@ -55,7 +55,7 @@ interface UseMetricSamplesOptions<F extends Field> {
 }
 
 export interface MetricsSamplesResults<F extends Field> {
-  data: Pick<ResultFieldTypes, F | 'summary'>[];
+  data: Array<Pick<ResultFieldTypes, F | 'summary'>>;
   meta: any; // not going to type this yet
 }
 

--- a/static/app/utils/number/rangeMap.tsx
+++ b/static/app/utils/number/rangeMap.tsx
@@ -23,9 +23,9 @@ export type Range<T> = {
  * ```
  */
 export class RangeMap<T> {
-  ranges: Range<T>[];
+  ranges: Array<Range<T>>;
 
-  constructor(ranges: Range<T>[]) {
+  constructor(ranges: Array<Range<T>>) {
     // Filter out sparse array slots just in case
     const filteredRanges = ranges.filter(Boolean);
 

--- a/static/app/utils/parseHtmlMarks.tsx
+++ b/static/app/utils/parseHtmlMarks.tsx
@@ -22,7 +22,7 @@ type Options = {
 export default function parseHtmlMarks({key, htmlString, markTags}: Options) {
   const {highlightPreTag, highlightPostTag} = markTags;
 
-  const indices: [number, number][] = [];
+  const indices: Array<[number, number]> = [];
   let value = htmlString;
 
   while (true) {

--- a/static/app/utils/performance/histogram/constants.tsx
+++ b/static/app/utils/performance/histogram/constants.tsx
@@ -3,7 +3,7 @@ import type {SelectValue} from 'sentry/types/core';
 
 import type {DataFilter} from './types';
 
-export const FILTER_OPTIONS: SelectValue<DataFilter>[] = [
+export const FILTER_OPTIONS: Array<SelectValue<DataFilter>> = [
   {label: t('Exclude'), value: 'exclude_outliers'},
   {label: t('Include'), value: 'all'},
 ];

--- a/static/app/utils/profiling/canvasScheduler.spec.tsx
+++ b/static/app/utils/profiling/canvasScheduler.spec.tsx
@@ -1,7 +1,7 @@
 import type {FlamegraphEvents} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 
-const handlers: (keyof FlamegraphEvents)[] = [
+const handlers: Array<keyof FlamegraphEvents> = [
   'reset zoom',
   'set config view',
   'highlight frame',

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -386,7 +386,7 @@ export function makeColorMapByFrequency(
 }
 
 export function makeSpansColorMapByOpAndDescription(
-  spans: readonly SpanChart['spans'][0][],
+  spans: ReadonlyArray<SpanChart['spans'][0]>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
 ): Map<SpanChartNode['node']['span']['span_id'], ColorChannels> {
   const colors = new Map<SpanChartNode['node']['span']['span_id'], ColorChannels>();

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -304,7 +304,7 @@ export class Flamegraph {
 
   findAllMatchingFramesBy(
     query: string,
-    fields: (keyof FlamegraphFrame['frame'])[]
+    fields: Array<keyof FlamegraphFrame['frame']>
   ): FlamegraphFrame[] {
     const matches: FlamegraphFrame[] = [];
     if (!fields.length) {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
@@ -3,11 +3,11 @@ import type {SpanChartNode} from 'sentry/utils/profiling/spanChart';
 
 export type FlamegraphSearchResult = {
   frame: FlamegraphFrame;
-  match: readonly [number, number][];
+  match: ReadonlyArray<[number, number]>;
 };
 
 export type SpansSearchResult = {
-  match: readonly [number, number][];
+  match: ReadonlyArray<[number, number]>;
   span: SpanChartNode;
 };
 

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -13,14 +13,14 @@ interface Series {
   fillColor: string;
   lineColor: string;
   name: string;
-  points: {x: number; y: number}[];
+  points: Array<{x: number; y: number}>;
   type: 'line' | 'area';
 }
 
 export interface ProfileSeriesMeasurement {
   name: string;
   unit: string;
-  values: {elapsed: number; value: number}[];
+  values: Array<{elapsed: number; value: number}>;
 }
 
 function computeLabelPrecision(min: number, max: number): number {

--- a/static/app/utils/profiling/fzf/fzf.ts
+++ b/static/app/utils/profiling/fzf/fzf.ts
@@ -25,7 +25,7 @@
 
 interface Result {
   readonly end: number;
-  readonly matches: readonly [number, number][];
+  readonly matches: ReadonlyArray<[number, number]>;
   readonly score: number;
   readonly start: number;
 }
@@ -170,7 +170,7 @@ function calculateScore(
   sidx: number,
   eidx: number,
   caseSensitive: boolean
-): [number, readonly [number, number][]] {
+): [number, ReadonlyArray<[number, number]>] {
   let pidx = 0;
   let score = 0;
   let inGap: boolean = false;
@@ -238,7 +238,7 @@ function calculateScore(
   // we want to update/extend our current range, otherwise we want to add a new range.
 
   // Init range to first match, at this point we should have at least 1
-  const matches = [[pos[0], pos[0]! + 1]] as [number, number][];
+  const matches = [[pos[0], pos[0]! + 1]] as Array<[number, number]>;
 
   // iterate over all positions and check for overlaps from current and end of last
   // range. Positions are already sorted by match index, we can just check the last range.

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -821,7 +821,7 @@ export function getMinimapCanvasCursor(
 }
 
 export function useResizeCanvasObserver(
-  canvases: (HTMLCanvasElement | null)[],
+  canvases: Array<HTMLCanvasElement | null>,
   canvasPoolManager: CanvasPoolManager,
   canvas: FlamegraphCanvas | null,
   view: CanvasView<any> | null

--- a/static/app/utils/profiling/hooks/types.tsx
+++ b/static/app/utils/profiling/hooks/types.tsx
@@ -24,7 +24,7 @@ export type EventsResultsMeta<F extends string> = {
 };
 
 export type EventsResults<F extends string> = {
-  data: EventsResultsDataRow<F>[];
+  data: Array<EventsResultsDataRow<F>>;
   meta: EventsResultsMeta<F>;
 };
 

--- a/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
+++ b/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
@@ -45,7 +45,7 @@ export function useRovingTabIndex(items: any[]) {
 
 export function useKeyboardNavigation() {
   const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
-  const items: {id: number; node: HTMLElement | null}[] = [];
+  const items: Array<{id: number; node: HTMLElement | null}> = [];
 
   const {tabIndex, setTabIndex, onKeyDown} = useRovingTabIndex(items);
 

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -18,7 +18,7 @@ export interface UseProfileEventsOptions<F extends string = ProfilingFieldType> 
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
   limit?: number;
-  projects?: (number | string)[];
+  projects?: Array<number | string>;
   query?: string;
   refetchOnMount?: boolean;
 }

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
@@ -13,7 +13,7 @@ interface UseProfileFunctionTrendsOptions<F extends string> {
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
   limit?: number;
-  projects?: (number | string)[];
+  projects?: Array<number | string>;
   query?: string;
   refetchOnMount?: boolean;
 }

--- a/static/app/utils/profiling/hooks/useProfileFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.tsx
@@ -14,7 +14,7 @@ export interface UseProfileFunctionsOptions<F extends string> {
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
   limit?: number;
-  projects?: (number | string)[];
+  projects?: Array<number | string>;
   query?: string;
   refetchOnMount?: boolean;
 }

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
@@ -5,8 +5,8 @@ const n = (d: any) => {
   return {...d, children: []};
 };
 
-function toFlattenedList(tree: VirtualizedTree<any>): VirtualizedTreeNode<any>[] {
-  const list: VirtualizedTreeNode<any>[] = [];
+function toFlattenedList(tree: VirtualizedTree<any>): Array<VirtualizedTreeNode<any>> {
+  const list: Array<VirtualizedTreeNode<any>> = [];
 
   function visit(node: VirtualizedTreeNode<any>): void {
     list.push(node);

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -3,10 +3,13 @@ import type {TreeLike} from 'sentry/utils/profiling/hooks/useVirtualizedTree/use
 import {VirtualizedTreeNode} from './VirtualizedTreeNode';
 
 export class VirtualizedTree<T extends TreeLike> {
-  roots: VirtualizedTreeNode<T>[] = [];
-  flattened: VirtualizedTreeNode<T>[] = [];
+  roots: Array<VirtualizedTreeNode<T>> = [];
+  flattened: Array<VirtualizedTreeNode<T>> = [];
 
-  constructor(roots: VirtualizedTreeNode<T>[], flattenedList?: VirtualizedTreeNode<T>[]) {
+  constructor(
+    roots: Array<VirtualizedTreeNode<T>>,
+    flattenedList?: Array<VirtualizedTreeNode<T>>
+  ) {
     this.roots = roots;
     this.flattened = flattenedList || VirtualizedTree.toExpandedList(this.roots);
   }
@@ -21,12 +24,12 @@ export class VirtualizedTree<T extends TreeLike> {
     // to carry-them over and preserver their state.
     expandedNodes?: Set<T>
   ): VirtualizedTree<T> {
-    const roots: VirtualizedTreeNode<T>[] = [];
+    const roots: Array<VirtualizedTreeNode<T>> = [];
 
     function toTreeNode(
       node: T,
       parent: VirtualizedTreeNode<T> | null,
-      collection: VirtualizedTreeNode<T>[] | null,
+      collection: Array<VirtualizedTreeNode<T>> | null,
       depth: number
     ) {
       const shouldUseExpandedSet = expandedNodes && expandedNodes.size > 0;
@@ -68,9 +71,9 @@ export class VirtualizedTree<T extends TreeLike> {
 
   // Returns a list of nodes that are visible in the tree.
   static toExpandedList<T extends TreeLike>(
-    nodes: VirtualizedTreeNode<T>[]
-  ): VirtualizedTreeNode<T>[] {
-    const list: VirtualizedTreeNode<T>[] = [];
+    nodes: Array<VirtualizedTreeNode<T>>
+  ): Array<VirtualizedTreeNode<T>> {
+    const list: Array<VirtualizedTreeNode<T>> = [];
 
     function visit(node: VirtualizedTreeNode<T>): void {
       list.push(node);

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -1,7 +1,7 @@
 export class VirtualizedTreeNode<T> {
   node: T;
   parent: VirtualizedTreeNode<T> | null;
-  children: VirtualizedTreeNode<T>[];
+  children: Array<VirtualizedTreeNode<T>>;
   expanded: boolean;
   depth: number;
 
@@ -60,7 +60,7 @@ export class VirtualizedTreeNode<T> {
     this.expanded = value;
 
     // Collect the newly visible children.
-    const list: VirtualizedTreeNode<T>[] = [];
+    const list: Array<VirtualizedTreeNode<T>> = [];
     function visit(node: VirtualizedTreeNode<T>): void {
       if (opts?.expandChildren) {
         node.expanded = true;

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -162,7 +162,7 @@ export function useVirtualizedTree<T extends TreeLike>(
     [state.scrollHeight, state.scrollTop, state.overscroll, tree, props.rowHeight]
   );
 
-  const flattenedHistory = useRef<readonly VirtualizedTreeNode<T>[]>(tree.flattened);
+  const flattenedHistory = useRef<ReadonlyArray<VirtualizedTreeNode<T>>>(tree.flattened);
   const expandedHistory = useRef<Set<T>>(new Set());
 
   // Keep a ref to latest state to avoid re-rendering
@@ -713,7 +713,7 @@ export function useVirtualizedTree<T extends TreeLike>(
       // it enables us to make constant space updates to the tree and avoid doing an O(n) lookup
       // for all node children when they are expanded. Since stack size is capped, this should never
       // exceed a couple hundred iterations and **should** be a reasonable tradeoff in performance.
-      const edges: VirtualizedTreeNode<T>[] = [];
+      const edges: Array<VirtualizedTreeNode<T>> = [];
       let path: VirtualizedTreeNode<T> | null = node.parent;
 
       while (path && !path.expanded) {

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
@@ -41,7 +41,7 @@ export function updateGhostRow({
 
 export function markRowAsHovered(
   hoveredRowKey: VirtualizedTreeRenderedRow<any>['key'] | null,
-  renderedItems: VirtualizedTreeRenderedRow<any>[],
+  renderedItems: Array<VirtualizedTreeRenderedRow<any>>,
   {
     rowHeight,
     scrollTop,
@@ -80,7 +80,7 @@ export function markRowAsHovered(
 
 export function markRowAsClicked(
   clickedRowKey: VirtualizedTreeRenderedRow<any>['key'] | null,
-  renderedItems: VirtualizedTreeRenderedRow<any>[],
+  renderedItems: Array<VirtualizedTreeRenderedRow<any>>,
   {
     rowHeight,
     scrollTop,
@@ -163,7 +163,7 @@ export function findOptimisticStartIndex<T extends TreeLike>({
   scrollTop,
   viewport,
 }: {
-  items: VirtualizedTreeNode<T>[];
+  items: Array<VirtualizedTreeNode<T>>;
   overscroll: number;
   rowHeight: number;
   scrollTop: number;
@@ -189,7 +189,7 @@ export function findRenderedItems<T extends TreeLike>({
   scrollHeight,
   scrollTop,
 }: {
-  items: VirtualizedTreeNode<T>[];
+  items: Array<VirtualizedTreeNode<T>>;
   overscroll: NonNullable<UseVirtualizedTreeProps<T>['overscroll']>;
   rowHeight: UseVirtualizedTreeProps<T>['rowHeight'];
   scrollHeight: VirtualizedState<T>['scrollHeight'];
@@ -198,7 +198,7 @@ export function findRenderedItems<T extends TreeLike>({
   // This is overscroll height for single direction, when computing the total,
   // we need to multiply this by 2 because we overscroll in both directions.
   const OVERSCROLL_HEIGHT = overscroll * rowHeight;
-  const renderedRows: VirtualizedTreeRenderedRow<T>[] = [];
+  const renderedRows: Array<VirtualizedTreeRenderedRow<T>> = [];
 
   // Clamp viewport to scrollHeight bounds [0, length * rowHeight] because some browsers may fire
   // scrollTop with negative values when the user scrolls up past the top of the list (overscroll behavior)

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -473,7 +473,7 @@ const tryParseInputString: JSONParser = input => {
 type JSONParser = (input: string) => [any, null] | [null, Error];
 
 // @ts-ignore TS(7051): Parameter has a name but no type. Did you mean 'ar... Remove this comment to see the full error message
-const TRACE_JSON_PARSERS: ((string) => ReturnType<JSONParser>)[] = [
+const TRACE_JSON_PARSERS: Array<(string) => ReturnType<JSONParser>> = [
   (input: string) => tryParseInputString(input),
   (input: string) => tryParseInputString(input + ']'),
 ];

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -49,7 +49,11 @@ function sortSamples(
   profile: Readonly<Profiling.SampledProfile>,
   profileIds: Profiling.ProfileReference[][] = [],
   frameFilter?: (i: number) => boolean
-): {aggregate_sample_duration: number; stack: number[]; weight: number | undefined}[] {
+): Array<{
+  aggregate_sample_duration: number;
+  stack: number[];
+  weight: number | undefined;
+}> {
   return stacksWithWeights(profile, profileIds, frameFilter).sort(sortStacks);
 }
 

--- a/static/app/utils/profiling/profile/testUtils.tsx
+++ b/static/app/utils/profiling/profile/testUtils.tsx
@@ -17,7 +17,7 @@ export const nthCallee = (node: CallTreeNode, n: number) => {
 };
 
 export const makeTestingBoilerplate = () => {
-  const timings: [Frame['name'], string][] = [];
+  const timings: Array<[Frame['name'], string]> = [];
 
   const openSpy = jest.fn();
   const closeSpy = jest.fn();

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -143,7 +143,7 @@ class SpanChart {
     const transactionStart = tree.root.span.start_timestamp;
 
     // We only want to collect the root most node once
-    const queue: [SpanChartNode | null, SpanTreeNode][] =
+    const queue: Array<[SpanChartNode | null, SpanTreeNode]> =
       depthOffset === 0
         ? [[null, tree.root]]
         : tree.root.children.map(child => [null, child] as [null, SpanTreeNode]);

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -147,7 +147,7 @@ export function useApiQuery<TResponseData, TError = RequestError>(
 export function useApiQueries<TResponseData, TError = RequestError>(
   queryKeys: ApiQueryKey[],
   options: UseApiQueryOptions<TResponseData, TError>
-): UseApiQueryResult<TResponseData, TError>[] {
+): Array<UseApiQueryResult<TResponseData, TError>> {
   const api = useApi({persistInFlight: PERSIST_IN_FLIGHT});
   const queryFn = fetchDataQuery(api);
 

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -57,7 +57,7 @@ export function getRegions(): Region[] {
   return ConfigStore.get('regions') ?? [];
 }
 
-export function getRegionChoices(exclude: RegionData[] = []): [string, string][] {
+export function getRegionChoices(exclude: RegionData[] = []): Array<[string, string]> {
   const regions = getRegions();
   const excludedRegionNames = exclude.map(region => region.name);
 

--- a/static/app/utils/replays/getCurrentUrl.tsx
+++ b/static/app/utils/replays/getCurrentUrl.tsx
@@ -10,7 +10,7 @@ import type {ReplayRecord} from 'sentry/views/replays/types';
 
 function getCurrentUrl(
   replayRecord: undefined | ReplayRecord,
-  frames: undefined | (BreadcrumbFrame | SpanFrame)[],
+  frames: undefined | Array<BreadcrumbFrame | SpanFrame>,
   currentOffsetMS: number
 ) {
   const framesBeforeCurrentOffset = frames?.filter(

--- a/static/app/utils/replays/hooks/useExtractPageHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractPageHtml.tsx
@@ -24,7 +24,7 @@ async function extractPageHtml({
   offsetMsToStopAt,
   rrwebEvents,
   startTimestampMs,
-}: Args): Promise<[number, string][]> {
+}: Args): Promise<Array<[number, string]>> {
   const frames: ReplayFrame[] = offsetMsToStopAt.map(offsetMs => ({
     offsetMs,
     timestamp: new Date(startTimestampMs + offsetMs),

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -63,9 +63,9 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
  */
 export function replayTimestamps(
   replayRecord: ReplayRecord,
-  rrwebEvents: {timestamp: number}[],
-  rawCrumbs: {timestamp: number}[],
-  rawSpanData: {endTimestamp: number; op: string; startTimestamp: number}[]
+  rrwebEvents: Array<{timestamp: number}>,
+  rawCrumbs: Array<{timestamp: number}>,
+  rawSpanData: Array<{endTimestamp: number; op: string; startTimestamp: number}>
 ) {
   const rrwebTimestamps = rrwebEvents.map(event => event.timestamp).filter(Boolean);
   const breadcrumbTimestamps = rawCrumbs

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -8,7 +8,7 @@ export class Timer extends EventTarget {
   private _time: number = 0;
   private _pausedAt: number = 0;
   private _additionalTime: number = 0;
-  private _callbacks: Map<number, (() => void)[]> = new Map();
+  private _callbacks: Map<number, Array<() => void>> = new Map();
   private _speed: number = 1;
 
   step = () => {

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -464,7 +464,7 @@ export const SpanOps = [
  * This is a result of a custom discover query
  */
 export type RawReplayError = {
-  ['error.type']: (string | undefined | null)[];
+  ['error.type']: Array<string | undefined | null>;
   id: string;
   issue: string;
   ['issue.id']: number;

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -3,7 +3,7 @@ import type {Location, LocationDescriptor} from 'history';
 import ConfigStore from 'sentry/stores/configStore';
 
 // If you change this also update the patterns in sentry.api.utils
-const NORMALIZE_PATTERNS: [pattern: RegExp, replacement: string][] = [
+const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   // /organizations/slug/section, but not /organizations/new
   [/\/organizations\/(?!new)[^\/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/

--- a/static/app/utils/useCombinedReducer.tsx
+++ b/static/app/utils/useCombinedReducer.tsx
@@ -32,7 +32,7 @@ export type CombinedReducer<M extends ReducersObject> = Reducer<
 export function makeCombinedReducers<M extends ReducersObject>(
   reducers: M
 ): CombinedReducer<M> {
-  const keys: (keyof M)[] = Object.keys(reducers);
+  const keys: Array<keyof M> = Object.keys(reducers);
 
   return (state, action) => {
     const nextState = {} as ReducersState<M>;

--- a/static/app/utils/useDimensionsMultiple.tsx
+++ b/static/app/utils/useDimensionsMultiple.tsx
@@ -1,7 +1,7 @@
 import {useLayoutEffect, useRef, useState} from 'react';
 
 interface Props<Element extends HTMLElement> {
-  elements: (Element | null)[];
+  elements: Array<Element | null>;
 }
 
 /**

--- a/static/app/utils/useDispatchingReducer.tsx
+++ b/static/app/utils/useDispatchingReducer.tsx
@@ -80,7 +80,7 @@ export class DispatchingReducerEmitter<R extends React.Reducer<any, any>> {
 
 function update<R extends React.Reducer<any, any>>(
   state: ReducerState<R>,
-  actions: ReducerAction<R>[],
+  actions: Array<ReducerAction<R>>,
   reducer: R,
   emitter: DispatchingReducerEmitter<R>
 ) {
@@ -116,7 +116,7 @@ export function useDispatchingReducer<R extends React.Reducer<any, any>>(
   const reducerRef = useRef(reducer);
   reducerRef.current = reducer;
 
-  const actionQueue = useRef<ReducerAction<R>[]>([]);
+  const actionQueue = useRef<Array<ReducerAction<R>>>([]);
   const updatesRef = useRef<number | null>(null);
 
   const wrappedDispatch = useCallback(

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -49,7 +49,7 @@ const getPrismGrammar = (language: string) => {
 };
 
 const splitMultipleTokensByLine = (
-  tokens: (string | Prism.Token)[],
+  tokens: Array<string | Prism.Token>,
   types: Set<string> = new Set(['token'])
 ) => {
   const lines: IntermediateToken[][] = [];
@@ -112,7 +112,7 @@ const splitTokenContentByLine = (
 };
 
 export const breakTokensByLine = (
-  tokens: (string | Prism.Token)[]
+  tokens: Array<string | Prism.Token>
 ): SyntaxHighlightLine[] => {
   const lines = splitMultipleTokensByLine(tokens);
 

--- a/static/app/utils/useProjectSdkNeedsUpdate.spec.tsx
+++ b/static/app/utils/useProjectSdkNeedsUpdate.spec.tsx
@@ -18,10 +18,10 @@ function wrapper({children}: {children?: ReactNode}) {
 }
 
 function mockCurrentVersion(
-  mockUpdates: {
+  mockUpdates: Array<{
     projectId: string;
     sdkVersion: string;
-  }[]
+  }>
 ) {
   MockApiClient.addMockResponse({
     url: `/organizations/${MOCK_ORG.slug}/sdk-updates/`,

--- a/static/app/utils/useRoutes.tsx
+++ b/static/app/utils/useRoutes.tsx
@@ -5,7 +5,7 @@ import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 
 import {useTestRouteContext} from './useRouteContext';
 
-export function useRoutes(): PlainRoute<any>[] {
+export function useRoutes(): Array<PlainRoute<any>> {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const testRouteContext = useTestRouteContext();

--- a/static/app/views/admin/adminEnvironment.tsx
+++ b/static/app/views/admin/adminEnvironment.tsx
@@ -12,7 +12,7 @@ import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 type Data = {
-  config: [key: string, value: string][];
+  config: Array<[key: string, value: string]>;
   environment: {
     config: string;
     start_date: string;

--- a/static/app/views/admin/adminPackages.tsx
+++ b/static/app/views/admin/adminPackages.tsx
@@ -6,8 +6,8 @@ import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 type Data = {
-  extensions: [key: string, value: string][];
-  modules: [key: string, value: string][];
+  extensions: Array<[key: string, value: string]>;
+  modules: Array<[key: string, value: string]>;
 };
 
 export default function AdminPackages() {

--- a/static/app/views/admin/adminWarnings.tsx
+++ b/static/app/views/admin/adminWarnings.tsx
@@ -5,7 +5,7 @@ import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 type Data = {
-  groups: [groupName: string, grouppedWarnings: string[]][];
+  groups: Array<[groupName: string, grouppedWarnings: string[]]>;
   warnings: string[];
 };
 

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -20,7 +20,7 @@ export type Field = {
   key: string;
   label: React.ReactNode;
   allowEmpty?: boolean;
-  choices?: [value: string, label: string][];
+  choices?: Array<[value: string, label: string]>;
   component?: React.ComponentType<any>;
   defaultValue?: () => string | number | false;
   disabled?: boolean;

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 function BuilderBreadCrumbs({title, alertName, projectSlug, organization}: Props) {
-  const crumbs: (Crumb | CrumbDropdown)[] = [
+  const crumbs: Array<Crumb | CrumbDropdown> = [
     {
       to: `/organizations/${organization.slug}/alerts/rules/`,
       label: t('Alerts'),

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -82,7 +82,7 @@ function AlertRulesList() {
     getResponseHeader,
     isPending,
     isError,
-  } = useApiQuery<(CombinedAlerts | null)[]>(
+  } = useApiQuery<Array<CombinedAlerts | null>>(
     getAlertListQueryKey(organization.slug, location.query),
     {
       staleTime: 0,
@@ -160,7 +160,7 @@ function AlertRulesList() {
 
     try {
       await api.requestPromise(deleteEndpoints[rule.type], {method: 'DELETE'});
-      setApiQueryData<(CombinedAlerts | null)[]>(
+      setApiQueryData<Array<CombinedAlerts | null>>(
         queryClient,
         getAlertListQueryKey(organization.slug, location.query),
         data => data?.filter(r => r?.id !== rule.id && r?.type !== rule.type)

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -51,7 +51,7 @@ jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: jest.fn(),
 }));
 
-const projectAlertRuleDetailsRoutes: PlainRoute<any>[] = [
+const projectAlertRuleDetailsRoutes: Array<PlainRoute<any>> = [
   {
     path: '/',
   },

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -282,7 +282,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
       ]);
     }
 
-    return endpoints as [string, string][];
+    return endpoints as Array<[string, string]>;
   }
 
   onRequestSuccess({stateKey, data}: any) {

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -65,10 +65,10 @@ type Props = {
 
 const createSelectOptions = (
   actions: IssueAlertRuleActionTemplate[]
-): {
+): Array<{
   label: React.ReactNode;
   value: IssueAlertRuleActionTemplate;
-}[] => {
+}> => {
   return actions.map(node => {
     if (node.id === IssueAlertActionType.NOTIFY_EMAIL) {
       const label = t('Suggested Assignees, Team, or Member');

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -19,7 +19,7 @@ describe('SetupAlertIntegrationButton', function () {
     GitHubIntegrationProviderFixture({key: providerKey}),
   ];
   const providerKeys = ['slack', 'discord', 'msteams'];
-  let mockResponses: jest.Mock<any>[] = [];
+  let mockResponses: Array<jest.Mock<any>> = [];
 
   const getComponent = () => (
     <SetupMessagingIntegrationButton

--- a/static/app/views/alerts/rules/metric/details/constants.tsx
+++ b/static/app/views/alerts/rules/metric/details/constants.tsx
@@ -11,7 +11,7 @@ export const SELECTOR_RELATIVE_PERIODS = {
 
 export const ALERT_DEFAULT_CHART_PERIOD = '7d';
 
-export const TIME_OPTIONS: SelectValue<string>[] = [
+export const TIME_OPTIONS: Array<SelectValue<string>> = [
   {label: t('Last 6 hours'), value: TimePeriod.SIX_HOURS},
   {label: t('Last 24 hours'), value: TimePeriod.ONE_DAY},
   {label: t('Last 3 days'), value: TimePeriod.THREE_DAYS},

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -560,7 +560,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     } = this.props;
 
     const {environments, filterKeys} = this.state;
-    const environmentOptions: SelectValue<string | null>[] = [
+    const environmentOptions: Array<SelectValue<string | null>> = [
       {
         value: null,
         label: t('All Environments'),

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1410,7 +1410,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
 function formatStatsToHistoricalDataset(
   data: EventsStats | MultiSeriesEventsStats | null
-): [number, {count: number}][] {
+): Array<[number, {count: number}]> {
   return Array.isArray(data?.data)
     ? data.data.flatMap(([timestamp, entries]) =>
         entries.map(entry => [timestamp, entry] as [number, {count: number}])

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -131,7 +131,7 @@ export interface SavedMetricRule extends UnsavedMetricRule {
   snooze: boolean;
   status: number;
   createdBy?: {email: string; id: number; name: string} | null;
-  errors?: {detail: string}[];
+  errors?: Array<{detail: string}>;
   /**
    * Returned with the expand=latestIncident query parameter
    */
@@ -247,7 +247,7 @@ export type MetricActionTemplate = {
   /**
    * For some available actions, we pass in the list of available targets.
    */
-  options?: {label: string; value: any}[];
+  options?: Array<{label: string; value: any}>;
 
   /**
    * SentryApp id for this `type`, should be passed to backend as `sentryAppId` when creating an action.
@@ -316,7 +316,7 @@ type UnsavedAction = {
   /**
    * For some available actions, we pass in the list of available targets.
    */
-  options: {label: string; value: any}[] | null;
+  options: Array<{label: string; value: any}> | null;
   /**
    * How to identify the target. Can be email, slack channel, pagerduty service,
    * user_id, team_id, SentryApp id, etc

--- a/static/app/views/alerts/rules/uptime/httpSnippet.tsx
+++ b/static/app/views/alerts/rules/uptime/httpSnippet.tsx
@@ -8,7 +8,7 @@ import {safeURL} from 'sentry/utils/url/safeURL';
 
 interface Props {
   body: string | null;
-  headers: [key: string, value: string][];
+  headers: Array<[key: string, value: string]>;
   method: string;
   traceSampling: boolean;
   url: string;

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -14,7 +14,7 @@ export enum UptimeMonitorMode {
 export interface UptimeRule {
   body: string | null;
   environment: string | null;
-  headers: [key: string, value: string][];
+  headers: Array<[key: string, value: string]>;
   id: string;
   intervalSeconds: number;
   method: string;

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -4,7 +4,7 @@ import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
 import type {Monitor} from 'sentry/views/monitors/types';
 
-type Data = [number, {count: number}[]][];
+type Data = Array<[number, Array<{count: number}>]>;
 
 export enum AlertRuleType {
   METRIC = 'metric',

--- a/static/app/views/alerts/utils/constants.tsx
+++ b/static/app/views/alerts/utils/constants.tsx
@@ -20,11 +20,11 @@ export const COMPARISON_TYPE_CHOICE_VALUES = {
   count: 'more than {value} in {interval}',
   percent: '{value}% higher in {interval} compared to {comparisonInterval} ago',
 };
-export const COMPARISON_TYPE_CHOICES: [string, string][] = [
+export const COMPARISON_TYPE_CHOICES: Array<[string, string]> = [
   ['count', COMPARISON_TYPE_CHOICE_VALUES.count],
   ['percent', COMPARISON_TYPE_CHOICE_VALUES.percent],
 ];
-export const COMPARISON_INTERVAL_CHOICES: [string, string][] = [
+export const COMPARISON_INTERVAL_CHOICES: Array<[string, string]> = [
   ['5m', '5 minutes'],
   ['15m', '15 minutes'],
   ['1h', 'one hour'],

--- a/static/app/views/alerts/utils/getComparisonMarkLines.tsx
+++ b/static/app/views/alerts/utils/getComparisonMarkLines.tsx
@@ -18,7 +18,7 @@ export const getComparisonMarkLines = (
   triggers: Trigger[],
   thresholdType: AlertRuleThresholdType
 ): LineChartSeries[] => {
-  const changeStatuses: {name: number | string; status: string}[] = [];
+  const changeStatuses: Array<{name: number | string; status: string}> = [];
 
   if (
     timeseriesData?.[0]?.data !== undefined &&

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -347,14 +347,14 @@ export function datasetOmittedTags(
   dataset: Dataset,
   org: Organization
 ):
-  | (
+  | Array<
       | FieldKey
       | WebVital
       | MobileVital
       | SpanOpBreakdown
       | ReplayFieldKey
       | ReplayClickFieldKey
-    )[]
+    >
   | undefined {
   // @ts-ignore TS(2339): Property 'events_analytics_platform' does not exis... Remove this comment to see the full error message
   return {

--- a/static/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/static/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -7,7 +7,7 @@ type RadioPanelGroupProps<C extends string> = {
   /**
    * An array of [id, name]
    */
-  choices: [C, React.ReactNode, React.ReactNode?][];
+  choices: Array<[C, React.ReactNode, React.ReactNode?]>;
   label: string;
   onChange: (id: C, e: React.FormEvent<HTMLInputElement>) => void;
   value: string | null;

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -191,7 +191,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
   getTableSortOptions?: (
     organization: Organization,
     widgetQuery: WidgetQuery
-  ) => SelectValue<string>[];
+  ) => Array<SelectValue<string>>;
   /**
    * Generate the list of sort options for timeseries
    * displays on the 'Sort by' step of the Widget Builder.

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -172,7 +172,7 @@ export function getTableSortOptions(
   widgetQuery: WidgetQuery
 ) {
   const {columns, aggregates} = widgetQuery;
-  const options: SelectValue<string>[] = [];
+  const options: Array<SelectValue<string>> = [];
   let equations = 0;
   [...aggregates, ...columns]
     .filter(field => !!field)

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -149,7 +149,7 @@ function disableSortOptions(widgetQuery: WidgetQuery) {
 
 function getTableSortOptions(_organization: Organization, widgetQuery: WidgetQuery) {
   const {columns, aggregates} = widgetQuery;
-  const options: SelectValue<string>[] = [];
+  const options: Array<SelectValue<string>> = [];
   [...aggregates, ...columns]
     .filter(field => !!field)
     .filter(field => !DISABLED_SORT.includes(field))

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -231,7 +231,7 @@ describe('Dashboards > Detail', function () {
 
   describe('custom dashboards', function () {
     let initialData!: ReturnType<typeof initializeOrg>;
-    let widgets!: ReturnType<typeof WidgetFixture>[];
+    let widgets!: Array<ReturnType<typeof WidgetFixture>>;
     let mockVisit!: jest.Mock;
     let mockPut!: jest.Mock;
 

--- a/static/app/views/dashboards/layoutUtils.tsx
+++ b/static/app/views/dashboards/layoutUtils.tsx
@@ -60,7 +60,7 @@ export function getMobileLayout(desktopLayout: Layout[], widgets: Widget[]) {
     return [];
   }
 
-  const layoutWidgetPairs = zip(desktopLayout, widgets) as [Layout, Widget][];
+  const layoutWidgetPairs = zip(desktopLayout, widgets) as Array<[Layout, Widget]>;
 
   // Sort by y and then subsort by x
   const sorted = sortBy(layoutWidgetPairs, ['0.y', '0.x']);
@@ -109,7 +109,7 @@ export function getInitialColumnDepths() {
  * Creates an array from layouts where each column stores how deep it is.
  */
 export function calculateColumnDepths(
-  layouts: Pick<Layout, 'h' | 'w' | 'x' | 'y'>[]
+  layouts: Array<Pick<Layout, 'h' | 'w' | 'x' | 'y'>>
 ): number[] {
   const depths = getInitialColumnDepths();
 

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -120,7 +120,7 @@ function DashboardTable({
   onDashboardsChange,
   isLoading,
 }: Props) {
-  const columnOrder: GridColumnOrder<ResponseKeys>[] = [
+  const columnOrder: Array<GridColumnOrder<ResponseKeys>> = [
     {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
     {key: ResponseKeys.WIDGETS, name: t('Widgets'), width: COL_WIDTH_UNDEFINED},
     {key: ResponseKeys.OWNER, name: t('Owner'), width: COL_WIDTH_UNDEFINED},

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -57,7 +57,7 @@ import {
 } from './settings';
 import TemplateCard from './templateCard';
 
-const SORT_OPTIONS: SelectValue<string>[] = [
+const SORT_OPTIONS: Array<SelectValue<string>> = [
   {label: t('My Dashboards'), value: 'mydashboards'},
   {label: t('Dashboard Name (A-Z)'), value: 'title'},
   {label: t('Dashboard Name (Z-A)'), value: '-title'},

--- a/static/app/views/dashboards/metrics/table.tsx
+++ b/static/app/views/dashboards/metrics/table.tsx
@@ -126,7 +126,7 @@ const getEmptyGroup = (tags: string[]) =>
 function getGroupByCombos(
   queries: MetricsQueryApiRequestQuery[],
   results: MetricsQueryApiResponse['data']
-): Record<string, string>[] {
+): Array<Record<string, string>> {
   const groupBys = Array.from(new Set(queries.flatMap(query => query.groupBy ?? [])));
   const emptyBy = getEmptyGroup(groupBys);
 
@@ -144,12 +144,12 @@ function getGroupByCombos(
 type Row = Record<string, {formattedValue?: string; value?: number}>;
 
 interface TableData {
-  headers: {
+  headers: Array<{
     label: string;
     name: string;
     order: Order;
     type: string;
-  }[];
+  }>;
   rows: Row[];
 }
 

--- a/static/app/views/dashboards/metrics/utils.tsx
+++ b/static/app/views/dashboards/metrics/utils.tsx
@@ -65,10 +65,10 @@ function getExpressionIdFromWidgetQuery(query: WidgetQuery): number {
 }
 
 function fillMissingExpressionIds(
-  expressions: (DashboardMetricsExpression | null)[],
+  expressions: Array<DashboardMetricsExpression | null>,
   indizesWithoutId: number[],
   usedIds: Set<number>
-): (DashboardMetricsExpression | null)[] {
+): Array<DashboardMetricsExpression | null> {
   if (indizesWithoutId.length > 0) {
     const generateId = getUniqueQueryIdGenerator(usedIds);
     for (const index of indizesWithoutId) {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -112,7 +112,7 @@ export function eventViewFromWidget(
 
 export function getThresholdUnitSelectOptions(
   dataType: string
-): {label: string; value: string}[] {
+): Array<{label: string; value: string}> {
   if (dataType === 'duration') {
     return Object.keys(DURATION_UNITS)
       .map(unit => ({label: unit, value: unit}))

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields.tsx
@@ -19,7 +19,7 @@ interface Props {
   onChange: (newColumns: QueryFieldValue[]) => void;
   organization: Organization;
   widgetType: WidgetType;
-  errors?: Record<string, string>[];
+  errors?: Array<Record<string, string>>;
   filterAggregateParameters?: (option: FieldValueOption) => boolean;
   filterPrimaryOptions?: (option: FieldValueOption) => boolean;
   noFieldsMessage?: string;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
@@ -22,7 +22,7 @@ interface Props {
   onQueryChange: (queryIndex: number, newQuery: WidgetQuery) => void;
   tags: TagCollection;
   widgetType: WidgetType;
-  queryErrors?: Record<string, any>[];
+  queryErrors?: Array<Record<string, any>>;
 }
 
 export function ColumnsStep({

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -53,7 +53,7 @@ interface Props {
   widgetType: WidgetType;
   dashboardFilters?: DashboardFilters;
   projectIds?: number[] | readonly number[];
-  queryErrors?: Record<string, any>[];
+  queryErrors?: Array<Record<string, any>>;
 }
 
 export function FilterResultsStep({

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -28,7 +28,7 @@ function mockSpanTags({
   type,
   mockedTags,
 }: {
-  mockedTags: {key: string; name: string}[];
+  mockedTags: Array<{key: string; name: string}>;
   type: 'string' | 'number';
 }) {
   MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
@@ -30,7 +30,7 @@ type ThresholdRowProp = {
   color: string;
   maxInputProps: NumberFieldProps;
   minInputProps: NumberFieldProps;
-  unitOptions: {label: string; value: string}[];
+  unitOptions: Array<{label: string; value: string}>;
   unitSelectProps: SelectFieldProps<any>;
   maxKey?: ThresholdMaxKeys;
   onThresholdChange?: (maxKey: ThresholdMaxKeys, value: string) => void;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/index.tsx
@@ -16,7 +16,7 @@ interface Props {
   onYAxisChange: (newFields: QueryFieldValue[], newSelectedAggregate?: number) => void;
   tags: TagCollection;
   widgetType: WidgetType;
-  queryErrors?: Record<string, any>[];
+  queryErrors?: Array<Record<string, any>>;
   selectedAggregate?: number;
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -16,7 +16,7 @@ function WidgetBuilderDatasetSelector() {
   const organization = useOrganization();
   const {state, dispatch} = useWidgetBuilderContext();
 
-  const datasetChoices: RadioOption<WidgetType>[] = [];
+  const datasetChoices: Array<RadioOption<WidgetType>> = [];
   datasetChoices.push([WidgetType.ERRORS, t('Errors')]);
   datasetChoices.push([WidgetType.TRANSACTIONS, t('Transactions')]);
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -64,7 +64,7 @@ const NONE_AGGREGATE = {
 
 function formatColumnOptions(
   dataset: WidgetType,
-  options: SelectValue<FieldValue>[],
+  options: Array<SelectValue<FieldValue>>,
   columnFilterMethod: (
     option: SelectValue<FieldValue>,
     field?: QueryFieldValue
@@ -146,7 +146,7 @@ function getColumnOptions(
 }
 
 function validateParameter(
-  columnOptions: SelectValue<string>[],
+  columnOptions: Array<SelectValue<string>>,
   parameter: AggregateParameter,
   value: string | undefined
 ) {

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
@@ -36,7 +36,7 @@ export const ISSUE_WIDGET_SORT_OPTIONS = [
   IssueSortOptions.USER,
 ];
 
-export function generateIssueWidgetOrderOptions(): SelectValue<string>[] {
+export function generateIssueWidgetOrderOptions(): Array<SelectValue<string>> {
   const sortOptions = [...ISSUE_WIDGET_SORT_OPTIONS];
   return sortOptions.map(sortOption => ({
     label: getSortLabel(sortOption),

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -119,9 +119,9 @@ export const generateOrderOptions = ({
   aggregates: string[];
   columns: string[];
   widgetType: WidgetType;
-}): SelectValue<string>[] => {
+}): Array<SelectValue<string>> => {
   const isRelease = widgetType === WidgetType.RELEASE;
-  const options: SelectValue<string>[] = [];
+  const options: Array<SelectValue<string>> = [];
   let equations = 0;
   (isRelease
     ? [...aggregates.map(stripDerivedMetricsPrefix), ...columns]

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -131,7 +131,10 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
     // Also don't count empty fields when checking for field changes
     const previousQueries = prevProps.widget.queries;
     const [prevWidgetQueryNames, prevWidgetQueries] = previousQueries.reduce(
-      ([names, queries]: [string[], Omit<WidgetQuery, 'name'>[]], {name, ...rest}) => {
+      (
+        [names, queries]: [string[], Array<Omit<WidgetQuery, 'name'>>],
+        {name, ...rest}
+      ) => {
         names.push(name);
         rest.fields = rest.fields?.filter(field => !!field) ?? [];
 
@@ -145,7 +148,10 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
 
     const nextQueries = widget.queries;
     const [widgetQueryNames, widgetQueries] = nextQueries.reduce(
-      ([names, queries]: [string[], Omit<WidgetQuery, 'name'>[]], {name, ...rest}) => {
+      (
+        [names, queries]: [string[], Array<Omit<WidgetQuery, 'name'>>],
+        {name, ...rest}
+      ) => {
         names.push(name);
         rest.fields = rest.fields?.filter(field => !!field) ?? [];
 

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -158,7 +158,7 @@ function WidgetQueries({
   }
 
   const isSeriesMetricsDataResults: boolean[] = [];
-  const isSeriesMetricsExtractedDataResults: (boolean | undefined)[] = [];
+  const isSeriesMetricsExtractedDataResults: Array<boolean | undefined> = [];
   const afterFetchSeriesData = (rawResults: SeriesResult) => {
     if (rawResults.data) {
       rawResults = rawResults as EventsStats;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/splitSeriesIntoCompleteAndIncomplete.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/splitSeriesIntoCompleteAndIncomplete.tsx
@@ -5,7 +5,7 @@ import type {TimeseriesData} from '../common/types';
 export function splitSeriesIntoCompleteAndIncomplete(
   serie: TimeseriesData,
   delay: number
-): (TimeseriesData | undefined)[] {
+): Array<TimeseriesData | undefined> {
   const penultimateDatum = serie.data.at(-2);
   const finalDatum = serie.data.at(-1);
 

--- a/static/app/views/discover/chartFooter.tsx
+++ b/static/app/views/discover/chartFooter.tsx
@@ -15,7 +15,7 @@ export const PROCESSED_BASELINE_TOGGLE_KEY = 'show-processed-baseline';
 
 type Props = {
   displayMode: string;
-  displayOptions: SelectValue<string>[];
+  displayOptions: Array<SelectValue<string>>;
   eventView: EventView;
   onAxisChange: (value: string[]) => void;
   onDisplayChange: (value: string) => void;
@@ -23,7 +23,7 @@ type Props = {
   onTopEventsChange: (value: string) => void;
   topEvents: string;
   total: number | null;
-  yAxisOptions: SelectValue<string>[];
+  yAxisOptions: Array<SelectValue<string>>;
   yAxisValue: string[];
 };
 
@@ -52,7 +52,7 @@ export default function ChartFooter({
       <SectionValue key="total-value">{total.toLocaleString()}</SectionValue>
     )
   );
-  const topEventOptions: SelectValue<string>[] = [];
+  const topEventOptions: Array<SelectValue<string>> = [];
   for (let i = 1; i <= 10; i++) {
     topEventOptions.push({value: i.toString(), label: i.toString()});
   }

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -28,7 +28,7 @@ import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
 import QueryList from './queryList';
 import {getPrebuiltQueries, setRenderPrebuilt, shouldRenderPrebuilt} from './utils';
 
-const SORT_OPTIONS: SelectValue<string>[] = [
+const SORT_OPTIONS: Array<SelectValue<string>> = [
   {label: t('My Queries'), value: 'myqueries'},
   {label: t('Recently Edited'), value: '-dateUpdated'},
   {label: t('Query Name (A-Z)'), value: 'name'},

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -21,7 +21,7 @@ jest.mock('sentry/actionCreators/modal');
 
 describe('Discover > QueryList', function () {
   let location: ReturnType<typeof LocationFixture>;
-  let savedQueries: ReturnType<typeof DiscoverSavedQueryFixture>[];
+  let savedQueries: Array<ReturnType<typeof DiscoverSavedQueryFixture>>;
   let organization: ReturnType<typeof OrganizationFixture>;
   let deleteMock: jest.Mock;
   let duplicateMock: jest.Mock;

--- a/static/app/views/discover/resultsChart.tsx
+++ b/static/app/views/discover/resultsChart.tsx
@@ -182,7 +182,7 @@ type ContainerProps = {
 };
 
 type ContainerState = {
-  yAxisOptions: SelectValue<string>[];
+  yAxisOptions: Array<SelectValue<string>>;
 };
 
 class ResultsChartContainer extends Component<ContainerProps, ContainerState> {

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -167,7 +167,7 @@ function ResultsSearchQueryBuilder(props: Props) {
   // with data when ready
   const getEventFieldValues = useCallback(
     async (tag: any, query: any): Promise<string[]> => {
-      const projectIdStrings = (projectIds as Readonly<number>[])?.map(String);
+      const projectIdStrings = (projectIds as Array<Readonly<number>>)?.map(String);
 
       if (isAggregateField(tag.key) || isMeasurement(tag.key)) {
         // We can't really auto suggest values for aggregate fields

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -53,7 +53,7 @@ export type ParameterDescription =
   | {
       dataType: string;
       kind: 'dropdown';
-      options: SelectValue<string>[];
+      options: Array<SelectValue<string>>;
       required: boolean;
       value: string;
       placeholder?: string;

--- a/static/app/views/discover/table/types.tsx
+++ b/static/app/views/discover/table/types.tsx
@@ -24,8 +24,8 @@ export type TableColumn<K> = GridColumnOrder<K> & {
 export type TableColumnSort<K> = GridColumnSortBy<K>;
 
 export type TableState = {
-  columnOrder: TableColumn<keyof TableDataRow>[];
-  columnSortBy: TableColumnSort<keyof TableDataRow>[];
+  columnOrder: Array<TableColumn<keyof TableDataRow>>;
+  columnSortBy: Array<TableColumnSort<keyof TableDataRow>>;
 };
 
 export enum FieldValueKind {

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -84,7 +84,7 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<string> = {
   width: COL_WIDTH_UNDEFINED,
 };
 
-export function decodeColumnOrder(fields: readonly Field[]): TableColumn<string>[] {
+export function decodeColumnOrder(fields: readonly Field[]): Array<TableColumn<string>> {
   return fields.map((f: Field) => {
     const column: TableColumn<string> = {...TEMPLATE_TABLE_COLUMN};
 
@@ -280,7 +280,7 @@ export function getExpandedResults(
   const fieldSet = new Set();
   // Expand any functions in the resulting column, and dedupe the result.
   // Mark any column as null to remove it.
-  const expandedColumns: (Column | null)[] = eventView.fields.map((field: Field) => {
+  const expandedColumns: Array<Column | null> = eventView.fields.map((field: Field) => {
     const exploded = explodeFieldString(field.field, field.alias);
     const column = exploded.kind === 'function' ? drilldownAggregate(exploded) : exploded;
 
@@ -490,7 +490,7 @@ function generateExpandedConditions(
 type FieldGeneratorOpts = {
   organization: OrganizationSummary;
   aggregations?: Record<string, Aggregation>;
-  customMeasurements?: {functions: string[]; key: string}[] | null;
+  customMeasurements?: Array<{functions: string[]; key: string}> | null;
   fieldKeys?: string[];
   measurementKeys?: string[] | null;
   spanOperationBreakdownKeys?: string[];

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -80,7 +80,7 @@ export function ExploreCharts({
   const previousTimeseriesResult = usePrevious(timeseriesResult);
 
   const getSeries = useCallback(
-    (dedupedYAxes: string[], formattedYAxes: (string | undefined)[]) => {
+    (dedupedYAxes: string[], formattedYAxes: Array<string | undefined>) => {
       const shouldUsePreviousResults =
         timeseriesResult.isPending &&
         canUsePreviousResults &&

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -68,7 +68,7 @@ export function useTableStyles(
       : options?.prefixColumnWidth;
 
   const resizingColumnIndex = useRef<number | null>(null);
-  const columnWidthsRef = useRef<(number | null)[]>(fields.map(() => null));
+  const columnWidthsRef = useRef<Array<number | null>>(fields.map(() => null));
 
   useEffect(() => {
     columnWidthsRef.current = fields.map(

--- a/static/app/views/explore/hooks/useChartInterval.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.tsx
@@ -27,7 +27,7 @@ interface Options {
 export function useChartInterval(): [
   string,
   (interval: string) => void,
-  intervalOptions: {label: string; value: string}[],
+  intervalOptions: Array<{label: string; value: string}>,
 ] {
   const location = useLocation();
   const navigate = useNavigate();
@@ -44,7 +44,7 @@ function useChartIntervalImpl({
 }: Options): [
   string,
   (interval: string) => void,
-  intervalOptions: {label: string; value: string}[],
+  intervalOptions: Array<{label: string; value: string}>,
 ] {
   const {datetime} = pagefilters.selection;
   const intervalOptions = useMemo(

--- a/static/app/views/explore/hooks/useTraceSpans.tsx
+++ b/static/app/views/explore/hooks/useTraceSpans.tsx
@@ -10,7 +10,7 @@ import type {TraceResult} from './useTraces';
 export type SpanResult<F extends string> = Record<F, any>;
 
 export interface SpanResults<F extends string> {
-  data: SpanResult<F>[];
+  data: Array<SpanResult<F>>;
   meta: any;
 }
 

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -128,7 +128,7 @@ describe('ColumnEditorModal', function () {
       expect(column).toHaveTextContent(columns2[i]!);
     });
 
-    const options: [string, 'string' | 'number'][] = [
+    const options: Array<[string, 'string' | 'number']> = [
       ['id', 'string'],
       ['project', 'string'],
       ['span.duration', 'number'],
@@ -176,7 +176,7 @@ describe('ColumnEditorModal', function () {
       expect(column).toHaveTextContent(columns1[i]!);
     });
 
-    const options: [string, 'string' | 'number'][] = [
+    const options: Array<[string, 'string' | 'number']> = [
       ['id', 'string'],
       ['project', 'string'],
       ['span.duration', 'number'],

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -40,7 +40,7 @@ export function ColumnEditorModal({
   numberTags,
   stringTags,
 }: ColumnEditorModalProps) {
-  const tags: SelectOption<string>[] = useMemo(() => {
+  const tags: Array<SelectOption<string>> = useMemo(() => {
     const allTags = [
       ...columns
         .filter(
@@ -149,7 +149,7 @@ interface ColumnEditorRowProps {
   column: Column;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
-  options: SelectOption<string>[];
+  options: Array<SelectOption<string>>;
 }
 
 function ColumnEditorRow({

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -42,7 +42,7 @@ export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
   const groupBys = useExploreGroupBys();
   const setGroupBys = useSetExploreGroupBys();
 
-  const options: SelectOption<string>[] = useMemo(() => {
+  const options: Array<SelectOption<string>> = useMemo(() => {
     const potentialOptions = [
       ...Object.keys(tags),
 
@@ -137,7 +137,7 @@ interface ColumnEditorRowProps {
   column: Column;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
-  options: SelectOption<string>[];
+  options: Array<SelectOption<string>>;
   disabled?: boolean;
 }
 

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -45,7 +45,7 @@ export function ToolbarSortBy({
   const numberTags = useSpanTags('number');
   const stringTags = useSpanTags('string');
 
-  const fieldOptions: SelectOption<string>[] = useMemo(() => {
+  const fieldOptions: Array<SelectOption<string>> = useMemo(() => {
     const uniqueOptions: string[] = [];
     if (mode === Mode.SAMPLES) {
       for (const field of fields) {
@@ -126,7 +126,7 @@ export function ToolbarSortBy({
     [setSorts, sorts]
   );
 
-  const kindOptions: SelectOption<Sort['kind']>[] = useMemo(() => {
+  const kindOptions: Array<SelectOption<Sort['kind']>> = useMemo(() => {
     return [
       {
         label: 'Desc',

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -60,7 +60,7 @@ export function ToolbarVisualize() {
     );
   }, [visualizes]);
 
-  const fieldOptions: SelectOption<string>[] = useMemo(() => {
+  const fieldOptions: Array<SelectOption<string>> = useMemo(() => {
     const unknownOptions = parsedVisualizeGroups
       .flatMap(group =>
         group.flatMap(entry => {
@@ -101,7 +101,7 @@ export function ToolbarVisualize() {
     return options;
   }, [numberTags, parsedVisualizeGroups]);
 
-  const aggregateOptions: SelectOption<string>[] = useMemo(() => {
+  const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
     return ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.map(aggregate => {
       return {
         label: aggregate,

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -28,7 +28,7 @@ export function getExploreUrl({
   interval: string;
   orgSlug: string;
   selection: PageFilters;
-  visualize: Omit<Visualize, 'label'>[];
+  visualize: Array<Omit<Visualize, 'label'>>;
   field?: string[];
   groupBy?: string[];
   mode?: Mode;
@@ -132,7 +132,7 @@ export function limitMaxPickableDays(organization: Organization): {
     30: '30d',
   };
 
-  const relativeOptions: [DefaultPeriod, React.ReactNode][] = [
+  const relativeOptions: Array<[DefaultPeriod, React.ReactNode]> = [
     ['7d', t('Last 7 days')],
     ['14d', t('Last 14 days')],
     ['30d', t('Last 30 days')],

--- a/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
@@ -65,7 +65,7 @@ function ResourceSummaryTable() {
     renderBlockingStatus: filters[RESOURCE_RENDER_BLOCKING_STATUS],
   });
 
-  const columnOrder: GridColumnOrder<keyof Row>[] = [
+  const columnOrder: Array<GridColumnOrder<keyof Row>> = [
     {key: 'transaction', width: COL_WIDTH_UNDEFINED, name: 'Found on page'},
     {
       key: 'spm()',

--- a/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
@@ -91,7 +91,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
     referrer: 'api.performance.browser.resources.main-table',
   });
 
-  const columnOrder: GridColumnOrder<keyof Row>[] = [
+  const columnOrder: Array<GridColumnOrder<keyof Row>> = [
     {
       key: SPAN_DESCRIPTION,
       width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
+++ b/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
@@ -88,7 +88,7 @@ export default function BrowserTypeSelector() {
       triggerLabel={value.length === 0 ? 'All' : undefined}
       menuTitle={'Filter Browsers'}
       options={browserOptions ?? []}
-      onChange={(selectedOptions: SelectOption<string>[]) => {
+      onChange={(selectedOptions: Array<SelectOption<string>>) => {
         trackAnalytics('insight.vital.select_browser_value', {
           organization,
           browsers: selectedOptions.map(v => v.value),

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
@@ -12,7 +12,12 @@ type Props = React.HTMLAttributes<SVGSVGElement> & {
   backgroundColors: readonly string[];
   segmentColors: readonly string[];
   text: React.ReactNode;
-  values: {key: string; maxValue: number; value: number; onHoverActions?: () => void}[];
+  values: Array<{
+    key: string;
+    maxValue: number;
+    value: number;
+    onHoverActions?: () => void;
+  }>;
   /**
    * The width of the progress ring bar
    */

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -40,7 +40,7 @@ import {
 
 type Column = GridColumnHeader<keyof RowWithScoreAndOpportunity>;
 
-const COLUMN_ORDER: GridColumnOrder<keyof RowWithScoreAndOpportunity>[] = [
+const COLUMN_ORDER: Array<GridColumnOrder<keyof RowWithScoreAndOpportunity>> = [
   {key: 'transaction', width: COL_WIDTH_UNDEFINED, name: 'Pages'},
   {key: 'project', width: COL_WIDTH_UNDEFINED, name: 'Project'},
   {key: 'count()', width: COL_WIDTH_UNDEFINED, name: 'Pageloads'},

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -60,7 +60,9 @@ import {generateReplayLink} from 'sentry/views/performance/transactionSummary/ut
 type Column = GridColumnHeader<keyof TransactionSampleRowWithScore>;
 type InteractionsColumn = GridColumnHeader<keyof InteractionSpanSampleRowWithScore>;
 
-const PAGELOADS_COLUMN_ORDER: GridColumnOrder<keyof TransactionSampleRowWithScore>[] = [
+const PAGELOADS_COLUMN_ORDER: Array<
+  GridColumnOrder<keyof TransactionSampleRowWithScore>
+> = [
   {key: 'id', width: COL_WIDTH_UNDEFINED, name: t('Event ID')},
   {key: 'user.display', width: COL_WIDTH_UNDEFINED, name: t('User')},
   {key: 'measurements.lcp', width: COL_WIDTH_UNDEFINED, name: 'LCP'},
@@ -72,9 +74,9 @@ const PAGELOADS_COLUMN_ORDER: GridColumnOrder<keyof TransactionSampleRowWithScor
   {key: 'totalScore', width: COL_WIDTH_UNDEFINED, name: t('Score')},
 ];
 
-const INTERACTION_SAMPLES_COLUMN_ORDER: GridColumnOrder<
-  keyof InteractionSpanSampleRowWithScore
->[] = [
+const INTERACTION_SAMPLES_COLUMN_ORDER: Array<
+  GridColumnOrder<keyof InteractionSpanSampleRowWithScore>
+> = [
   {
     key: SpanIndexedField.SPAN_DESCRIPTION,
     width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -110,7 +110,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
 
   // @ts-ignore TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   result?.data?.['p75(measurements.lcp)']?.data.forEach((interval: any, index: any) => {
-    const map: {key: string; series: SeriesDataUnit[]}[] = [
+    const map: Array<{key: string; series: SeriesDataUnit[]}> = [
       {key: 'p75(measurements.cls)', series: data.cls},
       {key: 'p75(measurements.lcp)', series: data.lcp},
       {key: 'p75(measurements.fcp)', series: data.fcp},

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -108,7 +108,7 @@ type Props = {
   scatterPlot?: Series[];
   showLegend?: boolean;
   stacked?: boolean;
-  throughput?: {count: number; interval: string}[];
+  throughput?: Array<{count: number; interval: string}>;
   tooltipFormatterOptions?: FormatterOptions;
 };
 

--- a/static/app/views/insights/common/components/releaseSelector.tsx
+++ b/static/app/views/insights/common/components/releaseSelector.tsx
@@ -51,7 +51,7 @@ export function ReleaseSelector({
   const navigate = useNavigate();
   const location = useLocation();
 
-  const options: (SelectOption<string> & {count?: number})[] = [];
+  const options: Array<SelectOption<string> & {count?: number}> = [];
   if (defined(selectorValue)) {
     const index = data?.findIndex(({version}) => version === selectorValue);
     const selectedRelease = defined(index) ? data?.[index] : undefined;

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -71,7 +71,7 @@ export const useMetrics = <Fields extends MetricsProperty[]>(
   );
 };
 
-const useDiscover = <T extends Extract<keyof ResponseType, string>[], ResponseType>(
+const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, ResponseType>(
   options: UseMetricsOptions<T> = {},
   dataset: DiscoverDatasets,
   referrer: string
@@ -107,7 +107,7 @@ const useDiscover = <T extends Extract<keyof ResponseType, string>[], ResponseTy
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data
-  const data = (result?.data ?? []) as Pick<ResponseType, T[number]>[];
+  const data = (result?.data ?? []) as Array<Pick<ResponseType, T[number]>>;
 
   return {
     ...result,

--- a/static/app/views/insights/common/queries/useReleases.tsx
+++ b/static/app/views/insights/common/queries/useReleases.tsx
@@ -95,11 +95,11 @@ export function useReleases(
     );
   }
 
-  const releaseStats: {
+  const releaseStats: Array<{
     dateCreated: string;
     version: string;
     count?: number;
-  }[] =
+  }> =
     releaseResults.data?.length && metricsFetched
       ? releaseResults.data.flatMap(release => {
           const releaseVersion = release.version;

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -155,8 +155,8 @@ export function transformToSeriesMap(
   // Multiple series, applies to multi axis or topN events queries
   const hasMultipleYAxes = yAxis.length > 1;
   if (isMultiSeriesEventsStats(result)) {
-    const processedResults: [number, Series][] = Object.keys(result).map(seriesName =>
-      processSingleEventStats(seriesName, result[seriesName]!)
+    const processedResults: Array<[number, Series]> = Object.keys(result).map(
+      seriesName => processSingleEventStats(seriesName, result[seriesName]!)
     );
 
     if (!hasMultipleYAxes) {
@@ -179,7 +179,7 @@ export function transformToSeriesMap(
   // Grouped multi series, applies to topN events queries with multiple y-axes
   // First, we process the grouped multi series into a list of [seriesName, order, {[aggFunctionAlias]: EventsStats}]
   // to enable sorting.
-  const processedResults: [string, number, MultiSeriesEventsStats][] = [];
+  const processedResults: Array<[string, number, MultiSeriesEventsStats]> = [];
   Object.keys(result).forEach(seriesName => {
     const {order: groupOrder, ...groupData} = result[seriesName]!;
     processedResults.push([seriesName, groupOrder || 0, groupData]);

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries.tsx
@@ -10,7 +10,7 @@ import type {SpanIndexedResponse} from 'sentry/views/insights/types';
 
 /** Given an array of indexed spans, create a `Series` for each one, and set the correct styling based on how it compares to the average value. This is a hack, in which our `Chart` component doesn't work otherwise. The right solution would be to create a single series of `type: "scatter"` but that doesn' work with the current implementation */
 export function useSampleScatterPlotSeries(
-  spans: Partial<SpanIndexedResponse>[],
+  spans: Array<Partial<SpanIndexedResponse>>,
   average?: number,
   highlightedSpanId?: string,
   key: string = 'span.self_time'

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -43,7 +43,7 @@ export function ActionSelector({value = '', moduleName, spanCategory, filters}: 
 
   const useHTTPActions = moduleName === ModuleName.HTTP;
 
-  const {data: actions} = useSpansQuery<{'span.action': string}[]>({
+  const {data: actions} = useSpansQuery<Array<{'span.action': string}>>({
     eventView,
     initialData: [],
     enabled: !useHTTPActions,

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -126,7 +126,7 @@ export function DomainSelector({
     textValue: t('(No %s)', domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName]),
   };
 
-  const options: SelectOption<string>[] = [
+  const options: Array<SelectOption<string>> = [
     {value: '', label: 'All'},
     ...(emptyOptionLocation === 'top' ? [emptyOption] : []),
     ...domainOptions,

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -77,7 +77,7 @@ export default function SubregionSelector({size}: Props) {
         </MenuTitleContainer>
       }
       options={options}
-      onChange={(selectedOptions: SelectOption<string>[]) => {
+      onChange={(selectedOptions: Array<SelectOption<string>>) => {
         trackAnalytics('insight.general.select_region_value', {
           organization,
           // @ts-ignore TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -24,7 +24,7 @@ export function useSystemSelectorOptions() {
     'api.starfish.database-system-selector'
   );
 
-  const options: SelectOption<string>[] = [];
+  const options: Array<SelectOption<string>> = [];
   data.forEach(entry => {
     const system = entry['span.system'];
     if (system) {

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -49,17 +49,19 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
 
   const result = useApiQuery<{
     data:
-      | Pick<
-          SpanIndexedResponse,
-          | Fields[number]
-          // These fields are returned by default
-          | SpanIndexedField.PROJECT
-          | SpanIndexedField.TRANSACTION_ID
-          | SpanIndexedField.TIMESTAMP
-          | SpanIndexedField.ID
-          | SpanIndexedField.PROFILE_ID
-          | SpanIndexedField.SPAN_SELF_TIME
-        >[]
+      | Array<
+          Pick<
+            SpanIndexedResponse,
+            | Fields[number]
+            // These fields are returned by default
+            | SpanIndexedField.PROJECT
+            | SpanIndexedField.TRANSACTION_ID
+            | SpanIndexedField.TIMESTAMP
+            | SpanIndexedField.ID
+            | SpanIndexedField.PROFILE_ID
+            | SpanIndexedField.SPAN_SELF_TIME
+          >
+        >
       // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data
       // eslint-disable-next-line @typescript-eslint/no-restricted-types
       | [];

--- a/static/app/views/insights/mobile/common/components/tables/screensTable.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/screensTable.tsx
@@ -27,7 +27,7 @@ type Props = {
   columnOrder: string[];
   columnTooltipMap: Record<string, string> | undefined;
   data: TableData | undefined;
-  defaultSort: GridColumnSortBy<string>[];
+  defaultSort: Array<GridColumnSortBy<string>>;
   eventView: EventView;
   isLoading: boolean;
   pageLinks: string | undefined;

--- a/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
@@ -49,7 +49,7 @@ export function ScreensBarChart({
   const yAxis = decodeScalar(location.query[chartKey]);
   const selectedDisplay = yAxis ? chartOptions.findIndex(o => o.yAxis === yAxis) : 0;
 
-  const menuOptions: SelectOption<string>[] = [];
+  const menuOptions: Array<SelectOption<string>> = [];
 
   for (const option of chartOptions) {
     menuOptions.push({

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -360,7 +360,7 @@ function ProducerMetricsRibbon({
   isLoading,
 }: {
   isLoading: boolean;
-  metrics: Partial<SpanMetricsResponse>[];
+  metrics: Array<Partial<SpanMetricsResponse>>;
 }) {
   const errorRate = 1 - (metrics[0]?.['trace_status_rate(ok)'] ?? 0);
   return (
@@ -386,7 +386,7 @@ function ConsumerMetricsRibbon({
   isLoading,
 }: {
   isLoading: boolean;
-  metrics: Partial<SpanMetricsResponse>[];
+  metrics: Array<Partial<SpanMetricsResponse>>;
 }) {
   const errorRate = 1 - (metrics[0]?.['trace_status_rate(ok)'] ?? 0);
   return (

--- a/static/app/views/integrationPipeline/components/footerWithButtons.tsx
+++ b/static/app/views/integrationPipeline/components/footerWithButtons.tsx
@@ -7,7 +7,7 @@ import {space} from 'sentry/styles/space';
 interface FooterWithButtonsProps {
   buttonText: string;
   disabled?: boolean;
-  formFields?: {name: string; value: any}[];
+  formFields?: Array<{name: string; value: any}>;
   formProps?: React.FormHTMLAttributes<HTMLFormElement>;
   href?: string;
   onClick?: ButtonProps['onClick'];

--- a/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
@@ -49,7 +49,9 @@ interface GroupEventAttachmentsQuery {
   screenshot?: '1';
   start?: DateString;
   statsPeriod?: string;
-  types?: `${GroupEventAttachmentsTypeFilter}` | `${GroupEventAttachmentsTypeFilter}`[];
+  types?:
+    | `${GroupEventAttachmentsTypeFilter}`
+    | Array<`${GroupEventAttachmentsTypeFilter}`>;
 }
 
 export const makeFetchGroupEventAttachmentsQueryKey = ({

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -34,8 +34,8 @@ type Props = {
   };
   score?: Record<string, any>;
   scoresByInterface?: {
-    exception: [string, number | null][];
-    message: [string, any | null][];
+    exception: Array<[string, number | null]>;
+    message: Array<[string, any | null]>;
   };
 };
 

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -17,7 +17,7 @@ type Props = {
   hasSimilarityEmbeddingsFeature: boolean;
   onMerge: () => void;
   groupId?: string;
-  itemsWouldGroup?: {id: string; shouldBeGrouped: string | undefined}[] | undefined;
+  itemsWouldGroup?: Array<{id: string; shouldBeGrouped: string | undefined}> | undefined;
   organization?: Organization;
   project?: Project;
 };

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -30,12 +30,12 @@ import {
 
 type SimpleTag = {
   key: string;
-  topValues: {
+  topValues: Array<{
     count: number;
     name: string;
     value: string;
     query?: string;
-  }[];
+  }>;
   totalValues: number;
 };
 

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -10,7 +10,7 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 export interface GroupTag {
   key: string;
   name: string;
-  topValues: {
+  topValues: Array<{
     count: number;
     firstSeen: string;
     lastSeen: string;
@@ -26,7 +26,7 @@ export interface GroupTag {
      * @deprecated - Use the frontend to get readable device names
      */
     readable?: string;
-  }[];
+  }>;
   totalValues: number;
 }
 

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -108,7 +108,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     });
 
   const {data: uniqueUsersCount, isPending: isPendingUniqueUsersCount} = useApiQuery<{
-    data: {count_unique: number}[];
+    data: Array<{count_unique: number}>;
   }>(
     [
       `/organizations/${organization.slug}/events/`,

--- a/static/app/views/issueDetails/traceTimeline/utils.tsx
+++ b/static/app/views/issueDetails/traceTimeline/utils.tsx
@@ -9,7 +9,7 @@ export function getEventsByColumn(
   durationMs: number,
   totalColumns: number,
   start: number
-): [column: number, events: TimelineEvent[]][] {
+): Array<[column: number, events: TimelineEvent[]]> {
   const eventsByColumn = events.reduce((map, event) => {
     const columnPositionCalc =
       Math.floor((getEventTimestamp(start, event) / durationMs) * (totalColumns - 1)) + 1;

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -375,7 +375,7 @@ function IssueViewsIssueListHeaderTabsContent({
 
   return (
     <DraggableTabList
-      onReorder={(newOrder: Node<DraggableTabListItemProps>[]) =>
+      onReorder={(newOrder: Array<Node<DraggableTabListItemProps>>) =>
         dispatch({
           type: 'REORDER_TABS',
           newKeyOrder: newOrder.map(node => node.key.toString()),

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -51,7 +51,7 @@ type OverviewTab = {
  * Get a list of currently active tabs
  */
 export function getTabs() {
-  const tabs: [string, OverviewTab][] = [
+  const tabs: Array<[string, OverviewTab]> = [
     [
       Query.PRIORITIZED,
       {

--- a/static/app/views/metrics/codeLocations.tsx
+++ b/static/app/views/metrics/codeLocations.tsx
@@ -174,12 +174,12 @@ type CodeLocationContextProps = {
 function CodeLocationContext({codeLocation, isLast}: CodeLocationContextProps) {
   const lineNo = codeLocation.lineNo ?? 0;
 
-  const preContextLines: [number, string][] = useMemo(
+  const preContextLines: Array<[number, string]> = useMemo(
     () => codeLocation.preContext?.map((line, index) => [lineNo - 5 + index, line]) ?? [],
     [codeLocation.preContext, lineNo]
   );
 
-  const postContextLines: [number, string][] = useMemo(
+  const postContextLines: Array<[number, string]> = useMemo(
     () => codeLocation.postContext?.map((line, index) => [lineNo + index, line]) ?? [],
     [codeLocation.postContext, lineNo]
   );

--- a/static/app/views/metrics/ddmOnboarding/sidebar.tsx
+++ b/static/app/views/metrics/ddmOnboarding/sidebar.tsx
@@ -46,7 +46,7 @@ function MetricsOnboardingSidebar(props: CommonSidebarProps) {
   });
 
   const projectSelectOptions = useMemo(() => {
-    const supportedProjectItems: SelectValue<string>[] = supportedProjects
+    const supportedProjectItems: Array<SelectValue<string>> = supportedProjects
       .sort((aProject, bProject) => {
         // if we're comparing two projects w/ or w/o custom metrics alphabetical sort
         if (aProject.hasCustomMetrics === bProject.hasCustomMetrics) {
@@ -65,7 +65,7 @@ function MetricsOnboardingSidebar(props: CommonSidebarProps) {
         };
       });
 
-    const unsupportedProjectItems: SelectValue<string>[] = unsupportedProjects.map(
+    const unsupportedProjectItems: Array<SelectValue<string>> = unsupportedProjects.map(
       project => {
         return {
           value: project.id,

--- a/static/app/views/metrics/utils/index.tsx
+++ b/static/app/views/metrics/utils/index.tsx
@@ -19,7 +19,7 @@ import {addToFilter, excludeFromFilter} from '../../discover/table/cellAction';
  */
 export function extendQueryWithGroupBys(
   query: string,
-  groupBys: (Record<string, string> | undefined)[]
+  groupBys: Array<Record<string, string> | undefined>
 ) {
   const mutableSearch = new MutableSearch(query);
 

--- a/static/app/views/metrics/utils/metricsChartPalette.spec.tsx
+++ b/static/app/views/metrics/utils/metricsChartPalette.spec.tsx
@@ -2,7 +2,7 @@ import {getCachedChartPalette} from 'sentry/views/metrics/utils/metricsChartPale
 
 describe('getQuerySymbol', () => {
   it('should cache palettes', () => {
-    const cache: Record<string, string>[] = [];
+    const cache: Array<Record<string, string>> = [];
 
     const abcPalette = getCachedChartPalette(cache, ['a', 'b', 'c']);
     expect(cache).toHaveLength(1);
@@ -20,7 +20,7 @@ describe('getQuerySymbol', () => {
   });
 
   it('should not cache single series palettes', () => {
-    const cache: Record<string, string>[] = [];
+    const cache: Array<Record<string, string>> = [];
 
     const aPalette = getCachedChartPalette(cache, ['a']);
     expect(cache).toHaveLength(0);
@@ -32,7 +32,7 @@ describe('getQuerySymbol', () => {
   });
 
   it('should not cache more than CACHE_SIZE (20) palettes', () => {
-    const cache: Record<string, string>[] = Array.from({length: 20}).map(() => ({
+    const cache: Array<Record<string, string>> = Array.from({length: 20}).map(() => ({
       z: '#123123',
     }));
 
@@ -41,7 +41,7 @@ describe('getQuerySymbol', () => {
     expect(cache).toHaveLength(20);
 
     // Ensure it removes more than 1 cache entry
-    const cache2: Record<string, string>[] = Array.from({length: 100}).map(() => ({
+    const cache2: Array<Record<string, string>> = Array.from({length: 100}).map(() => ({
       z: '#123123',
     }));
 

--- a/static/app/views/metrics/utils/metricsChartPalette.tsx
+++ b/static/app/views/metrics/utils/metricsChartPalette.tsx
@@ -35,7 +35,7 @@ export function createChartPalette(seriesNames: string[]): Record<string, string
  * @returns an object mapping seriesNames to colors
  */
 export function getCachedChartPalette(
-  cache: Readonly<Record<string, string>>[],
+  cache: Array<Readonly<Record<string, string>>>,
   seriesNames: string[]
 ): Readonly<Record<string, string>> {
   // Check if we already have a palette that includes all of the given seriesNames
@@ -82,7 +82,7 @@ export function getCachedChartPalette(
  * **NOTE: Not yet optimized for performance, it should only be used for the metrics page with a limited amount of series**
  */
 export const useGetCachedChartPalette = () => {
-  const cacheRef = useRef<Readonly<Record<string, string>>[]>([]);
+  const cacheRef = useRef<Array<Readonly<Record<string, string>>>>([]);
   return useCallback((seriesNames: string[]) => {
     // copy the cache to avoid mutating it
     return {...getCachedChartPalette(cacheRef.current, seriesNames)};

--- a/static/app/views/metrics/utils/useMetricsIntervalParam.tsx
+++ b/static/app/views/metrics/utils/useMetricsIntervalParam.tsx
@@ -79,7 +79,7 @@ export function getIntervalOptionsForStatsPeriod(
 
 export function validateInterval(
   interval: string,
-  options: {label: string; value: string; disabled?: boolean}[]
+  options: Array<{label: string; value: string; disabled?: boolean}>
 ) {
   const isPeriod = !!parseStatsPeriod(interval);
   const enabledOptions = options.filter(option => !option.disabled);

--- a/static/app/views/metrics/widget.tsx
+++ b/static/app/views/metrics/widget.tsx
@@ -167,7 +167,9 @@ export const MetricWidget = memo(
       onChange(index, {displayType: value});
     };
 
-    const handleOverlayChange = (options: SelectOption<MetricChartOverlayType>[]) => {
+    const handleOverlayChange = (
+      options: Array<SelectOption<MetricChartOverlayType>>
+    ) => {
       const values = options.map(({value}) => value);
 
       Sentry.metrics.increment('ddm.widget.overlay', 1, {

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -38,7 +38,7 @@ import {ScheduleType} from '../types';
 
 import {platformsWithGuides} from './monitorQuickStartGuide';
 
-const SCHEDULE_OPTIONS: SelectValue<string>[] = [
+const SCHEDULE_OPTIONS: Array<SelectValue<string>> = [
   {value: ScheduleType.CRONTAB, label: t('Crontab')},
   {value: ScheduleType.INTERVAL, label: t('Interval')},
 ];

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -123,10 +123,10 @@ export interface Monitor {
   slug: string;
   status: ObjectStatus;
   alertRule?: {
-    targets: {
+    targets: Array<{
       targetIdentifier: number;
       targetType: 'Member' | 'Team';
-    }[];
+    }>;
     environment?: string;
   };
 }
@@ -173,7 +173,7 @@ export interface CheckIn {
   /**
    * Groups associated to this check-in (determiend by traceId)
    */
-  groups?: {id: number; shortId: string}[];
+  groups?: Array<{id: number; shortId: string}>;
 }
 
 type StatsBucket = {

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -89,7 +89,7 @@ export const tickStyle: Record<CheckInStatus, TickStyle> = {
   },
 };
 
-export const getScheduleIntervals = (n: number): SelectValue<string>[] => [
+export const getScheduleIntervals = (n: number): Array<SelectValue<string>> => [
   {value: 'minute', label: tn('minute', 'minutes', n)},
   {value: 'hour', label: tn('hour', 'hours', n)},
   {value: 'day', label: tn('day', 'days', n)},

--- a/static/app/views/monitors/utils/selectCheckInData.tsx
+++ b/static/app/views/monitors/utils/selectCheckInData.tsx
@@ -5,7 +5,7 @@ import type {CheckInStatus, MonitorBucket} from '../types';
 export function selectCheckInData(
   stats: MonitorBucket[],
   env: string
-): CheckInBucket<CheckInStatus>[] {
+): Array<CheckInBucket<CheckInStatus>> {
   return stats.map(([ts, envs]) => [
     ts,
     envs[env] ?? {in_progress: 0, ok: 0, error: 0, missed: 0, timeout: 0, unknown: 0},

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -93,7 +93,7 @@ export enum ChartDataTransform {
   PERIODIC = 'periodic',
 }
 
-export const CHART_OPTIONS_DATA_TRANSFORM: SelectValue<ChartDataTransform>[] = [
+export const CHART_OPTIONS_DATA_TRANSFORM: Array<SelectValue<ChartDataTransform>> = [
   {
     label: t('Cumulative'),
     value: ChartDataTransform.CUMULATIVE,

--- a/static/app/views/performance/landing/samplingModal.tsx
+++ b/static/app/views/performance/landing/samplingModal.tsx
@@ -27,7 +27,7 @@ function SamplingModal(props: Props) {
 
   const project = projects.find(p => `${eventView.project[0]}` === p.id);
 
-  const choices: [string, ReactNode][] = [
+  const choices: Array<[string, ReactNode]> = [
     ['true', t('Automatically switch to sampled data when required')],
     ['false', t('Always show sampled data')],
   ];

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -396,7 +396,7 @@ export function VitalBar(props: VitalBarProps) {
   const vitals = toArray(vital);
   vitals.forEach(vitalName => {
     const c = data?.[vitalName] ?? {};
-    (Object.keys(counts) as (keyof typeof counts)[]).forEach(
+    (Object.keys(counts) as Array<keyof typeof counts>).forEach(
       countKey => (counts[countKey] += (c as any)[countKey])
     );
   });

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -228,7 +228,7 @@ export function WidgetInteractiveTitle({
 }) {
   const navigate = useNavigate();
   const organization = useOrganization();
-  const menuOptions: SelectOption<string>[] = [];
+  const menuOptions: Array<SelectOption<string>> = [];
 
   const settingsMap = WIDGET_DEFINITIONS({organization});
   for (const setting of allowedCharts) {
@@ -293,7 +293,7 @@ export function WidgetContainerActions({
 }) {
   const navigate = useNavigate();
   const organization = useOrganization();
-  const menuOptions: SelectOption<PerformanceWidgetSetting>[] = [];
+  const menuOptions: Array<SelectOption<PerformanceWidgetSetting>> = [];
 
   const settingsMap = WIDGET_DEFINITIONS({organization});
   for (const setting of allowedCharts) {

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -116,7 +116,7 @@ type Visualization<T> = {
   queryFields?: string[]; // Used to determine placeholder and loading sizes. Will also be passed to the component.
 };
 
-type Visualizations<T extends WidgetDataConstraint> = readonly Visualization<T>[]; // Readonly because of index being used for React key.
+type Visualizations<T extends WidgetDataConstraint> = ReadonlyArray<Visualization<T>>; // Readonly because of index being used for React key.
 
 type HeaderActions<T> = React.ComponentType<{
   widgetData: T;
@@ -177,7 +177,7 @@ export type QueryDefinitionWithKey<T extends WidgetDataConstraint> = QueryDefini
 export type QueryHandlerProps<T extends WidgetDataConstraint> = {
   api: Client;
   eventView: EventView;
-  queries: QueryDefinitionWithKey<T>[];
+  queries: Array<QueryDefinitionWithKey<T>>;
   queryProps: WidgetPropUnion<T>;
   children?: React.ReactNode;
 } & WidgetDataProps<T>;

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -207,7 +207,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
     const index = node ? props.tree.list.indexOf(node) : -1;
 
     if (node) {
-      const preserveNodes: TraceTreeNode<TraceTree.NodeValue>[] = [node];
+      const preserveNodes: Array<TraceTreeNode<TraceTree.NodeValue>> = [node];
 
       let start = index;
       while (--start > 0) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -102,7 +102,7 @@ function SpanChildrenTraversalButton({
   organization: Organization;
 }) {
   const childTransactions = useMemo(() => {
-    const transactions: TraceTreeNode<TraceTree.Transaction>[] = [];
+    const transactions: Array<TraceTreeNode<TraceTree.Transaction>> = [];
     TraceTree.ForEachChild(node, c => {
       if (isTransactionNode(c)) {
         transactions.push(c);
@@ -170,7 +170,7 @@ export function useSpanAncestryAndGroupingItems({
   const hasTraceNewUi = useHasTraceNewUi();
   const parentTransaction = useMemo(() => TraceTree.ParentTransaction(node), [node]);
   const childTransactions = useMemo(() => {
-    const transactions: TraceTreeNode<TraceTree.Transaction>[] = [];
+    const transactions: Array<TraceTreeNode<TraceTree.Transaction>> = [];
     TraceTree.ForEachChild(node, c => {
       if (isTransactionNode(c)) {
         transactions.push(c);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -268,7 +268,9 @@ export function TransactionNodeDetails({
 }
 
 type TransactionSpecificSectionsProps = {
-  cacheMetrics: Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>[];
+  cacheMetrics: Array<
+    Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>
+  >;
   event: EventTransaction;
   node: TraceTreeNode<TraceTree.Transaction>;
   onParentClick: (node: TraceTreeNode<TraceTree.NodeValue>) => void;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/builtIn.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/builtIn.tsx
@@ -10,7 +10,9 @@ import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles'
 import {hasSDKContext} from './sdk';
 
 type Props = {
-  cacheMetrics: Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>[];
+  cacheMetrics: Array<
+    Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>
+  >;
   event: EventTransaction;
 };
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/cacheMetrics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/cacheMetrics.tsx
@@ -9,7 +9,9 @@ import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles'
 export function CacheMetrics({
   cacheMetrics,
 }: {
-  cacheMetrics: Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>[];
+  cacheMetrics: Array<
+    Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>
+  >;
 }) {
   const itemSize: number | null = cacheMetrics[0]!['avg(cache.item_size)'];
   const missRate: number | null = cacheMetrics[0]!['cache_miss_rate()'];

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
@@ -29,7 +29,9 @@ import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles'
 import {OpsBreakdown} from './opsBreakDown';
 
 type GeneralInfoProps = {
-  cacheMetrics: Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>[];
+  cacheMetrics: Array<
+    Pick<SpanMetricsResponse, 'avg(cache.item_size)' | 'cache_miss_rate()'>
+  >;
   event: EventTransaction;
   location: Location;
   node: TraceTreeNode<TraceTree.Transaction>;

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
@@ -87,7 +87,7 @@ describe('IssuesTraceTree', () => {
     const error = IssuesTraceTree.Find(tree.root, hasErrors);
 
     let node = error;
-    const nodes: TraceTreeNode<any>[] = [];
+    const nodes: Array<TraceTreeNode<any>> = [];
     while (node && !isTraceNode(node)) {
       nodes.push(node);
       node = node.parent;

--- a/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.tsx
@@ -7,7 +7,7 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
   groupCount: number = 0;
   profiles: TraceTree.Profile[] = [];
 
-  private _autogroupedSegments: [number, number][] | undefined;
+  private _autogroupedSegments: Array<[number, number]> | undefined;
 
   constructor(
     parent: TraceTreeNode<TraceTree.NodeValue> | null,
@@ -23,12 +23,12 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
     this.tail = tail;
   }
 
-  get autogroupedSegments(): [number, number][] {
+  get autogroupedSegments(): Array<[number, number]> {
     if (this._autogroupedSegments) {
       return this._autogroupedSegments;
     }
 
-    const children: TraceTreeNode<TraceTree.NodeValue>[] = [];
+    const children: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
     let start: TraceTreeNode<TraceTree.NodeValue> | undefined = this.head;
 
     while (start && start !== this.tail) {
@@ -47,15 +47,15 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
 // It looks for gaps between spans and creates a segment for each gap. If there are no gaps, it
 // merges the n and n+1 segments.
 export function computeCollapsedBarSpace(
-  nodes: TraceTreeNode<TraceTree.NodeValue>[]
-): [number, number][] {
+  nodes: Array<TraceTreeNode<TraceTree.NodeValue>>
+): Array<[number, number]> {
   if (nodes.length === 0) {
     return [];
   }
 
   const first = nodes[0]!;
 
-  const segments: [number, number][] = [];
+  const segments: Array<[number, number]> = [];
 
   let start = first.space[0];
   let end = first.space[0] + first.space[1];

--- a/static/app/views/performance/newTraceDetails/traceModels/siblingAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/siblingAutogroupNode.tsx
@@ -6,7 +6,7 @@ export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogro
   groupCount: number = 0;
   profiles: TraceTree.Profile[] = [];
 
-  private _autogroupedSegments: [number, number][] | undefined;
+  private _autogroupedSegments: Array<[number, number]> | undefined;
 
   constructor(
     parent: TraceTreeNode<TraceTree.NodeValue> | null,
@@ -17,7 +17,7 @@ export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogro
     this.expanded = false;
   }
 
-  get autogroupedSegments(): [number, number][] {
+  get autogroupedSegments(): Array<[number, number]> {
     if (this._autogroupedSegments) {
       return this._autogroupedSegments;
     }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -248,7 +248,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
   profiled_events = new Set<TraceTreeNode<TraceTree.NodeValue>>();
   indicators: TraceTree.Indicator[] = [];
 
-  list: TraceTreeNode<TraceTree.NodeValue>[] = [];
+  list: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
   events: Map<string, EventTransaction> = new Map();
 
   private _spanPromises: Map<string, Promise<EventTransaction>> = new Map();
@@ -430,12 +430,12 @@ export class TraceTree extends TraceTreeEventDispatcher {
     event: EventTransaction | null
   ): [TraceTreeNode<TraceTree.NodeValue>, [number, number]] {
     // collect transactions
-    const transactions = TraceTree.FindAll(node, n =>
-      isTransactionNode(n)
-    ) as TraceTreeNode<TraceTree.Transaction>[];
+    const transactions = TraceTree.FindAll(node, n => isTransactionNode(n)) as Array<
+      TraceTreeNode<TraceTree.Transaction>
+    >;
 
     // Create span nodes
-    const spanNodes: TraceTreeNode<TraceTree.Span>[] = [];
+    const spanNodes: Array<TraceTreeNode<TraceTree.Span>> = [];
     const spanIdToNode = new Map<string, TraceTreeNode<TraceTree.NodeValue>>();
 
     // Transactions have a span_id that needs to be used as the edge to child child span
@@ -990,7 +990,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
   static DirectVisibleChildren(
     node: TraceTreeNode<TraceTree.NodeValue>
-  ): TraceTreeNode<TraceTree.NodeValue>[] {
+  ): Array<TraceTreeNode<TraceTree.NodeValue>> {
     if (isParentAutogroupedNode(node)) {
       if (node.expanded) {
         return [node.head];
@@ -1003,9 +1003,9 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
   static VisibleChildren(
     root: TraceTreeNode<TraceTree.NodeValue>
-  ): TraceTreeNode<TraceTree.NodeValue>[] {
-    const queue: TraceTreeNode<TraceTree.NodeValue>[] = [];
-    const visibleChildren: TraceTreeNode<TraceTree.NodeValue>[] = [];
+  ): Array<TraceTreeNode<TraceTree.NodeValue>> {
+    const queue: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
+    const visibleChildren: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
 
     if (root.expanded || isParentAutogroupedNode(root)) {
       const children = TraceTree.DirectVisibleChildren(root);
@@ -1041,7 +1041,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
     }
 
     // Otherwise, we need to traverse up the tree until we find a transaction node.
-    const nodes: TraceTreeNode<TraceTree.NodeValue>[] = [node];
+    const nodes: Array<TraceTreeNode<TraceTree.NodeValue>> = [node];
     let current: TraceTreeNode<TraceTree.NodeValue> | null = node.parent;
 
     while (current && !isTransactionNode(current)) {
@@ -1059,7 +1059,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
     root: TraceTreeNode<TraceTree.NodeValue>,
     cb: (node: TraceTreeNode<TraceTree.NodeValue>) => void
   ): void {
-    const queue: TraceTreeNode<TraceTree.NodeValue>[] = [];
+    const queue: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
 
     if (isParentAutogroupedNode(root)) {
       queue.push(root.head);
@@ -1134,9 +1134,9 @@ export class TraceTree extends TraceTreeEventDispatcher {
   static FindAll(
     root: TraceTreeNode<TraceTree.NodeValue>,
     predicate: (node: TraceTreeNode<TraceTree.NodeValue>) => boolean
-  ): TraceTreeNode<TraceTree.NodeValue>[] {
+  ): Array<TraceTreeNode<TraceTree.NodeValue>> {
     const queue = [root];
-    const results: TraceTreeNode<TraceTree.NodeValue>[] = [];
+    const results: Array<TraceTreeNode<TraceTree.NodeValue>> = [];
 
     while (queue.length > 0) {
       const next = queue.pop()!;
@@ -1724,7 +1724,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
     return connectors;
   }
 
-  toList(): TraceTreeNode<TraceTree.NodeValue>[] {
+  toList(): Array<TraceTreeNode<TraceTree.NodeValue>> {
     this.list = TraceTree.VisibleChildren(this.root);
     return this.list;
   }

--- a/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
+++ b/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
@@ -19,7 +19,7 @@ interface TracePreferencesDropdownProps {
   onMissingInstrumentationChange: () => void;
 }
 
-const TRACE_PREFERENCES_DROPDOWN_OPTIONS: SelectOption<string>[] = [
+const TRACE_PREFERENCES_DROPDOWN_OPTIONS: Array<SelectOption<string>> = [
   {
     label: t('Autogrouping'),
     value: 'autogroup',
@@ -52,7 +52,7 @@ export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
   const onMissingInstrumentationChange = props.onMissingInstrumentationChange;
 
   const onChange = useCallback(
-    (newValues: SelectOption<string>[]) => {
+    (newValues: Array<SelectOption<string>>) => {
       const newValuesArray = newValues.map(v => v.value);
 
       if (values.length < newValuesArray.length) {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
@@ -10,7 +10,7 @@ interface TraceRowWidthMeasurerEvents<T> {
 
 export class TraceRowWidthMeasurer<T> {
   cache: Map<T, number> = new Map();
-  queue: [T, HTMLElement][] = [];
+  queue: Array<[T, HTMLElement]> = [];
   drainRaf: number | null = null;
   max: number = 0;
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -1,6 +1,6 @@
 type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
 type EventStore = {
-  [K in keyof TraceEvents]: [number, TraceEvents[K]][];
+  [K in keyof TraceEvents]: Array<[number, TraceEvents[K]]>;
 };
 
 export enum TraceEventPriority {
@@ -76,10 +76,9 @@ export class TraceScheduler {
       return;
     }
 
-    (this.events as any)[eventName] = arr.filter(a => a[1] !== cb) as unknown as [
-      TraceEventPriority,
-      K,
-    ][];
+    (this.events as any)[eventName] = arr.filter(a => a[1] !== cb) as unknown as Array<
+      [TraceEventPriority, K]
+    >;
   }
 
   dispatch<K extends keyof TraceEvents>(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
@@ -18,7 +18,7 @@ export interface VirtualizedRow {
 }
 interface UseVirtualizedListProps {
   container: HTMLElement | null;
-  items: readonly TraceTreeNode<TraceTree.NodeValue>[];
+  items: ReadonlyArray<TraceTreeNode<TraceTree.NodeValue>>;
   manager: VirtualizedViewManager;
   render: (item: VirtualizedRow) => React.ReactNode;
   scheduler: TraceScheduler;
@@ -62,7 +62,7 @@ export const useVirtualizedList = (
 
   const renderRef = useRef<(item: VirtualizedRow) => React.ReactNode>(props.render);
   renderRef.current = props.render;
-  const itemsRef = useRef<readonly TraceTreeNode<TraceTree.NodeValue>[]>(props.items);
+  const itemsRef = useRef<ReadonlyArray<TraceTreeNode<TraceTree.NodeValue>>>(props.items);
   itemsRef.current = props.items;
   const managerRef = useRef<VirtualizedViewManager>(props.manager);
   managerRef.current = props.manager;
@@ -269,7 +269,7 @@ function findRenderedItems({
   render,
   manager,
 }: {
-  items: readonly TraceTreeNode<TraceTree.NodeValue>[];
+  items: ReadonlyArray<TraceTreeNode<TraceTree.NodeValue>>;
   manager: VirtualizedViewManager;
   overscroll: number;
   render: (arg: VirtualizedRow) => React.ReactNode;
@@ -353,7 +353,7 @@ export function findOptimisticStartIndex({
   scrollTop,
   viewport,
 }: {
-  items: readonly TraceTreeNode<TraceTree.NodeValue>[];
+  items: ReadonlyArray<TraceTreeNode<TraceTree.NodeValue>>;
   overscroll: number;
   rowHeight: number;
   scrollTop: number;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -33,8 +33,8 @@ function getHorizontalDelta(x: number, y: number): number {
 }
 
 type ViewColumn = {
-  column_nodes: TraceTreeNode<TraceTree.NodeValue>[];
-  column_refs: (HTMLElement | undefined)[];
+  column_nodes: Array<TraceTreeNode<TraceTree.NodeValue>>;
+  column_refs: Array<HTMLElement | undefined>;
   translate: [number, number];
   width: number;
 };
@@ -71,22 +71,25 @@ export class VirtualizedViewManager {
   horizontal_scrollbar_container: HTMLElement | null = null;
   indicator_container: HTMLElement | null = null;
 
-  intervals: (number | undefined)[] = [];
+  intervals: Array<number | undefined> = [];
   // We want to render an indicator every 100px, but because we dont track resizing
   // of the container, we need to precompute the number of intervals we need to render.
   // We'll oversize the count by 3x, assuming no user will ever resize the window to 3x the
   // original size.
   interval_bars = new Array(Math.ceil(window.innerWidth / 100) * 3).fill(0);
-  indicators: ({indicator: TraceTree['indicators'][0]; ref: HTMLElement} | undefined)[] =
-    [];
-  timeline_indicators: (HTMLElement | undefined)[] = [];
+  indicators: Array<
+    {indicator: TraceTree['indicators'][0]; ref: HTMLElement} | undefined
+  > = [];
+  timeline_indicators: Array<HTMLElement | undefined> = [];
   vertical_indicators: {[key: string]: VerticalIndicator} = {};
   vertical_indicator_labels: {[key: string]: HTMLElement | undefined} = {};
-  span_bars: ({color: string; ref: HTMLElement; space: [number, number]} | undefined)[] =
+  span_bars: Array<
+    {color: string; ref: HTMLElement; space: [number, number]} | undefined
+  > = [];
+  span_patterns: Array<Array<{ref: HTMLElement; space: [number, number]} | undefined>> =
     [];
-  span_patterns: ({ref: HTMLElement; space: [number, number]} | undefined)[][] = [];
-  invisible_bars: ({ref: HTMLElement; space: [number, number]} | undefined)[] = [];
-  span_arrows: (
+  invisible_bars: Array<{ref: HTMLElement; space: [number, number]} | undefined> = [];
+  span_arrows: Array<
     | {
         position: 0 | 1;
         ref: HTMLElement;
@@ -94,9 +97,10 @@ export class VirtualizedViewManager {
         visible: boolean;
       }
     | undefined
-  )[] = [];
-  span_text: ({ref: HTMLElement; space: [number, number]; text: string} | undefined)[] =
-    [];
+  > = [];
+  span_text: Array<
+    {ref: HTMLElement; space: [number, number]; text: string} | undefined
+  > = [];
 
   row_depth_padding: number = 22;
 
@@ -1725,7 +1729,7 @@ function getIconTimestamps(
 function computeTimelineIntervals(
   view: TraceView,
   targetInterval: number,
-  results: (number | undefined)[]
+  results: Array<number | undefined>
 ): void {
   const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
   let interval = minInterval;

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
@@ -238,7 +238,7 @@ interface AutogroupedTraceBarProps {
   errors: TraceTreeNode<TraceTree.Transaction>['errors'];
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.NodeValue>;
-  node_spaces: [number, number][];
+  node_spaces: Array<[number, number]>;
   performance_issues: TraceTreeNode<TraceTree.Transaction>['performance_issues'];
   profiles: TraceTreeNode<TraceTree.NodeValue>['profiles'];
   virtualized_index: number;

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -37,7 +37,7 @@ export type TraceSearchResult = {
  */
 export function searchInTraceTreeTokens(
   tree: TraceTree,
-  tokens: TokenResult<Token>[],
+  tokens: Array<TokenResult<Token>>,
   previousNode: TraceTreeNode<TraceTree.NodeValue> | null,
   cb: (
     results: [
@@ -121,10 +121,9 @@ export function searchInTraceTreeTokens(
   const left: Map<TraceTreeNode<TraceTree.NodeValue>, number> = new Map();
   const right: Map<TraceTreeNode<TraceTree.NodeValue>, number> = new Map();
 
-  const stack: (
-    | ProcessedTokenResult
-    | Map<TraceTreeNode<TraceTree.NodeValue>, number>
-  )[] = [];
+  const stack: Array<
+    ProcessedTokenResult | Map<TraceTreeNode<TraceTree.NodeValue>, number>
+  > = [];
 
   function search(): void {
     const ts = performance.now();

--- a/static/app/views/performance/newTraceDetails/traceShortcutsModal.tsx
+++ b/static/app/views/performance/newTraceDetails/traceShortcutsModal.tsx
@@ -31,13 +31,13 @@ export function TraceShortcuts() {
   );
 }
 
-const KEYBOARD_SHORTCUTS: [string, string][] = [
+const KEYBOARD_SHORTCUTS: Array<[string, string]> = [
   ['\u2191 / \u2193', t('Navigate up or down')],
   ['\u2190 / \u2192', t('Collapse or expand')],
   [t('Shift') + ' + \u2191 / \u2193', t('Jump to first/last element')],
 ];
 
-const TIMELINE_SHORTCUTS: [string, string][] = [
+const TIMELINE_SHORTCUTS: Array<[string, string]> = [
   [t('Cmd / Ctrl + Scroll'), t('Zoom in/out at cursor')],
   [t('Shift + Scroll'), t('Scroll horizontally')],
   [t('Double click'), t('Zoom to fill')],

--- a/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
@@ -32,7 +32,7 @@ async function maybeAutoExpandTrace(
     return tree;
   }
 
-  const promises: Promise<any>[] = [];
+  const promises: Array<Promise<any>> = [];
   for (const transaction of transactions) {
     promises.push(tree.zoom(transaction, true, options));
   }

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -95,7 +95,7 @@ type Props = {
   transactionName: string;
   applyEnvironmentFilter?: boolean;
   columnTitles?: string[];
-  customColumns?: ('attachments' | 'minidump')[];
+  customColumns?: Array<'attachments' | 'minidump'>;
   domainViewFilters?: DomainViewFilters;
   excludedTags?: string[];
   hidePagination?: boolean;

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -42,7 +42,7 @@ import VitalsChart from './vitalsChart';
 
 function generateDisplayOptions(
   currentFilter: SpanOperationBreakdownFilter
-): SelectValue<string>[] {
+): Array<SelectValue<string>> {
   if (currentFilter === SpanOperationBreakdownFilter.NONE) {
     return [
       {value: DisplayModes.DURATION, label: t('Duration Breakdown')},
@@ -65,7 +65,7 @@ function generateDisplayOptions(
   ];
 }
 
-const TREND_FUNCTIONS_OPTIONS: SelectValue<string>[] = TRENDS_FUNCTIONS.map(
+const TREND_FUNCTIONS_OPTIONS: Array<SelectValue<string>> = TRENDS_FUNCTIONS.map(
   ({field, label}) => ({
     value: field,
     label,
@@ -127,7 +127,7 @@ function TransactionSummaryCharts({
     });
   }
 
-  const TREND_PARAMETERS_OPTIONS: SelectValue<string>[] = TRENDS_PARAMETERS.map(
+  const TREND_PARAMETERS_OPTIONS: Array<SelectValue<string>> = TRENDS_PARAMETERS.map(
     ({label}) => ({
       value: label,
       label,

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
@@ -9,7 +9,7 @@ const FUNCTION_FIELD_VALUE_EXTRACT_PATTERN = /(\d+)\)$/;
  * Convert a discover response into a barchart compatible series
  */
 export function transformData(
-  data: Record<string, number>[],
+  data: Array<Record<string, number>>,
   useAggregateAlias: boolean = true
 ) {
   const extractedData = Object.keys(data[0]!)

--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -221,7 +221,7 @@ function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
   const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);
   const spans = useMemo(() => [], []);
 
-  const frameSelectOptions: SelectOption<'system' | 'application' | 'all'>[] =
+  const frameSelectOptions: Array<SelectOption<'system' | 'application' | 'all'>> =
     useMemo(() => {
       return [
         {value: 'system', label: t('System Frames')},
@@ -349,7 +349,7 @@ const ALLOWED_SORTS = [
 ] as const;
 type SortOption = (typeof ALLOWED_SORTS)[number];
 
-const sortOptions: SelectOption<SortOption>[] = [
+const sortOptions: Array<SelectOption<SortOption>> = [
   {value: '-timestamp', label: t('Newest Events')},
   {value: 'timestamp', label: t('Oldest Events')},
   {value: '-transaction.duration', label: t('Slowest Events')},

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
@@ -183,7 +183,7 @@ function SpanSummaryContent(props: ContentProps) {
   );
 }
 
-function parseSpanHeaderData(data: Partial<SpanMetricsResponse>[]) {
+function parseSpanHeaderData(data: Array<Partial<SpanMetricsResponse>>) {
   if (!data || data.length === 0) {
     return undefined;
   }

--- a/static/app/views/performance/transactionSummary/transactionTags/constants.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/constants.tsx
@@ -3,7 +3,7 @@ import type {SelectValue} from 'sentry/types/core';
 
 import {XAxisOption} from './types';
 
-export const X_AXIS_SELECT_OPTIONS: SelectValue<XAxisOption>[] = [
+export const X_AXIS_SELECT_OPTIONS: Array<SelectValue<XAxisOption>> = [
   {label: t('LCP'), value: XAxisOption.LCP},
   {label: t('Duration'), value: XAxisOption.DURATION},
 ];

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -226,7 +226,7 @@ export function generateProfileLink() {
   };
 }
 
-export function generateReplayLink(routes: PlainRoute<any>[]) {
+export function generateReplayLink(routes: Array<PlainRoute<any>>) {
   const referrer = getRouteStringFromRoutes(routes);
 
   return (

--- a/static/app/views/performance/trends/utils/index.tsx
+++ b/static/app/views/performance/trends/utils/index.tsx
@@ -390,7 +390,7 @@ function getLimitTransactionItems(query: string) {
   return limitQuery.formatString();
 }
 
-export const smoothTrend = (data: [number, number][], resolution = 100) => {
+export const smoothTrend = (data: Array<[number, number]>, resolution = 100) => {
   return ASAP(data, resolution);
 };
 

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -111,7 +111,7 @@ const BACKEND_PLATFORMS: string[] = backend.filter(
 const MOBILE_PLATFORMS: string[] = [...mobile];
 
 export function platformToPerformanceType(
-  projects: (Project | ReleaseProject)[],
+  projects: Array<Project | ReleaseProject>,
   projectIds: readonly number[]
 ) {
   if (projectIds.length === 0 || projectIds[0] === ALL_ACCESS_PROJECTS) {

--- a/static/app/views/profiling/landing/landingWidgetSelector.tsx
+++ b/static/app/views/profiling/landing/landingWidgetSelector.tsx
@@ -146,7 +146,7 @@ export function LandingWidgetSelector({
   }
 }
 
-const WIDGET_OPTIONS: SelectOption<WidgetOption>[] = [
+const WIDGET_OPTIONS: Array<SelectOption<WidgetOption>> = [
   {
     label: t('Slowest Functions (breakdown by AVG)'),
     value: 'slowest functions avg' as const,

--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -91,7 +91,7 @@ function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
   const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);
   const spans = useMemo(() => [], []);
 
-  const frameSelectOptions: SelectOption<'system' | 'application' | 'all'>[] =
+  const frameSelectOptions: Array<SelectOption<'system' | 'application' | 'all'>> =
     useMemo(() => {
       return [
         {value: 'system', label: t('System Frames')},

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -523,7 +523,7 @@ function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
   const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);
   const spans = useMemo(() => [], []);
 
-  const frameSelectOptions: SelectOption<'system' | 'application' | 'all'>[] =
+  const frameSelectOptions: Array<SelectOption<'system' | 'application' | 'all'>> =
     useMemo(() => {
       return [
         {value: 'system', label: t('System Frames')},

--- a/static/app/views/profiling/profileSummary/profilingSparklineChart.tsx
+++ b/static/app/views/profiling/profileSummary/profilingSparklineChart.tsx
@@ -12,7 +12,7 @@ const durationFormatter = makeFormatter('nanoseconds', 0);
 function asSeries(
   seriesName: string,
   color: string | undefined,
-  data: {timestamp: number; value: number}[]
+  data: Array<{timestamp: number; value: number}>
 ) {
   return {
     data: data.map(p => ({
@@ -38,7 +38,7 @@ function getTooltipFormatter(label: string, baseline: number) {
 
 interface BaseSparklineChartProps {
   name: string;
-  points: {timestamp: number; value: number}[];
+  points: Array<{timestamp: number; value: number}>;
   chartProps?: Partial<LineChartProps>;
   color?: string;
 }

--- a/static/app/views/profiling/profileSummary/regressedProfileFunctions.tsx
+++ b/static/app/views/profiling/profileSummary/regressedProfileFunctions.tsx
@@ -35,7 +35,7 @@ import {ProfilingSparklineChart} from './profilingSparklineChart';
 const REGRESSED_FUNCTIONS_LIMIT = 5;
 const REGRESSED_FUNCTIONS_CURSOR = 'functionRegressionCursor';
 
-function trendToPoints(trend: FunctionTrend): {timestamp: number; value: number}[] {
+function trendToPoints(trend: FunctionTrend): Array<{timestamp: number; value: number}> {
   if (!trend.stats.data.length) {
     return [];
   }
@@ -490,7 +490,7 @@ const RegressedFunctionsQueryState = styled('div')`
 `;
 
 const TRIGGER_PROPS = {borderless: true, size: 'zero' as const};
-const TREND_FUNCTION_OPTIONS: SelectOption<TrendType>[] = [
+const TREND_FUNCTION_OPTIONS: Array<SelectOption<TrendType>> = [
   {
     label: t('Most Regressed Functions'),
     value: 'regression' as const,

--- a/static/app/views/profiling/profileSummary/slowestProfileFunctions.tsx
+++ b/static/app/views/profiling/profileSummary/slowestProfileFunctions.tsx
@@ -296,7 +296,7 @@ const SlowestFunctionMetricsRow = styled('div')`
 `;
 
 const TRIGGER_PROPS = {borderless: true, size: 'zero' as const};
-const SLOWEST_FUNCTION_OPTIONS: SelectOption<'application' | 'system' | 'all'>[] = [
+const SLOWEST_FUNCTION_OPTIONS: Array<SelectOption<'application' | 'system' | 'all'>> = [
   {
     label: t('Slowest Application Functions'),
     value: 'application' as const,

--- a/static/app/views/profiling/utils.tsx
+++ b/static/app/views/profiling/utils.tsx
@@ -26,7 +26,7 @@ const COLOR_ENCODING_LABELS: Record<ColorEncoding, string> = {
   transaction_name: t('Transaction Name'),
 };
 
-export const COLOR_ENCODINGS: SelectValue<ColorEncoding>[] = Object.entries(
+export const COLOR_ENCODINGS: Array<SelectValue<ColorEncoding>> = Object.entries(
   COLOR_ENCODING_LABELS
 ).map(([value, label]) => ({label, value: value as ColorEncoding}));
 

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -137,7 +137,7 @@ class ProjectCharts extends Component<Props, State> {
     return displayMode;
   }
 
-  get displayModes(): SelectValue<string>[] {
+  get displayModes(): Array<SelectValue<string>> {
     const {organization, hasSessions, hasTransactions, project} = this.props;
     const hasPerformance = organization.features.includes('performance-view');
     const noPerformanceTooltip = NOT_AVAILABLE_MESSAGES.performance;

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -35,7 +35,7 @@ describe('MessagingIntegrationAlertRule', function () {
       GitHubIntegrationProviderFixture({key: providerKey}),
     ];
     const providerKeys = ['slack', 'discord', 'msteams'];
-    const mockResponses: jest.Mock<any>[] = [];
+    const mockResponses: Array<jest.Mock<any>> = [];
     providerKeys.forEach(providerKey => {
       mockResponses.push(
         MockApiClient.addMockResponse({

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -122,7 +122,7 @@ export function useCreateNotificationAction() {
 
   type Props = {
     actionMatch: string | undefined;
-    conditions: {id: string; interval: string; value: string}[] | undefined;
+    conditions: Array<{id: string; interval: string; value: string}> | undefined;
     frequency: number | undefined;
     name: string | undefined;
     projectSlug: string;

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -59,7 +59,7 @@ type State = DeprecatedAsyncComponent['state'] & {
   // TODO(ts): When we have alert conditional types, convert this
   conditions: any;
   interval: string;
-  intervalChoices: [string, string][] | undefined;
+  intervalChoices: Array<[string, string]> | undefined;
   metric: MetricValues;
 
   threshold: string;
@@ -67,8 +67,8 @@ type State = DeprecatedAsyncComponent['state'] & {
 
 type RequestDataFragment = {
   actionMatch: string;
-  actions: Omit<IssueAlertRuleAction, 'label' | 'name' | 'prompt'>[];
-  conditions: {id: string; interval: string; value: string}[] | undefined;
+  actions: Array<Omit<IssueAlertRuleAction, 'label' | 'name' | 'prompt'>>;
+  conditions: Array<{id: string; interval: string; value: string}> | undefined;
   defaultRules: boolean;
   frequency: number;
   name: string;
@@ -139,7 +139,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
 
   getIssueAlertsChoices(
     hasProperlyLoadedConditions: boolean
-  ): [string, string | React.ReactElement][] {
+  ): Array<[string, string | React.ReactElement]> {
     const customizedAlertOption: [string, React.ReactNode] = [
       RuleAction.CUSTOMIZED_ALERTS.toString(),
       <CustomizeAlert
@@ -188,7 +188,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
 
     const default_label = t('Alert me on high priority issues');
 
-    const options: [string, React.ReactNode][] = [
+    const options: Array<[string, React.ReactNode]> = [
       [RuleAction.DEFAULT_ALERT.toString(), default_label],
       ...(hasProperlyLoadedConditions ? [customizedAlertOption] : []),
       [RuleAction.CREATE_ALERT_LATER.toString(), t("I'll create my own alerts later")],

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -13,7 +13,7 @@ type ProjectWithBadPlatform = Omit<Project, 'platform'> & {
   platform: string;
 };
 
-function mockProjectApiResponses(projects: (Project | ProjectWithBadPlatform)[]) {
+function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatform>) {
   MockApiClient.addMockResponse({
     method: 'GET',
     url: '/organizations/org-slug/projects/',

--- a/static/app/views/projectInstall/platformOrIntegration.spec.tsx
+++ b/static/app/views/projectInstall/platformOrIntegration.spec.tsx
@@ -13,7 +13,7 @@ type ProjectWithBadPlatform = Omit<Project, 'platform'> & {
   platform: string;
 };
 
-function mockProjectApiResponses(projects: (Project | ProjectWithBadPlatform)[]) {
+function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatform>) {
   MockApiClient.addMockResponse({
     method: 'GET',
     url: '/projects/org-slug/project-slug/rules/',

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -36,7 +36,7 @@ export function transformSelectorQuery(selector: string) {
     .replaceAll('*', '\\*');
 }
 interface Props {
-  clickCountColumns: {key: string; name: string}[];
+  clickCountColumns: Array<{key: string; name: string}>;
   clickCountSortable: boolean;
   data: DeadRageSelectorItem[];
   isError: boolean;
@@ -45,7 +45,7 @@ interface Props {
   title?: ReactNode;
 }
 
-const BASE_COLUMNS: GridColumnOrder<string>[] = [
+const BASE_COLUMNS: Array<GridColumnOrder<string>> = [
   {key: 'project_id', name: 'project'},
   {key: 'element', name: 'element'},
   {key: 'dom_element', name: 'selector'},

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -20,7 +20,7 @@ type Options = {
 
 type Return = {
   expandPathsRef: RefObject<Map<number, Set<string>>>;
-  getBreadcrumbTypes: () => {label: string; value: string}[];
+  getBreadcrumbTypes: () => Array<{label: string; value: string}>;
   items: ReplayFrame[];
   searchTerm: string;
   setSearchTerm: (searchTerm: string) => void;

--- a/static/app/views/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/replays/detail/console/useConsoleFilters.tsx
@@ -27,7 +27,7 @@ type Options = {
 
 type Return = {
   expandPathsRef: RefObject<Map<number, Set<string>>>;
-  getLogLevels: () => {label: string; value: string}[];
+  getLogLevels: () => Array<{label: string; value: string}>;
   items: BreadcrumbFrame[];
   logLevel: string[];
   searchTerm: string;

--- a/static/app/views/replays/detail/errorList/errorFilters.tsx
+++ b/static/app/views/replays/detail/errorList/errorFilters.tsx
@@ -25,7 +25,7 @@ function ErrorFilters({
       <CompactSelect
         disabled={!projectOptions.length}
         multiple
-        onChange={setFilters as (selection: SelectOption<string>[]) => void}
+        onChange={setFilters as (selection: Array<SelectOption<string>>) => void}
         options={projectOptions}
         size="sm"
         triggerLabel={selectValue?.length === 0 ? t('Any') : null}

--- a/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
@@ -14,11 +14,11 @@ type Props = {
   style: CSSProperties;
 };
 
-const COLUMNS: {
+const COLUMNS: Array<{
   field: SortConfig['by'];
   label: string;
   tooltipTitle?: ComponentProps<typeof Tooltip>['title'];
-}[] = [
+}> = [
   {field: 'id', label: t('Event ID')},
   {field: 'title', label: t('Title')},
   {field: 'project', label: t('Issue')},

--- a/static/app/views/replays/detail/network/networkFilters.tsx
+++ b/static/app/views/replays/detail/network/networkFilters.tsx
@@ -28,7 +28,7 @@ function NetworkFilters({
       <CompactSelect
         disabled={!methodTypes.length && !statusTypes.length && !resourceTypes}
         multiple
-        onChange={setFilters as (selection: SelectOption<string>[]) => void}
+        onChange={setFilters as (selection: Array<SelectOption<string>>) => void}
         options={[
           {
             label: t('Method'),

--- a/static/app/views/replays/detail/network/networkHeaderCell.tsx
+++ b/static/app/views/replays/detail/network/networkHeaderCell.tsx
@@ -15,11 +15,11 @@ type Props = {
   style: CSSProperties;
 };
 
-const COLUMNS: {
+const COLUMNS: Array<{
   field: SortConfig['by'];
   label: string;
   tooltipTitle?: ComponentProps<typeof Tooltip>['title'];
-}[] = [
+}> = [
   {field: 'method', label: t('Method')},
   {
     field: 'status',

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -191,13 +191,13 @@ export type DeadRageSelectorItem = {
 };
 
 export type DeadRageSelectorListResponse = {
-  data: {
+  data: Array<{
     count_dead_clicks: number;
     count_rage_clicks: number;
     dom_element: string;
     element: ReplayClickElement;
     project_id: number;
-  }[];
+  }>;
 };
 
 export type ReplayClickElement = {

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -6,7 +6,7 @@ export type FineTuneField = {
   title: string;
   type: 'select';
   defaultValue?: string;
-  options?: SelectValue<string>[];
+  options?: Array<SelectValue<string>>;
 };
 
 // TODO: clean up unused fields

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -291,7 +291,7 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
     const {notificationType} = this.props;
     // get the choices but only the ones that are available to the user
     const choices = (
-      NOTIFICATION_SETTING_FIELDS.provider!.choices as [SupportedProviders, string][]
+      NOTIFICATION_SETTING_FIELDS.provider!.choices as Array<[SupportedProviders, string]>
     ).filter(([providerSlug]) => this.isProviderSupported(providerSlug));
 
     const defaultField = Object.assign({}, NOTIFICATION_SETTING_FIELDS.provider, {

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 type State = {
   activeSuggestion: number;
-  fieldValues: (SourceSuggestion | SourceSuggestion[])[];
+  fieldValues: Array<SourceSuggestion | SourceSuggestion[]>;
   help: string;
   hideCaret: boolean;
   showSuggestions: boolean;
@@ -104,7 +104,7 @@ class SourceField extends Component<Props, State> {
   }
 
   // @ts-ignore TS(7023): 'getNewSuggestions' implicitly has return type 'an... Remove this comment to see the full error message
-  getNewSuggestions(fieldValues: (SourceSuggestion | SourceSuggestion[])[]) {
+  getNewSuggestions(fieldValues: Array<SourceSuggestion | SourceSuggestion[]>) {
     const lastFieldValue = fieldValues[fieldValues.length - 1]!;
     const penultimateFieldValue = fieldValues[fieldValues.length - 2]!;
 
@@ -168,7 +168,7 @@ class SourceField extends Component<Props, State> {
   }
 
   loadFieldValues(newValue: string) {
-    const fieldValues: (SourceSuggestion | SourceSuggestion[])[] = [];
+    const fieldValues: Array<SourceSuggestion | SourceSuggestion[]> = [];
 
     const splittedValue = newValue.split(' ');
 
@@ -256,7 +256,7 @@ class SourceField extends Component<Props, State> {
 
   getNewFieldValues(
     suggestion: SourceSuggestion
-  ): (SourceSuggestion | SourceSuggestion[])[] {
+  ): Array<SourceSuggestion | SourceSuggestion[]> {
     const fieldValues = [...this.state.fieldValues]!;
     const lastFieldValue = fieldValues[fieldValues.length - 1]!;
 

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -40,7 +40,7 @@ type State = {
   errors: FormProps['errors'];
   eventId: EventId;
   isFormValid: boolean;
-  requiredValues: (keyof Values)[];
+  requiredValues: Array<keyof Values>;
   sourceSuggestions: SourceSuggestions;
   values: Values;
 };
@@ -94,7 +94,7 @@ class ModalManager extends Component<Props, State> {
 
   getRequiredValues(values: Values) {
     const {type} = values;
-    const requiredValues: KeysOfUnion<Values>[] = ['type', 'method', 'source'];
+    const requiredValues: Array<KeysOfUnion<Values>> = ['type', 'method', 'source'];
 
     if (type === RuleType.PATTERN) {
       requiredValues.push('pattern');

--- a/static/app/views/settings/dynamicSampling/utils/testScaleSapleRates.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/testScaleSapleRates.spec.tsx
@@ -1,6 +1,6 @@
 import {scaleSampleRates} from 'sentry/views/settings/dynamicSampling/utils/scaleSampleRates';
 
-function getAverageSampleRate(items: {count: number; sampleRate: number}[]) {
+function getAverageSampleRate(items: Array<{count: number; sampleRate: number}>) {
   const total = items.reduce((acc, item) => acc + item.count, 0);
   return items.reduce((acc, item) => acc + (item.count * item.sampleRate) / total, 0);
 }

--- a/static/app/views/settings/dynamicSampling/utils/useProjectSampleCounts.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/useProjectSampleCounts.tsx
@@ -10,7 +10,7 @@ export interface ProjectSampleCount {
   count: number;
   ownCount: number;
   project: Project;
-  subProjects: {count: number; slug: string}[];
+  subProjects: Array<{count: number; slug: string}>;
 }
 
 export type ProjectionSamplePeriod = '24h' | '30d';
@@ -66,7 +66,7 @@ export function useProjectSampleCounts({period}: {period: ProjectionSamplePeriod
         count: number;
         ownCount: number;
         slug: string;
-        subProjects: {count: number; slug: string}[];
+        subProjects: Array<{count: number; slug: string}>;
       }
     >();
 

--- a/static/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/static/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -38,7 +38,10 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
    * We should update the hook interface for the two hooks used here
    */
   unsubscribe = HookStore.listen(
-    (hookName: HookName, hooks: Hooks['settings:organization-navigation-config'][]) => {
+    (
+      hookName: HookName,
+      hooks: Array<Hooks['settings:organization-navigation-config']>
+    ) => {
       this.handleHooks(hookName, hooks);
     },
     undefined
@@ -58,7 +61,10 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
     };
   }
 
-  handleHooks(name: HookName, hooks: Hooks['settings:organization-navigation-config'][]) {
+  handleHooks(
+    name: HookName,
+    hooks: Array<Hooks['settings:organization-navigation-config']>
+  ) {
     const org = this.props.organization;
     if (name !== 'settings:organization-navigation-config') {
       return;

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -38,7 +38,7 @@ function OrganizationDeveloperSettings() {
   const value =
     ['public', 'internal'].find(tab => tab === location?.query?.type) || 'internal';
   const analyticsView = 'developer_settings';
-  const tabs: [id: Tab, label: string][] = [
+  const tabs: Array<[id: Tab, label: string]> = [
     ['internal', t('Internal Integration')],
     ['public', t('Public Integration')],
   ];

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
@@ -25,16 +25,16 @@ import RequestLog from './requestLog';
 
 type Interactions = {
   componentInteractions: {
-    [key: string]: [number, number][];
+    [key: string]: Array<[number, number]>;
   };
-  views: [number, number][];
+  views: Array<[number, number]>;
 };
 
 type Stats = {
-  installStats: [number, number][];
+  installStats: Array<[number, number]>;
   totalInstalls: number;
   totalUninstalls: number;
-  uninstallStats: [number, number][];
+  uninstallStats: Array<[number, number]>;
 };
 
 function SentryApplicationDashboard() {
@@ -231,7 +231,7 @@ export default SentryApplicationDashboard;
 
 type InteractionsChartProps = {
   data: {
-    [key: string]: [number, number][];
+    [key: string]: Array<[number, number]>;
   };
 };
 function InteractionsChart({data}: InteractionsChartProps) {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -176,7 +176,7 @@ class SentryApplicationDetails extends DeprecatedAsyncComponent<Props, State> {
       if (this.hasTokenAccess) {
         endpoints.push(['tokens', `/sentry-apps/${appSlug}/api-tokens/`]);
       }
-      return endpoints as [string, string][];
+      return endpoints as Array<[string, string]>;
     }
 
     return [];

--- a/static/app/views/settings/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -98,7 +98,7 @@ abstract class AbstractIntegrationDetailedView<
   }
 
   // Returns a list of the resources displayed at the bottom of the overview card
-  get resourceLinks(): {title: string; url: string}[] {
+  get resourceLinks(): Array<{title: string; url: string}> {
     // Allow children to implement this
     throw new Error('Not implemented');
   }

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -453,7 +453,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
       ['codeMappings', t('Code Mappings')],
       ...(hasCodeOwners ? [['userMappings', t('User Mappings')]] : []),
       ...(hasCodeOwners ? [['teamMappings', t('Team Mappings')]] : []),
-    ] as [id: Tab, label: string][];
+    ] as Array<[id: Tab, label: string]>;
 
     return (
       <Fragment>

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.tsx
@@ -25,7 +25,7 @@ type Props = Pick<FormProps, 'onCancel' | 'onSubmitSuccess' | 'onSubmitError'> &
     dataEndpoint: string;
     getBaseFormEndpoint: (mapping?: ExternalActorMappingOrSuggestion) => string;
     integration: Integration;
-    sentryNamesMapper: (v: any) => {id: string; name: string}[];
+    sentryNamesMapper: (v: any) => Array<{id: string; name: string}>;
     type: 'user' | 'team';
     isInline?: boolean;
     mapping?: ExternalActorMappingOrSuggestion;

--- a/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -28,7 +28,7 @@ type Props = DeprecatedAsyncComponent['props'] &
 
 type State = DeprecatedAsyncComponent['state'] & {
   initialResults: Member[];
-  members: (Member & {externalUsers: ExternalUser[]})[];
+  members: Array<Member & {externalUsers: ExternalUser[]}>;
 };
 
 class IntegrationExternalUserMappings extends DeprecatedAsyncComponent<Props, State> {

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
@@ -13,7 +13,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import IntegrationListDirectory from 'sentry/views/settings/organizationIntegrations/integrationListDirectory';
 
-const mockResponse = (mocks: [string, unknown][]) => {
+const mockResponse = (mocks: Array<[string, unknown]>) => {
   mocks.forEach(([url, body]) => MockApiClient.addMockResponse({url, body}));
 };
 

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -175,7 +175,7 @@ export class IntegrationListDirectory extends DeprecatedAsyncComponent<
 
   getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
     const {organization} = this.props;
-    const baseEndpoints: ([string, string, any] | [string, string])[] = [
+    const baseEndpoints: Array<[string, string, any] | [string, string]> = [
       ['config', `/organizations/${organization.slug}/config/integrations/`],
       [
         'integrations',

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -20,7 +20,7 @@ const hasValue = (value: any) => !!value || value === 0;
 export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
   type: 'select' | 'textarea' | 'text';
   async?: boolean;
-  choices?: [any, string][];
+  choices?: Array<[any, string]>;
   default?: 'issue.title' | 'issue.description';
   depends_on?: string[];
   skip_load_on_open?: boolean;
@@ -42,7 +42,7 @@ type SentryAppSetting = {
 
 // only need required_fields and optional_fields
 type State = Omit<SchemaFormConfig, 'uri' | 'description'> & {
-  optionsByField: Map<string, {label: string; value: any}[]>;
+  optionsByField: Map<string, Array<{label: string; value: any}>>;
   selectedOptions: {[name: string]: GeneralSelectValue};
 };
 

--- a/static/app/views/settings/organizationRelay/modals/modalManager.tsx
+++ b/static/app/views/settings/organizationRelay/modals/modalManager.tsx
@@ -27,7 +27,7 @@ type State = {
   disables: FormProps['disables'];
   errors: FormProps['errors'];
   isFormValid: boolean;
-  requiredValues: (keyof Values)[];
+  requiredValues: Array<keyof Values>;
   title: string;
   values: Values;
 };

--- a/static/app/views/settings/project/projectOwnership/codeownerErrors.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeownerErrors.tsx
@@ -152,7 +152,7 @@ export function CodeOwnerErrors({
       {filteredCodeowners.map(({id, codeMapping, errors}) => {
         const errorPairs = Object.entries(errors).filter(
           ([_, values]) => values.length
-        ) as [CodeOwnerErrorKeys, string[]][];
+        ) as Array<[CodeOwnerErrorKeys, string[]]>;
         const errorCount = errorPairs.reduce(
           (acc, [_, values]) => acc + values.length,
           0

--- a/static/app/views/settings/project/projectServiceHookDetails.tsx
+++ b/static/app/views/settings/project/projectServiceHookDetails.tsx
@@ -36,7 +36,7 @@ type StatsProps = {
 };
 
 type StatsState = {
-  stats: {total: number; ts: number}[] | null;
+  stats: Array<{total: number; ts: number}> | null;
 } & DeprecatedAsyncComponent['state'];
 
 class HookStats extends DeprecatedAsyncComponent<StatsProps, StatsState> {

--- a/static/app/views/traces/hooks/useTraceSpans.tsx
+++ b/static/app/views/traces/hooks/useTraceSpans.tsx
@@ -9,7 +9,7 @@ import type {TraceResult} from './useTraces';
 export type SpanResult<F extends string> = Record<F, any>;
 
 export interface SpanResults<F extends string> {
-  data: SpanResult<F>[];
+  data: Array<SpanResult<F>>;
   meta: any;
 }
 

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -24,7 +24,7 @@ interface PartialInjectedRouter<P>
 interface InitializeOrgOptions<RouterParams> {
   organization?: Partial<Organization>;
   project?: Partial<Project>;
-  projects?: Partial<Project>[];
+  projects?: Array<Partial<Project>>;
   router?: PartialInjectedRouter<RouterParams>;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./config/tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
+    "allowJs": true
   },
   "include": [
     "eslint.config.mjs",


### PR DESCRIPTION
This was suggested in slack and I really like the [`array-simple`](https://typescript-eslint.io/rules/array-type/#array-simple) variation over the default [`array`](https://typescript-eslint.io/rules/array-type/#array) that we enabled [yesterday](https://github.com/getsentry/sentry/pull/83804).

TL/DR the `array-simple` variation will prefer `MyType[]` when `MyType` is a simple, or named type. If there's anything more complex in that spot, like a union or unnamed object type then we'll see `Array<...>` instead. This means in practice we wont' see round braces near our complex array definitions; less syntax for my eyes to parse.