### PR TITLE
chore(relocation) Improve relocation logging

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -83,7 +83,7 @@ from sentry.utils.relocation import (
     uuid_to_identifier,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.relocation.tasks")
 
 # Time limits for various steps in the process.
 RETRY_BACKOFF = 60  # So the 1st retry is after ~1 min, 2nd after ~2 min, 3rd after ~4 min, etc.

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -468,7 +468,7 @@ def start_relocation_task(
     Returns a tuple of relocation model and the number of attempts remaining for this task.
     """
 
-    logger_data = {"uuid": str(uuid)}
+    logger_data = {"uuid": str(uuid), "task": task.name}
     try:
         relocation: Relocation = Relocation.objects.get(uuid=uuid)
     except Relocation.DoesNotExist:


### PR DESCRIPTION
- Use fewer logger names. Having both `sentry.relocation.tasks` and `sentry.tasks.relocation` is silly and makes looking at logs hard.
- Log the task that was skipped when that happens.
