### PR TITLE
ref(workflow_engine): Refactor the Validators to be broken a part a bit more granularly

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/__init__.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/__init__.py
@@ -1,0 +1,11 @@
+__all__ = [
+    "BaseDataConditionValidator",
+    "BaseDataSourceValidator",
+    "BaseGroupTypeDetectorValidator",
+    "DataSourceCreator",
+    "NumericComparisonConditionValidator",
+]
+
+from .data_condition import BaseDataConditionValidator, NumericComparisonConditionValidator
+from .data_source import BaseDataSourceValidator, DataSourceCreator
+from .detector import BaseGroupTypeDetectorValidator

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
@@ -1,0 +1,67 @@
+from rest_framework import serializers
+from rest_framework.fields import Field
+
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+
+class BaseDataConditionValidator(CamelSnakeSerializer):
+    type = serializers.CharField(
+        required=True,
+        max_length=200,
+        help_text="Condition used to compare data value to the stored comparison value",
+    )
+
+    @property
+    def comparison(self) -> Field:
+        raise NotImplementedError
+
+    @property
+    def result(self) -> Field:
+        raise NotImplementedError
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        return attrs
+
+
+class NumericComparisonConditionValidator(BaseDataConditionValidator):
+    comparison = serializers.FloatField(
+        required=True,
+        help_text="Comparison value to be compared against value from data.",
+    )
+    result = serializers.ChoiceField(
+        choices=[
+            (DetectorPriorityLevel.HIGH, "High"),
+            (DetectorPriorityLevel.MEDIUM, "Medium"),
+            (DetectorPriorityLevel.LOW, "Low"),
+        ]
+    )
+
+    @property
+    def supported_conditions(self) -> frozenset[Condition]:
+        raise NotImplementedError
+
+    @property
+    def supported_results(self) -> frozenset[DetectorPriorityLevel]:
+        raise NotImplementedError
+
+    def validate_type(self, value: str) -> Condition:
+        try:
+            type = Condition(value)
+        except ValueError:
+            type = None
+
+        if type not in self.supported_conditions:
+            raise serializers.ValidationError(f"Unsupported type {value}")
+        return type
+
+    def validate_result(self, value: str) -> DetectorPriorityLevel:
+        try:
+            result = DetectorPriorityLevel(int(value))
+        except ValueError:
+            result = None
+        if result not in self.supported_results:
+            raise serializers.ValidationError("Unsupported condition result")
+        return result

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_source.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_source.py
@@ -1,0 +1,35 @@
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.db.models import Model
+from sentry.workflow_engine.registry import data_source_type_registry
+from sentry.workflow_engine.types import DataSourceTypeHandler
+
+T = TypeVar("T", bound=Model)
+
+
+class DataSourceCreator(Generic[T]):
+    def __init__(self, create_fn: Callable[[], T]):
+        self._create_fn = create_fn
+        self._instance: T | None = None
+
+    def create(self) -> T:
+        if self._instance is None:
+            self._instance = self._create_fn()
+        return self._instance
+
+
+class BaseDataSourceValidator(CamelSnakeSerializer, Generic[T]):
+    @property
+    def data_source_type_handler(self) -> type[DataSourceTypeHandler]:
+        raise NotImplementedError
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        attrs["_creator"] = DataSourceCreator[T](lambda: self.create_source(attrs))
+        attrs["data_source_type"] = data_source_type_registry.get_key(self.data_source_type_handler)
+        return attrs
+
+    def create_source(self, validated_data) -> T:
+        raise NotImplementedError

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -1,116 +1,22 @@
-from collections.abc import Callable
-from typing import Generic, TypeVar
-
 from django.db import router, transaction
 from rest_framework import serializers
-from rest_framework.fields import Field
 
 from sentry import audit_log
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
-from sentry.db.models import Model
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.endpoints.validators.base import (
+    BaseDataConditionValidator,
+    BaseDataSourceValidator,
+)
 from sentry.workflow_engine.models import (
     DataConditionGroup,
     DataSource,
     DataSourceDetector,
     Detector,
 )
