### PR TITLE
feat(insights): redirect performance in sidebar to domain view

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -53,6 +53,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {
   AI_LANDING_SUB_PATH,
@@ -75,7 +76,10 @@ import {
   DOMAIN_VIEW_BASE_URL,
 } from 'sentry/views/insights/pages/settings';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
-import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
+import {
+  getPerformanceBaseUrl,
+  platformToDomainView,
+} from 'sentry/views/performance/utils';
 
 import {ProfilingOnboardingSidebar} from '../profiling/profilingOnboardingSidebar';
 
@@ -137,6 +141,8 @@ function Sidebar() {
   const activePanel = useLegacyStore(SidebarPanelStore);
   const organization = useOrganization({allowNull: true});
   const {shouldAccordionFloat} = useContext(ExpandedContext);
+  const {selection} = usePageFilters();
+  const {projects: projectList} = useProjects();
   const hasNewNav = organization?.features.includes('navigation-sidebar-v2');
   const hasOrganization = !!organization;
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
@@ -291,6 +297,12 @@ function Sidebar() {
     </Feature>
   );
 
+  const hasPerfLandingRemovalFlag = organization?.features.includes(
+    'insights-performance-landing-removal'
+  );
+  const view = hasPerfLandingRemovalFlag
+    ? platformToDomainView(projectList, selection.projects)
+    : undefined;
   const performance = hasOrganization && (
     <Feature
       hookName="feature-disabled:performance-sidebar-item"
@@ -305,7 +317,7 @@ function Sidebar() {
             {hasNewNav ? 'Perf.' : t('Performance')}
           </GuideAnchor>
         }
-        to={`${getPerformanceBaseUrl(organization.slug)}/`}
+        to={`${getPerformanceBaseUrl(organization.slug, view)}/`}
         id="performance"
       />
     </Feature>

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -149,6 +149,22 @@ export function platformToPerformanceType(
   return PlatformKey;
 }
 
+export function platformToDomainView(
+  projects: Array<Project | ReleaseProject>,
+  projectIds: readonly number[]
+): DomainView | undefined {
+  const performanceType = platformToPerformanceType(projects, projectIds);
+  switch (performanceType) {
+    case ProjectPerformanceType.FRONTEND:
+      return 'frontend';
+    case ProjectPerformanceType.BACKEND:
+      return 'backend';
+    case ProjectPerformanceType.MOBILE:
+      return 'mobile';
+    default:
+      return undefined;
+  }
+}
 /**
  * Used for transaction summary to determine appropriate columns on a page, since there is no display field set for the page.
  */


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/84021

While we transition to domain views fully, we are keeping performance in the sidebar. To make the transition smoother, the performance link in the sidebar will automatically route to the insight domain views.