### PR TITLE
fix(explore): Remove aggregate suggestions from samples mode

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -212,7 +212,7 @@ export function SearchQueryBuilderFilter({item, state, token}: SearchQueryTokenP
     <FilterWrapper
       aria-label={token.text}
       aria-invalid={tokenHasError}
-      state={tokenHasError ? 'invalid' : tokenHasWarning ? 'warning' : 'valid'}
+      state={tokenHasWarning ? 'warning' : tokenHasError ? 'invalid' : 'valid'}
       ref={ref}
       {...modifiedRowProps}
     >

--- a/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
@@ -57,7 +57,7 @@ export function InvalidTokenTooltip({
       skipWrapper
       forceVisible={getForceVisible({isFocused, isInvalid, hasWarning, forceVisible})}
       position="bottom"
-      title={invalid?.reason ?? warning ?? t('This token is invalid')}
+      title={warning ?? invalid?.reason ?? t('This token is invalid')}
       {...tooltipProps}
     >
       {children}

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -164,7 +164,9 @@ export function SpansTabContentImpl({
                   }
                 : undefined
             }
-            supportedAggregates={ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
+            supportedAggregates={
+              mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
+            }
             numberTags={numberTags}
             stringTags={stringTags}
           />


### PR DESCRIPTION
Aggregate suggestions should not be shown in samples mode, only aggregates mode. And prioritize warnings over invalid states so the warning that aggregates are not applied to the search is visible even when it's not a allowed search key.