### PR TITLE
chore(ci): Remove use new devservices flag in CI

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'Directory where the sentry source is located'
     required: false
     default: '.'
+  python-version:
+    description: 'python version to install'
+    required: false
+    default: '3.13.1'
   mode:
     description: 'Mode to bring up by new devservices'
     required: false

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -7,46 +7,6 @@ inputs:
     description: 'Directory where the sentry source is located'
     required: false
     default: '.'
-  snuba:
-    description: 'Is snuba required?'
-    required: false
-    default: 'false'
-  clickhouse:
-    description: 'Is clickhouse required?'
-    required: false
-    default: 'false'
-  kafka:
-    description: 'Is kafka required?'
-    required: false
-    default: 'false'
-  chartcuterie:
-    description: 'Is chartcuterie required?'
-    required: false
-    default: 'false'
-  bigtable:
-    description: 'Is bigtable required?'
-    required: false
-    default: 'false'
-  redis_cluster:
-    description: 'Is redis cluster required?'
-    required: false
-    default: 'false'
-  symbolicator:
-    description: 'Is symbolicator required?'
-    required: false
-    default: 'false'
-  python-version:
-    description: 'python version to install'
-    required: false
-    default: '3.13.1'
-  pg-version:
-    description: 'PostgreSQL version to use'
-    default: '14'
-    required: false
-  use-new-devservices:
-    description: 'Use new devservices'
-    required: false
-    default: 'false'
   mode:
     description: 'Mode to bring up by new devservices'
     required: false
@@ -145,68 +105,7 @@ runs:
         # We need to install editable otherwise things like check migration will fail.
         python3 -m tools.fast_editable --path .
 
-    - name: Start devservices
-      shell: bash --noprofile --norc -eo pipefail -ux {0}
-      if: ${{ inputs.use-new-devservices != 'true' }}
-      env:
-        NEED_KAFKA: ${{ inputs.kafka }}
-        NEED_SNUBA: ${{ inputs.snuba }}
-        NEED_CLICKHOUSE: ${{ inputs.clickhouse }}
-        NEED_BIGTABLE: ${{ inputs.bigtable }}
-        NEED_CHARTCUTERIE: ${{ inputs.chartcuterie }}
-        NEED_REDIS_CLUSTER: ${{ inputs.redis_cluster }}
-        NEED_SYMBOLICATOR: ${{ inputs.symbolicator }}
-        WORKDIR: ${{ inputs.workdir }}
-        PG_VERSION: ${{ inputs.pg-version }}
-        ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES: '1'
-      run: |
-        sentry init
-
-        # redis, postgres are needed for almost every code path.
-        services=(redis postgres)
-
-        if [ "$NEED_CLICKHOUSE" = "true" ] || [ "$NEED_SNUBA" = "true" ]; then
-          services+=(clickhouse)
-        fi
-
-        if [ "$NEED_SNUBA" = "true" ]; then
-          services+=(snuba)
-        fi
-
-        if [ "$NEED_BIGTABLE" = "true" ]; then
-          echo "BIGTABLE_EMULATOR_HOST=127.0.0.1:8086" >> $GITHUB_ENV
-          services+=(bigtable)
-        fi
-
-        if [ "$NEED_CHARTCUTERIE" = "true" ]; then
-          services+=(chartcuterie)
-        fi
-
-        if [ "$NEED_REDIS_CLUSTER" = "true" ]; then
-          services+=(redis-cluster)
-        fi
-
-        if [ "$NEED_SYMBOLICATOR" = "true" ]; then
-          services+=(symbolicator)
-        fi
-
-        if [ "$NEED_KAFKA" = "true" ]; then
-          services+=(kafka)
-        fi
-
-        sentry devservices up "${services[@]}"
-
-        # have tests listen on the docker gateway ip so loopback can occur
-        echo "DJANGO_LIVE_TEST_SERVER_ADDRESS=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')" >> "$GITHUB_ENV"
-
-        docker ps -a
-
-        # This is necessary when other repositories (e.g. relay) want to take advantage of this workflow
-        # without needing to fork it. The path needed is the one where tools are located
-        cd "$WORKDIR"
-
     - name: Start new devservices
-      if: ${{ inputs.use-new-devservices == 'true' }}
       shell: bash --noprofile --norc -eo pipefail -ux {0}
       env:
         WORKDIR: ${{ inputs.workdir }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -117,7 +117,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: acceptance-ci
 
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,7 +58,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: default
 
       - name: Run API docs tests
@@ -105,7 +104,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: backend-ci
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
@@ -156,7 +154,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: default
 
       - name: run tests
@@ -195,7 +192,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: migrations
 
       - name: Run test
@@ -268,7 +264,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: migrations
 
       - name: Migration & lockfile checks
@@ -301,7 +296,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
-          use-new-devservices: true
           mode: migrations
 
       - name: Run test


### PR DESCRIPTION
This removes the `use-new-devservices` flag in the setup-sentry action. Since symbolicator, snuba, and relay are now using the flag for integraiton tests, we can remove code related to `sentry devservices` in the action as well.