### PR TITLE
feat(insights): update breadcrumbs on transaction summary to be within insights

### DIFF
--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -6,6 +6,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {DOMAIN_VIEW_BASE_TITLE} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {vitalDetailRouteWithQuery} from 'sentry/views/performance/vitalDetail/utils';
 
@@ -29,6 +30,9 @@ type Props = {
 
 function Breadcrumb(props: Props) {
   function getCrumbs() {
+    const hasPerfLandingRemovalFlag = props.organization.features.includes(
+      'insights-performance-landing-removal'
+    );
     const crumbs: Crumb[] = [];
     const {
       organization,
@@ -40,20 +44,26 @@ function Breadcrumb(props: Props) {
       traceSlug,
     } = props;
 
-    const performanceTarget: LocationDescriptor = {
-      pathname: getPerformanceLandingUrl(organization),
-      query: {
-        ...location.query,
-        // clear out the transaction name
-        transaction: undefined,
-      },
-    };
+    if (hasPerfLandingRemovalFlag) {
+      crumbs.push({
+        label: DOMAIN_VIEW_BASE_TITLE,
+      });
+    } else {
+      const performanceTarget: LocationDescriptor = {
+        pathname: getPerformanceLandingUrl(organization),
+        query: {
+          ...location.query,
+          // clear out the transaction name
+          transaction: undefined,
+        },
+      };
 
-    crumbs.push({
-      to: performanceTarget,
-      label: t('Performance'),
-      preservePageFilters: true,
-    });
+      crumbs.push({
+        to: performanceTarget,
+        label: t('Performance'),
+        preservePageFilters: true,
+      });
+    }
 
     crumbs.push(
       ...getTabCrumbs({


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/84021

When you navigate to the transaction summary from outside a domain view, (for example, clicking on the transaction name in the issues detail page). We should remain under the insights scope.

To get us closer to that state, this PR updates the breadcrumbs on the transaction summary to be `Insights > Transaction Summary` instead of `Performance > Transaction Summary` when navigating from outside a domain view.

<img width="808" alt="image" src="https://github.com/user-attachments/assets/a6f6a7f0-c11b-48cd-a34c-6443d20ee91b" />
