### PR TITLE
fix(widget-builder): Tooltip always visible when description entered

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -345,6 +345,7 @@ export function WidgetPreviewContainer({
                       dashboard={dashboard}
                       isWidgetInvalid={isWidgetInvalid}
                       onDataFetched={onDataFetched}
+                      shouldForceDescriptionTooltip={!isSmallScreen}
                     />
                   )}
                 </SampleWidgetCard>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -21,6 +21,7 @@ interface WidgetPreviewProps {
   dashboardFilters: DashboardFilters;
   isWidgetInvalid?: boolean;
   onDataFetched?: (tableData: TableDataWithTitle[]) => void;
+  shouldForceDescriptionTooltip?: boolean;
 }
 
 function WidgetPreview({
@@ -28,6 +29,7 @@ function WidgetPreview({
   dashboardFilters,
   isWidgetInvalid,
   onDataFetched,
+  shouldForceDescriptionTooltip,
 }: WidgetPreviewProps) {
   const organization = useOrganization();
   const location = useLocation();
@@ -56,6 +58,8 @@ function WidgetPreview({
     <WidgetCard
       disableFullscreen
       borderless
+      // need to pass in undefined to avoid tooltip not showing up on hover
+      forceDescriptionTooltip={shouldForceDescriptionTooltip ? true : undefined}
       isWidgetInvalid={isWidgetInvalid}
       shouldResize={state.displayType !== DisplayType.TABLE}
       organization={organization}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -71,6 +71,7 @@ type Props = WithRouterProps & {
   borderless?: boolean;
   dashboardFilters?: DashboardFilters;
   disableFullscreen?: boolean;
+  forceDescriptionTooltip?: boolean;
   hasEditAccess?: boolean;
   index?: string;
   isEditingWidget?: boolean;
@@ -312,6 +313,7 @@ function WidgetCard(props: Props) {
                   error={widgetQueryError || errorMessage || undefined}
                   preferredPolarity="-"
                   borderless={props.borderless}
+                  forceDescriptionTooltip={props.forceDescriptionTooltip}
                 />
               );
             }}
@@ -328,6 +330,7 @@ function WidgetCard(props: Props) {
             actions={actions}
             onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
             borderless={props.borderless}
+            forceDescriptionTooltip={props.forceDescriptionTooltip}
           >
             <WidgetCardChartContainer
               location={location}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -35,6 +35,7 @@ export function BigNumberWidget(props: BigNumberWidgetProps) {
         title={props.title}
         description={props.description}
         borderless={props.borderless}
+        forceDescriptionTooltip={props.forceDescriptionTooltip}
       >
         <LoadingPlaceholder>{LOADING_PLACEHOLDER}</LoadingPlaceholder>
       </WidgetFrame>
@@ -67,6 +68,7 @@ export function BigNumberWidget(props: BigNumberWidgetProps) {
       error={error}
       onRetry={props.onRetry}
       borderless={props.borderless}
+      forceDescriptionTooltip={props.forceDescriptionTooltip}
     >
       {defined(value) && (
         <BigNumberResizeWrapper>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -60,6 +60,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
   return (
     <WidgetLayout
       ariaLabel="Widget panel"
+      forceShowActions={props.forceDescriptionTooltip}
       Title={
         <Fragment>
           {props.warnings && props.warnings.length > 0 && (
@@ -82,7 +83,11 @@ export function WidgetFrame(props: WidgetFrameProps) {
         <Fragment>
           {props.description && (
             // Ideally we'd use `QuestionTooltip` but we need to firstly paint the icon dark, give it 100% opacity, and remove hover behaviour.
-            <WidgetDescription title={props.title} description={props.description} />
+            <WidgetDescription
+              title={props.title}
+              description={props.description}
+              forceDescriptionTooltip={props.forceDescriptionTooltip}
+            />
           )}
 
           {shouldShowActions && (

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetDescription.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetDescription.tsx
@@ -8,6 +8,7 @@ import {space} from 'sentry/styles/space';
 
 export interface WidgetDescriptionProps {
   description?: React.ReactElement | string;
+  forceDescriptionTooltip?: boolean;
   title?: string;
 }
 
@@ -24,6 +25,7 @@ export function WidgetDescription(props: WidgetDescriptionProps) {
       }
       containerDisplayMode="grid"
       isHoverable
+      forceVisible={props.forceDescriptionTooltip}
     >
       <WidgetTooltipButton
         aria-label={t('Widget description')}

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -11,12 +11,17 @@ export interface WidgetLayoutProps {
   Title?: React.ReactNode;
   Visualization?: React.ReactNode;
   ariaLabel?: string;
+  forceShowActions?: boolean;
   height?: number;
 }
 
 export function WidgetLayout(props: WidgetLayoutProps) {
   return (
-    <Frame aria-label={props.ariaLabel} height={props.height}>
+    <Frame
+      aria-label={props.ariaLabel}
+      height={props.height}
+      forceShowActions={props.forceShowActions}
+    >
       <Header>
         {props.Title && <Fragment>{props.Title}</Fragment>}
         {props.Actions && <TitleHoverItems>{props.Actions}</TitleHoverItems>}
@@ -43,7 +48,7 @@ const TitleHoverItems = styled('div')`
   transition: opacity 0.1s;
 `;
 
-const Frame = styled('div')<{height?: number}>`
+const Frame = styled('div')<{forceShowActions?: boolean; height?: number}>`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -66,12 +71,14 @@ const Frame = styled('div')<{height?: number}>`
     box-shadow: ${p => p.theme.dropShadowLight};
   }
 
-  &:not(:hover):not(:focus-within) {
+  ${p =>
+    !p.forceShowActions &&
+    `&:not(:hover):not(:focus-within) {
     ${TitleHoverItems} {
       opacity: 0;
-      ${p => p.theme.visuallyHidden}
+      ${p.theme.visuallyHidden}
     }
-  }
+  }`}
 `;
 
 const Header = styled('div')`


### PR DESCRIPTION
In the original design the description tooltip is constantly visible when a description is entered so I've implemented that. Had to make some changes to the widget frame code to pass this prop through. The tooltip is not constantly visible on responsive screens as it takes up too much space and cuts off important form inputs. 

This is what it looks like:

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/f7127f11-8856-4a40-bec3-278ce228d2de" />