### PR TITLE
fix(taskbroker): Use arroyo producer utility wrapper

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -346,10 +346,11 @@ def taskbroker_send_tasks(
     task_args = [] if not args else eval(args)
     task_kwargs = {} if not kwargs else eval(kwargs)
 
+    checkmarks = {int(repeat * (i / 10)) for i in range(1, 10)}
     for i in range(repeat):
         func.delay(*task_args, **task_kwargs)
-        if i > 0 and int((i / repeat) * 100) % 10 == 0:
-            click.echo(message=f"{int((i / repeat) * 100)}%")
+        if i in checkmarks:
+            click.echo(message=f"{int((i / repeat) * 100)}% complete")
 
     click.echo(message=f"Successfully sent {repeat} messages.")
 

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import logging
 from collections.abc import Callable
-from functools import cached_property
 from typing import Any
 
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
@@ -17,6 +16,7 @@ from sentry.taskworker.retry import Retry
 from sentry.taskworker.router import TaskRouter
 from sentry.taskworker.task import P, R, Task
 from sentry.utils import metrics
+from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.imports import import_string
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
@@ -44,17 +44,12 @@ class TaskNamespace:
         self.default_expires = expires  # seconds
         self.default_processing_deadline_duration = processing_deadline_duration  # seconds
         self._registered_tasks: dict[str, Task[Any, Any]] = {}
-        self._producer: KafkaProducer | None = None
+        self._producer: SingletonProducer = SingletonProducer(self.producer, max_futures=1000)
 
-    @cached_property
     def producer(self) -> KafkaProducer:
-        if self._producer:
-            return self._producer
         cluster_name = get_topic_definition(self.topic)["cluster"]
         producer_config = get_kafka_producer_cluster_options(cluster_name)
-        self._producer = KafkaProducer(producer_config)
-
-        return self._producer
+        return KafkaProducer(producer_config)
 
     def get(self, name: str) -> Task[Any, Any]:
         """
@@ -134,7 +129,7 @@ class TaskNamespace:
     def send_task(self, activation: TaskActivation, wait_for_delivery: bool = False) -> None:
         metrics.incr("taskworker.registry.send_task", tags={"namespace": activation.namespace})
 
-        produce_future = self.producer.produce(
+        produce_future = self._producer.produce(
             ArroyoTopic(name=self.topic.value),
             KafkaPayload(key=None, value=activation.SerializeToString(), headers=[]),
         )

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -44,9 +44,11 @@ class TaskNamespace:
         self.default_expires = expires  # seconds
         self.default_processing_deadline_duration = processing_deadline_duration  # seconds
         self._registered_tasks: dict[str, Task[Any, Any]] = {}
-        self._producer: SingletonProducer = SingletonProducer(self.producer, max_futures=1000)
+        self._producer: SingletonProducer = SingletonProducer(
+            self._basic_producer, max_futures=1000
+        )
 
-    def producer(self) -> KafkaProducer:
+    def _basic_producer(self) -> KafkaProducer:
         cluster_name = get_topic_definition(self.topic)["cluster"]
         producer_config = get_kafka_producer_cluster_options(cluster_name)
         return KafkaProducer(producer_config)

--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -118,7 +118,7 @@ def test_namespace_send_task_no_retry() -> None:
     assert activation.retry_state.max_attempts == 1
     assert activation.retry_state.on_attempts_exceeded == ON_ATTEMPTS_EXCEEDED_DISCARD
 
-    with patch.object(namespace, "producer") as mock_producer:
+    with patch.object(namespace, "_producer") as mock_producer:
         namespace.send_task(activation)
         assert mock_producer.produce.call_count == 1
 
@@ -147,7 +147,7 @@ def test_namespace_send_task_with_retry() -> None:
     assert activation.retry_state.max_attempts == 3
     assert activation.retry_state.on_attempts_exceeded == ON_ATTEMPTS_EXCEEDED_DEADLETTER
 
-    with patch.object(namespace, "producer") as mock_producer:
+    with patch.object(namespace, "_producer") as mock_producer:
         namespace.send_task(activation)
         assert mock_producer.produce.call_count == 1
 
@@ -172,7 +172,7 @@ def test_namespace_with_retry_send_task() -> None:
     assert activation.retry_state.max_attempts == 3
     assert activation.retry_state.on_attempts_exceeded == ON_ATTEMPTS_EXCEEDED_DEADLETTER
 
-    with patch.object(namespace, "producer") as mock_producer:
+    with patch.object(namespace, "_producer") as mock_producer:
         namespace.send_task(activation)
         assert mock_producer.produce.call_count == 1
 
@@ -196,7 +196,7 @@ def test_namespace_with_wait_for_delivery_send_task() -> None:
 
     activation = simple_task.create_activation()
 
-    with patch.object(namespace, "producer") as mock_producer:
+    with patch.object(namespace, "_producer") as mock_producer:
         ret_value: Future[None] = Future()
         ret_value.set_result(None)
         mock_producer.produce.return_value = ret_value


### PR DESCRIPTION
The KafkaProducer class that was being used directly doesn't implement some key features, one being
buffer management (periodic flushing) and the other being handling shutdowns cleanly. Use the
utility class that periodically waits for the produce call to ack, and also registers a shutdown
handler to process all the remaining writes.