### PR TITLE
chore(dashboards): Get rid of unused Dashboard page view analytics

### DIFF
--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -69,10 +69,6 @@ class OrgDashboards extends DeprecatedAsyncComponent<Props, State> {
 
     if (params.dashboardId) {
       endpoints.push(['selectedDashboard', `${url}${params.dashboardId}/`]);
-      this.props.setEventNames('dashboards2.view', 'Dashboards2: View dashboard');
-      this.props.setRouteAnalyticsParams({
-        dashboard_id: params.dashboardId,
-      });
     }
 
     return endpoints;


### PR DESCRIPTION
There was an unused page view analytic tracker that could be being triggered when viewing dashboard details. Removing that so it doesn't get pinged in amplitude.