### PR TITLE
feat(metric-issues): Add lastChecked to OpenPeriods

### DIFF
--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -20,7 +20,7 @@ class OpenPeriod:
     end: datetime | None
     duration: timedelta | None
     is_open: bool
-    last_checked: datetime | None
+    last_checked: datetime
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -20,6 +20,7 @@ class OpenPeriod:
     end: datetime | None
     duration: timedelta | None
     is_open: bool
+    last_checked: datetime | None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -27,6 +28,7 @@ class OpenPeriod:
             "end": self.end,
             "duration": self.duration,
             "isOpen": self.is_open,
+            "lastChecked": self.last_checked,
         }
 
 

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -329,11 +329,23 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         group.type = MetricIssuePOC.type_id
         group.save()
 
+        alert_rule = self.create_alert_rule(
+            organization=self.organization,
+            projects=[self.project],
+            name="Test Alert Rule",
+        )
+        time = timezone.now() - timedelta(seconds=alert_rule.snuba_query.time_window)
+
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
-        assert response.data["openPeriods"] == [
-            {"start": group.first_seen, "end": None, "duration": None, "isOpen": True}
-        ]
+        open_periods = response.data["openPeriods"]
+        assert len(open_periods) == 1
+        open_period = open_periods[0]
+        assert open_period["start"] == group.first_seen
+        assert open_period["end"] is None
+        assert open_period["duration"] is None
+        assert open_period["isOpen"] is True
+        assert open_period["lastChecked"] > time
 
     def test_open_periods_resolved_group(self) -> None:
         self.login_as(user=self.user)
@@ -354,16 +366,23 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             datetime=resolved_time,
         )
 
+        alert_rule = self.create_alert_rule(
+            organization=self.organization,
+            projects=[self.project],
+            name="Test Alert Rule",
+        )
+        time = timezone.now() - timedelta(seconds=alert_rule.snuba_query.time_window)
+
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
-        assert response.data["openPeriods"] == [
-            {
-                "start": group.first_seen,
-                "end": resolved_time,
-                "duration": resolved_time - group.first_seen,
-                "isOpen": False,
-            }
-        ]
+        open_periods = response.data["openPeriods"]
+        assert len(open_periods) == 1
+        open_period = open_periods[0]
+        assert open_period["start"] == group.first_seen
+        assert open_period["end"] == resolved_time
+        assert open_period["duration"] == resolved_time - group.first_seen
+        assert open_period["isOpen"] is False
+        assert open_period["lastChecked"] > time
 
     def test_open_periods_unresolved_group(self) -> None:
         self.login_as(user=self.user)
@@ -376,7 +395,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         group.status = GroupStatus.RESOLVED
         group.save()
         resolved_time = timezone.now()
-        Activity.objects.create(
+        first_resolved_activity = Activity.objects.create(
             group=group,
             project=group.project,
             type=ActivityType.SET_RESOLVED.value,
@@ -397,7 +416,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         second_resolved_time = timezone.now()
         group.status = GroupStatus.RESOLVED
         group.save()
-        Activity.objects.create(
+        second_resolved_activity = Activity.objects.create(
             group=group,
             project=group.project,
             type=ActivityType.SET_RESOLVED.value,
@@ -411,12 +430,14 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
                 "end": second_resolved_time,
                 "duration": second_resolved_time - unresolved_time,
                 "isOpen": False,
+                "lastChecked": second_resolved_activity.datetime,
             },
             {
                 "start": group.first_seen,
                 "end": resolved_time,
                 "duration": resolved_time - group.first_seen,
                 "isOpen": False,
+                "lastChecked": first_resolved_activity.datetime,
             },
         ]
 


### PR DESCRIPTION
Metric issues only send a new occurrence when the alert threshold changes. This means an alert can be open at CRITICAL level for 2h and the last_seen on the group would be 2 hours ago. Behind the scenes, the snuba query processor would be checking this value more frequently. This new field, `lastChecked` is a new field intended to track a closer estimate of when the snuba query was processed. for open periods that are resolved, we can set `lastChecked` to the resolution time.