### PR TITLE
ref(insights): unregister insight region filter flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -420,8 +420,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:stacktrace-processing-caching", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable SAML2 Single-logout
     manager.add("organizations:sso-saml2-slo", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
-    # Enable access to insights region filter in the UI
-    manager.add("organizations:insights-region-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show links and upsells to Insights modules
     manager.add("organizations:insights-entry-points", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable access to initial Insights modules (Queries, Requests, Vitals, App Starts, Page Loads, Resources)


### PR DESCRIPTION
Once the following PRs are merged and deployed, it is safe to unregister the region filter flag
https://github.com/getsentry/sentry/pull/84096
https://github.com/getsentry/sentry-options-automator/pull/3061