### PR TITLE
feat(dashboards): Use new assignee selector w/ issues

### DIFF
--- a/static/app/utils/dashboards/issueAssignee.tsx
+++ b/static/app/utils/dashboards/issueAssignee.tsx
@@ -1,58 +1,37 @@
-import styled from '@emotion/styled';
-
-import ActorAvatar from 'sentry/components/avatar/actorAvatar';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconUser} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {
+  AssigneeSelector,
+  useHandleAssigneeChange,
+} from 'sentry/components/group/assigneeSelector';
 import GroupStore from 'sentry/stores/groupStore';
+import MemberListStore from 'sentry/stores/memberListStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {Group} from 'sentry/types/group';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface IssueAssigneeProps {
   groupId: string;
 }
 
 export function IssueAssignee({groupId}: IssueAssigneeProps) {
+  const organization = useOrganization();
   const groups = useLegacyStore(GroupStore);
-  const group = groups.find(item => item.id === groupId);
-  const assignedTo = group?.assignedTo;
+  const group = groups.find(item => item.id === groupId) as Group | undefined;
+  const memberListState = useLegacyStore(MemberListStore);
+  const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
+    group: group!,
+    organization,
+  });
 
-  if (assignedTo) {
-    return (
-      <ActorContainer>
-        <ActorAvatar
-          actor={assignedTo}
-          className="avatar"
-          size={22}
-          tooltip={t(
-            'Assigned to %s',
-            assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name
-          )}
-        />
-      </ActorContainer>
-    );
+  if (!group) {
+    return null;
   }
 
   return (
-    <UnassignedContainer>
-      <Tooltip isHoverable skipWrapper title={t('Unassigned')}>
-        <IconUser size="md" color="gray400" aria-label={t('Unassigned')} />
-      </Tooltip>
-    </UnassignedContainer>
+    <AssigneeSelector
+      group={group}
+      memberList={memberListState.members}
+      assigneeLoading={assigneeLoading}
+      handleAssigneeChange={handleAssigneeChange}
+    />
   );
 }
-
-const ActorContainer = styled('div')`
-  display: flex;
-  justify-content: left;
-  padding-left: 18px;
-  align-items: center;
-  height: 22px;
-`;
-
-const UnassignedContainer = styled('div')`
-  display: flex;
-  justify-content: left;
-  padding-left: 20px;
-  align-items: center;
-  height: 22px;
-`;


### PR DESCRIPTION
in https://github.com/getsentry/sentry/pull/83686 I removed the assignee functionality and deleted the deprecated assignee selector.

This adds back the ability to assign issues with the new assignee selector.

It does attempt to fit within the scrolling container

![image](https://github.com/user-attachments/assets/e44acd61-db45-42ce-b03c-ed03bf327130)
