### PR TITLE
feat(taskworker) Start building task scheduler 

### DIFF
--- a/src/sentry/taskworker/scheduler.py
+++ b/src/sentry/taskworker/scheduler.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import abc
-import dataclasses
 import heapq
+import logging
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
@@ -10,69 +10,48 @@ from typing import Any, TypedDict
 from django.utils import timezone
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
+from sentry_sdk import capture_exception
 
 from sentry.taskworker.registry import TaskRegistry
 from sentry.taskworker.task import Task
+from sentry.utils import metrics
 
-
-@dataclasses.dataclass
-class crontab:
-    """
-    crontab schedule value object
-
-    Used in configuration to define a task schedule.
-    """
-
-    minute: str = "*"
-    hour: str = "*"
-    day_of_week: str = "*"
-    day_of_month: str = "*"
-    month_of_year: str = "*"
+logger = logging.getLogger(__name__)
 
 
 class ScheduleConfig(TypedDict):
     """The schedule definition for an individual task."""
 
     task: str
-    schedule: timedelta | crontab
+    # TODO(taskworker) Implement crontab schedules
+    schedule: timedelta
 
 
 ScheduleConfigMap = Mapping[str, ScheduleConfig]
 """A collection of schedule configuration, usually defined in application configuration"""
 
 
-class RunStorage(metaclass=abc.ABCMeta):
-    """Interface for storing task runtimes."""
+class RunStorage:
+    """
+    Storage interface for tracking the last run time of tasks.
+    This is split out from `ScheduleSet` to allow us to change storage
+    in the future, or adapt taskworkers for other applications should we need to.
+    """
 
-    @abc.abstractmethod
-    def set(self, taskname: str, next_runtime: datetime) -> bool:
-        """
-        Record a spawn time for a task.
-        The next_runtime parameter indicates when this task should run again.
-
-        If a key is already set this method will raise an error.
-        """
-
-    @abc.abstractmethod
-    def read(self, taskname: str) -> datetime | None:
-        """
-        Retrieve the last run time of a task
-        Returns None if last run time has expired or is unknown.
-        """
-
-    @abc.abstractmethod
-    def delete(self, taskname: str) -> None:
-        """remove a task key - mostly for testing."""
-
-
-class RedisRunStorage(RunStorage):
-    def __init__(self, redis: RedisCluster[bytes] | StrictRedis[bytes]) -> None:
+    def __init__(self, redis: RedisCluster[str] | StrictRedis[str]) -> None:
         self._redis = redis
 
     def _make_key(self, taskname: str) -> str:
         return f"tw:scheduler:{taskname}"
 
     def set(self, taskname: str, next_runtime: datetime) -> bool:
+        """
+        Record a spawn time for a task.
+        The next_runtime parameter indicates when the record should expire,
+        and a task can be spawned again.
+
+        Returns False when the key is set and a task should not be spawned.
+        """
         now = timezone.now()
         duration = next_runtime - now
 
@@ -80,12 +59,28 @@ class RedisRunStorage(RunStorage):
         return bool(result)
 
     def read(self, taskname: str) -> datetime | None:
+        """
+        Retrieve the last run time of a task
+        Returns None if last run time has expired or is unknown.
+        """
         result = self._redis.get(self._make_key(taskname))
         if result:
-            return datetime.fromisoformat(result.decode())
+            return datetime.fromisoformat(result)
         return None
 
+    def read_many(self, tasknames: list[str]) -> Mapping[str, datetime | None]:
+        """
+        Retreive last run times in bulk
+        """
+        values = self._redis.mget([self._make_key(taskname) for taskname in tasknames])
+        run_times = {
+            taskname: datetime.fromisoformat(value) if value else None
+            for taskname, value in zip(tasknames, values)
+        }
+        return run_times
+
     def delete(self, taskname: str) -> None:
+        """remove a task key - mostly for testing."""
         self._redis.delete(self._make_key(taskname))
 
 
