### PR TITLE
feat(issue-views): Update endpoints to send and receive page filters

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -11,6 +11,10 @@ class GroupSearchViewSerializerResponse(TypedDict):
     query: str
     querySort: SORT_LITERALS
     position: int
+    projects: list[int]
+    isAllProjects: bool
+    environments: list[str]
+    timeFilters: dict
     dateCreated: str | None
     dateUpdated: str | None
 
@@ -24,6 +28,10 @@ class GroupSearchViewSerializer(Serializer):
             "query": obj.query,
             "querySort": obj.query_sort,
             "position": obj.position,
+            "projects": list(obj.projects.values_list("id", flat=True)),
+            "isAllProjects": obj.is_all_projects,
+            "environments": obj.environments,
+            "timeFilters": obj.time_filters,
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
         }

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -13,10 +13,10 @@ class GroupSearchViewValidatorResponse(TypedDict):
     query: str
     querySort: SORT_LITERALS
     position: int
-    timeFilters: dict[str, Any]
-    projects: list[int] | None
-    environments: list[str] | None
-    isAllProjects: bool | None
+    projects: NotRequired[list[int]]
+    isAllProjects: NotRequired[bool]
+    environments: NotRequired[list[str]]
+    timeFilters: NotRequired[dict[str, Any]]
     dateCreated: str | None
     dateUpdated: str | None
 

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -1,4 +1,4 @@
-from typing import NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from rest_framework import serializers
 
@@ -13,6 +13,10 @@ class GroupSearchViewValidatorResponse(TypedDict):
     query: str
     querySort: SORT_LITERALS
     position: int
+    timeFilters: dict[str, Any]
+    projects: list[int] | None
+    environments: list[str] | None
+    isAllProjects: bool | None
     dateCreated: str | None
     dateUpdated: str | None
 
@@ -24,6 +28,20 @@ class ViewValidator(serializers.Serializer):
     querySort = serializers.ChoiceField(
         choices=SortOptions.as_choices(), default=SortOptions.DATE, required=False
     )
+    # TODO(msun): Once frontend is updated, make these fields required
+    projects = serializers.ListField(required=False, allow_empty=True)
+    environments = serializers.ListField(required=False, allow_empty=True)
+    timeFilters = serializers.DictField(
+        required=False,
+        allow_empty=True,
+    )
+    isAllProjects = serializers.BooleanField(required=False)
+
+    def validate_timeFilters(self, value):
+        # Replace empty dict or None with default time filter
+        if not value:
+            return {"period": "14d"}
+        return value
 
 
 class GroupSearchViewValidator(serializers.Serializer):

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -109,7 +109,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
                 validate_projects(organization, request.user, view)
             except ValidationError as e:
                 sentry_sdk.capture_message(e.args[0])
-                return Response({"detail": e.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+                return Response(status=status.HTTP_400_BAD_REQUEST, data={"detail": e.args[0]})
 
         try:
             with transaction.atomic(using=router.db_for_write(GroupSearchView)):
@@ -122,8 +122,8 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
             ):
                 sentry_sdk.capture_exception(e)
                 return Response(
-                    {"detail": "One or more projects do not exist"},
                     status=status.HTTP_400_BAD_REQUEST,
+                    data={"detail": "One or more projects do not exist"},
                 )
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar
 
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -35,7 +36,7 @@ class TeamManager(BaseManager["Team"]):
     def get_for_user(
         self,
         organization: Organization,
-        user: User | RpcUser,
+        user: User | RpcUser | AnonymousUser,
         scope: str | None = None,
         is_team_admin: bool = False,
     ) -> Sequence[Team]:

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -581,7 +581,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert response.content == {"detail": "One or more projects do not exist"}
+        assert response.content == b'{"detail":"One or more projects do not exist"}'
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -2,15 +2,29 @@ from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers.base import serialize
+from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
 
-class OrganizationGroupSearchViewsGetTest(APITestCase):
-    endpoint = "sentry-api-0-organization-group-search-views"
-    method = "get"
+# Ignores the dateCreated and dateUpdated fields
+def are_views_equal(
+    view_1: GroupSearchViewValidatorResponse, view_2: GroupSearchViewValidatorResponse
+) -> bool:
+    return (
+        view_1["name"] == view_2["name"]
+        and view_1["query"] == view_2["query"]
+        and view_1["querySort"] == view_2["querySort"]
+        and view_1["position"] == view_2["position"]
+        and view_1["isAllProjects"] == view_2["isAllProjects"]
+        and view_1["environments"] == view_2["environments"]
+        and view_1["timeFilters"] == view_2["timeFilters"]
+        and view_1["projects"] == view_2["projects"]
+    )
 
+
+class BaseGSVTestCase(APITestCase):
     def create_base_data(self) -> dict[str, list[GroupSearchView]]:
         user_1 = self.user
         self.user_2 = self.create_user()
@@ -74,7 +88,13 @@ class OrganizationGroupSearchViewsGetTest(APITestCase):
             "user_two_views": [first_custom_view_user_two, second_custom_view_user_two],
         }
 
