### PR TITLE
fix(widget-builder): Change all add buttons to link type

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -230,11 +230,16 @@ export function GroupBySelector({
           </DndContext>
         )}
       </StyledField>
-      {columns.length < GROUP_BY_LIMIT && (
-        <AddGroupButton size="sm" icon={<IconAdd isCircled />} onClick={handleAdd}>
-          {t('Add Group')}
-        </AddGroupButton>
-      )}
+      {columns.length < GROUP_BY_LIMIT &&
+        (builderVersion === WidgetBuilderVersion.PAGE ? (
+          <AddGroupButton size="sm" icon={<IconAdd isCircled />} onClick={handleAdd}>
+            {t('Add Group')}
+          </AddGroupButton>
+        ) : (
+          <Button size="sm" priority="link" onClick={handleAdd}>
+            {t('+ Add Group')}
+          </Button>
+        ))}
     </Fragment>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -236,7 +236,12 @@ export function GroupBySelector({
             {t('Add Group')}
           </AddGroupButton>
         ) : (
-          <Button size="sm" priority="link" onClick={handleAdd}>
+          <Button
+            size="sm"
+            priority="link"
+            onClick={handleAdd}
+            aria-label={t('Add Group')}
+          >
             {t('+ Add Group')}
           </Button>
         ))}

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -1,9 +1,15 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+
+const organization = OrganizationFixture({
+  features: ['dashboards-widget-builder-redesign'],
+});
 
 describe('WidgetBuilderGroupBySelector', function () {
   beforeEach(function () {
@@ -19,12 +25,15 @@ describe('WidgetBuilderGroupBySelector', function () {
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
           <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
         </SpanTagsProvider>
-      </WidgetBuilderProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+      }
     );
 
     expect(await screen.findByText('Group by')).toBeInTheDocument();
     expect(await screen.findByText('Select group')).toBeInTheDocument();
-    expect(await screen.findByText('Add Group')).toBeInTheDocument();
+    expect(await screen.findByText('+ Add Group')).toBeInTheDocument();
   });
 
   it('renders the group by field and can function', async function () {
@@ -33,17 +42,20 @@ describe('WidgetBuilderGroupBySelector', function () {
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
           <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
         </SpanTagsProvider>
-      </WidgetBuilderProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+      }
     );
 
     expect(await screen.findByText('Group by')).toBeInTheDocument();
     expect(await screen.findByText('Select group')).toBeInTheDocument();
-    expect(await screen.findByText('Add Group')).toBeInTheDocument();
+    expect(await screen.findByText('+ Add Group')).toBeInTheDocument();
 
     await userEvent.click(await screen.findByText('Select group'));
     await userEvent.click(await screen.findByText('timestamp'));
 
-    await userEvent.click(await screen.findByText('Add Group'));
+    await userEvent.click(await screen.findByText('+ Add Group'));
     await userEvent.click(await screen.findByText('Select group'));
     await userEvent.click(await screen.findByText('id'));
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -10,7 +10,14 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 
 const {organization, projects, router} = initializeOrg({
-  organization: {features: ['global-views', 'open-membership', 'dashboards-eap']},
+  organization: {
+    features: [
+      'global-views',
+      'open-membership',
+      'dashboards-eap',
+      'dashboards-widget-builder-redesign',
+    ],
+  },
   projects: [
     {id: '1', slug: 'project-1', isMember: true},
     {id: '2', slug: 'project-2', isMember: true},
@@ -177,12 +184,12 @@ describe('NewWidgetBuiler', function () {
 
     // see if alias field and add button are there
     expect(screen.getByPlaceholderText('Legend Alias')).toBeInTheDocument();
-    expect(screen.getByText('Add Filter')).toBeInTheDocument();
+    expect(screen.getByText('+ Add Filter')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.queryByLabelText('Remove this filter')).not.toBeInTheDocument();
     });
     // add a field and see if delete buttons are there
-    await userEvent.click(screen.getByText('Add Filter'));
+    await userEvent.click(screen.getByText('+ Add Filter'));
     expect(screen.getAllByLabelText('Remove this filter')).toHaveLength(2);
   });
 
@@ -207,7 +214,7 @@ describe('NewWidgetBuiler', function () {
     await waitFor(() => {
       expect(screen.queryByPlaceholderText('Legend Alias')).not.toBeInTheDocument();
     });
-    expect(screen.queryByText('Add Filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('+ Add Filter')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Remove this filter')).not.toBeInTheDocument();
   });
 
@@ -238,7 +245,7 @@ describe('NewWidgetBuiler', function () {
 
     expect(await screen.findByText('Group by')).toBeInTheDocument();
     expect(await screen.findByText('Select group')).toBeInTheDocument();
-    expect(await screen.findByText('Add Group')).toBeInTheDocument();
+    expect(await screen.findByText('+ Add Group')).toBeInTheDocument();
   });
 
   it('renders empty widget preview when no widget selected from templates', async function () {

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -130,11 +130,11 @@ describe('QueryFilterBuilder', () => {
     expect(
       screen.getByPlaceholderText('Search for events, users, tags, and more')
     ).toBeInTheDocument();
-    expect(await screen.findByText('Add Filter')).toBeInTheDocument();
+    expect(await screen.findByText('+ Add Filter')).toBeInTheDocument();
 
-    await userEvent.click(await screen.findByText('Add Filter'));
-    await userEvent.click(await screen.findByText('Add Filter'));
+    await userEvent.click(await screen.findByText('+ Add Filter'));
+    await userEvent.click(await screen.findByText('+ Add Filter'));
 
-    expect(screen.queryByText('Add Filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('+ Add Filter')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import {Button} from 'sentry/components/button';
 import Input from 'sentry/components/input';
-import {IconAdd, IconDelete} from 'sentry/icons';
+import {IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -241,8 +241,13 @@ function WidgetBuilderQueryFilterBuilder({
         </QueryFieldRowWrapper>
       ))}
       {canAddSearchConditions && (
-        <Button size="sm" icon={<IconAdd isCircled />} onClick={onAddSearchConditions}>
-          {t('Add Filter')}
+        <Button
+          size="sm"
+          priority="link"
+          onClick={onAddSearchConditions}
+          aria-label={t('Add Filter')}
+        >
+          {t('+ Add Filter')}
         </Button>
       )}
     </Fragment>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -275,5 +275,5 @@ const SlideoutBodyWrapper = styled('div')`
 `;
 
 const Section = styled('div')`
-  margin-bottom: ${space(3)};
+  margin-bottom: 24px;
 `;


### PR DESCRIPTION
Talked to Vasudha and it seems like we want to keep consistency in the widget builder. All "Add" buttons have been changed to the link looking buttons with the '+' in front of it.  I've also updated the tests to account for this.

It looks like this:

![image](https://github.com/user-attachments/assets/f8a20b11-6a8f-44f1-b472-57b3117bb954)

related to this bug: https://www.notion.so/sentry/Replace-Add-Filter-and-Add-Group-with-next-to-the-field-1738b10e4b5d804991d5fde4c534796b?pvs=4
