### PR TITLE
feat(issue summary) Only show possible cause if confident and novel

### DIFF
--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -33,12 +33,18 @@ logger = logging.getLogger(__name__)
 from rest_framework.request import Request
 
 
+class SummarizeIssueScores(BaseModel):
+    possible_cause_confidence: float
+    possible_cause_novelty: float
+
+
 class SummarizeIssueResponse(BaseModel):
     group_id: str
     headline: str
     whats_wrong: str | None = None
     trace: str | None = None
     possible_cause: str | None = None
+    scores: SummarizeIssueScores | None = None
 
 
 @region_silo_endpoint

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -16,11 +16,18 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
+const POSSIBLE_CAUSE_CONFIDENCE_THRESHOLD = 0.468;
+const POSSIBLE_CAUSE_NOVELTY_THRESHOLD = 0.419;
+
 interface GroupSummaryData {
   groupId: string;
   headline: string;
   eventId?: string | null;
   possibleCause?: string | null;
+  scores?: {
+    possibleCauseConfidence: number;
+    possibleCauseNovelty: number;
+  } | null;
   trace?: string | null;
   whatsWrong?: string | null;
 }
@@ -152,6 +159,11 @@ export function GroupSummary({
       : []),
   ];
 
+  const shouldShowPossibleCause =
+    !data?.scores ||
+    (data.scores.possibleCauseConfidence >= POSSIBLE_CAUSE_CONFIDENCE_THRESHOLD &&
+      data.scores.possibleCauseNovelty >= POSSIBLE_CAUSE_NOVELTY_THRESHOLD);
+
   const insightCards = [
     {
       id: 'whats_wrong',
@@ -167,13 +179,17 @@ export function GroupSummary({
       icon: <IconSpan size="sm" />,
       showWhenLoading: false,
     },
-    {
-      id: 'possible_cause',
-      title: t('Possible cause'),
-      insight: data?.possibleCause,
-      icon: <IconFocus size="sm" />,
-      showWhenLoading: true,
-    },
+    ...(shouldShowPossibleCause
+      ? [
+          {
+            id: 'possible_cause',
+            title: t('Possible cause'),
+            insight: data?.possibleCause,
+            icon: <IconFocus size="sm" />,
+            showWhenLoading: false,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/tests/sentry/api/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/api/endpoints/test_group_ai_summary.py
@@ -3,7 +3,11 @@ from unittest.mock import ANY, Mock, call, patch
 
 import orjson
 
-from sentry.api.endpoints.group_ai_summary import GroupAiSummaryEndpoint, SummarizeIssueResponse
+from sentry.api.endpoints.group_ai_summary import (
+    GroupAiSummaryEndpoint,
+    SummarizeIssueResponse,
+    SummarizeIssueScores,
+)
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
@@ -37,6 +41,10 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
             "whats_wrong": "Existing whats wrong",
             "trace": "Existing trace",
             "possible_cause": "Existing possible cause",
+            "scores": {
+                "possible_cause_confidence": 0.9,
+                "possible_cause_novelty": 0.8,
+            },
         }
 
         # Set the cache with the existing summary
@@ -82,6 +90,10 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
             whats_wrong="Test whats wrong",
             trace="Test trace",
             possible_cause="Test possible cause",
+            scores=SummarizeIssueScores(
+                possible_cause_confidence=0.0,
+                possible_cause_novelty=0.0,
+            ),
         )
         mock_call_seer.return_value = mock_summary
         mock_get_connected_issues.return_value = [self.group, self.group]
@@ -126,6 +138,10 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
             "trace": "Test trace",
             "possible_cause": "Test possible cause",
             "headline": "Test headline",
+            "scores": {
+                "possible_cause_confidence": 0.9,
+                "possible_cause_novelty": 0.8,
+            },
         }
         mock_post.return_value = mock_response
 
@@ -230,6 +246,10 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
                 "trace": "Test trace",
                 "possible_cause": "Test possible cause",
                 "headline": "Test headline",
+                "scores": {
+                    "possible_cause_confidence": 0.9,
+                    "possible_cause_novelty": 0.8,
+                },
             }
 
             self.client.post(self.url, format="json")


### PR DESCRIPTION
<!-- Describe your PR here. -->
`possible_cause_confidence` increases when there's less speculation (which correlates w/ slightly more accurate causes)

`possible_cause_novelty` increases when there's more novelty / less redundancy wrt `whats_wrong`

thresholds led to 50% of possible causes getting dropped on our autofix sentry issues ([notebook here](https://github.com/getsentry/data-analysis/blob/main/autofix/issue_summary/issue_summary_confidence.ipynb))

tested that this change is independent of the backend one by running sentry + seer on main and then on [this branch](https://github.com/getsentry/seer/pull/1788). manually tested the threshold is respected by hardcoding the novelty score to 1 in seer locally
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

