### PR TITLE
feat(uptime): Add redis cluster to region config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3469,6 +3469,7 @@ UPTIME_REGIONS = [
         slug="default",
         name="Default Region",
         config_topic=Topic.UPTIME_CONFIGS,
+        config_redis_cluster=SENTRY_UPTIME_DETECTOR_CLUSTER,
         enabled=True,
     ),
 ]

--- a/src/sentry/conf/types/uptime.py
+++ b/src/sentry/conf/types/uptime.py
@@ -13,3 +13,5 @@ class UptimeRegionConfig:
     name: str
     config_topic: Topic
     enabled: bool
+    # Temporarily defaulted for backwards compat
+    config_redis_cluster: str = "default"


### PR DESCRIPTION
Splitting this into a separate pr so that we can configure it in getsentry before merging the main pr

<!-- Describe your PR here. -->