### PR TITLE
feat(dashboards): Improve `BarChartWidget` incomplete data point handling

### DIFF
--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.stories.tsx
@@ -9,6 +9,7 @@ import type {DateString} from 'sentry/types/core';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 import type {TimeseriesData} from '../common/types';
+import {shiftTimeserieToNow} from '../timeSeriesWidget/shiftTimeserieToNow';
 
 import {BarChartWidget} from './barChartWidget';
 import sampleLatencyTimeSeries from './sampleLatencyTimeSeries.json';
@@ -61,7 +62,11 @@ export default storyBook(BarChartWidget, story => {
           <BarChartWidget
             title="Duration Breakdown"
             description="Explains what proportion of total duration is taken up by latency vs. span duration"
-            timeseries={[latencyTimeSeries, spanDurationTimeSeries]}
+            timeseries={[
+              shiftTimeserieToNow(latencyTimeSeries),
+              shiftTimeserieToNow(spanDurationTimeSeries),
+            ]}
+            dataCompletenessDelay={600}
           />
         </SmallSizingWindow>
       </Fragment>

--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidgetSeries.tsx
@@ -1,3 +1,5 @@
+import Color from 'color';
+
 import BarSeries from 'sentry/components/charts/series/barSeries';
 
 import type {TimeseriesData} from '../common/types';
@@ -5,35 +7,23 @@ import type {TimeseriesData} from '../common/types';
 /**
  *
  * @param timeserie
- * @param complete Whether this series is fully ingested and processed data, or it's still behind the ingestion delay
  */
-export function BarChartWidgetSeries(timeserie: TimeseriesData, complete?: boolean) {
-  return complete
-    ? BarSeries({
-        name: timeserie.field,
-        color: timeserie.color,
-        stack: 'complete',
-        animation: false,
-        itemStyle: {
-          color: timeserie.color,
-          opacity: 1.0,
-        },
-        data: timeserie.data.map(datum => {
-          return [datum.timestamp, datum.value];
-        }),
-      })
-    : BarSeries({
-        name: timeserie.field,
-        color: timeserie.color,
-        stack: 'incomplete',
-        animation: false,
-        data: timeserie.data.map(datum => {
-          return [datum.timestamp, datum.value];
-        }),
-        itemStyle: {
-          color: timeserie.color,
-          opacity: 0.8,
-        },
-        silent: true,
-      });
+export function BarChartWidgetSeries(timeserie: TimeseriesData) {
+  return BarSeries({
+    name: timeserie.field,
+    color: timeserie.color,
+    stack: 'complete',
+    animation: false,
+    itemStyle: {
+      color: params => {
+        const datum = timeserie.data[params.dataIndex]!;
+
+        return datum.delayed ? Color(params.color).lighten(0.5).string() : params.color!;
+      },
+      opacity: 1.0,
+    },
+    data: timeserie.data.map(datum => {
+      return [datum.timestamp, datum.value];
+    }),
+  });
 }

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -11,6 +11,7 @@ export type TableData = TableRow[];
 export type TimeSeriesItem = {
   timestamp: string;
   value: number;
+  delayed?: boolean;
 };
 
 export type TimeseriesData = {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/markDelayedData.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/markDelayedData.tsx
@@ -1,0 +1,36 @@
+import type {TimeseriesData} from '../common/types';
+
+/**
+ * Given a timeseries and a delay in seconds, goes through the timeseries data, and marks each point as either delayed (data bucket ended before the delay threshold) or not
+ */
+
+export function markDelayedData(timeserie: TimeseriesData, delay: number) {
+  if (delay === 0) {
+    return timeserie;
+  }
+
+  const penultimateDatum = timeserie.data.at(-2);
+  const finalDatum = timeserie.data.at(-1);
+
+  let bucketSize: number = 0;
+  if (penultimateDatum && finalDatum) {
+    bucketSize =
+      new Date(finalDatum.timestamp).getTime() -
+      new Date(penultimateDatum.timestamp).getTime();
+  }
+
+  const ingestionDelayTimestamp = Date.now() - delay * 1000;
+
+  return {
+    ...timeserie,
+    data: timeserie.data.map(datum => {
+      const bucketEndTimestamp = new Date(datum.timestamp).getTime() + bucketSize;
+      const delayed = bucketEndTimestamp >= ingestionDelayTimestamp;
+
+      return {
+        ...datum,
+        delayed,
+      };
+    }),
+  };
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/splitSeriesIntoCompleteAndIncomplete.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/splitSeriesIntoCompleteAndIncomplete.tsx
@@ -2,14 +2,17 @@ import partition from 'lodash/partition';
 
 import type {TimeseriesData} from '../common/types';
 
+import {markDelayedData} from './markDelayedData';
+
 export function splitSeriesIntoCompleteAndIncomplete(
   serie: TimeseriesData,
   delay: number
 ): Array<TimeseriesData | undefined> {
   const markedTimeserie = markDelayedData(serie, delay);
 
-  const [completeData, incompleteData] = partition(markedTimeserie.data, datum =>
-    Boolean(datum.delayed)
+  const [completeData, incompleteData] = partition(
+    markedTimeserie.data,
+    datum => !datum.delayed
   );
 
   // If there is both complete and incomplete data, prepend the incomplete data
@@ -37,40 +40,6 @@ export function splitSeriesIntoCompleteAndIncomplete(
         }
       : undefined,
   ];
-}
-
-/**
- * Given a timeseries and a delay in seconds, goes through the timeseries data, and marks each point as either delayed (data bucket ended before the delay threshold) or not
- */
-function markDelayedData(timeserie: TimeseriesData, delay: number) {
-  if (delay === 0) {
-    return timeserie;
-  }
-
-  const penultimateDatum = timeserie.data.at(-2);
-  const finalDatum = timeserie.data.at(-1);
-
-  let bucketSize: number = 0;
-  if (penultimateDatum && finalDatum) {
-    bucketSize =
-      new Date(finalDatum.timestamp).getTime() -
-      new Date(penultimateDatum.timestamp).getTime();
-  }
-
-  const ingestionDelayTimestamp = Date.now() - delay * 1000;
-
-  return {
-    ...timeserie,
-    data: timeserie.data.map(datum => {
-      const bucketEndTimestamp = new Date(datum.timestamp).getTime() + bucketSize;
-      const delayed = bucketEndTimestamp < ingestionDelayTimestamp;
-
-      return {
-        ...datum,
-        delayed,
-      };
-    }),
-  };
 }
 
 function discardDelayProperty(

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -116,8 +116,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   } else if (dataCompletenessDelay > 0 && props.visualizationType === 'bar') {
     // Bar charts are not continuous (there are gaps between the bars) so no
     // shenanigan is needed. Simply mark the "incomplete" bars
-    props.timeseries.map(timeserie => {
-      return markDelayedBuckets(timeserie, dataCompletenessDelay);
+    completeSeries = props.timeseries.map(timeserie => {
+      return markDelayedData(timeserie, dataCompletenessDelay);
     });
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -32,6 +32,7 @@ import {LineChartWidgetSeries} from '../lineChartWidget/lineChartWidgetSeries';
 
 import {formatTooltipValue} from './formatTooltipValue';
 import {formatYAxisValue} from './formatYAxisValue';
+import {markDelayedData} from './markDelayedData';
 import {ReleaseSeries} from './releaseSeries';
 import {splitSeriesIntoCompleteAndIncomplete} from './splitSeriesIntoCompleteAndIncomplete';
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -92,7 +92,10 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   let completeSeries: TimeseriesData[] = props.timeseries;
   const incompleteSeries: TimeseriesData[] = [];
 
-  if (dataCompletenessDelay > 0) {
+  if (dataCompletenessDelay > 0 && ['line', 'area'].includes(props.visualizationType)) {
+    // In order to show incomplete data for line and area series, we have to do
+    // a shenanigan in which we split the series into two, style the
+    // "incomplete" series differently, and show both series on the chart
     completeSeries = [];
 
     props.timeseries.forEach(timeserie => {
@@ -108,6 +111,12 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       if (incompleteSerie && incompleteSerie.data.length > 0) {
         incompleteSeries.push(incompleteSerie);
       }
+    });
+  } else if (dataCompletenessDelay > 0 && props.visualizationType === 'bar') {
+    // Bar charts are not continuous (there are gaps between the bars) so no
+    // shenanigan is needed. Simply mark the "incomplete" bars
+    props.timeseries.map(timeserie => {
+      return markDelayedBuckets(timeserie, dataCompletenessDelay);
     });
   }
 


### PR DESCRIPTION
Bar charts series don't have to be split! We only split the dataseries because it's not possible to conditionally style sections of a continuous line. It _is_ possible to do that with bar charts, and it improves the bar chart behaviour, and also is much simpler.

Our incorrect splitting logic was causing the bars to be too narrow, also. Incomplete bars have a lower opacity.

**e.g.,**
![Screenshot 2025-01-30 at 1 52 13 PM](https://github.com/user-attachments/assets/864f1574-52ad-4753-9732-ce07d0e737e1)
