### PR TITLE
chore(issue-details): Variety of small fixes

### DIFF
--- a/static/app/utils/issueTypeConfig/cronConfig.tsx
+++ b/static/app/utils/issueTypeConfig/cronConfig.tsx
@@ -27,6 +27,11 @@ const cronConfig: IssueCategoryConfigMapping = {
       tagDistribution: {enabled: false},
       timelineSummary: {enabled: false},
     },
+    detector: {
+      enabled: true,
+      title: t('Cron Monitor'),
+      ctaText: t('View monitor details'),
+    },
     attachments: {enabled: false},
     autofix: false,
     mergedIssues: {enabled: false},

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -14,6 +14,7 @@ import type {
   IssueTypeConfig,
 } from 'sentry/utils/issueTypeConfig/types';
 import uptimeConfig from 'sentry/utils/issueTypeConfig/uptimeConfig';
+import {Tab} from 'sentry/views/issueDetails/types';
 
 type Config = Record<IssueCategory, IssueCategoryConfigMapping>;
 
@@ -45,6 +46,7 @@ const BASE_CONFIG: IssueTypeConfig = {
     resolution: t('Resolved'),
     eventUnits: t('Events'),
   },
+  allEventsPath: Tab.EVENTS,
   attachments: {enabled: false},
   autofix: false,
   eventAndUserCounts: {enabled: true},