+
+class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
+    endpoint = "sentry-api-0-organization-group-search-views"
+    method = "get"
+
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_get_user_one_custom_views(self) -> None:
         objs = self.create_base_data()
 
@@ -84,6 +104,7 @@ class OrganizationGroupSearchViewsGetTest(APITestCase):
         assert response.data == serialize(objs["user_one_views"])
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_get_user_two_custom_views(self) -> None:
         objs = self.create_base_data()
 
@@ -93,6 +114,7 @@ class OrganizationGroupSearchViewsGetTest(APITestCase):
         assert response.data == serialize(objs["user_two_views"])
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_get_default_views(self) -> None:
         self.create_base_data()
 
@@ -107,46 +129,22 @@ class OrganizationGroupSearchViewsGetTest(APITestCase):
         assert view["querySort"] == "date"
         assert view["position"] == 0
 
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_get_views_has_correct_default_page_filters(self) -> None:
+        self.create_base_data()
 
-class OrganizationGroupSearchViewsPutTest(APITestCase):
+        self.login_as(user=self.user)
+        response = self.get_success_response(self.organization.slug)
+
+        assert response.data[0]["timeFilters"] == {"period": "14d"}
+        assert response.data[0]["projects"] == []
+        assert response.data[0]["environments"] == []
+
+
+class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
     endpoint = "sentry-api-0-organization-group-search-views"
     method = "put"
-
-    def create_base_data(self) -> dict[str, list[GroupSearchView]]:
-        self.custom_view_one = GroupSearchView.objects.create(
-            name="Custom View One",
-            organization=self.organization,
-            user_id=self.user.id,
-            query="is:unresolved",
-            query_sort="date",
-            position=0,
-        )
-
-        self.custom_view_two = GroupSearchView.objects.create(
-            name="Custom View Two",
-            organization=self.organization,
-            user_id=self.user.id,
-            query="is:resolved",
-            query_sort="new",
-            position=1,
-        )
-
-        self.custom_view_three = GroupSearchView.objects.create(
-            name="Custom View Three",
-            organization=self.organization,
-            user_id=self.user.id,
-            query="is:ignored",
-            query_sort="freq",
-            position=2,
-        )
-
-        return {
-            "views": [
-                self.custom_view_one,
-                self.custom_view_two,
-                self.custom_view_three,
-            ]
-        }
 
     def setUp(self) -> None:
         self.login_as(user=self.user)
@@ -158,6 +156,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         )
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_deletes_missing_views(self) -> None:
         views = self.client.get(self.url).data
 
@@ -172,10 +171,11 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
 
         assert len(response.data) == 2
         # The first view should remain unchanged
