### PR TITLE
fix(widget-builder): Disallow default sorting by equations

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.spec.tsx
@@ -934,6 +934,29 @@ describe('Visualize', () => {
     expect(screen.getByRole('textbox', {name: 'Numeric Input'})).toHaveValue('300');
   });
 
+  it('does not allow for deleting the only field or aggregate when there is an equation', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.TRANSACTIONS,
+              field: ['equation|count()+1', 'count()'],
+            },
+          }),
+        }),
+      }
+    );
+
+    const removeButtons = await screen.findAllByRole('button', {name: 'Remove field'});
+    expect(removeButtons[0]).toBeEnabled();
+    expect(removeButtons[1]).toBeDisabled();
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -326,6 +326,12 @@ function Visualize({error, setError}: VisualizeProps) {
               field
             );
 
+            const isOnlyFieldOrAggregate =
+              fields.length === 2 &&
+              field.kind !== FieldValueKind.EQUATION &&
+              fields.filter(fieldItem => fieldItem.kind === FieldValueKind.EQUATION)
+                .length > 0;
+
             // Depending on the dataset and the display type, we use different options for
             // displaying in the column select.
             // For charts, we show aggregate parameter options for the y-axis as primary options.
@@ -790,7 +796,7 @@ function Visualize({error, setError}: VisualizeProps) {
                     borderless
                     icon={<IconDelete />}
                     size="zero"
-                    disabled={fields.length <= 1 || !canDelete}
+                    disabled={fields.length <= 1 || !canDelete || isOnlyFieldOrAggregate}
                     onClick={() => {
                       dispatch({
                         type: updateAction,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -1143,6 +1143,32 @@ describe('useWidgetBuilderState', () => {
       // The y-axis takes priority
       expect(result.current.state.sort).toEqual([{field: 'count()', kind: 'desc'}]);
     });
+
+    it('ensures that default sort is not an equation', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.LINE,
+            field: [],
+            yAxis: ['equation|count()+1', 'count()'],
+          },
+        })
+      );
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.sort).toEqual([]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_FIELDS,
+          payload: [{field: 'browser.name', kind: FieldValueKind.FIELD}],
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([{field: 'count()', kind: 'desc'}]);
+    });
   });
 
   describe('yAxis', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -23,6 +23,7 @@ import {MAX_NUM_Y_AXES} from 'sentry/views/dashboards/widgetBuilder/buildSteps/y
 import {useQueryParamState} from 'sentry/views/dashboards/widgetBuilder/hooks/useQueryParamState';
 import {DEFAULT_RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
 import type {Thresholds} from 'sentry/views/dashboards/widgets/common/types';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 export type WidgetBuilderStateQueryParams = {
   dataset?: WidgetType;
@@ -306,21 +307,28 @@ function useWidgetBuilderState(): {
               return;
             }
 
+            const firstActionPayloadNotEquation = action.payload.filter(
+              field => field.kind !== FieldValueKind.EQUATION
+            )[0];
+
             if (isRemoved) {
               setSort([
                 {
                   kind: 'desc',
-                  field: generateFieldAsString(action.payload[0] as QueryFieldValue),
+                  field: generateFieldAsString(
+                    firstActionPayloadNotEquation as QueryFieldValue
+                  ),
                 },
               ]);
             } else {
-              // Find the index of the first field that doesn't match the old fields.
+              // Find the index of the first field that doesn't match the old fields and is not an equation.
               const changedFieldIndex = action.payload.findIndex(
                 field =>
                   !fields?.find(
                     originalField =>
                       generateFieldAsString(originalField) ===
-                      generateFieldAsString(field)
+                        generateFieldAsString(field) ||
+                      originalField.kind === FieldValueKind.EQUATION
                   )
               );
               if (changedFieldIndex !== -1) {
@@ -343,13 +351,19 @@ function useWidgetBuilderState(): {
             displayType !== DisplayType.BIG_NUMBER &&
             action.payload.length > 0
           ) {
+            const firstYAxisNotEquation = yAxis?.filter(
+              field => field.kind !== FieldValueKind.EQUATION
+            )[0];
+            const firstActionPayloadNotEquation = action.payload.filter(
+              field => field.kind !== FieldValueKind.EQUATION
+            )[0];
             // Adding a grouping, so default the sort to the first aggregate if possible
             setSort([
               {
                 kind: 'desc',
                 field: generateFieldAsString(
-                  (yAxis?.[0] as QueryFieldValue) ??
-                    (action.payload[0] as QueryFieldValue)
+                  (firstYAxisNotEquation as QueryFieldValue) ??
+                    (firstActionPayloadNotEquation as QueryFieldValue)
                 ),
               },
             ]);


### PR DESCRIPTION
The widget builder currently defaults the sort by to the first aggregate/equation/field in the visualize field. If the equation is blank, it causes an error state in the widget preview. To fix this there are two changes I made:
1. There cannot be an equation without an aggregate (i.e. the aggregate cannot be deleted if there is only an aggregate and equation)
2. The sort by field is always defaulted to an aggregate/field (that's in the visualize field), not an equation

referencing [this widget builder bug](https://www.notion.so/sentry/Sorting-issue-with-removing-last-field-and-having-equation-leftover-17a8b10e4b5d803fa74be51b6ffc5dcb?pvs=4)
