### PR TITLE
fix(github): Always fetch max number of pages

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -9,7 +9,6 @@ import orjson
 import sentry_sdk
 from requests import PreparedRequest
 
-from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
     create_blame_query,
@@ -331,24 +330,15 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
 
         return should_count_error
 
-    def get_repos(self, fetch_max_pages: bool = False) -> list[dict[str, Any]]:
+    def get_repos(self) -> list[dict[str, Any]]:
         """
-        args:
-         * fetch_max_pages - fetch as many repos as possible using pagination (slow)
-
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
 
         It uses page_size from the base class to specify how many items per page.
         The upper bound of requests is controlled with self.page_number_limit to prevent infinite requests.
         """
-        if not fetch_max_pages:
-            fetch_max_pages = options.get("github-app.fetch-max-pages")
-        return self.get_with_pagination(
-            "/installation/repositories",
-            response_key="repositories",
-            page_number_limit=self.page_number_limit if fetch_max_pages else 1,
-        )
+        return self.get_with_pagination("/installation/repositories", response_key="repositories")
 
     # XXX: Find alternative approach
     def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -230,19 +230,16 @@ class GitHubIntegration(
         _, _, source_path = url.partition("/")
         return source_path
 
-    def get_repositories(
-        self, query: str | None = None, fetch_max_pages: bool = False
-    ) -> list[dict[str, Any]]:
+    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
         """
         args:
         * query - a query to filter the repositories by
-        * fetch_max_pages - fetch as many repos as possible using pagination (slow)
 
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
         """
         if not query:
-            all_repos = self.get_client().get_repos(fetch_max_pages)
+            all_repos = self.get_client().get_repos()
             return [
                 {
                     "name": i["name"],

--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -79,7 +79,7 @@ def link_all_repos(
         client = installation.get_client()
 
         try:
-            repositories = client.get_repos(fetch_max_pages=True)
+            repositories = client.get_repos()
         except ApiError as e:
             if installation.is_rate_limited_error(e):
                 lifecycle.record_halt(str(LinkAllReposHaltReason.RATE_LIMITED))

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -181,11 +181,9 @@ class GitHubEnterpriseIntegration(
 
     # RepositoryIntegration methods
 
-    def get_repositories(
-        self, query: str | None = None, fetch_max_pages: bool = False
-    ) -> list[dict[str, Any]]:
+    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
         if not query:
-            all_repos = self.get_client().get_repos(fetch_max_pages)
+            all_repos = self.get_client().get_repos()
             return [
                 {
                     "name": i["name"],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -569,7 +569,6 @@ register("github-app.webhook-secret", default="", flags=FLAG_CREDENTIAL)
 register("github-app.private-key", default="", flags=FLAG_CREDENTIAL)
 register("github-app.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("github-app.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
-register("github-app.fetch-max-pages", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
     "github-app.get-trees-refactored-code",
     default=False,

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -539,7 +539,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         with patch.object(sentry.integrations.github.client.GitHubBaseClient, "page_size", 1):
-            result = installation.get_repositories(fetch_max_pages=True)
+            result = installation.get_repositories()
             assert result == [
                 {"name": "foo", "identifier": "Test-Organization/foo", "default_branch": "master"},
                 {"name": "bar", "identifier": "Test-Organization/bar", "default_branch": "main"},


### PR DESCRIPTION
I enabled fetching the maximum number of pages last week without any noticeable issues ([this](https://github.com/getsentry/sentry-options-automator/pull/3082)).

It is easy to call `get_repositories()` without passing the `fetch_max_pages` parameter, thus, we won't get all repositories for a customer.

This may slow calls for customers with thousands of repositories, however, it will be more accurate.

We still have `self.page_number_limit` to stop the requests after 50-page fetches (5,000 repositories).