### PR TITLE
chore(workflow-engine): comparison json schema for EventAttributeHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -15,6 +15,16 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionHand
 class EventAttributeConditionHandler(DataConditionHandler[WorkflowJob]):
     type = DataConditionHandlerType.ACTION_FILTER
 
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "attribute": {"type": "string"},
+            "match": {"type": "string", "enum": [*MatchType]},
+            "value": {"type": "string"},
+        },
+        "required": ["attribute", "match", "value"],
+    }
+
     @staticmethod
     def get_attribute_values(event: GroupEvent, attribute: str) -> list[str]:
         path = attribute.split(".")

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -23,6 +23,7 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowJob]):
             "value": {"type": "string"},
         },
         "required": ["attribute", "match", "value"],
+        "additionalProperties": False,
     }
 
     @staticmethod

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from jsonschema import ValidationError
 
 from sentry.eventstream.base import GroupState
 from sentry.rules.conditions.event_attribute import EventAttributeCondition, attribute_registry
@@ -138,11 +139,45 @@ class TestEventAttributeCondition(ConditionTestCase):
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
+    def test_json_schema(self):
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "platform", "value": "php"}
+        )
+        self.dc.save()
+
+        self.dc.comparison.update(
+            {"match": "invalid_match", "attribute": "platform", "value": "php"}
+        )
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": 0, "value": "php"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "platform", "value": 2000}
+        )
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"attribute": "platform", "value": 2000})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"match": MatchType.EQUAL, "value": 2000})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "platform"})
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
     def test_not_in_registry(self):
         with pytest.raises(NoRegistrationExistsError):
             attribute_registry.get("transaction")
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "transaction",
                 "value": "asdf",
