### PR TITLE
feat(sentry apps): adopt new error design for alert rule action

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
@@ -294,10 +293,10 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             try:
                 trigger_sentry_app_action_creators_for_issues(actions=kwargs["actions"])
             except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-                response: dict[str, Any] = {"actions": [e.message]}
-                if public_context := e.public_context:
-                    response.update({"context": public_context})
-                return Response(response, status=e.status_code)
+                response = e.response_from_exception()
+                response.data["actions"] = [response.data.pop("detail")]
+
+                return response
 
             updated_rule = ProjectRuleUpdater(
                 rule=rule,

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
@@ -293,7 +294,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             try:
                 trigger_sentry_app_action_creators_for_issues(actions=kwargs["actions"])
             except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-                response = {"actions": [e.message]}
+                response: dict[str, Any] = {"actions": [e.message]}
                 if public_context := e.public_context:
                     response.update({"context": public_context})
                 return Response(response, status=e.status_code)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -35,11 +35,7 @@ from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.projects.project_rules.updater import ProjectRuleUpdater
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.utils import get_changed_data, get_updated_rule_data
-from sentry.sentry_apps.utils.errors import (
-    SentryAppError,
-    SentryAppIntegratorError,
-    SentryAppSentryError,
-)
+from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
 from sentry.utils import metrics
@@ -292,7 +288,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
             try:
                 trigger_sentry_app_action_creators_for_issues(actions=kwargs["actions"])
-            except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
+            except SentryAppBaseError as e:
                 response = e.response_from_exception()
                 response.data["actions"] = [response.data.pop("detail")]
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -35,7 +35,11 @@ from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.projects.project_rules.updater import ProjectRuleUpdater
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.utils import get_changed_data, get_updated_rule_data
-from sentry.sentry_apps.utils.errors import SentryAppError, SentryAppIntegratorError
+from sentry.sentry_apps.utils.errors import (
+    SentryAppError,
+    SentryAppIntegratorError,
+    SentryAppSentryError,
+)
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
 from sentry.utils import metrics
@@ -288,7 +292,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
             try:
                 trigger_sentry_app_action_creators_for_issues(actions=kwargs["actions"])
-            except (SentryAppError, SentryAppIntegratorError) as e:
+            except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
                 response = {}
                 if public_context := e.public_context:
                     response.update({"context": public_context})

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -293,10 +293,9 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             try:
                 trigger_sentry_app_action_creators_for_issues(actions=kwargs["actions"])
             except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-                response = {}
+                response = {"actions": [e.message]}
                 if public_context := e.public_context:
                     response.update({"context": public_context})
-
                 return Response(response, status=e.status_code)
 
             updated_rule = ProjectRuleUpdater(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -851,7 +851,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 kwargs["actions"]
             )
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response = {}
+            response = {"actions": [e.message]}
             if public_context := e.public_context:
                 response.update({"context": public_context})
             return Response(response, status=e.status_code)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -851,7 +851,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 kwargs["actions"]
             )
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response = {"actions": [e.message]}
+            response: dict[str, Any] = {"actions": [e.message]}
             if public_context := e.public_context:
                 response.update({"context": public_context})
             return Response(response, status=e.status_code)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -851,10 +851,10 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 kwargs["actions"]
             )
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response: dict[str, Any] = {"actions": [e.message]}
-            if public_context := e.public_context:
-                response.update({"context": public_context})
-            return Response(response, status=e.status_code)
+            response = e.response_from_exception()
+            response.data["actions"] = [response.data.pop("detail")]
+
+            return response
 
         rule = ProjectRuleCreator(
             name=kwargs["name"],

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -32,11 +32,7 @@ from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.base import instantiate_action
 from sentry.rules.processing.processor import is_condition_slow
-from sentry.sentry_apps.utils.errors import (
-    SentryAppError,
-    SentryAppIntegratorError,
-    SentryAppSentryError,
-)
+from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_created
 from sentry.utils import metrics
 
@@ -850,7 +846,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             created_alert_rule_ui_component = trigger_sentry_app_action_creators_for_issues(
                 kwargs["actions"]
             )
-        except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
+        except SentryAppBaseError as e:
             response = e.response_from_exception()
             response.data["actions"] = [response.data.pop("detail")]
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -36,11 +36,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.sentry_apps.services.app import app_service
-from sentry.sentry_apps.utils.errors import (
-    SentryAppError,
-    SentryAppIntegratorError,
-    SentryAppSentryError,
-)
+from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.users.services.user.service import user_service
 
 
@@ -89,7 +85,7 @@ def update_alert_rule(request: Request, organization, alert_rule):
     if serializer.is_valid():
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
-        except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
+        except SentryAppBaseError as e:
             return e.response_from_exception()
 
         if get_slack_actions_with_async_lookups(organization, request.user, data):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
@@ -90,7 +92,7 @@ def update_alert_rule(request: Request, organization, alert_rule):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response = {"sentry_app": e.message}
+            response: dict[str, Any] = {"sentry_app": e.message}
             if public_context := e.public_context:
                 response.update({"context": public_context})
             return Response(response, status=e.status_code)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -90,7 +90,7 @@ def update_alert_rule(request: Request, organization, alert_rule):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            e.response_from_exception()
+            return e.response_from_exception()
 
         if get_slack_actions_with_async_lookups(organization, request.user, data):
             # need to kick off an async job for Slack

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -90,7 +90,7 @@ def update_alert_rule(request: Request, organization, alert_rule):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response = {"detail": e.message}
+            response = {"sentry_app": e.message}
             if public_context := e.public_context:
                 response.update({"context": public_context})
             return Response(response, status=e.status_code)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
@@ -92,10 +90,7 @@ def update_alert_rule(request: Request, organization, alert_rule):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response: dict[str, Any] = {"sentry_app": e.message}
-            if public_context := e.public_context:
-                response.update({"context": public_context})
-            return Response(response, status=e.status_code)
+            e.response_from_exception()
 
         if get_slack_actions_with_async_lookups(organization, request.user, data):
             # need to kick off an async job for Slack

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from datetime import UTC, datetime
-from typing import Any
 
 from django.conf import settings
 from django.db.models import Case, DateTimeField, IntegerField, OuterRef, Q, Subquery, Value, When
@@ -132,10 +131,7 @@ class AlertRuleIndexMixin(Endpoint):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response: dict[str, Any] = {"sentry_app": e.message}
-            if public_context := e.public_context:
-                response.update({"context": public_context})
-            return Response(response, status=e.status_code)
+            return e.response_from_exception()
 
         if get_slack_actions_with_async_lookups(organization, request.user, request.data):
             # need to kick off an async job for Slack

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -59,11 +59,7 @@ from sentry.monitors.models import (
     MonitorStatus,
 )
 from sentry.sentry_apps.services.app import app_service
-from sentry.sentry_apps.utils.errors import (
-    SentryAppError,
-    SentryAppIntegratorError,
-    SentryAppSentryError,
-)
+from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.uptime.models import (
@@ -130,7 +126,7 @@ class AlertRuleIndexMixin(Endpoint):
 
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
-        except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
+        except SentryAppBaseError as e:
             return e.response_from_exception()
 
         if get_slack_actions_with_async_lookups(organization, request.user, request.data):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -131,10 +131,11 @@ class AlertRuleIndexMixin(Endpoint):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response = {"detail": e.message}
+            response = {"sentry_app": e.message}
             if public_context := e.public_context:
                 response.update({"context": public_context})
             return Response(response, status=e.status_code)
+
         if get_slack_actions_with_async_lookups(organization, request.user, request.data):
             # need to kick off an async job for Slack
             client = RedisRuleStatus()

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from datetime import UTC, datetime
+from typing import Any
 
 from django.conf import settings
 from django.db.models import Case, DateTimeField, IntegerField, OuterRef, Q, Subquery, Value, When
@@ -131,7 +132,7 @@ class AlertRuleIndexMixin(Endpoint):
         try:
             trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
-            response = {"sentry_app": e.message}
+            response: dict[str, Any] = {"sentry_app": e.message}
             if public_context := e.public_context:
                 response.update({"context": public_context})
             return Response(response, status=e.status_code)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -59,6 +59,11 @@ from sentry.monitors.models import (
     MonitorStatus,
 )
 from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.utils.errors import (
+    SentryAppError,
+    SentryAppIntegratorError,
+    SentryAppSentryError,
+)
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.uptime.models import (
@@ -123,7 +128,13 @@ class AlertRuleIndexMixin(Endpoint):
         if not serializer.is_valid():
             raise ValidationError(serializer.errors)
 
-        trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
+        try:
+            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
+        except (SentryAppError, SentryAppIntegratorError, SentryAppSentryError) as e:
+            response = {"detail": e.message}
+            if public_context := e.public_context:
+                response.update({"context": public_context})
+            return Response(response, status=e.status_code)
         if get_slack_actions_with_async_lookups(organization, request.user, request.data):
             # need to kick off an async job for Slack
             client = RedisRuleStatus()

--- a/src/sentry/incidents/utils/sentry_apps.py
+++ b/src/sentry/incidents/utils/sentry_apps.py
@@ -8,6 +8,7 @@ from sentry.incidents.logic import get_filtered_actions
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.serializers import AlertRuleTriggerActionSerializer
 from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.utils.alert_rule_action import raise_alert_rule_action_result_errors
 
 
 def trigger_sentry_app_action_creators_for_incidents(alert_rule_data: Mapping[str, Any]) -> None:
@@ -32,5 +33,6 @@ def trigger_sentry_app_action_creators_for_incidents(alert_rule_data: Mapping[st
             fields=action.get("sentry_app_config"),
             install_uuid=action.get("sentry_app_installation_uuid"),
         )
+
         if not result.success:
-            raise serializers.ValidationError({"sentry_app": result.message})
+            raise_alert_rule_action_result_errors(result)

--- a/src/sentry/rules/actions/sentry_apps/utils.py
+++ b/src/sentry/rules/actions/sentry_apps/utils.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from rest_framework import serializers
-
 from sentry.constants import SENTRY_APP_ACTIONS
 from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.utils.alert_rule_action import raise_alert_rule_action_result_errors
 
 
 def trigger_sentry_app_action_creators_for_issues(
@@ -23,6 +22,6 @@ def trigger_sentry_app_action_creators_for_issues(
         )
         # Bubble up errors from Sentry App to the UI
         if not result.success:
-            raise serializers.ValidationError({"actions": [result.message]})
+            raise_alert_rule_action_result_errors(result)
         created = "alert-rule-action"
     return created

--- a/src/sentry/sentry_apps/alert_rule_action_creator.py
+++ b/src/sentry/sentry_apps/alert_rule_action_creator.py
@@ -5,13 +5,13 @@ from typing import Any
 from django.db import router, transaction
 from django.utils.functional import cached_property
 
-from sentry.coreapi import APIError
 from sentry.sentry_apps.external_requests.alert_rule_action_requester import (
     AlertRuleActionRequester,
     AlertRuleActionResult,
 )
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.sentry_apps.utils.errors import SentryAppErrorType
 
 
 @dataclass
@@ -34,7 +34,11 @@ class AlertRuleActionCreator:
 
     def _make_external_request(self, uri=None):
         if uri is None:
-            raise APIError("Sentry App request url not found")
+            return AlertRuleActionResult(
+                message="Request url for alert-rule-action not found, please check your integration schema",
+                success=False,
+                error_type=SentryAppErrorType.INTEGRATOR,
+            )
         response = AlertRuleActionRequester(
             install=self.install,
             uri=uri,

--- a/src/sentry/sentry_apps/alert_rule_action_creator.py
+++ b/src/sentry/sentry_apps/alert_rule_action_creator.py
@@ -38,6 +38,7 @@ class AlertRuleActionCreator:
                 message="Request url for alert-rule-action not found, please check your integration schema",
                 success=False,
                 error_type=SentryAppErrorType.INTEGRATOR,
+                status_code=500,
             )
         response = AlertRuleActionRequester(
             install=self.install,

--- a/src/sentry/sentry_apps/alert_rule_action_creator.py
+++ b/src/sentry/sentry_apps/alert_rule_action_creator.py
@@ -6,8 +6,8 @@ from django.db import router, transaction
 from django.utils.functional import cached_property
 
 from sentry.sentry_apps.external_requests.alert_rule_action_requester import (
-    AlertRuleActionRequester,
-    AlertRuleActionResult,
+    SentryAppAlertRuleActionRequester,
+    SentryAppAlertRuleActionResult,
 )
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
@@ -15,11 +15,11 @@ from sentry.sentry_apps.utils.errors import SentryAppErrorType
 
 
 @dataclass
-class AlertRuleActionCreator:
+class SentryAppAlertRuleActionCreator:
     install: SentryAppInstallation
     fields: list[Mapping[str, Any]] = field(default_factory=list)
 
-    def run(self) -> AlertRuleActionResult:
+    def run(self) -> SentryAppAlertRuleActionResult:
         with transaction.atomic(router.db_for_write(SentryAppComponent)):
             uri = self._fetch_sentry_app_uri()
             response = self._make_external_request(uri)
@@ -34,13 +34,13 @@ class AlertRuleActionCreator:
 
     def _make_external_request(self, uri=None):
         if uri is None:
-            return AlertRuleActionResult(
+            return SentryAppAlertRuleActionResult(
                 message="Request url for alert-rule-action not found, please check your integration schema",
                 success=False,
                 error_type=SentryAppErrorType.INTEGRATOR,
                 status_code=500,
             )
-        response = AlertRuleActionRequester(
+        response = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri=uri,
             fields=self.fields,

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -21,7 +21,7 @@ DEFAULT_ERROR_MESSAGE = "Something went wrong!"
 logger = logging.getLogger("sentry.sentry_apps.external_requests")
 
 
-class AlertRuleActionResult(TypedDict, total=False):
+class SentryAppAlertRuleActionResult(TypedDict, total=False):
     success: bool
     message: str
     error_type: SentryAppErrorType | None
@@ -31,13 +31,13 @@ class AlertRuleActionResult(TypedDict, total=False):
 
 
 @dataclass
-class AlertRuleActionRequester:
+class SentryAppAlertRuleActionRequester:
     install: SentryAppInstallation | RpcSentryAppInstallation
     uri: str
     fields: Sequence[Mapping[str, str]] = field(default_factory=list)
     http_method: str | None = "POST"
 
-    def run(self) -> AlertRuleActionResult:
+    def run(self) -> SentryAppAlertRuleActionResult:
         try:
             response = send_and_save_sentry_app_request(
                 url=self._build_url(),
@@ -63,14 +63,14 @@ class AlertRuleActionRequester:
                 extra={**extras},
             )
 
-            return AlertRuleActionResult(
+            return SentryAppAlertRuleActionResult(
                 success=False,
                 message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
                 error_type=SentryAppErrorType.INTEGRATOR,
                 webhook_context={"error_type": "alert_rule_action.error", **extras},
                 status_code=500,
             )
-        return AlertRuleActionResult(
+        return SentryAppAlertRuleActionResult(
             success=True, message=self._get_response_message(response, DEFAULT_SUCCESS_MESSAGE)
         )
 

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -27,7 +27,6 @@ class AlertRuleActionResult(TypedDict):
     error_type: SentryAppErrorType | None
     webhook_context: dict[str, Any] | None
     public_context: dict[str, Any] | None
-    status_code: int | None
 
 
 @dataclass

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -27,6 +27,7 @@ class AlertRuleActionResult(TypedDict, total=False):
     error_type: SentryAppErrorType | None
     webhook_context: dict[str, Any] | None
     public_context: dict[str, Any] | None
+    status_code: int | None
 
 
 @dataclass
@@ -53,7 +54,7 @@ class AlertRuleActionRequester:
             error_type = "alert_rule_action.error"
             extras = {
                 "sentry_app_slug": self.sentry_app.slug,
-                "install_uuid": self.install.uuid,
+                "installation_uuid": self.install.uuid,
                 "uri": self.uri,
                 "error_message": str(e),
             }
@@ -67,6 +68,7 @@ class AlertRuleActionRequester:
                 message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
                 error_type=SentryAppErrorType.INTEGRATOR,
                 webhook_context={"error_type": "alert_rule_action.error", **extras},
+                status_code=500,
             )
         return AlertRuleActionResult(
             success=True, message=self._get_response_message(response, DEFAULT_SUCCESS_MESSAGE)

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -21,7 +21,7 @@ DEFAULT_ERROR_MESSAGE = "Something went wrong!"
 logger = logging.getLogger("sentry.sentry_apps.external_requests")
 
 
-class AlertRuleActionResult(TypedDict):
+class AlertRuleActionResult(TypedDict, total=False):
     success: bool
     message: str
     error_type: SentryAppErrorType | None

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -49,6 +49,7 @@ class AlertRuleActionRequester:
             )
 
         except RequestException as e:
+
             error_type = "alert_rule_action.error"
             extras = {
                 "sentry_app_slug": self.sentry_app.slug,
@@ -60,6 +61,7 @@ class AlertRuleActionRequester:
                 error_type,
                 extra={**extras},
             )
+
             return AlertRuleActionResult(
                 success=False,
                 message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -38,6 +38,7 @@ from sentry.sentry_apps.services.app.serial import (
     serialize_sentry_app_component,
     serialize_sentry_app_installation,
 )
+from sentry.sentry_apps.utils.errors import SentryAppErrorType
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 
@@ -254,7 +255,12 @@ class DatabaseBackedAppService(AppService):
         try:
             install = SentryAppInstallation.objects.get(uuid=install_uuid)
         except SentryAppInstallation.DoesNotExist:
-            return RpcAlertRuleActionResult(success=False, message="Installation does not exist")
+            return RpcAlertRuleActionResult(
+                success=False,
+                message="Installation does not exist",
+                error_type=SentryAppErrorType.SENTRY,
+                webhook_type={"installation_uuid": install_uuid},
+            )
         result = AlertRuleActionCreator(install=install, fields=fields).run()
         return RpcAlertRuleActionResult(success=result["success"], message=result["message"])
 

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -268,6 +268,7 @@ class DatabaseBackedAppService(AppService):
             error_type=result.get("error_type"),
             webhook_context=result.get("webhook_context"),
             public_context=result.get("public_context"),
+            status_code=result.get("status_code"),
         )
 
     def find_service_hook_sentry_app(self, *, api_application_id: int) -> RpcSentryApp | None:

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -262,7 +262,13 @@ class DatabaseBackedAppService(AppService):
                 webhook_type={"installation_uuid": install_uuid},
             )
         result = AlertRuleActionCreator(install=install, fields=fields).run()
-        return RpcAlertRuleActionResult(success=result["success"], message=result["message"])
+        return RpcAlertRuleActionResult(
+            success=result["success"],
+            message=result["message"],
+            error_type=result.get("error_type"),
+            webhook_context=result.get("webhook_context"),
+            public_context=result.get("public_context"),
+        )
 
     def find_service_hook_sentry_app(self, *, api_application_id: int) -> RpcSentryApp | None:
         try:

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.auth.services.auth import AuthenticationContext
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
 from sentry.hybridcloud.rpc.filter_query import FilterQueryDatabaseImpl, OpaqueSerializedResponse
-from sentry.sentry_apps.alert_rule_action_creator import AlertRuleActionCreator
+from sentry.sentry_apps.alert_rule_action_creator import SentryAppAlertRuleActionCreator
 from sentry.sentry_apps.api.serializers.sentry_app_component import (
     SentryAppAlertRuleActionSerializer,
 )
@@ -261,7 +261,7 @@ class DatabaseBackedAppService(AppService):
                 error_type=SentryAppErrorType.SENTRY,
                 webhook_type={"installation_uuid": install_uuid},
             )
-        result = AlertRuleActionCreator(install=install, fields=fields).run()
+        result = SentryAppAlertRuleActionCreator(install=install, fields=fields).run()
         return RpcAlertRuleActionResult(
             success=result["success"],
             message=result["message"],

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -104,6 +104,7 @@ class RpcAlertRuleActionResult(RpcModel):
     error_type: SentryAppErrorType | None
     webhook_context: dict[str, Any] | None
     public_context: dict[str, Any] | None
+    status_code: int | None
 
 
 class SentryAppEventDataInterface(Protocol):

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -14,6 +14,7 @@ from typing_extensions import TypedDict
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.hybridcloud.rpc import RpcModel, RpcModelProtocolMeta
+from sentry.sentry_apps.utils.errors import SentryAppErrorType
 
 
 class RpcApiApplication(RpcModel):
@@ -100,6 +101,10 @@ class RpcSentryAppComponentContext(RpcModel):
 class RpcAlertRuleActionResult(RpcModel):
     success: bool
     message: str
+    error_type: SentryAppErrorType | None
+    webhook_context: dict[str, Any] | None
+    public_context: dict[str, Any] | None
+    status_code: int | None
 
 
 class SentryAppEventDataInterface(Protocol):

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -104,7 +104,6 @@ class RpcAlertRuleActionResult(RpcModel):
     error_type: SentryAppErrorType | None
     webhook_context: dict[str, Any] | None
     public_context: dict[str, Any] | None
-    status_code: int | None
 
 
 class SentryAppEventDataInterface(Protocol):

--- a/src/sentry/sentry_apps/utils/alert_rule_action.py
+++ b/src/sentry/sentry_apps/utils/alert_rule_action.py
@@ -1,0 +1,35 @@
+import logging
+
+from rest_framework import serializers
+
+from sentry.coreapi import APIError
+from sentry.sentry_apps.services.app.model import RpcAlertRuleActionResult
+from sentry.sentry_apps.utils.errors import SentryAppErrorType
+
+logger = logging.getLogger("sentry.sentry_apps.alert_rule_action")
+
+
+def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> None:
+    if result.error_type is None:
+        return None
+
+    error_type = SentryAppErrorType(result.error_type)
+    match error_type:
+        case SentryAppErrorType.INTEGRATOR:
+            raise APIError(
+                message=result.message,
+            )
+        case SentryAppErrorType.CLIENT:
+            raise serializers.ValidationError(result.message, result.public_context)
+        case SentryAppErrorType.SENTRY:
+            logger.error(
+                "create-failed",
+                extras={
+                    "message": result.message,
+                    **result.webhook_context,
+                    **result.public_context,
+                },
+            )
+            raise Exception(
+                message=result.message,
+            )

--- a/src/sentry/sentry_apps/utils/alert_rule_action.py
+++ b/src/sentry/sentry_apps/utils/alert_rule_action.py
@@ -13,7 +13,10 @@ logger = logging.getLogger("sentry.sentry_apps.alert_rule_action")
 
 def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> None:
     if result.error_type is None:
-        return None
+        raise SentryAppSentryError(
+            message="Missing error type from alert rule action creator response",
+            webhook_context={**result.dict()},
+        )
 
     error_type = SentryAppErrorType(result.error_type)
     match error_type:
@@ -21,6 +24,7 @@ def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> N
             raise SentryAppIntegratorError(
                 message=result.message,
                 public_context=result.public_context,
+                webhook_context=result.webhook_context,
                 status_code=result.status_code,
             )
         case SentryAppErrorType.CLIENT:
@@ -30,15 +34,9 @@ def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> N
                 status_code=result.status_code,
             )
         case SentryAppErrorType.SENTRY:
-            logger.error(
-                "create-failed",
-                extra={
-                    "message_str": result.message,
-                    "webhook_context": result.webhook_context if result.webhook_context else None,
-                    "public_context": result.public_context if result.public_context else None,
-                },
-            )
             raise SentryAppSentryError(
                 message="Something went wrong during the alert rule action process!",
                 status_code=result.status_code,
+                webhook_context=result.webhook_context,
+                public_context=result.public_context,
             )

--- a/src/sentry/sentry_apps/utils/alert_rule_action.py
+++ b/src/sentry/sentry_apps/utils/alert_rule_action.py
@@ -17,19 +17,19 @@ def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> N
     match error_type:
         case SentryAppErrorType.INTEGRATOR:
             raise APIError(
-                message=result.message,
+                result.message,
             )
         case SentryAppErrorType.CLIENT:
-            raise serializers.ValidationError(result.message, result.public_context)
+            raise serializers.ValidationError(result.message)
         case SentryAppErrorType.SENTRY:
-            logger.error(
+            logger.info(
                 "create-failed",
-                extras={
-                    "message": result.message,
-                    **result.webhook_context,
-                    **result.public_context,
+                extra={
+                    "message_str": result.message,
+                    "webhook_context": result.webhook_context if result.webhook_context else None,
+                    "public_context": result.public_context if result.public_context else None,
                 },
             )
             raise Exception(
-                message=result.message,
+                result.message,
             )

--- a/src/sentry/sentry_apps/utils/alert_rule_action.py
+++ b/src/sentry/sentry_apps/utils/alert_rule_action.py
@@ -19,10 +19,16 @@ def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> N
     match error_type:
         case SentryAppErrorType.INTEGRATOR:
             raise SentryAppIntegratorError(
-                message=result.message, public_context=result.public_context
+                message=result.message,
+                public_context=result.public_context,
+                status_code=result.status_code,
             )
         case SentryAppErrorType.CLIENT:
-            raise SentryAppError(message=result.message, public_context=result.public_context)
+            raise SentryAppError(
+                message=result.message,
+                public_context=result.public_context,
+                status_code=result.status_code,
+            )
         case SentryAppErrorType.SENTRY:
             logger.error(
                 "create-failed",
@@ -34,4 +40,5 @@ def raise_alert_rule_action_result_errors(result: RpcAlertRuleActionResult) -> N
             )
             raise SentryAppSentryError(
                 message="Something went wrong during the alert rule action process!",
+                status_code=result.status_code,
             )

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -20,6 +20,8 @@ from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
 from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.sentry_apps.services.app.model import RpcAlertRuleActionResult
+from sentry.sentry_apps.utils.errors import SentryAppErrorType
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack
@@ -1512,6 +1514,114 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert len(responses.calls) == 1
         assert error_message in response.json().get("actions")[0]
+
+    @patch("sentry.sentry_apps.services.app.app_service.trigger_sentry_app_action_creators")
+    def test_update_sentry_app_action_failure_with_public_context(self, result):
+        error_message = "Something is totally broken :'("
+        result.return_value = RpcAlertRuleActionResult(
+            success=False,
+            message=error_message,
+            error_type=SentryAppErrorType.CLIENT,
+            public_context={"bruh": "bruhhhh"},
+            status_code=409,
+        )
+
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "settings": self.sentry_app_settings_payload,
+                "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
+                "hasSchemaFormConfig": True,
+            },
+        ]
+        payload = {
+            "name": "my super cool rule",
+            "actionMatch": "any",
+            "filterMatch": "any",
+            "actions": actions,
+            "conditions": [],
+            "filters": [],
+        }
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=409, **payload
+        )
+        assert error_message in response.json().get("actions")[0]
+        assert response.json().get("context") == {"bruh": "bruhhhh"}
+
+    @patch("sentry.sentry_apps.services.app.app_service.trigger_sentry_app_action_creators")
+    def test_update_sentry_app_action_failure_sentry_error(self, result):
+        error_message = "Something is totally broken :'("
+        result.return_value = RpcAlertRuleActionResult(
+            success=False,
+            message=error_message,
+            error_type=SentryAppErrorType.SENTRY,
+            public_context={"bruh": "bro!"},
+            webhook_context={"swig": "swoog"},
+            status_code=510,
+        )
+
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "settings": self.sentry_app_settings_payload,
+                "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
+                "hasSchemaFormConfig": True,
+            },
+        ]
+        payload = {
+            "name": "my super cool rule",
+            "actionMatch": "any",
+            "filterMatch": "any",
+            "actions": actions,
+            "conditions": [],
+            "filters": [],
+        }
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=510, **payload
+        )
+        assert error_message not in response.json().get("actions")[0]
+        assert (
+            response.json().get("actions")[0]
+            == "Something went wrong during the custom integration process!"
+        )
+        assert response.json().get("context") == {"bruh": "bro!"}
+        assert list(response.json().keys()) == ["context", "actions"]
+
+    @patch("sentry.sentry_apps.services.app.app_service.trigger_sentry_app_action_creators")
+    def test_update_sentry_app_action_failure_missing_error_type(self, result):
+        error_message = "Something is totally broken :'("
+        result.return_value = RpcAlertRuleActionResult(
+            success=False,
+            message=error_message,
+            error_type=None,
+            status_code=500,
+        )
+
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "settings": self.sentry_app_settings_payload,
+                "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
+                "hasSchemaFormConfig": True,
+            },
+        ]
+        payload = {
+            "name": "my super cool rule",
+            "actionMatch": "any",
+            "filterMatch": "any",
+            "actions": actions,
+            "conditions": [],
+            "filters": [],
+        }
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=500, **payload
+        )
+        assert error_message not in response.json().get("actions")[0]
+        assert (
+            response.json().get("actions")[0]
+            == "Something went wrong during the custom integration process!"
+        )
+        assert list(response.json().keys()) == ["actions"]
 
     def test_edit_condition_metric(self):
         payload = {

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1508,7 +1508,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "filters": [],
         }
         response = self.get_error_response(
-            self.organization.slug, self.project.slug, self.rule.id, status_code=400, **payload
+            self.organization.slug, self.project.slug, self.rule.id, status_code=500, **payload
         )
         assert len(responses.calls) == 1
         assert error_message in response.json().get("actions")[0]

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -994,7 +994,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             self.organization.slug,
             self.project.slug,
             **payload,
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=500,
         )
         assert len(responses.calls) == 1
         assert error_message in response.json().get("actions")[0]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1627,9 +1627,8 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
