### PR TITLE
fix(widget-builder): Bring chart tooltip in front of slideout

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -241,7 +241,12 @@ export function WidgetPreviewContainer({
     top: isDragEnabled ? top ?? 0 : undefined,
     left: isDragEnabled ? left ?? 0 : undefined,
     opacity: isDragging ? 0.5 : 1,
-    zIndex: isDragEnabled ? theme.zIndex.modal : theme.zIndex.initial,
+    zIndex: isDragEnabled
+      ? theme.zIndex.modal
+      : isSmallScreen
+        ? theme.zIndex.initial
+        : // if not responsive, set z-index to default in styled component
+          undefined,
     cursor: isDragEnabled ? 'grab' : undefined,
     margin: isDragEnabled ? '0' : undefined,
     alignSelf: isDragEnabled ? 'flex-start' : undefined,


### PR DESCRIPTION
The timeseries tooltip was getting lost behind the widget builder slideout. There was a problem with the z-index conditional so that fixed it.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/5e38e1fc-f9c0-47d8-a819-637aca9fb810" />