@@ -151,24 +186,24 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_equals(self):
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "platform", "value": "php"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "platform", "value": "php"}
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "platform", "value": "python"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "platform", "value": "python"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_not_equals(self):
-        self.dc.update(
-            comparison={"match": MatchType.NOT_EQUAL, "attribute": "platform", "value": "php"}
+        self.dc.comparison.update(
+            {"match": MatchType.NOT_EQUAL, "attribute": "platform", "value": "php"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_EQUAL,
                 "attribute": "platform",
                 "value": "python",
@@ -177,8 +212,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_starts_with(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.STARTS_WITH,
                 "attribute": "platform",
                 "value": "ph",
@@ -186,8 +221,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.STARTS_WITH,
                 "attribute": "platform",
                 "value": "py",
@@ -196,8 +231,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_does_not_start_with(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_STARTS_WITH,
                 "attribute": "platform",
                 "value": "ph",
@@ -205,8 +240,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_STARTS_WITH,
                 "attribute": "platform",
                 "value": "py",
@@ -215,13 +250,13 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_ends_with(self):
-        self.dc.update(
-            comparison={"match": MatchType.ENDS_WITH, "attribute": "platform", "value": "hp"}
+        self.dc.comparison.update(
+            {"match": MatchType.ENDS_WITH, "attribute": "platform", "value": "hp"}
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.ENDS_WITH,
                 "attribute": "platform",
                 "value": "thon",
@@ -230,8 +265,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_does_not_end_with(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_ENDS_WITH,
                 "attribute": "platform",
                 "value": "hp",
@@ -239,8 +274,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_ENDS_WITH,
                 "attribute": "platform",
                 "value": "thon",
@@ -249,19 +284,19 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_contains(self):
-        self.dc.update(
-            comparison={"match": MatchType.CONTAINS, "attribute": "platform", "value": "p"}
+        self.dc.comparison.update(
+            {"match": MatchType.CONTAINS, "attribute": "platform", "value": "p"}
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.CONTAINS, "attribute": "platform", "value": "z"}
+        self.dc.comparison.update(
+            {"match": MatchType.CONTAINS, "attribute": "platform", "value": "z"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_contains_message(self):
-        self.dc.update(
-            comparison={"match": MatchType.CONTAINS, "attribute": "message", "value": "hello"}
+        self.dc.comparison.update(
+            {"match": MatchType.CONTAINS, "attribute": "message", "value": "hello"}
         )
         self.assert_passes(self.dc, self.job)
 
@@ -269,14 +304,14 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.event = self.get_event(message="")
         self.setup_group_event_and_job()
         # This should still pass, even though the message is now empty
-        self.dc.update(
-            comparison={"match": MatchType.CONTAINS, "attribute": "message", "value": "hello"}
+        self.dc.comparison.update(
+            {"match": MatchType.CONTAINS, "attribute": "message", "value": "hello"}
         )
         self.assert_passes(self.dc, self.job)
 
         # The search should also include info from the exception if present
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.CONTAINS,
                 "attribute": "message",
                 "value": "SyntaxError",
@@ -284,8 +319,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.CONTAINS,
                 "attribute": "message",
                 "value": "not present",
@@ -294,8 +329,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_does_not_contain(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_CONTAINS,
                 "attribute": "platform",
                 "value": "p",
@@ -303,8 +338,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_CONTAINS,
                 "attribute": "platform",
                 "value": "z",
@@ -313,8 +348,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_message(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "message",
                 "value": "hello world",
@@ -322,14 +357,14 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "message", "value": "php"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "message", "value": "php"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_environment(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "environment",
                 "value": "production",
@@ -337,8 +372,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "environment",
                 "value": "staging",
@@ -347,8 +382,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_compares_case_insensitive(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "environment",
                 "value": "PRODUCTION",
@@ -359,25 +394,25 @@ class TestEventAttributeCondition(ConditionTestCase):
     def test_compare_int_value(self):
         self.event.data["extra"]["number"] = 1
         self.setup_group_event_and_job()
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "extra.number", "value": "1"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "extra.number", "value": "1"}
         )
         self.assert_passes(self.dc, self.job)
 
     def test_http_method(self):
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "http.method", "value": "GET"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "http.method", "value": "GET"}
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "http.method", "value": "POST"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "http.method", "value": "POST"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_http_url(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "http.url",
                 "value": "http://example.com/",
@@ -385,8 +420,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "http.url",
                 "value": "http://foo.com/",
@@ -395,8 +430,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_http_status_code(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "http.status_code",
                 "value": "500",
@@ -404,8 +439,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "http.status_code",
                 "value": "400",
@@ -414,15 +449,15 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_user_id(self):
-        self.dc.update(comparison={"match": MatchType.EQUAL, "attribute": "user.id", "value": "1"})
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "user.id", "value": "1"})
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(comparison={"match": MatchType.EQUAL, "attribute": "user.id", "value": "2"})
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "user.id", "value": "2"})
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_user_ip_address(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "user.ip_address",
                 "value": "127.0.0.1",
@@ -430,8 +465,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "user.ip_address",
                 "value": "2",
@@ -440,8 +475,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_user_email(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "user.email",
                 "value": "foo@example.com",
@@ -449,14 +484,14 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "user.email", "value": "2"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "user.email", "value": "2"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_user_username(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "user.username",
                 "value": "foo",
@@ -464,14 +499,14 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "user.username", "value": "2"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "user.username", "value": "2"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_exception_type(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "exception.type",
                 "value": "SyntaxError",
@@ -479,8 +514,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "exception.type",
                 "value": "TypeError",
@@ -490,8 +525,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
     @patch("sentry.eventstore.models.get_interfaces", return_value={})
     def test_exception_type_keyerror(self, mock_get_interfaces):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "exception.type",
                 "value": "SyntaxError",
@@ -501,8 +536,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
     def test_error_handled(self):
         self.error_setup()
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "error.handled",
                 "value": "False",
@@ -510,8 +545,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "error.handled",
                 "value": "True",
@@ -520,8 +555,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_error_handled_not_defined(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "error.handled",
                 "value": "True",
@@ -532,8 +567,8 @@ class TestEventAttributeCondition(ConditionTestCase):
     @patch("sentry.eventstore.models.get_interfaces", return_value={})
     def test_error_handled_keyerror(self, mock_get_interfaces):
         self.error_setup()
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "error.handled",
                 "value": "False",
@@ -543,8 +578,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
     def test_error_unhandled(self):
         self.error_setup()
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "error.unhandled",
                 "value": "True",
@@ -552,8 +587,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "error.unhandled",
                 "value": "False",
@@ -562,8 +597,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_exception_value(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "exception.value",
                 "value": "hello world",
@@ -571,8 +606,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "exception.value",
                 "value": "foo bar",
@@ -581,8 +616,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_sdk_name(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "sdk.name",
                 "value": "sentry.javascript.react",
@@ -590,8 +625,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "sdk.name",
                 "value": "sentry.python",
@@ -623,8 +658,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
         # correctly matching filenames, at various locations in the stacktrace
         for value in ["example.php", "somecode.php", "othercode.php"]:
-            self.dc.update(
-                comparison={
+            self.dc.comparison.update(
+                {
                     "match": MatchType.EQUAL,
                     "attribute": "stacktrace.filename",
                     "value": value,
@@ -633,8 +668,8 @@ class TestEventAttributeCondition(ConditionTestCase):
             self.assert_passes(self.dc, self.job)
 
         # non-matching filename
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "stacktrace.filename",
                 "value": "foo.php",
@@ -658,8 +693,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.setup_group_event_and_job()
 
         for value in ["example.php", "somecode.php", "othercode.php"]:
-            self.dc.update(
-                comparison={
+            self.dc.comparison.update(
+                {
                     "match": MatchType.EQUAL,
                     "attribute": "stacktrace.filename",
                     "value": value,
@@ -691,8 +726,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
         # correctly matching modules, at various locations in the stacktrace
         for value in ["example", "somecode", "othercode"]:
-            self.dc.update(
-                comparison={
+            self.dc.comparison.update(
+                {
                     "match": MatchType.EQUAL,
                     "attribute": "stacktrace.module",
                     "value": value,
@@ -701,8 +736,8 @@ class TestEventAttributeCondition(ConditionTestCase):
             self.assert_passes(self.dc, self.job)
 
         # non-matching module
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "stacktrace.module",
                 "value": "foo",
@@ -749,8 +784,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
         # correctly matching code, at various locations in the stacktrace
         for value in ["somecode.bar()", "othercode.baz()", "hi()"]:
-            self.dc.update(
-                comparison={
+            self.dc.comparison.update(
+                {
                     "match": MatchType.EQUAL,
                     "attribute": "stacktrace.code",
                     "value": value,
@@ -759,8 +794,8 @@ class TestEventAttributeCondition(ConditionTestCase):
             self.assert_passes(self.dc, self.job)
 
         # non-matching code
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "stacktrace.code",
                 "value": "foo",
@@ -804,8 +839,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
         # correctly matching abs_paths, at various locations in the stacktrace
         for value in ["path/to/example.php", "path/to/somecode.php", "path/to/othercode.php"]:
-            self.dc.update(
-                comparison={
+            self.dc.comparison.update(
+                {
                     "match": MatchType.EQUAL,
                     "attribute": "stacktrace.abs_path",
                     "value": value,
@@ -814,8 +849,8 @@ class TestEventAttributeCondition(ConditionTestCase):
             self.assert_passes(self.dc, self.job)
 
         # non-matching abs_path
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "stacktrace.abs_path",
                 "value": "path/to/foo.php",
@@ -853,8 +888,8 @@ class TestEventAttributeCondition(ConditionTestCase):
 
         # correctly matching filenames, at various locations in the stacktrace
         for value in ["package/example.lib", "package/otherpackage.lib", "package/somepackage.lib"]:
-            self.dc.update(
-                comparison={
+            self.dc.comparison.update(
+                {
                     "match": MatchType.EQUAL,
                     "attribute": "stacktrace.package",
                     "value": value,
@@ -863,8 +898,8 @@ class TestEventAttributeCondition(ConditionTestCase):
             self.assert_passes(self.dc, self.job)
 
         # non-matching filename
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "stacktrace.package",
                 "value": "package/otherotherpackage.lib",
@@ -873,19 +908,19 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_extra_simple_value(self):
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "extra.bar", "value": "foo"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "extra.bar", "value": "foo"}
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "extra.bar", "value": "bar"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "extra.bar", "value": "bar"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_extra_nested_value(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "extra.foo.bar",
                 "value": "baz",
@@ -893,8 +928,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "extra.foo.bar",
                 "value": "bar",
@@ -903,28 +938,28 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_extra_nested_list(self):
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "extra.biz", "value": "baz"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "extra.biz", "value": "baz"}
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={"match": MatchType.EQUAL, "attribute": "extra.biz", "value": "bar"}
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "extra.biz", "value": "bar"}
         )
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_event_type(self):
         self.event.data["type"] = "error"
         self.setup_group_event_and_job()
-        self.dc.update(comparison={"match": MatchType.EQUAL, "attribute": "type", "value": "error"})
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "type", "value": "error"})
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(comparison={"match": MatchType.EQUAL, "attribute": "type", "value": "csp"})
+        self.dc.comparison.update({"match": MatchType.EQUAL, "attribute": "type", "value": "csp"})
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_device_screen_width_pixels(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_width_pixels",
                 "value": "1920",
@@ -932,8 +967,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_width_pixels",
                 "value": "400",
@@ -942,8 +977,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_device_screen_height_pixels(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_height_pixels",
                 "value": "1080",
@@ -951,8 +986,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_height_pixels",
                 "value": "400",
@@ -961,8 +996,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_device_screen_dpi(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_dpi",
                 "value": "123",
@@ -970,8 +1005,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_dpi",
                 "value": "400",
@@ -980,8 +1015,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_device_screen_density(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_density",
                 "value": "2.5",
@@ -989,8 +1024,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "device.screen_density",
                 "value": "400",
@@ -999,8 +1034,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_app_in_foreground(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "app.in_foreground",
                 "value": "True",
@@ -1008,8 +1043,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "app.in_foreground",
                 "value": "False",
@@ -1018,8 +1053,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_os_distribution_name_and_version(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "os.distribution_name",
                 "value": "ubuntu",
@@ -1027,8 +1062,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "os.distribution_name",
                 "value": "slackware",
@@ -1036,8 +1071,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "os.distribution_version",
                 "value": "22.04",
@@ -1045,8 +1080,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "os.distribution_version",
                 "value": "20.04",
@@ -1055,8 +1090,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_unreal_crash_type(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "unreal.crash_type",
                 "value": "Crash",
@@ -1064,8 +1099,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "unreal.crash_type",
                 "value": "NoCrash",
@@ -1097,8 +1132,8 @@ class TestEventAttributeCondition(ConditionTestCase):
             }
         )
         self.setup_group_event_and_job()
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.EQUAL,
                 "attribute": "exception.type",
                 "value": "SyntaxError",
@@ -1107,22 +1142,22 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_passes(self.dc, self.job)
 
     def test_is_set(self):
-        self.dc.update(comparison={"match": MatchType.IS_SET, "attribute": "platform"})
+        self.dc.comparison.update({"match": MatchType.IS_SET, "attribute": "platform"})
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(comparison={"match": MatchType.IS_SET, "attribute": "missing"})
+        self.dc.comparison.update({"match": MatchType.IS_SET, "attribute": "missing"})
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_not_set(self):
-        self.dc.update(comparison={"match": MatchType.NOT_SET, "attribute": "platform"})
+        self.dc.comparison.update({"match": MatchType.NOT_SET, "attribute": "platform"})
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(comparison={"match": MatchType.NOT_SET, "attribute": "missing"})
+        self.dc.comparison.update({"match": MatchType.NOT_SET, "attribute": "missing"})
         self.assert_passes(self.dc, self.job)
 
     def test_attr_is_in(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.IS_IN,
                 "attribute": "platform",
                 "value": "php, python",
@@ -1130,8 +1165,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_passes(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.IS_IN,
                 "attribute": "platform",
                 "value": "python, ruby",
@@ -1140,8 +1175,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.job)
 
     def test_attr_not_in(self):
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_IN,
                 "attribute": "platform",
                 "value": "php, python",
@@ -1149,8 +1184,8 @@ class TestEventAttributeCondition(ConditionTestCase):
         )
         self.assert_does_not_pass(self.dc, self.job)
 
-        self.dc.update(
-            comparison={
+        self.dc.comparison.update(
+            {
                 "match": MatchType.NOT_IN,
                 "attribute": "platform",
                 "value": "python, ruby",

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -173,6 +173,12 @@ class TestEventAttributeCondition(ConditionTestCase):
         with pytest.raises(ValidationError):
             self.dc.save()
 
+        self.dc.comparison.update(
+            {"match": MatchType.EQUAL, "attribute": "platform", "value": 2000, "extra": "extra"}
+        )
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
     def test_not_in_registry(self):
         with pytest.raises(NoRegistrationExistsError):
             attribute_registry.get("transaction")


### PR DESCRIPTION
comparison for `EventAttributeHandler` should be a `dict` with `attribute: str`, `match: MatchType`, and `value: str`