### PR TITLE
ref(routes): Move issue list and details routes into same route tree

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -27,8 +27,8 @@ import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 import {GroupEventDetailsLoading} from 'sentry/views/issueDetails/groupEventDetails/groupEventDetailsLoading';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
-import IssueListContainer from 'sentry/views/issueList';
 import {OverviewWrapper} from 'sentry/views/issueList/overviewWrapper';
+import {IssuesWrapper} from 'sentry/views/issues/issuesWrapper';
 import OrganizationContainer from 'sentry/views/organizationContainer';
 import OrganizationLayout from 'sentry/views/organizationLayout';
 import OrganizationRoot from 'sentry/views/organizationRoot';
@@ -1929,120 +1929,78 @@ function buildRoutes() {
     </Route>
   );
 
-  const issueListRoutes = (
-    <Route path="/issues" component={errorHandler(IssueListContainer)} withOrgPath>
-      <IndexRoute component={errorHandler(OverviewWrapper)} />
-      <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
-      {traceViewRoute}
-    </Route>
-  );
-
-  // Once org issues is complete, these routes can be nested under
-  // /organizations/:orgId/issues
-  const issueTabs = ({forCustomerDomain}: {forCustomerDomain: boolean}) => {
-    const hoc = forCustomerDomain ? withDomainRequired : (x: any) => x;
-    return (
-      <Fragment>
-        <IndexRoute
-          component={hoc(
-            make(
-              () =>
-                import('sentry/views/issueDetails/groupEventDetails/groupEventDetails'),
-              <GroupEventDetailsLoading />
-            )
-          )}
-        />
-        <Route
-          path={TabPaths[Tab.REPLAYS]}
-          component={hoc(make(() => import('sentry/views/issueDetails/groupReplays')))}
-        />
-        <Route
-          path={TabPaths[Tab.ACTIVITY]}
-          component={hoc(make(() => import('sentry/views/issueDetails/groupActivity')))}
-        />
-        <Route
-          path={TabPaths[Tab.EVENTS]}
-          component={hoc(make(() => import('sentry/views/issueDetails/groupEvents')))}
-        />
-        <Route
-          path={TabPaths[Tab.OPEN_PERIODS]}
-          component={hoc(
-            make(() => import('sentry/views/issueDetails/groupOpenPeriods'))
-          )}
-        />
-        <Route
-          path={TabPaths[Tab.TAGS]}
-          component={hoc(
-            make(() => import('sentry/views/issueDetails/groupTags/groupTagsTab'))
-          )}
-        />
-        <Route
-          path={`${TabPaths[Tab.TAGS]}:tagKey/`}
-          component={make(() => import('sentry/views/issueDetails/groupTagValues'))}
-        />
-        <Route
-          path={TabPaths[Tab.USER_FEEDBACK]}
-          component={hoc(
-            make(() => import('sentry/views/issueDetails/groupUserFeedback'))
-          )}
-        />
-        <Route
-          path={TabPaths[Tab.ATTACHMENTS]}
-          component={hoc(
-            make(() => import('sentry/views/issueDetails/groupEventAttachments'))
-          )}
-        />
-        <Route
-          path={TabPaths[Tab.SIMILAR_ISSUES]}
-          component={hoc(
-            make(
-              () =>
-                import(
-                  'sentry/views/issueDetails/groupSimilarIssues/groupSimilarIssuesTab'
-                )
-            )
-          )}
-        />
-        <Route
-          path={TabPaths[Tab.MERGED]}
-          component={hoc(
-            make(() => import('sentry/views/issueDetails/groupMerged/groupMergedTab'))
-          )}
-        />
-      </Fragment>
-    );
-  };
-  const issueDetailsChildRoutes = ({forCustomerDomain}: {forCustomerDomain: boolean}) => (
+  const issueTabs = (
     <Fragment>
-      {issueTabs({forCustomerDomain})}
-      <Route path={`${TabPaths[Tab.EVENTS]}:eventId/`}>
-        {issueTabs({forCustomerDomain})}
-      </Route>
+      <IndexRoute
+        component={make(
+          () => import('sentry/views/issueDetails/groupEventDetails/groupEventDetails'),
+          <GroupEventDetailsLoading />
+        )}
+      />
+      <Route
+        path={TabPaths[Tab.REPLAYS]}
+        component={make(() => import('sentry/views/issueDetails/groupReplays'))}
+      />
+      <Route
+        path={TabPaths[Tab.ACTIVITY]}
+        component={make(() => import('sentry/views/issueDetails/groupActivity'))}
+      />
+      <Route
+        path={TabPaths[Tab.EVENTS]}
+        component={make(() => import('sentry/views/issueDetails/groupEvents'))}
+      />
+      <Route
+        path={TabPaths[Tab.OPEN_PERIODS]}
+        component={make(() => import('sentry/views/issueDetails/groupOpenPeriods'))}
+      />
+      <Route
+        path={TabPaths[Tab.TAGS]}
+        component={make(() => import('sentry/views/issueDetails/groupTags/groupTagsTab'))}
+      />
+      <Route
+        path={`${TabPaths[Tab.TAGS]}:tagKey/`}
+        component={make(() => import('sentry/views/issueDetails/groupTagValues'))}
+      />
+      <Route
+        path={TabPaths[Tab.USER_FEEDBACK]}
+        component={make(() => import('sentry/views/issueDetails/groupUserFeedback'))}
+      />
+      <Route
+        path={TabPaths[Tab.ATTACHMENTS]}
+        component={make(() => import('sentry/views/issueDetails/groupEventAttachments'))}
+      />
+      <Route
+        path={TabPaths[Tab.SIMILAR_ISSUES]}
+        component={make(
+          () =>
+            import('sentry/views/issueDetails/groupSimilarIssues/groupSimilarIssuesTab')
+        )}
+      />
+      <Route
+        path={TabPaths[Tab.MERGED]}
+        component={make(
+          () => import('sentry/views/issueDetails/groupMerged/groupMergedTab')
+        )}
+      />
     </Fragment>
   );
-  const issueDetailsRoutes = (
-    <Fragment>
+
+  const issueRoutes = (
+    <Route path="/issues" component={errorHandler(IssuesWrapper)} withOrgPath>
+      <IndexRoute component={errorHandler(OverviewWrapper)} />
+      <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
       <Route
-        path="/organizations/:orgId/issues/:groupId/"
+        path=":groupId/"
         component={withDomainRedirect(
           make(() => import('sentry/views/issueDetails/groupDetails'))
         )}
         key="org-issues-group-id"
       >
-        {issueDetailsChildRoutes({forCustomerDomain: false})}
+        {issueTabs}
+        <Route path={`${TabPaths[Tab.EVENTS]}:eventId/`}>{issueTabs}</Route>
       </Route>
-      {USING_CUSTOMER_DOMAIN && (
-        <Route
-          path="/issues/:groupId/"
-          component={withDomainRequired(
-            make(() => import('sentry/views/issueDetails/groupDetails'))
-          )}
-          key="orgless-issues-group-id-route"
-        >
-          {issueDetailsChildRoutes({forCustomerDomain: true})}
-        </Route>
-      )}
-    </Fragment>
+      {traceViewRoute}
+    </Route>
   );
 
   // These are the "manage" pages. For sentry.io, these are _different_ from
@@ -2320,8 +2278,7 @@ function buildRoutes() {
       {dashboardRoutes}
       {userFeedbackRoutes}
       {feedbackv2Routes}
-      {issueListRoutes}
-      {issueDetailsRoutes}
+      {issueRoutes}
       {alertRoutes}
       {cronsRoutes}
       {replayRoutes}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1991,9 +1991,7 @@ function buildRoutes() {
       <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
       <Route
         path=":groupId/"
-        component={withDomainRedirect(
-          make(() => import('sentry/views/issueDetails/groupDetails'))
-        )}
+        component={make(() => import('sentry/views/issueDetails/groupDetails'))}
         key="org-issues-group-id"
       >
         {issueTabs}

--- a/static/app/views/issueList/overviewWrapper.tsx
+++ b/static/app/views/issueList/overviewWrapper.tsx
@@ -1,5 +1,6 @@
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
+import IssueListContainer from 'sentry/views/issueList';
 import IssueListOverview from 'sentry/views/issueList/overview';
 import IssueListOverviewFc from 'sentry/views/issueList/overviewFc';
 
@@ -11,8 +12,16 @@ export function OverviewWrapper(props: OverviewWrapperProps) {
   const organization = useOrganization();
 
   if (organization.features.includes('issue-stream-functional-refactor')) {
-    return <IssueListOverviewFc {...props} />;
+    return (
+      <IssueListContainer>
+        <IssueListOverviewFc {...props} />
+      </IssueListContainer>
+    );
   }
 
-  return <IssueListOverview {...props} />;
+  return (
+    <IssueListContainer>
+      <IssueListOverview {...props} />
+    </IssueListContainer>
+  );
 }

--- a/static/app/views/issues/issuesWrapper.tsx
+++ b/static/app/views/issues/issuesWrapper.tsx
@@ -1,0 +1,10 @@
+import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+
+interface IssuesWrapperProps extends RouteComponentProps<{}, {}> {
+  children: React.ReactNode;
+}
+
+// TODO(malwilley): Add navigation to the issues module here
+export function IssuesWrapper({children}: IssuesWrapperProps) {
+  return children;
+}


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

I wanted to add navigation components that would show up on both issues stream and details, but currently issue details is not a child of the `/issues` route which means I'd have to render it in two places.

I moved the issue details routes so that it is a child of the `/issues` `Route`, which was relatively simple. The one thing I'm a bit worried about is that I removed the customer domain logic. I _believe_ this is okay because the `/issues` route has the prop `withOrgPath` which adds the `/organizations/:orgSlug` path as well. Here's an example of this being done before: https://github.com/getsentry/sentry/pull/66747