### PR TITLE
chore(uptime): Add completion_time stat for uptime

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -282,6 +282,15 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         if options.get("uptime.snuba_uptime_results.enabled"):
             self._produce_snuba_uptime_result(project_subscription, result)
 
+        # The amount of time it took for a check result to get from the checker to this consumer and be processed
+        metrics.distribution(
+            "uptime.result_processor.completion_time",
+            datetime.timestamp() - (result["actual_check_time_ms"] + result["duration_ms"]),
+            sample_rate=1.0,
+            unit="millisecond",
+            tags=metric_tags,
+        )
+
     def handle_result_for_project_auto_onboarding_mode(
         self, project_subscription: ProjectUptimeSubscription, result: CheckResult
     ):

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -285,7 +285,12 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         # The amount of time it took for a check result to get from the checker to this consumer and be processed
         metrics.distribution(
             "uptime.result_processor.completion_time",
-            datetime.timestamp() - (result["actual_check_time_ms"] + result["duration_ms"]),
+            datetime.now().timestamp()
+            - (
+                result["actual_check_time_ms"] + result["duration_ms"]
+                if result["duration_ms"]
+                else 0
+            ),
             sample_rate=1.0,
             unit="millisecond",
             tags=metric_tags,


### PR DESCRIPTION
This stat keeps track of how long it took to take a check result and finish processing it in our consumer. We use the time the check was run + the duration to get the time that the check finished running. The difference between that and the current time in the consumer is the completion time.

<!-- Describe your PR here. -->