### PR TITLE
feat(ui): Measure app bootstrap using sentry

### DIFF
--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import * as Sentry from '@sentry/react';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import {switchOrganization} from 'sentry/actionCreators/organizations';
@@ -17,11 +18,8 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
-import {metric} from 'sentry/utils/analytics';
-import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import useApi from 'sentry/utils/useApi';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 
 interface OrganizationLoaderContextProps {
   organizationPromise: Promise<unknown> | null;
@@ -75,11 +73,10 @@ export function OrganizationContextProvider({children}: Props) {
   const [organizationPromise, setOrganizationPromise] = useState<Promise<unknown> | null>(
     null
   );
+  const spanRef = useRef<Sentry.Span | null>(null);
 
   const lastOrganizationSlug: string | null =
     configStore.lastOrganization ?? organizations[0]?.slug ?? null;
-
-  const routes = useRoutes();
   const params = useParams<{orgId?: string}>();
 
   // XXX(epurkhiser): When running in deploy preview mode customer domains are
@@ -90,7 +87,12 @@ export function OrganizationContextProvider({children}: Props) {
 
   useEffect(() => {
     // Nothing to do if we already have the organization loaded
+    const previousBootstrapKey = `previousBootstrapTime-${orgSlug}`;
     if (organization && organization.slug === orgSlug) {
+      if (spanRef.current && organization) {
+        spanRef.current.end();
+        localStorage.setItem(previousBootstrapKey, `${Date.now()}`);
+      }
       return;
     }
 
@@ -99,32 +101,21 @@ export function OrganizationContextProvider({children}: Props) {
       return;
     }
 
-    metric.mark({name: 'organization-details-fetch-start'});
+    const previousBootstrapTime = localStorage.getItem(previousBootstrapKey);
+    spanRef.current = Sentry.startInactiveSpan({
+      name: 'ui.bootstrap',
+      op: 'ui.render',
+      forceTransaction: true,
+      attributes: {
+        // Bootstrapped in the last 10 minutes
+        is_recent_boot: previousBootstrapTime
+          ? Date.now() - Number(previousBootstrapTime) < 10 * 60 * 1000
+          : false,
+      },
+    });
 
     setOrganizationPromise(fetchOrganizationDetails(api, orgSlug, false, true));
   }, [api, orgSlug, organization]);
-
-  // Take a measurement for when organization details are done loading and the
-  // new state is applied
-  useEffect(
-    () => {
-      if (organization === null) {
-        return;
-      }
-      metric.measure({
-        name: 'app.component.perf',
-        start: 'organization-details-fetch-start',
-        data: {
-          name: 'org-details',
-          route: getRouteStringFromRoutes(routes),
-          organization_id: parseInt(organization.id, 10),
-        },
-      });
-    },
-    // Ignore the `routes` dependency for the metrics measurement
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [organization]
-  );
 
   // XXX(epurkhiser): User may be null in some scenarios at this point in app
   // boot. We should fix the types here in the future

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -87,7 +87,7 @@ export function OrganizationContextProvider({children}: Props) {
 
   useEffect(() => {
     // Nothing to do if we already have the organization loaded
-    const previousBootstrapKey = `previousBootstrapTime-${orgSlug}`;
+    const previousBootstrapKey = `previous-bootstrap-${orgSlug}`;
     if (organization && organization.slug === orgSlug) {
       if (spanRef.current) {
         spanRef.current.end();

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -89,8 +89,9 @@ export function OrganizationContextProvider({children}: Props) {
     // Nothing to do if we already have the organization loaded
     const previousBootstrapKey = `previousBootstrapTime-${orgSlug}`;
     if (organization && organization.slug === orgSlug) {
-      if (spanRef.current && organization) {
+      if (spanRef.current) {
         spanRef.current.end();
+        spanRef.current = null;
         localStorage.setItem(previousBootstrapKey, `${Date.now()}`);
       }
       return;


### PR DESCRIPTION
Instead of sending this to datadog, measure using a sentry transaction. 

Adds what we are considering to be a "warm" start when we attempt to add local caching.
