### PR TITLE
feat(issue-views): Start silently saved user's most recent page filters to their views 

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -264,6 +264,9 @@ export type IssueEventParameters = {
   'issue_views.deleted_view': {};
   'issue_views.discarded_changes': {};
   'issue_views.duplicated_view': {};
+  'issue_views.page_filters_logged': {
+    user_id: string;
+  };
   'issue_views.renamed_view': {};
   'issue_views.reordered_views': {};
   'issue_views.saved_changes': {};
@@ -427,6 +430,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.shared_view_opened': 'Issue Views: Shared View Opened',
   'issue_views.temp_view_discarded': 'Issue Views: Temporary View Discarded',
   'issue_views.temp_view_saved': 'Issue Views: Temporary View Saved',
+  'issue_views.page_filters_logged': 'Issue Views: Page Filters Logged',
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',
   'issue.search_sidebar_clicked': 'Issue Search Sidebar Clicked',

--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -431,6 +431,12 @@ export function IssueViewsStateProvider({
   const debounceUpdateViews = useMemo(
     () =>
       debounce((newTabs: IssueView[]) => {
+        const isAllProjects =
+          pageFilters.selection.projects.length === 1 &&
+          pageFilters.selection.projects[0] === -1;
+
+        const projects = isAllProjects ? [] : pageFilters.selection.projects;
+
         if (newTabs) {
           updateViews({
             orgSlug: organization.slug,
@@ -445,11 +451,21 @@ export function IssueViewsStateProvider({
                 name: tab.label,
                 query: tab.query,
                 querySort: tab.querySort,
+                projects,
+                isAllProjects,
+                environments: pageFilters.selection.environments,
+                timeFilters: pageFilters.selection.datetime,
               })),
           });
         }
       }, 500),
-    [organization.slug, updateViews]
+    [
+      organization.slug,
+      updateViews,
+      pageFilters.selection.datetime,
+      pageFilters.selection.environments,
+      pageFilters.selection.projects,
+    ]
   );
 
   const reducer: Reducer<IssueViewsState, IssueViewsActions> = useCallback(

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -78,9 +78,18 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
     });
 
     it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
+
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
@@ -130,6 +139,10 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
@@ -168,13 +181,17 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
         router: queryOnlyRouter,
       });
 
       expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
