### PR TITLE
fix(issues): Adjust bootstrap.ui transaction

### DIFF
--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -66,7 +66,7 @@ function setRecentBootstrapTag(orgSlug: string) {
     const isRecentBoot = previousBootstrapTime
       ? Date.now() - Number(previousBootstrapTime) < 10 * 60 * 1000
       : false;
-    Sentry.setTag('is_recent_boot', isRecentBoot.toString());
+    Sentry.setTag('is_recent_boot', isRecentBoot);
     localStorage.setItem(previousBootstrapKey, `${Date.now()}`);
   } catch {
     // Ignore errors

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -57,6 +57,24 @@ export function useEnsureOrganization() {
 }
 
 /**
+ * Record if the organization was bootstrapped in the last 10 minutes
+ */
+function setRecentBootstrapTag(orgSlug: string) {
+  const previousBootstrapKey = `previous-bootstrap-${orgSlug}`;
+  try {
+    const previousBootstrapTime = localStorage.getItem(previousBootstrapKey);
+    Sentry.setTag(
+      'is_recent_boot',
+      previousBootstrapTime
+        ? Date.now() - Number(previousBootstrapTime) < 10 * 60 * 1000
+        : false
+    );
+    localStorage.setItem(previousBootstrapKey, `${Date.now()}`);
+  } catch {
+    // Ignore errors
+  }
+}
+/**
  * Context provider responsible for loading the organization into the
  * OrganizationStore if it is not already present.
  *
@@ -73,7 +91,6 @@ export function OrganizationContextProvider({children}: Props) {
   const [organizationPromise, setOrganizationPromise] = useState<Promise<unknown> | null>(
     null
   );
-  const spanRef = useRef<Sentry.Span | null>(null);
 
   const lastOrganizationSlug: string | null =
     configStore.lastOrganization ?? organizations[0]?.slug ?? null;
@@ -87,13 +104,7 @@ export function OrganizationContextProvider({children}: Props) {
 
   useEffect(() => {
     // Nothing to do if we already have the organization loaded
-    const previousBootstrapKey = `previous-bootstrap-${orgSlug}`;
     if (organization && organization.slug === orgSlug) {
-      if (spanRef.current) {
-        spanRef.current.end();
-        spanRef.current = null;
-        localStorage.setItem(previousBootstrapKey, `${Date.now()}`);
-      }
       return;
     }
 
@@ -102,20 +113,18 @@ export function OrganizationContextProvider({children}: Props) {
       return;
     }
 
-    const previousBootstrapTime = localStorage.getItem(previousBootstrapKey);
-    spanRef.current = Sentry.startInactiveSpan({
-      name: 'ui.bootstrap',
-      op: 'ui.render',
-      forceTransaction: true,
-      attributes: {
-        // Bootstrapped in the last 10 minutes
-        is_recent_boot: previousBootstrapTime
-          ? Date.now() - Number(previousBootstrapTime) < 10 * 60 * 1000
-          : false,
-      },
-    });
+    setRecentBootstrapTag(orgSlug);
 
-    setOrganizationPromise(fetchOrganizationDetails(api, orgSlug, false, true));
+    const promise = Sentry.startSpan(
+      {
+        name: 'ui.bootstrap',
+        op: 'ui.render',
+        forceTransaction: true,
+      },
+      // Bootstraps organization, projects, and teams
+      () => fetchOrganizationDetails(api, orgSlug, false, true)
+    );
+    setOrganizationPromise(promise);
   }, [api, orgSlug, organization]);
 
   // XXX(epurkhiser): User may be null in some scenarios at this point in app

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -63,12 +63,10 @@ function setRecentBootstrapTag(orgSlug: string) {
   const previousBootstrapKey = `previous-bootstrap-${orgSlug}`;
   try {
     const previousBootstrapTime = localStorage.getItem(previousBootstrapKey);
-    Sentry.setTag(
-      'is_recent_boot',
-      previousBootstrapTime
-        ? Date.now() - Number(previousBootstrapTime) < 10 * 60 * 1000
-        : false
-    );
+    const isRecentBoot = previousBootstrapTime
+      ? Date.now() - Number(previousBootstrapTime) < 10 * 60 * 1000
+      : false;
+    Sentry.setTag('is_recent_boot', isRecentBoot.toString());
     localStorage.setItem(previousBootstrapKey, `${Date.now()}`);
   } catch {
     // Ignore errors


### PR DESCRIPTION
The previous version #84287 only measured the time until the organization was available. :( 

Adds a tag for is recent boot instead of a span attribute so we can group them