### PR TITLE
chore: Remove Sentry SDK metric calls

### DIFF
--- a/static/app/components/replays/canvasReplayerPlugin.tsx
+++ b/static/app/components/replays/canvasReplayerPlugin.tsx
@@ -275,8 +275,6 @@ export function CanvasReplayerPlugin(events: eventWithTime[]): ReplayPlugin {
       errorHandler: (err: unknown) => {
         if (err instanceof Error) {
           Sentry.captureException(err);
-        } else {
-          Sentry.metrics.increment('replay.canvas_player.error_canvas_mutation');
         }
       },
     });
@@ -358,7 +356,6 @@ export function CanvasReplayerPlugin(events: eventWithTime[]): ReplayPlugin {
 function handleProcessEventError(err: unknown) {
   if (err instanceof InvalidCanvasNodeError) {
     // This can throw if mirror DOM is not ready
-    Sentry.metrics.increment('replay.canvas_player.no_canvas_id');
     return;
   }
 

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -14,7 +14,7 @@ interface Props {
   className?: string;
 }
 
-export default function ReplayProcessingError({className, processingErrors}: Props) {
+export default function ReplayProcessingError({className}: Props) {
   const {replay} = useReplayContext();
   const {sdk} = replay?.getReplay() || {};
 
@@ -25,20 +25,8 @@ export default function ReplayProcessingError({className, processingErrors}: Pro
       if (sdk) {
         scope.setTag('sdk.version', sdk.version);
       }
-      processingErrors.forEach(error => {
-        Sentry.metrics.increment(`replay.processing-error`, 1, {
-          tags: {
-            'sdk.version': sdk?.version ?? 'unknown',
-            // There are only 2 different error types
-            type:
-              error.toLowerCase() === 'missing meta frame'
-                ? 'missing-meta-frame'
-                : 'insufficient-replay-frames',
-          },
-        });
-      });
     });
-  }, [processingErrors, sdk]);
+  }, [sdk]);
 
   return (
     <StyledAlert type="error" showIcon className={className}>

--- a/static/app/utils/metrics/useIncrementQueryMetric.tsx
+++ b/static/app/utils/metrics/useIncrementQueryMetric.tsx
@@ -28,9 +28,6 @@ export const useIncrementQueryMetric = (options: Options) => {
         isGrouped: !!mergedValues.groupBy?.length,
         isFiltered: !!mergedValues.query,
       };
-      Sentry.metrics.increment(metricName, 1, {
-        tags,
-      });
 
       const span = Sentry.getActiveSpan();
       if (span) {

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -605,28 +605,6 @@ function isINPEntity(entry: PerformanceEntry): entry is INPPerformanceEntry {
   return entry.entryType === 'first-input';
 }
 
-function getNearestElementName(node: HTMLElement | undefined | null): string | undefined {
-  if (!node) {
-    return 'no-element';
-  }
-
-  let current: HTMLElement | null = node;
-  while (current && current !== document.body) {
-    const elementName =
-      current.dataset?.testId ??
-      current.dataset?.sentryComponent ??
-      current.dataset?.element;
-
-    if (elementName) {
-      return elementName;
-    }
-
-    current = current.parentElement;
-  }
-
-  return `${node.tagName.toLowerCase()}.${node.className ?? ''}`;
-}
-
 export function makeIssuesINPObserver(): PerformanceObserver | undefined {
   if (!supportsINP()) {
     return undefined;
@@ -643,15 +621,6 @@ export function makeIssuesINPObserver(): PerformanceObserver | undefined {
         if (entry.duration < 16) {
           return;
         }
-
-        Sentry.metrics.distribution('issues-stream.inp', entry.duration, {
-          unit: 'millisecond',
-          tags: {
-            element: getNearestElementName(entry.target),
-            entryType: entry.entryType,
-            interaction: entry.name,
-          },
-        });
       }
     });
   });

--- a/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
+++ b/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import * as Sentry from '@sentry/react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
@@ -58,30 +57,6 @@ function useLogReplayDataLoaded({fetchError, fetching, projectSlug, replay}: Pro
         num_errors: hydrationErrorFrames.length,
         replay_id: replayRecord.id,
       });
