### PR TITLE
fix(widget-builder): Reset legend alias on dataset change

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -908,6 +908,33 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.thresholds).toBeUndefined();
     });
+
+    it('resets the legend alias when the dataset is switched', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ERRORS,
+            displayType: DisplayType.LINE,
+            legendAlias: ['test'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.legendAlias).toEqual(['test']);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: WidgetType.TRANSACTIONS,
+        });
+      });
+
+      expect(result.current.state.legendAlias).toEqual([]);
+    });
   });
 
   describe('fields', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -288,6 +288,7 @@ function useWidgetBuilderState(): {
 
           setThresholds(undefined);
           setQuery([config.defaultWidgetQuery.conditions]);
+          setLegendAlias([]);
           setSelectedAggregate(undefined);
           break;
         case BuilderStateAction.SET_FIELDS:


### PR DESCRIPTION
The legend alias didn't reset when changing the datasets which didn't make sense so now it does (for chart widgets). It isn't reset when changing between chart types (this is the behaviour in the old widget builder so I'm keeping that). Let me know if there's any other odd behaviour with the legend aliases that you want me to change i can do it in this pr.
