### PR TITLE
feat(metric-issues): Add lastChecked to OpenPeriod

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -849,6 +849,7 @@ export interface GroupOpenPeriod {
   end: string;
   isOpen: boolean;
   start: string;
+  lastChecked?: string;
 }
 
 export interface GroupReprocessing extends BaseGroup, GroupStats {


### PR DESCRIPTION
Add the new field to the GroupOpenPeriod definition. The backend change that adds this field is https://github.com/getsentry/sentry/pull/83969