### PR TITLE
build(ui): Remove preset-react importSource, transform-react-jsx

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -6,7 +6,6 @@ const config: TransformOptions = {
       '@babel/preset-react',
       {
         runtime: 'automatic',
-        importSource: '@emotion/react',
       },
     ],
     [
@@ -28,7 +27,6 @@ const config: TransformOptions = {
     development: {
       plugins: [
         '@emotion/babel-plugin',
-        '@babel/plugin-transform-react-jsx-source',
         ...(process.env.SENTRY_UI_HOT_RELOAD ? ['react-refresh/babel'] : []),
       ],
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@acemarke/react-prod-sourcemaps": "^0.2.1",
     "@babel/core": "~7.25.9",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
-    "@babel/plugin-transform-react-jsx-source": "^7.25.9",
     "@babel/plugin-transform-runtime": "~7.25.9",
     "@babel/preset-env": "~7.25.9",
     "@babel/preset-react": "^7.25.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,13 +866,6 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.25.9"
 
-"@babel/plugin-transform-react-jsx-source@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz#4c6b8daa520b5f155b5fb55547d7c9fa91417503"
-  integrity sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-
 "@babel/plugin-transform-react-jsx@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz#06367940d8325b36edff5e2b9cbe782947ca4166"


### PR DESCRIPTION
we have the following text all over our production app hundreds of times.

```
You have tried to stringify object returned from `css` function. It isn't supposed to be used directly (e.g. as value of the `className` prop), but rather handed to emotion so it can handle it (e.g. as value of `css` prop).
```

that lead me to https://github.com/emotion-js/emotion/issues/2135 which seems to say we don't need the importSource  if we're already using emotion/babel-plugin


`@babel/plugin-transform-react-jsx-source` is already included in `@babel/preset-react`