### PR TITLE
fix(issues): Tag preview hover/click

### DIFF
--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -6,6 +6,7 @@ import Color from 'color';
 
 import {LinkButton} from 'sentry/components/button';
 import {DeviceName} from 'sentry/components/deviceName';
+import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
 import TextOverflow from 'sentry/components/textOverflow';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -35,6 +36,7 @@ const BACKEND_TAGS = [
   'environment',
 ];
 const MOBILE_TAGS = ['device', 'os', 'release', 'environment', 'transaction'];
+const RTL_TAGS = ['transaction', 'url'];
 
 type Segment = {
   count: number;
@@ -45,58 +47,30 @@ type Segment = {
 
 const bgColor = (index: number) =>
   Color(CHART_PALETTE[4].at(index)).alpha(0.8).toString();
+const getRoundedPercentage = (percentage: number) =>
+  percentage < 1 ? '<1%' : `${Math.floor(percentage)}%`;
 
-function SegmentedBar({
-  segments,
-  otherPercentage,
-  tagName,
-}: {
-  otherPercentage: string | null;
-  segments: Segment[];
-  tagName: string;
-}) {
-  const theme = useTheme();
-  const tooltipContent = (
-    <TooltipLegend>
-      <LegendTitle>{tagName}</LegendTitle>
-      <LegendGrid>
-        {segments.map((segment, idx) => (
-          <Fragment key={idx}>
-            <LegendColor style={{backgroundColor: bgColor(idx)}} />
-            <LegendText>{segment.name}</LegendText>
-            <LegendPercentage>{segment.percentage.toFixed(0)}%</LegendPercentage>
-          </Fragment>
-        ))}
-        {otherPercentage && (
-          <Fragment>
-            <LegendColor style={{backgroundColor: theme.gray200}} />
-            <LegendText>{t('Other')}</LegendText>
-            <LegendPercentage>{otherPercentage}</LegendPercentage>
-          </Fragment>
-        )}
-      </LegendGrid>
-    </TooltipLegend>
-  );
-
+function SegmentedBar({segments}: {segments: Segment[]}) {
   return (
-    <Tooltip title={tooltipContent} skipWrapper>
-      <TagBarPlaceholder>
-        {segments.map((segment, idx) => (
-          <TagBarSegment
-            key={idx}
-            style={{
-              left: `${segments.slice(0, idx).reduce((sum, s) => sum + s.percentage, 0)}%`,
-              width: `${segment.percentage}%`,
-              backgroundColor: bgColor(idx),
-            }}
-          />
-        ))}
-      </TagBarPlaceholder>
-    </Tooltip>
+    <TagBarPlaceholder>
+      {segments.map((segment, idx) => (
+        <TagBarSegment
+          key={idx}
+          style={{
+            left: `${segments.slice(0, idx).reduce((sum, s) => sum + s.percentage, 0)}%`,
+            width: `${segment.percentage}%`,
+            backgroundColor: bgColor(idx),
+          }}
+        />
+      ))}
+    </TagBarPlaceholder>
   );
 }
 
 function TagPreviewProgressBar({tag}: {tag: GroupTag}) {
+  const theme = useTheme();
+  const {baseUrl} = useGroupDetailsRoute();
+  const location = useLocation();
   const segments: Segment[] = tag.topValues.map(value => {
     let name: string | React.ReactNode = value.name;
     if (tag.key === 'release') {
@@ -117,28 +91,54 @@ function TagPreviewProgressBar({tag}: {tag: GroupTag}) {
     return null;
   }
 
-  const topPercentageString =
-    topSegment.percentage < 1 ? '<1%' : `${topSegment.percentage.toFixed(0)}%`;
+  const topPercentageString = getRoundedPercentage(topSegment.percentage);
   const otherPercentage = segments.reduce((sum, s) => sum - s.percentage, 100);
   const otherPercentageString =
-    otherPercentage === 0
-      ? null
-      : otherPercentage < 1
-        ? '<1%'
-        : `${otherPercentage.toFixed(0)}%`;
+    otherPercentage === 0 ? null : getRoundedPercentage(otherPercentage);
+
+  const tooltipContent = (
+    <TooltipLegend>
+      <LegendTitle>{tag.key}</LegendTitle>
+      <LegendGrid>
+        {segments.map((segment, idx) => (
+          <Fragment key={idx}>
+            <LegendColor style={{backgroundColor: bgColor(idx)}} />
+            <LegendText ellipsisDirection={RTL_TAGS.includes(tag.key) ? 'left' : 'right'}>
+              {segment.name}
+            </LegendText>
+            <LegendPercentage>
+              {getRoundedPercentage(segment.percentage)}
+            </LegendPercentage>
+          </Fragment>
+        ))}
+        {otherPercentageString && (
+          <Fragment>
+            <LegendColor style={{backgroundColor: theme.gray200}} />
+            <LegendText>{t('Other')}</LegendText>
+            <LegendPercentage>{otherPercentageString}</LegendPercentage>
+          </Fragment>
+        )}
+      </LegendGrid>
+    </TooltipLegend>
+  );
 
   return (
-    <Fragment>
-      <TagBarPlaceholder>
-        <SegmentedBar
-          segments={segments}
-          otherPercentage={otherPercentageString}
-          tagName={tag.key}
-        />
-      </TagBarPlaceholder>
-      <TopPercentage>{topPercentageString}</TopPercentage>
-      <TextOverflow>{topSegment?.name}</TextOverflow>
-    </Fragment>
+    <Tooltip title={tooltipContent} skipWrapper maxWidth={420}>
+      <TagPreviewGrid
+        to={{
+          pathname: `${baseUrl}${TabPaths[Tab.TAGS]}${tag.key}/`,
+          query: location.query,
+        }}
+      >
+        <TagBarPlaceholder>
+          <SegmentedBar segments={segments} />
+        </TagBarPlaceholder>
+        <TopPercentage>{topPercentageString}</TopPercentage>
+        <TextOverflow ellipsisDirection={RTL_TAGS.includes(tag.key) ? 'left' : 'right'}>
+          {topSegment?.name}
+        </TextOverflow>
+      </TagPreviewGrid>
+    </Tooltip>
   );
 }
 
@@ -315,10 +315,26 @@ const LegendColor = styled('div')`
   border-radius: 100%;
 `;
 
-const LegendText = styled('span')`
+const TagPreviewGrid = styled(Link)`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  align-items: center;
+  padding: 0 ${space(0.75)};
+  margin: 0 -${space(0.75)};
+  border-radius: ${p => p.theme.borderRadius};
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+
+  &:hover {
+    background: ${p => p.theme.backgroundSecondary};
+    color: ${p => p.theme.textColor};
+  }
+`;
+
+const LegendText = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeSmall};
   white-space: nowrap;
-  ${p => p.theme.overflowEllipsis};
 `;
 
 const LegendPercentage = styled('span')`
@@ -329,9 +345,7 @@ const LegendPercentage = styled('span')`
 `;
 
 const LegendTitle = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
-  color: ${p => p.theme.textColor};
   margin-bottom: ${space(0.75)};
 `;
 


### PR DESCRIPTION
- Allows hovering over the entire row to see the tooltip
- Adds a link to the tag details on click
- Some style adjusting and fixes for long urls and transactions

![image](https://github.com/user-attachments/assets/26a4d714-397e-47b6-b43b-ac3cc9b0c40f)
