### PR TITLE
feat(relay): Add option to drop transaction attachments

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -530,6 +530,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Drop attachments in transaction envelopes in Relay.
+register(
+    "relay.drop-transaction-attachments",
+    type=Bool,
+    default=False,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)
 register("analytics.options", default={}, flags=FLAG_NOSTORE)

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -23,6 +23,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.metric-stats.rollout-rate",
     "relay.span-extraction.sample-rate",
     "relay.span-normalization.allowed_hosts",
+    "relay.drop-transaction-attachments",
 ]
 
 


### PR DESCRIPTION
Register the new option and forward it to Relay. See https://github.com/getsentry/relay/pull/4466.

https://github.com/getsentry/team-ingest/issues/607