### PR TITLE
fix(issue-details): Fix 100% value for tags

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
@@ -72,7 +72,7 @@ describe('TagDetailsDrawerContent', () => {
 
     // Affected user column
     expect(screen.getByText('David Cramer')).toBeInTheDocument();
-    expect(screen.getByText('17%')).toBeInTheDocument();
+    expect(screen.getByText('16%')).toBeInTheDocument();
     // Count column
     expect(screen.getByText('3')).toBeInTheDocument();
 

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -162,7 +162,7 @@ function TagDetailsRow({
     pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
     query,
   };
-  const percentage = percent(tagValue.count ?? 0, tag.totalValues ?? 0);
+  const percentage = Math.floor(percent(tagValue.count ?? 0, tag.totalValues ?? 0));
   const displayPercentage = percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
 
   return (

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -40,7 +40,7 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
         </TagHeader>
         <TagValueContent>
           {visibleTagValues.map((tagValue, tagValueIdx) => {
-            const percentage = percent(tagValue.count, tag.totalValues);
+            const percentage = Math.floor(percent(tagValue.count, tag.totalValues));
             const displayPercentage =
               percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
             return (


### PR DESCRIPTION
in a previous pr we fixed the 100% value for "Other" but this pr updates the tag distribution so non-other values also don't show 100% if there are more than 1 value.

before: 
<img width="413" alt="Screenshot 2025-01-24 at 2 07 53 PM" src="https://github.com/user-attachments/assets/8a0202ca-d182-4aa0-943a-0569df8a29e8" />

after: 
<img width="414" alt="Screenshot 2025-01-24 at 2 07 40 PM" src="https://github.com/user-attachments/assets/4b0131fc-ef3a-49ae-bd13-31e69e56958c" />

