### PR TITLE
fix(insights): remove extra filters when navigating to transaction summary

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -27,6 +27,7 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'sentry/utils/discover/fields';
 import {MEPConsumer} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
@@ -284,10 +285,21 @@ class _Table extends Component<Props, State> {
       const project = getProject(dataRow, projects);
       const projectID = project?.id;
       const summaryView = eventView.clone();
+      const existingQuery = new MutableSearch(summaryView.query);
       if (dataRow['http.method']) {
         summaryView.additionalConditions.setFilterValues('http.method', [
           dataRow['http.method'] as string,
         ]);
+      }
+      if (dataRow.hasOwnProperty('transaction.op')) {
+        existingQuery.removeFilter('!transaction.op');
+        existingQuery.removeFilter('transaction.op');
+        summaryView.query = existingQuery.formatString();
+        if (dataRow['transaction.op']) {
+          summaryView.additionalConditions.setFilterValues('transaction.op', [
+            dataRow['transaction.op'] as string,
+          ]);
+        }
       }
       summaryView.query = summaryView.getQueryWithAdditionalConditions();
       if (isUnparameterizedRow && !this.unparameterizedMetricSet) {


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/82661

Each overview page has a select set of filters applied to it, for example the frontend overview page applies filters `(transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction`. 

Currently when you click on a transaction on the overview page you end up at the transaction summary page, because those filters are applied to the eventView, they end up at the transaction summary page too.
<img width="900" alt="image" src="https://github.com/user-attachments/assets/0f621930-ceb1-4710-8262-f6ca85327e9d" />

This creates an ugly experience, and it actually does something that user does not expect. Because the overviewpage table includes `transaction.op` as a column, we would expect that the row that they clicked, has the corresponding transaction op applied. 
For example, clicking on this row, we would expect the filter to be `transaction.op:navigation` only
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/ccd1995b-24ad-48b2-b50e-874959509026" />

This PR updates the table so that if a transaction.op exists on the row, when you click on the transaction only that op will be applied.

I.e with the previous screenshot, we now end up with
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/c1398e8c-658f-4573-a0be-fe37ba343208" />
