### PR TITLE
feat(widget-builder): Make visualize select fields searchable

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -901,7 +901,7 @@ describe('Visualize', () => {
     expect(
       await screen.findByRole('button', {name: 'Aggregate Selection'})
     ).toHaveTextContent('apdex');
-    expect(screen.getAllByRole('textbox')[0]).toHaveValue('3000');
+    expect(screen.getByRole('textbox', {name: 'Numeric Input'})).toHaveValue('3000');
     expect(
       screen.queryByRole('button', {name: 'Column Selection'})
     ).not.toBeInTheDocument();
@@ -928,7 +928,7 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'user_misery'}));
 
-    expect(screen.getAllByRole('textbox')[0]).toHaveValue('300');
+    expect(screen.getByRole('textbox', {name: 'Numeric Input'})).toHaveValue('300');
   });
 
   describe('spans', () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -462,6 +462,7 @@ function Visualize({error, setError}: VisualizeProps) {
                           />
                         )}
                         <AggregateCompactSelect
+                          searchable
                           hasColumnParameter={hasColumnParameter}
                           disabled={aggregateOptions.length <= 1}
                           options={aggregateOptions}
@@ -859,6 +860,7 @@ function AggregateParameterField({
         onChange={({value}: any) => {
           onChange(value);
         }}
+        searchable
       />
     );
   }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -822,6 +822,7 @@ function AggregateParameterField({
             type="text"
             inputMode="numeric"
             pattern="[0-9]*(\.[0-9]*)?"
+            aria-label={t('Numeric Input')}
             {...inputProps}
           />
         );
@@ -833,6 +834,7 @@ function AggregateParameterField({
             type="text"
             inputMode="numeric"
             pattern="[0-9]*"
+            aria-label={t('Integer Input')}
             {...inputProps}
           />
         );
@@ -842,6 +844,7 @@ function AggregateParameterField({
             name="refinement"
             key="parameter:text"
             type="text"
+            aria-label={t('Text Input')}
             {...inputProps}
           />
         );


### PR DESCRIPTION
Makes the select fields in the visualize component searchable and easier to use.

<img width="585" alt="Screenshot 2025-01-23 at 12 43 05 PM" src="https://github.com/user-attachments/assets/87f2b1dd-d444-4cb6-afb1-d9c0b86cd947" />

I tried to make the group by searchable too but I wasn't able to figure it out quick enough because it's using a bunch of old components. I'll circle back to them later possibly.