### PR TITLE
chore: Remove _browserPerformanceTimeOriginMode

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line simple-import-sort/imports
 import * as Sentry from '@sentry/react';
-import {type Event, _browserPerformanceTimeOriginMode} from '@sentry/core';
+import type {Event} from '@sentry/core';
 
 import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import type {Config} from 'sentry/types/system';
@@ -234,7 +234,6 @@ export function initializeSdk(config: Config) {
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations
   Sentry.addEventProcessor((event: Sentry.Event, _hint?: Sentry.EventHint) => {
     event.tags = event.tags || {};
-    event.tags['timeOrigin.mode'] = _browserPerformanceTimeOriginMode;
     return event;
   });
 

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -2,11 +2,7 @@ import type {ProfilerOnRenderCallback, ReactNode} from 'react';
 import {Fragment, Profiler, useEffect, useRef} from 'react';
 import type {MeasurementUnit, Span, TransactionEvent} from '@sentry/core';
 import * as Sentry from '@sentry/react';
-import {
-  _browserPerformanceTimeOriginMode,
-  browserPerformanceTimeOrigin,
-  timestampInSeconds,
-} from '@sentry/utils';
+import {browserPerformanceTimeOrigin, timestampInSeconds} from '@sentry/utils';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import usePrevious from 'sentry/utils/usePrevious';


### PR DESCRIPTION
In preparation for upgrading to Sentry SDK v9, we need to remove `_browserPerformanceTimeOriginMode` as it's deprecated.