### PR TITLE
fix(crons): fix monitors margins typo

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -431,7 +431,7 @@ function MonitorForm({
                   DEFAULT_MAX_RUNTIME
                 )}
                 help={t(
-                  'Number of a minutes before an in-progress check-in is marked timed out.'
+                  'Number of minutes before an in-progress check-in is marked timed out.'
                 )}
                 label={t('Max Runtime')}
               />


### PR DESCRIPTION
Fixes small typo in Crons form.

![image](https://github.com/user-attachments/assets/29ff171d-7483-45b0-b1a1-b2747fed6094)
