### PR TITLE
fix(widget-builder): Pass organization in save event

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -31,7 +31,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
       builder_version: WidgetBuilderVersion.SLIDEOUT,
       data_set: state.dataset ?? '',
       new_widget: !isEditing,
-      organization: organization.slug,
+      organization,
     });
     const widget = convertBuilderStateToWidget(state);
     setIsSaving(true);
@@ -44,7 +44,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
       setError(errorDetails);
       addErrorMessage(t('Unable to save widget'));
     }
-  }, [api, onSave, organization.slug, state, widgetIndex, setError, isEditing]);
+  }, [api, onSave, organization, state, widgetIndex, setError, isEditing]);
 
   return (
     <Button priority="primary" onClick={handleSave} busy={isSaving}>


### PR DESCRIPTION
We aren't able to see any events created for the widget builder form save. It may be because I was passing the org slug down and not the org. Let's give this a try.