### PR TITLE
feat(uptime): add uptime check index endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -332,6 +332,9 @@ from sentry.uptime.endpoints.organiation_uptime_alert_index import (
     OrganizationUptimeAlertIndexEndpoint,
 )
 from sentry.uptime.endpoints.organization_uptime_stats import OrganizationUptimeStatsEndpoint
+from sentry.uptime.endpoints.project_uptime_alert_checks_index import (
+    ProjectUptimeAlertCheckIndexEndpoint,
+)
 from sentry.uptime.endpoints.project_uptime_alert_details import ProjectUptimeAlertDetailsEndpoint
 from sentry.uptime.endpoints.project_uptime_alert_index import ProjectUptimeAlertIndexEndpoint
 from sentry.users.api.endpoints.authenticator_index import AuthenticatorIndexEndpoint
@@ -2183,6 +2186,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/uptime-stats/$",
         OrganizationUptimeStatsEndpoint.as_view(),
         name="sentry-api-0-organization-uptime-stats",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/uptime-alert/(?P<uptime_project_subscription_id>[^\/]+)/checks/$",
+        ProjectUptimeAlertCheckIndexEndpoint.as_view(),
+        name="sentry-api-0-project-uptime-alert-checks",
     ),
     *workflow_urls.organization_urlpatterns,
 ]

