### PR TITLE
fix(widget-builder): Change font sizing/spacing to explore

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/common/sectionHeader.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/common/sectionHeader.tsx
@@ -35,15 +35,15 @@ export function SectionHeader({
 }
 
 const StyledHeader = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  margin-bottom: ${space(1)};
+  font-size: ${p => p.theme.form.md.fontSize};
+  margin-bottom: ${space(0.5)};
 `;
 
 const OptionalHeader = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
+  font-size: ${p => p.theme.form.md.fontSize};
   color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(0.5)};
 `;
 
 const HeaderWrapper = styled('div')`

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -80,5 +80,5 @@ const FeatureBadgeAlignmentWrapper = styled('div')`
 `;
 
 const StyledSectionHeader = styled(SectionHeader)`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -255,5 +255,5 @@ const SlideoutBodyWrapper = styled('div')`
 `;
 
 const Section = styled('div')`
-  margin-bottom: ${space(4)};
+  margin-bottom: ${space(3)};
 `;


### PR DESCRIPTION
In an effort to make the explore experience and widget builder experience cohesive, I made the headers fonts and spacing the same.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f5feaaf5-f938-4533-9a27-4cf97ff860d7) | ![image](https://github.com/user-attachments/assets/5b9f4f23-9e7b-416c-a9d4-17a46d491831) | 
