### PR TITLE
chore(workflow-engine): comparison json schema for TaggedEventHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -30,6 +30,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
                     "key": {"type": "string"},
                     "match": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
                 },
+                "required": ["key", "match"],
                 "not": {"required": ["value"]},
             },
             {
@@ -40,7 +41,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
                     },
                     "value": {"type": "string"},
                 },
-                "required": ["value"],
+                "required": ["key", "match", "value"],
             },
         ],
         "additionalProperties": False,

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -11,16 +11,47 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionHand
 class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
     type = DataConditionHandlerType.ACTION_FILTER
 
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "key": {"type": "string"},
+            "match": {
+                "type": "string",
+                "enum": [*MatchType],
+            },
+            "value": {
+                "type": "string",
+                "optional": True,
+            },
+        },
+        "oneOf": [
+            {
+                "properties": {
+                    "key": {"type": "string"},
+                    "match": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
+                },
+                "not": {"required": ["value"]},
+            },
+            {
+                "properties": {
+                    "key": {"type": "string"},
+                    "match": {
+                        "not": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
+                    },
+                    "value": {"type": "string"},
+                },
+                "required": ["value"],
+            },
+        ],
+        "additionalProperties": False,
+    }
+
     @staticmethod
     def evaluate_value(job: WorkflowJob, comparison: Any) -> bool:
         event = job["event"]
         raw_tags = event.tags
-        key = comparison.get("key")
-        match = comparison.get("match")
-        value = comparison.get("value")
-
-        if not key or not match:
-            return False
+        key = comparison["key"]
+        match = comparison["match"]
 
         key = key.lower()
 
@@ -40,9 +71,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowJob]):
         elif match == MatchType.NOT_SET:
             return key not in tag_keys
 
-        if not value:
-            return False
-
+        value = comparison["value"]
         value = value.lower()
 
         # This represents the fetched tag values given the provided key


### PR DESCRIPTION
`comparison` for `TaggedEventHandler` should be a dict with `key: str`, `match: MatchType` and `value: str`
(`value` is only provided if `match` is not `MatchType.IS_SET` or `MatchType.NOT_SET`)