### PR TITLE
feat(widget-builder): Add source to add to dashboard flows

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -26,6 +26,7 @@ import {IndexedEventsSelectionAlert} from 'sentry/views/dashboards/indexedEvents
 import type {
   DashboardDetails,
   DashboardListItem,
+  DashboardWidgetSource,
   Widget,
 } from 'sentry/views/dashboards/types';
 import {DisplayType, MAX_WIDGETS, WidgetType} from 'sentry/views/dashboards/types';
@@ -70,6 +71,7 @@ export type AddToDashboardModalProps = {
   organization: Organization;
   router: InjectedRouter;
   selection: PageFilters;
+  source: DashboardWidgetSource;
   widget: Widget;
   widgetAsQueryParams: WidgetAsQueryParams;
   actions?: AddToDashboardModalActions[];
@@ -94,6 +96,7 @@ function AddToDashboardModal({
   organization,
   router,
   selection,
+  source,
   widget,
   widgetAsQueryParams,
   actions = DEFAULT_ACTIONS,
@@ -167,6 +170,7 @@ function AddToDashboardModal({
         query: {
           ...widgetAsQueryParams,
           ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
+          source,
         },
       })
     );

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -26,7 +26,6 @@ import {IndexedEventsSelectionAlert} from 'sentry/views/dashboards/indexedEvents
 import type {
   DashboardDetails,
   DashboardListItem,
-  DashboardWidgetSource,
   Widget,
 } from 'sentry/views/dashboards/types';
 import {DisplayType, MAX_WIDGETS, WidgetType} from 'sentry/views/dashboards/types';
@@ -71,7 +70,6 @@ export type AddToDashboardModalProps = {
   organization: Organization;
   router: InjectedRouter;
   selection: PageFilters;
-  source: DashboardWidgetSource;
   widget: Widget;
   widgetAsQueryParams: WidgetAsQueryParams;
   actions?: AddToDashboardModalActions[];
@@ -96,7 +94,6 @@ function AddToDashboardModal({
   organization,
   router,
   selection,
-  source,
   widget,
   widgetAsQueryParams,
   actions = DEFAULT_ACTIONS,
@@ -170,7 +167,6 @@ function AddToDashboardModal({
         query: {
           ...widgetAsQueryParams,
           ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
-          source,
         },
       })
     );

--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -17,6 +17,7 @@ type DashboardsEventParametersWidgetBuilder = {
   };
   'dashboards_views.widget_builder.opened': {
     builder_version: WidgetBuilderVersion;
+    from: string;
     new_widget: boolean;
   };
   'dashboards_views.widget_builder.save': {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -37,6 +37,7 @@ import WidgetBuilderTypeSelector from 'sentry/views/dashboards/widgetBuilder/com
 import Visualize from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import WidgetTemplatesList from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 
@@ -75,6 +76,7 @@ function WidgetBuilderSlideout({
   const [error, setError] = useState<Record<string, any>>({});
   const theme = useTheme();
   const isEditing = useIsEditingWidget();
+  const source = useDashboardWidgetSource();
 
   const validatedWidgetResponse = useValidateWidgetQuery(
     convertBuilderStateToWidget(state)
@@ -86,6 +88,7 @@ function WidgetBuilderSlideout({
         builder_version: WidgetBuilderVersion.SLIDEOUT,
         new_widget: !isEditing,
         organization,
+        from: source,
       });
     }
     // Ignore isEditing because it won't change during the

--- a/static/app/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource.tsx
@@ -12,7 +12,7 @@ function useDashboardWidgetSource(): DashboardWidgetSource | '' {
 
   return defined(source) && validSources.includes(source as DashboardWidgetSource)
     ? (source as DashboardWidgetSource)
-    : '';
+    : DashboardWidgetSource.DASHBOARDS;
 }
 
 export default useDashboardWidgetSource;

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -318,6 +318,7 @@ function WidgetBuilder({
       organization,
       new_widget: !isEditing,
       builder_version: WidgetBuilderVersion.PAGE,
+      from: source,
     });
 
     if (isEmptyObject(tags) && dataSet !== DataSet.SPANS) {

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -23,6 +23,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeList} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
+import {DashboardWidgetSource} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import {
@@ -196,6 +197,7 @@ class QueryList extends Component<Props> {
                     getSavedQueryDataset(organization, location, newQuery)
                   ]
                 : undefined,
+              source: DashboardWidgetSource.DISCOVERV2,
             }),
         },
         {
@@ -292,6 +294,7 @@ class QueryList extends Component<Props> {
                           getSavedQueryDataset(organization, location, savedQuery)
                         ]
                       : undefined,
+                    source: DashboardWidgetSource.DISCOVERV2,
                   }),
               },
             ]

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -35,6 +35,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOverlay from 'sentry/utils/useOverlay';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
+import {DashboardWidgetSource} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {
   handleAddQueryToDashboard,
@@ -460,6 +461,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
                   getSavedQueryDataset(organization, location, savedQuery)
                 ]
               : undefined,
+            source: DashboardWidgetSource.DISCOVERV2,
           })
         }
       >