-
         assert resp.status_code == 500
-        assert error_message in resp.data["sentry_app"]
+        assert error_message in resp.data["detail"]
 
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1628,7 +1628,7 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
 
-        assert resp.status_code == 400
+        assert resp.status_code == 500
         assert error_message in resp.data["sentry_app"]
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -775,7 +775,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp = self.get_response(self.organization.slug, **alert_rule)
 
         assert resp.status_code == 500
-        assert error_message in resp.data["sentry_app"]
+        assert error_message in resp.data["detail"]
 
     def test_no_label(self):
         rule_one_trigger_no_label = {

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -774,7 +774,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_response(self.organization.slug, **alert_rule)
 
-        assert resp.status_code == 400
+        assert resp.status_code == 500
         assert error_message in resp.data["sentry_app"]
 
     def test_no_label(self):

--- a/tests/sentry/sentry_apps/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/sentry_apps/external_requests/test_alert_rule_action_requester.py
@@ -5,7 +5,7 @@ import responses
 from sentry.sentry_apps.external_requests.alert_rule_action_requester import (
     DEFAULT_ERROR_MESSAGE,
     DEFAULT_SUCCESS_MESSAGE,
-    AlertRuleActionRequester,
+    SentryAppAlertRuleActionRequester,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -14,7 +14,7 @@ from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
 @control_silo_test
-class TestAlertRuleActionRequester(TestCase):
+class TestSentryAppAlertRuleActionRequester(TestCase):
     def setUp(self):
         super().setUp()
 
@@ -53,7 +53,7 @@ class TestAlertRuleActionRequester(TestCase):
             status=200,
         )
 
-        result = AlertRuleActionRequester(
+        result = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri="/sentry/alert-rule",
             fields=self.fields,
@@ -89,7 +89,7 @@ class TestAlertRuleActionRequester(TestCase):
             json={"message": self.success_message},
         )
 
-        result = AlertRuleActionRequester(
+        result = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri="/sentry/alert-rule",
             fields=self.fields,
@@ -105,7 +105,7 @@ class TestAlertRuleActionRequester(TestCase):
             status=200,
             body=self.success_message.encode(),
         )
-        result = AlertRuleActionRequester(
+        result = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri="/sentry/alert-rule",
             fields=self.fields,
@@ -122,7 +122,7 @@ class TestAlertRuleActionRequester(TestCase):
             status=401,
         )
 
-        result = AlertRuleActionRequester(
+        result = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri="/sentry/alert-rule",
             fields=self.fields,
@@ -164,7 +164,7 @@ class TestAlertRuleActionRequester(TestCase):
             status=401,
             json={"message": self.error_message},
         )
-        result = AlertRuleActionRequester(
+        result = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri="/sentry/alert-rule",
             fields=self.fields,
@@ -180,7 +180,7 @@ class TestAlertRuleActionRequester(TestCase):
             status=401,
             body=self.error_message.encode(),
         )
-        result = AlertRuleActionRequester(
+        result = SentryAppAlertRuleActionRequester(
             install=self.install,
             uri="/sentry/alert-rule",
             fields=self.fields,


### PR DESCRIPTION
must go in after this PR: https://github.com/getsentry/sentry/pull/84033
Adopts the new error design, unfortunately the endpoints that call these functions don't descend from our `IntegrationPlatformEndpoints`, so we just handle the error in the endpoint 😳 