### PR TITLE
fix(tempest): Update cron job interval

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1193,8 +1193,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     "poll_tempest": {
         "task": "sentry.tempest.tasks.poll_tempest",
         # Run every 5 minute
-        "schedule": crontab(minute="*/5"),
-        "options": {"expires": 5 * 60},
+        "schedule": crontab(minute="*/1"),
+        "options": {"expires": 60},
     },
     "transaction-name-clusterer": {
         "task": "sentry.ingest.transaction_clusterer.tasks.spawn_clusterers",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1192,7 +1192,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "poll_tempest": {
         "task": "sentry.tempest.tasks.poll_tempest",
-        # Run every 5 minute
+        # Run every minute
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 60},
     },

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
     name="sentry.tempest.tasks.poll_tempest",
     queue="tempest",
     silo_mode=SiloMode.REGION,
-    soft_time_limit=4 * 60,
-    time_limit=4 * 60 + 5,
+    soft_time_limit=55,
+    time_limit=60,
 )
 def poll_tempest(**kwargs):
     # FIXME: Once we have more traffic this needs to be done smarter.
@@ -34,8 +34,8 @@ def poll_tempest(**kwargs):
     name="sentry.tempest.tasks.fetch_latest_item_id",
     queue="tempest",
     silo_mode=SiloMode.REGION,
-    soft_time_limit=1 * 60,
-    time_limit=1 * 60 + 5,
+    soft_time_limit=55,
+    time_limit=60,
 )
 def fetch_latest_item_id(credentials_id: int) -> None:
     # FIXME: Try catch this later
@@ -120,8 +120,8 @@ def fetch_latest_item_id(credentials_id: int) -> None:
     name="sentry.tempest.tasks.poll_tempest_crashes",
     queue="tempest",
     silo_mode=SiloMode.REGION,
-    soft_time_limit=4 * 60,
-    time_limit=4 * 60 + 5,
+    soft_time_limit=55,
+    time_limit=60,
 )
 def poll_tempest_crashes(credentials_id: int) -> None:
     credentials = TempestCredentials.objects.select_related("project").get(id=credentials_id)
@@ -212,9 +212,9 @@ def fetch_items_from_tempest(
     client_secret: str,
     dsn: str,
     offset: int,
-    limit: int = 348,
+    limit: int = 10,
     attach_screenshot: bool = False,
-    time_out: int = 235,
+    time_out: int = 50,  # Since there is a timeout of 45s in the middleware anyways
 ) -> Response:
     payload = {
         "org_id": org_id,


### PR DESCRIPTION
Since there is a timeout in the middleware of 45s anyways we might as well run the cron every minute instead of every 5 min. Since the "longer" time between intervals is not being used effectively at the moment anyways. This has the benefit of theoretically increasing throughput 5 fold.