### PR TITLE
fix(issue-details): Hide support link if new org on streamlined experience 

### DIFF
--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -72,7 +72,6 @@ export default function StreamlinedGroupHeader({
   const issueTypeConfig = getConfigForIssueType(group, project);
 
   const hasOnlyOneUIOption = defined(organization.streamlineOnly);
-
   const [showLearnMore, setShowLearnMore] = useLocalStorageState(
     'issue-details-learn-more',
     true

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -21,6 +21,7 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getMessage, getTitle} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -69,6 +70,8 @@ export default function StreamlinedGroupHeader({
   const statusProps = getBadgeProperties(group.status, group.substatus);
   const shareUrl = group?.shareId ? getShareUrl(group) : null;
   const issueTypeConfig = getConfigForIssueType(group, project);
+
+  const hasOnlyOneUIOption = defined(organization.streamlineOnly);
 
   const [showLearnMore, setShowLearnMore] = useLocalStorageState(
     'issue-details-learn-more',
@@ -134,20 +137,22 @@ export default function StreamlinedGroupHeader({
             ) : null}
           </Flex>
           <ButtonBar gap={0.5}>
-            <LinkButton
-              size="xs"
-              external
-              title={t('Learn more about the new UI')}
-              href={`https://sentry.zendesk.com/hc/en-us/articles/30882241712795`}
-              aria-label={t('Learn more about the new UI')}
-              icon={<IconInfo />}
-              analyticsEventKey="issue_details.streamline_ui_learn_more"
-              analyticsEventName="Issue Details: Streamline UI Learn More"
-              analyticsParams={{show_learn_more: showLearnMore}}
-              onClick={() => setShowLearnMore(false)}
-            >
-              {showLearnMore ? t("See What's New") : null}
-            </LinkButton>
+            {!hasOnlyOneUIOption && (
+              <LinkButton
+                size="xs"
+                external
+                title={t('Learn more about the new UI')}
+                href={`https://sentry.zendesk.com/hc/en-us/articles/30882241712795`}
+                aria-label={t('Learn more about the new UI')}
+                icon={<IconInfo />}
+                analyticsEventKey="issue_details.streamline_ui_learn_more"
+                analyticsEventName="Issue Details: Streamline UI Learn More"
+                analyticsParams={{show_learn_more: showLearnMore}}
+                onClick={() => setShowLearnMore(false)}
+              >
+                {showLearnMore ? t("See What's New") : null}
+              </LinkButton>
+            )}
             <NewIssueExperienceButton />
           </ButtonBar>
         </Flex>


### PR DESCRIPTION
if a new org has the streamlined experience, we are currently showing the "see what's new" button , but to a new user, there's nothing new and they can't switch to the old experience, so we should hide it. 

example: https://x.com/ank_it_kr/status/1883840551461810489