@@ -57,7 +59,6 @@ const BASE_CONFIG: IssueTypeConfig = {
   regression: {enabled: false},
   replays: {enabled: false},
   showFeedbackWidget: false,
-  showOpenPeriods: false,
   similarIssues: {enabled: false},
   spanEvidence: {enabled: false},
   stacktrace: {enabled: true},

--- a/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
 
 const metricIssueConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
@@ -30,7 +31,7 @@ const metricIssueConfig: IssueCategoryConfigMapping = {
     mergedIssues: {enabled: false},
     replays: {enabled: false},
     similarIssues: {enabled: false},
-    showOpenPeriods: true,
+    allEventsPath: Tab.OPEN_PERIODS,
     userFeedback: {enabled: false},
     usesIssuePlatform: true,
     useOpenPeriodChecks: true,

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -1,5 +1,6 @@
 import type {IssueType} from 'sentry/types/group';
 import type {PlatformKey} from 'sentry/types/project';
+import type {Tab} from 'sentry/views/issueDetails/types';
 
 export type ResourceLink = {
   link: string;
@@ -25,6 +26,10 @@ export type IssueTypeConfig = {
     resolveInRelease: DisabledWithReasonConfig;
     share: DisabledWithReasonConfig;
   };
+  /**
+   * The key for determining which 'All Events' tab will be used for this issue type
+   */
+  allEventsPath: Tab;
   /**
    * Is the Attachments tab shown for this issue
    */
@@ -119,10 +124,6 @@ export type IssueTypeConfig = {
    * Should the page show the feedback widget
    */
   showFeedbackWidget: boolean;
-  /**
-   * showOpenPeriods
-   */
-  showOpenPeriods: boolean;
   /**
    * Is the Similar Issues tab shown for this issue
    */

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
 
 const uptimeConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
@@ -27,6 +28,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
       eventUnits: t('Check-ins'),
       resolution: t('Resolved'),
     },
+    allEventsPath: Tab.EVENTS,
     attachments: {enabled: false},
     resources: null,
     autofix: false,

--- a/static/app/views/issueDetails/groupOpenPeriods.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.tsx
@@ -13,12 +13,12 @@ import {t} from 'sentry/locale';
 import {useParams} from 'sentry/utils/useParams';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
-type OpenPeriodDisplayData = {
+interface OpenPeriodDisplayData {
   duration: React.ReactNode;
   end: React.ReactNode;
   start: React.ReactNode;
   title: React.ReactNode;
-};
+}
 
 // TODO(snigdha): make this work for the old UI
 // TODO(snigdha): support pagination

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -35,7 +35,6 @@ export function EventDetailsHeader({
   const location = useLocation();
   const environments = useEnvironmentsFromUrl();
   const searchQuery = useEventQuery({groupId: group.id});
-
   const issueTypeConfig = getConfigForIssueType(group, project);
 
   if (!issueTypeConfig.header.filterAndSearch.enabled) {

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -76,10 +76,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
     [Tab.ATTACHMENTS]: t('Attachments'),
     [Tab.USER_FEEDBACK]: t('Feedback'),
   };
-
-  const allEventsPath = issueTypeConfig.showOpenPeriods
-    ? `${baseUrl}${TabPaths[Tab.OPEN_PERIODS]}`
-    : `${baseUrl}${TabPaths[Tab.EVENTS]}`;
+  const allEventsPath = `${baseUrl}${TabPaths[issueTypeConfig.allEventsPath]}`;
 
   return (
     <EventNavigationWrapper role="navigation">
@@ -199,18 +196,20 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
             </LinkButton>
           </Fragment>
         )}
-        {(currentTab === Tab.EVENTS || currentTab === Tab.OPEN_PERIODS) && (
+        {currentTab === issueTypeConfig.allEventsPath && (
           <ButtonBar gap={1}>
-            <LinkButton
-              to={discoverUrl}
-              aria-label={t('Open in Discover')}
-              size="xs"
-              icon={<IconTelescope />}
-              analyticsEventKey="issue_details.discover_clicked"
-              analyticsEventName="Issue Details: Discover Clicked"
-            >
-              {t('Discover')}
-            </LinkButton>
+            {currentTab === Tab.EVENTS && (
+              <LinkButton
+                to={discoverUrl}
+                aria-label={t('Open in Discover')}
+                size="xs"
+                icon={<IconTelescope />}
+                analyticsEventKey="issue_details.discover_clicked"
+                analyticsEventName="Issue Details: Discover Clicked"
+              >
+                {t('Discover')}
+              </LinkButton>
+            )}
             <LinkButton
               to={{
                 pathname: `${baseUrl}${TabPaths[Tab.DETAILS]}`,

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -5,17 +5,26 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 
 interface DetectorDetails {
-  alertRuleId?: string;
   description?: string;
+  detectorPath?: string;
 }
 
-export function getDetectorDetails({event}: {event: Event}): DetectorDetails {
+export function getDetectorDetails({
+  event,
+  organization,
+  project,
+}: {
+  event: Event;
+  organization: Organization;
+  project: Project;
+}): DetectorDetails {
   /**
    * Rather than check the issue category, we just check all the current set locations
    * for Alert Rule IDs. Hopefully we can consolidate this when we move to the detector system.
@@ -24,7 +33,7 @@ export function getDetectorDetails({event}: {event: Event}): DetectorDetails {
   const metricAlertRuleId = event?.contexts?.metric_alert?.alert_rule_id;
   if (metricAlertRuleId) {
     return {
-      alertRuleId: metricAlertRuleId,
+      detectorPath: `/organizations/${organization.slug}/alerts/rules/details/${metricAlertRuleId}/`,
       // TODO(issues): We can probably enrich this description with details from the alert itself.
       description: t(
         'This issue was created by a metric alert detector. View the detector details to learn more.'
@@ -34,7 +43,7 @@ export function getDetectorDetails({event}: {event: Event}): DetectorDetails {
   const uptimeAlertRuleId = event?.tags?.find(tag => tag?.key === 'uptime_rule')?.value;
   if (uptimeAlertRuleId) {
     return {
-      alertRuleId: uptimeAlertRuleId,
+      detectorPath: `/organizations/${organization.slug}/alerts/rules/uptime/${project.slug}/${uptimeAlertRuleId}/details/`,
       // TODO(issues): Update this to mention detectors when that language is user-facing
       description: t(
         'This issue was created by an uptime alert rule. After 2 consecutive failed check-ins, an open period will be created.'
@@ -42,7 +51,7 @@ export function getDetectorDetails({event}: {event: Event}): DetectorDetails {
     };
   }
   return {
-    alertRuleId: undefined,
+    detectorPath: undefined,
     description: undefined,
   };
 }
@@ -57,10 +66,10 @@ export function DetectorSection({
   project: Project;
 }) {
   const organization = useOrganization();
-  const {alertRuleId, description} = getDetectorDetails({event});
+  const {detectorPath, description} = getDetectorDetails({event, organization, project});
   const issueConfig = getConfigForIssueType(group, project);
 
-  if (!alertRuleId) {
+  if (!detectorPath) {
     return null;
   }
 
@@ -72,7 +81,7 @@ export function DetectorSection({
       {description && <DetectorDescription>{description}</DetectorDescription>}
       <LinkButton
         aria-label={issueConfig.detector.ctaText ?? t('View detector details')}
-        href={`/organizations/${organization.slug}/alerts/rules/details/${alertRuleId}/`}
+        href={detectorPath}
         style={{width: '100%'}}
         size="sm"
       >

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -40,6 +40,17 @@ export function getDetectorDetails({
       ),
     };
   }
+
+  const cronSlug = event?.tags?.find(({key}) => key === 'monitor.slug')?.value;
+  if (cronSlug) {
+    return {
+      detectorPath: `/organizations/${organization.slug}/alerts/rules/crons/${project.slug}/${cronSlug}/details/`,
+      description: t(
+        'This issue was created by a cron monitor. View the monitor details to learn more.'
+      ),
+    };
+  }
+
   const uptimeAlertRuleId = event?.tags?.find(tag => tag?.key === 'uptime_rule')?.value;
   if (uptimeAlertRuleId) {
     return {

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -10,6 +10,7 @@ import {EntryType} from 'sentry/types/event';
 import {IssueCategory} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import SolutionsSection from 'sentry/views/issueDetails/streamline/sidebar/solutionsSection';
+import {Tab} from 'sentry/views/issueDetails/types';
 
 jest.mock('sentry/utils/issueTypeConfig');
 
@@ -77,6 +78,7 @@ describe('SolutionsSection', () => {
         tagDistribution: {enabled: false},
         timelineSummary: {enabled: true},
       },
+      allEventsPath: Tab.EVENTS,
       logLevel: {enabled: true},
       mergedIssues: {enabled: false},
       performanceDurationRegression: {enabled: false},
@@ -84,7 +86,6 @@ describe('SolutionsSection', () => {
       regression: {enabled: false},
       replays: {enabled: false},
       showFeedbackWidget: false,
-      showOpenPeriods: false,
       similarIssues: {enabled: false},
       spanEvidence: {enabled: false},
       stacktrace: {enabled: false},

--- a/static/app/views/issueDetails/types.tsx
+++ b/static/app/views/issueDetails/types.tsx
@@ -9,6 +9,7 @@ export enum Tab {
   SIMILAR_ISSUES = 'similar-issues',
   REPLAYS = 'Replays',
   OPEN_PERIODS = 'open-periods',
+  CHECK_INS = 'check-ins',
 }
 
 export const TabPaths: Record<Tab, string> = {
@@ -22,4 +23,5 @@ export const TabPaths: Record<Tab, string> = {
   [Tab.SIMILAR_ISSUES]: 'similar/',
   [Tab.REPLAYS]: 'replays/',
   [Tab.OPEN_PERIODS]: 'open-periods/',
+  [Tab.CHECK_INS]: 'check-ins/',
 };


### PR DESCRIPTION
Pulled out some changes from a separate PR to put together the 'All Check-ins' page, hopefully making that PR a bit easier to review whenever it's ready to put up.

Things in this PR:
- Add the 'all events path' directly to the issue config. The only issue that changes this is currently metric issues, but uptime and crons will change this in my other PR.
- Omit the discover button on non-All Events pages. If the tab is not All Events, the discover query will not match the data in the table, so the button should be omitted
- Fixes the links for uptime monitors, which I incorrectly thought matched metric alerts.
- Adds links for cron monitors to the sidebar for cron issues