### PR TITLE
ref(alerts): Use Pause over Mute for "disabled" rule badge

### DIFF
--- a/static/app/components/badge/alertBadge.tsx
+++ b/static/app/components/badge/alertBadge.tsx
@@ -6,7 +6,7 @@ import {
   IconExclamation,
   IconFire,
   IconIssues,
-  IconMute,
+  IconPause,
 } from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
@@ -48,7 +48,7 @@ function AlertBadge({status, withText, isIssue, isDisabled}: Props) {
 
   if (isDisabled) {
     statusText = t('Disabled');
-    Icon = IconMute;
+    Icon = IconPause;
     color = 'disabled';
   } else if (isIssue) {
     statusText = t('Issue');


### PR DESCRIPTION
Disabled rules (for crons and uptime) do nothing, they are not muted
they just do nothing.