### PR TITLE
feat(issue-details): Update tags preview to show more tags

### DIFF
--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -225,7 +225,9 @@ export default function IssueTagsPreview({
       .filter(tag => priorityTags.includes(tag.key))
       .sort((a, b) => priorityTags.indexOf(a.key) - priorityTags.indexOf(b.key));
 
-    return sortedTags.slice(0, 4);
+    const remainingTagKeys = tags.filter(tag => !priorityTags.includes(tag.key)).sort();
+    const orderedTags = [...sortedTags, ...remainingTagKeys];
+    return orderedTags.slice(0, 4);
   }, [tags, project?.platform]);
 
   if (isPending) {


### PR DESCRIPTION
this pr updates the tags preview to supplement the curated list of tags with additional tags (chosen alphabetically). this means that if our chosen list of tags doesn't have 4 tags for an issue, we will still try to show 4 tags. 