### PR TITLE
chore(metric-issues): Add project-level flag for metric issues

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -191,6 +191,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-views-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("projects:metric-issue-creation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:issue-open-periods", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
+from sentry import features
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import get_incident_status_text
 from sentry.issues.grouptype import MetricIssuePOC
@@ -69,6 +70,11 @@ def create_or_update_metric_issue(
 ) -> IssueOccurrence | None:
     project = incident.alert_rule.projects.first()
     if not project:
+        return None
+
+    if not features.has("projects:metric-issue-creation", project):
+        # We've already checked for the feature flag at the organization level,
+        # but this flag helps us test with a smaller set of projects.
         return None
 
     # collect the data from the incident to treat as an event

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2878,6 +2878,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_incident_is_latest_for_rule(new_incident)
 
     @with_feature("organizations:metric-issue-poc")
+    @with_feature("projects:metric-issue-creation")
     @mock.patch("sentry.incidents.utils.metric_issue_poc.produce_occurrence_to_kafka")
     def test_alert_creates_metric_issue(self, mock_produce_occurrence_to_kafka):
         rule = self.rule
@@ -2907,6 +2908,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert occurrence.evidence_data["metric_value"] == trigger.alert_threshold + 1
 
     @with_feature("organizations:metric-issue-poc")
+    @with_feature("projects:metric-issue-creation")
     @mock.patch("sentry.incidents.utils.metric_issue_poc.produce_occurrence_to_kafka")
     def test_resolved_alert_updates_metric_issue(self, mock_produce_occurrence_to_kafka):
         from sentry.models.group import GroupStatus

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -11,6 +11,7 @@ from tests.sentry.issues.test_occurrence_consumer import IssueOccurrenceTestBase
 
 
 @apply_feature_flag_on_cls("organizations:metric-issue-poc-ingest")
+@apply_feature_flag_on_cls("projects:metric-issue-creation")
 class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
     def setUp(self):
         self.organization = self.create_organization()


### PR DESCRIPTION
We already have an organization level flag, but this project level flag helps us test internally with lesser used projects before we enable it for all of Sentry.