### PR TITLE
ref: replace BaseApiResponseX with Any

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ module = [
     "sentry.integrations.jira.views.base",
     "sentry.integrations.jira.webhooks.base",
     "sentry.integrations.jira.webhooks.issue_updated",
-    "sentry.integrations.jira_server.client",
     "sentry.integrations.jira_server.integration",
     "sentry.integrations.metric_alerts",
     "sentry.integrations.msteams.actions.form",

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -13,7 +13,6 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.repository import RepositoryClient
 from sentry.integrations.utils.atlassian_connect import get_query_hash
 from sentry.models.repository import Repository
-from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
 from sentry.utils.patch_set import patch_to_file_changes
@@ -168,7 +167,7 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
 
         return self.zip_commit_data(repo, commits)
 
-    def check_file(self, repo: Repository, path: str, version: str | None) -> BaseApiResponseX:
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         return self.head_cached(
             path=BitbucketAPIPath.source.format(
                 repo=repo.name,

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -11,7 +11,6 @@ from sentry.integrations.client import ApiClient
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.repository import RepositoryClient
 from sentry.models.repository import Repository
-from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.bitbucket_server")
@@ -255,7 +254,7 @@ class BitbucketServerClient(ApiClient, RepositoryClient):
         )
         return values
 
-    def check_file(self, repo: Repository, path: str, version: str | None) -> BaseApiResponseX:
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         raise IntegrationFeatureNotImplementedError
 
     def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -76,7 +76,7 @@ class DiscordClient(ApiClient):
 
     def get_guild_name(self, guild_id: str) -> str:
         response = self.get(GUILD_URL.format(guild_id=guild_id), headers=self.prepare_auth_header())
-        return response["name"]  # type: ignore[index]
+        return response["name"]
 
     def get_access_token(self, code: str, url: str):
         data = {
@@ -91,8 +91,7 @@ class DiscordClient(ApiClient):
             "Content-Type": "application/x-www-form-urlencoded",
         }
         response = self.post(TOKEN_URL, json=False, data=urlencode(data), headers=headers)
-        access_token = response["access_token"]  # type: ignore[index]
-        return access_token
+        return response["access_token"]
 
     def get_user_id(self, access_token: str):
         headers = {"Authorization": f"Bearer {access_token}"}
@@ -100,8 +99,7 @@ class DiscordClient(ApiClient):
             USER_URL,
             headers=headers,
         )
-        user_id = response["id"]  # type: ignore[index]
-        return user_id
+        return response["id"]
 
     def check_user_bot_installation_permission(self, access_token: str, guild_id: str) -> bool:
         headers = {"Authorization": f"Bearer {access_token}"}

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -33,7 +33,6 @@ from sentry.issues.auto_source_code_config.code_mapping import (
     filter_source_code_files,
 )
 from sentry.models.repository import Repository
-from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.mapping import MappingApiResponse
@@ -632,7 +631,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         """
         return self.get(f"/repos/{repo}/labels", params={"per_page": 100})
 
-    def check_file(self, repo: Repository, path: str, version: str | None) -> BaseApiResponseX:
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         return self.head_cached(path=f"/repos/{repo.name}/contents/{path}", params={"ref": version})
 
     def get_file(

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -19,7 +19,6 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.integrations.source_code_management.repository import RepositoryClient
 from sentry.models.repository import Repository
-from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.silo.base import SiloMode, control_silo_function
@@ -329,7 +328,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         path = GitLabApiClientPath.diff.format(project=project_id, sha=sha)
         return self.get(path)
 
-    def check_file(self, repo: Repository, path: str, version: str | None) -> BaseApiResponseX:
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         """Fetch a file for stacktrace linking
 
         See https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -9,7 +9,6 @@ from sentry.integrations.on_call.metrics import OnCallInteractionType
 from sentry.integrations.opsgenie.metrics import record_event
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.group import Group
-from sentry.shared_integrations.client.base import BaseApiResponseX
 
 OPSGENIE_API_VERSION = "v2"
 # Defaults to P3 if null, but we can be explicit - https://docs.opsgenie.com/docs/alert-api
@@ -34,7 +33,7 @@ class OpsgenieClient(ApiClient):
     def _get_auth_headers(self):
         return {"Authorization": f"GenieKey {self.integration_key}"}
 
-    def get_alerts(self, limit: int | None = 1) -> BaseApiResponseX:
+    def get_alerts(self, limit: int | None = 1) -> object | None:
         path = f"/alerts?limit={limit}"
         return self.get(path=path, headers=self._get_auth_headers())
 

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -7,7 +7,6 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.client import ApiClient
 from sentry.integrations.on_call.metrics import OnCallInteractionType
 from sentry.integrations.pagerduty.metrics import record_event
-from sentry.shared_integrations.client.base import BaseApiResponseX
 
 LEVEL_SEVERITY_MAP = {
     "debug": "info",
@@ -29,7 +28,7 @@ class PagerDutyClient(ApiClient):
         self.integration_key = integration_key
         super().__init__(integration_id=integration_id)
 
-    def request(self, method: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
+    def request(self, method: str, *args: Any, **kwargs: Any) -> Any:
         headers = kwargs.pop("headers", None)
         if headers is None:
             headers = {"Content-Type": "application/json"}

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -14,7 +14,6 @@ from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionType,
 )
 from sentry.models.repository import Repository
-from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.users.models.identity import Identity
 
@@ -217,7 +216,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
 
 class RepositoryClient(ABC):
     @abstractmethod
-    def check_file(self, repo: Repository, path: str, version: str | None) -> BaseApiResponseX:
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         """Check if the file exists. Currently used for stacktrace linking and CODEOWNERS."""
         raise NotImplementedError
 

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -15,7 +15,6 @@ from sentry.integrations.client import ApiClient
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.source_code_management.repository import RepositoryClient
 from sentry.models.repository import Repository
-from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.silo.base import control_silo_function
 from sentry.users.models.identity import Identity
@@ -144,9 +143,7 @@ class VstsSetupApiClient(ApiClient, VstsApiMixin):
         self.oauth_redirect_url = oauth_redirect_url
         self.access_token = access_token
 
-    def request(
-        self, method, path, data=None, params=None, api_preview: bool = False
-    ) -> BaseApiResponseX:
+    def request(self, method, path, data=None, params=None, api_preview: bool = False) -> Any:
         headers = prepare_headers(
             api_version=self.api_version,
             method=method,
@@ -179,7 +176,7 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin, RepositoryClient):
         self._identity = Identity.objects.get(id=self.identity_id)
         return self._identity
 
-    def request(self, method: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
+    def request(self, method: str, *args: Any, **kwargs: Any) -> Any:
         api_preview = kwargs.pop("api_preview", False)
         headers = kwargs.pop("headers", {})
         new_headers = prepare_headers(
@@ -437,7 +434,7 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin, RepositoryClient):
             api_preview=True,
         )
 
-    def check_file(self, repo: Repository, path: str, version: str | None) -> BaseApiResponseX:
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         return self.get_cached(
             path=VstsApiPath.items.format(
                 instance=repo.config["instance"],

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -18,7 +18,7 @@ from requests.adapters import Retry
 from sentry import options
 from sentry.http import build_session
 from sentry.net.http import SafeSession
-from sentry.shared_integrations.client.base import BaseApiClient, BaseApiResponseX
+from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
     PROXY_DIRECT_LOCATION_HEADER,
@@ -154,7 +154,7 @@ class RegionSiloClient(BaseApiClient):
         json: bool = True,
         raw_response: bool = False,
         prefix_hash: str | None = None,
-    ) -> BaseApiResponseX:
+    ) -> Any:
         """
         Sends a request to the region silo.
         If prefix_hash is provided, the request will be retries up to REQUEST_ATTEMPTS_LIMIT times.

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Literal, overload
+from typing import Any, Literal, overload
 
 from requests import PreparedRequest, Response
 
-from sentry.shared_integrations.client.base import BaseApiClient, BaseApiResponseX
+from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.shared_integrations.client.internal import BaseInternalApiClient
 from sentry.shared_integrations.exceptions import ApiUnauthorized
 from sentry.users.services.usersocialauth.service import usersocialauth_service
@@ -78,7 +78,7 @@ class AuthApiClient(ApiClient):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: bool = ...,
-    ) -> BaseApiResponseX: ...
+    ) -> Any: ...
 
     def _request(self, method, path, **kwargs):
         headers = kwargs.setdefault("headers", {})


### PR DESCRIPTION
the original type is not very useful as it represents a triple union.  really the api client should get refactored to return concrete types but this is a first step to unblock some improvements elsewhere and is a more "honest" representation of the return value

<!-- Describe your PR here. -->