### PR TITLE
:bug: fix(bitbucket): make no issue tracker error to halt

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -8,9 +8,18 @@ from django.urls import reverse
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
-from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    IntegrationFormError,
+    IntegrationInstallationConfigurationError,
+)
 from sentry.silo.base import all_silo_function
 from sentry.users.models.user import User
+
+# Generated based on the response from the Bitbucket API
+# Example: {"type": "error", "error": {"message": "Repository has no issue tracker."}}
+BITBUCKET_HALT_ERROR_CODES = ["Repository has no issue tracker."]
+
 
 ISSUE_TYPES = (
     ("bug", "Bug"),
@@ -140,6 +149,11 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
         try:
             issue = client.create_issue(data.get("repo"), data)
         except ApiError as e:
+            if e.json:
+                if (
+                    message := e.json.get("error", {}).get("message")
+                ) in BITBUCKET_HALT_ERROR_CODES:
+                    raise IntegrationInstallationConfigurationError(message)
             self.raise_error(e)
 
         return {

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -140,10 +140,10 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def raise_error(self, exc: Exception, identity: Identity | None = None) -> NoReturn:
-        if exc.json:
+        if isinstance(exc, ApiError) and exc.json:
             if (message := exc.json.get("error", {}).get("message")) in BITBUCKET_HALT_ERROR_CODES:
                 raise IntegrationInstallationConfigurationError(message)
-        return super().raise_error(exc, identity)
+        super().raise_error(exc, identity)
 
     def create_issue(self, data, **kwargs):
         client = self.get_client()


### PR DESCRIPTION
we were getting `{"type": "error", "error": {"message": "Repository has no issue tracker."}}` which should be recorded as a halt.