### PR TITLE
feat(onboarding): Add `send_default_pii=True` to Python onboarding snippets

### DIFF
--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -28,7 +28,10 @@ from aiohttp import web
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -26,7 +26,10 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from myapp import asgi_app
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -34,6 +34,9 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
     integrations=[AwsLambdaIntegration()],${
       params.isPerformanceSelected
         ? `

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -26,7 +26,10 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -27,7 +27,10 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -24,7 +24,10 @@ from sentry_sdk.integrations.chalice import ChaliceIntegration
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
-    integrations=[ChaliceIntegration()],${
+    integrations=[ChaliceIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -26,7 +26,10 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -27,7 +27,10 @@ import falcon
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -29,7 +29,10 @@ from fastapi import FastAPI
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -29,7 +29,10 @@ import sentry_sdk
 from flask import Flask
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -28,7 +28,10 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
-    integrations=[GcpIntegration()],${
+    integrations=[GcpIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -22,6 +22,9 @@ sentry_sdk.init(
         PyMongoIntegration(),
     ],
 
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for tracing.
     # We recommend adjusting this value in production,

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -26,6 +26,9 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
 )
 `;
 

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -47,7 +47,10 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%
@@ -192,7 +195,7 @@ import sentry_sdk
 
 sentry_sdk.init(
   dsn="${params.dsn.public}",
-  enable_tracing=True,
+  traces_sample_rate=1.0,
 )`,
           additionalInfo: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -29,7 +29,10 @@ from quart import Quart
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
-    integrations=[QuartIntegration()],${
+    integrations=[QuartIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -20,7 +20,10 @@ const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[rq]'`;
 
 const getInitCallSnippet = (params: Params) => `
 sentry_sdk.init(
-  dsn="${params.dsn.public}",${
+  dsn="${params.dsn.public}",
+  # Add data like request headers and IP for users,
+  # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+  send_default_pii=True,${
     params.isPerformanceSelected
       ? `
   # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -25,6 +25,9 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
 )
 `;
 

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -24,7 +24,10 @@ import sentry_sdk
 from sentry_sdk.integrations.serverless import serverless_function
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -27,7 +27,10 @@ from starlette.applications import Starlette
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -26,7 +26,10 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -19,9 +19,10 @@ from sentry_sdk.integrations.trytond import TrytondWSGIIntegration
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
-    integrations:[
-        sentry_sdk.integrations.trytond.TrytondWSGIIntegration(),
-    ],${
+    integrations=[TrytondWSGIIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -26,7 +26,10 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from my_wsgi_app import app
 
 sentry_sdk.init(
-    dsn="${params.dsn.public}",${
+    dsn="${params.dsn.public}",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%


### PR DESCRIPTION
As part of https://github.com/getsentry/team-sdks/issues/121 we want to add `send_default_pii=True` to all relevant onboarding snippets for better out-of-the-box debugability.