### PR TITLE
fix(relocation) Restore compatibility for exports with actor

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -266,6 +266,7 @@
     "slug": "testing",
     "name": "Testing",
     "status": 0,
+    "actor": 1,
     "idp_provisioned": false,
     "date_added": "2023-06-22T22:54:28.821Z"
   }
@@ -377,6 +378,7 @@
     "data": "{\"match\":\"all\",\"conditions\":[{\"id\":\"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition\"}],\"actions\":[{\"id\":\"sentry.mail.actions.NotifyEmailAction\",\"targetType\":\"IssueOwners\",\"targetIdentifier\":null,\"fallthroughType\":\"ActiveMembers\"}]}",
     "status": 0,
     "source": 0,
+    "owner": null,
     "date_added": "2023-06-22T22:54:28.982Z"
   }
 },

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -27,7 +27,13 @@ from sentry.utils import json
 # around even if the dict is empty, to ensure that there is a ready place to pop shims into. For
 # each entry in this dict, please leave a TODO comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
-DELETED_FIELDS: dict[str, set[str]] = {}
+DELETED_FIELDS: dict[str, set[str]] = {
+    # These fields were removed in 2023 but we need them to support exports from older sentry versions.
+    "sentry.team": {"actor"},
+    "sentry.rule": {"owner"},
+    "sentry.alertrule": {"owner"},
+    "sentry.grouphistory": {"actor"},
+}
 
 # When models are removed from the application, they will continue to be in exports
 # from previous releases. Models in this list are elided from data as imports are processed.
@@ -36,7 +42,10 @@ DELETED_FIELDS: dict[str, set[str]] = {}
 # around even if the set is empty, to ensure that there is a ready place to pop shims into. For
 # each entry in this set, please leave a TODO comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
-DELETED_MODELS: set[str] = set()
+DELETED_MODELS: set[str] = set(
+    # This model was removed in 2023, but we need to support imports from older sentry still.
+    "sentry.actor",
+)
 
 
 class NormalizedModelName:


### PR DESCRIPTION
We have had a few relocations fail because migrating customers are on older self-hosted versions that still include `actor` fields in their exports. Restore the field/model shims that make exports from old sentry versions work again.

Refs #82201
