### PR TITLE
chore: Update Codecov Bundler Plugin Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.1",
-    "@codecov/webpack-plugin": "^1.2.0",
+    "@codecov/webpack-plugin": "^1.8.0",
     "@emotion/eslint-plugin": "^11.12.0",
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -786,6 +786,7 @@ if (CODECOV_TOKEN && ENABLE_CODECOV_BA) {
       bundleName: 'app-webpack-bundle',
       uploadToken: CODECOV_TOKEN,
       debug: true,
+      gitService: 'github',
       uploadOverrides: {
         sha: GH_COMMIT_SHA,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,24 +1206,25 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.1.tgz#f754bb8a94f2dab6311eff39dc30c4a6aa0f5628"
   integrity sha512-liSRWjWzFhyG7s1jg/Bbv9FL+ha/CEd5tFO3+dFIJNplL4TnvAivtyfRVi/tu/pNjISbV1k9JwdBewtAKAgA0w==
 
-"@codecov/bundler-plugin-core@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@codecov/bundler-plugin-core/-/bundler-plugin-core-1.2.0.tgz#4a896dd3bd9f9f98a60519aadcf8e3daff37ae5d"
-  integrity sha512-ublUP5V0tW6oDnaJ1UBWvEmVAkvMmPNEwWkpF+WwJSCBWNLvWrkSwG84S3Gt5Xbnh17xEyAxXBmNzF+mXVXBgw==
+"@codecov/bundler-plugin-core@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@codecov/bundler-plugin-core/-/bundler-plugin-core-1.8.0.tgz#662369cc13efecc860759dcbdf90636cb665b21e"
+  integrity sha512-D1aeA8u3RHOkQVLImLHxW6zFdUrw5wgoeDzYrKZeDExGp5ePs4RpJxKwklg1N0e1JxRcAgKj+zZo/y3Q4nV+sA==
   dependencies:
     "@actions/core" "^1.10.1"
     "@actions/github" "^6.0.0"
+    "@sentry/core" "^8.42.0"
     chalk "4.1.2"
     semver "^7.5.4"
     unplugin "^1.10.1"
     zod "^3.22.4"
 
-"@codecov/webpack-plugin@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@codecov/webpack-plugin/-/webpack-plugin-1.2.0.tgz#db0466f0494f9a141697af4665830c650d030991"
-  integrity sha512-yawRyKgC8tXj/C/UoTJ+kRMePfhkYJtJey+xmywRqmVmvbxQGnYFkg+Dzix/HxKt4iGpSwKT4p8Glz2MNQ7gTQ==
+"@codecov/webpack-plugin@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@codecov/webpack-plugin/-/webpack-plugin-1.8.0.tgz#21430775530cde139c22a55318dccbfda3c0eb32"
+  integrity sha512-G62kbpAFuutQIrbuw97MAf5vkgIKXf64Nj0pRe6OPbC5Aps0nWrEL9v0Sr0WPdHcbQnr3i6noIXyUDdV1lUZ5g==
   dependencies:
-    "@codecov/bundler-plugin-core" "^1.2.0"
+    "@codecov/bundler-plugin-core" "^1.8.0"
     unplugin "^1.10.1"
 
 "@cspotcode/source-map-support@^0.8.0":
@@ -3380,6 +3381,11 @@
   version "8.48.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.48.0.tgz#3bb8d06305f0ec7c873453844687deafdeab168b"
   integrity sha512-VGwYgTfLpvJ5LRO5A+qWo1gpo6SfqaGXL9TOzVgBucAdpzbrYHpZ87sEarDVq/4275uk1b0S293/mfsskFczyw==
+
+"@sentry/core@^8.42.0":
+  version "8.51.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.51.0.tgz#d0c73dfe3489788911b7ce784d3ef8458344482c"
+  integrity sha512-Go0KxCYLw+OBIlLSv5YsYX+x9NW43fNVcyB6rhkSp2Q5Zme3tAE6KtZFvyu4SO7G/903wisW5Q6qV6UuK/ee4A==
 
 "@sentry/jest-environment@6.0.0":
   version "6.0.0"


### PR DESCRIPTION
This PR brings the Codecov Webpack plugin up to it's latest version. 

As well this PR sets the `gitService` field in the configuration which enables uploads to Codecov on forked upstream PRs, which you can read more about [here](https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token) and [here](https://docs.codecov.com/docs/tokenless-bundle-analysis).
