### PR TITLE
fix(taskworker): Add backoff sleep if no tasks exist

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -252,6 +252,7 @@ class TaskWorker:
         )
         self._children: list[multiprocessing.Process] = []
         self._shutdown_event = multiprocessing.Event()
+        self.backoff_sleep_seconds = 0
 
     def __del__(self) -> None:
         self._shutdown()
@@ -311,11 +312,15 @@ class TaskWorker:
         task = self.fetch_task()
         if task:
             try:
+                self.backoff_sleep_seconds = 0
                 self._child_tasks.put(task, timeout=0.1)
             except queue.Full:
                 logger.warning(
                     "taskworker.add_task.child_task_queue_full", extra={"task_id": task.id}
                 )
+        else:
+            time.sleep(self.backoff_sleep_seconds)
+            self.backoff_sleep_seconds = min(self.backoff_sleep_seconds + 1, 10)
 
     def _drain_result(self, fetch: bool = True) -> bool:
         """

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -380,9 +380,9 @@ class TaskWorker:
     def fetch_task(self) -> TaskActivation | None:
         try:
             activation = self.client.get_task(self._namespace)
-        except grpc.RpcError:
+        except grpc.RpcError as e:
             metrics.incr("taskworker.worker.fetch_task", tags={"status": "failed"})
-            logger.info("taskworker.fetch_task.failed")
+            logger.info("taskworker.fetch_task.failed", extra={"error": e})
             return None
 
         if not activation:


### PR DESCRIPTION
In the case where tasks either don't exist or can't be fetched, add a backoff so that the worker
isn't constantly pinging the gRPC server.