### PR TITLE
chore: Copy UrlEncode over 

### DIFF
--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -120,3 +120,12 @@ export function generateOrgSlugUrl(orgSlug: any) {
   const sentryDomain = window.__initialData.links.sentryUrl.split('/')[2];
   return `${window.location.protocol}//${orgSlug}.${sentryDomain}${window.location.pathname}`;
 }
+
+/**
+ * Encodes given object into url-friendly format
+ */
+export function urlEncode(object: {[key: string]: any}): string {
+  return Object.keys(object)
+    .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(object[key])}`)
+    .join('&');
+}

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -1,7 +1,5 @@
-import * as qs from 'query-string';
-
 import type {PageFilters} from 'sentry/types/core';
-import {defined} from 'sentry/utils';
+import {defined, urlEncode} from 'sentry/utils';
 import {MRIToField} from 'sentry/utils/metrics/mri';
 import type {MetricDisplayType, MetricsQuery} from 'sentry/utils/metrics/types';
 import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
@@ -70,15 +68,7 @@ export function getWidgetEquation(equation: EquationParams): WidgetQuery {
 }
 
 export function encodeWidgetQuery(query: any) {
-  return qs.stringify(
-    {
-      ...query,
-      aggregates: query.aggregates.join(','),
-      fields: query.fields?.join(','),
-      columns: query.columns.join(','),
-    },
-    {strict: false}
-  );
+  return urlEncode(query);
 }
 
 export function getWidgetAsQueryParams(

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -68,7 +68,12 @@ export function getWidgetEquation(equation: EquationParams): WidgetQuery {
 }
 
 export function encodeWidgetQuery(query: any) {
-  return urlEncode(query);
+  return urlEncode({
+    ...query,
+    aggregates: query.aggregates.join(','),
+    fields: query.fields?.join(','),
+    columns: query.columns.join(','),
+  });
 }
 
 export function getWidgetAsQueryParams(

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -70,12 +70,15 @@ export function getWidgetEquation(equation: EquationParams): WidgetQuery {
 }
 
 export function encodeWidgetQuery(query: any) {
-  return qs.stringify({
-    ...query,
-    aggregates: query.aggregates.join(','),
-    fields: query.fields?.join(','),
-    columns: query.columns.join(','),
-  });
+  return qs.stringify(
+    {
+      ...query,
+      aggregates: query.aggregates.join(','),
+      fields: query.fields?.join(','),
+      columns: query.columns.join(','),
+    },
+    {strict: false}
+  );
 }
 
 export function getWidgetAsQueryParams(

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -1,4 +1,4 @@
-import {urlEncode} from '@sentry/core';
+import * as qs from 'query-string';
 
 import type {PageFilters} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
@@ -70,7 +70,7 @@ export function getWidgetEquation(equation: EquationParams): WidgetQuery {
 }
 
 export function encodeWidgetQuery(query: any) {
-  return urlEncode({
+  return qs.stringify({
     ...query,
     aggregates: query.aggregates.join(','),
     fields: query.fields?.join(','),

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1,4 +1,3 @@
-import * as qs from 'query-string';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
@@ -21,6 +20,7 @@ import selectEvent from 'sentry-test/selectEvent';
 import * as modals from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
+import {urlEncode} from 'sentry/utils';
 import {DatasetSource, TOP_N} from 'sentry/utils/discover/types';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {
@@ -964,12 +964,7 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: qs.stringify({
-          ...defaultWidgetQuery,
-          aggregates: defaultWidgetQuery.aggregates.join(','),
-          fields: defaultWidgetQuery.fields?.join(','),
-          columns: defaultWidgetQuery.columns.join(','),
-        }),
+        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
         displayType: DisplayType.LINE,
         defaultTableColumns,
       },
@@ -1004,12 +999,7 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: qs.stringify({
-          ...defaultWidgetQuery,
-          aggregates: defaultWidgetQuery.aggregates.join(','),
-          fields: defaultWidgetQuery.fields?.join(','),
-          columns: defaultWidgetQuery.columns.join(','),
-        }),
+        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
       },
     });
 
@@ -1250,12 +1240,7 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: qs.stringify({
-          ...defaultWidgetQuery,
-          aggregates: defaultWidgetQuery.aggregates.join(','),
-          fields: defaultWidgetQuery.fields?.join(','),
-          columns: defaultWidgetQuery.columns.join(','),
-        }),
+        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
         defaultTableColumns,
         yAxis: ['equation|count_if(transaction.duration,equals,300)*2'],
       },
@@ -1536,12 +1521,7 @@ describe('WidgetBuilder', function () {
         orgFeatures: [...defaultOrgFeatures],
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: qs.stringify({
-            ...defaultWidgetQuery,
-            aggregates: defaultWidgetQuery.aggregates.join(','),
-            fields: defaultWidgetQuery.fields?.join(','),
-            columns: defaultWidgetQuery.columns.join(','),
-          }),
+          defaultWidgetQuery: urlEncode(defaultWidgetQuery),
           displayType: DisplayType.LINE,
           defaultTableColumns,
         },
@@ -1581,12 +1561,7 @@ describe('WidgetBuilder', function () {
         orgFeatures: [...defaultOrgFeatures],
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: qs.stringify({
-            ...defaultWidgetQuery,
-            aggregates: defaultWidgetQuery.aggregates.join(','),
-            fields: defaultWidgetQuery.fields?.join(','),
-            columns: defaultWidgetQuery.columns.join(','),
-          }),
+          defaultWidgetQuery: urlEncode(defaultWidgetQuery),
           displayType: DisplayType.LINE,
           defaultTableColumns,
         },

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1,4 +1,4 @@
-import {urlEncode} from '@sentry/core';
+import * as qs from 'query-string';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
@@ -964,7 +964,7 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+        defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
         displayType: DisplayType.LINE,
         defaultTableColumns,
       },
@@ -999,7 +999,7 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+        defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
       },
     });
 
@@ -1240,7 +1240,7 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+        defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
         defaultTableColumns,
         yAxis: ['equation|count_if(transaction.duration,equals,300)*2'],
       },
@@ -1521,7 +1521,7 @@ describe('WidgetBuilder', function () {
         orgFeatures: [...defaultOrgFeatures],
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+          defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
           displayType: DisplayType.LINE,
           defaultTableColumns,
         },
@@ -1561,7 +1561,7 @@ describe('WidgetBuilder', function () {
         orgFeatures: [...defaultOrgFeatures],
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+          defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
           displayType: DisplayType.LINE,
           defaultTableColumns,
         },

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -964,7 +964,12 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+        defaultWidgetQuery: qs.stringify({
+          ...defaultWidgetQuery,
+          aggregates: defaultWidgetQuery.aggregates.join(','),
+          fields: defaultWidgetQuery.fields?.join(','),
+          columns: defaultWidgetQuery.columns.join(','),
+        }),
         displayType: DisplayType.LINE,
         defaultTableColumns,
       },
@@ -1245,7 +1250,12 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+        defaultWidgetQuery: qs.stringify({
+          ...defaultWidgetQuery,
+          aggregates: defaultWidgetQuery.aggregates.join(','),
+          fields: defaultWidgetQuery.fields?.join(','),
+          columns: defaultWidgetQuery.columns.join(','),
+        }),
         defaultTableColumns,
         yAxis: ['equation|count_if(transaction.duration,equals,300)*2'],
       },
@@ -1526,7 +1536,12 @@ describe('WidgetBuilder', function () {
         orgFeatures: [...defaultOrgFeatures],
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+          defaultWidgetQuery: qs.stringify({
+            ...defaultWidgetQuery,
+            aggregates: defaultWidgetQuery.aggregates.join(','),
+            fields: defaultWidgetQuery.fields?.join(','),
+            columns: defaultWidgetQuery.columns.join(','),
+          }),
           displayType: DisplayType.LINE,
           defaultTableColumns,
         },
@@ -1566,7 +1581,12 @@ describe('WidgetBuilder', function () {
         orgFeatures: [...defaultOrgFeatures],
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+          defaultWidgetQuery: qs.stringify({
+            ...defaultWidgetQuery,
+            aggregates: defaultWidgetQuery.aggregates.join(','),
+            fields: defaultWidgetQuery.fields?.join(','),
+            columns: defaultWidgetQuery.columns.join(','),
+          }),
           displayType: DisplayType.LINE,
           defaultTableColumns,
         },

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -999,7 +999,12 @@ describe('WidgetBuilder', function () {
     renderTestComponent({
       query: {
         source: DashboardWidgetSource.DISCOVERV2,
-        defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+        defaultWidgetQuery: qs.stringify({
+          ...defaultWidgetQuery,
+          aggregates: defaultWidgetQuery.aggregates.join(','),
+          fields: defaultWidgetQuery.fields?.join(','),
+          columns: defaultWidgetQuery.columns.join(','),
+        }),
       },
     });
 

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -1,4 +1,4 @@
-import {urlEncode} from '@sentry/core';
+import * as qs from 'query-string';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
@@ -928,7 +928,7 @@ describe('WidgetBuilder', function () {
         renderTestComponent({
           query: {
             source: DashboardWidgetSource.DISCOVERV2,
-            defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+            defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
             displayType: DisplayType.TABLE,
             defaultTableColumns,
           },
@@ -980,7 +980,7 @@ describe('WidgetBuilder', function () {
         renderTestComponent({
           query: {
             source: DashboardWidgetSource.DISCOVERV2,
-            defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+            defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
             displayType: DisplayType.TABLE,
             defaultTableColumns,
           },
@@ -1031,7 +1031,7 @@ describe('WidgetBuilder', function () {
         renderTestComponent({
           query: {
             source: DashboardWidgetSource.DISCOVERV2,
-            defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+            defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
             displayType: DisplayType.TABLE,
             defaultTableColumns,
           },

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -1,4 +1,3 @@
-import * as qs from 'query-string';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
@@ -18,6 +17,7 @@ import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
+import {urlEncode} from 'sentry/utils';
 import {ERROR_FIELDS, ERRORS_AGGREGATION_FUNCTIONS} from 'sentry/utils/discover/fields';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {
@@ -928,7 +928,7 @@ describe('WidgetBuilder', function () {
         renderTestComponent({
           query: {
             source: DashboardWidgetSource.DISCOVERV2,
-            defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+            defaultWidgetQuery: urlEncode(defaultWidgetQuery),
             displayType: DisplayType.TABLE,
             defaultTableColumns,
           },
@@ -980,7 +980,7 @@ describe('WidgetBuilder', function () {
         renderTestComponent({
           query: {
             source: DashboardWidgetSource.DISCOVERV2,
-            defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+            defaultWidgetQuery: urlEncode(defaultWidgetQuery),
             displayType: DisplayType.TABLE,
             defaultTableColumns,
           },
@@ -1031,7 +1031,7 @@ describe('WidgetBuilder', function () {
         renderTestComponent({
           query: {
             source: DashboardWidgetSource.DISCOVERV2,
-            defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+            defaultWidgetQuery: urlEncode(defaultWidgetQuery),
             displayType: DisplayType.TABLE,
             defaultTableColumns,
           },

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -1,4 +1,4 @@
-import {urlEncode} from '@sentry/core';
+import * as qs from 'query-string';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
@@ -396,7 +396,7 @@ describe('WidgetBuilder', function () {
       const {router} = renderTestComponent({
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+          defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
           displayType: DisplayType.TABLE,
           defaultTableColumns: ['title', 'count()', 'count_unique(user)', 'epm()'],
         },

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -1,4 +1,3 @@
-import * as qs from 'query-string';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricsFieldFixture} from 'sentry-fixture/metrics';
@@ -11,6 +10,7 @@ import selectEvent from 'sentry-test/selectEvent';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
+import {urlEncode} from 'sentry/utils';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {
   DashboardWidgetSource,
@@ -396,7 +396,7 @@ describe('WidgetBuilder', function () {
       const {router} = renderTestComponent({
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
-          defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+          defaultWidgetQuery: urlEncode(defaultWidgetQuery),
           displayType: DisplayType.TABLE,
           defaultTableColumns: ['title', 'count()', 'count_unique(user)', 'epm()'],
         },

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -1,6 +1,5 @@
 import type {Location, Query} from 'history';
 import * as Papa from 'papaparse';
-import * as qs from 'query-string';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
@@ -15,7 +14,7 @@ import type {
   OrganizationSummary,
 } from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {defined} from 'sentry/utils';
+import {defined, urlEncode} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventData} from 'sentry/utils/discover/eventView';
@@ -887,18 +886,7 @@ export function constructAddQueryToDashboardLink({
       start: eventView.start,
       end: eventView.end,
       statsPeriod: eventView.statsPeriod,
-      defaultWidgetQuery: qs.stringify(
-        {
-          ...defaultWidgetQuery,
-          aggregates: defaultWidgetQuery.aggregates.join(','),
-          fields: defaultWidgetQuery.fields?.join(','),
-          columns: defaultWidgetQuery.columns.join(','),
-        },
-        {
-          sort: false,
-          strict: false,
-        }
-      ),
+      defaultWidgetQuery: urlEncode(defaultWidgetQuery),
       defaultTableColumns: defaultTableFields,
       defaultTitle,
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -887,7 +887,18 @@ export function constructAddQueryToDashboardLink({
       start: eventView.start,
       end: eventView.end,
       statsPeriod: eventView.statsPeriod,
-      defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
+      defaultWidgetQuery: qs.stringify(
+        {
+          ...defaultWidgetQuery,
+          aggregates: defaultWidgetQuery.aggregates.join(','),
+          fields: defaultWidgetQuery.fields?.join(','),
+          columns: defaultWidgetQuery.columns.join(','),
+        },
+        {
+          sort: false,
+          strict: false,
+        }
+      ),
       defaultTableColumns: defaultTableFields,
       defaultTitle,
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -1,6 +1,6 @@
-import {urlEncode} from '@sentry/core';
 import type {Location, Query} from 'history';
 import * as Papa from 'papaparse';
+import * as qs from 'query-string';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
@@ -887,7 +887,7 @@ export function constructAddQueryToDashboardLink({
       start: eventView.start,
       end: eventView.end,
       statsPeriod: eventView.statsPeriod,
-      defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+      defaultWidgetQuery: qs.stringify(defaultWidgetQuery),
       defaultTableColumns: defaultTableFields,
       defaultTitle,
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import {urlEncode} from '@sentry/core';
+import * as qs from 'query-string';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Alert} from 'sentry/components/alert';
@@ -203,7 +203,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
     window.location.assign(
       `${organization?.links.organizationUrl || ''}/extensions/${
         this.integrationSlug
-      }/configure/?${urlEncode(query)}`
+      }/configure/?${qs.stringify(query)}`
     );
   };
 

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Alert} from 'sentry/components/alert';
@@ -18,7 +17,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
-import {generateOrgSlugUrl} from 'sentry/utils';
+import {generateOrgSlugUrl, urlEncode} from 'sentry/utils';
 import type {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
 import {
   getIntegrationFeatureGate,
@@ -203,7 +202,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncComponen
     window.location.assign(
       `${organization?.links.organizationUrl || ''}/extensions/${
         this.integrationSlug
-      }/configure/?${qs.stringify(query)}`
+      }/configure/?${urlEncode(query)}`
     );
   };
 


### PR DESCRIPTION
In preparation for upgrading to Sentry SDK v9, we need to replace `urlEncode` as it's deprecated. We copied `urlEncode` over from the sentry-javascript repo.

Merge after https://github.com/getsentry/sentry/pull/84196