### PR TITLE
ref(seer grouping): Improve backfill logging

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -269,7 +269,7 @@ def backfill_seer_grouping_records_for_project(
             extra={
                 "reason": seer_response.get("reason"),
                 "project_id": current_project_id,
-                "last_processed_project_index": last_processed_project_index,
+                "project_index_in_cohort": last_processed_project_index,
                 "worker_number": worker_number,
             },
         )

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -91,7 +91,7 @@ def backfill_seer_grouping_records_for_project(
     logger.info(
         "backfill_seer_grouping_records.task_start",
         extra={
-            "current_project_id": current_project_id,
+            "project_id": current_project_id,
             "last_processed_group_id": last_processed_group_id_input,
             "cohort": cohort,
             "last_processed_project_index": last_processed_project_index_input,
@@ -115,7 +115,7 @@ def backfill_seer_grouping_records_for_project(
     except Project.DoesNotExist:
         logger.info(
             "backfill_seer_grouping_records.project_does_not_exist",
-            extra={"current_project_id": current_project_id},
+            extra={"project_id": current_project_id},
         )
         assert last_processed_project_index_input is not None
         call_next_backfill(
@@ -149,7 +149,7 @@ def backfill_seer_grouping_records_for_project(
         delete_seer_grouping_records(current_project_id)
         logger.info(
             "backfill_seer_grouping_records.deleted_all_records",
-            extra={"current_project_id": current_project_id},
+            extra={"project_id": current_project_id},
         )
 
     # Only check if project is seer eligible if we are running the GA backfill
@@ -268,7 +268,7 @@ def backfill_seer_grouping_records_for_project(
             "backfill_seer_grouping_records.seer_failed",
             extra={
                 "reason": seer_response.get("reason"),
-                "current_project_id": current_project_id,
+                "project_id": current_project_id,
                 "last_processed_project_index": last_processed_project_index,
                 "worker_number": worker_number,
             },

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -345,7 +345,7 @@ def call_next_backfill(
             logger.info(
                 "backfill_seer_grouping_records.project_list_end",
                 extra={
-                    "cohort_name": cohort,
+                    "cohort": cohort,
                     "last_processed_project_index": last_processed_project_index,
                 },
             )

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -110,20 +110,6 @@ def backfill_seer_grouping_records_for_project(
         logger.info("backfill_seer_grouping_records.killswitch_enabled")
         return
 
-    logger.info(
-        "backfill_seer_grouping_records.task_start",
-        extra={
-            "project_id": current_project_id,
-            "last_processed_group_id": last_processed_group_id_input,
-            "cohort": cohort,
-            "last_processed_project_index": last_processed_project_index_input,
-            "only_delete": only_delete,
-            "skip_processed_projects": skip_processed_projects,
-            "skip_project_ids": skip_project_ids,
-            "worker_number": worker_number,
-        },
-    )
-
     try:
         (
             project,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -109,7 +109,11 @@ def backfill_seer_grouping_records_for_project(
     ):
         logger.info(
             "backfill_seer_grouping_records.killswitch_enabled",
-            extra={"worker_number": worker_number},
+            extra={
+                "project_id": current_project_id,
+                "last_processed_group_id": last_processed_group_id_input,
+                "worker_number": worker_number,
+            },
         )
         return
 

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -87,7 +87,7 @@ def backfill_seer_grouping_records_for_project(
         )
         if not cohort:
             logger.info(
-                "backfill_seer_grouping_records.cohort_finished",
+                "backfill_seer_grouping_records.backfill_finished",
                 extra={
                     "worker_number": worker_number,
                 },
@@ -357,7 +357,7 @@ def call_next_backfill(
 
         if batch_project_id is None and worker_number is None:
             logger.info(
-                "backfill_seer_grouping_records.project_list_end",
+                "backfill_seer_grouping_records.project_list_backfill_finished",
                 extra={
                     "cohort": cohort,
                     "last_processed_project_index": last_processed_project_index,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -372,6 +372,13 @@ def call_next_backfill(
             # we're at the end of the project list
             return
         elif batch_project_id is None:
+            logger.info(
+                "backfill_seer_grouping_records.cohort_finished",
+                extra={
+                    "cohort": cohort,
+                    "worker_number": worker_number,
+                },
+            )
             cohort = None
             last_processed_project_id = project_id
 

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -93,6 +93,14 @@ def backfill_seer_grouping_records_for_project(
                 },
             )
             return
+
+        logger.info(
+            "backfill_seer_grouping_records.cohort_created",
+            extra={
+                "cohort": cohort,
+                "worker_number": worker_number,
+            },
+        )
         current_project_id = cohort[0]
     assert current_project_id is not None
 

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -67,6 +67,20 @@ def backfill_seer_grouping_records_for_project(
     child tasks that will pass the last_processed_group_id
     """
 
+    # This is our first time through
+    if last_processed_project_id is None:
+        logger.info(
+            "backfill_seer_grouping_records.backfill_start",
+            extra={
+                "project_id": current_project_id,
+                "cohort": cohort,
+                "only_delete": only_delete,
+                "skip_processed_projects": skip_processed_projects,
+                "skip_project_ids": skip_project_ids,
+                "worker_number": worker_number,
+            },
+        )
+
     if cohort is None and worker_number is not None:
         cohort = create_project_cohort(
             worker_number, skip_processed_projects, last_processed_project_id
@@ -127,6 +141,7 @@ def backfill_seer_grouping_records_for_project(
             skip_processed_projects=skip_processed_projects,
             skip_project_ids=skip_project_ids,
             worker_number=worker_number,
+            last_processed_project_id=current_project_id,
         )
         return
 
@@ -173,6 +188,7 @@ def backfill_seer_grouping_records_for_project(
             skip_processed_projects=skip_processed_projects,
             skip_project_ids=skip_project_ids,
             worker_number=worker_number,
+            last_processed_project_id=current_project_id,
         )
         return
 
@@ -192,6 +208,7 @@ def backfill_seer_grouping_records_for_project(
             skip_processed_projects=skip_processed_projects,
             skip_project_ids=skip_project_ids,
             worker_number=worker_number,
+            last_processed_project_id=current_project_id,
         )
         return
 
@@ -212,6 +229,7 @@ def backfill_seer_grouping_records_for_project(
             skip_processed_projects=skip_processed_projects,
             skip_project_ids=skip_project_ids,
             worker_number=worker_number,
+            last_processed_project_id=current_project_id,
         )
         return
 
@@ -241,6 +259,7 @@ def backfill_seer_grouping_records_for_project(
             skip_processed_projects=skip_processed_projects,
             skip_project_ids=skip_project_ids,
             worker_number=worker_number,
+            last_processed_project_id=current_project_id,
         )
         return
 
@@ -294,6 +313,7 @@ def backfill_seer_grouping_records_for_project(
         skip_processed_projects=skip_processed_projects,
         skip_project_ids=skip_project_ids,
         worker_number=worker_number,
+        last_processed_project_id=current_project_id,
     )
 
 

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -73,7 +73,7 @@ def backfill_seer_grouping_records_for_project(
         )
         if not cohort:
             logger.info(
-                "reached the end of the projects in cohort",
+                "backfill_seer_grouping_records.cohort_finished",
                 extra={
                     "worker_number": worker_number,
                 },
@@ -89,7 +89,7 @@ def backfill_seer_grouping_records_for_project(
         return
 
     logger.info(
-        "backfill_seer_grouping_records",
+        "backfill_seer_grouping_records.task_start",
         extra={
             "current_project_id": current_project_id,
             "last_processed_group_id": last_processed_group_id_input,
@@ -228,9 +228,7 @@ def backfill_seer_grouping_records_for_project(
             "project_id": project.id,
             "error": e.message,
         }
-        logger.exception(
-            "tasks.backfill_seer_grouping_records.bulk_event_lookup_exception", extra=extra
-        )
+        logger.exception("backfill_seer_grouping_records.bulk_event_lookup_exception", extra=extra)
         group_hashes_dict = {}
 
     if not group_hashes_dict:
@@ -332,7 +330,7 @@ def call_next_backfill(
         # call the backfill on next project
         if not cohort:
             logger.info(
-                "backfill finished, no cohort",
+                "backfill_seer_grouping_records.single_project_backfill_finished",
                 extra={"project_id": project_id},
             )
             return
@@ -345,7 +343,7 @@ def call_next_backfill(
 
         if batch_project_id is None and worker_number is None:
             logger.info(
-                "reached the end of the project list",
+                "backfill_seer_grouping_records.project_list_end",
                 extra={
                     "cohort_name": cohort,
                     "last_processed_project_index": last_processed_project_index,

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -70,7 +70,7 @@ class GroupStacktraceData(TypedDict):
 def filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, project):
     if not snuba_results or not snuba_results[0].get("data"):
         logger.info(
-            "tasks.backfill_seer_grouping_records.results",
+            "backfill_seer_grouping_records.results",
             extra={
                 "project_id": project.id,
                 "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding),
@@ -88,7 +88,7 @@ def filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, pr
             groups_to_backfill_with_no_embedding_has_snuba_row.append(group_id)
         else:
             logger.info(
-                "tasks.backfill_seer_grouping_records.no_snuba_event",
+                "backfill_seer_grouping_records.no_snuba_event",
                 extra={
                     "organization_id": project.organization.id,
                     "project_id": project.id,
@@ -327,7 +327,7 @@ def _make_snuba_call(project, snuba_requests, referrer):
             "error": message,
         }
         logger.exception(
-            "tasks.backfill_seer_grouping_records.snuba_query_limit_exceeded",
+            "backfill_seer_grouping_records.snuba_query_limit_exceeded",
             extra=extra,
         )
         raise
@@ -343,7 +343,7 @@ def get_events_from_nodestore(
     # If nodestore returns no data
     if len(nodestore_events) == 0:
         logger.info(
-            "tasks.backfill_seer_grouping_records.no_data",
+            "backfill_seer_grouping_records.no_data",
             extra={
                 "project_id": project.id,
                 "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding_has_snuba_row),
@@ -551,7 +551,7 @@ def update_groups(project, seer_response, group_id_batch_filtered, group_hashes_
                     delete_seer_grouping_records_by_hash.delay(project.id, [parent_hash])
 
                 logger.exception(
-                    "tasks.backfill_seer_grouping_records.invalid_parent_group",
+                    "backfill_seer_grouping_records.invalid_parent_group",
                     extra={
                         "project_id": project.id,
                         "group_id": group.id,
@@ -664,7 +664,7 @@ def lookup_group_data_stacktrace_bulk(
                             "event_id": event_id,
                         }
                         logger.error(
-                            "tasks.backfill_seer_grouping_records.event_lookup_error", extra=extra
+                            "backfill_seer_grouping_records.event_lookup_error", extra=extra
                         )
                         continue
                     event = Event(event_id=event_id, project_id=project_id, group_id=group_id)

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -336,7 +336,7 @@ def get_events_from_nodestore(
     # If nodestore returns no data
     if len(nodestore_events) == 0:
         logger.info(
-            "backfill_seer_grouping_records.no_data",
+            "backfill_seer_grouping_records.no_nodestore_events",
             extra={
                 "project_id": project.id,
                 "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding_has_snuba_row),

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -133,13 +133,6 @@ def initialize_backfill(
     last_processed_group_id: int | None,
     last_processed_project_index: int | None,
 ):
-    logger.info(
-        "backfill_seer_grouping_records.start",
-        extra={
-            "project_id": project_id,
-            "last_processed_index": last_processed_group_id,
-        },
-    )
     project = Project.objects.get_from_cache(id=project_id)
 
     last_processed_project_index_ret = (

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -70,7 +70,7 @@ class GroupStacktraceData(TypedDict):
 def filter_snuba_results(snuba_results, groups_to_backfill_with_no_embedding, project):
     if not snuba_results or not snuba_results[0].get("data"):
         logger.info(
-            "backfill_seer_grouping_records.results",
+            "backfill_seer_grouping_records.empty_snuba_results",
             extra={
                 "project_id": project.id,
                 "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding),

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -234,7 +234,10 @@ def get_current_batch_groups_from_postgres(
             "backfill_seer_grouping_records.groups_already_had_embedding",
             extra={
                 "project_id": project.id,
-                "num_groups": len(groups_to_backfill_with_no_embedding),
+                "total_batch_groups": len(groups_to_backfill_batch),
+                "groups_with_embedding": (
+                    len(groups_to_backfill_batch) - len(groups_to_backfill_with_no_embedding)
+                ),
                 "worker_number": worker_number,
             },
         )


### PR DESCRIPTION
This makes a number of improvements to the logging we do during the Seer backfill, in hopes of making debugging problems with it easier.

- Standardize the name of all log events to `backfill_seer_grouping_records.xxxxx`.
- Clarify/correct the names of various log events.
- Add a log when the backfill starts, with all of the parameters passed to it. (This required passing `last_processed_project_id` in a few places where we hadn't been.) Remove config parameters (`only_delete`, `skip_processed_projects`, and `skip_project_ids`) from other logs.
- Add logs for cohort creation and cohort processing end.
- Remove the `backfill_seer_grouping_records` and `backfill_seer_grouping_records.start` logs, as they always log in tandem with the `backfill_seer_grouping_records.batch` log.
- Standardize/clarify various field names in `extra`.
- Add to/improve data in `extra`, including always sending `worker_number`.