### PR TITLE
fix(issue-details): Fix environment in first/last seen tooltip

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
@@ -13,6 +13,7 @@ import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useFetchAllEnvsGroupData} from 'sentry/views/issueDetails/groupSidebar';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 interface GroupRelease {
   firstRelease: Release;
@@ -32,10 +33,18 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
       gcTime: 30000,
     }
   );
+  const environments = useEnvironmentsFromUrl();
 
   const lastSeen = issueTypeConfig.useOpenPeriodChecks
     ? group.openPeriods?.[0]?.lastChecked ?? group.lastSeen
     : group.lastSeen;
+
+  const shortEnvironmentLabel =
+    environments.length > 1
+      ? t('selected environments')
+      : environments.length === 1
+        ? environments[0]
+        : undefined;
 
   const dateGlobal = issueTypeConfig.useOpenPeriodChecks
     ? lastSeen
@@ -46,34 +55,28 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
       <div>
         <Flex gap={space(0.5)}>
           <Title>{t('Last seen')}</Title>
-          {group.lastSeen ? (
-            <SeenInfo
-              date={lastSeen}
-              dateGlobal={dateGlobal}
-              organization={organization}
-              projectId={project.id}
-              projectSlug={project.slug}
-            />
-          ) : (
-            t('N/A')
-          )}
+          <SeenInfo
+            date={lastSeen}
+            dateGlobal={dateGlobal}
+            organization={organization}
+            projectId={project.id}
+            projectSlug={project.slug}
+            environment={shortEnvironmentLabel}
+          />
         </Flex>
         <ReleaseText project={group.project} release={groupReleaseData?.lastRelease} />
       </div>
       <div>
         <Flex gap={space(0.5)}>
           <Title>{t('First seen')}</Title>
-          {group.firstSeen ? (
-            <SeenInfo
-              date={group.firstSeen}
-              dateGlobal={allEnvironments?.firstSeen ?? group.firstSeen}
-              organization={organization}
-              projectId={project.id}
-              projectSlug={project.slug}
-            />
-          ) : (
-            t('N/A')
-          )}
+          <SeenInfo
+            date={group.firstSeen}
+            dateGlobal={allEnvironments?.firstSeen ?? group.firstSeen}
+            organization={organization}
+            projectId={project.id}
+            projectSlug={project.slug}
+            environment={shortEnvironmentLabel}
+          />
         </Flex>
         <ReleaseText project={group.project} release={groupReleaseData?.firstRelease} />
       </div>


### PR DESCRIPTION
this pr fixes an issue with the tooltip for first/last seen. in the old experience, if you selected an environment you would both see the tooltip and see the first/last seen for all envs and the selected environments. in the new experience, we would only show the tooltip if the environment had events and the tooltip only showed the global first/last seen. 

before: 
![Screenshot 2025-01-27 at 10 12 44 AM](https://github.com/user-attachments/assets/ef2a63c0-3756-42d7-a40e-ceed4090e6e8)
![Screenshot 2025-01-27 at 10 12 54 AM](https://github.com/user-attachments/assets/86f942ba-5fee-437d-8f73-6cd649f80578)

after: 
![Screenshot 2025-01-27 at 10 12 33 AM](https://github.com/user-attachments/assets/8cca0062-3e22-4484-8a35-61b55538cb07)
