### PR TITLE
fix(widget-builder): Add tempId for layout

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -812,7 +812,7 @@ class DashboardDetail extends Component<Props, State> {
 
     // Get the "base" widget and merge the changes to persist information like tempIds and layout
     const baseWidget = defined(index) ? currentDashboard.widgets[index] : {};
-    const mergedWidget = {...baseWidget, ...widget};
+    const mergedWidget = assignTempId({...baseWidget, ...widget});
 
     const newWidgets = defined(index)
       ? [


### PR DESCRIPTION
The `tempId` is important for layouts because it's how the layout library differentiates where a specific widget goes. For existing widgets, they have an `id` which we default to using but if there isn't an `id` we look for `tempId` and this helper ensures we have one of those two values.

This fixes the issue where widgets would overlap when added in dashboard edit mode.