### PR TITLE
chore(hybridcloud) Try smaller outbox cleanup slices

### DIFF
--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -246,11 +246,11 @@ class OutboxBase(Model):
             deleted_count = 0
 
             # Use a fetch and delete loop as doing cleanup in a single query
-            # causes timeouts with large datasets. Fetch in batches of 100 and
+            # causes timeouts with large datasets. Fetch in batches of 50 and
             # Apply the ID condition in python as filtering rows in postgres
             # leads to timeouts.
             while True:
-                batch = self.select_coalesced_messages().values_list("id", flat=True)[:100]
+                batch = self.select_coalesced_messages().values_list("id", flat=True)[:50]
                 delete_ids = [item_id for item_id in batch if item_id < coalesced.id]
                 if not len(delete_ids):
                     break


### PR DESCRIPTION
We're having some timeouts while cleaning up coalesced outboxes. I want to see if smaller slices help reduce the frequency of those timeouts.

Refs SENTRY-3DEZ
