### PR TITLE
fix(issues): Only expand first native frame

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -173,4 +173,35 @@ describe('Native StackTrace', function () {
     ).toBeInTheDocument();
     expect(within(frames[2]!).queryByTestId(/symbolication/)).not.toBeInTheDocument();
   });
+
+  it('expands the first in app frame', function () {
+    const newData = {
+      ...data,
+      frames: [
+        EventStacktraceFrameFixture({
+          symbolicatorStatus: SymbolicatorStatus.MISSING,
+          function: 'missing()',
+          inApp: true,
+        }),
+        EventStacktraceFrameFixture({
+          symbolicatorStatus: SymbolicatorStatus.UNKNOWN_IMAGE,
+          function: 'unknown_image()',
+          inApp: false,
+        }),
+        EventStacktraceFrameFixture({
+          symbolicatorStatus: SymbolicatorStatus.SYMBOLICATED,
+          function: 'symbolicated()',
+          inApp: true,
+        }),
+      ],
+    };
+
+    render(
+      <NativeContent data={newData} platform="cocoa" event={event} includeSystemFrames />
+    );
+
+    expect(screen.getByRole('button', {name: 'Collapse Context'})).toBeInTheDocument();
+    const collapsed = screen.getAllByRole('button', {name: 'Expand Context'});
+    expect(collapsed).toHaveLength(2);
+  });
 });

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -177,6 +177,9 @@ export function NativeContent({
     0
   );
 
+  const firstInAppFrameIndex = frames[newestFirst ? 'findLastIndex' : 'findIndex'](
+    frame => frame.inApp
+  );
   let convertedFrames = frames
     .map((frame, frameIndex) => {
       const prevFrame = frames[frameIndex - 1];
@@ -222,6 +225,7 @@ export function NativeContent({
           isHoverPreviewed,
           isShowFramesToggleExpanded: toggleFrameMap[frameIndex],
           isSubFrame: hiddenFrameIndices.includes(frameIndex),
+          isFirstInAppFrame: firstInAppFrameIndex === frameIndex,
           isUsedForGrouping,
           frameMeta: meta?.frames?.[frameIndex],
           registersMeta: meta?.registers,

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -52,6 +52,7 @@ type Props = {
   components: Array<SentryAppComponent<SentryAppSchemaStacktraceLink>>;
   event: Event;
   frame: Frame;
+  isFirstInAppFrame: boolean;
   isUsedForGrouping: boolean;
   platform: PlatformKey;
   registers: Record<string, string>;
@@ -59,7 +60,6 @@ type Props = {
   frameMeta?: Record<any, any>;
   hiddenFrameCount?: number;
   image?: React.ComponentProps<typeof DebugImage>['image'];
-  includeSystemFrames?: boolean;
   isHoverPreviewed?: boolean;
   isOnlyFrame?: boolean;
   isShowFramesToggleExpanded?: boolean;
@@ -87,6 +87,7 @@ function NativeFrame({
   event,
   components,
   hiddenFrameCount,
+  isFirstInAppFrame,
   isShowFramesToggleExpanded,
   isSubFrame,
   onShowFramesToggle,
@@ -149,7 +150,7 @@ function NativeFrame({
     defined(frame.function) &&
     frame.function !== frame.rawFunction;
 
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(() => isOnlyFrame || isFirstInAppFrame);
   const [isHovering, setHovering] = useState(false);
 
   const contextLine = (frame?.context || []).find(l => l[0] === frame.lineNo);
@@ -417,10 +418,10 @@ function NativeFrame({
           <ExpandCell>
             {expandable && (
               <ToggleButton
+                type="button"
                 size="zero"
                 borderless
-                aria-label={t('Toggle Context')}
-                tooltipProps={isHoverPreviewed ? {delay: SLOW_TOOLTIP_DELAY} : undefined}
+                aria-label={expanded ? t('Collapse Context') : t('Expand Context')}
                 icon={<Chevron size="medium" direction={expanded ? 'up' : 'down'} />}
               />
             )}


### PR DESCRIPTION
Expands the first in native in app frame. It was changed to expand all by default, this causes the stacktrace link to make requests for every line which is not what the github api can handle.

related https://github.com/getsentry/sentry/pull/82641 
fixes #84045
