### PR TITLE
feat(nav): Implement new secondary nav in explore

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1902,10 +1902,12 @@ function buildRoutes() {
 
   const exploreRoutes = (
     <Route
-      path="/explore/logs"
-      component={make(() => import('sentry/views/explore/logs'))}
+      path="/explore/"
+      component={make(() => import('sentry/views/explore/navigation'))}
       withOrgPath
-    />
+    >
+      <Route path="logs" component={make(() => import('sentry/views/explore/logs'))} />
+    </Route>
   );
 
   const userFeedbackRoutes = (

--- a/static/app/views/explore/navigation.tsx
+++ b/static/app/views/explore/navigation.tsx
@@ -1,0 +1,68 @@
+import {Fragment} from 'react';
+
+import Feature from 'sentry/components/acl/feature';
+import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function ExploreNavigation({children}: Props) {
+  const organization = useOrganization();
+  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+  if (!hasNavigationV2) {
+    return children;
+  }
+
+  const baseUrl = `/organizations/${organization.slug}/explore`;
+
+  // TODO(malwilley): Move other products under the /explore/ route
+  return (
+    <Fragment>
+      <SecondaryNav>
+        <SecondaryNav.Body>
+          <SecondaryNav.Section>
+            <Feature features="performance-trace-explorer">
+              <SecondaryNav.Item to={`/organizations/${organization.slug}/traces/`}>
+                {t('Traces')}
+              </SecondaryNav.Item>
+            </Feature>
+            <Feature features="ourlogs-enabled">
+              <SecondaryNav.Item to={`${baseUrl}/logs/`}>{t('Logs')}</SecondaryNav.Item>
+            </Feature>
+            <Feature features="custom-metrics">
+              <SecondaryNav.Item to={`/organizations/${organization.slug}/metrics/`}>
+                {t('Metrics')}
+              </SecondaryNav.Item>
+            </Feature>
+            <Feature features="profiling">
+              <SecondaryNav.Item to={`/organizations/${organization.slug}/profiling/`}>
+                {t('Profiles')}
+              </SecondaryNav.Item>
+            </Feature>
+            <Feature features="session-replay-ui">
+              <SecondaryNav.Item to={`/organizations/${organization.slug}/replays/`}>
+                {t('Replays')}
+              </SecondaryNav.Item>
+            </Feature>
+            <Feature features="discover-basic">
+              <SecondaryNav.Item to={`/organizations/${organization.slug}/discover/`}>
+                {t('Discover')}
+              </SecondaryNav.Item>
+            </Feature>
+            <SecondaryNav.Item to={`/organizations/${organization.slug}/releases/`}>
+              {t('Releases')}
+            </SecondaryNav.Item>
+            <SecondaryNav.Item to={`/organizations/${organization.slug}/crons/`}>
+              {t('Crons')}
+            </SecondaryNav.Item>
+          </SecondaryNav.Section>
+        </SecondaryNav.Body>
+      </SecondaryNav>
+      {children}
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

This doesn't do anything yet, since I haven't enabled the new secondary navigation, but this is how the items in the nav will be defined for insights.

- Renders the `ExploreNavigation` component at the top of the insights route tree
- When feature flag is enabled, renders the `<SecondaryNav />` links when under the `/explore` path

![CleanShot 2025-01-27 at 16 36 31](https://github.com/user-attachments/assets/66379acb-cbe3-41e9-968e-acbca38d03fb)
