### PR TITLE
feat(taskbroker) Add crontab schedule support

### DIFF
--- a/src/sentry/taskworker/scheduler.py
+++ b/src/sentry/taskworker/scheduler.py
@@ -257,7 +257,7 @@ class CrontabSchedule(Schedule):
 class ScheduleEntry:
     """Metadata about a task that can be scheduled"""
 
-    def __init__(self, *, task: Task[Any, Any], schedule: timedelta) -> None:
+    def __init__(self, *, task: Task[Any, Any], schedule: timedelta | crontab) -> None:
         self._task = task
         scheduler: Schedule
         if isinstance(schedule, crontab):

--- a/src/sentry/taskworker/scheduler.py
+++ b/src/sentry/taskworker/scheduler.py
@@ -25,8 +25,7 @@ class ScheduleConfig(TypedDict):
     """The schedule definition for an individual task."""
 
     task: str
-    # TODO(taskworker) Implement crontab schedules
-    schedule: timedelta
+    schedule: timedelta | crontab
 
 
 ScheduleConfigMap = Mapping[str, ScheduleConfig]
@@ -251,7 +250,7 @@ class CrontabSchedule(Schedule):
 
     def runtime_after(self, start: datetime) -> datetime:
         """Get the next time a task should be spawned after `start`"""
-        start = start.replace(second=0, microsecond=0)
+        start = start.replace(second=0, microsecond=0) + timedelta(minutes=1)
         return self._advance(start)
 
 
@@ -289,6 +288,7 @@ class ScheduleEntry:
         return self._schedule.runtime_after(start)
 
     def delay_task(self) -> None:
+        logger.info("taskworker.scheduler.delay_task", extra={"task": self._task.fullname})
         self._task.delay()
 
 

--- a/src/sentry/taskworker/scheduler.py
+++ b/src/sentry/taskworker/scheduler.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import abc
+import dataclasses
 import heapq
 import logging
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
+from cronsim import CronSim, CronSimError
 from django.utils import timezone
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
@@ -139,12 +141,130 @@ class TimedeltaSchedule(Schedule):
         return start + self._delta
 
 
+@dataclasses.dataclass
+class crontab:
+    """
+    crontab schedule value object
+
+    Used in configuration to define a task schedule.
+    """
+
+    minute: str = "*"
+    hour: str = "*"
+    day_of_week: str = "*"
+    day_of_month: str = "*"
+    month_of_year: str = "*"
+
+    def __str__(self) -> str:
+        return (
+            f"{self.minute} {self.hour} {self.day_of_month} {self.month_of_year} {self.day_of_week}"
+        )
+
+
+class CrontabSchedule(Schedule):
+    """
+    Task schedules defined as crontab expressions.
+
+    Last run state is used to determine the next scheduled time.
+
+    If last run is in the future, the future value will be used to
+    calculate the next scheduled time.
+
+    If runs are missed, the schedule will align to the next interval
+    that would be scheduled. Lost runs are not recovered.
+    """
+
+    def __init__(self, name: str, crontab: crontab) -> None:
+        self._crontab = crontab
+        self._name = name
+        try:
+            self._cronsim = CronSim(str(crontab), timezone.now())
+        except CronSimError as e:
+            raise ValueError(f"crontab expression {self._crontab} is invalid") from e
+
+    def is_due(self, last_run: datetime | None = None) -> bool:
+        """Check if the schedule is due to run again based on last_run."""
+        if last_run is None:
+            return True
+        remaining = self.remaining_seconds(last_run)
+        return remaining <= 0
+
+    def remaining_seconds(self, last_run: datetime | None = None) -> int:
+        """
+        Get the number of seconds until this schedule is due again
+
+        Use the current time to find the next schedule time
+        """
+        if last_run is None:
+            return 0
+
+        # This could result in missed beats, or increased load on redis.
+        last_run = last_run.replace(second=0, microsecond=0)
+        now = timezone.now().replace(second=0, microsecond=0)
+
+        # A future last_run means we should wait until the
+        # next scheduled time, and then we can try again.
+        # we could be competing with another scheduler, or
+        # missing beats.
+        if last_run > now:
+            logger.warning(
+                "taskworker.scheduler.future_value",
+                extra={
+                    "task": self._name,
+                    "last_run": last_run,
+                    "now": now,
+                },
+            )
+            next_run = self._advance(last_run + timedelta(minutes=1))
+            return int(next_run.timestamp() - now.timestamp())
+
+        # If last run is in the past, see if the next runtime
+        # is in the future.
+        if last_run < now:
+            next_run = self._advance(last_run)
+            # Our next runtime is in the future, or now
+            if next_run >= now:
+                return int(next_run.timestamp() - now.timestamp())
+
+            # still in the past, we missed an interval :(
+            next_run = self._advance(now)
+            logger.warning(
+                "taskworker.scheduler.missed_interval",
+                extra={
+                    "task": self._name,
+                    "last_run": last_run,
+                    "now": now,
+                    "next_run": next_run,
+                },
+            )
+            return int(next_run.timestamp() - now.timestamp())
+
+        # last_run == now, we are on the beat, find the next interval
+        next_run = self._advance(now + timedelta(minutes=1))
+
+        return int(next_run.timestamp() - now.timestamp())
+
+    def _advance(self, dt: datetime) -> datetime:
+        self._cronsim.dt = dt
+        self._cronsim.advance()
+        return self._cronsim.dt
+
+    def runtime_after(self, start: datetime) -> datetime:
+        """Get the next time a task should be spawned after `start`"""
+        start = start.replace(second=0, microsecond=0)
+        return self._advance(start)
+
+
 class ScheduleEntry:
     """Metadata about a task that can be scheduled"""
 
     def __init__(self, *, task: Task[Any, Any], schedule: timedelta) -> None:
         self._task = task
