### PR TITLE
feat(metric-issues): Show a more accurate last seen value 

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -848,8 +848,8 @@ export interface GroupOpenPeriod {
   duration: string;
   end: string;
   isOpen: boolean;
+  lastChecked: string;
   start: string;
-  lastChecked?: string;
 }
 
 export interface GroupReprocessing extends BaseGroup, GroupStats {

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -64,6 +64,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   resources: null,
   usesIssuePlatform: true,
   issueSummary: {enabled: false},
+  useOpenPeriodChecks: true,
 };
 
 const issueTypeConfig: Config = {

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -64,7 +64,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   resources: null,
   usesIssuePlatform: true,
   issueSummary: {enabled: false},
-  useOpenPeriodChecks: true,
+  useOpenPeriodChecks: false,
 };
 
 const issueTypeConfig: Config = {

--- a/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
@@ -27,6 +27,7 @@ const metricIssueConfig: IssueCategoryConfigMapping = {
     similarIssues: {enabled: false},
     userFeedback: {enabled: false},
     usesIssuePlatform: true,
+    useOpenPeriodChecks: true,
     stats: {enabled: false},
     tags: {enabled: false},
     tagsTab: {enabled: false},

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -129,6 +129,10 @@ export type IssueTypeConfig = {
    */
   tagsTab: DisabledWithReasonConfig;
   /**
+   * Whether to use open periods for the last checked date
+   */
+  useOpenPeriodChecks: boolean;
+  /**
    * Is the User Feedback tab shown for this issue
    */
   userFeedback: DisabledWithReasonConfig;

--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
@@ -9,6 +9,7 @@ import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useFetchAllEnvsGroupData} from 'sentry/views/issueDetails/groupSidebar';
@@ -21,6 +22,7 @@ interface GroupRelease {
 export default function FirstLastSeenSection({group}: {group: Group}) {
   const organization = useOrganization();
   const {project} = group;
+  const issueTypeConfig = getConfigForIssueType(group, group.project);
 
   const {data: allEnvironments} = useFetchAllEnvsGroupData(organization, group);
   const {data: groupReleaseData} = useApiQuery<GroupRelease>(
@@ -31,6 +33,14 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
     }
   );
 
+  const lastSeen = issueTypeConfig.useOpenPeriodChecks
+    ? group.openPeriods?.[0]?.lastChecked ?? group.lastSeen
+    : group.lastSeen;
+
+  const dateGlobal = issueTypeConfig.useOpenPeriodChecks
+    ? lastSeen
+    : allEnvironments?.lastSeen ?? lastSeen;
+
   return (
     <Flex column gap={space(0.75)}>
       <div>
@@ -38,8 +48,8 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
           <Title>{t('Last seen')}</Title>
           {group.lastSeen ? (
             <SeenInfo
-              date={group.lastSeen}
-              dateGlobal={allEnvironments?.lastSeen ?? group.lastSeen}
+              date={lastSeen}
+              dateGlobal={dateGlobal}
               organization={organization}
               projectId={project.id}
               projectSlug={project.slug}

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -85,6 +85,7 @@ describe('SolutionsSection', () => {
       stats: {enabled: false},
       tags: {enabled: false},
       tagsTab: {enabled: false},
+      useOpenPeriodChecks: false,
       userFeedback: {enabled: false},
       usesIssuePlatform: false,
     });


### PR DESCRIPTION
Use the lastChecked field added in https://github.com/getsentry/sentry/pull/83969 to show a more accurate value for the last_seen on an issue. This is easier to handle on the frontend than overloading the last_seen on the backend, which is generally treated as the timestamp of the latest event/occurrence. 

Extra context:
> Metric issues only send a new occurrence when the alert threshold changes. This means an alert can be open at CRITICAL level for 2h and the last_seen on the group would be 2 hours ago. Behind the scenes, the snuba query processor would be checking this value more frequently. This new field, lastChecked is a new field intended to track a closer estimate of when the snuba query was processed. for open periods that are resolved, we can set lastChecked to the resolution time.

