### PR TITLE
:sparkles: feat(aci): migration util for email actions

### DIFF
--- a/src/sentry/notifications/models/notificationaction.py
+++ b/src/sentry/notifications/models/notificationaction.py
@@ -86,6 +86,8 @@ class ActionTarget(FlexibleIntEnum):
     TEAM = 2
     # The target_identifier is an id from the SentryApp model in Sentry
     SENTRY_APP = 3
+    # There is no target_identifier, but we want to send notifications to the issue owners
+    ISSUE_OWNERS = 4
 
     @classmethod
     def as_choices(cls) -> tuple[tuple[int, str], ...]:
@@ -94,6 +96,7 @@ class ActionTarget(FlexibleIntEnum):
             (cls.USER.value, "user"),
             (cls.TEAM.value, "team"),
             (cls.SENTRY_APP.value, "sentry_app"),
+            (cls.ISSUE_OWNERS.value, "issue_owners"),
         )
 
 

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -321,11 +321,10 @@ class EmailActionTranslator(BaseActionTranslator):
             return ActionTarget.USER
         elif target_type == ActionTargetType.TEAM.value:
             return ActionTarget.TEAM
-        else:
-            return ActionTarget.ISSUE_OWNERS
+        return ActionTarget.ISSUE_OWNERS
 
     @property
-    def integration_id(self) -> Any | None:
+    def integration_id(self) -> None:
         return None
 
     @property
@@ -343,7 +342,9 @@ class EmailActionTranslator(BaseActionTranslator):
         return None
 
     def get_sanitized_data(self) -> dict[str, Any]:
