### PR TITLE
:bug: fix(discord): fix incident_alert_notification slos and DRY tests

### DIFF
--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -13,6 +13,7 @@ from sentry.constants import ObjectStatus
 from sentry.identity.services.identity import RpcIdentityProvider
 from sentry.identity.services.identity.model import RpcIdentity
 from sentry.identity.services.identity.service import identity_service
+from sentry.integrations.discord.client import DISCORD_BASE_URL
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -131,7 +132,7 @@ class DiscordRequest:
         token = self._data.get("token")
         if not token or not application_id:
             return None
-        return f"https://discord.com/api/v10/webhooks/{application_id}/{token}"
+        return f"{DISCORD_BASE_URL}/webhooks/{application_id}/{token}"
 
     def _get_context(self):
         context = integration_service.get_integration_identity_context(

--- a/src/sentry/integrations/discord/utils/metrics.py
+++ b/src/sentry/integrations/discord/utils/metrics.py
@@ -11,7 +11,7 @@ def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiErro
     if isinstance(error, ApiRateLimitedError):
         # TODO(ecosystem): We should batch this on a per-organization basis
         lifecycle.record_halt(error)
-    elif error.code in DISCORD_HALT_ERROR_CODES:
+    elif error.json.get("code") in DISCORD_HALT_ERROR_CODES:
         lifecycle.record_halt(error)
     else:
         lifecycle.record_failure(error)

--- a/src/sentry/integrations/discord/utils/metrics.py
+++ b/src/sentry/integrations/discord/utils/metrics.py
@@ -11,7 +11,7 @@ def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiErro
     if isinstance(error, ApiRateLimitedError):
         # TODO(ecosystem): We should batch this on a per-organization basis
         lifecycle.record_halt(error)
-    elif error.json.get("code") in DISCORD_HALT_ERROR_CODES:
+    elif error.json and error.json.get("code") in DISCORD_HALT_ERROR_CODES:
         lifecycle.record_halt(error)
     else:
         lifecycle.record_failure(error)

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -123,7 +123,10 @@ class DiscordActionHandlerTest(FireTest):
 
     @patch(
         "sentry.integrations.discord.client.DiscordClient.send_message",
-        side_effect=ApiError(code=50001, text="Missing access"),
+        side_effect=ApiError(
+            code=403,
+            text='{"message": "Missing access", "code": 50001}',
+        ),
     )
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_metric_alert_halt_for_missing_access(self, mock_record_event, mock_send_message):

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule_trigger_action.py
@@ -12,6 +12,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
+from sentry.integrations.discord.client import DISCORD_BASE_URL
 from sentry.integrations.discord.utils.channel import ChannelType
 from sentry.testutils.cases import TestCase
 
@@ -53,10 +54,9 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
 
     @responses.activate
     def test_discord(self):
-        base_url: str = "https://discord.com/api/v10"
         responses.add(
             method=responses.GET,
-            url=f"{base_url}/channels/channel-id",
+            url=f"{DISCORD_BASE_URL}/channels/channel-id",
             json={"guild_id": "guild_id", "name": "guild_id", "type": ChannelType.GUILD_TEXT.value},
         )
 
@@ -85,10 +85,9 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
 
     @responses.activate
     def test_discord_channel_id_none(self):
-        base_url: str = "https://discord.com/api/v10"
         responses.add(
             method=responses.GET,
-            url=f"{base_url}/channels/None",
+            url=f"{DISCORD_BASE_URL}/channels/None",
             json={
                 "guild_id": "guild_id",
                 "name": "guild_id",

--- a/tests/sentry/integrations/discord/test_client.py
+++ b/tests/sentry/integrations/discord/test_client.py
@@ -5,6 +5,7 @@ from sentry import options
 from sentry.integrations.discord.client import (
     APPLICATION_COMMANDS_URL,
     CHANNEL_URL,
+    DISCORD_BASE_URL,
     GUILD_URL,
     MESSAGE_URL,
     USERS_GUILD_URL,
@@ -86,7 +87,7 @@ class DiscordClientTest(TestCase):
     def test_get_access_token(self):
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=f"{DISCORD_BASE_URL}/oauth2/token",
             json={
                 "access_token": "access_token",
             },
@@ -98,7 +99,9 @@ class DiscordClientTest(TestCase):
     @responses.activate
     def test_get_user_id(self):
         responses.add(
-            responses.GET, url="https://discord.com/api/v10/users/@me", json={"id": "user_id"}
+            responses.GET,
+            url=f"{DISCORD_BASE_URL}/users/@me",
+            json={"id": "user_id"},
         )
 
         user_id = self.discord_client.get_user_id("access_token")

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -7,7 +7,12 @@ from responses.matchers import header_matcher, json_params_matcher
 
 from sentry import audit_log, options
 from sentry.api.client import ApiError
-from sentry.integrations.discord.client import APPLICATION_COMMANDS_URL, GUILD_URL, DiscordClient
+from sentry.integrations.discord.client import (
+    APPLICATION_COMMANDS_URL,
+    DISCORD_BASE_URL,
+    GUILD_URL,
+    DiscordClient,
+)
 from sentry.integrations.discord.integration import COMMANDS, DiscordIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.models.auditlogentry import AuditLogEntry
@@ -29,6 +34,7 @@ class DiscordSetupTestCase(IntegrationTestCase):
         options.set("discord.public-key", self.public_key)
         options.set("discord.bot-token", self.bot_token)
         options.set("discord.client-secret", self.client_secret)
+        self.token_url = f"{DISCORD_BASE_URL}/oauth2/token"
 
     @mock.patch("sentry.integrations.discord.client.DiscordClient.set_application_command")
     def assert_setup_flow(
@@ -91,7 +97,7 @@ class DiscordSetupTestCase(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },
@@ -161,7 +167,7 @@ class DiscordSetupTestCase(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },
@@ -270,7 +276,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
         )
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },
@@ -307,10 +313,10 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
     def test_get_guild_name_failure(self):
         provider = self.provider()
 
-        (responses.add(responses.GET, "https://discord.com/api/v10/guilds/guild_name", status=500),)
+        (responses.add(responses.GET, f"{DISCORD_BASE_URL}/guilds/guild_name", status=500),)
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },
@@ -342,7 +348,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
         )
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },
@@ -366,7 +372,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
 
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },
@@ -382,7 +388,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
     @responses.activate
     def test_get_discord_user_id_oauth_failure(self):
         provider = self.provider()
