### PR TITLE
ref: remove unused ARM64 django setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 import os.path
-import platform
 import re
 import socket
 import sys
@@ -2290,12 +2289,6 @@ SENTRY_USE_TASKBROKER = False
 #     )
 # }
 
-
-# platform.processor() changed at some point between these:
-# 11.2.3: arm
-# 12.3.1: arm64
-# ubuntu: aarch64
-ARM64 = platform.processor() in {"arm", "arm64", "aarch64"}
 
 SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     "redis": lambda settings, options: (


### PR DESCRIPTION
last reference removed in ae8ec6969a67389d20dfde307d4069a1ea1ba04f

<!-- Describe your PR here. -->