-    }
-
-    const metricData = {
-      unit: 'millisecond',
-      tags: {
-        // This is a boolean to reduce cardinality -- technically this can
-        // match 7.8.x, but replay wasn't released in that version, so this should be fine
-        recentSdkVersion: replayRecord.sdk.version?.startsWith('7.8') ?? false,
-      },
-    };
-
-    if (replay.timestampDeltas.startedAtDelta !== 0) {
-      Sentry.metrics.distribution(
-        'replay.start-time-delta',
-        replay.timestampDeltas.startedAtDelta,
-        metricData
-      );
-    }
-    if (replay.timestampDeltas.finishedAtDelta !== 0) {
-      Sentry.metrics.distribution(
-        'replay.end-time-delta',
-        replay.timestampDeltas.finishedAtDelta,
-        metricData
-      );
     }
   }, [organization, project, fetchError, fetching, projectSlug, replay]);
 }

--- a/static/app/views/insights/browser/resources/components/sampleImages.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.tsx
@@ -208,15 +208,6 @@ function ImageContainer(props: {
 
   const handleError = () => {
     setHasError(true);
-    Sentry.metrics.increment('performance.resource.image_load', 1, {
-      tags: {status: 'error'},
-    });
-  };
-
-  const handleLoad = () => {
-    Sentry.metrics.increment('performance.resource.image_load', 1, {
-      tags: {status: 'success'},
-    });
   };
 
   return (
@@ -231,7 +222,6 @@ function ImageContainer(props: {
           <img
             data-test-id="sample-image"
             onError={handleError}
-            onLoad={handleLoad}
             src={src}
             style={{
               width: '100%',

--- a/static/app/views/metrics/context.tsx
+++ b/static/app/views/metrics/context.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useState,
 } from 'react';
-import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
 import type {FocusAreaSelection} from 'sentry/components/metrics/chart/types';
@@ -316,10 +315,8 @@ export function MetricsContextProvider({children}: {children: React.ReactNode}) 
   const handleAddFocusArea = useCallback(
     (area: FocusAreaSelection) => {
       if (!area.range.start || !area.range.end) {
-        Sentry.metrics.increment('ddm.enhance.range-undefined');
         return;
       }
-      Sentry.metrics.increment('ddm.enhance.add');
       handleSetSelectedWidgetIndex(area.widgetIndex);
       updateQuery({focusArea: JSON.stringify(area)}, {replace: true});
     },
@@ -327,7 +324,6 @@ export function MetricsContextProvider({children}: {children: React.ReactNode}) 
   );
 
   const handleRemoveFocusArea = useCallback(() => {
-    Sentry.metrics.increment('ddm.enhance.remove');
     updateQuery({focusArea: undefined}, {replace: true});
   }, [updateQuery]);
 

--- a/static/app/views/metrics/layout.tsx
+++ b/static/app/views/metrics/layout.tsx
@@ -1,6 +1,5 @@
 import {Fragment, memo, useCallback} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import emptyStateImg from 'sentry-images/spot/custom-metrics-empty-state.svg';
 
@@ -71,11 +70,6 @@ export const MetricsLayout = memo(() => {
 
   const addCustomMetric = useCallback(
     (referrer: 'header' | 'onboarding_panel' | 'banner') => {
-      Sentry.metrics.increment('ddm.add_custom_metric', 1, {
-        tags: {
-          referrer,
-        },
-      });
       trackAnalytics('ddm.open-onboarding', {
         organization,
         source: referrer,
@@ -86,7 +80,6 @@ export const MetricsLayout = memo(() => {
   );
 
   const viewPerformanceMetrics = useCallback(() => {
-    Sentry.metrics.increment('ddm.view_performance_metrics', 1);
     trackAnalytics('ddm.view_performance_metrics', {
       organization,
     });

--- a/static/app/views/metrics/metricFormulaContextMenu.tsx
+++ b/static/app/views/metrics/metricFormulaContextMenu.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import Feature from 'sentry/components/acl/feature';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
@@ -46,7 +45,6 @@ export function MetricFormulaContextMenu({
           trackAnalytics('ddm.widget.duplicate', {
             organization,
           });
-          Sentry.metrics.increment('ddm.widget.duplicate');
           duplicateWidget(widgetIndex);
         },
       },
@@ -75,7 +73,6 @@ export function MetricFormulaContextMenu({
             organization,
             source: 'widget',
           });
-          Sentry.metrics.increment('ddm.widget.dashboard');
           createDashboardWidget?.();
         },
       },
@@ -85,7 +82,6 @@ export function MetricFormulaContextMenu({
         label: t('Remove Equation'),
         disabled: !canDelete,
         onAction: () => {
-          Sentry.metrics.increment('ddm.widget.delete');
           removeWidget(widgetIndex);
         },
       },

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import * as Sentry from '@sentry/react';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import {navigateTo} from 'sentry/actionCreators/navigation';
@@ -76,7 +75,6 @@ export function MetricQueryContextMenu({
         trackAnalytics('ddm.widget.duplicate', {
           organization,
         });
-        Sentry.metrics.increment('ddm.widget.duplicate');
         duplicateWidget(widgetIndex);
       },
     };
@@ -91,7 +89,6 @@ export function MetricQueryContextMenu({
           organization,
           source: 'widget',
         });
-        Sentry.metrics.increment('ddm.widget.alert');
         createAlert?.();
       },
     };
@@ -130,7 +127,6 @@ export function MetricQueryContextMenu({
           organization,
           source: 'widget',
         });
-        Sentry.metrics.increment('ddm.widget.dashboard');
         createDashboardWidget?.();
       },
     };
@@ -144,7 +140,6 @@ export function MetricQueryContextMenu({
         trackAnalytics('ddm.widget.settings', {
           organization,
         });
-        Sentry.metrics.increment('ddm.widget.settings');
 
         if (!isVirtualMetric(metricsQuery)) {
           navigateTo(
@@ -166,7 +161,6 @@ export function MetricQueryContextMenu({
         trackAnalytics('ddm.widget.delete', {
           organization,
         });
-        Sentry.metrics.increment('ddm.widget.delete');
         removeWidget(widgetIndex);
       },
     };

--- a/static/app/views/metrics/metrics.tsx
+++ b/static/app/views/metrics/metrics.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import * as Sentry from '@sentry/react';
 
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -25,7 +24,6 @@ function Metrics() {
     trackAnalytics('ddm.page-view', {
       organization,
     });
-    Sentry.metrics.increment('ddm.visit');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
 import Feature from 'sentry/components/acl/feature';
@@ -51,13 +50,11 @@ export function PageHeaderActions({showAddMetricButton, addCustomMetric}: Props)
 
   const handleToggleDefaultQuery = useCallback(() => {
     if (isDefaultQuery) {
-      Sentry.metrics.increment('ddm.remove-default-query');
       trackAnalytics('ddm.remove-default-query', {
         organization,
       });
       setDefaultQuery(null);
     } else {
-      Sentry.metrics.increment('ddm.set-default-query');
       trackAnalytics('ddm.set-default-query', {
         organization,
       });

--- a/static/app/views/metrics/shareButton.tsx
+++ b/static/app/views/metrics/shareButton.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/react';
-
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import TextCopyInput from 'sentry/components/textCopyInput';
@@ -29,7 +27,6 @@ function ShareButton() {
       size="sm"
       icon={<IconUpload size="sm" />}
       onClick={() => {
-        Sentry.metrics.increment('ddm.share');
         openModal(deps => <ShareModal {...deps} />);
       }}
     >

--- a/static/app/views/metrics/summaryTable.tsx
+++ b/static/app/views/metrics/summaryTable.tsx
@@ -1,6 +1,5 @@
 import {Fragment, memo, useCallback} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import colorFn from 'color';
 
 import {Button, LinkButton} from 'sentry/components/button';
@@ -61,12 +60,6 @@ export const SummaryTable = memo(function SummaryTable({
         organization,
         by: name ?? '(none)',
         order: sort.order,
-      });
-      Sentry.metrics.increment('ddm.widget.sort', 1, {
-        tags: {
-          by: name ?? '(none)',
-          order: sort.order,
-        },
       });
       if (sort.name === name) {
         if (sort.order === 'desc') {

--- a/static/app/views/metrics/widget.tsx
+++ b/static/app/views/metrics/widget.tsx
@@ -1,6 +1,5 @@
 import {Fragment, memo, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import type {SeriesOption} from 'echarts';
 import moment from 'moment-timezone';
 
@@ -163,7 +162,6 @@ export const MetricWidget = memo(
     );
 
     const handleDisplayTypeChange = ({value}: SelectOption<MetricDisplayType>) => {
-      Sentry.metrics.increment('ddm.widget.display');
       onChange(index, {displayType: value});
     };
 
@@ -171,13 +169,6 @@ export const MetricWidget = memo(
       options: Array<SelectOption<MetricChartOverlayType>>
     ) => {
       const values = options.map(({value}) => value);
-
-      Sentry.metrics.increment('ddm.widget.overlay', 1, {
-        tags: {
-          releases: values.includes(MetricChartOverlayType.RELEASES),
-          samples: values.includes(MetricChartOverlayType.SAMPLES),
-        },
-      });
 
       onChange(index, {overlays: values});
     };
@@ -407,7 +398,6 @@ const MetricWidgetBody = memo(
 
     const handleZoom = useCallback(
       (range: DateTimeObject) => {
-        Sentry.metrics.increment('ddm.enhance.zoom');
         updateDateTime(range, router, {save: true});
       },
       [router]

--- a/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
@@ -13,8 +13,6 @@ const trackTraceMetadata = (
   organization: Organization,
   hasExceededPerformanceUsageLimit: boolean | null
 ) => {
-  Sentry.metrics.increment(`trace.trace_shape.${tree.shape}`);
-
   // space[1] represents the node duration (in milliseconds)
   const trace_duration_seconds = (tree.root.space?.[1] ?? 0) / 1000;
   const projectSlugs = [
@@ -41,11 +39,6 @@ const trackTraceMetadata = (
     organization,
   });
 };
-
-const trackFailedToFetchTraceState = () =>
-  Sentry.metrics.increment('trace.failed_to_fetch_trace');
-
-const trackEmptyTraceState = () => Sentry.metrics.increment('trace.empty_trace');
 
 const trackLayoutChange = (layout: string, organization: Organization) =>
   trackAnalytics('trace.trace_layout.change', {
@@ -207,8 +200,6 @@ const traceAnalytics = {
   // Trace shape
   trackTraceMetadata,
   trackTraceShape,
-  trackEmptyTraceState,
-  trackFailedToFetchTraceState,
   // Drawer actions
   trackShowInView,
   trackViewEventJSON,

--- a/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallState.tsx
@@ -1,10 +1,9 @@
-import {useEffect, useRef} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 
 function TraceLoading() {
   return (
@@ -20,10 +19,6 @@ function TraceLoading() {
 function TraceError() {
   const linkref = useRef<HTMLAnchorElement>(null);
   const feedback = useFeedbackWidget({buttonRef: linkref});
-
-  useEffect(() => {
-    traceAnalytics.trackFailedToFetchTraceState();
-  }, []);
 
   return (
     <LoadingContainer animate error>
@@ -47,10 +42,6 @@ function TraceError() {
 function TraceEmpty() {
   const linkref = useRef<HTMLAnchorElement>(null);
   const feedback = useFeedbackWidget({buttonRef: linkref});
-
-  useEffect(() => {
-    traceAnalytics.trackEmptyTraceState();
-  }, []);
 
   return (
     <LoadingContainer animate>

--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import * as Sentry from '@sentry/react';
 
 import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -34,11 +33,6 @@ function ProjectMetrics({project, organization}: Props) {
           <Button
             priority="primary"
             onClick={() => {
-              Sentry.metrics.increment('ddm.add_custom_metric', 1, {
-                tags: {
-                  referrer: 'settings',
-                },
-              });
               activateSidebar();
             }}
             size="sm"


### PR DESCRIPTION
In preparation for upgrading to Sentry SDK v9, we need to remove calls to the old Sentry Metrics SDK.