### PR TITLE
ref(crons): Simplify StatusToggleButton

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -11,7 +11,6 @@ import type SelectorItems from 'sentry/components/timeRangeSelector/selectorItem
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import type {UseExperiment} from 'sentry/utils/useExperiment';
 import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
-import type {StatusToggleButtonProps} from 'sentry/views/monitors/components/statusToggleButton';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
@@ -205,7 +204,6 @@ export type ComponentHooks = {
   'component:insights-date-range-query-limit-footer': () => React.ComponentType<{}>;
   'component:insights-upsell-page': () => React.ComponentType<InsightsUpsellHook>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
-  'component:monitor-status-toggle': () => React.ComponentType<StatusToggleButtonProps>;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
   'component:organization-header': () => React.ComponentType<OrganizationHeaderProps>;
   'component:organization-membership-settings': () => React.ComponentType<MembershipSettingsProps>;

--- a/static/app/views/monitors/components/statusToggleButton.tsx
+++ b/static/app/views/monitors/components/statusToggleButton.tsx
@@ -1,6 +1,5 @@
 import type {BaseButtonProps} from 'sentry/components/button';
 import {Button} from 'sentry/components/button';
-import HookOrDefault from 'sentry/components/hookOrDefault';
 import {IconPause, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
@@ -8,12 +7,12 @@ import type {ObjectStatus} from 'sentry/types/core';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {Monitor} from 'sentry/views/monitors/types';
 
-interface StatusToggleButtonProps extends Omit<BaseButtonProps, 'onClick'> {
+export interface StatusToggleButtonProps extends Omit<BaseButtonProps, 'onClick'> {
   monitor: Monitor;
   onToggleStatus: (status: ObjectStatus) => Promise<void>;
 }
 
-function SimpleStatusToggle({
+export function StatusToggleButton({
   monitor,
   onToggleStatus,
   ...props
@@ -36,18 +35,11 @@ function SimpleStatusToggle({
       title={label}
       onClick={async () => {
         await onToggleStatus(isDisabled ? 'active' : 'disabled');
-        // TODO(davidenwang): Lets place this in the monitor-status-toggle hook once its created
+        // TODO(epurkhiser): This hook is probably too specialized and could
+        // maybe do to be a component hook instead
         monitorCreationCallbacks.map(cb => cb(organization));
       }}
       {...props}
     />
   );
 }
-
-const StatusToggleButton = HookOrDefault({
-  hookName: 'component:monitor-status-toggle',
-  defaultComponent: SimpleStatusToggle,
-});
-
-export type {StatusToggleButtonProps};
-export {StatusToggleButton};


### PR DESCRIPTION
We weren't using this hook yet. If we decide we wanted it (I don't
remember why we have it) we should bring it back then