### PR TITLE
:sparkles: feat(msteams): add exception parser to update failures to halts

### DIFF
--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -8,6 +8,7 @@ from sentry.integrations.messaging.metrics import (
 from sentry.integrations.msteams.actions.form import MsTeamsNotifyServiceForm
 from sentry.integrations.msteams.card_builder.issues import MSTeamsIssueMessageBuilder
 from sentry.integrations.msteams.client import MsTeamsClient
+from sentry.integrations.msteams.metrics import record_lifecycle_termination_level
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
 from sentry.integrations.msteams.utils import get_channel_id
 from sentry.integrations.services.integration import RpcIntegration
@@ -63,7 +64,7 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
                 try:
                     client.send_card(channel, card)
                 except ApiError as e:
-                    lifecycle.record_failure(e)
+                    record_lifecycle_termination_level(lifecycle, e)
             rule = rules[0] if rules else None
             self.record_notification_sent(event, channel, rule, notification_uuid)
 

--- a/src/sentry/integrations/msteams/card_builder/issues.py
+++ b/src/sentry/integrations/msteams/card_builder/issues.py
@@ -25,12 +25,12 @@ from sentry.integrations.msteams.card_builder.block import (
     TextBlock,
 )
 from sentry.integrations.msteams.card_builder.utils import IssueConstants
+from sentry.integrations.msteams.utils import ACTION_TYPE
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 
-from ..utils import ACTION_TYPE
 from .base import MSTeamsMessageBuilder
 from .block import (
     ActionType,

--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -1,0 +1,22 @@
+from sentry.integrations.utils.metrics import EventLifecycle
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+
+# Generated based on the response from the MsTeams API
+# Example: {"error":{"code":"ConversationBlockedByUser","message":"User blocked the conversation with the bot."}}"
+MSTEAMS_HALT_ERROR_CODES = [
+    "ConversationBlockedByUser",
+    "ConversationNotFound",
+]
+
+
+def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiError) -> None:
+    if isinstance(error, ApiRateLimitedError):
+        # TODO(ecosystem): We should batch this on a per-organization basis
+        lifecycle.record_halt(error)
+    elif error.json:
+        if error.json.get("error", {}).get("code") in MSTEAMS_HALT_ERROR_CODES:
+            lifecycle.record_halt(error)
+        else:
+            lifecycle.record_failure(error)
+    else:
+        lifecycle.record_failure(error)


### PR DESCRIPTION
similar to https://github.com/getsentry/sentry/pull/83656, i added a exception parser to msteams issue alert and incident alert notification  contexts so we can filter out user configuration problems (access revoked, deleted channels) as halts.