### PR TITLE
feat(dashboards): `TimeSeriesWidget` unit conversions

### DIFF
--- a/static/app/utils/unitConversion/convertRate.spec.tsx
+++ b/static/app/utils/unitConversion/convertRate.spec.tsx
@@ -5,10 +5,11 @@ import {convertRate} from './convertRate';
 describe('convertRate', () => {
   it.each([
     [0, RateUnit.PER_MINUTE, RateUnit.PER_MINUTE, 0],
-    [17, RateUnit.PER_MINUTE, RateUnit.PER_SECOND, 1020],
-    [17, RateUnit.PER_MINUTE, RateUnit.PER_HOUR, 0.28333333],
-    [0.2, RateUnit.PER_HOUR, RateUnit.PER_MINUTE, 12],
-    [0.2, RateUnit.PER_HOUR, RateUnit.PER_SECOND, 720],
+    [17, RateUnit.PER_MINUTE, RateUnit.PER_SECOND, 0.28333333],
+    [17, RateUnit.PER_MINUTE, RateUnit.PER_HOUR, 1020],
+    [0.2, RateUnit.PER_HOUR, RateUnit.PER_MINUTE, 0.00333333],
+    [0.2, RateUnit.PER_HOUR, RateUnit.PER_SECOND, 0.00005555],
+    [35, RateUnit.PER_SECOND, RateUnit.PER_MINUTE, 2100],
   ])('Converts %s %s to %s', (value, fromUnit, toUnit, result) => {
     expect(convertRate(value, fromUnit, toUnit)).toBeCloseTo(result, 5);
   });

--- a/static/app/utils/unitConversion/convertRate.tsx
+++ b/static/app/utils/unitConversion/convertRate.tsx
@@ -1,5 +1,5 @@
 import {RATE_UNIT_MULTIPLIERS, type RateUnit} from '../discover/fields';
 
 export function convertRate(value: number, fromUnit: RateUnit, toUnit: RateUnit): number {
-  return value * (RATE_UNIT_MULTIPLIERS[toUnit] / RATE_UNIT_MULTIPLIERS[fromUnit]);
+  return value * (RATE_UNIT_MULTIPLIERS[fromUnit] / RATE_UNIT_MULTIPLIERS[toUnit]);
 }

--- a/static/app/views/dashboards/widgets/common/typePredicates.tsx
+++ b/static/app/views/dashboards/widgets/common/typePredicates.tsx
@@ -9,3 +9,8 @@ export function isASizeUnit(unit?: string): unit is SizeUnit {
 export function isARateUnit(unit?: string): unit is RateUnit {
   return Object.values(RateUnit).includes(unit as unknown as RateUnit);
 }
+export function isAUnitConvertibleFieldType(
+  fieldType?: string
+): fieldType is 'duration' | 'size' | 'rate' {
+  return ['duration', 'size', 'rate'].includes(fieldType as unknown as string);
+}

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -146,6 +146,43 @@ export default storyBook(LineChartWidget, story => {
             Toggle 99th Percentile
           </Button>
         </SideBySide>
+
+        <p>
+          <JSXNode name="LineChartWidget" /> will automatically check the types and unit
+          of all the incoming timeseries. If they do not all match, it will fall back to a
+          plain number scale. If the types match but the units do not, it will fall back
+          to a sensible unit
+        </p>
+
+        <MediumWidget>
+          <LineChartWidget
+            title="span.duration"
+            timeseries={[
+              {
+                ...durationTimeSeries1,
+                meta: {
+                  fields: durationTimeSeries1.meta?.fields!,
+                  units: {
+                    'p99(span.duration)': 'millisecond',
+                  },
+                },
+              },
+              {
+                ...durationTimeSeries2,
+                data: durationTimeSeries2.data.map(datum => ({
+                  ...datum,
+                  value: datum.value / 1000,
+                })),
+                meta: {
+                  fields: durationTimeSeries2.meta?.fields!,
+                  units: {
+                    'p50(span.duration)': 'second',
+                  },
+                },
+              },
+            ]}
+          />
+        </MediumWidget>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatTooltipValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatTooltipValue.tsx
@@ -1,14 +1,14 @@
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
-import {
-  ABYTE_UNITS,
-  DURATION_UNITS,
-  SIZE_UNITS,
-} from 'sentry/utils/discover/fieldRenderers';
-import type {RateUnit} from 'sentry/utils/discover/fields';
+import {ABYTE_UNITS} from 'sentry/utils/discover/fieldRenderers';
+import {DurationUnit, type RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {formatRate} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
+import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
+import {convertSize} from 'sentry/utils/unitConversion/convertSize';
+
+import {isADurationUnit, isASizeUnit} from '../common/typePredicates';
 
 export function formatTooltipValue(value: number, type: string, unit?: string): string {
   switch (type) {
@@ -18,18 +18,24 @@ export function formatTooltipValue(value: number, type: string, unit?: string): 
     case 'percentage':
       return formatPercentage(value, 2);
     case 'duration':
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      return getDuration((value * (unit ? DURATION_UNITS[unit] : 1)) / 1000, 2, true);
+      const durationUnit = isADurationUnit(unit) ? unit : DurationUnit.MILLISECOND;
+      const durationInSeconds = convertDuration(value, durationUnit, DurationUnit.SECOND);
+
+      return getDuration(durationInSeconds, 2, true);
     case 'size':
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      const bytes = value * SIZE_UNITS[unit ?? 'byte'];
+      const sizeUnit = isASizeUnit(unit) ? unit : SizeUnit.BYTE;
+      const sizeInBytes = convertSize(value, sizeUnit, SizeUnit.BYTE);
 
       const formatter = ABYTE_UNITS.includes(unit ?? 'byte')
         ? formatBytesBase10
         : formatBytesBase2;
 
-      return formatter(bytes);
+      return formatter(sizeInBytes);
     case 'rate':
+      // Always show rate in the original dataset's unit. If the unit is not
+      // appropriate, always convert the unit in the original dataset first.
+      // This way, named rate functions like `epm()` will be shows in per minute
+      // units
       return formatRate(value, unit as RateUnit);
     default:
       return value.toString();

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatYAxisValue.tsx
@@ -1,12 +1,18 @@
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
-import {ABYTE_UNITS, SIZE_UNITS} from 'sentry/utils/discover/fieldRenderers';
-import {DurationUnit, RATE_UNIT_LABELS, RateUnit} from 'sentry/utils/discover/fields';
+import {ABYTE_UNITS} from 'sentry/utils/discover/fieldRenderers';
+import {
+  DurationUnit,
+  RATE_UNIT_LABELS,
+  RateUnit,
+  SizeUnit,
+} from 'sentry/utils/discover/fields';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
+import {convertSize} from 'sentry/utils/unitConversion/convertSize';
 
-import {isADurationUnit, isARateUnit} from '../common/typePredicates';
+import {isADurationUnit, isARateUnit, isASizeUnit} from '../common/typePredicates';
 
 import {formatYAxisDuration} from './formatYAxisDuration';
 
@@ -31,15 +37,19 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
       );
       return formatYAxisDuration(durationInMilliseconds);
     case 'size':
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      const bytes = value * SIZE_UNITS[unit ?? 'byte'];
+      const sizeUnit = isASizeUnit(unit) ? unit : SizeUnit.BYTE;
+      const sizeInBytes = convertSize(value, sizeUnit, SizeUnit.BYTE);
 
       const formatter = ABYTE_UNITS.includes(unit ?? 'byte')
         ? formatBytesBase10
         : formatBytesBase2;
 
-      return formatter(bytes);
+      return formatter(sizeInBytes);
     case 'rate':
+      // Always show rate in the original dataset's unit. If the unit is not
+      // appropriate, always convert the unit in the original dataset first.
+      // This way, named rate functions like `epm()` will be shows in per minute
+      // units
       const rateUnit = isARateUnit(unit) ? unit : RateUnit.PER_SECOND;
       return `${value.toLocaleString(undefined, {
         notation: 'compact',

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.spec.tsx
@@ -91,4 +91,42 @@ describe('scaleTimeSeriesData', () => {
       },
     });
   });
+
+  it('scales size units from mebibyte to byte', () => {
+    const timeserie: TimeseriesData = {
+      field: 'file.size',
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          value: 17,
+        },
+      ],
+      meta: {
+        fields: {
+          'file.size': 'size',
+        },
+        units: {
+          'file.size': 'mebibyte',
+        },
+      },
+    };
+
+    expect(scaleTimeSeriesData(timeserie, SizeUnit.BYTE)).toEqual({
+      field: 'file.size',
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          value: 17825792,
+        },
+      ],
+      meta: {
+        fields: {
+          'file.size': 'size',
+        },
+        units: {
+          'file.size': 'byte',
+        },
+      },
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.spec.tsx
@@ -1,0 +1,94 @@
+import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
+
+import type {TimeseriesData} from '../common/types';
+
+import {scaleTimeSeriesData} from './scaleTimeSeriesData';
+
+describe('scaleTimeSeriesData', () => {
+  describe('does not scale unscalable types', () => {
+    const timeserie: TimeseriesData = {
+      field: 'user',
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          value: 17,
+        },
+      ],
+      meta: {
+        fields: {
+          user: 'string',
+        },
+        units: {
+          user: null,
+        },
+      },
+    };
+
+    it.each([RateUnit.PER_MINUTE, DurationUnit.SECOND, SizeUnit.GIBIBYTE, null] as const)(
+      'Does not scale strings to %s',
+      unit => {
+        expect(scaleTimeSeriesData(timeserie, unit)).toEqual(timeserie);
+      }
+    );
+  });
+
+  it('does not scale duration units from second to gigabyte', () => {
+    const timeserie: TimeseriesData = {
+      field: 'transaction.duration',
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          value: 17,
+        },
+      ],
+      meta: {
+        fields: {
+          'transaction.duration': 'duration',
+        },
+        units: {
+          'transaction.duration': 'second',
+        },
+      },
+    };
+
+    expect(scaleTimeSeriesData(timeserie, SizeUnit.GIGABYTE)).toEqual(timeserie);
+  });
+
+  it('scales duration units from second to millisecond', () => {
+    const timeserie: TimeseriesData = {
+      field: 'transaction.duration',
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          value: 17,
+        },
+      ],
+      meta: {
+        fields: {
+          'transaction.duration': 'duration',
+        },
+        units: {
+          'transaction.duration': 'second',
+        },
+      },
+    };
+
+    expect(scaleTimeSeriesData(timeserie, DurationUnit.MILLISECOND)).toEqual({
+      field: 'transaction.duration',
+      data: [
+        {
+          timestamp: '2025-01-01T00:00:00',
+          value: 17000,
+        },
+      ],
+      meta: {
+        fields: {
+          'transaction.duration': 'duration',
+        },
+        units: {
+          'transaction.duration': 'millisecond',
+        },
+      },
+    });
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.tsx
@@ -1,0 +1,102 @@
+import * as Sentry from '@sentry/react';
+
+import {
+  type AggregationOutputType,
+  DurationUnit,
+  RateUnit,
+  SizeUnit,
+} from 'sentry/utils/discover/fields';
+import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
+import {convertRate} from 'sentry/utils/unitConversion/convertRate';
+import {convertSize} from 'sentry/utils/unitConversion/convertSize';
+
+import {
+  isADurationUnit,
+  isARateUnit,
+  isASizeUnit,
+  isAUnitConvertibleFieldType,
+} from '../common/typePredicates';
+import type {TimeseriesData} from '../common/types';
+
+import {FALLBACK_TYPE} from './timeSeriesWidgetVisualization';
+
+export function scaleTimeSeriesData(
+  timeserie: Readonly<TimeseriesData>,
+  destinationUnit: DurationUnit | SizeUnit | RateUnit | null
+): TimeseriesData {
+  // TODO: Instead of a fallback, allow this to be `null`, which might happen
+  const sourceType =
+    (timeserie.meta?.fields[timeserie.field] as AggregationOutputType) ??
+    (FALLBACK_TYPE as AggregationOutputType);
+
+  // Don't bother trying to convert numbers, dates, etc.
+  if (!isAUnitConvertibleFieldType(sourceType)) {
+    return timeserie;
+  }
+
+  const sourceUnit = timeserie.meta?.units?.[timeserie.field] ?? null;
+
+  if (!destinationUnit || sourceUnit === destinationUnit) {
+    return timeserie;
+  }
+
+  // Don't bother with invalid conversions
+  if (
+    (sourceType === 'duration' && !isADurationUnit(destinationUnit)) ||
+    (sourceType === 'size' && !isASizeUnit(destinationUnit)) ||
+    (sourceType === 'rate' && !isARateUnit(destinationUnit))
+  ) {
+    Sentry.captureMessage(
+      `Attempted invalid timeseries conversion from ${sourceType} in ${sourceUnit} to ${destinationUnit}`
+    );
+
+    return timeserie;
+  }
+
+  return {
+    ...timeserie,
+    data: timeserie.data.map(datum => {
+      const {value} = datum;
+
+      let scaledValue: number = value;
+
+      if (sourceType === 'duration') {
+        scaledValue = convertDuration(
+          value,
+          (sourceUnit ?? DurationUnit.MILLISECOND) as DurationUnit,
+          destinationUnit as DurationUnit
+        );
+      } else if (sourceType === 'size') {
+        scaledValue = convertSize(
+          value,
+          (sourceUnit ?? SizeUnit.BYTE) as SizeUnit,
+          destinationUnit as SizeUnit
+        );
+      } else if (sourceType === 'rate') {
+        scaledValue = convertRate(
+          value,
+          (sourceUnit ?? RateUnit.PER_SECOND) as RateUnit,
+          destinationUnit as RateUnit
+        );
+      } else {
+        Sentry.captureMessage(
+          `Attempted invalid timeseries conversion from ${sourceType} in ${sourceUnit} to ${destinationUnit}`
+        );
+      }
+
+      return {
+        ...datum,
+        value: scaledValue,
+      };
+    }),
+    meta: {
+      ...timeserie.meta,
+      fields: {
+        [timeserie.field]: sourceType,
+      },
+      units: {
+        [timeserie.field]: destinationUnit,
+      },
+    },
+  };
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.tsx
@@ -18,7 +18,7 @@ import {
 } from '../common/typePredicates';
 import type {TimeseriesData} from '../common/types';
 
-import {FALLBACK_TYPE} from './timeSeriesWidgetVisualization';
+import {FALLBACK_TYPE} from './settings';
 
 export function scaleTimeSeriesData(
   timeserie: Readonly<TimeseriesData>,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/settings.tsx
@@ -1,0 +1,14 @@
+import { DurationUnit, SizeUnit, RateUnit, type AggregationOutputType } from "sentry/utils/discover/fields";
+
+
+export const FALLBACK_TYPE = 'number';
+export const FALLBACK_UNIT_FOR_FIELD_TYPE = {
+  number: null,
+  integer: null,
+  date: null,
+  duration: DurationUnit.MILLISECOND,
+  percentage: null,
+  string: null,
+  size: SizeUnit.BYTE,
+  rate: RateUnit.PER_SECOND,
+} satisfies Record<AggregationOutputType, DurationUnit | SizeUnit | RateUnit | null>;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/settings.tsx
@@ -1,5 +1,9 @@
-import { DurationUnit, SizeUnit, RateUnit, type AggregationOutputType } from "sentry/utils/discover/fields";
-
+import {
+  type AggregationOutputType,
+  DurationUnit,
+  RateUnit,
+  SizeUnit,
+} from 'sentry/utils/discover/fields';
 
 export const FALLBACK_TYPE = 'number';
 export const FALLBACK_UNIT_FOR_FIELD_TYPE = {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -80,8 +80,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     releaseSeries = ReleaseSeries(theme, props.releases, onClick, utc ?? false);
   }
 
-  // @ts-expect-error TS(7051): Parameter has a name but no type. Did you mean 'ar... Remove this comment to see the full error message
-  const formatSeriesName: (string) => string = name => {
+  const formatSeriesName: (string: string) => string = name => {
     return props.aliases?.[name] ?? name;
   };
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -16,8 +16,8 @@ import {isChartHovered} from 'sentry/components/charts/utils';
 import type {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import {uniq} from 'sentry/utils/array/uniq';
-import {
-  type AggregationOutputType,
+import type {
+  AggregationOutputType,
   DurationUnit,
   RateUnit,
   SizeUnit,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -88,28 +88,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     saveOnZoom: true,
   });
 
-  let completeSeries: TimeseriesData[] = props.timeseries;
-  const incompleteSeries: TimeseriesData[] = [];
-
-  if (dataCompletenessDelay > 0) {
-    completeSeries = [];
-
-    props.timeseries.forEach(timeserie => {
-      const [completeSerie, incompleteSerie] = splitSeriesIntoCompleteAndIncomplete(
-        timeserie,
-        dataCompletenessDelay
-      );
-
-      if (completeSerie && completeSerie.data.length > 0) {
-        completeSeries.push(completeSerie);
-      }
-
-      if (incompleteSerie && incompleteSerie.data.length > 0) {
-        incompleteSeries.push(incompleteSerie);
-      }
-    });
-  }
-
   // TODO: There's a TypeScript indexing error here. This _could_ in theory be
   // `undefined`. We need to guard against this in the parent component, and
   // show an error.
@@ -137,6 +115,28 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   // TODO: It would be smart, here, to check the units and convert if necessary
   const yAxisUnit = firstSeries?.meta?.units?.[firstSeriesField] ?? undefined;
+
+  let completeSeries: TimeseriesData[] = props.timeseries;
+  const incompleteSeries: TimeseriesData[] = [];
+
+  if (dataCompletenessDelay > 0) {
+    completeSeries = [];
+
+    props.timeseries.forEach(timeserie => {
+      const [completeSerie, incompleteSerie] = splitSeriesIntoCompleteAndIncomplete(
+        timeserie,
+        dataCompletenessDelay
+      );
+
+      if (completeSerie && completeSerie.data.length > 0) {
+        completeSeries.push(completeSerie);
+      }
+
+      if (incompleteSerie && incompleteSerie.data.length > 0) {
+        incompleteSeries.push(incompleteSerie);
+      }
+    });
+  }
 
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = (
     params,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -41,6 +41,7 @@ import {formatTooltipValue} from './formatTooltipValue';
 import {formatYAxisValue} from './formatYAxisValue';
 import {ReleaseSeries} from './releaseSeries';
 import {scaleTimeSeriesData} from './scaleTimeSeriesData';
+import {FALLBACK_TYPE, FALLBACK_UNIT_FOR_FIELD_TYPE} from './settings';
 import {splitSeriesIntoCompleteAndIncomplete} from './splitSeriesIntoCompleteAndIncomplete';
 
 type VisualizationType = 'area' | 'line' | 'bar';
@@ -317,19 +318,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     />
   );
 }
-
-export const FALLBACK_TYPE = 'number';
-
-const FALLBACK_UNIT_FOR_FIELD_TYPE = {
-  number: null,
-  integer: null,
-  date: null,
-  duration: DurationUnit.MILLISECOND,
-  percentage: null,
-  string: null,
-  size: SizeUnit.BYTE,
-  rate: RateUnit.PER_SECOND,
-} satisfies Record<AggregationOutputType, DurationUnit | SizeUnit | RateUnit | null>;
 
 const SeriesConstructors: Record<VisualizationType, SeriesConstructor> = {
   area: AreaChartWidgetSeries,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -93,7 +93,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // show an error.
   const firstSeries = props.timeseries[0]!;
 
-  let yAxisType: string;
+  let yAxisFieldType: string;
 
   const types = Array.from(
     new Set(
@@ -106,9 +106,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   ) as string[];
 
   if (types.length === 0 || types.length > 1) {
-    yAxisType = FALLBACK_TYPE;
+    yAxisFieldType = FALLBACK_TYPE;
   } else {
-    yAxisType = types[0]!;
+    yAxisFieldType = types[0]!;
   }
 
   const firstSeriesField = firstSeries?.field;
@@ -271,7 +271,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         animation: false,
         axisLabel: {
           formatter(value: number) {
-            return formatYAxisValue(value, yAxisType, yAxisUnit);
+            return formatYAxisValue(value, yAxisFieldType, yAxisUnit);
           },
         },
         axisPointer: {


### PR DESCRIPTION
`TimeSeriesWidgetVisualization` will now automatically determine the field types, and the correct units. If the timeseries have mismatched units, it will automatically convert them to a matching unit. Right now, this is usually done outside of the component, before rendering, but this approach makes it simpler to pass any kind of data to the visualization, and it'll do the right thing. In the future it'll also make it possible to render the tooltips in the original unit, if desired.

I also fixed an embarrassing error in `convertRate` which I spotted during QA, and moved some constants around for simplicity. This feature is a requirement for supporting both Dashboards and Explore neatly.
