### PR TITLE
chore(issue-details): Darken background in tag preview hover

### DIFF
--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -337,7 +337,7 @@ const TagPreviewGrid = styled(Link)`
   font-size: ${p => p.theme.fontSizeSmall};
 
   &:hover {
-    background: ${p => p.theme.backgroundSecondary};
+    background: ${p => p.theme.backgroundTertiary};
     color: ${p => p.theme.textColor};
   }
 `;


### PR DESCRIPTION
before:
![Screenshot 2025-01-27 at 2 42 42 PM](https://github.com/user-attachments/assets/15f0a349-6965-42a8-9a82-438fc44ec585)

after: 
![Screenshot 2025-01-27 at 2 42 46 PM](https://github.com/user-attachments/assets/b38c3597-0ff4-42fe-a190-d29fdf0f067a)
