### PR TITLE
styles(explore): Shift explore expand button within chart

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -313,9 +313,7 @@ const StyledPageFilterBar = styled(PageFilterBar)`
 const Toggle = styled('div')<{withToolbar: boolean}>`
   display: none;
   position: absolute;
-  top: 5px;
-  left: ${p => (p.withToolbar ? '-17px' : '-31px')};
-  transition: 700ms;
+  top: 0px;
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     display: block;
@@ -324,6 +322,7 @@ const Toggle = styled('div')<{withToolbar: boolean}>`
 
 const StyledButton = styled(Button)`
   width: 28px;
+  border-left: 0px;
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
 `;


### PR DESCRIPTION
The updated positioning for the expand/collapse button is always on the top left corner of the chart.