### PR TITLE
chore(insights): Remove feature flag for mobile screen rendering

### DIFF
--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -27,7 +27,6 @@ const ALL_AVAILABLE_FEATURES = [
   'ourlogs-enabled',
   'performance-view',
   'performance-trace-explorer',
-  'starfish-mobile-ui-module',
   'profiling',
 ];
 

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -35,7 +35,6 @@ const ALL_AVAILABLE_FEATURES = [
   'session-replay-ui',
   'performance-view',
   'performance-trace-explorer',
-  'starfish-mobile-ui-module',
   'profiling',
 ];
 

--- a/static/app/views/insights/mobile/common/components/tables/samplesTables.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/samplesTables.tsx
@@ -32,7 +32,7 @@ export interface SpanOperationTableProps {
 }
 
 interface SamplesTablesProps {
-  EventSamples: React.ComponentType<EventSamplesProps>;
+  EventSamples: React.ComponentType<EventSamplesProps> | undefined;
   SpanOperationTable: React.ComponentType<SpanOperationTableProps>;
   transactionName: string;
 }
@@ -50,22 +50,26 @@ export function SamplesTables({
       return (
         <EventSplitContainer>
           <ErrorBoundary mini>
-            <EventSamples
-              cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-              sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-              release={primaryRelease}
-              transaction={transactionName}
-              footerAlignedPagination
-            />
+            {EventSamples && (
+              <EventSamples
+                cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+                sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                release={primaryRelease}
+                transaction={transactionName}
+                footerAlignedPagination
+              />
+            )}
           </ErrorBoundary>
           <ErrorBoundary mini>
-            <EventSamples
-              cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-              sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-              release={secondaryRelease}
-              transaction={transactionName}
-              footerAlignedPagination
-            />
+            {EventSamples && (
+              <EventSamples
+                cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
+                sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
+                release={secondaryRelease}
+                transaction={transactionName}
+                footerAlignedPagination
+              />
+            )}
           </ErrorBoundary>
         </EventSplitContainer>
       );
@@ -103,18 +107,20 @@ export function SamplesTables({
           <DeviceClassSelector size="md" clearSpansTableCursor />
           <SubregionSelector />
         </FiltersContainer>
-        <SegmentedControl
-          onChange={value => setSampleType(value)}
-          defaultValue={SPANS}
-          label={t('Sample Type Selection')}
-        >
-          <SegmentedControl.Item key={SPANS} aria-label={t('By Spans')}>
-            {t('By Spans')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key={EVENT} aria-label={t('By Event')}>
-            {t('By Event')}
-          </SegmentedControl.Item>
-        </SegmentedControl>
+        {EventSamples && (
+          <SegmentedControl
+            onChange={value => setSampleType(value)}
+            defaultValue={SPANS}
+            label={t('Sample Type Selection')}
+          >
+            <SegmentedControl.Item key={SPANS} aria-label={t('By Spans')}>
+              {t('By Spans')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key={EVENT} aria-label={t('By Event')}>
+              {t('By Event')}
+            </SegmentedControl.Item>
+          </SegmentedControl>
+        )}
       </Controls>
       {content}
     </div>

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
@@ -13,11 +13,7 @@ jest.mock('sentry/utils/useLocation');
 
 describe('ScreenDetailsPage', function () {
   const organization = OrganizationFixture({
-    features: [
-      'insights-addon-modules',
-      'insights-mobile-screens-module',
-      'starfish-mobile-ui-module',
-    ],
+    features: ['insights-addon-modules', 'insights-mobile-screens-module'],
   });
   const project = ProjectFixture();
 

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
@@ -61,7 +61,6 @@ export function ScreenDetailsPage() {
     {
       key: 'screen_rendering',
       label: t('Screen Rendering'),
-      feature: 'starfish-mobile-ui-module',
       alpha: true,
       content: () => {
         return <UiPage key={'screen_rendering'} />;

--- a/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
@@ -104,8 +104,8 @@ export function ScreenSummaryContent() {
         <SamplesTables
           transactionName={transactionName}
           SpanOperationTable={SpanOperationTable}
-          // TODO(nar): Add event samples component specific to ui module
-          EventSamples={_props => <div />}
+          // for now, let's only show the span ops table
+          EventSamples={undefined}
         />
       </SamplesContainer>
     </Fragment>


### PR DESCRIPTION
As it's anyway hidden behind the Mobile Vitals (aka mobile-screens) feature flag.
On top of that the events samples table hasn't been implemented so far, so let's just hide the event/span toggle altogether.

Fixes: https://github.com/getsentry/sentry/issues/84161