### PR TITLE
feat(grouping): Use `project_root` for in-app logic

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -350,6 +350,11 @@ def normalize_stacktraces_for_grouping(
 
     # If a grouping config is available, run grouping enhancers
     if grouping_config is not None:
+        # Some SDKs (so far only Python, but could be extended to others in the future) send the
+        # running app's working directory as `project_root`, so it can be used when determining
+        # what's in and out of app
+        _add_project_root_rule_to_enhancements(data, grouping_config)
+
         with sentry_sdk.start_span(op=op, name="apply_modifications_to_frame"):
             for frames, stacktrace_container in zip(stacktrace_frames, stacktrace_containers):
                 # This call has a caching mechanism when the same stacktrace and rules are used


### PR DESCRIPTION
In the python SDK, we automatically mark frames whose filepath matches the project root as being in-app. As we are now moving to a world where all auto-in-app detection [happens on the server](https://github.com/getsentry/sentry/issues/83603), we need to replicate that logic in sentry.

The first step in this change is handled in https://github.com/getsentry/sentry-python/pull/3941, which sends the `project_root` value used in the current SDK logic to the server in `debug_meta`. This is the second step: using that value on the server to set frames' `in-app` values. Once this is live, we can remove the corresponding logic from the SDK.

Because we apply the server-side `in_app` logic in two different places for a total of three times per event (once to [set in-app values,](https://github.com/getsentry/sentry/blob/5f1fef10806db1d4d048912702f5c12cb38c2c08/src/sentry/grouping/enhancer/__init__.py#L149-L168) and once each for the app and system variants [to get hints](https://github.com/getsentry/sentry/blob/5f1fef10806db1d4d048912702f5c12cb38c2c08/src/sentry/grouping/enhancer/__init__.py#L170-L206)), the easiest way to incorporate the new logic was to bundle it in with our other built-in stacktrace rules. That way, it gets applied all three times the others do. 

We don't currently have the ability to include variables in stacktrace rules the way we do in fingerprint rules, so this is done by manually constructing the rule text and merging it into the already-loaded config before any stacktrace rules are applied. It's not gated by platform, but since for now the Python SDK is the only one sending `debug_meta.project_root`, it's effectively restricted to Python events.