### PR TITLE
chore(testing): Skip flaky uptime test

### DIFF
--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -1,6 +1,8 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from sentry.testutils.cases import UptimeCheckSnubaTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
@@ -84,6 +86,7 @@ class OrganizationUptimeCheckIndexEndpointTest(
         )
         assert response.status_code == 400
 
+    @pytest.mark.skip(reason="flaky test")
     @freeze_time(datetime(2025, 1, 21, 19, 4, 18, tzinfo=timezone.utc))
     def test_too_many_periods(self):
         """Test that the endpoint returns data for a simple uptime check."""


### PR DESCRIPTION
This skips flaky test that is failing CI on master:

Examples:
https://github.com/getsentry/sentry/actions/runs/13041264236/job/36383484362
https://github.com/getsentry/sentry/actions/runs/13041064429/job/36382834991
https://github.com/getsentry/sentry/actions/runs/13041119056/job/36383003377