### PR TITLE
:sparkles: feat: support jira for issue alert migration

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -418,7 +418,7 @@ class JiraActionTranslatorBase(TicketActionTranslator):
         return ["integration"]
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return JiraDataBlob
 
     def get_sanitized_data(self) -> dict[str, Any]:
@@ -442,6 +442,10 @@ class JiraActionTranslatorBase(TicketActionTranslator):
             }
             data["additional_fields"] = additional_fields
         return data
+
+    @staticmethod
+    def standard_fields() -> list[str]:
+        return [f.name for f in dataclasses.fields(JiraDataBlob) if f.name != "additional_fields"]
 
 
 @issue_alert_action_translator_registry.register(

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -415,7 +415,7 @@ class WebhookActionTranslator(BaseActionTranslator):
 class JiraActionTranslatorBase(TicketActionTranslator):
     @property
     def required_fields(self) -> list[str]:
-        return ["integration", "project", "issuetype"]
+        return ["integration"]
 
     @property
     def blob_type(self) -> type["DataBlob"]:
@@ -607,12 +607,8 @@ class JiraDataBlob(TicketDataBlob):
 
     project: str = ""
     issuetype: str = ""
-    assignee: str = ""
-    reporter: str = ""
-    description: str = ""
-    # Optional standard fields
-    labels: str = ""
-    parent: str = ""
     priority: str = ""
+    labels: str = ""
+    reporter: str = ""
     # Store any custom fields (customfield_*) or additional fields
     additional_fields: dict[str, Any] = field(default_factory=dict)

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -413,8 +413,6 @@ class WebhookActionTranslator(BaseActionTranslator):
 
 
 class JiraActionTranslatorBase(TicketActionTranslator):
-    action_type = Action.Type.JIRA
-
     @property
     def required_fields(self) -> list[str]:
         return ["integration", "project", "issuetype"]

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -413,6 +413,46 @@ class WebhookActionTranslator(BaseActionTranslator):
 
 
 @issue_alert_action_translator_registry.register(
+    "sentry.integrations.jira.notify_action.JiraCreateTicketAction"
+)
+@issue_alert_action_translator_registry.register(
+    "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction"
+)
+class JiraActionTranslator(TicketActionTranslator):
+    action_type = Action.Type.JIRA
+
+    @property
+    def required_fields(self) -> list[str]:
+        return ["integration", "project", "issuetype"]
+
+    @property
+    def blob_type(self) -> type["DataBlob"]:
+        return JiraDataBlob
+
+    def get_sanitized_data(self) -> dict[str, Any]:
+        """
+        Override to handle custom fields and additional fields that aren't part of the standard fields.
+        """
+        data = super().get_sanitized_data()
+        if self.blob_type:
+            # Get all fields that aren't part of the standard JiraDataBlob fields
+            standard_fields = {
+                f.name for f in dataclasses.fields(JiraDataBlob) if f.name != "additional_fields"
+            }
+            additional_fields = {
+                k: v
+                for k, v in self.action.items()
+                if k not in standard_fields
+                and k not in EXCLUDED_ACTION_DATA_KEYS
+                and k not in self.required_fields
+                and k != "dynamic_form_fields"
+                and v  # Only include non-empty values
+            }
+            data["additional_fields"] = additional_fields
+        return data
+
+
+@issue_alert_action_translator_registry.register(
     "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
 )
 class SentryAppActionTranslator(BaseActionTranslator):
@@ -550,3 +590,23 @@ class EmailDataBlob(DataBlob):
     """
 
     fallthroughType: str = ""
+
+
+@dataclass
+class JiraDataBlob(TicketDataBlob):
+    """
+    JiraDataBlob represents the data blob for a Jira ticket creation action.
+    Includes required fields and supports dynamic custom fields.
+    """
+
+    project: str = ""
+    issuetype: str = ""
+    assignee: str = ""
+    reporter: str = ""
+    description: str = ""
+    # Optional standard fields
+    labels: str = ""
+    parent: str = ""
+    priority: str = ""
+    # Store any custom fields (customfield_*) or additional fields
+    additional_fields: dict[str, Any] = field(default_factory=dict)

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -412,13 +412,7 @@ class WebhookActionTranslator(BaseActionTranslator):
         return self.action.get("service")
 
 
-@issue_alert_action_translator_registry.register(
-    "sentry.integrations.jira.notify_action.JiraCreateTicketAction"
-)
-@issue_alert_action_translator_registry.register(
-    "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction"
-)
-class JiraActionTranslator(TicketActionTranslator):
+class JiraActionTranslatorBase(TicketActionTranslator):
     action_type = Action.Type.JIRA
 
     @property
@@ -450,6 +444,20 @@ class JiraActionTranslator(TicketActionTranslator):
             }
             data["additional_fields"] = additional_fields
         return data
+
+
+@issue_alert_action_translator_registry.register(
+    "sentry.integrations.jira.notify_action.JiraCreateTicketAction"
+)
+class JiraActionTranslator(JiraActionTranslatorBase):
+    action_type = Action.Type.JIRA
+
+
+@issue_alert_action_translator_registry.register(
+    "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction"
+)
+class JiraServerActionTranslator(JiraActionTranslatorBase):
+    action_type = Action.Type.JIRA_SERVER
 
 
 @issue_alert_action_translator_registry.register(

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any
 from unittest.mock import patch
 
@@ -12,6 +13,7 @@ from sentry.workflow_engine.migration_helpers.rule_action import (
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
+    JiraDataBlob,
     issue_alert_action_translator_registry,
 )
 
@@ -50,23 +52,54 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         # If we have a blob type, verify the data matches the blob structure
         if translator.blob_type:
-            for field in translator.blob_type.__dataclass_fields__:
-                mapping = translator.field_mappings.get(field)
-                if mapping:
-                    # For mapped fields, check against the source field with default value
-                    source_value = compare_dict.get(mapping.source_field, mapping.default_value)
-                    assert action.data.get(field) == source_value
-                else:
-                    # For unmapped fields, check directly with empty string default
-                    if action.type == Action.Type.EMAIL and field == "fallthroughType":
-                        # for email actions, the default value for fallthroughType should be "ActiveMembers"
-                        assert action.data.get(field) == compare_dict.get(field, "ActiveMembers")
+            # Special handling for JiraDataBlob which has additional_fields
+            if translator.blob_type == JiraDataBlob:
+                # Get standard fields from JiraDataBlob, excluding additional_fields
+                standard_fields = {
+                    f.name
+                    for f in dataclasses.fields(JiraDataBlob)
+                    if f.name != "additional_fields"
+                }
+
+                # Check standard fields
+                for field in standard_fields:
+                    assert action.data.get(field, "") == compare_dict.get(field, "")
+
+                # Check that additional_fields contains all other non-excluded fields
+                additional_fields = action.data.get("additional_fields", {})
+                for key, value in compare_dict.items():
+                    if (
+                        key not in exclude_keys
+                        and key not in standard_fields
+                        and key != "id"
+                        and value  # Only check non-empty values
+                    ):
+                        assert additional_fields.get(key) == value
+
+                # Ensure no unexpected fields
+                expected_keys = standard_fields | {"additional_fields"}
+                assert set(action.data.keys()) == expected_keys
+            else:
+                # Original logic for other blob types
+                for field in translator.blob_type.__dataclass_fields__:
+                    mapping = translator.field_mappings.get(field)
+                    if mapping:
+                        # For mapped fields, check against the source field with default value
+                        source_value = compare_dict.get(mapping.source_field, mapping.default_value)
+                        assert action.data.get(field) == source_value
                     else:
-                        assert action.data.get(field) == compare_dict.get(field, "")
-            # Ensure no extra fields
-            assert set(action.data.keys()) == {
-                f.name for f in translator.blob_type.__dataclass_fields__.values()
-            }
+                        # For unmapped fields, check directly with empty string default
+                        if action.type == Action.Type.EMAIL and field == "fallthroughType":
+                            # for email actions, the default value for fallthroughType should be "ActiveMembers"
+                            assert action.data.get(field) == compare_dict.get(
+                                field, "ActiveMembers"
+                            )
+                        else:
+                            assert action.data.get(field) == compare_dict.get(field, "")
+                # Ensure no extra fields
+                assert set(action.data.keys()) == {
+                    f.name for f in translator.blob_type.__dataclass_fields__.values()
+                }
         else:
             # Assert the rest of the data is the same
             for key in compare_dict:
@@ -1242,6 +1275,438 @@ class TestNotificationActionMigrationUtils(TestCase):
                 f"Action {action_data['id']} has incorrect type after migration. "
                 f"Expected {expected_type}, got {actions[0].type}"
             )
+
+    def test_jira_action_migration(self):
+        action_data = [
+            {
+                "integration": "12345",
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": [
+                    {
+                        "name": "project",
+                        "label": "Jira Project",
+                        "choices": [["10001", "PROJ1"], ["10002", "PROJ2"], ["10003", "PROJ3"]],
+                        "default": "10001",
+                        "type": "select",
+                        "updatesForm": True,
+                    },
+                    {
+                        "name": "issuetype",
+                        "label": "Issue Type",
+                        "default": "10001",
+                        "type": "select",
+                        "choices": [["10001", "Story"], ["10002", "Bug"], ["10003", "Task"]],
+                        "updatesForm": True,
+                        "required": True,
+                    },
+                    {
+                        "label": "Fix versions",
+                        "required": False,
+                        "multiple": True,
+                        "choices": [],
+                        "default": "",
+                        "type": "select",
+                        "name": "fixVersions",
+                    },
+                    {
+                        "label": "Assignee",
+                        "required": False,
+                        "url": "/extensions/jira/search/example/12345/",
+                        "choices": [["user123", "John Doe"]],
+                        "type": "select",
+                        "name": "assignee",
+                    },
+                ],
+                "description": "This will be generated from the Sentry Issue details.",
+                "project": "10001",
+                "issuetype": "10001",
+                "assignee": "user123",
+                "reporter": "user123",
+                "parent": "PROJ-123",
+                "labels": "Sentry",
+                "uuid": "11111111-1111-1111-1111-111111111111",
+            },
+            {
+                "integration": "12345",
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": [
+                    {
+                        "name": "project",
+                        "label": "Jira Project",
+                        "choices": [["10001", "PROJ1"], ["10002", "PROJ2"], ["10003", "PROJ3"]],
+                        "default": "10001",
+                        "type": "select",
+                        "updatesForm": True,
+                    },
+                    {
+                        "name": "issuetype",
+                        "label": "Issue Type",
+                        "default": "10001",
+                        "type": "select",
+                        "choices": [["10001", "Task"], ["10002", "Bug"], ["10003", "Story"]],
+                        "updatesForm": True,
+                        "required": True,
+                    },
+                    {
+                        "label": "Priority",
+                        "required": False,
+                        "choices": [
+                            ["1", "Highest"],
+                            ["2", "High"],
+                            ["3", "Medium"],
+                            ["4", "Low"],
+                            ["5", "Lowest"],
+                        ],
+                        "type": "select",
+                        "name": "priority",
+                        "default": "",
+                    },
+                    {
+                        "label": "Team",
+                        "required": False,
+                        "choices": [
+                            ["Team A", "Team A"],
+                            ["Team B", "Team B"],
+                            ["Team C", "Team C"],
+                        ],
+                        "type": "select",
+                        "name": "customfield_10253",
+                    },
+                    {
+                        "label": "Platform",
+                        "required": False,
+                        "multiple": True,
+                        "choices": [
+                            ["iOS", "iOS"],
+                            ["Android", "Android"],
+                            ["Backend", "Backend"],
+                            ["Frontend", "Frontend"],
+                        ],
+                        "default": "",
+                        "type": "select",
+                        "name": "customfield_10285",
+                    },
+                ],
+                "description": "This will be generated from the Sentry Issue details.",
+                "project": "10001",
+                "issuetype": "10001",
+                "priority": "",
+                "labels": "",
+                "reporter": "user123",
+                "customfield_10253": "Team A",
+                "customfield_10285": ["Backend"],
+                "customfield_10290": "",
+                "customfield_10301": "",
+                "customfield_10315": "",
+                "versions": "",
+                "uuid": "12345678-1234-5678-1234-567812345678",
+            },
+            {
+                "integration": "123456",
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": [
+                    {
+                        "name": "project",
+                        "label": "Jira Project",
+                        "choices": [["10000", "PROJ1"], ["10003", "PROJ2"]],
+                        "default": "10000",
+                        "type": "select",
+                        "updatesForm": True,
+                    },
+                    {
+                        "name": "issuetype",
+                        "label": "Issue Type",
+                        "default": "10031",
+                        "type": "select",
+                        "choices": [
+                            ["10001", "Task"],
+                            ["10002", "Epic"],
+                            ["10003", "Subtask"],
+                            ["10005", "Question"],
+                            ["10018", "Wireframe"],
+                            ["10028", "Folder"],
+                            ["10029", "Story"],
+                            ["10031", "Bug"],
+                        ],
+                        "updatesForm": True,
+                        "required": True,
+                    },
+                    {
+                        "label": "Assignee",
+                        "required": False,
+                        "url": "/extensions/jira/search/organization/123456/",
+                        "choices": [],
+                        "type": "select",
+                        "name": "assignee",
+                    },
+                    {
+                        "label": "Development",
+                        "required": False,
+                        "type": "text",
+                        "name": "customfield_10000",
+                    },
+                    {
+                        "label": "Team",
+                        "required": False,
+                        "type": "text",
+                        "name": "customfield_10001",
+                    },
+                    {
+                        "label": "Story point estimate",
+                        "required": False,
+                        "type": "text",
+                        "name": "customfield_10016",
+                    },
+                    {
+                        "label": "Rank",
+                        "required": False,
+                        "type": "text",
+                        "name": "customfield_10019",
+                    },
+                    {
+                        "label": "Flagged",
+                        "required": False,
+                        "multiple": True,
+                        "choices": [["Impediment", "Impediment"]],
+                        "default": "",
+                        "type": "select",
+                        "name": "customfield_10021",
+                    },
+                    {
+                        "label": "Design",
+                        "required": False,
+                        "multiple": True,
+                        "choices": [],
+                        "default": "",
+                        "type": "select",
+                        "name": "customfield_10036",
+                    },
+                    {
+                        "label": "Description",
+                        "required": False,
+                        "type": "text",
+                        "name": "description",
+                    },
+                    {
+                        "label": "Restrict to",
+                        "required": False,
+                        "type": "text",
+                        "name": "issuerestriction",
+                    },
+                    {
+                        "label": "Labels",
+                        "required": False,
+                        "type": "text",
+                        "name": "labels",
+                        "default": "",
+                    },
+                    {
+                        "label": "Parent",
+                        "required": False,
+                        "url": "/extensions/jira/search/organization/123456/",
+                        "choices": [],
+                        "type": "select",
+                        "name": "parent",
+                    },
+                    {
+                        "label": "Reporter",
+                        "required": True,
+                        "url": "/extensions/jira/search/organization/123456/",
+                        "choices": [["user123", "Test User"]],
+                        "type": "select",
+                        "name": "reporter",
+                    },
+                ],
+                "description": "This will be generated from the Sentry Issue details.",
+                "project": "10000",
+                "issuetype": "10031",
+                "reporter": "user123",
+                "uuid": "00000000-0000-0000-0000-000000000000",
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        self.assert_actions_migrated_correctly(actions, action_data, "integration", None, None)
+
+    def test_jira_action_migration_malformed(self):
+        action_data = [
+            # Missing required fields
+            {
+                "uuid": "12345678-90ab-cdef-0123-456789abcdef",
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+            },
+            # Empty additional fields
+            {
+                "integration": "12345",
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "project": "10001",
+                "issuetype": "10001",
+                "reporter": "user123",
+                "uuid": "11111111-1111-1111-1111-111111111111",
+                "customfield_10253": "",
+                "customfield_10285": [],
+                "customfield_10290": "",
+                "customfield_10301": "",
+                "customfield_10315": "",
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        # Only the second action should be created since it has required fields
+        assert len(actions) == 1
+
+        # Verify empty additional fields are handled correctly
+        action = actions[0]
+        assert action.data.get("additional_fields") == {}
+
+    def test_jira_server_action_migration(self):
+        action_data = [
+            {
+                "integration": "123456",
+                "id": "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction",
+                "dynamic_form_fields": [
+                    {
+                        "name": "project",
+                        "label": "Jira Project",
+                        "choices": [["10001", "PROJ1"], ["10002", "PROJ2"], ["10003", "PROJ3"]],
+                        "default": "10001",
+                        "type": "select",
+                        "updatesForm": True,
+                    },
+                    {
+                        "name": "issuetype",
+                        "label": "Issue Type",
+                        "default": "1",
+                        "type": "select",
+                        "choices": [["1", "Defect"], ["3", "Task"], ["7", "Epic"], ["8", "Story"]],
+                        "updatesForm": True,
+                        "required": True,
+                    },
+                    {
+                        "label": "Priority",
+                        "required": False,
+                        "choices": [["2", "Blocker"], ["3", "High"], ["6", "Medium"], ["4", "Low"]],
+                        "type": "select",
+                        "name": "priority",
+                        "default": "",
+                    },
+                    {
+                        "label": "Fix Version/s",
+                        "required": False,
+                        "multiple": True,
+                        "choices": [
+                            ["81527", "Version 1.0"],
+                            ["81529", "Version 1.1"],
+                            ["82011", "Version 2.0"],
+                        ],
+                        "default": "",
+                        "type": "select",
+                        "name": "fixVersions",
+                    },
+                    {
+                        "label": "Component/s",
+                        "required": False,
+                        "multiple": True,
+                        "choices": [
+                            ["11841", "Backend"],
+                            ["12385", "Frontend"],
+                            ["12422", "Mobile"],
+                        ],
+                        "default": "",
+                        "type": "select",
+                        "name": "components",
+                    },
+                    {
+                        "label": "Description",
+                        "required": True,
+                        "type": "text",
+                        "name": "description",
+                    },
+                    {
+                        "label": "Labels",
+                        "required": False,
+                        "type": "text",
+                        "name": "labels",
+                        "default": "",
+                    },
+                    {
+                        "label": "Reporter",
+                        "required": True,
+                        "url": "/extensions/jira-server/search/org/123456/",
+                        "choices": [["user123", "Test User"]],
+                        "type": "select",
+                        "name": "reporter",
+                    },
+                ],
+                "description": "This will be generated from the Sentry Issue details.",
+                "project": "10001",
+                "issuetype": "1",
+                "priority": "3",
+                "components": ["11841"],
+                "reporter": "user123",
+                "uuid": "11111111-1111-1111-1111-111111111111",
+            },
+            {
+                "integration": "123456",
+                "id": "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction",
+                "dynamic_form_fields": [
+                    {
+                        "name": "project",
+                        "label": "Jira Project",
+                        "choices": [["20001", "TEAM1"], ["20002", "TEAM2"]],
+                        "default": "20001",
+                        "type": "select",
+                        "updatesForm": True,
+                    },
+                    {
+                        "name": "issuetype",
+                        "label": "Issue Type",
+                        "default": "8",
+                        "type": "select",
+                        "choices": [["1", "Defect"], ["8", "Story"]],
+                        "updatesForm": True,
+                        "required": True,
+                    },
+                ],
+                "description": "This will be generated from the Sentry Issue details.",
+                "project": "20001",
+                "issuetype": "8",
+                "reporter": "user123",
+                "uuid": "22222222-2222-2222-2222-222222222222",
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        self.assert_actions_migrated_correctly(actions, action_data, "integration", None, None)
+
+    def test_jira_server_action_migration_malformed(self):
+        action_data = [
+            # Missing required fields
+            {
+                "uuid": "12345678-90ab-cdef-0123-456789abcdef",
+                "id": "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction",
+            },
+            # Empty additional fields
+            {
+                "integration": "123456",
+                "id": "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction",
+                "project": "10001",
+                "issuetype": "1",
+                "reporter": "user123",
+                "uuid": "11111111-1111-1111-1111-111111111111",
+                "priority": "",
+                "components": [],
+                "fixVersions": [],
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        # Only the second action should be created since it has required fields
+        assert len(actions) == 1
+
+        # Verify empty additional fields are handled correctly
+        action = actions[0]
+        assert action.data.get("additional_fields") == {}
 
     def test_sentry_app_action_migration(self):
         app = self.create_sentry_app(

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1551,13 +1551,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        # Only the second action should be created since it has required fields
-        assert len(actions) == 1
-
-        # Verify empty additional fields are handled correctly
-        action = actions[0]
-        assert action.data.get("additional_fields") == {}
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_jira_server_action_migration(self):
         action_data = [
@@ -1700,13 +1695,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        # Only the second action should be created since it has required fields
-        assert len(actions) == 1
-
-        # Verify empty additional fields are handled correctly
-        action = actions[0]
-        assert action.data.get("additional_fields") == {}
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_sentry_app_action_migration(self):
         app = self.create_sentry_app(

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any
 from unittest.mock import patch
 
@@ -13,6 +12,7 @@ from sentry.workflow_engine.migration_helpers.rule_action import (
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
+    JiraActionTranslator,
     JiraDataBlob,
     issue_alert_action_translator_registry,
 )
@@ -22,6 +22,27 @@ class TestNotificationActionMigrationUtils(TestCase):
     def setUp(self):
         self.group = self.create_group(project=self.project)
         self.group_event = GroupEvent.from_event(self.event, self.group)
+
+    def assert_jira_action_data_blob(
+        self, action: Action, compare_dict: dict, exclude_keys: list[str]
+    ):
+        # Get standard fields from JiraDataBlob, excluding additional_fields
+        standard_fields = JiraActionTranslator.standard_fields()
+
+        # Check standard fields
+        for field in standard_fields:
+            assert action.data.get(field, "") == compare_dict.get(field, "")
+
+        # Check that additional_fields contains all other non-excluded fields
+        additional_fields = action.data.get("additional_fields", {})
+        for key, value in compare_dict.items():
+            if (
+                key not in exclude_keys
+                and key not in standard_fields
+                and key != "id"
+                and value  # Only check non-empty values
+            ):
+                assert additional_fields.get(key) == value
 
     def assert_action_data_blob(
         self,
@@ -54,31 +75,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         if translator.blob_type:
             # Special handling for JiraDataBlob which has additional_fields
             if translator.blob_type == JiraDataBlob:
-                # Get standard fields from JiraDataBlob, excluding additional_fields
-                standard_fields = {
-                    f.name
-                    for f in dataclasses.fields(JiraDataBlob)
-                    if f.name != "additional_fields"
-                }
-
-                # Check standard fields
-                for field in standard_fields:
-                    assert action.data.get(field, "") == compare_dict.get(field, "")
-
-                # Check that additional_fields contains all other non-excluded fields
-                additional_fields = action.data.get("additional_fields", {})
-                for key, value in compare_dict.items():
-                    if (
-                        key not in exclude_keys
-                        and key not in standard_fields
-                        and key != "id"
-                        and value  # Only check non-empty values
-                    ):
-                        assert additional_fields.get(key) == value
-
-                # Ensure no unexpected fields
-                expected_keys = standard_fields | {"additional_fields"}
-                assert set(action.data.keys()) == expected_keys
+                self.assert_jira_action_data_blob(action, compare_dict, exclude_keys)
             else:
                 # Original logic for other blob types
                 for field in translator.blob_type.__dataclass_fields__:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1529,7 +1529,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         self.assert_actions_migrated_correctly(actions, action_data, "integration", None, None)
 
     def test_jira_action_migration_malformed(self):
-        action_data = [
+        action_data: list[dict[str, Any]] = [
             # Missing required fields
             {
                 "uuid": "12345678-90ab-cdef-0123-456789abcdef",
@@ -1680,7 +1680,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         self.assert_actions_migrated_correctly(actions, action_data, "integration", None, None)
 
     def test_jira_server_action_migration_malformed(self):
-        action_data = [
+        action_data: list[dict[str, Any]] = [
             # Missing required fields
             {
                 "uuid": "12345678-90ab-cdef-0123-456789abcdef",


### PR DESCRIPTION
wraps up the ticketing migrations.

this one was a bit more tricky since we don't keep every custom field composed in dynamic form fields and have an arbitrary amount of fields that exist at the base on the dict. i introduced an `additional_fields` key which should encompass this fields.

for: https://www.notion.so/sentry/Alerts-Create-Issues-Notification-Action-NOA-1268b10e4b5d805b967ed2655c962db6?pvs=4#15b8b10e4b5d80ff8898d01d146f56d9 

closes https://getsentry.atlassian.net/browse/ACI-100
closes https://getsentry.atlassian.net/browse/ACI-101