-        scheduler = TimedeltaSchedule(schedule)
+        scheduler: Schedule
+        if isinstance(schedule, crontab):
+            scheduler = CrontabSchedule(task.fullname, schedule)
+        else:
+            scheduler = TimedeltaSchedule(schedule)
         self._schedule = scheduler
         self._last_run: datetime | None = None
 

--- a/tests/sentry/taskworker/test_scheduler.py
+++ b/tests/sentry/taskworker/test_scheduler.py
@@ -5,7 +5,13 @@ import pytest
 from django.utils import timezone
 
 from sentry.taskworker.registry import TaskRegistry
-from sentry.taskworker.scheduler import RunStorage, ScheduleSet, TimedeltaSchedule
+from sentry.taskworker.scheduler import (
+    CrontabSchedule,
+    RunStorage,
+    ScheduleSet,
+    TimedeltaSchedule,
+    crontab,
+)
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.redis import redis_clusters
 
@@ -44,8 +50,7 @@ def test_timedeltaschedule_invalid() -> None:
 @freeze_time("2025-01-24 14:25:00")
 def test_timedeltaschedule_is_due() -> None:
     now = timezone.now()
-    delta = timedelta(minutes=5)
-    schedule = TimedeltaSchedule(delta)
+    schedule = TimedeltaSchedule(timedelta(minutes=5))
 
     assert not schedule.is_due(now)
 
@@ -76,6 +81,106 @@ def test_timedeltaschedule_remaining_seconds() -> None:
 
     ten_min_ago = now - timedelta(minutes=10)
     assert schedule.remaining_seconds(ten_min_ago) == 0
