### PR TITLE
feat(nav): Use new secondary nav in settings

### DIFF
--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -57,7 +57,9 @@ SecondaryNav.Item = function SecondaryNavItem({
   ...linkProps
 }: SecondaryNavItemProps) {
   const {pathname} = useLocation();
-  const isActive = incomingIsActive || isLinkActive(to, pathname);
+  const isActive =
+    incomingIsActive ||
+    isLinkActive(typeof to === 'string' ? to : to.pathname ?? '/', pathname);
 
   return (
     <Item

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import {createPortal} from 'react-dom';
+import type {To} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
@@ -15,7 +16,7 @@ type SecondaryNavProps = {
 
 interface SecondaryNavItemProps extends Omit<LinkProps, 'ref'> {
   children: ReactNode;
-  to: string;
+  to: To;
   isActive?: boolean;
 }
 

--- a/static/app/views/settings/account/accountSettingsLayout.tsx
+++ b/static/app/views/settings/account/accountSettingsLayout.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {Component, Fragment} from 'react';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organizations';
 import type {Client} from 'sentry/api';
@@ -33,6 +33,17 @@ class AccountSettingsLayout extends Component<Props> {
 
   render() {
     const {organization} = this.props;
+
+    const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+    if (hasNavigationV2) {
+      return (
+        <Fragment>
+          <AccountSettingsNavigation organization={organization} />
+          <SettingsLayout {...this.props}>{this.props.children}</SettingsLayout>
+        </Fragment>
+      );
+    }
 
     return (
       <SettingsLayout

--- a/static/app/views/settings/account/accountSettingsNavigation.tsx
+++ b/static/app/views/settings/account/accountSettingsNavigation.tsx
@@ -7,7 +7,12 @@ type Props = {
 };
 
 function AccountSettingsNavigation({organization}: Props) {
-  return <SettingsNavigation navigationObjects={getConfiguration({organization})} />;
+  return (
+    <SettingsNavigation
+      organization={organization}
+      navigationObjects={getConfiguration({organization})}
+    />
+  );
 }
 
 export default AccountSettingsNavigation;

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -1,12 +1,12 @@
 import type {ReactElement} from 'react';
 import {Fragment} from 'react';
-import {NavLink as RouterNavLink} from 'react-router-dom';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
 import Badge from 'sentry/components/badge/badge';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import HookOrDefault from 'sentry/components/hookOrDefault';
+import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -26,79 +26,36 @@ const LabelHook = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
-function SettingsNavItem({badge, label, index, id, to, ...props}: Props) {
-  let renderedBadge: React.ReactNode;
-
+function SettingsNavBadge({badge}: {badge: string | number | null | ReactElement}) {
   if (badge === 'new') {
-    renderedBadge = <FeatureBadge type="new" />;
-  } else if (badge === 'beta') {
-    renderedBadge = <FeatureBadge type="beta" />;
-  } else if (badge === 'warning') {
-    renderedBadge = (
+    return <FeatureBadge type="new" />;
+  }
+  if (badge === 'beta') {
+    return <FeatureBadge type="beta" />;
+  }
+  if (badge === 'warning') {
+    return (
       <Tooltip title={t('This setting needs review')} position="right">
         <StyledBadge text={badge} type="warning" />
       </Tooltip>
     );
-  } else if (typeof badge === 'string' || typeof badge === 'number') {
-    renderedBadge = <StyledBadge text={badge} />;
-  } else {
-    renderedBadge = badge;
+  }
+  if (typeof badge === 'string' || typeof badge === 'number') {
+    return <StyledBadge text={badge} />;
   }
 
-  return (
-    <StyledNavItem end={index} to={locationDescriptorToTo(to)} {...props}>
-      <LabelHook id={id}>{label}</LabelHook>
-      {badge ? renderedBadge : null}
-    </StyledNavItem>
-  );
+  return badge;
 }
 
-const StyledNavItem = styled(RouterNavLink)`
-  display: block;
-  color: ${p => p.theme.gray300};
-  font-size: 14px;
-  line-height: 30px;
-  position: relative;
-
-  &.active {
-    color: ${p => p.theme.textColor};
-
-    &:before {
-      background: ${p => p.theme.active};
-    }
-  }
-
-  &:hover,
-  &:focus,
-  &:active {
-    color: ${p => p.theme.textColor};
-    outline: none;
-  }
-
-  &:focus-visible {
-    outline: none;
-    background: ${p => p.theme.backgroundSecondary};
-    padding-left: 15px;
-    margin-left: -15px;
-    border-radius: 3px;
-
-    &:before {
-      left: -15px;
-    }
-  }
-
-  &:before {
-    position: absolute;
-    content: '';
-    display: block;
-    top: 4px;
-    left: -30px;
-    height: 20px;
-    width: 4px;
-    background: transparent;
-    border-radius: 0 2px 2px 0;
-  }
-`;
+function SettingsNavItem({badge, label, id, to, ...props}: Props) {
+  // TODO(malwilley): Support `end` prop in `SecondaryNav.Item`
+  return (
+    <SecondaryNav.Item to={locationDescriptorToTo(to)} {...props}>
+      <LabelHook id={id}>{label}</LabelHook>
+      {badge ? <SettingsNavBadge badge={badge} /> : null}
+    </SecondaryNav.Item>
+  );
+}
 
 const StyledBadge = styled(Badge)`
   font-weight: ${p => p.theme.fontWeightNormal};

--- a/static/app/views/settings/components/settingsNavItemDeprecated.tsx
+++ b/static/app/views/settings/components/settingsNavItemDeprecated.tsx
@@ -1,0 +1,112 @@
+import type {ReactElement} from 'react';
+import {Fragment} from 'react';
+import {NavLink as RouterNavLink} from 'react-router-dom';
+import styled from '@emotion/styled';
+import type {LocationDescriptor} from 'history';
+
+import Badge from 'sentry/components/badge/badge';
+import FeatureBadge from 'sentry/components/badge/featureBadge';
+import HookOrDefault from 'sentry/components/hookOrDefault';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
+
+type Props = {
+  label: React.ReactNode;
+  to: LocationDescriptor;
+  badge?: string | number | null | ReactElement;
+  id?: string;
+  index?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+};
+
+const LabelHook = HookOrDefault({
+  hookName: 'sidebar:item-label',
+  defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
+});
+
+function SettingsNavItemDeprecated({badge, label, index, id, to, ...props}: Props) {
+  let renderedBadge: React.ReactNode;
+
+  if (badge === 'new') {
+    renderedBadge = <FeatureBadge type="new" />;
+  } else if (badge === 'beta') {
+    renderedBadge = <FeatureBadge type="beta" />;
+  } else if (badge === 'warning') {
+    renderedBadge = (
+      <Tooltip title={t('This setting needs review')} position="right">
+        <StyledBadge text={badge} type="warning" />
+      </Tooltip>
+    );
+  } else if (typeof badge === 'string' || typeof badge === 'number') {
+    renderedBadge = <StyledBadge text={badge} />;
+  } else {
+    renderedBadge = badge;
+  }
+
+  return (
+    <StyledNavItem end={index} to={locationDescriptorToTo(to)} {...props}>
+      <LabelHook id={id}>{label}</LabelHook>
+      {badge ? renderedBadge : null}
+    </StyledNavItem>
+  );
+}
+
+const StyledNavItem = styled(RouterNavLink)`
+  display: block;
+  color: ${p => p.theme.gray300};
+  font-size: 14px;
+  line-height: 30px;
+  position: relative;
+
+  &.active {
+    color: ${p => p.theme.textColor};
+
+    &:before {
+      background: ${p => p.theme.active};
+    }
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: ${p => p.theme.textColor};
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: none;
+    background: ${p => p.theme.backgroundSecondary};
+    padding-left: 15px;
+    margin-left: -15px;
+    border-radius: 3px;
+
+    &:before {
+      left: -15px;
+    }
+  }
+
+  &:before {
+    position: absolute;
+    content: '';
+    display: block;
+    top: 4px;
+    left: -30px;
+    height: 20px;
+    width: 4px;
+    background: transparent;
+    border-radius: 0 2px 2px 0;
+  }
+`;
+
+const StyledBadge = styled(Badge)`
+  font-weight: ${p => p.theme.fontWeightNormal};
+  height: auto;
+  line-height: 1;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 3px ${space(0.75)};
+  vertical-align: middle;
+`;
+
+export default SettingsNavItemDeprecated;

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -2,8 +2,10 @@ import {cloneElement, Component} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
+import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {space} from 'sentry/styles/space';
 import SettingsNavigationGroup from 'sentry/views/settings/components/settingsNavigationGroup';
+import SettingsNavigationGroupDeprecated from 'sentry/views/settings/components/settingsNavigationGroupDeprecated';
 import type {NavigationProps, NavigationSection} from 'sentry/views/settings/types';
 
 type DefaultProps = {
@@ -29,6 +31,26 @@ type Props = DefaultProps &
     navigationObjects: NavigationSection[];
   };
 
+function SettingsSecondaryNavigation({
+  navigationObjects,
+  hookConfigs,
+  hooks,
+  ...otherProps
+}: Props) {
+  const navWithHooks = navigationObjects.concat(hookConfigs);
+
+  return (
+    <SecondaryNav>
+      <SecondaryNav.Body>
+        {navWithHooks.map(config => (
+          <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />
+        ))}
+        {hooks.map((Hook, i) => cloneElement(Hook, {key: `hook-${i}`}))}
+      </SecondaryNav.Body>
+    </SecondaryNav>
+  );
+}
+
 class SettingsNavigation extends Component<Props> {
   static defaultProps: DefaultProps = {
     hooks: [],
@@ -51,10 +73,26 @@ class SettingsNavigation extends Component<Props> {
     const {navigationObjects, hooks, hookConfigs, stickyTop, ...otherProps} = this.props;
     const navWithHooks = navigationObjects.concat(hookConfigs);
 
+    if (this.props.organization?.features.includes('navigation-sidebar-v2')) {
+      return (
+        <SettingsSecondaryNavigation
+          navigationObjects={navigationObjects}
+          hooks={hooks}
+          hookConfigs={hookConfigs}
+          stickyTop={stickyTop}
+          {...otherProps}
+        />
+      );
+    }
+
     return (
       <PositionStickyWrapper stickyTop={stickyTop}>
         {navWithHooks.map(config => (
-          <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />
+          <SettingsNavigationGroupDeprecated
+            key={config.name}
+            {...otherProps}
+            {...config}
+          />
         ))}
         {hooks.map((Hook, i) => cloneElement(Hook, {key: `hook-${i}`}))}
       </PositionStickyWrapper>

--- a/static/app/views/settings/components/settingsNavigationGroupDeprecated.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroupDeprecated.tsx
@@ -1,10 +1,13 @@
-import {SecondaryNav} from 'sentry/components/nav/secondary';
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
-import SettingsNavItem from 'sentry/views/settings/components/settingsNavItem';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import SettingsNavItemDeprecated from 'sentry/views/settings/components/settingsNavItemDeprecated';
 import type {NavigationGroupProps} from 'sentry/views/settings/types';
 
-function SettingsNavigationGroup(props: NavigationGroupProps) {
+function SettingsNavigationGroupDeprecated(props: NavigationGroupProps) {
   const {organization, project, name, items} = props;
 
   const navLinks = items.map(({path, title, index, show, badge, id, recordAnalytics}) => {
@@ -33,9 +36,9 @@ function SettingsNavigationGroup(props: NavigationGroupProps) {
     };
 
     return (
-      <SettingsNavItem
+      <SettingsNavItemDeprecated
         key={title}
-        to={to}
+        to={normalizeUrl(to)}
         label={title}
         index={index}
         badge={badgeResult}
@@ -49,7 +52,24 @@ function SettingsNavigationGroup(props: NavigationGroupProps) {
     return null;
   }
 
-  return <SecondaryNav.Section title={name}>{navLinks}</SecondaryNav.Section>;
+  return (
+    <NavSection data-test-id={name}>
+      <SettingsHeading role="heading">{name}</SettingsHeading>
+      {navLinks}
+    </NavSection>
+  );
 }
 
-export default SettingsNavigationGroup;
+const NavSection = styled('div')`
+  margin-bottom: 20px;
+`;
+
+const SettingsHeading = styled('div')`
+  color: ${p => p.theme.text};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightBold};
+  text-transform: uppercase;
+  margin-bottom: ${space(0.5)};
+`;
+
+export default SettingsNavigationGroupDeprecated;

--- a/static/app/views/settings/organization/organizationSettingsLayout.tsx
+++ b/static/app/views/settings/organization/organizationSettingsLayout.tsx
@@ -1,4 +1,7 @@
+import {Fragment} from 'react';
+
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import useOrganization from 'sentry/utils/useOrganization';
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 import OrganizationSettingsNavigation from 'sentry/views/settings/organization/organizationSettingsNavigation';
 
@@ -7,6 +10,19 @@ type Props = RouteComponentProps<{}, {}> & {
 };
 
 function OrganizationSettingsLayout(props: Props) {
+  const organization = useOrganization();
+
+  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+  if (hasNavigationV2) {
+    return (
+      <Fragment>
+        <OrganizationSettingsNavigation />
+        <SettingsLayout {...props} />
+      </Fragment>
+    );
+  }
+
   return (
     <SettingsLayout
       {...props}

--- a/static/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/static/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -78,6 +78,7 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
     const access = new Set(organization.access);
     const features = new Set(organization.features);
     const isSelfHosted = ConfigStore.get('isSelfHosted');
+
     return (
       <SettingsNavigation
         navigationObjects={navigationConfiguration}

--- a/static/app/views/settings/project/projectSettingsLayout.tsx
+++ b/static/app/views/settings/project/projectSettingsLayout.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, isValidElement} from 'react';
+import {cloneElement, Fragment, isValidElement} from 'react';
 
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
@@ -29,6 +29,22 @@ function InnerProjectSettingsLayout({
     project_id: project.id,
     project_platform: project.platform,
   });
+
+  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+  if (hasNavigationV2) {
+    return (
+      <Fragment>
+        <ProjectSettingsNavigation organization={organization} />
+        <SettingsLayout params={params} routes={routes} {...props}>
+          {children && isValidElement(children)
+            ? cloneElement<any>(children, {organization, project})
+            : children}
+        </SettingsLayout>
+      </Fragment>
+    );
+  }
+
   return (
     <SettingsLayout
       params={params}


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

This PR duplicates existing components which render the settings navigation sidebar so that, when the feature flag is enabled, they instead render the new `<SecondaryNav />` components.

There are still a few bugs that need to be ironed out, but for now the correct items are being rendered from the existing config.

![CleanShot 2025-01-30 at 11 10 58](https://github.com/user-attachments/assets/6857c119-2a7f-431e-8205-6f5e912c05b5)