--- a/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
+++ b/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
@@ -5,6 +5,7 @@
 """
 
 SENTRY_API_PAGINATION_ALLOWLIST_DO_NOT_MODIFY = {
+    "ProjectUptimeAlertCheckIndexEndpoint",
     "OrganizationUptimeStatsEndpoint",
     "ApiTokensEndpoint",
     "AssistantEndpoint",

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -196,9 +196,10 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         self, value: str, col_name: str, uptime_subscription: ProjectUptimeSubscription
     ) -> Mapping[str, int | str | float]:
         if col_name == "uptime_subscription_id":
+            # map this back to the project uptime subscription id
             return {
-                "project_uptime_subscription_id": str(uptime_subscription.id),
-                col_name: str(uptime_subscription.id),
+                "project_uptime_subscription_id": uptime_subscription.id,
+                col_name: uptime_subscription.id,
             }
         return {col_name: value}
 

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -170,7 +171,7 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
     def _format_row(
         self,
         row_idx: int,
-        column_values: list,
+        column_values: Any,
         column_names: list[str],
         uptime_subscription: ProjectUptimeSubscription,
     ) -> dict[str, int | str | float]:
@@ -182,7 +183,7 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
 
     def _extract_field_value(
         self, result, col_name: str, uptime_subscription: ProjectUptimeSubscription
-    ) -> dict[str, int | str | float]:
+    ) -> Mapping[str, int | str | float]:
         if result.HasField("val_str"):
             return self._handle_string_field(result.val_str, col_name, uptime_subscription)
         elif result.HasField("val_int"):
@@ -193,15 +194,15 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
 
     def _handle_string_field(
         self, value: str, col_name: str, uptime_subscription: ProjectUptimeSubscription
-    ) -> dict[str, str]:
+    ) -> Mapping[str, int | str | float]:
         if col_name == "uptime_subscription_id":
             return {
-                "project_uptime_subscription_id": uptime_subscription.id,
-                col_name: uptime_subscription.id,
+                "project_uptime_subscription_id": str(uptime_subscription.id),
+                col_name: str(uptime_subscription.id),
             }
         return {col_name: value}
 
-    def _handle_float_field(self, value: float, col_name: str) -> dict[str, str | float]:
+    def _handle_float_field(self, value: float, col_name: str) -> Mapping[str, int | str | float]:
         if col_name in ("scheduled_check_time", "timestamp"):
             return {col_name: datetime.fromtimestamp(value).strftime("%Y-%m-%dT%H:%M:%SZ")}
         return {col_name: value}

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -15,6 +15,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, Trace
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.models.project import Project
 from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
 from sentry.uptime.models import ProjectUptimeSubscription
@@ -147,6 +148,9 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
                     # Extract the actual value based on which field is set
                     if result.HasField("val_str"):
                         if col_name == "uptime_subscription_id":
+                            if col_name in row_dict:
+                                del row_dict[col_name]
+                            row_dict["project_uptime_subscription_id"] = uptime_subscription.id
                             row_dict[col_name] = uptime_subscription.id
                         else:
                             row_dict[col_name] = result.val_str
@@ -159,5 +163,5 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
                             )
                         else:
                             row_dict[col_name] = result.val_float
-                results.append(row_dict)
+                results.append(convert_dict_key_case(row_dict, snake_to_camel_case))
         return results

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -2,6 +2,7 @@ import uuid
 
 from sentry.testutils.cases import UptimeCheckSnubaTestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.cursors import Cursor
 from tests.sentry.uptime.endpoints.test_organization_uptime_alert_index import (
     OrganizationUptimeAlertIndexBaseEndpointTest,
 )
@@ -55,39 +56,39 @@ class ProjectUptimeAlertCheckIndexEndpoint(
         assert first["uptimeSubscriptionId"] == self.project_uptime_subscription.id
 
     # TODO: fix this test once snuba is fixed
-    # def test_get_paginated(self):
-    #     response = self.get_success_response(
-    #         self.organization.slug,
-    #         self.project.slug,
-    #         self.project_uptime_subscription.id,
-    #         qs_params={"cursor": Cursor(0, 0), "per_page": 2},
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 2
+    def test_get_paginated(self):
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.project_uptime_subscription.id,
+            qs_params={"cursor": Cursor(0, 0), "per_page": 2},
+        )
+        assert response.data is not None
+        assert len(response.data) == 2
 
-    #     response = self.get_success_response(
-    #         self.organization.slug,
-    #         self.project.slug,
-    #         self.project_uptime_subscription.id,
-    #         qs_params={"cursor": Cursor(0, 2), "per_page": 2},
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 2
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.project_uptime_subscription.id,
+            qs_params={"cursor": Cursor(0, 2), "per_page": 2},
+        )
+        assert response.data is not None
+        assert len(response.data) == 2
 
-    #     response = self.get_success_response(
-    #         self.organization.slug,
-    #         self.project.slug,
-    #         self.project_uptime_subscription.id,
-    #         qs_params={"cursor": Cursor(0, 4), "per_page": 2},
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 2
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.project_uptime_subscription.id,
+            qs_params={"cursor": Cursor(0, 4), "per_page": 2},
+        )
+        assert response.data is not None
+        assert len(response.data) == 2
 
-    #     response = self.get_success_response(
-    #         self.organization.slug,
-    #         self.project.slug,
-    #         self.project_uptime_subscription.id,
-    #         qs_params={"cursor": Cursor(0, 20), "per_page": 2},
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 0
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.project_uptime_subscription.id,
+            qs_params={"cursor": Cursor(0, 20), "per_page": 2},
+        )
+        assert response.data is not None
+        assert len(response.data) == 0

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -45,15 +45,15 @@ class ProjectUptimeAlertCheckIndexEndpoint(
         assert len(response.data) == 6
         first = response.data[0]
         for key in [
-            "uptime_subscription_id",
-            "uptime_check_id",
-            "scheduled_check_time",
+            "uptimeSubscriptionId",
+            "uptimeCheckId",
+            "scheduledCheckTime",
             "timestamp",
-            "duration_ms",
+            "durationMs",
             "region",
-            "check_status",
-            "check_status_reason",
-            "trace_id",
+            "checkStatus",
+            "checkStatusReason",
+            "traceId",
         ]:
             assert key in first, f"{key} not in {first}"
-        assert first["uptime_subscription_id"] == self.project_uptime_subscription.id
+        assert first["uptimeSubscriptionId"] == self.project_uptime_subscription.id

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -1,8 +1,6 @@
 import uuid
-from datetime import datetime, timezone
 
 from sentry.testutils.cases import UptimeCheckSnubaTestCase
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 from tests.sentry.uptime.endpoints.test_organization_uptime_alert_index import (
     OrganizationUptimeAlertIndexBaseEndpointTest,
@@ -10,7 +8,6 @@ from tests.sentry.uptime.endpoints.test_organization_uptime_alert_index import (
 
 
 @region_silo_test
-@freeze_time(datetime(2025, 1, 21, 19, 4, 18, tzinfo=timezone.utc))
 class ProjectUptimeAlertCheckIndexEndpoint(
     OrganizationUptimeAlertIndexBaseEndpointTest, UptimeCheckSnubaTestCase
 ):
@@ -34,7 +31,6 @@ class ProjectUptimeAlertCheckIndexEndpoint(
         self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="success")
         self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="failure")
 
-    @freeze_time(datetime(2025, 1, 21, 19, 4, 18, tzinfo=timezone.utc))
     def test_get(self):
         response = self.get_success_response(
             self.organization.slug,
@@ -57,3 +53,41 @@ class ProjectUptimeAlertCheckIndexEndpoint(
         ]:
             assert key in first, f"{key} not in {first}"
         assert first["uptimeSubscriptionId"] == self.project_uptime_subscription.id
+
+    # TODO: fix this test once snuba is fixed
+    # def test_get_paginated(self):
+    #     response = self.get_success_response(
+    #         self.organization.slug,
+    #         self.project.slug,
+    #         self.project_uptime_subscription.id,
+    #         qs_params={"cursor": Cursor(0, 0), "per_page": 2},
+    #     )
+    #     assert response.data is not None
+    #     assert len(response.data) == 2
+
+    #     response = self.get_success_response(
+    #         self.organization.slug,
+    #         self.project.slug,
+    #         self.project_uptime_subscription.id,
+    #         qs_params={"cursor": Cursor(0, 2), "per_page": 2},
+    #     )
+    #     assert response.data is not None
+    #     assert len(response.data) == 2
+
+    #     response = self.get_success_response(
+    #         self.organization.slug,
+    #         self.project.slug,
+    #         self.project_uptime_subscription.id,
+    #         qs_params={"cursor": Cursor(0, 4), "per_page": 2},
+    #     )
+    #     assert response.data is not None
+    #     assert len(response.data) == 2
+
+    #     response = self.get_success_response(
+    #         self.organization.slug,
+    #         self.project.slug,
+    #         self.project_uptime_subscription.id,
+    #         qs_params={"cursor": Cursor(0, 20), "per_page": 2},
+    #     )
+    #     assert response.data is not None
+    #     assert len(response.data) == 0

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -1,0 +1,59 @@
+import uuid
+from datetime import datetime, timezone
+
+from sentry.testutils.cases import UptimeCheckSnubaTestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import region_silo_test
+from tests.sentry.uptime.endpoints.test_organization_uptime_alert_index import (
+    OrganizationUptimeAlertIndexBaseEndpointTest,
+)
+
+
+@region_silo_test
+@freeze_time(datetime(2025, 1, 21, 19, 4, 18, tzinfo=timezone.utc))
+class ProjectUptimeAlertCheckIndexEndpoint(
+    OrganizationUptimeAlertIndexBaseEndpointTest, UptimeCheckSnubaTestCase
+):
+    endpoint = "sentry-api-0-project-uptime-alert-checks"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.subscription_id = uuid.uuid4().hex
+        self.subscription = self.create_uptime_subscription(
+            url="https://santry.io", subscription_id=self.subscription_id
+        )
+        self.project_uptime_subscription = self.create_project_uptime_subscription(
+            uptime_subscription=self.subscription
+        )
+
+        self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="success")
+        self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="failure")
+        self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="success")
+        self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="failure")
+        self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="success")
+        self.store_snuba_uptime_check(subscription_id=self.subscription_id, check_status="failure")
+
+    @freeze_time(datetime(2025, 1, 21, 19, 4, 18, tzinfo=timezone.utc))
+    def test_get(self):
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.project_uptime_subscription.id,
+        )
+        assert response.data is not None
+        assert len(response.data) == 6
+        first = response.data[0]
+        for key in [
+            "uptime_subscription_id",
+            "uptime_check_id",
+            "scheduled_check_time",
+            "timestamp",
+            "duration_ms",
+            "region",
+            "check_status",
+            "check_status_reason",
+            "trace_id",
+        ]:
+            assert key in first, f"{key} not in {first}"
+        assert first["uptime_subscription_id"] == self.project_uptime_subscription.id


### PR DESCRIPTION
given an uptime alert id (really need to get naming pinned down), retrieve a set of checks for the alert. 

I'd like to follow up on:
- [ ] there is a problem with the EAP API and the http_status_code field.
- [x] need to add pagination

but i think we can merge as is so we can at least populate some data.
