### PR TITLE
fix(widget-builder): Only show save message when not in dashboard edit

### DIFF
--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -19,6 +19,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import * as dashboardActions from 'sentry/actionCreators/dashboards';
+import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import * as modals from 'sentry/actionCreators/modal';
 import ConfigStore from 'sentry/stores/configStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
@@ -36,6 +37,7 @@ import useWidgetBuilderState from 'sentry/views/dashboards/widgetBuilder/hooks/u
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState');
+jest.mock('sentry/actionCreators/indicator');
 
 describe('Dashboards > Detail', function () {
   const organization = OrganizationFixture({
@@ -2410,6 +2412,9 @@ describe('Dashboards > Detail', function () {
             widgets: [expect.objectContaining({title: 'Totally new widget'})],
           })
         );
+        await waitFor(() => {
+          expect(addLoadingMessage).toHaveBeenCalledWith('Saving widget');
+        });
       });
     });
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -12,7 +12,12 @@ import {
   updateDashboard,
   updateDashboardPermissions,
 } from 'sentry/actionCreators/dashboards';
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {hasEveryAccess} from 'sentry/components/acl/access';
@@ -820,7 +825,9 @@ class DashboardDetail extends Component<Props, State> {
     try {
       if (!this.isEditingDashboard) {
         // If we're not in edit mode, send a request to update the dashboard
+        addLoadingMessage(t('Saving widget'));
         await this.handleUpdateWidgetList(newWidgets);
+        clearIndicators();
       } else {
         // If we're in edit mode, update the edit state
         this.onUpdateWidget(newWidgets);

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -1,11 +1,7 @@
 import {useCallback, useState} from 'react';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  clearIndicators,
-} from 'sentry/actionCreators/indicator';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -41,11 +37,9 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
     setIsSaving(true);
     try {
       await validateWidget(api, organization.slug, widget);
-      addLoadingMessage(t('Saving widget'));
       onSave({index: Number(widgetIndex), widget});
     } catch (error) {
       setIsSaving(false);
-      clearIndicators();
       const errorDetails = error.responseJSON || error;
       setError(errorDetails);
       addErrorMessage(t('Unable to save widget'));

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -11,7 +11,7 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import ModalStore from 'sentry/stores/modalStore';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -21,7 +21,6 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
-jest.mock('sentry/actionCreators/indicator');
 
 describe('WidgetBuilderSlideout', () => {
   let organization!: ReturnType<typeof OrganizationFixture>;
@@ -263,52 +262,6 @@ describe('WidgetBuilderSlideout', () => {
     });
 
     expect(screen.getByText('Create Custom Widget')).toBeInTheDocument();
-  });
-
-  it('should save the widget from the widget builder with loading messages if the widget is valid', async () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/dashboards/widgets/',
-      method: 'POST',
-      body: {},
-      statusCode: 200,
-    });
-
-    render(
-      <WidgetBuilderProvider>
-        <WidgetBuilderSlideout
-          dashboard={DashboardFixture([])}
-          dashboardFilters={{release: undefined}}
-          isWidgetInvalid
-          onClose={jest.fn()}
-          onQueryConditionChange={jest.fn()}
-          onSave={jest.fn()}
-          setIsPreviewDraggable={jest.fn()}
-          isOpen
-          openWidgetTemplates={false}
-          setOpenWidgetTemplates={jest.fn()}
-        />
-      </WidgetBuilderProvider>,
-      {
-        organization,
-        router: RouterFixture({
-          location: LocationFixture({
-            query: {
-              field: [],
-              yAxis: ['count()'],
-              dataset: WidgetType.TRANSACTIONS,
-              displayType: DisplayType.LINE,
-              title: 'Widget Title',
-            },
-          }),
-        }),
-      }
-    );
-
-    await userEvent.click(await screen.findByText('Add Widget'));
-
-    await waitFor(() => {
-      expect(addLoadingMessage).toHaveBeenCalledWith('Saving widget');
-    });
   });
 
   it('clears the alias when dataset changes', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -21,6 +21,7 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
+jest.mock('sentry/actionCreators/indicator');
 
 describe('WidgetBuilderSlideout', () => {
   let organization!: ReturnType<typeof OrganizationFixture>;


### PR DESCRIPTION
If you're in the Edit state, we were showing the "Saving widget..." toast when clicking "Add Widget", but since this doesn't need to wait on a request to update the dashboard we shouldn't be triggering the toast.

I moved the message call up to where the handler for the saving is so we can control it depending on the state of the dashboard.