### PR TITLE
chore(eslint): Ignore @typescript-eslint/unified-signatures rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -426,7 +426,7 @@ export default typescript.config([
       '@typescript-eslint/no-extraneous-class': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/no-invalid-void-type': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/no-non-null-assertion': 'off', // TODO(ryan953): Fix violations and delete this line
-      '@typescript-eslint/unified-signatures': 'off', // TODO(ryan953): Fix violations and delete this line
+      '@typescript-eslint/unified-signatures': 'off',
 
       // Stylistic overrides
       '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],


### PR DESCRIPTION
Following up to https://github.com/getsentry/sentry/pull/83803 we don't need this rule enabled, there are few places that violate it, probably not a lot of new violations will appear in the future. 
I'm removing it from my todo list.