### PR TITLE
fix(widget-builder): Release series showing on bar chart

### DIFF
--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -316,11 +316,11 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
   };
 
   render() {
-    const {children} = this.props;
+    const {children, enabled} = this.props;
 
     return children({
-      releases: this.state.releases,
-      releaseSeries: this.state.releaseSeries,
+      releases: enabled ? this.state.releases : [],
+      releaseSeries: enabled ? this.state.releaseSeries : [],
     });
   }
 }

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -316,7 +316,7 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
   };
 
   render() {
-    const {children, enabled} = this.props;
+    const {children, enabled = true} = this.props;
 
     return children({
       releases: enabled ? this.state.releases : [],


### PR DESCRIPTION
I noticed that some of the new widget changes were messing with the release series on some widgets. When switching display types from line/area chart to bar chart the releases were showing up on the bar chart. I think it may have something to do with the memoization. Regardless I just added an additional check before returning the release series so that this doesn't happen.