@@ -585,6 +587,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
                   getSavedQueryDataset(organization, location, savedQuery)
                 ]
               : undefined,
+            source: DashboardWidgetSource.DISCOVERV2,
           });
         },
       });

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -13,7 +13,11 @@ import type {Organization} from 'sentry/types/organization';
 import type {EventViewOptions} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
 import {DisplayModes} from 'sentry/utils/discover/types';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DashboardWidgetSource,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {
   constructAddQueryToDashboardLink,
   decodeColumnOrder,
@@ -940,6 +944,7 @@ describe('constructAddQueryToDashboardLink', function () {
         eventView,
         organization,
         location,
+        source: DashboardWidgetSource.DISCOVERV2,
         yAxis: ['count()', 'count_unique(user)'],
         widgetType: WidgetType.TRANSACTIONS,
       });
@@ -956,6 +961,7 @@ describe('constructAddQueryToDashboardLink', function () {
         dataset: WidgetType.TRANSACTIONS,
         displayType: DisplayType.AREA,
         yAxis: ['count()', 'count_unique(user)'],
+        source: DashboardWidgetSource.DISCOVERV2,
       });
     });
     it('should construct a link with the correct params - topN', function () {
@@ -970,6 +976,7 @@ describe('constructAddQueryToDashboardLink', function () {
         eventView,
         organization,
         location,
+        source: DashboardWidgetSource.DISCOVERV2,
         yAxis: ['count()'],
         widgetType: WidgetType.TRANSACTIONS,
       });
@@ -986,6 +993,7 @@ describe('constructAddQueryToDashboardLink', function () {
         displayType: DisplayType.AREA,
         yAxis: ['count()'],
         limit: 5,
+        source: DashboardWidgetSource.DISCOVERV2,
       });
     });
     it('should construct a link with the correct params - daily top N', function () {
@@ -1000,6 +1008,7 @@ describe('constructAddQueryToDashboardLink', function () {
         eventView,
         organization,
         location,
+        source: DashboardWidgetSource.DISCOVERV2,
         yAxis: ['count()'],
         widgetType: WidgetType.TRANSACTIONS,
       });
@@ -1016,6 +1025,7 @@ describe('constructAddQueryToDashboardLink', function () {
         displayType: DisplayType.BAR,
         yAxis: ['count()'],
         limit: 5,
+        source: DashboardWidgetSource.DISCOVERV2,
       });
     });
   });
@@ -1046,6 +1056,7 @@ describe('handleAddQueryToDashboard', function () {
       router,
       widgetType: WidgetType.TRANSACTIONS,
       yAxis: ['count()'],
+      source: DashboardWidgetSource.DISCOVERV2,
     });
     expect(mockedOpenAddToDashboardModal).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1082,6 +1093,7 @@ describe('handleAddQueryToDashboard', function () {
       organization,
       location,
       router,
+      source: DashboardWidgetSource.DISCOVERV2,
       widgetType: WidgetType.TRANSACTIONS,
       yAxis: ['count()'],
     });
@@ -1119,6 +1131,7 @@ describe('handleAddQueryToDashboard', function () {
       organization,
       location,
       router,
+      source: DashboardWidgetSource.DISCOVERV2,
       widgetType: WidgetType.TRANSACTIONS,
       yAxis: ['count()', 'count_unique(user)'],
     });
@@ -1163,6 +1176,7 @@ describe('handleAddQueryToDashboard', function () {
         organization,
         location,
         router,
+        source: DashboardWidgetSource.DISCOVERV2,
         widgetType: WidgetType.TRANSACTIONS,
         yAxis: ['count()'],
       });
@@ -1185,6 +1199,7 @@ describe('handleAddQueryToDashboard', function () {
             limit: undefined,
             widgetType: WidgetType.TRANSACTIONS,
           },
+          source: DashboardWidgetSource.DISCOVERV2,
         })
       );
     });
@@ -1201,6 +1216,7 @@ describe('handleAddQueryToDashboard', function () {
         organization,
         location,
         router,
+        source: DashboardWidgetSource.DISCOVERV2,
         widgetType: WidgetType.TRANSACTIONS,
         yAxis: ['count()'],
       });
@@ -1223,6 +1239,7 @@ describe('handleAddQueryToDashboard', function () {
             limit: 5,
             widgetType: WidgetType.TRANSACTIONS,
           },
+          source: DashboardWidgetSource.DISCOVERV2,
         })
       );
     });
@@ -1238,6 +1255,7 @@ describe('handleAddQueryToDashboard', function () {
         organization,
         location,
         router,
+        source: DashboardWidgetSource.DISCOVERV2,
         widgetType: WidgetType.TRANSACTIONS,
         yAxis: ['count()', 'count_unique(user)'],
       });
