### PR TITLE
fix(widget-builder): Add widget preview title + animations

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -301,6 +301,20 @@ export function WidgetPreviewContainer({
                 {...attributes}
                 {...listeners}
               >
+                {!isSmallScreen && (
+                  <WidgetPreviewTitle
+                    initial={{opacity: 0, x: '50%', y: 0}}
+                    animate={{opacity: 1, x: 0, y: 0}}
+                    exit={{opacity: 0, x: '50%', y: 0}}
+                    transition={{
+                      type: 'spring',
+                      stiffness: 500,
+                      damping: 50,
+                    }}
+                  >
+                    {t('Widget Preview')}
+                  </WidgetPreviewTitle>
+                )}
                 <SampleWidgetCard
                   initial={{opacity: 0, x: '50%', y: 0}}
                   animate={{opacity: 1, x: 0, y: 0}}
@@ -483,4 +497,11 @@ const SurroundingWidgetContainer = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;
+`;
+
+const WidgetPreviewTitle = styled(motion.h5)`
+  margin-bottom: ${space(1)};
+  margin-left: ${space(1)};
+  color: ${p => p.theme.white};
+  font-weight: ${p => p.theme.fontWeightBold};
 `;


### PR DESCRIPTION
Added the `Widget Preview` title that was originally on the design. I also added the animation that is on the preview to the header so that they all animate in smoothly.

here's what it looks like:

| Before | After |
|--------|--------|
| <img width="1293" alt="image" src="https://github.com/user-attachments/assets/8821618d-c1ba-4117-999f-eec2a09688a8" /> | <img width="1288" alt="image" src="https://github.com/user-attachments/assets/2e415d9f-92f2-4ce8-b676-ae37a6e71e19" /> | 
