### PR TITLE
chore(billing): Add app_service.get_internal_integrations

### DIFF
--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -272,6 +272,30 @@ class DatabaseBackedAppService(AppService):
         )
         return [serialize_sentry_app(app) for app in published_apps]
 
+    def get_internal_integrations(
+        self, *, organization_id: int, integration_name: str
+    ) -> list[RpcSentryApp]:
+        """
+        Get all internal integrations for an organization matching a specific name.
+
+        Internal integrations are Sentry Apps that are created for use within a single
+        organization and are not available to be installed by users.
+
+        Args:
+            organization_id (int): The ID of the organization to search within
+            integration_name (str): The name of the internal integration to find
+
+        Returns:
+            list[RpcSentryApp]: A list of serialized internal Sentry Apps matching the criteria.
+                               Returns an empty list if no matches are found.
+        """
+        internal_integrations = SentryApp.objects.filter(
+            owner_id=organization_id,
+            status=SentryAppStatus.INTERNAL,
+            name=integration_name,
+        )
+        return [serialize_sentry_app(app) for app in internal_integrations]
+
     def create_internal_integration_for_channel_request(
         self,
         *,

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -178,6 +178,27 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_internal_integrations(
+        self, *, organization_id: int, integration_name: str
+    ) -> list[RpcSentryApp]:
+        """
+        Get all internal integrations for an organization matching a specific name.
+
+        Internal integrations are Sentry Apps that are created for use within a single
+        organization and are not available to be installed by users.
+
+        Args:
+            organization_id (int): The ID of the organization to search within
+            integration_name (str): The name of the internal integration to find
+
+        Returns:
+            list[RpcSentryApp]: A list of serialized internal Sentry Apps matching the criteria.
+                               Returns an empty list if no matches are found.
+        """
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def create_internal_integration_for_channel_request(
         self,
         *,


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/84333

We will need this for Vercel billing integration; and to be able to retrieve the `SentryApp` corresponding to the Vercel native marketplace integration from within the region silo.