### PR TITLE
ref(commandsource): allow toggling theme for non sudo users

### DIFF
--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -44,7 +44,7 @@ const ACTIONS: Action[] = [
   {
     title: t('Toggle dark mode'),
     description: t('Toggle dark mode (superuser only atm)'),
-    requiresSuperuser: true,
+    requiresSuperuser: false,
     action: () => {
       removeBodyTheme();
       ConfigStore.set('theme', ConfigStore.get('theme') === 'dark' ? 'light' : 'dark');


### PR DESCRIPTION
Not sure why this is limited to superuser, but given that users can toggle theme in settings without superuser, gating it in cmd+k menu isn't achieving much