### PR TITLE
chore(metric-issues): Replace issue type check with feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -191,6 +191,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-views-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:issue-open-periods", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable threshold period in metric alert rule builder

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -29,7 +29,7 @@ from sentry.integrations.api.serializers.models.external_issue import ExternalIs
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.constants import get_issue_tsdb_group_model
 from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
-from sentry.issues.grouptype import GroupCategory, MetricIssuePOC
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.group import Group
@@ -90,7 +90,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         return [seen for seen in serialize(seen_by, request.user) if seen is not None]
 
     def _get_open_periods_for_group(self, group: Group) -> list[OpenPeriod]:
-        if group.type != MetricIssuePOC.type_id:
+        if not features.has("organizations:issue-open-periods", group.organization):
             return []
 
         activities = Activity.objects.filter(

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -310,7 +310,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             assert response.data["id"] == str(group.id)
             assert response.data["count"] == "16"
 
-    def test_open_periods_non_metric(self) -> None:
+    def test_open_periods_flag_off(self) -> None:
         self.login_as(user=self.user)
         group = self.create_group()
         url = f"/api/0/issues/{group.id}/"
@@ -320,6 +320,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["openPeriods"] == []
 
+    @with_feature("organizations:issue-open-periods")
     def test_open_periods_new_group(self) -> None:
         self.login_as(user=self.user)
         group = self.create_group()
@@ -335,6 +336,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             {"start": group.first_seen, "end": None, "duration": None, "isOpen": True}
         ]
 
+    @with_feature("organizations:issue-open-periods")
     def test_open_periods_resolved_group(self) -> None:
         self.login_as(user=self.user)
         group = self.create_group()
@@ -365,6 +367,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             }
         ]
 
+    @with_feature("organizations:issue-open-periods")
     def test_open_periods_unresolved_group(self) -> None:
         self.login_as(user=self.user)
         group = self.create_group()


### PR DESCRIPTION
This feature flag will control whether open periods are enabled for an organization, independent of the issue type.