@@ -1260,6 +1278,7 @@ describe('handleAddQueryToDashboard', function () {
             limit: undefined,
             widgetType: WidgetType.TRANSACTIONS,
           },
+          source: DashboardWidgetSource.DISCOVERV2,
         })
       );
     });

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -1199,7 +1199,9 @@ describe('handleAddQueryToDashboard', function () {
             limit: undefined,
             widgetType: WidgetType.TRANSACTIONS,
           },
-          source: DashboardWidgetSource.DISCOVERV2,
+          widgetAsQueryParams: expect.objectContaining({
+            source: DashboardWidgetSource.DISCOVERV2,
+          }),
         })
       );
     });
@@ -1239,7 +1241,9 @@ describe('handleAddQueryToDashboard', function () {
             limit: 5,
             widgetType: WidgetType.TRANSACTIONS,
           },
-          source: DashboardWidgetSource.DISCOVERV2,
+          widgetAsQueryParams: expect.objectContaining({
+            source: DashboardWidgetSource.DISCOVERV2,
+          }),
         })
       );
     });
@@ -1278,7 +1282,9 @@ describe('handleAddQueryToDashboard', function () {
             limit: undefined,
             widgetType: WidgetType.TRANSACTIONS,
           },
-          source: DashboardWidgetSource.DISCOVERV2,
+          widgetAsQueryParams: expect.objectContaining({
+            source: DashboardWidgetSource.DISCOVERV2,
+          }),
         })
       );
     });

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -768,7 +768,6 @@ export function handleAddQueryToDashboard({
     // @ts-ignore TS(2322): Type '{ dataset?: WidgetType | undefined; descript... Remove this comment to see the full error message
     widgetAsQueryParams,
     location,
-    source,
   });
   return;
 }

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -53,7 +53,7 @@ import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 
 import {
-  DashboardWidgetSource,
+  type DashboardWidgetSource,
   DisplayType,
   type Widget,
   type WidgetQuery,
@@ -699,11 +699,13 @@ export function handleAddQueryToDashboard({
   router,
   yAxis,
   widgetType,
+  source,
 }: {
   eventView: EventView;
   location: Location;
   organization: Organization;
   router: InjectedRouter;
+  source: DashboardWidgetSource;
   widgetType: WidgetType | undefined;
   query?: NewQuery;
   yAxis?: string | string[];
@@ -722,6 +724,7 @@ export function handleAddQueryToDashboard({
     yAxis,
     location,
     widgetType,
+    source,
   });
 
   openAddToDashboardModal({
@@ -765,6 +768,7 @@ export function handleAddQueryToDashboard({
     // @ts-ignore TS(2322): Type '{ dataset?: WidgetType | undefined; descript... Remove this comment to see the full error message
     widgetAsQueryParams,
     location,
+    source,
   });
   return;
 }
@@ -813,9 +817,11 @@ export function constructAddQueryToDashboardLink({
   yAxis,
   location,
   widgetType,
+  source,
 }: {
   eventView: EventView;
   organization: Organization;
+  source: DashboardWidgetSource;
   location?: Location;
   query?: NewQuery;
   widgetType?: WidgetType;
@@ -870,6 +876,7 @@ export function constructAddQueryToDashboardLink({
         end: eventView.end,
         statsPeriod: eventView.statsPeriod,
         ...convertWidgetToBuilderStateParams(widget),
+        source,
       },
     };
   }
@@ -878,7 +885,6 @@ export function constructAddQueryToDashboardLink({
     pathname: `/organizations/${organization.slug}/dashboards/new/widget/new/`,
     query: {
       ...location?.query,
-      source: DashboardWidgetSource.DISCOVERV2,
       start: eventView.start,
       end: eventView.end,
       statsPeriod: eventView.statsPeriod,
@@ -889,6 +895,7 @@ export function constructAddQueryToDashboardLink({
       dataset: widgetType,
       field: eventView.getFields(),
       limit,
+      source,
     },
   };
 }

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -8,7 +8,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
-import {WidgetType} from 'sentry/views/dashboards/types';
+import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
 import {MAX_NUM_Y_AXES} from 'sentry/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {
@@ -102,6 +102,7 @@ export function useAddToDashboard() {
         router,
         yAxis: eventView.yAxis,
         widgetType: WidgetType.SPANS,
+        source: DashboardWidgetSource.TRACE_EXPLORER,
       });
     },
     [organization, location, getEventView, router]

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -581,7 +581,7 @@ describe('ExploreToolbar', function () {
               'timestamp',
             ],
             limit: undefined,
-            source: 'discoverv2',
+            source: 'traceExplorer',
             start: undefined,
             statsPeriod: '14d',
           }),


### PR DESCRIPTION
When the Add to Dashboard flow navigates to the widget builder, put a `source` parameter in the query params and use that to pass along to events so we can track where they came from when opening the builder.

