### PR TITLE
fix(uptime): normalize subscription uuid

### DIFF
--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from collections import defaultdict
 
 from drf_spectacular.utils import extend_schema
@@ -103,7 +104,7 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
             raise ValueError("Invalid project uptime subscription ids provided")
 
         subscription_id_to_project_uptime_subscription_id = {
-            project_uptime_subscription[1]: project_uptime_subscription[0]
+            str(uuid.UUID(project_uptime_subscription[1])): project_uptime_subscription[0]
             for project_uptime_subscription in project_uptime_subscriptions
             if project_uptime_subscription[0] is not None
             and project_uptime_subscription[1] is not None

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -18,7 +18,7 @@ class OrganizationUptimeCheckIndexEndpointTest(
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.subscription_id = str(uuid.uuid4())
+        self.subscription_id = uuid.uuid4().hex
         self.subscription = self.create_uptime_subscription(
             url="https://santry.io", subscription_id=self.subscription_id
         )


### PR DESCRIPTION
`UptimeSubscription.subscription_id` is stored as a uuid without dashes. this PR modifies the test to use a uuid without dashes, and normalizes it to match what EAP returns.

Fixes SENTRY-3MY0