-        """Override to handle the special case of IssueOwners target type"""
+        """
+        Override to handle the special case of IssueOwners target type
+        """
         if self.action.get("targetType") == ActionTargetType.ISSUE_OWNERS.value:
             return dataclasses.asdict(
                 EmailDataBlob(

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -54,7 +54,7 @@ class BaseActionTranslator(ABC):
         pass
 
     @property
-    def target_identifier(self) -> str | int | None:
+    def target_identifier(self) -> str | None:
         """Return the target identifier for this action, if any"""
         return None
 
@@ -321,9 +321,8 @@ class EmailActionTranslator(BaseActionTranslator):
             return ActionTarget.USER
         elif target_type == ActionTargetType.TEAM.value:
             return ActionTarget.TEAM
-        elif target_type == ActionTargetType.ISSUE_OWNERS.value:
+        else:
             return ActionTarget.ISSUE_OWNERS
-        return None
 
     @property
     def integration_id(self) -> Any | None:

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar
 from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.action import Action
 
@@ -53,7 +54,7 @@ class BaseActionTranslator(ABC):
         pass
 
     @property
-    def target_identifier(self) -> str | None:
+    def target_identifier(self) -> str | int | None:
         """Return the target identifier for this action, if any"""
         return None
 
@@ -301,6 +302,60 @@ class AzureDevOpsActionTranslator(TicketActionTranslator):
         return AzureDevOpsDataBlob
 
 
+@issue_alert_action_translator_registry.register("sentry.mail.actions.NotifyEmailAction")
+class EmailActionTranslator(BaseActionTranslator):
+    action_type = Action.Type.EMAIL
+
+    @property
+    def required_fields(self) -> list[str]:
+        return ["targetType"]
+
+    @property
+    def target_type(self) -> ActionTarget:
+        # If the targetType is Member, then set the target_type to User,
+        # if the targetType is Team, then set the target_type to Team,
+        # otherwise return None (this would be for IssueOwners (suggested assignees))
+
+        target_type = self.action.get("targetType")
+        if target_type == ActionTargetType.MEMBER.value:
+            return ActionTarget.USER
+        elif target_type == ActionTargetType.TEAM.value:
+            return ActionTarget.TEAM
+        elif target_type == ActionTargetType.ISSUE_OWNERS.value:
+            return ActionTarget.ISSUE_OWNERS
+        return None
+
+    @property
+    def integration_id(self) -> Any | None:
+        return None
+
+    @property
+    def target_identifier(self) -> str | None:
+        target_type = self.action.get("targetType")
+        if target_type in [ActionTargetType.MEMBER.value, ActionTargetType.TEAM.value]:
+            return self.action.get("targetIdentifier")
+        return None
+
+    @property
+    def blob_type(self) -> type["DataBlob"] | None:
+        target_type = self.action.get("targetType")
+        if target_type == ActionTargetType.ISSUE_OWNERS.value:
+            return EmailDataBlob
+        return None
+
+    def get_sanitized_data(self) -> dict[str, Any]:
+        """Override to handle the special case of IssueOwners target type"""
+        if self.action.get("targetType") == ActionTargetType.ISSUE_OWNERS.value:
+            return dataclasses.asdict(
+                EmailDataBlob(
+                    fallthroughType=self.action.get(
+                        "fallthroughType", FallthroughChoiceType.ACTIVE_MEMBERS.value
+                    )
+                )
+            )
+        return {}
+
+
 @issue_alert_action_translator_registry.register(
     "sentry.rules.actions.notify_event.NotifyEventAction"
 )
@@ -412,3 +467,10 @@ class AzureDevOpsDataBlob(TicketDataBlob):
 
     project: str = ""
     work_item_type: str = ""
+
+
+@dataclass
+class EmailDataBlob(DataBlob):
+    """EmailDataBlob represents the data blob for an email notification action."""
+
+    fallthroughType: str = ""

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1,11 +1,13 @@
+from typing import Any
 from unittest.mock import patch
 
 from sentry.eventstore.models import GroupEvent
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.migration_helpers.rule_action import (
     build_notification_actions_from_rule_data_actions,
 )
-from sentry.workflow_engine.models.action import Action, ActionTarget
+from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
     issue_alert_action_translator_registry,
@@ -922,7 +924,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         assert len(actions) == 0
 
     def test_email_migration(self):
-        action_data = [
+        action_data: list[dict[str, Any]] = [
             {
                 "targetType": "IssueOwners",
                 "id": "sentry.mail.actions.NotifyEmailAction",

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -5,7 +5,7 @@ from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.migration_helpers.rule_action import (
     build_notification_actions_from_rule_data_actions,
 )
-from sentry.workflow_engine.models.action import Action
+from sentry.workflow_engine.models.action import Action, ActionTarget
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
     issue_alert_action_translator_registry,
@@ -24,6 +24,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         integration_id_key: str | None = None,
         target_identifier_key: str | None = None,
         target_display_key: str | None = None,
+        target_type_key: str | None = None,
     ):
         """
         Asserts that the action data is equivalent to the compare_dict.
@@ -40,6 +41,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             exclude_keys.append(target_identifier_key)
         if target_display_key:
             exclude_keys.append(target_display_key)
+        if target_type_key:
+            exclude_keys.append(target_type_key)
 
         # If we have a blob type, verify the data matches the blob structure
         if translator.blob_type:
@@ -51,7 +54,11 @@ class TestNotificationActionMigrationUtils(TestCase):
                     assert action.data.get(field) == source_value
                 else:
                     # For unmapped fields, check directly with empty string default
-                    assert action.data.get(field) == compare_dict.get(field, "")
+                    if action.type == Action.Type.EMAIL and field == "fallthroughType":
+                        # for email actions, the default value for fallthroughType should be "ActiveMembers"
+                        assert action.data.get(field) == compare_dict.get(field, "ActiveMembers")
+                    else:
+                        assert action.data.get(field) == compare_dict.get(field, "")
             # Ensure no extra fields
             assert set(action.data.keys()) == {
                 f.name for f in translator.blob_type.__dataclass_fields__.values()
@@ -60,7 +67,15 @@ class TestNotificationActionMigrationUtils(TestCase):
             # Assert the rest of the data is the same
             for key in compare_dict:
                 if key not in exclude_keys:
-                    assert compare_dict[key] == action.data[key]
+                    if (
+                        action.type == Action.Type.EMAIL
+                        and key == "fallthroughType"
+                        and action.target_type != ActionTarget.ISSUE_OWNERS
+                    ):
+                        # for email actions, fallthroughType should only be set for when targetType is ISSUE_OWNERS
+                        continue
+                    else:
+                        assert compare_dict[key] == action.data[key]
 
             # Assert the action data blob doesn't contain more than the keys in the compare_dict
             for key in action.data:
@@ -89,7 +104,12 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         # Assert target_identifier matches if specified
         if target_identifier_key:
-            assert action.target_identifier == compare_dict.get(target_identifier_key)
+            compare_val = compare_dict.get(target_identifier_key)
+            # Handle both "None" string and None value
+            if compare_val in ["None", None, ""]:
+                assert action.target_identifier is None
+            else:
+                assert action.target_identifier == compare_val
 
         # Assert target_display matches if specified
         if target_display_key:
@@ -105,6 +125,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         integration_id_key: str | None = None,
         target_identifier_key: str | None = None,
         target_display_key: str | None = None,
+        target_type_key: str | None = None,
     ):
         """
         Asserts that the actions are equivalent to the Rule.
@@ -113,10 +134,19 @@ class TestNotificationActionMigrationUtils(TestCase):
         for action, rule_data in zip(actions, rule_data_actions):
             assert isinstance(action, Action)
             self.assert_action_attributes(
-                action, rule_data, integration_id_key, target_identifier_key, target_display_key
+                action,
+                rule_data,
+                integration_id_key,
+                target_identifier_key,
+                target_display_key,
             )
             self.assert_action_data_blob(
-                action, rule_data, integration_id_key, target_identifier_key, target_display_key
+                action,
+                rule_data,
+                integration_id_key,
+                target_identifier_key,
+                target_display_key,
+                target_type_key,
             )
 
     @patch("sentry.workflow_engine.migration_helpers.rule_action.logger.error")
@@ -891,6 +921,89 @@ class TestNotificationActionMigrationUtils(TestCase):
         actions = build_notification_actions_from_rule_data_actions(action_data)
         assert len(actions) == 0
 
+    def test_email_migration(self):
+        action_data = [
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "None",
+                "fallthroughType": "ActiveMembers",
+                "uuid": "2e8847d7-8fe4-44d2-8a16-e25040329790",
+            },
+            {
+                "targetType": "IssueOwners",
+                "targetIdentifier": "",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "NoOne",
+                "uuid": "fb039430-0848-4fc4-89b4-bc7689a9f851",
+            },
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": None,
+                "fallthroughType": "AllMembers",
+                "uuid": "41f13756-8f90-4afe-b162-55268c6e3cdb",
+            },
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "None",
+                "fallthroughType": "NoOne",
+                "uuid": "99c9b517-0a0f-47f0-b3ff-2a9cd2fd9c49",
+            },
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": 2160509,
+                "targetType": "Member",
+                "uuid": "42c3e1d6-4004-4a51-a90b-13d3404f1e55",
+            },
+            {
+                "targetType": "Member",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": 3234013,
+                "uuid": "6e83337b-9561-4167-a208-27d6bdf5e613",
+            },
+            {
+                "targetType": "Team",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "AllMembers",
+                "uuid": "71b445cf-573b-4e0c-86bc-8dfbad93c480",
+                "targetIdentifier": 188022,
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        self.assert_actions_migrated_correctly(
+            actions, action_data, None, "targetIdentifier", None, "targetType"
+        )
+
+    def test_email_migration_malformed(self):
+        action_data = [
+            {
+                "uuid": "12345678-90ab-cdef-0123-456789abcdef",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+            },
+            # This should also fail since we don't have a default value for targetType
+            {
+                "uuid": "12345678-90ab-cdef-0123-456789abcdef",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "NoOne",
+            },
+            # This should be ok since we have a default value for fallthroughType
+            {
+                "uuid": "12345678-90ab-cdef-0123-456789abcdef",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetType": "IssueOwners",
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        assert len(actions) == 1
+        self.assert_actions_migrated_correctly(
+            actions, [action_data[2]], None, "targetIdentifier", None, "targetType"
+        )
+
     def test_plugin_action_migration(self):
         action_data = [
             {
@@ -1010,6 +1123,10 @@ class TestNotificationActionMigrationUtils(TestCase):
                 Action.Type.AZURE_DEVOPS,
             ),
             (
+                "sentry.mail.actions.NotifyEmailAction",
+                Action.Type.EMAIL,
+            ),
+            (
                 "sentry.rules.actions.notify_event.NotifyEventAction",
                 Action.Type.PLUGIN,
             ),
@@ -1107,6 +1224,14 @@ class TestNotificationActionMigrationUtils(TestCase):
                     "uuid": "test-uuid",
                 },
                 Action.Type.AZURE_DEVOPS,
+            ),
+            # Email
+            (
+                {
+                    "id": "sentry.mail.actions.NotifyEmailAction",
+                    "uuid": "test-uuid",
+                },
+                Action.Type.EMAIL,
             ),
             # Plugin
             (

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1232,6 +1232,7 @@ class TestNotificationActionMigrationUtils(TestCase):
                 {
                     "id": "sentry.mail.actions.NotifyEmailAction",
                     "uuid": "test-uuid",
+                    "targetType": "IssueOwners",
                 },
                 Action.Type.EMAIL,
             ),


### PR DESCRIPTION
this pr updates the migration util for email actions. this pr builds on the assumption that we won't be supporting suggessted assignees for metric issues.

context for clarity:
Currently email actions rely on `targetType`, `fallthroughType` and `target_identifier` keys in order to make a decision of how to notify.

1. if the `targetType` if Member (send an email to a user), then set the `target_identifier` is set to `user_id`, and the `action.target_type` to Member, and have an empty data blob (ignore the `fallThroughType`)
2. if the `targetType` is Team, then set the `target_identifier` to the `team_id`, the `action.target_type` to Team, and have an empty blob_type (ignore the `fallthroughType`)
3. if the `targetType` is IssueOwners, then set the `target_identifier` to None, the `action.target_type` to IssueOwners (new), and have a blob_type which is fallbackThroughType defined

The first 2 cases don't to have a blob type with fallbackThroughType since it doesn't need a fallthrough option. This used to be set in our legacy action code as a mistake, but didn't effect antyhing since we checked for target_type first before checking for fallbackThroughType.


closes https://getsentry.atlassian.net/browse/ACI-104
[spec](https://www.notion.so/sentry/Alerts-Create-Issues-Notification-Action-NOA-1268b10e4b5d805b967ed2655c962db6#1268b10e4b5d812aaa59e13c96a04abd)
