### PR TITLE
fix(widget-builder): Use cache for widget validation

### DIFF
--- a/static/app/views/dashboards/hooks/useValidateWidget.tsx
+++ b/static/app/views/dashboards/hooks/useValidateWidget.tsx
@@ -24,8 +24,15 @@ export function useValidateWidgetQuery(_widget: Widget) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
+  const cleanedWidget = cleanWidgetForRequest(_widget);
+
+  // Pin title and description to avoid re-triggering validation on
+  // every change in title/description.
+  cleanedWidget.title = 'sentinel';
+  cleanedWidget.description = 'sentinel';
+
   const data = useApiQuery<ValidateWidgetResponse>(
-    validateWidgetRequest(organization.slug, cleanWidgetForRequest(_widget), selection),
+    validateWidgetRequest(organization.slug, cleanedWidget, selection),
     {
       staleTime: 10000,
       enabled: hasOnDemandMetricWidgetFeature(organization),

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -165,4 +165,19 @@ describe('convertBuilderStateToWidget', function () {
 
     expect(widget.queries[0]!.fields).toEqual(['geo.country', 'count()']);
   });
+
+  it('ignores empty fields', function () {
+    const mockState: WidgetBuilderState = {
+      fields: [{field: '', kind: FieldValueKind.FIELD}],
+      yAxis: [
+        {function: ['count', '', undefined, undefined], kind: FieldValueKind.FUNCTION},
+      ],
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.fields).toEqual(['count()']);
+    expect(widget.queries[0]!.aggregates).toEqual(['count()']);
+    expect(widget.queries[0]!.columns).toEqual([]);
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -29,10 +29,12 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
               field.kind as FieldValueKind
             )
           )
-          .map(generateFieldAsString);
+          .map(generateFieldAsString)
+          .filter(Boolean);
   const columns = state.fields
     ?.filter(field => field.kind === FieldValueKind.FIELD)
-    .map(generateFieldAsString);
+    .map(generateFieldAsString)
+    .filter(Boolean);
 
   const fields =
     state.displayType === DisplayType.TABLE


### PR DESCRIPTION
Changing the title and description was always triggering a widget validation request. This is because when the title and description change, the new widget triggers the validation request because the request key is no longer the same. This pins the description and title so when those fields are changed, they have no effect on the request key and therefore the validation request doesn't get made.

Also fixes a bug I saw where I clicked to add a group by but didn't set anything, and it was always sending an empty string in the request for `fields` that would fail the request.