### PR TITLE
feat(ourlogs): Implement the initial version of the logs tab

### DIFF
--- a/static/app/components/nav/config.tsx
+++ b/static/app/components/nav/config.tsx
@@ -90,6 +90,11 @@ export function createNavConfig({organization}: {organization: Organization}): N
             feature: {features: 'performance-trace-explorer'},
           },
           {
+            label: t('Logs'),
+            to: `/${prefix}/explore/logs/`,
+            feature: {features: 'ourlogs-enabled'},
+          },
+          {
             label: t('Metrics'),
             to: `/${prefix}/metrics/`,
             feature: {features: 'custom-metrics'},

--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -159,9 +159,10 @@ describe('Nav', function () {
       renderNav();
       const container = screen.getByRole('navigation', {name: 'Secondary Navigation'});
       const links = within(container).getAllByRole('link');
-      expect(links).toHaveLength(7);
+      expect(links).toHaveLength(8);
       [
         'Traces',
+        'Logs',
         'Metrics',
         'Profiles',
         'Replays',

--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -22,6 +22,7 @@ const ALL_AVAILABLE_FEATURES = [
   'custom-metrics',
   'user-feedback-ui',
   'session-replay-ui',
+  'ourlogs-enabled',
   'performance-view',
   'performance-trace-explorer',
   'starfish-mobile-ui-module',

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -279,6 +279,18 @@ function Sidebar() {
     </Feature>
   );
 
+  const logs = hasOrganization && (
+    <Feature features="ourlogs-enabled">
+      <SidebarItem
+        {...sidebarItemProps}
+        label={<GuideAnchor target="logs">{t('Logs')}</GuideAnchor>}
+        to={`/organizations/${organization?.slug}/explore/logs/`}
+        id="ourlogs"
+        icon={<SubitemDot collapsed />}
+      />
+    </Feature>
+  );
+
   const performance = hasOrganization && (
     <Feature
       hookName="feature-disabled:performance-sidebar-item"
@@ -497,6 +509,7 @@ function Sidebar() {
       exact={!shouldAccordionFloat}
     >
       {traces}
+      {logs}
       {metrics}
       {profiling}
       {replays}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1900,6 +1900,14 @@ function buildRoutes() {
     </Route>
   );
 
+  const exploreRoutes = (
+    <Route
+      path="/explore/logs"
+      component={make(() => import('sentry/views/explore/logs'))}
+      withOrgPath
+    />
+  );
+
   const userFeedbackRoutes = (
     <Route
       path="/user-feedback/"
@@ -2323,6 +2331,7 @@ function buildRoutes() {
       {performanceRoutes}
       {domainViewRoutes}
       {tracesRoutes}
+      {exploreRoutes}
       {llmMonitoringRedirects}
       {profilingRoutes}
       {metricsRoutes}

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -19,6 +19,7 @@ export enum DiscoverDatasets {
   METRICS = 'metrics',
   METRICS_ENHANCED = 'metricsEnhanced',
   ISSUE_PLATFORM = 'issuePlatform',
+  OURLOGS = 'ourlogs',
   SPANS_EAP = 'spans',
   SPANS_EAP_RPC = 'spansRpc',
   SPANS_INDEXED = 'spansIndexed',

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -10,13 +10,10 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
-import TraceExplorerTabs from 'sentry/views/explore/tabBar';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 
 export function ExploreContent() {
@@ -36,8 +33,6 @@ export function ExploreContent() {
       },
     });
   }, [location, navigate]);
-  const ourlogsEnabled = organization.features.includes('ourlogs-enabled');
-  const selectedTab = decodeScalar(location.query.exploreTab, 'spans');
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
@@ -72,17 +67,12 @@ export function ExploreContent() {
                 <FeedbackWidgetButton />
               </ButtonBar>
             </Layout.HeaderActions>
-            {ourlogsEnabled ? <TraceExplorerTabs selected={selectedTab} /> : null}
           </Layout.Header>
-          {ourlogsEnabled && selectedTab === 'logs' ? (
-            <LogsTabContent />
-          ) : (
-            <SpansTabContent
-              defaultPeriod={defaultPeriod}
-              maxPickableDays={maxPickableDays}
-              relativeOptions={relativeOptions}
-            />
-          )}
+          <SpansTabContent
+            defaultPeriod={defaultPeriod}
+            maxPickableDays={maxPickableDays}
+            relativeOptions={relativeOptions}
+          />
         </Layout.Page>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -1,0 +1,40 @@
+import FeatureBadge from 'sentry/components/badge/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
+import {limitMaxPickableDays} from 'sentry/views/explore/utils';
+
+export default function LogsPage() {
+  const organization = useOrganization();
+  const {defaultPeriod, maxPickableDays, relativeOptions} = limitMaxPickableDays(
+    organization!
+  );
+
+  return (
+    <SentryDocumentTitle title={t('Logs')} orgSlug={organization?.slug}>
+      <PageFiltersContainer maxPickableDays={maxPickableDays}>
+        <Layout.Page>
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <Layout.Title>
+                {t('Logs')}
+                <FeatureBadge
+                  title={t('This feature is experimental and might drastically change')}
+                  type="experimental"
+                />
+              </Layout.Title>
+            </Layout.HeaderContent>
+          </Layout.Header>
+          <LogsTabContent
+            defaultPeriod={defaultPeriod}
+            maxPickableDays={maxPickableDays}
+            relativeOptions={relativeOptions}
+          />
+        </Layout.Page>
+      </PageFiltersContainer>
+    </SentryDocumentTitle>
+  );
+}

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -21,10 +21,7 @@ export default function LogsPage() {
             <Layout.HeaderContent>
               <Layout.Title>
                 {t('Logs')}
-                <FeatureBadge
-                  title={t('This feature is experimental and might drastically change')}
-                  type="experimental"
-                />
+                <FeatureBadge type="experimental" />
               </Layout.Title>
             </Layout.HeaderContent>
           </Layout.Header>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -7,6 +7,7 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
@@ -41,7 +42,7 @@ export function LogsTabContent({
             />
           </PageFilterBar>
           <SearchQueryBuilder
-            placeholder="Search for logs"
+            placeholder={t('Search for logs')}
             filterKeys={{}}
             getTagValues={() => new Promise<string[]>(() => [])}
             initialQuery=""

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,67 @@
-export function LogsTabContent() {
-  // TODO implement
-  return <div>logs!</div>;
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import * as Layout from 'sentry/components/layouts/thirds';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import {space} from 'sentry/styles/space';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {LogsTable} from 'sentry/views/explore/logs/logsTable';
+import type {DefaultPeriod, MaxPickableDays} from 'sentry/views/explore/utils';
+
+export type LogsTabProps = {
+  defaultPeriod: DefaultPeriod;
+  maxPickableDays: MaxPickableDays;
+  relativeOptions: Record<string, React.ReactNode>;
+};
+
+export function LogsTabContent({
+  defaultPeriod,
+  maxPickableDays,
+  relativeOptions,
+}: LogsTabProps) {
+  const [search, setSearch] = useState(new MutableSearch(''));
+  return (
+    <Layout.Body>
+      <Layout.Main fullWidth>
+        <FilterBarContainer>
+          <PageFilterBar condensed>
+            <ProjectPageFilter />
+            <EnvironmentPageFilter />
+            <DatePageFilter
+              defaultPeriod={defaultPeriod}
+              maxPickableDays={maxPickableDays}
+              relativeOptions={({arbitraryOptions}) => ({
+                ...arbitraryOptions,
+                ...relativeOptions,
+              })}
+            />
+          </PageFilterBar>
+          <SearchQueryBuilder
+            placeholder="Search for logs"
+            filterKeys={{}}
+            getTagValues={() => new Promise<string[]>(() => [])}
+            initialQuery=""
+            searchSource="ourlogs"
+            onSearch={query => setSearch(new MutableSearch(query))}
+          />
+        </FilterBarContainer>
+      </Layout.Main>
+      <LogsTableContainer>
+        <LogsTable search={search} />
+      </LogsTableContainer>
+    </Layout.Body>
+  );
 }
+
+const FilterBarContainer = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+`;
+
+const LogsTableContainer = styled(Layout.Main)`
+  margin-top: ${space(2)};
+`;

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -50,7 +50,7 @@ export function LogsTabContent({
           />
         </FilterBarContainer>
       </Layout.Main>
-      <LogsTableContainer>
+      <LogsTableContainer fullWidth>
         <LogsTable search={search} />
       </LogsTableContainer>
     </Layout.Body>

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -11,14 +11,13 @@ export type LogsTableProps = {
 export function LogsTable(props: LogsTableProps) {
   const {data, error, isPending} = useOurlogs(
     {
-      limit: 30,
+      limit: 100,
       sorts: [],
       fields: ['sentry.severity_text', 'sentry.body', 'sentry.timestamp'],
       search: props.search,
     },
     'api.logs-tab.view'
   );
-  // data = data as OurlogsFields
   return (
     <GridEditable<OurlogsFields, keyof OurlogsFields>
       isLoading={isPending}

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -1,0 +1,59 @@
+import GridEditable from 'sentry/components/gridEditable';
+import TimeSince from 'sentry/components/timeSince';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useOurlogs} from 'sentry/views/insights/common/queries/useDiscover';
+import type {OurlogsFields} from 'sentry/views/insights/types';
+
+export type LogsTableProps = {
+  search: MutableSearch;
+};
+
+export function LogsTable(props: LogsTableProps) {
+  const {data, error, isPending} = useOurlogs(
+    {
+      limit: 30,
+      sorts: [],
+      fields: ['sentry.severity_text', 'sentry.body', 'sentry.timestamp'],
+      search: props.search,
+    },
+    'api.logs-tab.view'
+  );
+  // data = data as OurlogsFields
+  return (
+    <GridEditable<OurlogsFields, keyof OurlogsFields>
+      isLoading={isPending}
+      columnOrder={[
+        {key: 'sentry.severity_text', name: 'Severity', width: 60},
+        {key: 'sentry.body', name: 'Body', width: 500},
+        {key: 'sentry.timestamp', name: 'Timestamp', width: 90},
+      ]}
+      columnSortBy={[]}
+      data={data}
+      error={error}
+      grid={{
+        renderHeadCell: col => {
+          return <div>{col.name}</div>;
+        },
+        renderBodyCell: (col, dataRow) => {
+          if (col.key === 'sentry.timestamp') {
+            return timestampRenderer(dataRow['sentry.timestamp']);
+          }
+          if (col.key === 'sentry.severity_text') {
+            return severityTextRenderer(dataRow['sentry.severity_text']);
+          }
+          return <div>{dataRow[col.key]}</div>;
+        },
+      }}
+    />
+  );
+}
+
+function severityTextRenderer(text: string) {
+  return <div>{text.toUpperCase().slice(0, 4)}</div>;
+}
+
+function timestampRenderer(timestamp: string) {
+  return (
+    <TimeSince unitStyle="extraShort" date={new Date(timestamp)} tooltipShowSeconds />
+  );
+}

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -15,6 +15,7 @@ import type {
   SpanMetricsProperty,
   SpanMetricsResponse,
 } from 'sentry/views/insights/types';
+import type {OurlogsFields} from 'sentry/views/insights/types';
 
 interface UseMetricsOptions<Fields> {
   cursor?: string;
@@ -36,6 +37,19 @@ export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
     DiscoverDatasets.SPANS_INDEXED,
     referrer
   );
+};
+
+export const useOurlogs = <Fields extends Array<keyof OurlogsFields>>(
+  options: UseMetricsOptions<Fields> = {},
+  referrer: string
+) => {
+  const {data, ...rest} = useDiscover<Fields, OurlogsFields>(
+    options,
+    DiscoverDatasets.OURLOGS,
+    referrer
+  );
+  const castData = data as OurlogsFields[];
+  return {rest, data: castData};
 };
 
 export const useEAPSpans = <Fields extends EAPSpanProperty[]>(

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -49,7 +49,7 @@ export const useOurlogs = <Fields extends Array<keyof OurlogsFields>>(
     referrer
   );
   const castData = data as OurlogsFields[];
-  return {rest, data: castData};
+  return {...rest, data: castData};
 };
 
 export const useEAPSpans = <Fields extends EAPSpanProperty[]>(

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -415,3 +415,9 @@ export const subregionCodeToName = {
 };
 
 export type SubregionCode = keyof typeof subregionCodeToName;
+
+export type OurlogsFields = {
+  'sentry.body': string;
+  'sentry.severity_text': string;
+  'sentry.timestamp': string;
+};


### PR DESCRIPTION
Screenshot, data pulled end-to-end from clickhouse. Search also works.

<img width="1035" alt="Screenshot 2025-01-24 at 3 42 04 PM" src="https://github.com/user-attachments/assets/e17cd06a-d24e-4dac-b48e-4b1aabec1f64" />