-        responses.add(responses.POST, url="https://discord.com/api/v10/oauth2/token", status=500)
+        responses.add(responses.POST, url=self.token_url, status=500)
         with pytest.raises(IntegrationError):
             provider._get_discord_user_id("auth_code", "1")
 
@@ -391,7 +397,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
         provider = self.provider()
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={},
         )
         with pytest.raises(IntegrationError):
@@ -402,7 +408,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
         provider = self.provider()
         responses.add(
             responses.POST,
-            url="https://discord.com/api/v10/oauth2/token",
+            url=self.token_url,
             json={
                 "access_token": "access_token",
             },

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 
 from sentry.integrations.discord.actions.issue_alert.form import DiscordNotifyServiceForm
 from sentry.integrations.discord.actions.issue_alert.notification import DiscordNotifyServiceAction
-from sentry.integrations.discord.client import MESSAGE_URL
+from sentry.integrations.discord.client import DISCORD_BASE_URL, MESSAGE_URL
 from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.base.component import DiscordComponentCustomIds
 from sentry.integrations.messaging.message_builder import (
@@ -64,8 +64,9 @@ class DiscordIssueAlertTest(RuleTestCase):
 
         responses.add(
             method=responses.POST,
-            url=f"{MESSAGE_URL.format(channel_id=self.channel_id)}",
+            url=f"{DISCORD_BASE_URL}{MESSAGE_URL.format(channel_id=self.channel_id)}",
             status=200,
+            json={"message_id": "12345678910"},
         )
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -10,6 +10,7 @@ from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from rest_framework import status
 
+from sentry.integrations.discord.client import DISCORD_BASE_URL
 from sentry.integrations.discord.requests.base import DiscordRequestError, DiscordRequestTypes
 from sentry.integrations.middleware.hybrid_cloud.parser import create_async_request_payload
 from sentry.middleware.integrations.parsers.discord import DiscordRequestParser
@@ -189,7 +190,7 @@ class DiscordRequestParserTest(TestCase):
     @patch("sentry.middleware.integrations.parsers.discord.convert_to_async_discord_response")
     @patch("sentry.integrations.discord.requests.base.verify_signature", return_value=None)
     def test_triggers_async_response(self, mock_verify_signature, mock_discord_task):
-        response_url = "https://discord.com/api/v10/webhooks/application_id/token"
+        response_url = f"{DISCORD_BASE_URL}/webhooks/application_id/token"
         data = {
             "application_id": "application_id",
             "token": "token",

--- a/tests/sentry/middleware/integrations/test_tasks.py
+++ b/tests/sentry/middleware/integrations/test_tasks.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from responses import matchers
 
+from sentry.integrations.discord.client import DISCORD_BASE_URL
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
 from sentry.integrations.middleware.hybrid_cloud.parser import create_async_request_payload
 from sentry.middleware.integrations.tasks import (
@@ -156,7 +157,7 @@ class AsyncDiscordResponseTest(TestCase):
         super().setUp()
         application_id = "some-app-id"
         token = "some-token"
-        self.response_url = f"https://discord.com/api/v10/webhooks/{application_id}/{token}"
+        self.response_url = f"{DISCORD_BASE_URL}/webhooks/{application_id}/{token}"
         data = {
             "application_id": application_id,
             "token": token,


### PR DESCRIPTION
1. i realized we repeated the base discord url *everywhere* in our tests so this fixes that
3. in an earlier [pr](https://github.com/getsentry/sentry/pull/83656) where i introduced a method to determine if an exception warrants a halt or a failure, i incorrectly parse the error object, so i was grabbing the wrong error. this pr fixes that as well.