### PR TITLE
feat(aci): prepare data from buffer hash to query snuba in delayed processing

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,0 +1,135 @@
+import logging
+from collections import defaultdict
+from typing import Any
+
+from sentry import buffer
+from sentry.db import models
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.utils import json
+from sentry.workflow_engine.models import DataConditionGroup, Workflow
+
+logger = logging.getLogger("sentry.workflow_engine.processors.delayed_workflow")
+
+
+def fetch_project(project_id: int) -> Project | None:
+    try:
+        return Project.objects.get_from_cache(id=project_id)
+    except Project.DoesNotExist:
+        logger.info(
+            "delayed_processing.project_does_not_exist",
+            extra={"project_id": project_id},
+        )
+        return None
+
+
+# TODO: replace with shared function with delayed_processing.py
+def fetch_group_to_event_data(
+    project_id: int, model: type[models.Model], batch_key: str | None = None
+) -> dict[str, str]:
+    field: dict[str, models.Model | int | str] = {
+        "project_id": project_id,
+    }
+
+    if batch_key:
+        field["batch_key"] = batch_key
+
+    return buffer.backend.get_hash(model=model, field=field)
+
+
+def get_dcg_group_workflow_data(
+    worklow_event_dcg_data: dict[str, str]
+) -> tuple[dict[int, set[int]], dict[int, int], list[Any]]:
+    """
+    Parse the data in the buffer hash, which is in the form of {workflow_id}:{event_id}:{dcg_id, ..., dcg_id}
+    """
+
+    dcg_to_groups: dict[int, set[int]] = defaultdict(set)
+    dcg_to_workflow: dict[int, int] = {}
+    all_event_data = []
+
+    for workflow_event_dcg, instance_data in worklow_event_dcg_data.items():
+        data = workflow_event_dcg.split(":")
+        workflow_id = int(data[0])
+        event_id = int(data[1])
+        dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
+        event_data = json.loads(instance_data)
+
+        for dcg_id in dcg_ids:
+            dcg_to_groups[dcg_id].add(event_id)
+            dcg_to_workflow[dcg_id] = workflow_id
+            all_event_data.append(event_data)  # used in bulk fetching events from Snuba
+
+    return dcg_to_groups, dcg_to_workflow, all_event_data
+
+
+def fetch_workflows_and_environments(
+    workflow_ids: list[int],
+) -> tuple[dict[int, Workflow], dict[int, int | None]]:
+    workflows_to_envs: dict[int, int | None] = {}
+    workflow_ids_to_workflows: dict[int, Workflow] = {}
+    workflows = list(Workflow.objects.filter(id__in=workflow_ids))
+
+    for workflow in workflows:
+        workflows_to_envs[workflow.id] = workflow.environment.id if workflow.environment else None
+        workflow_ids_to_workflows[workflow.id] = workflow
+
+    return workflow_ids_to_workflows, workflows_to_envs
+
+
+def fetch_active_data_condition_groups(
+    dcg_ids: list[int],
+    dcg_to_workflow: dict[int, int],
+    workflow_ids_to_workflows: dict[int, Workflow],
+) -> list[DataConditionGroup]:
+    """
+    Fetch DataConditionGroups with enabled workflows
+    """
+
+    data_condition_groups = DataConditionGroup.objects.filter(id__in=dcg_ids)
+    active_dcgs: list[DataConditionGroup] = []
+
+    for dcg in data_condition_groups:
+        if workflow_ids_to_workflows[dcg_to_workflow[dcg.id]].enabled:
+            active_dcgs.append(dcg)
+
+    return active_dcgs
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.processors.delayed_workflow",
+    queue="delayed_rules",
+    default_retry_delay=5,
+    max_retries=5,
+    soft_time_limit=50,
+    time_limit=60,
+    silo_mode=SiloMode.REGION,
+)
+def process_delayed_workflows(
+    project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any
+) -> None:
+    """
+    Grab workflows, groups, and data condition groups from the Redis buffer, evaluate the "slow" conditions in a bulk snuba query, and fire them if they pass
+    """
+    project = fetch_project(project_id)
+    if not project:
+        return
+
+    workflow_event_dcg_data = fetch_group_to_event_data(project_id, Workflow, batch_key)
+
+    # Get mappings from DataConditionGroups to other info
+    dcg_to_groups, dcg_to_workflow, _ = get_dcg_group_workflow_data(workflow_event_dcg_data)
+    workflow_ids_to_workflows, _ = fetch_workflows_and_environments(list(dcg_to_workflow.values()))
+    _ = fetch_active_data_condition_groups(
+        list(dcg_to_groups.keys()), dcg_to_workflow, workflow_ids_to_workflows
+    )
+
+    # TODO(cathy): get unique condition queries
+    # TODO(cathy): fetch results from snuba
+    # TODO(cathy): evaluate condition groups
+    # TODO(cathy): fire actions on passing groups
+    # TODO(cathy): clean up redis buffer
+
+
+# TODO: add to registry

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,0 +1,243 @@
+from sentry import buffer
+from sentry.eventstore.models import Event
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.environment import Environment
+from sentry.models.group import Group
+from sentry.models.project import Project
+from sentry.rules.processing.delayed_processing import fetch_project
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.redis import mock_redis_buffer
+from sentry.utils import json
+from sentry.workflow_engine.models import DataConditionGroup, Detector, Workflow
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors.delayed_workflow import (
+    fetch_active_data_condition_groups,
+    fetch_group_to_event_data,
+    fetch_workflows_and_environments,
+    get_dcg_group_workflow_data,
+)
+from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
+
+FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
+
+
+class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
+    def setUp(self):
+        super().setUp()
+
+        self.workflow1, self.workflow1_dcgs = self.create_project_event_freq_workflow(
+            self.project, self.environment
+        )
+        self.workflow2, self.workflow2_dcgs = self.create_project_event_freq_workflow(self.project)
+
+        self.project2 = self.create_project()
+        self.environment2 = self.create_environment(project=self.project2)
+        self.workflow3, self.workflow3_dcgs = self.create_project_event_freq_workflow(
+            self.project2, self.environment2
+        )
+        self.workflow4, self.workflow4_dcgs = self.create_project_event_freq_workflow(self.project2)
+
+        self.event1, self.group1 = self.setup_event(self.project, self.environment, "group-1")
+        self.create_event(self.project.id, FROZEN_TIME, "group-1", self.environment.name)
+
+        self.event2, self.group2 = self.setup_event(self.project, self.environment, "group-2")
+        self.create_event(self.project.id, FROZEN_TIME, "group-2", self.environment.name)
+
+        self.workflow_group_dcg_mapping = {
+            f"{self.workflow1.id}:{self.group1.id}:{','.join(map(str, [dcg.id for dcg in self.workflow1_dcgs]))}",
+            f"{self.workflow2.id}:{self.group2.id}:{','.join(map(str, [dcg.id for dcg in self.workflow2_dcgs]))}",
+        }
+
+        self.event3, self.group3 = self.setup_event(self.project2, self.environment2, "group-3")
+        self.create_event(self.project2.id, FROZEN_TIME, "group-3", self.environment.name)
+        self.create_event(self.project2.id, FROZEN_TIME, "group-3", self.environment.name)
+        self.create_event(self.project2.id, FROZEN_TIME, "group-3", self.environment.name)
+
+        self.event4, self.group4 = self.setup_event(self.project2, self.environment2, "group-4")
+        self.create_event(self.project2.id, FROZEN_TIME, "group-4")
+        self._make_sessions(60, project=self.project2)
+
+        self.workflow_group_dcg_mapping2 = {
+            f"{self.workflow3.id}:{self.group3.id}:{','.join(map(str, [dcg.id for dcg in self.workflow3_dcgs]))}",
+            f"{self.workflow4.id}:{self.group4.id}:{','.join(map(str, [dcg.id for dcg in self.workflow4_dcgs]))}",
+        }
+
+        self.dcg_to_groups = {dcg.id: {self.group1.id} for dcg in self.workflow1_dcgs} | {
+            dcg.id: {self.group2.id} for dcg in self.workflow2_dcgs
+        }
+        self.dcg_to_workflow = {dcg.id: self.workflow1.id for dcg in self.workflow1_dcgs} | {
+            dcg.id: self.workflow2.id for dcg in self.workflow2_dcgs
+        }
+
+        self.mock_redis_buffer = mock_redis_buffer()
+        self.mock_redis_buffer.__enter__()
+
+        buffer.backend.push_to_sorted_set(
+            key=WORKFLOW_ENGINE_BUFFER_LIST_KEY, value=self.project.id
+        )
+        buffer.backend.push_to_sorted_set(
+            key=WORKFLOW_ENGINE_BUFFER_LIST_KEY, value=self.project2.id
+        )
+
+    def tearDown(self):
+        self.mock_redis_buffer.__exit__(None, None, None)
+
+    def create_project_event_freq_workflow(
+        self, project: Project, environment: Environment | None = None
+    ) -> tuple[Workflow, list[DataConditionGroup]]:
+        if not Detector.objects.filter(project_id=project.id, type=ErrorGroupType.slug).exists():
+            detector = self.create_detector(project=project, type=ErrorGroupType.slug)
+        else:
+            detector = Detector.objects.get(project_id=project.id, type=ErrorGroupType.slug)
+
+        workflow_trigger_group = self.create_data_condition_group(
+            logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        )
+        self.create_data_condition(
+            condition_group=workflow_trigger_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1h", "value": 100},
+            condition_result=True,
+        )
+        # TODO: add other conditions
+
+        workflow = self.create_workflow(
+            when_condition_group=workflow_trigger_group,
+            organization=project.organization,
+            environment=environment,
+        )
+        self.create_detector_workflow(
+            detector=detector,
+            workflow=workflow,
+        )
+
+        workflow_action_filter_group = self.create_data_condition_group(
+            logic_type=DataConditionGroup.Type.ALL
+        )
+        self.create_data_condition(
+            condition_group=workflow_action_filter_group,
+            type=Condition.EVENT_FREQUENCY_PERCENT,
+            comparison={"interval": "1h", "value": 100, "comparison_interval": "1w"},
+            condition_result=True,
+        )
+        # TODO: add other conditions
+
+        self.create_workflow_data_condition_group(
+            workflow=workflow, condition_group=workflow_action_filter_group
+        )
+
+        return workflow, [workflow_trigger_group, workflow_action_filter_group]
+
+    def setup_event(self, project, environment, name) -> tuple[Event, Group]:
+        event = self.create_event(project.id, FROZEN_TIME, name, environment.name)
+        assert event.group
+        return event, event.group
+
+    def push_to_hash(
+        self,
+        project_id: int,
+        workflow_id: int,
+        group_id: int,
+        dcg_ids: list[int],
+        event_id: str | None = None,
+        occurrence_id: str | None = None,
+    ) -> None:
+        value = json.dumps({"event_id": event_id, "occurrence_id": occurrence_id})
+        field = f"{workflow_id}:{group_id}:{','.join(map(str, dcg_ids))}"
+        buffer.backend.push_to_hash(
+            model=Workflow,
+            filters={"project_id": project_id},
+            field=field,
+            value=value,
+        )
+
+    def _push_base_events(self) -> None:
+        self.push_to_hash(
+            self.project.id,
+            self.workflow1.id,
+            self.group1.id,
+            [dcg.id for dcg in self.workflow1_dcgs],
+            self.event1.event_id,
+        )
+        self.push_to_hash(
+            self.project.id,
+            self.workflow2.id,
+            self.group2.id,
+            [dcg.id for dcg in self.workflow2_dcgs],
+            self.event2.event_id,
+        )
+        self.push_to_hash(
+            self.project2.id,
+            self.workflow3.id,
+            self.group3.id,
+            [dcg.id for dcg in self.workflow3_dcgs],
+            self.event3.event_id,
+        )
+        self.push_to_hash(
+            self.project2.id,
+            self.workflow4.id,
+            self.group4.id,
+            [dcg.id for dcg in self.workflow4_dcgs],
+            self.event4.event_id,
+        )
+
+
+class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
+    def test_fetch_project(self):
+        assert fetch_project(self.project.id) == self.project
+        assert fetch_project(1) is None
+
+    def test_fetch_group_to_event_data(self):
+        # nothing in buffer
+        assert fetch_group_to_event_data(self.project.id, Workflow) == {}
+
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        assert len(buffer_data) == 2
+        assert set(buffer_data.keys()) == self.workflow_group_dcg_mapping
+
+        buffer_data = fetch_group_to_event_data(self.project2.id, Workflow)
+        assert len(buffer_data) == 2
+        assert set(buffer_data.keys()) == self.workflow_group_dcg_mapping2
+
+    def test_get_dcg_group_workflow_data(self):
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        dcg_to_groups, dcg_to_workflow, all_event_data = get_dcg_group_workflow_data(buffer_data)
+
+        assert dcg_to_groups == self.dcg_to_groups
+        assert dcg_to_workflow == self.dcg_to_workflow
+        assert all_event_data.count({"event_id": self.event1.event_id, "occurrence_id": None}) == 2
+        assert all_event_data.count({"event_id": self.event2.event_id, "occurrence_id": None}) == 2
+
+    def test_fetch_workflows_and_environments(self):
+        workflow_ids_to_workflows, workflows_to_envs = fetch_workflows_and_environments(
+            list(self.dcg_to_workflow.values())
+        )
+        assert workflows_to_envs == {
+            self.workflow1.id: self.environment.id,
+            self.workflow2.id: None,
+        }
+        assert workflow_ids_to_workflows == {
+            self.workflow1.id: self.workflow1,
+            self.workflow2.id: self.workflow2,
+        }
+
+    def test_fetch_active_data_condition_groups(self):
+        workflow_ids_to_workflows = {
+            self.workflow1.id: self.workflow1,
+            self.workflow2.id: self.workflow2,
+        }
+
+        active_dcgs = fetch_active_data_condition_groups(
+            list(self.dcg_to_groups.keys()), self.dcg_to_workflow, workflow_ids_to_workflows
+        )
+        assert set(active_dcgs) == set(self.workflow1_dcgs + self.workflow2_dcgs)
+
+        self.workflow1.update(enabled=False)
+        active_dcgs = fetch_active_data_condition_groups(
+            list(self.dcg_to_groups.keys()), self.dcg_to_workflow, workflow_ids_to_workflows
+        )
+        assert set(active_dcgs) == set(self.workflow2_dcgs)

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -86,7 +86,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         **kwargs,
     ) -> tuple[Workflow, Detector, DetectorWorkflow, DataConditionGroup]:
         """
-        Create a Worfkllow, Detector, DetectorWorkflow, and DataConditionGroup for testing.
+        Create a Workflow, Detector, DetectorWorkflow, and DataConditionGroup for testing.
         These models are configured to work together to test the workflow engine.
         """
         workflow_triggers = workflow_triggers or self.create_data_condition_group()


### PR DESCRIPTION
Part 1 of delayed processing for workflows

This PR adds the delayed processing task for workflows and functions to parse the data from the buffer hash. The parsed data will be used query Snuba in follow up PRs.

Information will be enqueued in the hash like `{workflow_id}:{group_id}:{dcg_id, ..., dcg_id}` with fields `{"event_id": event_id, "occurrence_id": occurrence_id}`.

We parse this, then collect `DataConditionGroups` that are connected to _enabled_ `Workflows` and prepare lookup dicts connecting `DataConditionGroups`, environments, `Workflows`, and `Groups` (in various ways), and list all the Snuba event ids we enqueued to bulk fetch them later.

Relevant information
- [Existing delayed processing spec](https://www.notion.so/sentry/Fix-INC-666-62b150e46f564a3484c7929dcba7de4a)
- [ACI issue alert migration spec](https://www.notion.so/sentry/Alerts-Create-Issues-Issue-Alert-Migration-1198b10e4b5d8009b0b5e3da99d4937d), [plan for migrating delayed processing](https://www.notion.so/sentry/Migrating-inc-666-1268b10e4b5d80b79ea0cc708e148cec)