### PR TITLE
fix(store-minidumps): Remove disable properties

### DIFF
--- a/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -67,6 +67,8 @@ const formGroups: JsonFormObject[] = [
     title: t('Security & Privacy'),
     fields: [
       {
+        // The project settings cannot be overridden by the organization settings.
+        // It will only be disabled if the user does not have permission to edit.
         name: 'storeCrashReports',
         type: 'select',
         label: t('Store Minidumps As Attachments'),

--- a/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -67,8 +67,6 @@ const formGroups: JsonFormObject[] = [
     title: t('Security & Privacy'),
     fields: [
       {
-        disabled: hasProjectWriteAndOrgOverride,
-        disabledReason: projectWriteAndOrgOverrideDisabledReason,
         name: 'storeCrashReports',
         type: 'select',
         label: t('Store Minidumps As Attachments'),

--- a/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -67,6 +67,8 @@ const formGroups: JsonFormObject[] = [
     title: t('Security & Privacy'),
     fields: [
       {
+        // The project settings cannot be overridden by the organization settings.
+        // This field is only disabled if the user does not have permission to edit.
         name: 'storeCrashReports',
         type: 'select',
         label: t('Store Minidumps As Attachments'),


### PR DESCRIPTION
the disabled properties were introduced in the [PR](https://github.com/getsentry/sentry/blob/a6fbabb032afb0350c0b308edcf24fa29cb17a5d/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx#L70-L71) but they should not have as the org settings dot not overwrite the project settings. This PR reverts that 