### PR TITLE
ref(insights): remove insights geo region feature flag

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -273,4 +273,23 @@ const setupMockRequests = (organization: Organization) => {
       },
     },
   });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/events/`,
+    method: 'GET',
+    match: [
+      MockApiClient.matchQuery({
+        referrer: 'api.insights.user-geo-subregion-selector',
+      }),
+    ],
+    body: {
+      data: [
+        {'user.geo.subregion': '21', 'count()': 123},
+        {'user.geo.subregion': '155', 'count()': 123},
+      ],
+      meta: {
+        fields: {'user.geo.subregion': 'string', 'count()': 'integer'},
+      },
+    },
+  });
 };

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -1,4 +1,4 @@
-import {type ComponentProps, Fragment} from 'react';
+import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -26,14 +26,12 @@ export default function SubregionSelector({size}: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
-  const hasGeoSelectorFeature = organization.features.includes('insights-region-filter');
 
   const value = decodeList(location.query[SpanMetricsField.USER_GEO_SUBREGION]);
   const {data, isPending} = useSpanMetrics(
     {
       fields: [SpanMetricsField.USER_GEO_SUBREGION, 'count()'],
       search: new MutableSearch('has:user.geo.subregion'),
-      enabled: hasGeoSelectorFeature,
       sorts: [{field: 'count()', kind: 'desc'}],
     },
     'api.insights.user-geo-subregion-selector'
@@ -51,10 +49,6 @@ export default function SubregionSelector({size}: Props) {
         textValue: text,
       };
     }) ?? [];
-
-  if (!hasGeoSelectorFeature) {
-    return <Fragment />;
-  }
 
   const tooltip = t('These correspond to the subregions of the UN M49 standard.');
 

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -21,6 +21,7 @@ describe('HTTPLandingPage', function () {
 
   let spanListRequestMock!: jest.Mock;
   let spanChartsRequestMock!: jest.Mock;
+  let regionFilterRequestMock!: jest.Mock;
 
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 
@@ -77,6 +78,25 @@ describe('HTTPLandingPage', function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,
       body: [ProjectFixture({name: 'frontend'}), ProjectFixture({name: 'backend'})],
+    });
+
+    regionFilterRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.insights.user-geo-subregion-selector',
+        }),
+      ],
+      body: {
+        data: [
+          {'user.geo.subregion': '21', 'count()': 123},
+          {'user.geo.subregion': '155', 'count()': 123},
+        ],
+        meta: {
+          fields: {'user.geo.subregion': 'string', 'count()': 'integer'},
+        },
+      },
     });
 
     MockApiClient.addMockResponse({
@@ -189,6 +209,24 @@ describe('HTTPLandingPage', function () {
           topEvents: undefined,
           yAxis: 'spm()',
           transformAliasToInputFormat: '1',
+        },
+      })
+    );
+
+    expect(regionFilterRequestMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansMetrics',
+          environment: [],
+          field: ['user.geo.subregion', 'count()'],
+          per_page: 50,
+          project: [],
+          query: 'has:user.geo.subregion',
+          sort: '-count()',
+          referrer: 'api.insights.user-geo-subregion-selector',
+          statsPeriod: '10d',
         },
       })
     );

--- a/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
@@ -42,6 +42,24 @@ describe('ScreenLoadEventSamples', function () {
       secondaryRelease: 'com.example.vu.android@2.10.3+42',
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.insights.user-geo-subregion-selector',
+        }),
+      ],
+      body: {
+        data: [
+          {'user.geo.subregion': '21', 'count()': 123},
+          {'user.geo.subregion': '155', 'count()': 123},
+        ],
+        meta: {
+          fields: {'user.geo.subregion': 'string', 'count()': 'integer'},
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/`,
       body: [
         {
@@ -78,6 +96,9 @@ describe('ScreenLoadEventSamples', function () {
           },
         ],
       },
+      match: [
+        MockApiClient.matchQuery({referrer: 'api.starfish.mobile-startup-event-samples'}),
+      ],
     });
   });
 

--- a/static/app/views/insights/mobile/common/components/tables/samplesTables.spec.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/samplesTables.spec.tsx
@@ -12,6 +12,27 @@ jest.mocked(useReleaseSelection).mockReturnValue({
 });
 
 describe('SamplesTables', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.insights.user-geo-subregion-selector',
+        }),
+      ],
+      body: {
+        data: [
+          {'user.geo.subregion': '21', 'count()': 123},
+          {'user.geo.subregion': '155', 'count()': 123},
+        ],
+        meta: {
+          fields: {'user.geo.subregion': 'string', 'count()': 'integer'},
+        },
+      },
+    });
+  });
+
   it('accepts components for event samples and span operation table', async () => {
     render(
       <SamplesTables

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
@@ -42,6 +42,24 @@ describe('ScreenLoadEventSamples', function () {
       secondaryRelease: 'com.example.vu.android@2.10.3+42',
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.insights.user-geo-subregion-selector',
+        }),
+      ],
+      body: {
+        data: [
+          {'user.geo.subregion': '21', 'count()': 123},
+          {'user.geo.subregion': '155', 'count()': 123},
+        ],
+        meta: {
+          fields: {'user.geo.subregion': 'string', 'count()': 'integer'},
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/`,
       body: [
         {
@@ -78,6 +96,7 @@ describe('ScreenLoadEventSamples', function () {
           },
         ],
       },
+      match: [MockApiClient.matchQuery({referrer: 'api.starfish.mobile-event-samples'})],
     });
   });
 

--- a/static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.spec.tsx
@@ -29,6 +29,25 @@ describe('EventSamplesTable', function () {
     };
 
     mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.insights.user-geo-subregion-selector',
+        }),
+      ],
+      body: {
+        data: [
+          {'user.geo.subregion': '21', 'count()': 123},
+          {'user.geo.subregion': '155', 'count()': 123},
+        ],
+        meta: {
+          fields: {'user.geo.subregion': 'string', 'count()': 'integer'},
+        },
+      },
+    });
   });
 
   it('uses a column name map to render column names', function () {


### PR DESCRIPTION
This feature has been in GA for 2 months (https://github.com/getsentry/sentry-options-automator/pull/2832), it is safe to remove the feature conditional and the flag itself.
