### PR TITLE
fix(autofix): Minor UI fixes

### DIFF
--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -579,22 +579,20 @@ export function AutofixDiff({
 
   return (
     <div>
-      <div>
-        <DiffsColumn>
-          {diff.map(file => (
-            <FileDiff
-              key={file.path}
-              file={file}
-              groupId={groupId}
-              runId={runId}
-              repoId={repoId}
-              editable={editable}
-              previousDefaultStepIndex={previousDefaultStepIndex}
-              previousInsightCount={previousInsightCount}
-            />
-          ))}
-        </DiffsColumn>
-      </div>
+      <DiffsColumn>
+        {diff.map(file => (
+          <FileDiff
+            key={file.path}
+            file={file}
+            groupId={groupId}
+            runId={runId}
+            repoId={repoId}
+            editable={editable}
+            previousDefaultStepIndex={previousDefaultStepIndex}
+            previousInsightCount={previousInsightCount}
+          />
+        ))}
+      </DiffsColumn>
     </div>
   );
 }

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -578,22 +578,20 @@ export function AutofixDiff({
   }
 
   return (
-    <div>
-      <DiffsColumn>
-        {diff.map(file => (
-          <FileDiff
-            key={file.path}
-            file={file}
-            groupId={groupId}
-            runId={runId}
-            repoId={repoId}
-            editable={editable}
-            previousDefaultStepIndex={previousDefaultStepIndex}
-            previousInsightCount={previousInsightCount}
-          />
-        ))}
-      </DiffsColumn>
-    </div>
+    <DiffsColumn>
+      {diff.map(file => (
+        <FileDiff
+          key={file.path}
+          file={file}
+          groupId={groupId}
+          runId={runId}
+          repoId={repoId}
+          editable={editable}
+          previousDefaultStepIndex={previousDefaultStepIndex}
+          previousInsightCount={previousInsightCount}
+        />
+      ))}
+    </DiffsColumn>
   );
 }
 

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -494,14 +494,21 @@ function FileDiff({
   runId,
   repoId,
   editable,
+  previousDefaultStepIndex,
+  previousInsightCount,
 }: {
   editable: boolean;
   file: FilePatch;
   groupId: string;
   runId: string;
+  previousDefaultStepIndex?: number;
+  previousInsightCount?: number;
   repoId?: string;
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selection = useTextSelection(containerRef);
 
   return (
     <FileDiffWrapper>
@@ -520,8 +527,22 @@ function FileDiff({
           borderless
         />
       </FileHeader>
+      {selection && (
+        <AutofixHighlightPopup
+          selectedText={selection.selectedText}
+          referenceElement={selection.referenceElement}
+          groupId={groupId}
+          runId={runId}
+          stepIndex={previousDefaultStepIndex ?? 0}
+          retainInsightCardIndex={
+            previousInsightCount !== undefined && previousInsightCount >= 0
+              ? previousInsightCount - 1
+              : -1
+          }
+        />
+      )}
       {isExpanded && (
-        <DiffContainer>
+        <DiffContainer ref={containerRef}>
           {file.hunks.map(({section_header, source_start, lines}, index) => {
             return (
               <DiffHunkContent
@@ -552,30 +573,13 @@ export function AutofixDiff({
   previousDefaultStepIndex,
   previousInsightCount,
 }: AutofixDiffProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const selection = useTextSelection(containerRef);
-
   if (!diff || !diff.length) {
     return null;
   }
 
   return (
     <div>
-      {selection && (
-        <AutofixHighlightPopup
-          selectedText={selection.selectedText}
-          referenceElement={selection.referenceElement}
-          groupId={groupId}
-          runId={runId}
-          stepIndex={previousDefaultStepIndex ?? 0}
-          retainInsightCardIndex={
-            previousInsightCount !== undefined && previousInsightCount >= 0
-              ? previousInsightCount - 1
-              : -1
-          }
-        />
-      )}
-      <div ref={containerRef}>
+      <div>
         <DiffsColumn>
           {diff.map(file => (
             <FileDiff
@@ -585,6 +589,8 @@ export function AutofixDiff({
               runId={runId}
               repoId={repoId}
               editable={editable}
+              previousDefaultStepIndex={previousDefaultStepIndex}
+              previousInsightCount={previousInsightCount}
             />
           ))}
         </DiffsColumn>

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -268,6 +268,7 @@ const ActiveLogWrapper = styled('div')`
 
 const ActiveLog = styled('div')`
   flex-grow: 1;
+  word-break: break-word;
 `;
 
 const VerticalLine = styled('div')`

--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -34,12 +34,18 @@ export function useTextSelection(containerRef: React.RefObject<HTMLElement>) {
         return;
       }
 
+      // Clear selection if clicking the same text
+      if (selection?.referenceElement === target) {
+        setSelection(null);
+        return;
+      }
+
       setSelection({
         selectedText: clickedText,
         referenceElement: target,
       });
     },
-    [containerRef]
+    [containerRef, selection]
   );
 
   const clearSelection = useCallback(

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -355,8 +355,9 @@ const StyledButton = styled(Button)`
 const StyledCard = styled('div')`
   background: ${p => p.theme.backgroundElevated};
   overflow: hidden;
-  border-bottom: 1px solid ${p => p.theme.border};
-  padding: ${space(1)} ${space(0.5)} ${space(3)} ${space(0.5)};
+  border: 2px solid ${p => p.theme.innerBorder};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(2)};
 `;
 
 const HeaderText = styled('div')`


### PR DESCRIPTION
1. Fixes flicker when the assistant responded to the user in the highlight popup.
2. Makes sure the user can't send another message while the assistant responds.
3. Fix text overflow.
4. Add border back to summary card.
5. Add description to Fixes card and adjusts highlight popup locations on the card.
6. Clear highlight popup when re-selecting the same text.

<img width="663" alt="Screenshot 2025-01-25 at 4 25 10 PM" src="https://github.com/user-attachments/assets/b471a033-e5aa-4e8a-a262-2aa2ce036449" />
<img width="684" alt="Screenshot 2025-01-25 at 4 35 13 PM" src="https://github.com/user-attachments/assets/3ec1ba77-b30a-4789-b94d-47b90bfc1469" />
