### PR TITLE
fix(explore): Do not make explore queries past max pickable days

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -8,6 +8,7 @@ import {IconClock, IconGraph} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Confidence, NewQuery} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import EventView from 'sentry/utils/discover/eventView';
 import {
@@ -271,12 +272,12 @@ export function ExploreCharts({
 
 export function useExtrapolationMeta({
   dataset,
-  isAllowedSelection,
   query,
+  isAllowedSelection,
 }: {
   dataset: DiscoverDatasets;
-  isAllowedSelection: boolean;
   query: string;
+  isAllowedSelection?: boolean;
 }) {
   const {selection} = usePageFilters();
 
@@ -304,7 +305,9 @@ export function useExtrapolationMeta({
     eventView: extrapolationMetaEventView,
     initialData: [],
     referrer: 'api.explore.spans-extrapolation-meta',
-    enabled: isAllowedSelection && dataset === DiscoverDatasets.SPANS_EAP_RPC,
+    enabled:
+      (defined(isAllowedSelection) ? isAllowedSelection : true) &&
+      dataset === DiscoverDatasets.SPANS_EAP_RPC,
     trackResponseAnalytics: false,
   });
 }

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -40,6 +40,7 @@ import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
 interface ExploreChartsProps {
   canUsePreviousResults: boolean;
   confidences: Confidence[];
+  isAllowedSelection: boolean;
   query: string;
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
 }
@@ -64,6 +65,7 @@ export const EXPLORE_CHART_GROUP = 'explore-charts_group';
 export function ExploreCharts({
   canUsePreviousResults,
   confidences,
+  isAllowedSelection,
   query,
   timeseriesResult,
 }: ExploreChartsProps) {
@@ -74,6 +76,7 @@ export function ExploreCharts({
 
   const extrapolationMetaResults = useExtrapolationMeta({
     dataset,
+    isAllowedSelection,
     query,
   });
 
@@ -268,9 +271,11 @@ export function ExploreCharts({
 
 export function useExtrapolationMeta({
   dataset,
+  isAllowedSelection,
   query,
 }: {
   dataset: DiscoverDatasets;
+  isAllowedSelection: boolean;
   query: string;
 }) {
   const {selection} = usePageFilters();
@@ -299,7 +304,7 @@ export function useExtrapolationMeta({
     eventView: extrapolationMetaEventView,
     initialData: [],
     referrer: 'api.explore.spans-extrapolation-meta',
-    enabled: dataset === DiscoverDatasets.SPANS_EAP_RPC,
+    enabled: isAllowedSelection && dataset === DiscoverDatasets.SPANS_EAP_RPC,
     trackResponseAnalytics: false,
   });
 }

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -18,6 +18,7 @@ import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
 interface UseExploreTimeseriesOptions {
+  enabled: boolean;
   query: string;
 }
 
@@ -27,6 +28,7 @@ interface UseExploreTimeseriesResults {
 }
 
 export function useExploreTimeseries({
+  enabled,
   query,
 }: UseExploreTimeseriesOptions): UseExploreTimeseriesResults {
   const dataset = useExploreDataset();
@@ -76,8 +78,9 @@ export function useExploreTimeseries({
       fields,
       orderby,
       topEvents,
+      enabled,
     };
-  }, [query, yAxes, interval, fields, orderby, topEvents]);
+  }, [query, yAxes, interval, fields, orderby, topEvents, enabled]);
 
   const previousQuery = usePrevious(query);
   const previousOptions = usePrevious(options);


### PR DESCRIPTION
When forcing the max pickable days, there's a moment when the previous selection is carried over and we can fire long queries for 90 days. This is causing some issues right now so be more strict and prevent these queries.