### PR TITLE
fix(explore): Use previous tags when page filters change

### DIFF
--- a/static/app/utils/usePrevious.spec.tsx
+++ b/static/app/utils/usePrevious.spec.tsx
@@ -28,4 +28,21 @@ describe('usePrevious', () => {
     // Result should point to old value
     expect(result.current).toBe('New Value');
   });
+
+  it('skips updates when needed', () => {
+    const {result, rerender} = renderHook(
+      ([value, shouldUpdate]) => usePrevious<number>(value, shouldUpdate),
+      {initialProps: [0] as [number] | [number, boolean]}
+    );
+
+    rerender([1]);
+    // Result should point at initial prop of 0
+    expect(result.current).toBe(0);
+    rerender([2, true]);
+    // Result should point to previous prop of 1
+    expect(result.current).toBe(1);
+    rerender([3]);
+    // Result should point to previous prop of 1 because 2 was skipped
+    expect(result.current).toBe(1);
+  });
 });

--- a/static/app/utils/usePrevious.tsx
+++ b/static/app/utils/usePrevious.tsx
@@ -8,14 +8,16 @@ import {useEffect, useRef} from 'react';
  * @returns 'ref.current' and therefore should not be used as a dependency of useEffect.
  * Mutable values like 'ref.current' are not valid dependencies of useEffect because changing them does not re-render the component.
  */
-function usePrevious<T>(value: T): T {
+function usePrevious<T>(value: T, skipUpdate?: boolean): T {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
   const ref = useRef<T>(value);
   // Store current value in ref
   useEffect(() => {
-    ref.current = value;
-  }, [value]); // Only re-run if value changes
+    if (!skipUpdate) {
+      ref.current = value;
+    }
+  }, [value, skipUpdate]); // Only re-run if value changes
   // Return previous value (happens before update in useEffect above)
   return ref.current;
 }

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -8,6 +8,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import usePrevious from 'sentry/utils/usePrevious';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 import {useSpanFieldCustomTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
@@ -32,12 +33,12 @@ export function SpanTagsProvider({children, dataset, enabled}: SpanTagsProviderP
   const isEAP =
     dataset === DiscoverDatasets.SPANS_EAP || dataset === DiscoverDatasets.SPANS_EAP_RPC;
 
-  const numberTags: TagCollection = useTypedSpanTags({
+  const numberTags = useTypedSpanTags({
     enabled: isEAP && enabled,
     type: 'number',
   });
 
-  const stringTags: TagCollection = useTypedSpanTags({
+  const stringTags = useTypedSpanTags({
     enabled: isEAP && enabled,
     type: 'string',
   });
@@ -211,7 +212,9 @@ function useTypedSpanTags({
     }
 
     return allTags;
-  }, [result, type]);
+  }, [result.data, type]);
 
-  return tags;
+  const previousTags = usePrevious(tags, result.isLoading);
+
+  return result.isLoading ? previousTags : tags;
 }


### PR DESCRIPTION
When page filters change, there's a moment when the available tags are cleared while the new tags are loaded.