+
+
+def test_crontabschedule_invalid() -> None:
+    with pytest.raises(ValueError):
+        CrontabSchedule("test", crontab(hour="99"))
+
+    with pytest.raises(ValueError):
+        CrontabSchedule("test", crontab(hour="25"))
+
+    with pytest.raises(ValueError):
+        CrontabSchedule("test", crontab(day_of_week="25"))
+
+
+def test_crontabschedule_is_due() -> None:
+    schedule = CrontabSchedule("test", crontab(minute="*/5"))
+
+    with freeze_time("2025-01-24 14:25:00"):
+        now = timezone.now()
+        assert schedule.is_due(None)
+        assert not schedule.is_due(now)
+
+    # last run was 14:20, current time is 14:22 = not due
+    with freeze_time("2025-01-24 14:22:00"):
+        two_twenty = timezone.now() - timedelta(minutes=2)
+        assert not schedule.is_due(two_twenty)
+
+    # last run was 14:20, current time is 14:25 = due
+    with freeze_time("2025-01-24 14:25:00"):
+        two_twenty = timezone.now() - timedelta(minutes=5)
+        assert schedule.is_due(two_twenty)
+
+    # last run was 14:15, current time is 14:25 = due as we missed an interval
+    with freeze_time("2025-01-24 14:25:00"):
+        two_fifteen = timezone.now() - timedelta(minutes=10)
+        assert schedule.is_due(two_fifteen)
+
+    # last run was 14:26 (the future) current time is 14:25 = not due
+    with freeze_time("2025-01-24 14:25:00"):
+        future = timezone.now() + timedelta(minutes=1)
+        assert not schedule.is_due(future)
+
+
+def test_crontabschedule_remaining_seconds() -> None:
+    schedule = CrontabSchedule("test", crontab(minute="*/5"))
+
+    assert schedule.remaining_seconds(None) == 0
+
+    # last run was late (14:21), next spawn is at 14:25
+    with freeze_time("2025-01-24 14:25:00"):
+        four_min_ago = timezone.now() - timedelta(minutes=4)
+        assert schedule.remaining_seconds(four_min_ago) == 0
+
+    # last run was 5 min ago, right on schedule
+    with freeze_time("2025-01-24 14:25:00"):
+        five_min_ago = timezone.now() - timedelta(minutes=5)
+        assert schedule.remaining_seconds(five_min_ago) == 0
+
+    # last run was mere seconds ago. 5 min remaining
+    with freeze_time("2025-01-24 14:25:10"):
+        five_min_ago = timezone.now()
+        assert schedule.remaining_seconds(five_min_ago) == 300
+
+    with freeze_time("2025-01-24 14:25:59"):
+        five_min_ago = timezone.now()
+        assert schedule.remaining_seconds(five_min_ago) == 300
+
+    # 14:19 was 1 min late, we missed a beat but we're currently on time.
+    with freeze_time("2025-01-24 14:25:10"):
+        six_min_ago = timezone.now() - timedelta(minutes=6)
+        assert schedule.remaining_seconds(six_min_ago) == 0
+
+    # We have missed a few intervals, try to get back on schedule for the next beat
+    with freeze_time("2025-01-24 14:23:00"):
+        twenty_two_min_ago = timezone.now() - timedelta(minutes=22)
+        assert schedule.remaining_seconds(twenty_two_min_ago) == 120
+
+    # We have encountered a value from the future.
+    # Our clock could be wrong, or we competing with another scheduler.
+    # Advance to the next tick 14:30.
+    with freeze_time("2025-01-24 14:24:00"):
+        future_two = timezone.now() + timedelta(minutes=2)
+        assert schedule.remaining_seconds(future_two) == 360
+
+
+@freeze_time("2025-01-24 14:25:00")
+def test_crontabschedule_runtime_after() -> None:
+    schedule = CrontabSchedule("test", crontab(minute="*/15"))
+
+    now = timezone.now()
+    assert schedule.runtime_after(now) == datetime(2025, 1, 24, 14, 30, 0, tzinfo=UTC)
+
+    last_run = datetime(2025, 1, 24, 14, 29, 15, tzinfo=UTC)
+    assert schedule.runtime_after(last_run) == datetime(2025, 1, 24, 14, 30, 0, tzinfo=UTC)
+
+    last_run = datetime(2025, 1, 24, 14, 38, 23, tzinfo=UTC)
+    assert schedule.runtime_after(last_run) == datetime(2025, 1, 24, 14, 45, 0, tzinfo=UTC)
+
+    schedule = CrontabSchedule("test", crontab(minute="1", hour="*/6"))
+    last_run = datetime(2025, 1, 24, 14, 29, 15, tzinfo=UTC)
+    assert schedule.runtime_after(last_run) == datetime(2025, 1, 24, 18, 1, 0, tzinfo=UTC)
 
 
 def test_scheduleset_add_invalid(taskregistry) -> None:

--- a/tests/sentry/taskworker/test_scheduler.py
+++ b/tests/sentry/taskworker/test_scheduler.py
@@ -182,6 +182,10 @@ def test_crontabschedule_runtime_after() -> None:
     last_run = datetime(2025, 1, 24, 14, 29, 15, tzinfo=UTC)
     assert schedule.runtime_after(last_run) == datetime(2025, 1, 24, 18, 1, 0, tzinfo=UTC)
 
+    schedule = CrontabSchedule("test", crontab(minute="*/1"))
+    now = timezone.now()
+    assert schedule.runtime_after(now) == datetime(2025, 1, 24, 14, 26, 0, tzinfo=UTC)
+
 
 def test_scheduleset_add_invalid(taskregistry) -> None:
     run_storage = Mock(spec=RunStorage)


### PR DESCRIPTION
Add support for crontab schedules. crontab schedules quantize to specific minutes based on the defined interval. cronsim only supports minute level resolution, for anything smaller than a minute we'll need to use timedelta.

If we encounter a future version, we trust the stored version as our clock could be wrong, and we would prefer to miss beats instead of spawning too many tasks. If we miss intervals that's ok, we will advance to align on the next beat. There is no recovery for missed beats. This emulates both how celery works and the `timedelta` scheduling for taskworkers.

Refs #81458
