### PR TITLE
fix(stacktrace-linking): Enable set up code mapping for csharp

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -233,22 +233,6 @@ describe('StacktraceLink', function () {
     );
   });
 
-  it('hides stacktrace link if there is no source link for .NET projects', async function () {
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      body: {
-        config,
-        integrations: [integration],
-      },
-    });
-    const {container} = render(
-      <StacktraceLink frame={frame} event={{...event, platform: 'csharp'}} line="" />
-    );
-    await waitFor(() => {
-      expect(container).toBeEmptyDOMElement();
-    });
-  });
-
   it('renders in-frame stacktrace links and fetches data with 100ms delay', async function () {
     const mockRequest = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -27,15 +27,18 @@ import useProjects from 'sentry/utils/useProjects';
 import StacktraceLinkModal from './stacktraceLinkModal';
 import useStacktraceLink from './useStacktraceLink';
 
+// Keep this list in sync with SUPPORTED_LANGUAGES in code_mapping.py
 const supportedStacktracePlatforms: PlatformKey[] = [
+  'csharp',
+  'elixir',
   'go',
   'javascript',
   'node',
   'php',
   'python',
   'ruby',
-  'elixir',
 ];
+const scmProviders = ['github', 'gitlab'];
 
 function shouldShowCodecovFeatures(
   organization: Organization,
@@ -332,7 +335,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     }
 
     const sourceCodeProviders = match.integrations.filter(integration =>
-      ['github', 'gitlab'].includes(integration.provider?.key)
+      scmProviders.includes(integration.provider?.key)
     );
     return (
       <StacktraceLinkWrapper>

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -226,7 +226,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     return null;
   }
 
-  // Render the provided `sourceLink` for all the non-inapp frames for `csharp` platform Issues
+  // Render the provided `sourceLink` for all the non-in-app frames for `csharp` platform Issues
   // We skip fetching from the API for these frames.
   if (!match && hasGithubSourceLink && !frame.inApp && frame.sourceLink) {
     return (


### PR DESCRIPTION
It seems the list of platforms fell out of date.