### PR TITLE
chore(custom-metrics): remove metric type

### DIFF
--- a/tests/js/fixtures/metrics.ts
+++ b/tests/js/fixtures/metrics.ts
@@ -1,17 +1,16 @@
 // Totals will not be correct for all aggregation functions.
 // Consider adding aggregation specific fixture (e.g. MetricsP75Field) if your test depends on it.
 
-import type {MetricsApiResponse} from 'sentry/types/metrics';
+import { SessionApiResponse } from '../../../static/app/types/organization';
 
 export function MetricsFieldFixture(
   field: string,
-  params: Partial<MetricsApiResponse> = {}
-): MetricsApiResponse {
+  params: Partial<SessionApiResponse> = {}
+): SessionApiResponse {
   return {
     start: '2021-12-01T16:15:00Z',
     end: '2021-12-02T16:15:00Z',
     query: '',
-    meta: [],
     intervals: [
       '2021-12-01T16:15:00Z',
       '2021-12-01T16:30:00Z',
@@ -150,13 +149,12 @@ export function MetricsFieldFixture(
   };
 }
 
-export function MetricsTotalCountByReleaseIn24h(): MetricsApiResponse {
+export function MetricsTotalCountByReleaseIn24h(): SessionApiResponse {
   return {
     start: '2021-12-01T16:15:00Z',
     end: '2021-12-02T16:15:00Z',
     query:
       'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
-    meta: [],
     intervals: [
       '2021-03-17T10:00:00Z',
       '2021-03-17T11:00:00Z',
@@ -208,12 +206,11 @@ export function MetricsTotalCountByReleaseIn24h(): MetricsApiResponse {
   };
 }
 
-export function MetricsSessionUserCountByStatusByReleaseFixture(): MetricsApiResponse {
+export function MetricsSessionUserCountByStatusByReleaseFixture(): SessionApiResponse {
   return {
     start: '2022-01-15T00:00:00Z',
     end: '2022-01-29T00:00:00Z',
     query: '',
-    meta: [],
     intervals: [
       '2022-01-15T00:00:00Z',
       '2022-01-16T00:00:00Z',


### PR DESCRIPTION
- Removes usage of `MetricdsApiResponse` type, required for [CI checks](https://github.com/getsentry/getsentry/actions/runs/13028563057/job/36342524600#step:12:4) to pass. 
- Required for https://github.com/getsentry/sentry/pull/83982