### PR TITLE
feat(uptime): Respect seat quotas

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -7,9 +7,11 @@ from django.db.models import TextField
 from django.db.models.expressions import Value
 from django.db.models.functions import MD5, Coalesce
 
-from sentry.constants import ObjectStatus
+from sentry import quotas
+from sentry.constants import DataCategory, ObjectStatus
 from sentry.models.environment import Environment
 from sentry.models.project import Project
+from sentry.quotas.base import SeatAssignmentResult
 from sentry.types.actor import Actor
 from sentry.uptime.detectors.url_extraction import extract_domain_parts
 from sentry.uptime.models import (
@@ -25,6 +27,7 @@ from sentry.uptime.subscriptions.tasks import (
     create_remote_uptime_subscription,
     delete_remote_uptime_subscription,
 )
+from sentry.utils.outcomes import Outcome
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,24 @@ MAX_MANUAL_SUBSCRIPTIONS_PER_ORG = 100
 
 class MaxManualUptimeSubscriptionsReached(ValueError):
     pass
+
+
+class UptimeMonitorNoSeatAvailable(Exception):
+    """
+    Indicates that the quotes system is unable to allocate a seat for the new
+    uptime monitor.
+    """
+
+    result: SeatAssignmentResult | None
+    """
+    The assignment result. In rare cases may be None when there is a race
+    condition and seat assignment is not accepted after passing the assignment
+    check.
+    """
+
+    def __init__(self, result: SeatAssignmentResult | None) -> None:
+        super().__init__()
+        self.result = result
 
 
 def retrieve_uptime_subscription(
@@ -209,10 +230,17 @@ def get_or_create_project_uptime_subscription(
     )
 
     # Update status. This may have the side effect of removing or creating a
-    # remote subscription.
+    # remote subscription. When a new monitor is created we will ensure seat
+    # assignment, which may cause the monitor to be disabled if there are no
+    # available seat assignments.
     match status:
         case ObjectStatus.ACTIVE:
-            enable_project_uptime_subscription(uptime_monitor)
+            try:
+                enable_project_uptime_subscription(uptime_monitor, ensure_assignment=created)
+            except UptimeMonitorNoSeatAvailable:
+                # No need to do anything if we failed to handle seat
+                # assignment. The monitor will be created, but not enabled
+                pass
         case ObjectStatus.DISABLED:
             disable_project_uptime_subscription(uptime_monitor)
 
@@ -277,7 +305,8 @@ def update_project_uptime_subscription(
         remove_uptime_subscription_if_unused(cur_uptime_subscription)
 
     # Update status. This may have the side effect of removing or creating a
-    # remote subscription.
+    # remote subscription. Will raise a UptimeMonitorNoSeatAvailable if seat
+    # assignment fails.
     match status:
         case ObjectStatus.DISABLED:
             disable_project_uptime_subscription(uptime_monitor)
@@ -295,6 +324,8 @@ def disable_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscriptio
         return
 
     uptime_monitor.update(status=ObjectStatus.DISABLED)
+    quotas.backend.disable_seat(DataCategory.UPTIME, uptime_monitor)
+
     uptime_subscription = uptime_monitor.uptime_subscription
 
     # Are there any other project subscriptions associated to the subscription
@@ -310,14 +341,35 @@ def disable_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscriptio
         delete_remote_uptime_subscription.delay(uptime_subscription.id)
 
 
-def enable_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscription):
+def enable_project_uptime_subscription(
+    uptime_monitor: ProjectUptimeSubscription, ensure_assignment: bool = False
+):
     """
-    Re-enables a project uptime subscription. If the uptime subscription was
+    Enable a project uptime subscription. If the uptime subscription was
     also disabled it will be re-activated and the remote subscription will be
     published.
+
+    This method will attempt seat assignment via the quotas system. If There
+    are no available seats the monitor will be disabled and a
+    `UptimeMonitorNoSeatAvailable` will be raised.
+
+    By default if the monitor is already marked as ACTIVE this function is a
+    no-op. Pass `ensure_assignment=True` to force seat assignment.
     """
-    if uptime_monitor.status != ObjectStatus.DISABLED:
+    if not ensure_assignment and uptime_monitor.status != ObjectStatus.DISABLED:
         return
+
+    seat_assignment = quotas.backend.check_assign_seat(DataCategory.UPTIME, uptime_monitor)
+    if not seat_assignment.assignable:
+        disable_project_uptime_subscription(uptime_monitor)
+        raise UptimeMonitorNoSeatAvailable(seat_assignment)
+
+    outcome = quotas.backend.assign_seat(DataCategory.UPTIME, uptime_monitor)
+    if outcome != Outcome.ACCEPTED:
+        # Race condition, we were unable to assign the seat even though the
+        # earlier assignment check indicated assignability
+        disable_project_uptime_subscription(uptime_monitor)
+        raise UptimeMonitorNoSeatAvailable(None)
 
     uptime_monitor.update(status=ObjectStatus.ACTIVE)
     uptime_subscription = uptime_monitor.uptime_subscription

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -32,6 +32,8 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
     except UptimeSubscription.DoesNotExist:
         metrics.incr("uptime.subscriptions.create.subscription_does_not_exist", sample_rate=1.0)
         return
+
+    # May happen if a uptime subscription was created and then immediately disabled
     if subscription.status != UptimeSubscription.Status.CREATING.value:
         metrics.incr("uptime.subscriptions.create.incorrect_status", sample_rate=1.0)
         return

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -2,10 +2,12 @@ from unittest import mock
 
 import pytest
 from django.test import override_settings
+from pytest import raises
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.conf.types.uptime import UptimeRegionConfig
-from sentry.constants import ObjectStatus
+from sentry.constants import DataCategory, ObjectStatus
+from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
@@ -17,6 +19,7 @@ from sentry.uptime.models import (
 from sentry.uptime.subscriptions.subscriptions import (
     UPTIME_SUBSCRIPTION_TYPE,
     MaxManualUptimeSubscriptionsReached,
+    UptimeMonitorNoSeatAvailable,
     delete_project_uptime_subscription,
     delete_uptime_subscription,
     delete_uptime_subscriptions_for_project,
@@ -29,6 +32,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     remove_uptime_subscription_if_unused,
     update_project_uptime_subscription,
 )
+from sentry.utils.outcomes import Outcome
 
 pytestmark = [requires_kafka]
 
@@ -297,23 +301,31 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-                status=ObjectStatus.DISABLED,
-            )[0]
-            update_project_uptime_subscription(
-                proj_sub,
-                environment=self.environment,
-                url="https://santry.io",
-                interval_seconds=60,
-                timeout_ms=1000,
-                method="POST",
-                headers=[("some", "header")],
-                body="a body",
-                name="New name",
-                owner=Actor.from_orm_user(self.user),
-                trace_sampling=False,
                 status=ObjectStatus.ACTIVE,
+            )[0]
+            mock_enable_project_uptime_subscription.assert_called_with(
+                proj_sub, ensure_assignment=True
             )
-        mock_enable_project_uptime_subscription.assert_called()
+
+    @mock.patch(
+        "sentry.quotas.backend.check_assign_seat",
+        return_value=SeatAssignmentResult(assignable=False, reason="Testing"),
+    )
+    def test_no_seat_asssignment(self, _mock_check_assign_seat):
+        with self.tasks():
+            proj_sub = get_or_create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                status=ObjectStatus.ACTIVE,
+            )[0]
+
+        # Monitor created but is not enabled due to no seat assignment
+        assert proj_sub.status == ObjectStatus.DISABLED
+        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
 
 
 class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
@@ -757,7 +769,8 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
 
 
 class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
-    def test(self):
+    @mock.patch("sentry.quotas.backend.disable_seat")
+    def test(self, mock_disable_seat):
         proj_sub = get_or_create_project_uptime_subscription(
             self.project,
             self.environment,
@@ -773,6 +786,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         proj_sub.refresh_from_db()
         assert proj_sub.status == ObjectStatus.DISABLED
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        mock_disable_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
 
     def test_multiple_project_subs(self):
         project1 = self.project
@@ -820,21 +834,39 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
 
 
 class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
-    def test(self):
-        proj_sub = get_or_create_project_uptime_subscription(
-            self.project,
-            self.environment,
-            url="https://sentry.io",
-            interval_seconds=3600,
-            timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )[0]
+    @mock.patch(
+        "sentry.quotas.backend.assign_seat",
+        return_value=Outcome.ACCEPTED,
+    )
+    @mock.patch(
+        "sentry.quotas.backend.check_assign_seat",
+        return_value=SeatAssignmentResult(assignable=True),
+    )
+    def test(self, mock_assign_seat, mock_check_assign_seat):
+        # Mock out enable_project_uptime_subscription here to avoid calling it
+        # and polluting our mock quota calls.
+        with mock.patch(
+            "sentry.uptime.subscriptions.subscriptions.enable_project_uptime_subscription"
+        ):
+            proj_sub = get_or_create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.MANUAL,
+            )[0]
 
-        with self.tasks():
-            disable_project_uptime_subscription(proj_sub)
+        # Calling enable_project_uptime_subscription on an already enabled
+        # monitor does nothing
+        enable_project_uptime_subscription(proj_sub)
+        mock_check_assign_seat.assert_not_called()
 
-        # Subscription is disabled
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        # Manually mark the monitor and subscription as disabled
+        proj_sub.update(status=ObjectStatus.DISABLED)
+        proj_sub.uptime_subscription.update(status=UptimeSubscription.Status.DISABLED.value)
+        proj_sub.refresh_from_db()
+        proj_sub.uptime_subscription.refresh_from_db()
 
         # Enabling the subscription marks the suscription as active again
         with self.tasks():
@@ -843,3 +875,44 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         proj_sub.refresh_from_db()
         assert proj_sub.status == ObjectStatus.ACTIVE
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value
+
+        # Seat assignemnt was called
+        mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_assign_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+
+    @mock.patch(
+        "sentry.quotas.backend.assign_seat",
+        return_value=Outcome.RATE_LIMITED,
+    )
+    @mock.patch(
+        "sentry.quotas.backend.check_assign_seat",
+        return_value=SeatAssignmentResult(assignable=False, reason="Testing"),
+    )
+    def test_no_seat_assignment(self, mock_check_assign_seat, mock_assign_seat):
+        # Mock out enable_project_uptime_subscription here to avoid calling it
+        # and polluting our mock quota calls.
+        with mock.patch(
+            "sentry.uptime.subscriptions.subscriptions.enable_project_uptime_subscription"
+        ):
+            proj_sub = get_or_create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.MANUAL,
+            )[0]
+
+        # We'll be unable to assign a seat
+        with self.tasks(), raises(UptimeMonitorNoSeatAvailable) as exc_info:
+            enable_project_uptime_subscription(proj_sub, ensure_assignment=True)
+
+        assert exc_info.value.result is not None
+        assert exc_info.value.result.reason == "Testing"
+
+        proj_sub.refresh_from_db()
+        assert proj_sub.status == ObjectStatus.DISABLED
+        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+
+        mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_assign_seat.assert_not_called()


### PR DESCRIPTION
This teaches the enable_project_uptime_subscription and disable_project_uptime_subscription functions to consult the quota APIs to ensure a seat may be assigned for a monitor before it can be enabled

When creating a monitor it will be created as ACTIVE, but if seat assignment fails it will immediately be marked as DISABLED and the subscription will be marked as disabled.

When updating a monitor via the details APIs the a validation error will be raised if seat assignment cannot be done.