### PR TITLE
feat(widget-builder): More analytics

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -10,6 +10,8 @@ import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
@@ -19,7 +21,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   OnDemandExtractionState,
   type ValidateWidgetResponse,
+  type WidgetType,
 } from 'sentry/views/dashboards/types';
+import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
+import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import type {generateFieldOptions} from 'sentry/views/discover/utils';
 
@@ -36,6 +41,7 @@ interface Props {
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
   columns?: QueryFieldValue[];
   style?: React.CSSProperties;
+  widgetType?: WidgetType;
 }
 
 export function GroupBySelector({
@@ -44,8 +50,17 @@ export function GroupBySelector({
   onChange,
   validatedWidgetResponse,
   style,
+  widgetType,
 }: Props) {
   const [activeId, setActiveId] = useState<string | null>(null);
+  const organization = useOrganization();
+  const source = useDashboardWidgetSource();
+  const isEditing = useIsEditingWidget();
+  const builderVersion = organization.features.includes(
+    'dashboards-widget-builder-redesign'
+  )
+    ? WidgetBuilderVersion.SLIDEOUT
+    : WidgetBuilderVersion.PAGE;
 
   function handleAdd() {
     const newColumns =
@@ -53,6 +68,15 @@ export function GroupBySelector({
         ? [{...EMPTY_FIELD}, {...EMPTY_FIELD}]
         : [...columns, {...EMPTY_FIELD}];
     onChange(newColumns);
+    trackAnalytics('dashboards_views.widget_builder.change', {
+      builder_version: builderVersion,
+      field: 'groupBy.add',
+      from: source,
+      new_widget: !isEditing,
+      value: '',
+      widget_type: widgetType ?? '',
+      organization,
+    });
   }
 
   function handleSelect(value: QueryFieldValue, index?: number) {
@@ -63,12 +87,30 @@ export function GroupBySelector({
       newColumns[index] = value;
     }
     onChange(newColumns);
+    trackAnalytics('dashboards_views.widget_builder.change', {
+      builder_version: builderVersion,
+      field: 'groupBy.update',
+      from: source,
+      new_widget: !isEditing,
+      value: '',
+      widget_type: widgetType ?? '',
+      organization,
+    });
   }
 
   function handleRemove(index: number) {
     const newColumns = [...columns];
     newColumns.splice(index, 1);
     onChange(newColumns);
+    trackAnalytics('dashboards_views.widget_builder.change', {
+      builder_version: builderVersion,
+      field: 'groupBy.delete',
+      from: source,
+      new_widget: !isEditing,
+      value: '',
+      widget_type: widgetType ?? '',
+      organization,
+    });
   }
 
   const hasOnlySingleColumnWithValue =

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/index.tsx
@@ -45,6 +45,7 @@ export function GroupByStep({
         fieldOptions={groupByOptions}
         onChange={onGroupByChange}
         validatedWidgetResponse={validatedWidgetResponse}
+        widgetType={DATA_SET_TO_WIDGET_TYPE[dataSet]}
       />
     </BuildStep>
   );

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -61,6 +61,7 @@ function WidgetBuilderGroupBySelector({
         onChange={handleGroupByChange}
         validatedWidgetResponse={validatedWidgetResponse}
         style={{paddingRight: 0}}
+        widgetType={state.dataset}
       />
     </Fragment>
   );

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -51,7 +51,7 @@ function WidgetBuilderNameAndDescription({
             widget_type: state.dataset ?? '',
             builder_version: WidgetBuilderVersion.SLIDEOUT,
             field: 'title',
-            value: state.title ?? '',
+            value: '',
             new_widget: !isEditing,
             organization,
           });
@@ -88,7 +88,7 @@ function WidgetBuilderNameAndDescription({
               widget_type: state.dataset ?? '',
               builder_version: WidgetBuilderVersion.SLIDEOUT,
               field: 'description',
-              value: state.description ?? '',
+              value: '',
               new_widget: !isEditing,
               organization,
             });

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -7,6 +7,8 @@ import Input from 'sentry/components/input';
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {
   createOnDemandFilterWarning,
   shouldDisplayOnDemandWidgetWarning,
@@ -24,6 +26,8 @@ import {
 import {WidgetOnDemandQueryWarning} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
+import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {getDiscoverDatasetFromWidgetType} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
@@ -44,6 +48,8 @@ function WidgetBuilderQueryFilterBuilder({
     // Make a validity entry for each query condition initially
     return state.query?.map(() => true) ?? [];
   });
+  const source = useDashboardWidgetSource();
+  const isEditing = useIsEditingWidget();
 
   const widgetType = state.dataset ?? WidgetType.ERRORS;
   const datasetConfig = getDatasetConfig(state.dataset);
@@ -71,6 +77,15 @@ function WidgetBuilderQueryFilterBuilder({
     dispatch({
       type: BuilderStateAction.SET_LEGEND_ALIAS,
       payload: state.legendAlias?.length ? [...state.legendAlias, ''] : ['', ''],
+    });
+    trackAnalytics('dashboards_views.widget_builder.change', {
+      builder_version: WidgetBuilderVersion.SLIDEOUT,
+      field: 'filter.add',
+      from: source,
+      new_widget: !isEditing,
+      value: '',
+      widget_type: state.dataset ?? '',
+      organization,
     });
   };
 
@@ -104,6 +119,15 @@ function WidgetBuilderQueryFilterBuilder({
         type: BuilderStateAction.SET_LEGEND_ALIAS,
         payload: state.legendAlias?.filter((_, i) => i !== queryIndex) ?? [],
       });
+      trackAnalytics('dashboards_views.widget_builder.change', {
+        builder_version: WidgetBuilderVersion.SLIDEOUT,
+        field: 'filter.delete',
+        from: source,
+        new_widget: !isEditing,
+        value: '',
+        widget_type: state.dataset ?? '',
+        organization,
+      });
     },
     [
       dispatch,
@@ -111,6 +135,10 @@ function WidgetBuilderQueryFilterBuilder({
       state.query,
       onQueryConditionChange,
       state.legendAlias,
+      state.dataset,
+      source,
+      isEditing,
+      organization,
     ]
   );
 
@@ -156,6 +184,15 @@ function WidgetBuilderQueryFilterBuilder({
                 payload:
                   state.query?.map((q, i) => (i === index ? queryString : q)) ?? [],
               });
+              trackAnalytics('dashboards_views.widget_builder.change', {
+                builder_version: WidgetBuilderVersion.SLIDEOUT,
+                field: 'filter.update',
+                from: source,
+                new_widget: !isEditing,
+                value: '',
+                widget_type: state.dataset ?? '',
+                organization,
+              });
             }}
             widgetQuery={widget.queries[index]!}
             dataset={getDiscoverDatasetFromWidgetType(widgetType)}
@@ -172,6 +209,17 @@ function WidgetBuilderQueryFilterBuilder({
                   payload: state.legendAlias?.length
                     ? state.legendAlias?.map((q, i) => (i === index ? e.target.value : q))
                     : [e.target.value],
+                });
+              }}
+              onBlur={() => {
+                trackAnalytics('dashboards_views.widget_builder.change', {
+                  builder_version: WidgetBuilderVersion.SLIDEOUT,
+                  field: 'filter.alias',
+                  from: source,
+                  new_widget: !isEditing,
+                  value: '',
+                  widget_type: state.dataset ?? '',
+                  organization,
                 });
               }}
             />

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -8,12 +8,17 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
+import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {SortBySelectors} from 'sentry/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
+import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {
   getResultsLimit,
@@ -25,6 +30,9 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 function WidgetBuilderSortBySelector() {
   const {state, dispatch} = useWidgetBuilderContext();
   const widget = convertBuilderStateToWidget(state);
+  const organization = useOrganization();
+  const source = useDashboardWidgetSource();
+  const isEditing = useIsEditingWidget();
 
   const datasetConfig = getDatasetConfig(state.dataset);
 
@@ -133,6 +141,15 @@ function WidgetBuilderSortBySelector() {
               const newSortDirection =
                 sortDirection === SortDirection.HIGH_TO_LOW ? 'desc' : 'asc';
               handleSortByChange(sortBy, newSortDirection);
+              trackAnalytics('dashboards_views.widget_builder.change', {
+                builder_version: WidgetBuilderVersion.SLIDEOUT,
+                field: 'sortBy.update',
+                from: source,
+                new_widget: !isEditing,
+                value: '',
+                widget_type: state.dataset ?? '',
+                organization,
+              });
             }}
             tags={tags}
           />

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -1199,7 +1199,7 @@ function WidgetBuilder({
                                           {
                                             from: source,
                                             field: 'title',
-                                            value: state.title ?? '',
+                                            value: '',
                                             widget_type: widgetType,
                                             organization,
                                             new_widget: !isEditing,
@@ -1229,7 +1229,7 @@ function WidgetBuilder({
                                           {
                                             from: source,
                                             field: 'description',
-                                            value: state.description ?? '',
+                                            value: '',
                                             widget_type: widgetType,
                                             organization,
                                             new_widget: !isEditing,


### PR DESCRIPTION
Adds more analytics. Details can be found here: https://www.notion.so/sentry/Analytics-1858b10e4b5d80cdb0ddf07043bac41a

Most of the `value` fields are set to `''` because we don't need to know the exact value the user has set. I'm only using them for now to differentiate stuff like, if a user updates an aggregate is it going to stay an aggregate or change to a column. High level information like that could be useful. We may need to rename some of these fields at some point