### PR TITLE
feat(widget-builder): Ignore sort when making big number widget

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -165,4 +165,20 @@ describe('convertBuilderStateToWidget', function () {
 
     expect(widget.queries[0]!.fields).toEqual(['geo.country', 'count()']);
   });
+
+  it('ignores the sort state when producing a big number widget', function () {
+    const mockState: WidgetBuilderState = {
+      displayType: DisplayType.BIG_NUMBER,
+      fields: [
+        {function: ['count', '', undefined, undefined], kind: FieldValueKind.FUNCTION},
+      ],
+      dataset: WidgetType.TRANSACTIONS,
+      query: ['transaction.duration:>100'],
+      sort: [{field: 'count()', kind: 'desc'}],
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0]!.orderby).toBe('');
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -53,10 +53,12 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       aggregates: aggregates ?? [],
       columns: columns ?? [],
       conditions: query,
-      orderby: sort,
       fieldAliases: fieldAliases ?? [],
       name: legendAlias[index] ?? '',
       selectedAggregate: state.selectedAggregate,
+
+      // Big number widgets don't support sorting, so always ignore the sort state
+      orderby: state.displayType === DisplayType.BIG_NUMBER ? '' : sort,
     };
   });
 


### PR DESCRIPTION
Quick fix for bug where changing the fields where there's a sort field being added to the big number widget, but it should always be ignored. This is just a quick fix to unblock this issue but we'll fix why the sort is being applied or not updated properly in another PR.