### PR TITLE
test(widget-builder): Remove circular dependency in analytics

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -1,4 +1,4 @@
-import type {DashboardsLayout} from 'sentry/views/dashboards/manage';
+import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
 
 export enum WidgetBuilderVersion {
   PAGE = 'page',

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -39,6 +39,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DashboardImportButton} from 'sentry/views/dashboards/manage/dashboardImport';
 import DashboardTable from 'sentry/views/dashboards/manage/dashboardTable';
+import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
 import {MetricsRemovedAlertsWidgetsAlert} from 'sentry/views/metrics/metricsRemovedAlertsWidgetsAlert';
 import RouteError from 'sentry/views/routeError';
 
@@ -72,8 +73,6 @@ export const LAYOUT_KEY = 'dashboards-overview-layout';
 
 const GRID = 'grid';
 const TABLE = 'table';
-
-export type DashboardsLayout = 'grid' | 'table';
 
 function shouldShowTemplates(): boolean {
   const shouldShow = localStorage.getItem(SHOW_TEMPLATES_KEY);

--- a/static/app/views/dashboards/manage/types.tsx
+++ b/static/app/views/dashboards/manage/types.tsx
@@ -1,0 +1,1 @@
+export type DashboardsLayout = 'grid' | 'table';


### PR DESCRIPTION
Analytics was importing this type, which came from a file that imported analytics. Move the type into its own file to resolve some of these conflicts.