### PR TITLE
fix(assignee-selector): Teams should be searchable with #

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -373,7 +373,7 @@ export default function AssigneeSelectorDropdown({
   const makeTeamOption = (assignableTeam: AssignableTeam): SelectOption<string> => ({
     label: <TeamBadge data-test-id="assignee-option" team={assignableTeam.team} />,
     value: `team:${assignableTeam.team.id}`,
-    textValue: assignableTeam.team.slug,
+    textValue: `#${assignableTeam.team.slug}`,
   });
 
   const makeSuggestedAssigneeOption = (


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/84041

Typing `#issues` should bring up the issues team in the assignee selector