### PR TITLE
chore(codeowners): Move migration owners lower

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,6 @@
 ## Legal
 /LICENSE.md                                              @getsentry/owners-legal
 
-## Migrations
-/src/sentry/migrations/                                  @getsentry/owners-migrations
-/src/sentry/*/migrations/                                @getsentry/owners-migrations
-
 ## Snuba
 /src/sentry/eventstream/                                 @getsentry/owners-snuba
 /src/sentry/consumers/                                   @getsentry/ops @getsentry/owners-snuba
@@ -650,3 +646,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /static/app/views/automations/                             @getsentry/alerts-create-issues
 /static/app/views/detectors/                               @getsentry/alerts-create-issues
 # End of Workflow Engine (ACI)
+
+## Migrations
+/src/sentry/migrations/                                  @getsentry/owners-migrations
+/src/sentry/*/migrations/                                @getsentry/owners-migrations


### PR DESCRIPTION
Move the migrations codeowners to the bottom of the file so other codeowners higher up don't override it and the migrations team is always tagged as a reviewer.