### PR TITLE
chore(aci): Remove references to deprecated columns

### DIFF
--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -72,7 +72,7 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         Return a list of detectors for a given project.
         """
         queryset = Detector.objects.filter(
-            organization_id=project.organization_id,
+            project_id=project.id,
         ).order_by("id")
 
         return self.paginate(

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -185,7 +185,7 @@ class DetectorSerializer(Serializer):
     def serialize(self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
         return {
             "id": str(obj.id),
-            "organizationId": str(obj.organization_id),
+            "projectId": str(obj.project_id),
             "name": obj.name,
             "type": obj.type,
             "dateCreated": obj.date_added,

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -66,7 +66,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
                     condition_group=condition_group,
                 )
             detector = Detector.objects.create(
-                organization_id=self.context["project"].organization_id,
+                project_id=self.context["project"].id,
                 name=validated_data["name"],
                 workflow_condition_group=condition_group,
                 type=validated_data["group_type"].slug,

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -46,7 +46,6 @@ class ErrorDetectorValidator(BaseGroupTypeDetectorValidator):
         with transaction.atomic(router.db_for_write(Detector)):
             detector = Detector.objects.create(
                 project_id=self.context["project"].id,
-                organization_id=self.context["project"].organization_id,
                 name=validated_data["name"],
                 # no workflow_condition_group
                 type=validated_data["group_type"].slug,

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -142,7 +142,6 @@ def migrate_metric_action(
         "sentry_app_config": alert_rule_trigger_action.sentry_app_config,
     }
     action = Action.objects.create(
-        required=False,
         type=action_type,
         data=data,
         integration_id=alert_rule_trigger_action.integration_id,

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -43,7 +43,7 @@ class TestErrorDetectorValidator(TestCase):
         detector = Detector.objects.get(id=detector.id)
         assert detector.name == "Test Detector"
         assert detector.type == "error"
-        assert detector.organization_id == self.project.organization_id
+        assert detector.project_id == self.project.id
         assert detector.workflow_condition_group is None
 
         # Verify audit log

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -120,7 +120,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
         assert response.data == serialize([detector])[0]
         assert detector.name == "Test Detector"
         assert detector.type == MetricAlertFire.slug
-        assert detector.organization_id == self.organization.id
+        assert detector.project_id == self.project.id
 
         # Verify data source
         data_source = DataSource.objects.get(detector=detector)

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -33,10 +33,10 @@ class ProjectDetectorIndexBaseTest(APITestCase):
 class ProjectDetectorIndexGetTest(ProjectDetectorIndexBaseTest):
     def test_simple(self):
         detector = self.create_detector(
-            organization_id=self.organization.id, name="Test Detector", type=MetricAlertFire.slug
+            project_id=self.project.id, name="Test Detector", type=MetricAlertFire.slug
         )
         detector_2 = self.create_detector(
-            organization_id=self.organization.id, name="Test Detector 2", type=MetricAlertFire.slug
+            project_id=self.project.id, name="Test Detector 2", type=MetricAlertFire.slug
         )
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert response.data == serialize([detector, detector_2])

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -26,7 +26,7 @@ class TestDetectorSerializer(TestCase):
 
         assert result == {
             "id": str(detector.id),
-            "organizationId": str(self.organization.id),
+            "projectId": str(detector.project_id),
             "name": "Test Detector",
             "type": MetricAlertFire.slug,
             "dateCreated": detector.date_added,
@@ -79,7 +79,7 @@ class TestDetectorSerializer(TestCase):
         # print("result: ", result)
         assert result == {
             "id": str(detector.id),
-            "organizationId": str(self.organization.id),
+            "projectId": str(detector.project_id),
             "name": "Test Detector",
             "type": MetricAlertFire.slug,
             "dateCreated": detector.date_added,

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -20,7 +20,7 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 class TestDetectorSerializer(TestCase):
     def test_serialize_simple(self):
         detector = self.create_detector(
-            organization_id=self.organization.id, name="Test Detector", type=MetricAlertFire.slug
+            project_id=self.project.id, name="Test Detector", type=MetricAlertFire.slug
         )
         result = serialize(detector)
 
@@ -50,7 +50,7 @@ class TestDetectorSerializer(TestCase):
         action = self.create_action(type=Action.Type.EMAIL, data={"foo": "bar"})
         self.create_data_condition_group_action(condition_group=condition_group, action=action)
         detector = self.create_detector(
-            organization_id=self.organization.id,
+            project_id=self.project.id,
             name="Test Detector",
             type=MetricAlertFire.slug,
             workflow_condition_group=condition_group,
@@ -131,7 +131,7 @@ class TestDetectorSerializer(TestCase):
     def test_serialize_bulk(self):
         detectors = [
             self.create_detector(
-                organization_id=self.organization.id,
+                project_id=self.project.id,
                 name=f"Test Detector {i}",
                 type=MetricAlertFire.slug,
             )

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -210,7 +210,7 @@ class DetectorValidatorTest(TestCase):
         detector = Detector.objects.get(id=detector.id)
         assert detector.name == "Test Detector"
         assert detector.type == "metric_alert_fire"
-        assert detector.organization_id == self.project.organization_id
+        assert detector.project_id == self.project.id
 
         # Verify data source in DB
         data_source = DataSource.objects.get(detector=detector)
@@ -307,7 +307,7 @@ class TestMetricAlertsDetectorValidator(TestCase):
         detector = Detector.objects.get(id=detector.id)
         assert detector.name == "Test Detector"
         assert detector.type == "metric_alert_fire"
-        assert detector.organization_id == self.project.organization_id
+        assert detector.project_id == self.project.id
 
         # Verify data source and query subscription in DB
         data_source = DataSource.objects.get(detector=detector)


### PR DESCRIPTION
Following up on some TODOs to remove the `organization` column from the `Detector` model and the `required` column from the `Action` model, the first step is to remove the references to them. 