### PR TITLE
chore: add /explore as a route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -795,6 +795,12 @@ urlpatterns += [
         react_page_view,
         name="insights",
     ),
+    # Explore
+    re_path(
+        r"^explore/",
+        react_page_view,
+        name="explore",
+    ),
     # Traces
     re_path(
         r"^traces/",


### PR DESCRIPTION
We're putting logs under /explore/logs (along with everything else, eventually) - add that top level route