-      expect(await screen.findByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
       expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
         'aria-selected',
         'true'
@@ -297,6 +314,10 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
 
       const defaultTabDifferentQueryRouter = RouterFixture({
         location: LocationFixture({
@@ -348,6 +369,10 @@ describe('IssueViewsHeader', () => {
     });
 
     it('switches tabs when clicked, and updates the query params accordingly', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
       await userEvent.click(await screen.findByRole('tab', {name: /Medium Priority/}));
@@ -378,6 +403,10 @@ describe('IssueViewsHeader', () => {
     });
 
     it('renders the unsaved changes indicator if query params contain a viewId and a non-matching query', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
       const goodViewIdChangedQueryRouter = RouterFixture({
         location: LocationFixture({
           pathname: `/organizations/${organization.slug}/issues/`,
@@ -415,6 +444,10 @@ describe('IssueViewsHeader', () => {
     });
 
     it('renders the unsaved changes indicator if a viewId and non-matching sort are in the query params', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
       const goodViewIdChangedSortRouter = RouterFixture({
         location: LocationFixture({
           pathname: `/organizations/${organization.slug}/issues/`,
@@ -464,6 +497,10 @@ describe('IssueViewsHeader', () => {
         url: `/organizations/${organization.slug}/issues-count/`,
         method: 'GET',
         body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
       });
     });
 
@@ -781,6 +818,10 @@ describe('IssueViewsHeader', () => {
           [getRequestViews[0]!.query]: 42,
         },
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
@@ -801,6 +842,10 @@ describe('IssueViewsHeader', () => {
           [getRequestViews[1]!.query]: 6,
           [getRequestViews[2]!.query]: 98,
         },
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
@@ -825,6 +870,10 @@ describe('IssueViewsHeader', () => {
         body: {
           [getRequestViews[0]!.query]: 101,
         },
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -78,18 +78,9 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
     });
 
     it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
-
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
@@ -139,10 +130,6 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
@@ -180,10 +167,6 @@ describe('IssueViewsHeader', () => {
         url: `/organizations/${organization.slug}/issues-count/`,
         method: 'GET',
         body: {},
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
@@ -314,10 +297,6 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
 
       const defaultTabDifferentQueryRouter = RouterFixture({
         location: LocationFixture({
@@ -369,10 +348,6 @@ describe('IssueViewsHeader', () => {
     });
 
     it('switches tabs when clicked, and updates the query params accordingly', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
       await userEvent.click(await screen.findByRole('tab', {name: /Medium Priority/}));
@@ -403,10 +378,6 @@ describe('IssueViewsHeader', () => {
     });
 
     it('renders the unsaved changes indicator if query params contain a viewId and a non-matching query', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
       const goodViewIdChangedQueryRouter = RouterFixture({
         location: LocationFixture({
           pathname: `/organizations/${organization.slug}/issues/`,
@@ -444,10 +415,6 @@ describe('IssueViewsHeader', () => {
     });
 
     it('renders the unsaved changes indicator if a viewId and non-matching sort are in the query params', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
       const goodViewIdChangedSortRouter = RouterFixture({
         location: LocationFixture({
           pathname: `/organizations/${organization.slug}/issues/`,
@@ -497,10 +464,6 @@ describe('IssueViewsHeader', () => {
         url: `/organizations/${organization.slug}/issues-count/`,
         method: 'GET',
         body: {},
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
       });
     });
 
@@ -818,10 +781,6 @@ describe('IssueViewsHeader', () => {
           [getRequestViews[0]!.query]: 42,
         },
       });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
-      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
 
@@ -842,10 +801,6 @@ describe('IssueViewsHeader', () => {
           [getRequestViews[1]!.query]: 6,
           [getRequestViews[2]!.query]: 98,
         },
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
@@ -870,10 +825,6 @@ describe('IssueViewsHeader', () => {
         body: {
           [getRequestViews[0]!.query]: 101,
         },
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/group-search-views/`,
-        method: 'PUT',
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -78,6 +78,10 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: {},
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
     });
 
     it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
@@ -113,7 +117,6 @@ describe('IssueViewsHeader', () => {
     });
 
     it('creates a default viewId if no id is present in the request views', async () => {
-      MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
@@ -124,11 +127,6 @@ describe('IssueViewsHeader', () => {
             querySort: IssueSortOptions.DATE,
           },
         ],
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues-count/`,
-        method: 'GET',
-        body: {},
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
@@ -151,7 +149,6 @@ describe('IssueViewsHeader', () => {
     });
 
     it('allows you to manually enter a query, even if you only have a default tab', async () => {
-      MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
@@ -162,11 +159,6 @@ describe('IssueViewsHeader', () => {
             querySort: IssueSortOptions.DATE,
           },
         ],
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues-count/`,
-        method: 'GET',
-        body: {},
       });
 
       render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
@@ -280,7 +272,6 @@ describe('IssueViewsHeader', () => {
     });
 
     it('updates the unsaved changes indicator for a default tab if the query is different', async () => {
-      MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
@@ -291,11 +282,6 @@ describe('IssueViewsHeader', () => {
             querySort: IssueSortOptions.DATE,
           },
         ],
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues-count/`,
-        method: 'GET',
-        body: {},
       });
 
       const defaultTabDifferentQueryRouter = RouterFixture({
@@ -332,7 +318,7 @@ describe('IssueViewsHeader', () => {
     });
   });
 
-  describe('CustomViewsHeader query behavior', () => {
+  describe('CustomViewsHeader search query behavior', () => {
     beforeEach(() => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
@@ -344,6 +330,11 @@ describe('IssueViewsHeader', () => {
         url: `/organizations/${organization.slug}/issues-count/`,
         method: 'GET',
         body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
       });
     });
 
@@ -473,6 +464,11 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: getRequestViews,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} />);
 
@@ -504,6 +500,11 @@ describe('IssueViewsHeader', () => {
         method: 'GET',
         body: getRequestViews,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />);
 
@@ -532,6 +533,11 @@ describe('IssueViewsHeader', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
         body: [getRequestViews[0]],
       });
 
@@ -566,6 +572,7 @@ describe('IssueViewsHeader', () => {
         const mockPutRequest = MockApiClient.addMockResponse({
           url: `/organizations/org-slug/group-search-views/`,
           method: 'PUT',
+          body: getRequestViews,
         });
 
         render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
@@ -588,8 +595,8 @@ describe('IssueViewsHeader', () => {
         expect(defaultRouter.push).not.toHaveBeenCalled();
 
         // Make sure the put request is called, and the renamed view is in the request
-        expect(mockPutRequest).toHaveBeenCalledTimes(1);
-        const putRequestViews = mockPutRequest.mock.calls[0][1].data.views;
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
         expect(putRequestViews).toHaveLength(3);
         expect(putRequestViews).toEqual(
           expect.arrayContaining([
@@ -609,6 +616,7 @@ describe('IssueViewsHeader', () => {
         const mockPutRequest = MockApiClient.addMockResponse({
           url: `/organizations/org-slug/group-search-views/`,
           method: 'PUT',
+          body: getRequestViews,
         });
 
         render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
@@ -622,8 +630,8 @@ describe('IssueViewsHeader', () => {
         );
 
         // Make sure the put request is called, and the duplicated view is in the request
-        expect(mockPutRequest).toHaveBeenCalledTimes(1);
-        const putRequestViews = mockPutRequest.mock.calls[0][1].data.views;
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
         expect(putRequestViews).toHaveLength(4);
         expect(putRequestViews).toEqual(
           expect.arrayContaining([
@@ -658,6 +666,7 @@ describe('IssueViewsHeader', () => {
         const mockPutRequest = MockApiClient.addMockResponse({
           url: `/organizations/org-slug/group-search-views/`,
           method: 'PUT',
+          body: getRequestViews,
         });
 
         render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
@@ -669,8 +678,8 @@ describe('IssueViewsHeader', () => {
         await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
 
         // Make sure the put request is called, and the deleted view not in the request
-        expect(mockPutRequest).toHaveBeenCalledTimes(1);
-        const putRequestViews = mockPutRequest.mock.calls[0][1].data.views;
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
         expect(putRequestViews).toHaveLength(2);
         expect(putRequestViews.every).not.toEqual(
           expect.objectContaining({id: getRequestViews[0]!.id})
@@ -694,6 +703,7 @@ describe('IssueViewsHeader', () => {
         const mockPutRequest = MockApiClient.addMockResponse({
           url: `/organizations/org-slug/group-search-views/`,
           method: 'PUT',
+          body: getRequestViews,
         });
 
         render(
@@ -710,8 +720,8 @@ describe('IssueViewsHeader', () => {
         );
 
         // Make sure the put request is called, and the saved view is in the request
-        expect(mockPutRequest).toHaveBeenCalledTimes(1);
-        const putRequestViews = mockPutRequest.mock.calls[0][1].data.views;
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
         expect(putRequestViews).toHaveLength(3);
         expect(putRequestViews).toEqual(
           expect.arrayContaining([
@@ -733,6 +743,7 @@ describe('IssueViewsHeader', () => {
         const mockPutRequest = MockApiClient.addMockResponse({
           url: `/organizations/org-slug/group-search-views/`,
           method: 'PUT',
+          body: getRequestViews,
         });
 
         render(
@@ -748,7 +759,7 @@ describe('IssueViewsHeader', () => {
           await screen.findByRole('menuitemradio', {name: 'Discard Changes'})
         );
         // Just to be safe, make sure discarding changes does not trigger the put request
-        expect(mockPutRequest).not.toHaveBeenCalled();
+        expect(mockPutRequest).toHaveBeenCalledTimes(1);
 
         // Make sure that the tab's original query is restored
         expect(unsavedTabRouter.push).toHaveBeenCalledWith(
@@ -765,10 +776,19 @@ describe('IssueViewsHeader', () => {
   });
 
   describe('Issue views query counts', () => {
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+    });
+
     it('should render the correct count for a single view', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
         body: [getRequestViews[0]],
       });
       MockApiClient.addMockResponse({
@@ -791,6 +811,11 @@ describe('IssueViewsHeader', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
         body: getRequestViews,
       });
       MockApiClient.addMockResponse({
@@ -817,6 +842,11 @@ describe('IssueViewsHeader', () => {
         body: [getRequestViews[0]],
       });
       MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/issues-count/`,
         method: 'GET',
         query: {
@@ -836,6 +866,11 @@ describe('IssueViewsHeader', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/group-search-views/`,
         method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
         body: [getRequestViews[0]],
       });
       MockApiClient.addMockResponse({

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -34,6 +34,7 @@ import {
   IssueViewsContext,
 } from 'sentry/views/issueList/issueViews/issueViews';
 import {IssueViewTab} from 'sentry/views/issueList/issueViews/issueViewTab';
+import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 
@@ -191,6 +192,31 @@ function IssueViewsIssueListHeaderTabsContent({
     project,
     queryParams,
   ]);
+
+  const {mutate: updateViews} = useUpdateGroupSearchViews();
+
+  useEffect(() => {
+    const isAllProjects =
+      pageFilters.selection.projects.length === 1 &&
+      pageFilters.selection.projects[0] === -1;
+
+    const projects = isAllProjects ? [] : pageFilters.selection.projects;
+
+    updateViews({
+      orgSlug: organization.slug,
+      groupSearchViews: views.map(view => ({
+        id: view.id,
+        name: view.label,
+        query: view.query,
+        querySort: view.querySort,
+        projects,
+        isAllProjects,
+        environments: pageFilters.selection.environments,
+        timeFilters: pageFilters.selection.datetime,
+      })),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageFilters.selection]);
 
   // This insane useEffect ensures that the correct tab is selected when the url updates
   useEffect(() => {

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -215,31 +215,33 @@ function IssueViewsIssueListHeaderTabsContent({
   // This useEffect is here temporarily to start saving user's most recently used page filters
   // to their views. This will be removed once the frontend is updated to use a view's page filters
   useEffect(() => {
-    const isAllProjects =
-      pageFilters.selection.projects.length === 1 &&
-      pageFilters.selection.projects[0] === -1;
+    if (process.env.NODE_ENV !== 'test') {
+      const isAllProjects =
+        pageFilters.selection.projects.length === 1 &&
+        pageFilters.selection.projects[0] === -1;
 
-    const projects = isAllProjects ? [] : pageFilters.selection.projects;
+      const projects = isAllProjects ? [] : pageFilters.selection.projects;
 
-    debounceUpdateViews(
-      views
-        .filter(view => view.isCommitted)
-        .map(view => ({
-          id: view.id,
-          name: view.label,
-          query: view.query,
-          querySort: view.querySort,
-          projects,
-          isAllProjects,
-          environments: pageFilters.selection.environments,
-          timeFilters: pageFilters.selection.datetime,
-        }))
-    );
+      debounceUpdateViews(
+        views
+          .filter(view => view.isCommitted)
+          .map(view => ({
+            id: view.id,
+            name: view.label,
+            query: view.query,
+            querySort: view.querySort,
+            projects,
+            isAllProjects,
+            environments: pageFilters.selection.environments,
+            timeFilters: pageFilters.selection.datetime,
+          }))
+      );
 
-    trackAnalytics('issue_views.page_filters_logged', {
-      user_id: user.id,
-      organization,
-    });
+      trackAnalytics('issue_views.page_filters_logged', {
+        user_id: user.id,
+        organization,
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageFilters.selection]);
 

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -202,12 +202,10 @@ function IssueViewsIssueListHeaderTabsContent({
   const debounceUpdateViews = useMemo(
     () =>
       debounce((groupSearchViews: UpdateGroupSearchViewPayload[]) => {
-        if (groupSearchViews) {
-          updateViews({
-            orgSlug: organization.slug,
-            groupSearchViews,
-          });
-        }
+        updateViews({
+          orgSlug: organization.slug,
+          groupSearchViews,
+        });
       }, 10000),
     [updateViews, organization.slug]
   );
@@ -215,33 +213,31 @@ function IssueViewsIssueListHeaderTabsContent({
   // This useEffect is here temporarily to start saving user's most recently used page filters
   // to their views. This will be removed once the frontend is updated to use a view's page filters
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'test') {
-      const isAllProjects =
-        pageFilters.selection.projects.length === 1 &&
-        pageFilters.selection.projects[0] === -1;
+    const isAllProjects =
+      pageFilters.selection.projects.length === 1 &&
+      pageFilters.selection.projects[0] === -1;
 
-      const projects = isAllProjects ? [] : pageFilters.selection.projects;
+    const projects = isAllProjects ? [] : pageFilters.selection.projects;
 
-      debounceUpdateViews(
-        views
-          .filter(view => view.isCommitted)
-          .map(view => ({
-            id: view.id,
-            name: view.label,
-            query: view.query,
-            querySort: view.querySort,
-            projects,
-            isAllProjects,
-            environments: pageFilters.selection.environments,
-            timeFilters: pageFilters.selection.datetime,
-          }))
-      );
+    debounceUpdateViews(
+      views
+        .filter(view => view.isCommitted)
+        .map(view => ({
+          id: view.id,
+          name: view.label,
+          query: view.query,
+          querySort: view.querySort,
+          projects,
+          isAllProjects,
+          environments: pageFilters.selection.environments,
+          timeFilters: pageFilters.selection.datetime,
+        }))
+    );
 
-      trackAnalytics('issue_views.page_filters_logged', {
-        user_id: user.id,
-        organization,
-      });
-    }
+    trackAnalytics('issue_views.page_filters_logged', {
+      user_id: user.id,
+      organization,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageFilters.selection]);
 

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -27,6 +27,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 import {
   generateTempViewId,
   type IssueView,
@@ -167,6 +168,7 @@ function IssueViewsIssueListHeaderTabsContent({
   const navigate = useNavigate();
   const location = useLocation();
   const pageFilters = usePageFilters();
+  const user = useUser();
 
   const {newViewActive, setNewViewActive} = useContext(NewTabContext);
   const {tabListState, state, dispatch} = useContext(IssueViewsContext);
@@ -214,6 +216,11 @@ function IssueViewsIssueListHeaderTabsContent({
         environments: pageFilters.selection.environments,
         timeFilters: pageFilters.selection.datetime,
       })),
+    });
+
+    trackAnalytics('issue_views.page_filters_logged', {
+      user_id: user.id,
+      organization,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageFilters.selection]);

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -1,3 +1,4 @@
+import type {PageFilters} from 'sentry/types/core';
 import type {
   GroupStatusResolution,
   MarkReviewed,
@@ -23,5 +24,9 @@ export type GroupSearchView = {
 };
 
 export interface UpdateGroupSearchViewPayload extends Omit<GroupSearchView, 'id'> {
+  environments?: string[];
   id?: string;
+  isAllProjects?: boolean;
+  projects?: number[];
+  timeFilters?: PageFilters['datetime'];
 }


### PR DESCRIPTION
This PR adds temporary logic that saves page filters to a user's existing views. Analytics are also added to see how many users this will add views for. 


I've slightly changed the logic from the tech spec task ([here](https://www.notion.so/sentry/Update-frontend-to-sync-projects-w-page-filters-on-mount-and-on-change-1768b10e4b5d806e9c8ed5117116b5f5), internal only). In addition to  firing a mutate on mount, it's also fired when page filters are changed to always ensure the most recently used page filters are saved. 