### PR TITLE
feat(explore): Add save as button analytics

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -98,6 +98,9 @@ export type TracingEventParameters = {
     source: 'trace explorer' | 'new explore';
   };
   'trace_explorer.remove_span_condition': {};
+  'trace_explorer.save_as': {
+    save_type: 'alert' | 'dashboard';
+  };
   'trace_explorer.search_failure': {
     error: string;
     queries: string[];
@@ -166,4 +169,5 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace.preferences.autogrouping_change': 'Changed Autogrouping Preference',
   'trace.preferences.missing_instrumentation_change':
     'Changed Missing Instrumentation Preference',
+  'trace_explorer.save_as': 'Trace Explorer: Save As',
 };

--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -100,6 +100,7 @@ export type TracingEventParameters = {
   'trace_explorer.remove_span_condition': {};
   'trace_explorer.save_as': {
     save_type: 'alert' | 'dashboard';
+    ui_source: 'toolbar' | 'chart';
   };
   'trace_explorer.search_failure': {
     error: string;

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -4,6 +4,7 @@ import Feature from 'sentry/components/acl/feature';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -45,6 +46,14 @@ function ChartContextMenu({
       dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
       interval,
     }),
+    onAction: () => {
+      trackAnalytics('trace_explorer.save_as', {
+        save_type: 'alert',
+        ui_source: 'chart',
+        organization,
+      });
+      return undefined;
+    },
   }));
 
   const items: MenuItemProps[] = [];
@@ -74,7 +83,17 @@ function ChartContextMenu({
         </Feature>
       ),
       disabled: disableAddToDashboard,
-      onAction: !disableAddToDashboard ? () => addToDashboard(visualizeIndex) : undefined,
+      onAction: () => {
+        if (disableAddToDashboard) {
+          return undefined;
+        }
+        trackAnalytics('trace_explorer.save_as', {
+          save_type: 'dashboard',
+          ui_source: 'chart',
+          organization,
+        });
+        return addToDashboard(visualizeIndex);
+      },
     });
   }
 

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -53,6 +53,7 @@ export function ToolbarSaveAs() {
     onAction: () => {
       trackAnalytics('trace_explorer.save_as', {
         save_type: 'alert',
+        ui_source: 'toolbar',
         organization,
       });
     },
@@ -90,6 +91,7 @@ export function ToolbarSaveAs() {
 
           trackAnalytics('trace_explorer.save_as', {
             save_type: 'dashboard',
+            ui_source: 'toolbar',
             organization,
           });
           return addToDashboard(index);
@@ -118,6 +120,7 @@ export function ToolbarSaveAs() {
 
         trackAnalytics('trace_explorer.save_as', {
           save_type: 'dashboard',
+          ui_source: 'toolbar',
           organization,
         });
         return addToDashboard(0);

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -4,6 +4,7 @@ import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -49,6 +50,12 @@ export function ToolbarSaveAs() {
       dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
       interval,
     }),
+    onAction: () => {
+      trackAnalytics('trace_explorer.save_as', {
+        save_type: 'alert',
+        organization,
+      });
+    },
   }));
 
   const items: MenuItemProps[] = [];
@@ -76,7 +83,17 @@ export function ToolbarSaveAs() {
       return {
         key: chart.label,
         label: t('%s - %s', chart.label, formattedYAxes.filter(Boolean).join(', ')),
-        onAction: !disableAddToDashboard ? () => addToDashboard(index) : undefined,
+        onAction: () => {
+          if (disableAddToDashboard) {
+            return undefined;
+          }
+
+          trackAnalytics('trace_explorer.save_as', {
+            save_type: 'dashboard',
+            organization,
+          });
+          return addToDashboard(index);
+        },
       };
     });
     items.push({
@@ -94,10 +111,17 @@ export function ToolbarSaveAs() {
       ),
       disabled: disableAddToDashboard,
       children: chartOptions.length > 1 ? chartOptions : undefined,
-      onAction:
-        !disableAddToDashboard && chartOptions.length
-          ? () => addToDashboard(0)
-          : undefined, // This is hardcoding
+      onAction: () => {
+        if (disableAddToDashboard || chartOptions.length > 1) {
+          return undefined;
+        }
+
+        trackAnalytics('trace_explorer.save_as', {
+          save_type: 'dashboard',
+          organization,
+        });
+        return addToDashboard(0);
+      },
     });
   }
 


### PR DESCRIPTION
Adds a click event for saving as an alert or a dashboard. It just emits a click event and which type of entity for saving (i.e. 'alert' or 'dashboard')