### PR TITLE
feat(issue-views): Update GET endpoint to validate view's projects

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -21,15 +21,32 @@ class GroupSearchViewSerializerResponse(TypedDict):
 
 @register(GroupSearchView)
 class GroupSearchViewSerializer(Serializer):
+    def __init__(self, *args, **kwargs):
+        self.has_global_views = kwargs.pop("has_global_views", None)
+        self.default_project = kwargs.pop("default_project", None)
+        super().__init__(*args, **kwargs)
+
     def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
+        if self.has_global_views is False:
+            is_all_projects = False
+
+            projects = list(obj.projects.values_list("id", flat=True))
+            num_projects = len(projects)
+            if num_projects != 1:
+                projects = [projects[0] if num_projects > 1 else self.default_project]
+
+        else:
+            is_all_projects = obj.is_all_projects
+            projects = list(obj.projects.values_list("id", flat=True))
+
         return {
             "id": str(obj.id),
             "name": obj.name,
             "query": obj.query,
             "querySort": obj.query_sort,
             "position": obj.position,
-            "projects": list(obj.projects.values_list("id", flat=True)),
-            "isAllProjects": obj.is_all_projects,
+            "projects": projects,
+            "isAllProjects": is_all_projects,
             "environments": obj.environments,
             "timeFilters": obj.time_filters,
             "dateCreated": obj.date_added,

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -70,7 +70,9 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
 
         has_global_views = features.has("organizations:global-views", organization)
 
-        query = GroupSearchView.objects.filter(organization=organization, user_id=request.user.id)
+        query = GroupSearchView.objects.filter(
+            organization=organization, user_id=request.user.id
+        ).prefetch_related("projects")
 
         # Return only the default view(s) if user has no custom views yet
         if not query.exists():

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -198,7 +198,7 @@ def bulk_update_views(
             _update_existing_view(org, user_id, view, position=idx)
 
 
-def pick_default_project(org: Organization, user: User | AnonymousUser) -> int:
+def pick_default_project(org: Organization, user: User | AnonymousUser) -> int | None:
     user_teams = Team.objects.get_for_user(organization=org, user=user)
     user_team_ids = [team.id for team in user_teams]
     default_user_project = (

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.rest_framework.groupsearchview import GroupSearchViewValidatorResponse
+from sentry.issues.endpoints.organization_group_search_views import DEFAULT_VIEWS
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.testutils.cases import APITestCase, TransactionTestCase
 from sentry.testutils.helpers.features import with_feature
@@ -366,7 +367,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             query_sort="date",
             position=0,
             time_filters={"period": "14d"},
-            environments=["production"],
+            environments=[],
         )
         first_custom_view_user_one.projects.set([self.project1])
 
@@ -378,7 +379,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
             query_sort="new",
             position=1,
             time_filters={"period": "7d"},
-            environments=["staging"],
+            environments=["staging", "production"],
         )
         second_custom_view_user_one.projects.set([self.project1, self.project2, self.project3])
 
@@ -582,6 +583,188 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
         )
         assert response.status_code == 400
         assert response.content == b'{"detail":"One or more projects do not exist"}'
