### PR TITLE
feat(issue-details): Add tags prefetch to tags drawer

### DIFF
--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -198,7 +198,7 @@ export function GroupTagsDrawer({group}: {group: Group}) {
           <Wrapper>
             <Container>
               {displayTags.map((tag, tagIdx) => (
-                <TagDistribution tag={tag} key={tagIdx} />
+                <TagDistribution tag={tag} key={tagIdx} groupId={group.id} />
               ))}
             </Container>
           </Wrapper>

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 import Color from 'color';
@@ -45,6 +45,14 @@ export function TagDistribution({tag, groupId}: {groupId: string; tag: GroupTag}
       hoverTimeoutRef.current = undefined;
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        window.clearTimeout(hoverTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div>

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -1,3 +1,5 @@
+import {useState} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
@@ -10,10 +12,14 @@ import {space} from 'sentry/styles/space';
 import {percent} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {usePrefetchTagValues} from 'sentry/views/issueDetails/utils';
 
-export function TagDistribution({tag}: {tag: GroupTag}) {
+export function TagDistribution({tag, groupId}: {groupId: string; tag: GroupTag}) {
   const location = useLocation();
+  const [prefetchEnabled, setPrefetchEnabled] = useState(false);
+  const hoverTimeoutRef = useRef<number | undefined>();
 
+  usePrefetchTagValues(tag.key, groupId, prefetchEnabled);
   const visibleTagValues = tag.topValues.slice(0, 3);
 
   const totalVisible = visibleTagValues.reduce((sum, value) => sum + value.count, 0);
@@ -25,6 +31,21 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
   const otherDisplayPercentage =
     otherPercentage < 1 ? '<1%' : `${otherPercentage.toFixed(0)}%`;
 
+  // We only want to prefetch if the user hovers over the tag for 1 second
+  // This is to prevent every tag from prefetch when a user scrolls
+  const handleMouseEnter = () => {
+    hoverTimeoutRef.current = window.setTimeout(() => {
+      setPrefetchEnabled(true);
+    }, 1000);
+  };
+
+  const handleMouseLeave = () => {
+    if (hoverTimeoutRef.current) {
+      window.clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = undefined;
+    }
+  };
+
   return (
     <div>
       <TagPanel
@@ -32,6 +53,8 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
           pathname: `${location.pathname}${tag.key}/`,
           query: location.query,
         }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         <TagHeader>
           <Tooltip title={tag.key} showOnlyOnOverflow skipWrapper>

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -4,7 +4,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
-import {useFetchIssueTag, useFetchIssueTagValues} from 'sentry/actionCreators/group';
 import {LinkButton} from 'sentry/components/button';
 import {DeviceName} from 'sentry/components/deviceName';
 import Link from 'sentry/components/links/link';
@@ -19,13 +18,13 @@ import type {Project} from 'sentry/types/project';
 import {percent} from 'sentry/utils';
 import {isMobilePlatform} from 'sentry/utils/platform';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
+import {usePrefetchTagValues} from 'sentry/views/issueDetails/utils';
 
 const DEFAULT_TAGS = ['transaction', 'environment', 'release'];
 const FRONTEND_TAGS = ['browser', 'release', 'url', 'environment'];
@@ -40,41 +39,12 @@ const BACKEND_TAGS = [
 const MOBILE_TAGS = ['device', 'os', 'release', 'environment', 'transaction'];
 const RTL_TAGS = ['transaction', 'url'];
 
-type TagSort = 'date' | 'count';
-const DEFAULT_SORT: TagSort = 'count';
-
 type Segment = {
   count: number;
   name: string | React.ReactNode;
   percentage: number;
   color?: string;
 };
-
-function usePrefetchTagValues(tagKey: string, groupId: string, enabled: boolean) {
-  const organization = useOrganization();
-  const location = useLocation();
-  const sort: TagSort =
-    (location.query.tagDrawerSort as TagSort | undefined) ?? DEFAULT_SORT;
-  useFetchIssueTagValues(
-    {
-      orgSlug: organization.slug,
-      groupId,
-      tagKey,
-      sort,
-      cursor: location.query.tagDrawerCursor as string | undefined,
-    },
-    {enabled}
-  );
-
-  useFetchIssueTag(
-    {
-      orgSlug: organization.slug,
-      groupId,
-      tagKey,
-    },
-    {enabled}
-  );
-}
 
 const bgColor = (index: number) =>
   Color(CHART_PALETTE[4].at(index)).alpha(0.8).toString();

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -1,7 +1,11 @@
 import {useMemo} from 'react';
 import orderBy from 'lodash/orderBy';
 
-import {bulkUpdate} from 'sentry/actionCreators/group';
+import {
+  bulkUpdate,
+  useFetchIssueTag,
+  useFetchIssueTagValues,
+} from 'sentry/actionCreators/group';
 import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -305,4 +309,32 @@ export function useIsSampleEvent(): boolean {
     {enabled: defined(group)}
   );
   return data?.some(tag => tag.key === 'sample_event') ?? false;
+}
+
+type TagSort = 'date' | 'count';
+const DEFAULT_SORT: TagSort = 'count';
+
+export function usePrefetchTagValues(tagKey: string, groupId: string, enabled: boolean) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const sort: TagSort =
+    (location.query.tagDrawerSort as TagSort | undefined) ?? DEFAULT_SORT;
+  useFetchIssueTagValues(
+    {
+      orgSlug: organization.slug,
+      groupId,
+      tagKey,
+      sort,
+      cursor: location.query.tagDrawerCursor as string | undefined,
+    },
+    {enabled}
+  );
+  useFetchIssueTag(
+    {
+      orgSlug: organization.slug,
+      groupId,
+      tagKey,
+    },
+    {enabled}
+  );
 }


### PR DESCRIPTION
building off of https://github.com/getsentry/sentry/pull/84085, this pr makes 2 changes. first , it moves the prefetch code to allow for it to be used in multiple places. second, it adds prefetching for tags from the tags drawer. now, from both the preview and the drawer, you can hover to prefetch, but for the drawer, there's 1 second delay. this is because there are potentially a lot more tag values, and if a user scrolled , then they could prefetch a lot of tags which might make a bunch of unnecessary requests. 