### PR TITLE
fix(settings): fix auth token name font size

### DIFF
--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -28,7 +28,7 @@ describe('ApiTokenRow', () => {
         token={ApiTokenFixture({id: '1', name: 'token1'})}
       />
     );
-    screen.getByRole('heading', {name: /token1/i});
+    screen.getByText(/token1/);
   });
 
   it('calls onRemove callback when trash can is clicked', async () => {

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -37,7 +37,7 @@ function ApiTokenRow({token, onRemove, tokenPrefix = '', canEdit = false}: Props
             </Link>
           </LinkWrapper>
         ) : (
-          <h1>{token.name ? token.name : ''}</h1>
+          <StyledTokenName>{token.name ? token.name : ''}</StyledTokenName>
         )}
         <ButtonWrapper>
           <Confirm
@@ -149,6 +149,10 @@ const ButtonWrapper = styled('div')`
   justify-content: flex-end;
   font-size: ${p => p.theme.fontSizeSmall};
   gap: ${space(1)};
+`;
+
+const StyledTokenName = styled('p')`
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 export default ApiTokenRow;

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -37,7 +37,7 @@ function ApiTokenRow({token, onRemove, tokenPrefix = '', canEdit = false}: Props
             </Link>
           </LinkWrapper>
         ) : (
-          <StyledTokenName>{token.name ? token.name : ''}</StyledTokenName>
+          <p>{token.name ? token.name : ''}</p>
         )}
         <ButtonWrapper>
           <Confirm
@@ -149,10 +149,6 @@ const ButtonWrapper = styled('div')`
   justify-content: flex-end;
   font-size: ${p => p.theme.fontSizeSmall};
   gap: ${space(1)};
-`;
-
-const StyledTokenName = styled('p')`
-  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 export default ApiTokenRow;


### PR DESCRIPTION
no more `h1`

with edit access, link displays, same as before:

<img width="997" alt="SCR-20250123-lely" src="https://github.com/user-attachments/assets/0c993155-f9b6-4d29-9f2c-e6e58a0b9ebd" />

no edit access, the font is now a normal size:

<img width="984" alt="SCR-20250123-leru" src="https://github.com/user-attachments/assets/9e12d99b-47ab-462c-85f5-3b9a0d895610" />

in admin, will look something like this:

<img width="649" alt="SCR-20250123-lfal" src="https://github.com/user-attachments/assets/df44a821-be0e-446b-bbdf-11e63de7d720" />

instead of this
![image](https://github.com/user-attachments/assets/6b632220-a669-47c2-bfca-54153b28886a)

