### PR TITLE
ref(insights): pass in organization to getTransactionSummaryBaseUrl

### DIFF
--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -318,7 +318,7 @@ class _TransactionsList extends Component<Props> {
               <LinkButton
                 onClick={handleOpenAllEventsClick}
                 to={this.generatePerformanceTransactionEventsView().getPerformanceTransactionEventsViewUrlTarget(
-                  organization.slug,
+                  organization,
                   {
                     showTransactions: mapShowTransactionToPercentile(showTransactions),
                     breakdown,

--- a/static/app/components/events/contexts/knownContext/trace.tsx
+++ b/static/app/components/events/contexts/knownContext/trace.tsx
@@ -148,7 +148,7 @@ export function getTraceContextData({
           }
 
           const link = transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: transactionName,
             projectID: event.projectID,
             query: {},

--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -135,7 +135,7 @@ export function EventCustomPerformanceMetric({
     switch (source) {
       case EventDetailPageSource.PERFORMANCE:
         return transactionSummaryRouteWithQuery({
-          orgSlug: organization.slug,
+          organization,
           transaction: event.title,
           projectID: event.projectID,
           query: {query},
@@ -231,7 +231,7 @@ export function TraceEventCustomPerformanceMetric({
     switch (source) {
       case EventDetailPageSource.PERFORMANCE:
         return transactionSummaryRouteWithQuery({
-          orgSlug: organization.slug,
+          organization,
           transaction: event.title,
           projectID: event.projectID,
           query: {query},

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -203,7 +203,7 @@ function AggregateSpanDiff({event, project}: AggregateSpanDiffProps) {
         defaultValue: t('(unnamed span)'),
         link: (dataRow: any) => ({
           target: spanDetailsRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             spanSlug: {op: dataRow.operation, group: dataRow.group},
             transaction,
             projectID: project.id,

--- a/static/app/components/events/eventStatisticalDetector/eventRegressionSummary.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventRegressionSummary.tsx
@@ -58,7 +58,7 @@ export function getKeyValueListData(
     case IssueType.PERFORMANCE_DURATION_REGRESSION:
     case IssueType.PERFORMANCE_ENDPOINT_REGRESSION: {
       const target = transactionSummaryRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction: evidenceData.transaction,
         query: {},
         trendFunction: 'p95',

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -70,7 +70,7 @@ function EventStatisticalDetectorRegressedPerformanceMessage({
   });
 
   const transactionSummaryLink = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction,
     query: {},
     trendFunction: 'p95',

--- a/static/app/components/events/eventTags/eventTagContent.tsx
+++ b/static/app/components/events/eventTags/eventTagContent.tsx
@@ -59,7 +59,7 @@ function EventTagsContent({
           <EventTagsValue
             tag={tag}
             meta={meta?.value?.['']}
-            streamPath={`${getTransactionSummaryBaseUrl(organization.slug)}/`}
+            streamPath={`${getTransactionSummaryBaseUrl(organization)}/`}
             locationSearch={`?${qs.stringify({
               project: projectId,
               transaction: value,

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -220,7 +220,7 @@ function EventTagsTreeRowDropdown({
           to:
             originalTag.key === 'transaction'
               ? {
-                  pathname: `${getTransactionSummaryBaseUrl(organization.slug)}/`,
+                  pathname: `${getTransactionSummaryBaseUrl(organization)}/`,
                   query: {
                     project: event.projectID,
                     transaction: content.value,
@@ -297,7 +297,7 @@ function EventTagsTreeValue({
         transaction: content.value,
         referrer,
       });
-      const transactionDestination = `${getTransactionSummaryBaseUrl(organization.slug)}/?${transactionQuery}`;
+      const transactionDestination = `${getTransactionSummaryBaseUrl(organization)}/?${transactionQuery}`;
       tagValue = (
         <TagLinkText>
           <Link to={transactionDestination}>{content.value}</Link>

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -245,7 +245,7 @@ function MainThreadFunctionEvidence({
 
     if (evidenceData.transactionName) {
       const transactionSummaryLocation = transactionSummaryRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         projectID: event.projectID,
         transaction: evidenceData.transactionName,
         query: {},
@@ -466,7 +466,7 @@ const makeTransactionNameRow = (
   projectSlug?: string
 ) => {
   const transactionSummaryLocation = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     projectID: event.projectID,
     transaction: event.title,
     query: {},

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -208,7 +208,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
           }
 
           const target = transactionSummaryRouteWithQuery({
-            orgSlug: props.organization.slug,
+            organization: props.organization,
             transaction: transactionResult.transaction,
             query: omit(location.query, Object.values(PAGE_URL_PARAM)),
             projectID: String(childTransaction.value.project_id),
@@ -267,7 +267,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
         <LinkButton
           size="xs"
           to={spanDetailsRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: transactionName,
             query: location.query,
             spanSlug: {op: props.node.value.op, group: groupHash},

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -220,7 +220,7 @@ function SpanDetail(props: Props) {
           }
 
           const target = transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: transactionResult.transaction,
             query: omit(location.query, Object.values(PAGE_URL_PARAM)),
             projectID: String(childTransaction.project_id),
@@ -276,7 +276,7 @@ function SpanDetail(props: Props) {
         <LinkButton
           size="xs"
           to={spanDetailsRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: transactionName,
             query: location.query,
             spanSlug: {op: span.op, group: span.hash},

--- a/static/app/components/metrics/metricSamplesTable.tsx
+++ b/static/app/components/metrics/metricSamplesTable.tsx
@@ -565,7 +565,7 @@ function SpanId({
   }, [duration, selfTime, durationColor, selfTimeColor]);
 
   const transactionSummaryTarget = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction,
     query: {
       ...location.query,

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -232,7 +232,7 @@ function SearchBar(props: SearchBarProps) {
     setSearchResults([]);
 
     const next = transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction,
       projectID: String(project_id),
       query,

--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -238,7 +238,7 @@ function ProfileEventsCell<F extends FieldType>(props: ProfileEventsCellProps<F>
     if (defined(project)) {
       const linkToSummary = profilesRouteWithQuery({
         query: props.baggage.location.query,
-        orgSlug: props.baggage.organization.slug,
+        organization: props.baggage.organization,
         projectID: project.id,
         transaction: props.dataRow.transaction,
       });

--- a/static/app/utils/discover/eventView.spec.tsx
+++ b/static/app/utils/discover/eventView.spec.tsx
@@ -3140,7 +3140,7 @@ describe('EventView.getPerformanceTransactionEventsViewUrlTarget()', function ()
 
   it('generates a URL with customer domain context', function () {
     const view = new EventView(state);
-    const result = view.getPerformanceTransactionEventsViewUrlTarget(organization.slug, {
+    const result = view.getPerformanceTransactionEventsViewUrlTarget(organization, {
       showTransactions,
       breakdown,
       webVital,

--- a/static/app/utils/discover/eventView.spec.tsx
+++ b/static/app/utils/discover/eventView.spec.tsx
@@ -3123,7 +3123,7 @@ describe('EventView.getPerformanceTransactionEventsViewUrlTarget()', function ()
   it('generates a URL with non-customer domain context', function () {
     ConfigStore.set('customerDomain', null);
     const view = new EventView(state);
-    const result = view.getPerformanceTransactionEventsViewUrlTarget(organization.slug, {
+    const result = view.getPerformanceTransactionEventsViewUrlTarget(organization, {
       showTransactions,
       breakdown,
       webVital,

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -13,7 +13,7 @@ import {DEFAULT_PER_PAGE} from 'sentry/constants';
 import {ALL_ACCESS_PROJECTS, URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
-import type {NewQuery, SavedQuery} from 'sentry/types/organization';
+import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
 import toArray from 'sentry/utils/array/toArray';
@@ -1265,7 +1265,7 @@ class EventView {
   }
 
   getPerformanceTransactionEventsViewUrlTarget(
-    slug: string,
+    organization: Organization,
     options: {
       breakdown?: SpanOperationBreakdownFilter;
       showTransactions?: EventsDisplayFilterName;
@@ -1297,7 +1297,7 @@ class EventView {
     const query = cloneDeep(output as any);
     return {
       pathname: normalizeUrl(
-        `${getTransactionSummaryBaseUrl(slug, options.view)}/events/`
+        `${getTransactionSummaryBaseUrl(organization, options.view)}/events/`
       ),
       query,
     };

--- a/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
@@ -65,7 +65,7 @@ function RelatedTransactions({
       summaryView.query = summaryConditions;
 
       const target = transactionSummaryRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction: String(dataRow.transaction) || '',
         query: summaryView.generateQueryStringObject(),
         projectID,

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -114,7 +114,7 @@ function EventDetailsContent(props: Props) {
     const transactionSummaryTarget =
       event.type === 'transaction' && transactionName
         ? transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: transactionName,
             projectID: event.projectID,
             query: location.query,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -794,7 +794,7 @@ export function getTargetForTransactionSummaryLink(
   }
 
   const target = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction: String(dataRow.transaction),
     projectID,
     query: nextView?.getPageFiltersQuery() || {},

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -482,7 +482,7 @@ export function TransactionRenderer({
   const {projects} = useProjects({slugs: [projectSlug]});
 
   const target = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction,
     query: {
       ...location.query,

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -137,7 +137,7 @@ export function PageOverview() {
     !Array.isArray(location.query.project) && // Only render button to transaction summary when one project is selected.
     transaction &&
     transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction,
       query: {...location.query},
       projectID: project.id,

--- a/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
+++ b/static/app/views/insights/common/components/sampleDrawerHeaderTransaction.tsx
@@ -50,7 +50,7 @@ export function SampleDrawerHeaderTransaction(props: SampleDrawerHeaderProps) {
       {project ? (
         <TruncatedLink
           to={{
-            pathname: getTransactionSummaryBaseUrl(organization.slug, view),
+            pathname: getTransactionSummaryBaseUrl(organization, view),
             search: qs.stringify({
               project: project.slug,
               transaction,

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -64,7 +64,7 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
     undefined
   );
 
-  transactionRoute ??= `/${getTransactionSummaryBaseUrl(organization.slug, view, true)}`;
+  transactionRoute ??= `/${getTransactionSummaryBaseUrl(organization, view, true)}`;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debounceSetHighlightedSpanId = useCallback(

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanel.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanel.tsx
@@ -56,7 +56,7 @@ export function SpanSamplesPanel({groupId, moduleName, transactionRoute}: Props)
     ...(deviceClass ? {[SpanMetricsField.DEVICE_CLASS]: deviceClass} : {}),
   };
 
-  transactionRoute ??= getTransactionSummaryBaseUrl(organization.slug, view);
+  transactionRoute ??= getTransactionSummaryBaseUrl(organization, view);
 
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
 

--- a/static/app/views/metrics/summaryTable.tsx
+++ b/static/app/views/metrics/summaryTable.tsx
@@ -119,7 +119,7 @@ export const SummaryTable = memo(function SummaryTable({
 
   const transactionTo = (transaction: string) =>
     transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction,
       projectID: selection.projects.map(p => String(p)),
       query: {

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -132,7 +132,7 @@ function TeamMisery({
                     <TransactionWrapper>
                       <Link
                         to={transactionSummaryRouteWithQuery({
-                          orgSlug: organization.slug,
+                          organization,
                           transaction: dataRow.transaction as string,
                           projectID: project?.id,
                           query: {query: 'transaction.duration:<15m'},

--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -127,7 +127,7 @@ export const getTabCrumbs = ({
   }
 
   const routeQuery = {
-    orgSlug: organization.slug,
+    organization,
     transaction: transaction.name,
     projectID: transaction.project,
     query: location.query,

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -539,7 +539,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             location,
           })
         : transactionSummaryRouteWithQuery({
-            orgSlug: props.organization.slug,
+            organization: props.organization,
             projectID: listItem['project.id'] as string,
             transaction,
             query: props.eventView.getPageFiltersQuery(),

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -237,7 +237,7 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
             location,
           })
         : transactionSummaryRouteWithQuery({
-            orgSlug: props.organization.slug,
+            organization: props.organization,
             projectID: listItem['project.id'] as string,
             transaction,
             query: props.eventView.generateQueryStringObject(),

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -165,7 +165,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
       });
 
       const transactionTarget = transactionSummaryRouteWithQuery({
-        orgSlug: props.organization.slug,
+        organization: props.organization,
         projectID: getProjectID(listItem, projects),
         transaction: listItem.transaction,
         query: trendsTarget.query,

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -267,7 +267,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
 
       const isUnparameterizedRow = transaction === UNPARAMETERIZED_TRANSACTION;
       const transactionTarget = transactionSummaryRouteWithQuery({
-        orgSlug: props.organization.slug,
+        organization: props.organization,
         projectID: listItem['project.id'] as string,
         transaction: listItem.transaction as string,
         query: _eventView.generateQueryStringObject(),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -71,7 +71,7 @@ function SpanChild({
         }
 
         const target = transactionSummaryRouteWithQuery({
-          orgSlug: organization.slug,
+          organization,
           transaction: transactionResult.transaction,
           query: omit(location.query, Object.values(PAGE_URL_PARAM)),
           projectID: String(childTransaction.value.project_id),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -128,7 +128,7 @@ export function SpanDescription({
         <SpanSummaryLink event={node.event!} organization={organization} span={span} />
         <Link
           to={spanDetailsRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: node.event?.title ?? '',
             query: location.query,
             spanSlug: {op: span.op, group: groupHash},
@@ -387,7 +387,7 @@ function LegacySpanDescription({
         <LinkButton
           size="xs"
           to={spanDetailsRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: node.event?.title ?? '',
             query: location.query,
             spanSlug: {op: span.op, group: groupHash},

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -211,7 +211,7 @@ function LegacyGeneralInfo(props: GeneralnfoProps) {
           <TraceDrawerComponents.CopyableCardValueWithLink
             value={span.description}
             linkTarget={spanDetailsRouteWithQuery({
-              orgSlug: props.organization.slug,
+              organization: props.organization,
               transaction: props.node.event?.title ?? '',
               query: props.location.query,
               spanSlug: {op: span.op, group: groupHash},

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
@@ -238,7 +238,7 @@ function LegacyGeneralInfo({
       <TraceDrawerComponents.CopyableCardValueWithLink
         value={node.value.transaction}
         linkTarget={transactionSummaryRouteWithQuery({
-          orgSlug: organization.slug,
+          organization,
           transaction: node.value.transaction,
           // Omit the query from the target url, as we dont know where it may have came from
           // and if its syntax is supported on the target page. In this example, txn search does

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -63,7 +63,7 @@ export function TransactionHighlights(props: HighlightProps) {
     <BodyContentWrapper>
       <Link
         to={transactionSummaryRouteWithQuery({
-          orgSlug: props.organization.slug,
+          organization: props.organization,
           transaction: props.node.value.transaction,
           // Omit the query from the target url, as we dont know where it may have came from
           // and if its syntax is supported on the target page. In this example, txn search does

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/measurements.tsx
@@ -40,7 +40,7 @@ function generateLinkWithQuery(
   const eventView = EventView.fromLocation(location);
   eventView.query = query;
   return transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction: event.title,
     projectID: event.projectID,
     query: {query},

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -94,11 +94,7 @@ function getPerformanceBreadCrumbs(
   const crumbs: Crumb[] = [];
 
   const performanceUrl = getPerformanceBaseUrl(organization.slug, view, true);
-  const transactionSummaryUrl = getTransactionSummaryBaseUrl(
-    organization.slug,
-    view,
-    true
-  );
+  const transactionSummaryUrl = getTransactionSummaryBaseUrl(organization, view, true);
 
   crumbs.push({
     label: (view && DOMAIN_VIEW_TITLES[view]) || t('Performance'),

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -302,7 +302,7 @@ class _Table extends Component<Props, State> {
             location,
           })
         : transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: String(dataRow.transaction) || '',
             query: summaryView.generateQueryStringObject(),
             projectID,

--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -100,7 +100,6 @@ export function Tags({
     return null;
   }
 
-  const orgSlug = organization.slug;
   const renderText = showingAll ? t('Show less') : t('Show more') + '...';
 
   return (
@@ -114,7 +113,7 @@ export function Tags({
 
             if (isTraceTransaction(event)) {
               const route = transactionSummaryRouteWithQuery({
-                orgSlug,
+                organization,
                 transaction: event.transaction,
                 projectID: String(event.project_id),
                 query: {

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -355,7 +355,7 @@ function EventDetails({detail, organization, location}: EventDetailProps) {
           <Row title={t('Description')}>
             <Link
               to={transactionSummaryRouteWithQuery({
-                orgSlug: organization.slug,
+                organization,
                 transaction: detail.traceFullDetailedEvent.transaction,
                 query: omit(location.query, Object.values(PAGE_URL_PARAM)),
                 projectID: String(detail.traceFullDetailedEvent.project_id),

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -113,7 +113,7 @@ class TransactionDetail extends Component<Props> {
     const {location, organization, transaction} = this.props;
 
     const target = transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction: transaction.transaction,
       query: omit(location.query, Object.values(PAGE_URL_PARAM)),
       projectID: String(transaction.project_id),

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -100,7 +100,7 @@ function EventDetailsContent(props: Props) {
       query: appendTagCondition(query, formatTagKey(tag.key), tag.value),
     };
     return transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction: event.title,
       projectID: event.projectID,
       query: newQuery,

--- a/static/app/views/performance/transactionSummary/aggregateSpanWaterfall/utils.tsx
+++ b/static/app/views/performance/transactionSummary/aggregateSpanWaterfall/utils.tsx
@@ -1,24 +1,25 @@
 import type {Query} from 'history';
 
+import type {Organization} from 'sentry/types/organization';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
 export function aggregateWaterfallRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
   view?: DomainView;
 }) {
-  const pathname = `${getTransactionSummaryBaseUrl(orgSlug, view)}/aggregateWaterfall/`;
+  const pathname = `${getTransactionSummaryBaseUrl(organization, view)}/aggregateWaterfall/`;
 
   const filter = decodeScalar(query.query);
   let httpMethod: string | undefined = undefined;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -86,7 +86,7 @@ function TransactionHeader({
       }
 
       const routeQuery = {
-        orgSlug: organization.slug,
+        organization,
         transaction: transactionName,
         projectID: projectId,
         query: location.query,
@@ -112,7 +112,7 @@ function TransactionHeader({
           return transactionSummaryRouteWithQuery(routeQuery);
       }
     },
-    [location.query, organization.slug, projectId, transactionName, view]
+    [location.query, organization, projectId, transactionName, view]
   );
 
   const onTabChange = useCallback(

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -129,7 +129,7 @@ function PageLayout(props: Props) {
       }
 
       const routeQuery = {
-        orgSlug: organization.slug,
+        organization,
         transaction: transactionName,
         projectID: projectId,
         query: location.query,
@@ -151,7 +151,7 @@ function PageLayout(props: Props) {
           return aggregateWaterfallRouteWithQuery(routeQuery);
         case Tab.WEB_VITALS:
           return vitalsRouteWithQuery({
-            orgSlug: organization.slug,
+            organization,
             transaction: transactionName,
             projectID: decodeScalar(location.query.project),
             query: location.query,
@@ -161,7 +161,7 @@ function PageLayout(props: Props) {
           return transactionSummaryRouteWithQuery(routeQuery);
       }
     },
-    [location.query, organization.slug, projectId, transactionName]
+    [location.query, organization, projectId, transactionName]
   );
 
   const onTabChange = useCallback(
@@ -237,7 +237,7 @@ function PageLayout(props: Props) {
                 projects={selectableProjects}
                 router={router}
                 nextPath={{
-                  pathname: generateTransactionSummaryRoute({orgSlug: organization.slug}),
+                  pathname: generateTransactionSummaryRoute({organization}),
                   query: {
                     project: projectId,
                     transaction: transactionName,

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
@@ -1,6 +1,7 @@
 import type {Location, Query} from 'history';
 
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
@@ -88,19 +89,19 @@ export function getEventsFilterOptions(
 }
 
 export function eventsRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
   view?: DomainView;
 }) {
-  const pathname = `${getTransactionSummaryBaseUrl(orgSlug, view)}/events/`;
+  const pathname = `${getTransactionSummaryBaseUrl(organization, view)}/events/`;
   return {
     pathname,
     query: {

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
@@ -99,7 +99,7 @@ function SuspectSpansHeader(props: HeaderProps) {
   const navigate = useNavigate();
 
   const viewAllTarget = spansRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction: transactionName,
     projectID: projectId,
     query: location.query,

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -330,7 +330,7 @@ export class TagExplorer extends Component<Props> {
 
     if (column.key === 'key') {
       const target = tagsRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction: transactionName,
         projectID: decodeScalar(location.query.project),
         query: {...location.query, tagKey: dataRow.tags_key},
@@ -501,7 +501,7 @@ function TagsHeader(props: HeaderProps) {
   };
 
   const viewAllTarget = tagsRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction: transactionName,
     projectID: decodeScalar(location.query.project),
     query: {...location.query},

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -78,7 +78,7 @@ function UserStats({
   const orgSlug = organization.slug;
 
   let webVitalsTarget: LocationDescriptor = vitalsRouteWithQuery({
-    orgSlug,
+    organization,
     transaction: transactionName,
     projectID: decodeScalar(location.query.project),
     query: location.query,

--- a/static/app/views/performance/transactionSummary/transactionProfiles/utils.ts
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/utils.ts
@@ -1,22 +1,23 @@
 import type {Query} from 'history';
 
+import type {Organization} from 'sentry/types/organization';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
 export function profilesRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
   view?: DomainView;
 }) {
-  const pathname = `${getTransactionSummaryBaseUrl(orgSlug, view)}/profiles/`;
+  const pathname = `${getTransactionSummaryBaseUrl(organization, view)}/profiles/`;
 
   return {
     pathname,

--- a/static/app/views/performance/transactionSummary/transactionReplays/utils.ts
+++ b/static/app/views/performance/transactionSummary/transactionReplays/utils.ts
@@ -1,22 +1,23 @@
 import type {Query} from 'history';
 
+import type {Organization} from 'sentry/types/organization';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
 export function replaysRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
   view?: DomainView;
 }) {
-  const pathname = `${getTransactionSummaryBaseUrl(orgSlug, view)}/replays/`;
+  const pathname = `${getTransactionSummaryBaseUrl(organization, view)}/replays/`;
 
   return {
     pathname,

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {
   generateSuspectSpansResponse,
   initializeData as _initializeData,
@@ -648,8 +650,9 @@ describe('Performance > Transaction Spans > Span Summary', function () {
 
 describe('spanDetailsRouteWithQuery', function () {
   it('should encode slashes in span op', function () {
+    const organization = OrganizationFixture();
     const target = spanDetailsRouteWithQuery({
-      orgSlug: 'org-slug',
+      organization,
       transaction: 'transaction',
       query: {},
       spanSlug: {op: 'o/p', group: 'aaaaaaaaaaaaaaaa'},

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -1,31 +1,32 @@
 import type {Query} from 'history';
 
+import type {Organization} from 'sentry/types/organization';
 import type {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
 function generateSpanDetailsRoute({
-  orgSlug,
+  organization,
   spanSlug,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   spanSlug: SpanSlug;
   view?: DomainView;
 }): string {
   const spanComponent = `${encodeURIComponent(spanSlug.op)}:${spanSlug.group}`;
-  return `${getTransactionSummaryBaseUrl(orgSlug, view)}/spans/${spanComponent}/`;
+  return `${getTransactionSummaryBaseUrl(organization, view)}/spans/${spanComponent}/`;
 }
 
 export function spanDetailsRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   query,
   spanSlug,
   projectID,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   spanSlug: SpanSlug;
   transaction: string;
@@ -33,7 +34,7 @@ export function spanDetailsRouteWithQuery({
   view?: DomainView;
 }) {
   const pathname = generateSpanDetailsRoute({
-    orgSlug,
+    organization,
     spanSlug,
     view,
   });

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -196,7 +196,7 @@ function renderBodyCell(
   return function (column: Column, dataRow: DataRow): React.ReactNode {
     if (column.key === SpanMetricsField.SPAN_OP) {
       const target = spanDetailsRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction: transactionName,
         query: location.query,
         spanSlug: {op: dataRow['span.op'], group: ''},
@@ -217,7 +217,7 @@ function renderBodyCell(
       }
 
       const target = spanDetailsRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction: transactionName,
         query: location.query,
         spanSlug: {op: dataRow['span.op'], group: dataRow['span.group']},

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -106,7 +106,7 @@ function renderBodyCellWithMeta(
 
     if (column.key === 'description') {
       const target = spanDetailsRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction: transactionName,
         query: location.query,
         spanSlug: {op: dataRow.operation, group: dataRow.group},

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -3,6 +3,7 @@ import pick from 'lodash/pick';
 
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
@@ -16,30 +17,30 @@ import type {SpanSort, SpanSortOption} from './types';
 import {SpanSortOthers, SpanSortPercentiles} from './types';
 
 export function generateSpansRoute({
-  orgSlug,
+  organization,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   view?: DomainView;
 }): string {
-  return `${getTransactionSummaryBaseUrl(orgSlug, view)}/spans/`;
+  return `${getTransactionSummaryBaseUrl(organization, view)}/spans/`;
 }
 
 export function spansRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
   view?: DomainView;
 }) {
   const pathname = generateSpansRoute({
-    orgSlug,
+    organization,
     view,
   });
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -339,7 +339,7 @@ function TagsHeatMap(
                 }
 
                 const moreEventsTarget = eventsRouteWithQuery({
-                  orgSlug: organization.slug,
+                  organization,
                   transaction: transactionName,
                   projectID: decodeScalar(location.query.project),
                   query: {

--- a/static/app/views/performance/transactionSummary/transactionTags/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/utils.tsx
@@ -7,13 +7,13 @@ import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
 export function generateTagsRoute({
-  orgSlug,
+  organization,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   view?: DomainView;
 }): string {
-  return `${getTransactionSummaryBaseUrl(orgSlug, view)}/tags/`;
+  return `${getTransactionSummaryBaseUrl(organization, view)}/tags/`;
 }
 
 export function decodeSelectedTagKey(location: Location): string | undefined {
@@ -25,20 +25,20 @@ export function trackTagPageInteraction(organization: Organization) {
 }
 
 export function tagsRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
   view?: DomainView;
 }) {
   const pathname = generateTagsRoute({
-    orgSlug,
+    organization,
     view,
   });
 

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -237,7 +237,7 @@ class TransactionThresholdModal extends Component<Props, State> {
     const summaryView = eventView.clone();
     summaryView.query = summaryView.getQueryWithAdditionalConditions();
     const target = transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction: transactionName,
       query: summaryView.generateQueryStringObject(),
       projectID: project?.id,

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -1,6 +1,7 @@
 import type {ECharts} from 'echarts';
 import type {Query} from 'history';
 
+import type {Organization} from 'sentry/types/organization';
 import type {WebVital} from 'sentry/utils/fields';
 import type {HistogramData} from 'sentry/utils/performance/histogram/types';
 import {getBucketWidth} from 'sentry/utils/performance/histogram/utils';
@@ -9,23 +10,27 @@ import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transaction
 
 import type {Point, Rectangle} from './types';
 
-export function generateVitalsRoute({orgSlug}: {orgSlug: string}): string {
-  return `${getTransactionSummaryBaseUrl(orgSlug)}/vitals/`;
+export function generateVitalsRoute({
+  organization,
+}: {
+  organization: Organization;
+}): string {
+  return `${getTransactionSummaryBaseUrl(organization)}/vitals/`;
 }
 
 export function vitalsRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   projectID?: string | string[];
 }) {
   const pathname = generateVitalsRoute({
-    orgSlug,
+    organization,
   });
 
   return {

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -212,7 +212,7 @@ class VitalCard extends Component<Props, State> {
             to={newEventView
               .withColumns([{kind: 'field', field: column}])
               .withSorts([{kind: 'desc', field: column}])
-              .getPerformanceTransactionEventsViewUrlTarget(organization.slug, {
+              .getPerformanceTransactionEventsViewUrlTarget(organization, {
                 showTransactions:
                   dataFilter === 'all'
                     ? EventsDisplayFilterName.P100

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -37,15 +37,15 @@ export enum TransactionFilterOptions {
 }
 
 export function generateTransactionSummaryRoute({
-  orgSlug,
+  organization,
   subPath,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   subPath?: string;
   view?: DomainView; // TODO - this should be mantatory once we release domain view
 }): string {
-  return `${getTransactionSummaryBaseUrl(orgSlug, view)}/${subPath ? `${subPath}/` : ''}`;
+  return `${getTransactionSummaryBaseUrl(organization, view)}/${subPath ? `${subPath}/` : ''}`;
 }
 
 // normalizes search conditions by removing any redundant search conditions before presenting them in:
@@ -73,7 +73,7 @@ export function normalizeSearchConditionsWithTransactionName(
 }
 
 export function transactionSummaryRouteWithQuery({
-  orgSlug,
+  organization,
   transaction,
   projectID,
   query,
@@ -86,7 +86,7 @@ export function transactionSummaryRouteWithQuery({
   subPath,
   view,
 }: {
-  orgSlug: string;
+  organization: Organization;
   query: Query;
   transaction: string;
   additionalQuery?: Record<string, string | undefined>;
@@ -100,7 +100,7 @@ export function transactionSummaryRouteWithQuery({
   view?: DomainView;
 }) {
   const pathname = generateTransactionSummaryRoute({
-    orgSlug,
+    organization,
     subPath,
     view,
   });
@@ -266,11 +266,11 @@ export function generateReplayLink(routes: Array<PlainRoute<any>>) {
 }
 
 export function getTransactionSummaryBaseUrl(
-  orgSlug: string,
+  organization: Organization,
   view?: DomainView,
   bare: boolean = false
 ) {
-  return `${getPerformanceBaseUrl(orgSlug, view, bare)}/summary`;
+  return `${getPerformanceBaseUrl(organization.slug, view, bare)}/summary`;
 }
 
 export const SidebarSpacer = styled('div')`

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -577,7 +577,7 @@ function TransactionSummaryLink(props: TransactionSummaryLinkProps) {
   const summaryView = eventView.clone();
   const projectID = getTrendProjectId(transaction, projects);
   const target = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction: String(transaction.transaction),
     query: summaryView.generateQueryStringObject(),
     projectID,

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -163,7 +163,7 @@ class Table extends Component<Props, State> {
       const transaction = String(dataRow.transaction) || '';
 
       const target = transactionSummaryRouteWithQuery({
-        orgSlug: organization.slug,
+        organization,
         transaction,
         query: summaryView.generateQueryStringObject(),
         projectID,

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -127,7 +127,7 @@ function ProfileSummaryHeader(props: ProfileSummaryHeaderProps) {
     props.project &&
     props.transaction &&
     transactionSummaryRouteWithQuery({
-      orgSlug: props.organization.slug,
+      organization: props.organization,
       transaction: props.transaction,
       projectID: props.project.id,
       query: {query: props.query},

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -662,7 +662,7 @@ function generateTransactionLink(
     const {start, end, period} = datetime;
 
     return transactionSummaryRouteWithQuery({
-      orgSlug: organization.slug,
+      organization,
       transaction: transaction! as string,
       query: {
         query: trendTransaction ? '' : `release:${version}`,

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -493,7 +493,7 @@ export function TransactionRenderer({
   const {projects} = useProjects({slugs: [projectSlug]});
 
   const target = transactionSummaryRouteWithQuery({
-    orgSlug: organization.slug,
+    organization,
     transaction,
     query: {
       ...location.query,


### PR DESCRIPTION
As part of #84021 , we have to update the route for the transaction summary to be `/insights/summary` instead of `/performance/summary`. This route change should be behind a flag.

We have a helper function that returns the transaction summary url `getTransactionSummaryBaseUrl`, this function makes the most sense to add the conditional that returns either /insights/summary or /performance/summary. However the helper function does not have access to organization features.

This PR replaces the `orgSlug` parameter with the `organization` parameter, that way we can access `organization.features`. In another PR we can use this parameter to add the conditional on the feature flag.

