### PR TITLE
fix(tempest): Add logline for debugging

### DIFF
--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -230,7 +230,12 @@ def fetch_items_from_tempest(
     logger.info(
         "Tempest API request",
         extra={
-            "payload": payload,
+            "org_id": org_id,
+            "project_id": project_id,
+            "dsn": dsn,
+            "offset": offset,
+            "limit": limit,
+            "attach_screenshot": attach_screenshot,
             "endpoint": "/crashes",
         },
     )

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -227,6 +227,14 @@ def fetch_items_from_tempest(
         "attach_screenshot": attach_screenshot,
     }
 
+    logger.info(
+        "Tempest API request",
+        extra={
+            "payload": payload,
+            "endpoint": "/crashes",
+        },
+    )
+
     response = requests.post(
         url=settings.SENTRY_TEMPEST_URL + "/crashes",
         headers={"Content-Type": "application/json"},


### PR DESCRIPTION
After some investigation into the strange Tempest behaviour it is still not clear where it comes from, as such, we add the log line to see the exact payload that is causing the problem,  since there might just be something wrong with it.

This logline will only log once every 5 min and as such should not be too spammy.
