### PR TITLE
feat(uptime): Allow max org limit to be ignored

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -192,6 +192,7 @@ def get_or_create_project_uptime_subscription(
     name: str = "",
     owner: Actor | None = None,
     trace_sampling: bool = False,
+    override_manual_org_limit: bool = False,
 ) -> tuple[ProjectUptimeSubscription, bool]:
     """
     Links a project to an uptime subscription so that it can process results.
@@ -200,7 +201,10 @@ def get_or_create_project_uptime_subscription(
         manual_subscription_count = ProjectUptimeSubscription.objects.filter(
             project__organization=project.organization, mode=ProjectUptimeSubscriptionMode.MANUAL
         ).count()
-        if manual_subscription_count >= MAX_MANUAL_SUBSCRIPTIONS_PER_ORG:
+        if (
+            not override_manual_org_limit
+            and manual_subscription_count >= MAX_MANUAL_SUBSCRIPTIONS_PER_ORG
+        ):
             raise MaxManualUptimeSubscriptionsReached
 
     uptime_subscription = get_or_create_uptime_subscription(

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -237,6 +237,38 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                     mode=ProjectUptimeSubscriptionMode.MANUAL,
                 )[1]
 
+    def test_override_max_proj_subs(self):
+        with mock.patch(
+            "sentry.uptime.subscriptions.subscriptions.MAX_MANUAL_SUBSCRIPTIONS_PER_ORG", new=1
+        ):
+            assert get_or_create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.MANUAL,
+            )[1]
+            with pytest.raises(MaxManualUptimeSubscriptionsReached):
+                get_or_create_project_uptime_subscription(
+                    self.project,
+                    self.environment,
+                    url="https://santry.io",
+                    interval_seconds=3600,
+                    timeout_ms=1000,
+                    mode=ProjectUptimeSubscriptionMode.MANUAL,
+                    override_manual_org_limit=False,
+                )[1]
+            assert get_or_create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://santry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                override_manual_org_limit=True,
+            )[1]
+
     def test_auto_associates_active_regions(self):
         regions = [
             UptimeRegionConfig(


### PR DESCRIPTION
We want this for some load testing

<!-- Describe your PR here. -->