+
+
+class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
+    def create_base_data_with_page_filters(self) -> list[GroupSearchView]:
+        user_1 = self.user
+        self.user_2 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_2)
+        # User 3 has no views, will get the defaults
+        self.user_3 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_3)
+
+        self.team_1 = self.create_team(organization=self.organization, slug="team-1")
+        self.team_2 = self.create_team(organization=self.organization, slug="team-2")
+
+        # User 1 is on team 1 only
+        self.create_team_membership(user=user_1, team=self.team_1)
+        # User 2 is on team 1 and team 2
+        self.create_team_membership(user=self.user_2, team=self.team_1)
+        self.create_team_membership(user=self.user_2, team=self.team_2)
+        # User 3 is on team 1 only
+        self.create_team_membership(user=self.user_3, team=self.team_1)
+
+        # This project should NEVER get chosen as a default since it does not belong to any teams
+        self.project1 = self.create_project(
+            organization=self.organization, slug="project-a", teams=[]
+        )
+        # This project should be User 2's default project since it's the alphabetically the first one
+        self.project2 = self.create_project(
+            organization=self.organization, slug="project-b", teams=[self.team_2]
+        )
+        # This should be User 1's default project since it's the only one that the user has access to
+        self.project3 = self.create_project(
+            organization=self.organization, slug="project-c", teams=[self.team_1, self.team_2]
+        )
+
+        first_issue_view_user_one = GroupSearchView.objects.create(
+            name="Issue View One",
+            organization=self.organization,
+            user_id=user_1.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+            is_all_projects=False,
+            time_filters={"period": "14d"},
+            environments=[],
+        )
+        first_issue_view_user_one.projects.set([self.project3])
+
+        second_issue_view_user_one = GroupSearchView.objects.create(
+            name="Issue View Two",
+            organization=self.organization,
+            user_id=user_1.id,
+            query="is:resolved",
+            query_sort="new",
+            position=1,
+            is_all_projects=False,
+            time_filters={"period": "7d"},
+            environments=["staging", "production"],
+        )
+        second_issue_view_user_one.projects.set([])
+
+        third_issue_view_user_one = GroupSearchView.objects.create(
+            name="Issue View Three",
+            organization=self.organization,
+            user_id=user_1.id,
+            query="is:ignored",
+            query_sort="freq",
+            position=2,
+            is_all_projects=True,
+            time_filters={"period": "30d"},
+            environments=["development"],
+        )
+        third_issue_view_user_one.projects.set([])
+
+        first_issue_view_user_two = GroupSearchView.objects.create(
+            name="Issue View One",
+            organization=self.organization,
+            user_id=self.user_2.id,
+            query="is:unresolved",
+            query_sort="date",
+            position=0,
+            is_all_projects=False,
+            time_filters={"period": "14d"},
+            environments=[],
+        )
+        first_issue_view_user_two.projects.set([])
+
+    def setUp(self) -> None:
+        self.create_base_data_with_page_filters()
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-views",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_basic_get_page_filters_with_global_filters(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.url)
+
+        assert response.data[0]["timeFilters"] == {"period": "14d"}
+        assert response.data[0]["projects"] == [self.project3.id]
+        assert response.data[0]["environments"] == []
+        assert response.data[0]["isAllProjects"] is False
+
+        assert response.data[1]["timeFilters"] == {"period": "7d"}
+        assert response.data[1]["projects"] == []
+        assert response.data[1]["environments"] == ["staging", "production"]
+        assert response.data[1]["isAllProjects"] is False
+
+        assert response.data[2]["timeFilters"] == {"period": "30d"}
+        assert response.data[2]["projects"] == []
+        assert response.data[2]["environments"] == ["development"]
+        assert response.data[2]["isAllProjects"] is True
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_get_page_filters_without_global_filters(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.url)
+
+        assert response.data[0]["timeFilters"] == {"period": "14d"}
+        assert response.data[0]["projects"] == [self.project3.id]
+        assert response.data[0]["environments"] == []
+        assert response.data[0]["isAllProjects"] is False
+
+        assert response.data[1]["timeFilters"] == {"period": "7d"}
+        assert response.data[1]["projects"] == [self.project3.id]
+        assert response.data[1]["environments"] == ["staging", "production"]
+        assert response.data[1]["isAllProjects"] is False
+
+        assert response.data[2]["timeFilters"] == {"period": "30d"}
+        assert response.data[2]["projects"] == [self.project3.id]
+        assert response.data[2]["environments"] == ["development"]
+        assert response.data[2]["isAllProjects"] is False
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_get_page_filters_without_global_filters_user_2(self):
+        self.login_as(user=self.user_2)
+        response = self.client.get(self.url)
+
+        assert response.data[0]["timeFilters"] == {"period": "14d"}
+        assert response.data[0]["projects"] == [self.project2.id]
+        assert response.data[0]["environments"] == []
+        assert response.data[0]["isAllProjects"] is False
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": True})
+    def test_default_page_filters_with_global_views(self):
+        self.login_as(user=self.user_3)
+        response = self.client.get(self.url)
+
+        default_view_queries = {view["query"] for view in DEFAULT_VIEWS}
+        received_queries = {view["query"] for view in response.data}
+
+        assert default_view_queries == received_queries
+
+        for view in response.data:
+            assert view["timeFilters"] == {"period": "14d"}
+            # Global views means default project should be "My Projects"
+            assert view["projects"] == []
+            assert view["environments"] == []
+            assert view["isAllProjects"] is False
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:global-views": False})
+    def test_default_page_filters_without_global_views(self):
+        self.login_as(user=self.user_3)
+        response = self.client.get(self.url)
+
+        default_view_queries = {view["query"] for view in DEFAULT_VIEWS}
+        received_queries = {view["query"] for view in response.data}
+
+        assert default_view_queries == received_queries
+
+        for view in response.data:
+            assert view["timeFilters"] == {"period": "14d"}
+            # No global views means default project should be a single project
+            assert view["projects"] == [self.project3.id]
+            assert view["environments"] == []
+            assert view["isAllProjects"] is False
 
 
 class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -429,7 +429,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         # Ensure these have not been changed
         assert views[0]["timeFilters"] == {"period": "14d"}
         assert views[0]["projects"] == [self.project1.id]
