### PR TITLE
chore(ci): Only run devservices logs when devservices command exists

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -124,9 +124,11 @@ jobs:
         run: make run-acceptance
 
       - name: Inspect failure
-        if: failure() && command -v devservices
+        if: failure()
         run: |
-          devservices logs
+          if command -v devservices; then
+            devservices logs
+          fi
 
       - name: Collect test data
         uses: ./.github/actions/collect-test-data

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -124,7 +124,7 @@ jobs:
         run: make run-acceptance
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: |
           devservices logs
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -69,7 +69,7 @@ jobs:
           yarn add ts-node && make test-api-docs
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: devservices logs
 
   backend-test:
@@ -110,7 +110,7 @@ jobs:
           make test-python-ci
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: devservices logs
 
       - name: Collect test data
@@ -158,7 +158,7 @@ jobs:
           PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0" make test-python-ci
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: devservices logs
 
       # Upload coverage data even if running the tests step fails since
@@ -194,7 +194,7 @@ jobs:
           make test-cli
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: devservices logs
 
       # Upload coverage data even if running the tests step fails since
@@ -267,7 +267,7 @@ jobs:
           ./.github/workflows/scripts/migration-check.sh
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: devservices logs
 
   monolith-dbs:
@@ -294,7 +294,7 @@ jobs:
           make test-monolith-dbs
 
       - name: Inspect failure
-        if: failure()
+        if: failure() && command -v devservices
         run: devservices logs
 
       - name: Collect test data

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -108,11 +108,6 @@ jobs:
           use-new-devservices: true
           mode: backend-ci
 
-      - name: Test failure
-        run: |
-          echo "test failure"
-          exit 1
-
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           make test-python-ci

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -105,6 +105,11 @@ jobs:
           use-new-devservices: true
           mode: backend-ci
 
+      - name: Test failure
+        run: |
+          echo "test failure"
+          exit 1
+
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           make test-python-ci

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -69,8 +69,11 @@ jobs:
           yarn add ts-node && make test-api-docs
 
       - name: Inspect failure
-        if: failure() && command -v devservices
-        run: devservices logs
+        if: failure()
+        run: |
+          if command -v devservices; then
+            devservices logs
+          fi
 
   backend-test:
     if: needs.files-changed.outputs.backend == 'true'
@@ -115,8 +118,11 @@ jobs:
           make test-python-ci
 
       - name: Inspect failure
-        if: failure() && command -v devservices
-        run: devservices logs
+        if: failure()
+        run: |
+          if command -v devservices; then
+            devservices logs
+          fi
 
       - name: Collect test data
         uses: ./.github/actions/collect-test-data
@@ -163,8 +169,11 @@ jobs:
           PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0" make test-python-ci
 
       - name: Inspect failure
-        if: failure() && command -v devservices
-        run: devservices logs
+        if: failure()
+        run: |
+          if command -v devservices; then
+            devservices logs
+          fi
 
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations
@@ -199,8 +208,11 @@ jobs:
           make test-cli
 
       - name: Inspect failure
-        if: failure() && command -v devservices
-        run: devservices logs
+        if: failure()
+        run: |
+          if command -v devservices; then
+            devservices logs
+          fi
 
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations
@@ -272,8 +284,11 @@ jobs:
           ./.github/workflows/scripts/migration-check.sh
 
       - name: Inspect failure
-        if: failure() && command -v devservices
-        run: devservices logs
+        if: failure()
+        run: |
+          if command -v devservices; then
+            devservices logs
+          fi
 
   monolith-dbs:
     if: needs.files-changed.outputs.backend == 'true'
@@ -299,8 +314,11 @@ jobs:
           make test-monolith-dbs
 
       - name: Inspect failure
-        if: failure() && command -v devservices
-        run: devservices logs
+        if: failure()
+        run: |
+          if command -v devservices; then
+            devservices logs
+          fi
 
       - name: Collect test data
         uses: ./.github/actions/collect-test-data


### PR DESCRIPTION
We should not be running devservices on failures where devservices has not yet been installed