-from sentry.workflow_engine.models.data_condition import Condition, DataCondition
-from sentry.workflow_engine.registry import data_source_type_registry
-from sentry.workflow_engine.types import DataSourceTypeHandler, DetectorPriorityLevel
-
-T = TypeVar("T", bound=Model)
-
-
-class DataSourceCreator(Generic[T]):
-    def __init__(self, create_fn: Callable[[], T]):
-        self._create_fn = create_fn
-        self._instance: T | None = None
-
-    def create(self) -> T:
-        if self._instance is None:
-            self._instance = self._create_fn()
-        return self._instance
-
-
-class BaseDataConditionValidator(CamelSnakeSerializer):
-
-    type = serializers.CharField(
-        required=True,
-        max_length=200,
-        help_text="Condition used to compare data value to the stored comparison value",
-    )
-
-    @property
-    def comparison(self) -> Field:
-        raise NotImplementedError
-
-    @property
-    def result(self) -> Field:
-        raise NotImplementedError
-
-    def validate(self, attrs):
-        attrs = super().validate(attrs)
-        return attrs
-
-
-class NumericComparisonConditionValidator(BaseDataConditionValidator):
-
-    comparison = serializers.FloatField(
-        required=True,
-        help_text="Comparison value to be compared against value from data.",
-    )
-    result = serializers.ChoiceField(
-        choices=[
-            (DetectorPriorityLevel.HIGH, "High"),
-            (DetectorPriorityLevel.MEDIUM, "Medium"),
-            (DetectorPriorityLevel.LOW, "Low"),
-        ]
-    )
-
-    @property
-    def supported_conditions(self) -> frozenset[Condition]:
-        raise NotImplementedError
-
-    @property
-    def supported_results(self) -> frozenset[DetectorPriorityLevel]:
-        raise NotImplementedError
-
-    def validate_type(self, value: str) -> Condition:
-        try:
-            type = Condition(value)
-        except ValueError:
-            type = None
-
-        if type not in self.supported_conditions:
-            raise serializers.ValidationError(f"Unsupported type {value}")
-        return type
-
-    def validate_result(self, value: str) -> DetectorPriorityLevel:
-        try:
-            result = DetectorPriorityLevel(int(value))
-        except ValueError:
-            result = None
-        if result not in self.supported_results:
-            raise serializers.ValidationError("Unsupported condition result")
-        return result
-
-
-class BaseDataSourceValidator(CamelSnakeSerializer, Generic[T]):
-    @property
-    def data_source_type_handler(self) -> type[DataSourceTypeHandler]:
-        raise NotImplementedError
-
-    def validate(self, attrs):
-        attrs = super().validate(attrs)
-        attrs["_creator"] = DataSourceCreator[T](lambda: self.create_source(attrs))
-        attrs["data_source_type"] = data_source_type_registry.get_key(self.data_source_type_handler)
-        return attrs
-
-    def create_source(self, validated_data) -> T:
-        raise NotImplementedError
+from sentry.workflow_engine.models.data_condition import DataCondition
 
 
 class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -106,7 +106,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
             )
             assert response.data == {"groupType": ["Group type not compatible with detectors"]}
 
-    @mock.patch("sentry.workflow_engine.endpoints.validators.base.create_audit_entry")
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_valid_creation(self, mock_audit):
         with self.tasks():
             response = self.get_success_response(

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -200,7 +200,7 @@ class DetectorValidatorTest(TestCase):
             },
         }
 
-    @mock.patch("sentry.workflow_engine.endpoints.validators.base.create_audit_entry")
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_create_with_mock_validator(self, mock_audit):
         validator = MockDetectorValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid(), validator.errors
@@ -292,7 +292,7 @@ class TestMetricAlertsDetectorValidator(TestCase):
             ],
         }
 
-    @mock.patch("sentry.workflow_engine.endpoints.validators.base.create_audit_entry")
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_create_with_valid_data(self, mock_audit):
         validator = MetricAlertsDetectorValidator(
             data=self.valid_data,


### PR DESCRIPTION
## Description
Break apart the `validators/base.py` into many files for each of the bases (data source, data condition, detector) to prepare for adding more (actions and workflows).

This isn't changing any logic, just organizing the code. 