-        assert views[0]["environments"] == ["production"]
+        assert views[0]["environments"] == []
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -586,7 +586,7 @@ class OrganizationGroupSearchViewsProjectsTransactionTest(TransactionTestCase):
 
 
 class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
-    def create_base_data_with_page_filters(self) -> list[GroupSearchView]:
+    def create_base_data_with_page_filters(self) -> None:
         user_1 = self.user
         self.user_2 = self.create_user()
         self.create_member(organization=self.organization, user=self.user_2)
@@ -679,7 +679,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
-    def test_basic_get_page_filters_with_global_filters(self):
+    def test_basic_get_page_filters_with_global_filters(self) -> None:
         self.login_as(user=self.user)
         response = self.client.get(self.url)
 
@@ -700,7 +700,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
-    def test_get_page_filters_without_global_filters(self):
+    def test_get_page_filters_without_global_filters(self) -> None:
         self.login_as(user=self.user)
         response = self.client.get(self.url)
 
@@ -721,7 +721,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
-    def test_get_page_filters_without_global_filters_user_2(self):
+    def test_get_page_filters_without_global_filters_user_2(self) -> None:
         self.login_as(user=self.user_2)
         response = self.client.get(self.url)
 
@@ -732,7 +732,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
-    def test_default_page_filters_with_global_views(self):
+    def test_default_page_filters_with_global_views(self) -> None:
         self.login_as(user=self.user_3)
         response = self.client.get(self.url)
 
@@ -750,7 +750,7 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
-    def test_default_page_filters_without_global_views(self):
+    def test_default_page_filters_without_global_views(self) -> None:
         self.login_as(user=self.user_3)
         response = self.client.get(self.url)
 

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -414,7 +414,7 @@ class OrganizationGroupSearchViewsWithPageFiltersPutTest(BaseGSVTestCase):
         # Original Page filters
         assert views[0]["timeFilters"] == {"period": "14d"}
         assert views[0]["projects"] == [self.project1.id]
-        assert views[0]["environments"] == ["production"]
+        assert views[0]["environments"] == []
 
         view = views[0]
         # Change nothing but the name


### PR DESCRIPTION
This PR updates the GET `organization/.../group-search-views` endpoint to validate a views projecst before being sent. The logic is: 

If your org doesn't have the multi project stream feature (`organizations:global-views`) any views that have an invalid projects parameter ("All Projects", "My Projects", or len(projects) > 1) will be set to the first project you have, alphabetically. 

No validation is necessary for organizations that do have the multi project stream feature. 