-        assert response.data[0] == views[0]
-        assert response.data[1] == update_custom_view_three
+        assert are_views_equal(response.data[0], views[0])
+        assert are_views_equal(response.data[1], update_custom_view_three)
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_adds_view_with_no_id(self) -> None:
         views = self.client.get(self.url).data
         views.append(
@@ -194,6 +194,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[3]["querySort"] == "date"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_reorder_views(self) -> None:
         views = self.client.get(self.url).data
         view_one = views[0]
@@ -208,11 +209,12 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         response = self.get_success_response(self.organization.slug, views=views)
 
         assert len(response.data) == 3
-        assert response.data[0] == view_two
-        assert response.data[1] == view_one
-        assert response.data[2] == views[2]
+        assert are_views_equal(response.data[0], view_two)
+        assert are_views_equal(response.data[1], view_one)
+        assert are_views_equal(response.data[2], views[2])
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_rename_views(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -224,6 +226,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[0]["querySort"] == view["querySort"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_change_query(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -235,6 +238,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[0]["querySort"] == view["querySort"]
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_change_sort(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -246,6 +250,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[0]["querySort"] == "freq"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_change_everything(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -259,6 +264,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[0]["querySort"] == "freq"
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_invalid_no_views(self) -> None:
         response = self.get_error_response(self.organization.slug, views=[])
 
@@ -269,6 +275,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         }
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_invalid_sort(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -286,6 +293,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         }
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_invalid_over_max_views(self) -> None:
         from sentry.api.serializers.rest_framework.groupsearchview import MAX_VIEWS
 
@@ -303,6 +311,7 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         }
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_updated_deleted_view(self) -> None:
         views = self.client.get(self.url).data
 
@@ -331,7 +340,219 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[0]["querySort"] == view_two["querySort"]
         assert response.data[1]["query"] == view_one["query"]
         assert response.data[1]["querySort"] == view_one["querySort"]
-        assert response.data[2] == views[2]
+        assert are_views_equal(response.data[2], views[2])
+
+
+class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
+    endpoint = "sentry-api-0-organization-group-search-views"
+    method = "put"
+
+    def create_base_data_with_page_filters(self) -> list[GroupSearchView]:
+        user_1 = self.user
+        self.user_2 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_2)
+        self.user_3 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_3)
+
+        self.project1 = self.create_project(organization=self.organization, slug="project-a")
+        self.project2 = self.create_project(organization=self.organization, slug="project-b")
+        self.project3 = self.create_project(organization=self.organization, slug="project-c")
+
+        first_custom_view_user_one = GroupSearchView.objects.create(
+            name="Custom View One",
+            organization=self.organization,
+            user_id=user_1.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+            time_filters={"period": "14d"},
+            environments=["production"],
+        )
+        first_custom_view_user_one.projects.set([self.project1])
+
+        second_custom_view_user_one = GroupSearchView.objects.create(
+            name="Custom View Two",
+            organization=self.organization,
+            user_id=user_1.id,
+            query="is:resolved",
+            query_sort="new",
+            position=1,
+            time_filters={"period": "7d"},
+            environments=["staging"],
+        )
+        second_custom_view_user_one.projects.set([self.project1, self.project2, self.project3])
+
+        third_custom_view_user_one = GroupSearchView.objects.create(
+            name="Custom View Three",
+            organization=self.organization,
+            user_id=user_1.id,
+            query="is:ignored",
+            query_sort="freq",
+            position=2,
+            time_filters={"period": "30d"},
+            environments=["development"],
+        )
+        third_custom_view_user_one.projects.set([])
+
+        return [first_custom_view_user_one, second_custom_view_user_one, third_custom_view_user_one]
+
+    def setUp(self) -> None:
+        self.login_as(user=self.user)
+        self.base_data = self.create_base_data_with_page_filters()
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-views",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_not_including_page_filters_does_not_reset_them_for_existing_views(self) -> None:
+        views = self.client.get(self.url).data
+
+        # Original Page filters
+        assert views[0]["timeFilters"] == {"period": "14d"}
+        assert views[0]["projects"] == [self.project1.id]
+        assert views[0]["environments"] == ["production"]
+
+        view = views[0]
+        # Change nothing but the name
+        view["name"] = "New Name"
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["name"] == "New Name"
+        assert response.data[0]["query"] == view["query"]
+        assert response.data[0]["querySort"] == view["querySort"]
+
+        views = self.client.get(self.url).data
+        # Ensure these have not been changed
+        assert views[0]["timeFilters"] == {"period": "14d"}
+        assert views[0]["projects"] == [self.project1.id]
+        assert views[0]["environments"] == ["production"]
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_default_page_filters_with_global_views(self) -> None:
+        views = self.client.get(self.url).data
+        views.append(
+            {
+                "name": "New View",
+                "query": "is:unresolved",
+                "query_sort": "date",
+            }
+        )
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 4
+        assert response.data[3]["timeFilters"] == {"period": "14d"}
+        assert response.data[3]["projects"] == []
+        assert response.data[3]["environments"] == []
+        assert response.data[3]["isAllProjects"] is False
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_default_page_filters_without_global_views(self) -> None:
+        views = [
+            {
+                "name": "New View",
+                "query": "is:unresolved",
+                "query_sort": "date",
+            }
+        ]
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 1
+        assert response.data[0]["timeFilters"] == {"period": "14d"}
+        # Should choose the first project, alphabetically
+        assert len(response.data[0]["projects"]) == 1
+        assert response.data[0]["projects"][0] == self.project1.id
+        assert response.data[0]["environments"] == []
+        assert response.data[0]["isAllProjects"] is False
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_one_project_to_zero_projects(self) -> None:
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["projects"] = []
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["projects"] == []
+        assert response.data[0]["isAllProjects"] is False
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_to_all_projects(self) -> None:
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["projects"] = [-1]
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["projects"] == []
+        assert response.data[0]["isAllProjects"] is True
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_one_environment_to_zero_environments(self) -> None:
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["environments"] = []
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["environments"] == []
+
+    def test_update_time_filters(self) -> None:
+        views = self.client.get(self.url).data
+        view = views[0]
+        view["timeFilters"] = {"period": "7d"}
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["timeFilters"] == {"period": "7d"}
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_empty_time_filters_resets_to_default(self) -> None:
+        views = self.client.get(self.url).data
+        views[0]["timeFilters"] = {}
+        response = self.get_success_response(self.organization.slug, views=views)
+        assert len(response.data) == 3
+        assert response.data[0]["timeFilters"] == {"period": "14d"}
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_invalid_project_ids(self) -> None:
+        views = self.client.get(self.url).data
+        views[0]["projects"] = [self.project1.id, 123456]
+        response = self.get_error_response(self.organization.slug, views=views)
+        assert response.data == {"detail": "One or more projects do not exist"}
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_multiple_projects_without_global_views(self) -> None:
+        views = self.client.get(self.url).data
+        views[0]["projects"] = [self.project1.id, self.project2.id]
+        response = self.get_error_response(self.organization.slug, views=views)
+        assert response.data == {
+            "detail": "You do not have the multi project stream feature enabled"
+        }
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_all_projects_without_global_views(self) -> None:
+        views = self.client.get(self.url).data
+        views[0]["projects"] = [-1]
+        response = self.get_error_response(self.organization.slug, views=views)
+        assert response.data == {
+            "detail": "You do not have the multi project stream feature enabled"
+        }
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_my_projects_without_global_views(self) -> None:
+        views = self.client.get(self.url).data
+        views[0]["projects"] = []
+        response = self.get_error_response(self.organization.slug, views=views)
+        assert response.data == {
+            "detail": "You do not have the multi project stream feature enabled"
+        }
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -550,7 +550,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
         project1 = self.create_project(organization=self.organization, slug="project-a")
 
         issue_view_one = GroupSearchView.objects.create(
-            name="Custom View One",
+            name="Issue View One",
             organization=self.organization,
             user_id=self.user.id,
             query="is:unresolved",
@@ -561,12 +561,27 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
         )
         issue_view_one.projects.set([project1])
 
-        views = self.client.get(url).data
-        views[0]["projects"] = [project1.id, 123456]
         response = self.client.put(
-            url, data={"views": views}, format="json", content_type="application/json"
+            url,
+            data={
+                "views": [
+                    {
+                        "id": issue_view_one.id,
+                        "name": issue_view_one.name,
+                        "query": issue_view_one.query,
+                        "query_sort": issue_view_one.query_sort,
+                        "position": issue_view_one.position,
+                        "time_filters": issue_view_one.time_filters,
+                        "environments": issue_view_one.environments,
+                        "projects": [project1.id, 123456],
+                    }
+                ]
+            },
+            format="json",
+            content_type="application/json",
         )
-        assert response.status_code == 500
+        assert response.status_code == 400
+        assert response.data == {"detail": "One or more projects do not exist"}
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -499,6 +499,8 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         assert len(response.data) == 3
         assert response.data[0]["environments"] == []
 
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_update_time_filters(self) -> None:
         views = self.client.get(self.url).data
         view = views[0]
@@ -569,6 +571,7 @@ class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
         )
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
     def test_cannot_rename_other_users_views(self) -> None:
         self.login_as(user=self.user)
         views = self.client.get(self.url).data

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -581,7 +581,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert response.data == {"detail": "One or more projects do not exist"}
+        assert response.content == {"detail": "One or more projects do not exist"}
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import ErrorDetail
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
 from sentry.models.groupsearchview import GroupSearchView
-from sentry.testutils.cases import APITestCase, TransactionTestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
 
@@ -519,6 +519,14 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         assert response.data[0]["timeFilters"] == {"period": "14d"}
 
     @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_invalid_project_ids(self) -> None:
+        views = self.client.get(self.url).data
+        views[0]["projects"] = [self.project1.id, 123456]
+        response = self.get_error_response(self.organization.slug, views=views)
+        assert response.data == {"detail": "One or more projects do not exist"}
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
     def test_multiple_projects_without_global_views(self) -> None:
         views = self.client.get(self.url).data
@@ -547,25 +555,6 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         assert response.data == {
             "detail": "You do not have the multi project stream feature enabled"
         }
-
-
-class RandomTest(OrganizationGroupSearchViewsWithPageFiltersPutTest, TransactionTestCase):
-    def setUp(self) -> None:
-        self.login_as(user=self.user)
-        self.base_data = self.create_base_data_with_page_filters()
-
-        self.url = reverse(
-            "sentry-api-0-organization-group-search-views",
-            kwargs={"organization_id_or_slug": self.organization.slug},
-        )
-
-    @with_feature({"organizations:issue-stream-custom-views": True})
-    @with_feature({"organizations:global-views": True})
-    def test_invalid_project_ids(self) -> None:
-        views = self.client.get(self.url).data
-        views[0]["projects"] = [self.project1.id, 123456]
-        response = self.get_error_response(self.organization.slug, views=views)
-        assert response.data == {"detail": "One or more projects do not exist"}
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):


### PR DESCRIPTION
This PR updates the two Groupsearch view endpoints: 

* `PUT ../group-search-view`: updated to optionally accept the four new page filter parameters. The frontend will be updated shortly to send over these parameters.	
* `GET ../group-search-view`: updated to return the four new page filter parameters. The frontend will not do anything with these parameters until later. 
	*  validating projects parameter in this endpoint will come in a later PR 