### PR TITLE
feat(nav): Implement new secondary nav in insights

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1794,7 +1794,11 @@ function buildRoutes() {
   );
 
   const domainViewRoutes = (
-    <Route path={`/${DOMAIN_VIEW_BASE_URL}/`} withOrgPath>
+    <Route
+      path={`/${DOMAIN_VIEW_BASE_URL}/`}
+      withOrgPath
+      component={make(() => import('sentry/views/insights/navigation'))}
+    >
       <Route path={`${FRONTEND_LANDING_SUB_PATH}/`}>
         <IndexRoute
           component={make(

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -1,0 +1,66 @@
+import {Fragment} from 'react';
+
+import {SecondaryNav} from 'sentry/components/nav/secondary';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  AI_LANDING_SUB_PATH,
+  AI_SIDEBAR_LABEL,
+} from 'sentry/views/insights/pages/ai/settings';
+import {
+  BACKEND_LANDING_SUB_PATH,
+  BACKEND_SIDEBAR_LABEL,
+} from 'sentry/views/insights/pages/backend/settings';
+import {
+  FRONTEND_LANDING_SUB_PATH,
+  FRONTEND_SIDEBAR_LABEL,
+} from 'sentry/views/insights/pages/frontend/settings';
+import {
+  MOBILE_LANDING_SUB_PATH,
+  MOBILE_SIDEBAR_LABEL,
+} from 'sentry/views/insights/pages/mobile/settings';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
+
+type InsightsNavigationProps = {
+  children: React.ReactNode;
+};
+
+export default function InsightsNavigation({children}: InsightsNavigationProps) {
+  const organization = useOrganization();
+  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+  if (!hasNavigationV2) {
+    return children;
+  }
+
+  const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
+
+  return (
+    <Fragment>
+      <SecondaryNav>
+        <SecondaryNav.Body>
+          <SecondaryNav.Section>
+            {/* TODO(malwilley): Move projects to the /insights/projects/ route */}
+            <SecondaryNav.Item to={`/organizations/${organization.slug}/projects/`}>
+              All Projects
+            </SecondaryNav.Item>
+          </SecondaryNav.Section>
+          <SecondaryNav.Section>
+            <SecondaryNav.Item to={`${baseUrl}/${FRONTEND_LANDING_SUB_PATH}/`}>
+              {FRONTEND_SIDEBAR_LABEL}
+            </SecondaryNav.Item>
+            <SecondaryNav.Item to={`${baseUrl}/${BACKEND_LANDING_SUB_PATH}/`}>
+              {BACKEND_SIDEBAR_LABEL}
+            </SecondaryNav.Item>
+            <SecondaryNav.Item to={`${baseUrl}/${MOBILE_LANDING_SUB_PATH}/`}>
+              {MOBILE_SIDEBAR_LABEL}
+            </SecondaryNav.Item>
+            <SecondaryNav.Item to={`${baseUrl}/${AI_LANDING_SUB_PATH}/`}>
+              {AI_SIDEBAR_LABEL}
+            </SecondaryNav.Item>
+          </SecondaryNav.Section>
+        </SecondaryNav.Body>
+      </SecondaryNav>
+      {children}
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

This doesn't do anything yet, since I haven't enabled the new secondary navigation, but this is how the items in the nav will be defined for insights.

- Renders the `InsightsNavigation` component at the top of the insights route tree
- When feature flag is enabled, renders the `<SecondaryNav />` links

![CleanShot 2025-01-27 at 16 11 17](https://github.com/user-attachments/assets/0546e184-8ad5-4787-af94-ba888030911a)
