### PR TITLE
chore(relocation) Revert changes to relocation outbox handlers

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -140,10 +140,6 @@ def process_relocation_reply_with_export(payload: Mapping[str, Any], **kwds):
     except Exception:
         raise FileNotFoundError("Could not open SaaS -> SaaS export in proxy relocation bucket.")
 
-    # TODO(mark) Remove this once stuck outboxes have cleared up.
-    if slug == "demo":
-        return
-
     with encrypted_bytes:
         region_relocation_export_service.reply_with_export(
             relocation_uuid=payload["relocation_uuid"],

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -92,10 +92,6 @@ def process_relocation_reply_with_export(payload: Any, **kwds):
             "Could not open SaaS -> SaaS export in export-side relocation bucket."
         )
 
-    # TODO(mark) Remove this once stuck outboxes have cleared up.
-    if slug == "demo":
-        return
-
     with encrypted_bytes:
         control_relocation_export_service.reply_with_export(
             relocation_uuid=uuid,


### PR DESCRIPTION
Remove the skip logic added in #83865. If this happens again, I'll find a more permanent solution that gracefully handles this scenario.
