### PR TITLE
ref(ourlogs): Add project specific relay flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -555,6 +555,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Relay extracting logs from breadcrumbs for a project.
+    manager.add("projects:ourlogs-breadcrumb-extraction", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the new option to batch assemble debug files
     manager.add(
         "organizations:batch-assemble-debug-files",

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -69,6 +69,7 @@ EXPOSABLE_FEATURES = [
     "projects:relay-otel-endpoint",
     "organizations:ourlogs-ingestion",
     "organizations:view-hierarchy-scrubbing",
+    "projects:ourlogs-breadcrumb-extraction",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
### Summary
This adds a project feature for extracting logs from a breadcrumb, and exposes it to relay.

