### PR TITLE
fix(tempest): Update timeout and poll_limit

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1182,7 +1182,9 @@ register("symbolicate.symx-os-description-list", default=[], flags=FLAG_AUTOMATO
 register("reprocessing2.drop-delete-old-primary-hash", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The poll limit for the tempest service.
-register("tempest.poll-limit", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
+#
+# 348 every 5 min ~ 100k per day
+register("tempest.poll-limit", default=348, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # BEGIN ABUSE QUOTAS
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1181,6 +1181,9 @@ register("symbolicate.symx-os-description-list", default=[], flags=FLAG_AUTOMATO
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# The poll limit for the tempest service.
+register("tempest.poll-limit", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # BEGIN ABUSE QUOTAS
 
 # Example:

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -215,7 +215,7 @@ def fetch_items_from_tempest(
     offset: int,
     limit: int = POLL_LIMIT,
     attach_screenshot: bool = False,
-    time_out: int = 120,
+    time_out: int = 235,
 ) -> Response:
     payload = {
         "org_id": org_id,

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -4,14 +4,12 @@ import requests
 from django.conf import settings
 from requests import Response
 
+from sentry import options
 from sentry.models.projectkey import ProjectKey, UseCase
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.tempest.models import MessageType, TempestCredentials
-
-POLL_LIMIT = 348  # 348 every 5 min ~ 100k a day
-
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +151,7 @@ def poll_tempest_crashes(credentials_id: int) -> None:
                 client_secret=credentials.client_secret,
                 dsn=dsn,
                 offset=int(credentials.latest_fetched_item_id),
+                limit=options.get("tempest.poll-limit"),
                 attach_screenshot=attach_screenshot,
             )
         else:
@@ -213,7 +212,7 @@ def fetch_items_from_tempest(
     client_secret: str,
     dsn: str,
     offset: int,
-    limit: int = POLL_LIMIT,
+    limit: int = 348,
     attach_screenshot: bool = False,
     time_out: int = 235,
 ) -> Response:


### PR DESCRIPTION
Incident recover is currently not working as such the `time_out` has been increased and the `poll_limit` reduced (as well as made configure for fine-tuning) in the hops that now the recovering will work.

Talked with Vjeran about this and it will most likely not fix the issue that we are seeing at this moment however it does not hurt to have the `time_out` set a bit higher and the `poll_limit` configurable just in case.