@@ -111,21 +106,9 @@ class Schedule(metaclass=abc.ABCMeta):
         """
 
 
-class CrontabSchedule(Schedule):
-    def __init__(self, crontab: crontab) -> None:
-        self._crontab = crontab
-
-    def is_due(self, last_run: datetime | None = None) -> bool:
-        return False
-
-    def remaining_delta(self, last_run: datetime | None = None) -> timedelta:
-        return timedelta(seconds=0)
-
-    def runtime_after(self, start: datetime) -> datetime:
-        return timezone.now()
-
-
 class TimedeltaSchedule(Schedule):
+    """Task schedules defined as `datetime.timedelta` intervals"""
+
     def __init__(self, delta: timedelta) -> None:
         self._delta = delta
         if delta.microseconds:
@@ -159,13 +142,9 @@ class TimedeltaSchedule(Schedule):
 class ScheduleEntry:
     """Metadata about a task that can be scheduled"""
 
-    def __init__(self, *, task: Task[Any, Any], schedule: timedelta | crontab) -> None:
+    def __init__(self, *, task: Task[Any, Any], schedule: timedelta) -> None:
         self._task = task
-        scheduler: Schedule
-        if isinstance(schedule, timedelta):
-            scheduler = TimedeltaSchedule(schedule)
-        else:
-            scheduler = CrontabSchedule(schedule)
+        scheduler = TimedeltaSchedule(schedule)
         self._schedule = scheduler
         self._last_run: datetime | None = None
 
@@ -194,7 +173,14 @@ class ScheduleEntry:
 
 
 class ScheduleSet:
-    """A collection of ScheduleEntry objects"""
+    """
+    A task scheduler that a command run process can use to spawn tasks
+    based on their schedules.
+
+    Contains a collection of ScheduleEntry objects which are composed
+    using `ScheduleSet.add()`. Once the scheduler is built, `tick()`
+    is used in a while loop to spawn tasks and sleep.
+    """
 
     def __init__(self, registry: TaskRegistry, run_storage: RunStorage) -> None:
         self._entries: list[ScheduleEntry] = []
@@ -203,7 +189,7 @@ class ScheduleSet:
         self._heap: list[tuple[float, ScheduleEntry]] = []
 
     def add(self, task_config: ScheduleConfig) -> None:
-        """Add a task to the schedule."""
+        """Add a task to the scheduleset."""
         try:
             (namespace, taskname) = task_config["task"].split(":")
         except ValueError:
@@ -223,15 +209,15 @@ class ScheduleSet:
         self._build_heap()
 
         while True:
-            # Peek at the top, and if it is due, pop, spawn and update.
+            # Peek at the top, and if it is due, pop, spawn and update last run time
             _, entry = self._heap[0]
             if entry.is_due():
                 heapq.heappop(self._heap)
-                now = timezone.now()
-                next_runtime = entry.runtime_after(now)
-                if self._run_storage.set(entry.fullname, next_runtime):
-                    entry.delay_task()
-                entry.set_last_run(now)
+                try:
+                    self._try_spawn(entry)
+                except Exception as e:
+                    # Trap errors from spawning/update state so that the heap stays consistent.
+                    capture_exception(e)
                 heapq.heappush(self._heap, (entry.remaining_delta().total_seconds(), entry))
                 continue
             else:
@@ -240,13 +226,30 @@ class ScheduleSet:
 
         return entry.remaining_delta().total_seconds()
 
+    def _try_spawn(self, entry: ScheduleEntry) -> None:
+        now = timezone.now()
+        next_runtime = entry.runtime_after(now)
+        if self._run_storage.set(entry.fullname, next_runtime):
+            entry.delay_task()
+            entry.set_last_run(now)
+
+            logger.info("taskworker.scheduler.delay_task", extra={"task": entry.fullname})
+            metrics.incr("taskworker.scheduler.delay_task")
+        else:
+            # sync with last_run state in storage
+            entry.set_last_run(self._run_storage.read(entry.fullname))
+
+            logger.info("taskworker.scheduler.sync_with_storage", extra={"task": entry.fullname})
+            metrics.incr("taskworker.scheduler.sync_with_storage")
+
     def _build_heap(self) -> None:
         if self._heap:
             return
 
         heap_items = []
+        last_run_times = self._run_storage.read_many([item.fullname for item in self._entries])
         for item in self._entries:
-            last_run = self._run_storage.read(item.fullname)
+            last_run = last_run_times.get(item.fullname, None)
             item.set_last_run(last_run)
             remaining_time = item.remaining_delta()
             heap_items.append((remaining_time.total_seconds(), item))

--- a/src/sentry/taskworker/scheduler.py
+++ b/src/sentry/taskworker/scheduler.py
@@ -186,7 +186,7 @@ class ScheduleSet:
         self._entries: list[ScheduleEntry] = []
         self._registry = registry
         self._run_storage = run_storage
-        self._heap: list[tuple[float, ScheduleEntry]] = []
+        self._heap: list[tuple[int, ScheduleEntry]] = []
 
     def add(self, task_config: ScheduleConfig) -> None:
         """Add a task to the scheduleset."""

--- a/src/sentry/taskworker/scheduler.py
+++ b/src/sentry/taskworker/scheduler.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import abc
+import dataclasses
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from typing import Any, NotRequired, TypedDict
+
+from django.utils import timezone
+from rediscluster import RedisCluster
+
+from sentry.taskworker.registry import TaskRegistry
+from sentry.taskworker.task import Task
+
+
+@dataclasses.dataclass
+class crontab:
+    """
+    crontab schedule value object
+
+    Used in configuration to define a task schedule.
+    """
+
+    minute: str = "*"
+    hour: str = "*"
+    day_of_week: str = "*"
+    day_of_month: str = "*"
+    month_of_year: str = "*"
+
+
+class ScheduleOptions(TypedDict):
+    expires: timedelta | int
+
+
+class ScheduleConfig(TypedDict):
+    """The schedule definition for an individual task."""
+
+    task: str
+    schedule: timedelta | crontab
+    options: NotRequired[ScheduleOptions]
+
+
+ScheduleConfigMap = Mapping[str, ScheduleConfig]
+"""A collection of schedule configuration, usually defined in application configuration"""
+
+
+class RunStorage(metaclass=abc.ABCMeta):
+    """Interface for storing task runtimes."""
+
+    @abc.abstractmethod
+    def set(self, taskname: str, next_runtime: datetime) -> None:
+        """
+        Record a spawn time for a task.
+        The next_runtime parameter indicates when this task should run again.
+
+        If a key is already set this method will raise an error.
+        """
+
+    @abc.abstractmethod
+    def read(self, taskname: str) -> datetime | None:
+        """
+        Retrieve the last run time of a task
+        Returns None if last run time has expired or is unknown.
+        """
+
+
+class RedisRunStorage(RunStorage):
+    def __init__(self, cluster: RedisCluster) -> None:
+        self._cluster = cluster
+
+    def _make_key(self, taskname: str) -> str:
+        return f"tw:scheduler:{taskname}"
+
+    def set(self, taskname: str, next_runtime: datetime) -> None:
+        now = timezone.now()
+        duration = next_runtime - now
+
+        result = self._cluster.set(self._make_key(taskname), now.isoformat(), ex=duration, nx=True)
+        if not result:
+            raise ValueError(f"Cannot set runtime for {taskname} it already has a runtime set")
+
+    def read(self, taskname: str) -> datetime | None:
+        result = self._cluster.get(self._make_key(taskname))
+        if result:
+            return datetime.fromisoformat(result.decode())
+        return None
+
+
+class Schedule(metaclass=abc.ABCMeta):
+    """Interface for scheduling tasks to run at specific times."""
+
+    @abc.abstractmethod
+    def is_due(self, last_run: datetime | None = None) -> float:
+        """
+        Check if the schedule is due to run again based on last_run.
+        """
+
+
+class CrontabSchedule(Schedule):
+    def __init__(self, crontab: crontab) -> None:
+        self._crontab = crontab
+
+    def is_due(self, last_run: datetime | None = None) -> bool:
+        return False
+
+
+class TimedeltaSchedule(Schedule):
+    def __init__(self, delta: timedelta) -> None:
+        self._delta = delta
+
+    def is_due(self, last_run: datetime | None = None) -> bool:
+        return False
+
+
+class ScheduleEntry:
+    """Metadata about a task that can be scheduled"""
+
+    def __init__(
+        self, *, task: Task[Any, Any], schedule: timedelta | crontab, options: ScheduleOptions
+    ) -> None:
+        self._task = task
+        self._schedule = schedule
+        self._options = options
+
+    def is_due(self, last_run: datetime | None = None) -> bool:
+        return False
+
+    def delay_task(self) -> None:
+        pass
+
+
+class ScheduleSet:
+    """A collection of ScheduleEntry objects"""
+
+    def __init__(self, registry: TaskRegistry, run_storage: RunStorage) -> None:
+        self._entries: list[ScheduleEntry] = []
+        self._registry = registry
+        self._run_storage = run_storage
+
+    def add(self, task_config: ScheduleConfig) -> None:
+        """Add a task to the schedule."""
+        # Fetch task wrapper from registry/namespace
+        # Build schedule entry, read last run time, add to collection
+
+    def tick(self, current_time: datetime | None = None) -> float:
+        """
+        Check if any tasks are due to run at current_time, and spawn them.
+
+        Returns the number of seconds to sleep until the next task is due.
+        """
+        # - put all the entries into a heap, or rebuild the heap?
+        # - look at the top of the heap, if it has is_due() == true, spawn it
+        #   if the top of the heap can't be spawned find out when it runs and return that
+        #   duration in seconds
+        # - before spawning the task, set last run time, and then spawn task
+
+        return 0.0

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -61,6 +61,10 @@ class Task(Generic[P, R]):
         update_wrapper(self, func)
 
     @property
+    def fullname(self) -> str:
+        return f"{self._namespace.name}:{self.name}"
+
+    @property
     def retry(self) -> Retry | None:
         return self._retry
 

--- a/tests/sentry/taskworker/test_scheduler.py
+++ b/tests/sentry/taskworker/test_scheduler.py
@@ -60,22 +60,22 @@ def test_timedeltaschedule_is_due() -> None:
 
 
 @freeze_time("2025-01-24 14:25:00")
-def test_timedeltaschedule_remaining_delta() -> None:
+def test_timedeltaschedule_remaining_seconds() -> None:
     now = timezone.now()
     delta = timedelta(minutes=5)
     schedule = TimedeltaSchedule(delta)
 
-    assert schedule.remaining_delta(None).total_seconds() == 0
-    assert schedule.remaining_delta(now).total_seconds() == 300
+    assert schedule.remaining_seconds(None) == 0
+    assert schedule.remaining_seconds(now) == 300
 
     four_min_ago = now - timedelta(minutes=4, seconds=59)
-    assert schedule.remaining_delta(four_min_ago).total_seconds() == 1
+    assert schedule.remaining_seconds(four_min_ago) == 1
 
     five_min_ago = now - timedelta(minutes=5)
-    assert schedule.remaining_delta(five_min_ago).total_seconds() == 0
+    assert schedule.remaining_seconds(five_min_ago) == 0
 
     ten_min_ago = now - timedelta(minutes=10)
-    assert schedule.remaining_delta(ten_min_ago).total_seconds() == 0
+    assert schedule.remaining_seconds(ten_min_ago) == 0
 
 
 def test_scheduleset_add_invalid(taskregistry) -> None:

--- a/tests/sentry/taskworker/test_scheduler.py
+++ b/tests/sentry/taskworker/test_scheduler.py
@@ -1,0 +1,219 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+from django.utils import timezone
+
+from sentry.taskworker.registry import TaskRegistry
+from sentry.taskworker.scheduler import RedisRunStorage, RunStorage, ScheduleSet, TimedeltaSchedule
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils.redis import redis_clusters
+
+
+def test_timedeltaschedule_invalid() -> None:
+    with pytest.raises(ValueError):
+        TimedeltaSchedule(timedelta(microseconds=5))
+
+    with pytest.raises(ValueError):
+        TimedeltaSchedule(timedelta(seconds=-1))
+
+
+@freeze_time("2025-01-24 14:25:00")
+def test_timedeltaschedule_is_due() -> None:
+    now = timezone.now()
+    delta = timedelta(minutes=5)
+    schedule = TimedeltaSchedule(delta)
+
+    assert not schedule.is_due(now)
+
+    four_min_ago = now - timedelta(minutes=4, seconds=59)
+    assert not schedule.is_due(four_min_ago)
+
+    five_min_ago = now - timedelta(minutes=5)
+    assert schedule.is_due(five_min_ago)
+
+    six_min_ago = now - timedelta(minutes=6)
+    assert schedule.is_due(six_min_ago)
+
+
+@freeze_time("2025-01-24 14:25:00")
+def test_timedeltaschedule_remaining_delta() -> None:
+    now = timezone.now()
+    delta = timedelta(minutes=5)
+    schedule = TimedeltaSchedule(delta)
+
+    assert schedule.remaining_delta(None).total_seconds() == 0
+    assert schedule.remaining_delta(now).total_seconds() == 300
+
+    four_min_ago = now - timedelta(minutes=4, seconds=59)
+    assert schedule.remaining_delta(four_min_ago).total_seconds() == 1
+
+    five_min_ago = now - timedelta(minutes=5)
+    assert schedule.remaining_delta(five_min_ago).total_seconds() == 0
+
+    ten_min_ago = now - timedelta(minutes=10)
+    assert schedule.remaining_delta(ten_min_ago).total_seconds() == 0
+
+
+@pytest.fixture
+def taskregistry() -> TaskRegistry:
+    registry = TaskRegistry()
+    namespace = registry.create_namespace("test")
+
+    @namespace.register(name="valid")
+    def test_func() -> None:
+        pass
+
+    @namespace.register(name="second")
+    def second_func() -> None:
+        pass
+
+    return registry
+
+
+def test_scheduleset_add_invalid(taskregistry) -> None:
+    run_storage = Mock(spec=RunStorage)
+    schedule_set = ScheduleSet(registry=taskregistry, run_storage=run_storage)
+
+    with pytest.raises(ValueError) as err:
+        schedule_set.add(
+            {
+                "task": "invalid",
+                "schedule": timedelta(minutes=5),
+            }
+        )
+    assert "Invalid task name" in str(err)
+
+    with pytest.raises(KeyError) as err:
+        schedule_set.add(
+            {
+                "task": "test:invalid",
+                "schedule": timedelta(minutes=5),
+            }
+        )
+    assert "No task registered" in str(err)
+
+    with pytest.raises(ValueError) as err:
+        schedule_set.add(
+            {
+                "task": "test:valid",
+                "schedule": timedelta(microseconds=99),
+            }
+        )
+    assert "microseconds" in str(err)
+
+
+def test_scheduleset_tick_one_task_time_remaining(taskregistry) -> None:
+    run_storage = Mock(spec=RunStorage)
+    # Last run is two minutes from 'now'
+    run_storage.read.return_value = datetime(2025, 1, 24, 14, 23, 0)
+    schedule_set = ScheduleSet(registry=taskregistry, run_storage=run_storage)
+
+    schedule_set.add(
+        {
+            "task": "test:valid",
+            "schedule": timedelta(minutes=5),
+        }
+    )
+
+    with freeze_time("2025-01-24 14:25:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 180
+
+    assert run_storage.set.call_count == 0
+
+
+def test_scheduleset_tick_one_task_spawned(taskregistry) -> None:
+    run_storage = Mock(spec=RunStorage)
+    # Last run was 5 min, 5 sec ago
+    run_storage.read.return_value = datetime(2025, 1, 24, 14, 19, 55)
+    run_storage.set.return_value = True
+
+    namespace = taskregistry.get("test")
+    namespace.send_task = Mock()
+
+    schedule_set = ScheduleSet(registry=taskregistry, run_storage=run_storage)
+    schedule_set.add(
+        {
+            "task": "test:valid",
+            "schedule": timedelta(minutes=5),
+        }
+    )
+
+    with freeze_time("2025-01-24 14:25:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 300
+
+    assert run_storage.set.call_count == 1
+    assert namespace.send_task.call_count == 1
+    run_storage.set.assert_called_with("test:valid", datetime(2025, 1, 24, 14, 30, 0, tzinfo=UTC))
+
+
+def test_scheduleset_tick_one_task_multiple_ticks(taskregistry) -> None:
+    redis = redis_clusters.get("default")
+    redis.flushdb()
+    run_storage = RedisRunStorage(redis)
+
+    schedule_set = ScheduleSet(registry=taskregistry, run_storage=run_storage)
+    schedule_set.add(
+        {
+            "task": "test:valid",
+            "schedule": timedelta(minutes=5),
+        }
+    )
+
+    with freeze_time("2025-01-24 14:25:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 300
+
+    with freeze_time("2025-01-24 14:26:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 240
+
+    with freeze_time("2025-01-24 14:28:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 120
+
+
+def test_scheduleset_tick_multiple_tasks(taskregistry) -> None:
+    redis = redis_clusters.get("default")
+    redis.flushdb()
+
+    namespace = taskregistry.get("test")
+    namespace.send_task = Mock()
+
+    run_storage = RedisRunStorage(redis)
+    schedule_set = ScheduleSet(registry=taskregistry, run_storage=run_storage)
+    schedule_set.add(
+        {
+            "task": "test:valid",
+            "schedule": timedelta(minutes=5),
+        }
+    )
+    schedule_set.add(
+        {
+            "task": "test:second",
+            "schedule": timedelta(minutes=2),
+        }
+    )
+
+    with freeze_time("2025-01-24 14:25:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 120
+
+    assert namespace.send_task.call_count == 2
+
+    with freeze_time("2025-01-24 14:26:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 60
+
+    assert namespace.send_task.call_count == 2
+
+    # Remove the redis key, as the ttl in redis doesn't respect freeze_time()
+    run_storage.delete("test:second")
+    with freeze_time("2025-01-24 14:27:01"):
+        sleep_time = schedule_set.tick()
+        # two minutes left on the 5 min task
+        assert sleep_time == 120
+
+    assert namespace.send_task.call_count == 3


### PR DESCRIPTION
We'll need a way to reproduce the behavior of celery-beat with
taskworkers. These changes start the scheduler which will be responsible
for maintaining a heap of tasks and when they need to be spawned.
`ScheduleSet` will be used by a not-yet-written entry point that calls
tick() and sleep().

Last run state is planned to be stored in redis as using postgres,
sqlite, or another storage solution creates worse tradeoffs. If
scheduling state is lost, all tasks will spawn on the next tick() and
start to track state.

paired with @enochtangg on this

Refs https://github.com/getsentry/sentry/issues/81458