### PR TITLE
fix(aci milestone 3): always dual write resolution data conditions

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -515,15 +515,14 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                 )
                 raise BadRequest
 
-            if features.has(
+            should_dual_write = features.has(
                 "organizations:workflow-engine-metric-alert-processing", alert_rule.organization
-            ):
+            )
+            if should_dual_write:
                 migrate_alert_rule(alert_rule, user)
 
             self._handle_triggers(alert_rule, triggers)
-            if features.has(
-                "organizations:workflow-engine-metric-alert-processing", alert_rule.organization
-            ):
+            if should_dual_write:
                 # create the resolution data triggers once we've migrated the critical/warning triggers
                 migrate_resolve_threshold_data_conditions(alert_rule)
             return alert_rule

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -519,10 +519,13 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                 "organizations:workflow-engine-metric-alert-processing", alert_rule.organization
             ):
                 migrate_alert_rule(alert_rule, user)
-                if alert_rule.resolve_threshold:
-                    migrate_resolve_threshold_data_conditions(alert_rule)
 
             self._handle_triggers(alert_rule, triggers)
+            if features.has(
+                "organizations:workflow-engine-metric-alert-processing", alert_rule.organization
+            ):
+                # create the resolution data triggers once we've migrated the critical/warning triggers
+                migrate_resolve_threshold_data_conditions(alert_rule)
             return alert_rule
 
     def update(self, instance, validated_data):


### PR DESCRIPTION
The DataConditions that correspond to alert rule resolution should always be created, regardless of whether the resolution threshold is explicitly specified on the legacy alert rule. Migrate the resolve threshold after all the triggers have been migrated, because the logic for automatically determining the resolution threshold depends on their DataConditions existing.