### PR TITLE
fix(profiling): Make aggregate flamegraph panel taller and scrollable

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -373,7 +373,7 @@ const LayoutMain = styled(Layout.Main)`
 
 const LandingAggregateFlamegraphSizer = styled('div')`
   height: 100%;
-  min-height: max(50vh, 300px);
+  min-height: max(80vh, 300px);
   margin-bottom: ${space(2)};
   margin-top: ${space(2)};
 `;

--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -717,6 +717,7 @@ const AggregateFlamegraphFunctionBreakdownContainer = styled('div')`
   flex-direction: column;
   width: 360px;
   border-left: 1px solid ${p => p.theme.border};
+  overflow: scroll;
 `;
 const AggregateFlamegraphFunctionBreakdownHeaderRow = styled('div')<{
   fontSize?: string;


### PR DESCRIPTION
The flamegraph is too small so make it taller and the breakdown on the side needs to be scrollable when the list is too long.