### PR TITLE
ref(typing): handle None Group in bitbucket issue integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ module = [
     "sentry.integrations.aws_lambda.integration",
     "sentry.integrations.bitbucket.client",
     "sentry.integrations.bitbucket.integration",
-    "sentry.integrations.bitbucket.issues",
     "sentry.integrations.bitbucket_server.client",
     "sentry.integrations.bitbucket_server.integration",
     "sentry.integrations.example.integration",


### PR DESCRIPTION
from https://github.com/getsentry/sentry/pull/83644/, we decided that we should handle the `None` case here in the integration. I've looked at what other integrations do and saw https://github.com/getsentry/sentry/blob/9b8fcb099004ea6fba7c754a14bf25f6e664e982/src/sentry/integrations/github/issues.py#L121 so did something similar. Also added test for this.