### PR TITLE
:mag: nit(msteams): add more error codes to halts

### DIFF
--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -2,10 +2,12 @@ from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 
 # Generated based on the response from the MsTeams API
-# Example: {"error":{"code":"ConversationBlockedByUser","message":"User blocked the conversation with the bot."}}"
+# Example: {"error":{"code":"ConversationBlockedByUser","message":"User blocked the conversation with the bot."}}
 MSTEAMS_HALT_ERROR_CODES = [
+    "BotDisabledByAdmin",
     "ConversationBlockedByUser",
     "ConversationNotFound",
+    "TenantNoPermission",
 ]
 
 


### PR DESCRIPTION
found some other error codes that should be halts via [SENTRY-3KD0](https://sentry.sentry.io/issues/6128181745/). this should also resolve the issue.