### PR TITLE
fix(widget-builder): Make table preview columns more visible

### DIFF
--- a/static/app/components/charts/simpleTableChart.tsx
+++ b/static/app/components/charts/simpleTableChart.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -39,6 +40,7 @@ type Props = {
   ) => ReturnType<typeof getFieldRenderer> | null;
   loader?: PanelTableProps['loader'];
   metadata?: TableData['meta'];
+  minColumnWidth?: string;
   stickyHeaders?: boolean;
   topResultsIndicators?: number;
 };
@@ -58,6 +60,7 @@ function SimpleTableChart({
   location,
   fieldAliases,
   loader,
+  minColumnWidth,
 }: Props) {
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -111,6 +114,12 @@ function SimpleTableChart({
     <Fragment>
       {title && <h4>{title}</h4>}
       <StyledPanelTable
+        css={css`
+          grid-template-columns: repeat(
+            ${columns.length},
+            ${minColumnWidth ? `minmax(${minColumnWidth}, auto)` : 'auto'}
+          );
+        `}
         className={className}
         isLoading={loading}
         loader={loader}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -24,6 +24,8 @@ interface WidgetPreviewProps {
   shouldForceDescriptionTooltip?: boolean;
 }
 
+const MIN_TABLE_COLUMN_WIDTH = '125px';
+
 function WidgetPreview({
   dashboard,
   dashboardFilters,
@@ -88,6 +90,8 @@ function WidgetPreview({
       // onWidgetSplitDecision={onWidgetSplitDecision}
 
       showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
+      // ensure table columns are at least a certain width (helps with lack of truncation on large fields)
+      minTableColumnWidth={MIN_TABLE_COLUMN_WIDTH}
     />
   );
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -87,6 +87,7 @@ type WidgetCardChartProps = Pick<
   expandNumbers?: boolean;
   isMobile?: boolean;
   legendOptions?: LegendComponentOption;
+  minTableColumnWidth?: string;
   noPadding?: boolean;
   onLegendSelectChanged?: EChartEventHandler<{
     name: string;
@@ -132,7 +133,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
   }
 
   tableResultComponent({loading, tableResults}: TableResultProps): React.ReactNode {
-    const {location, widget, selection} = this.props;
+    const {location, widget, selection, minTableColumnWidth} = this.props;
     if (typeof tableResults === 'undefined') {
       // Align height to other charts.
       return <LoadingPlaceholder />;
@@ -170,6 +171,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
             stickyHeaders
             fieldHeaderMap={datasetConfig.getFieldHeaderMap?.(widget.queries[i])}
             getCustomFieldRenderer={getCustomFieldRenderer}
+            minColumnWidth={minTableColumnWidth}
           />
         </TableWrapper>
       );

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -79,6 +79,7 @@ type Props = WithRouterProps & {
   isPreview?: boolean;
   isWidgetInvalid?: boolean;
   legendOptions?: LegendComponentOption;
+  minTableColumnWidth?: string;
   onDataFetched?: (results: TableDataWithTitle[]) => void;
   onDelete?: () => void;
   onDuplicate?: () => void;
@@ -137,6 +138,7 @@ function WidgetCard(props: Props) {
     widgetLegendState,
     disableFullscreen,
     showConfidenceWarning,
+    minTableColumnWidth,
   } = props;
 
   if (widget.displayType === DisplayType.TOP_N) {
@@ -351,6 +353,7 @@ function WidgetCard(props: Props) {
               legendOptions={legendOptions}
               widgetLegendState={widgetLegendState}
               showConfidenceWarning={showConfidenceWarning}
+              minTableColumnWidth={minTableColumnWidth}
             />
           </WidgetFrame>
         )}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -38,6 +38,7 @@ type Props = {
   expandNumbers?: boolean;
   isMobile?: boolean;
   legendOptions?: LegendComponentOption;
+  minTableColumnWidth?: string;
   noPadding?: boolean;
   onDataFetched?: (results: {
     pageLinks?: string;
@@ -80,6 +81,7 @@ export function WidgetCardChartContainer({
   shouldResize,
   widgetLegendState,
   showConfidenceWarning,
+  minTableColumnWidth,
 }: Props) {
   const location = useLocation();
 
@@ -165,6 +167,7 @@ export function WidgetCardChartContainer({
               widgetLegendState={widgetLegendState}
               showConfidenceWarning={showConfidenceWarning}
               confidence={confidence}
+              minTableColumnWidth={minTableColumnWidth}
             />
           </Fragment>
         );


### PR DESCRIPTION
[This bug](https://www.notion.so/sentry/Design-Preview-seems-very-limited-for-tables-17a8b10e4b5d80a3ac81dcdc31c09703?pvs=4) brought up that for long fields in the table, we can only see that one field making it hard to see what else is being represented. I've basically set a minmax to check if the `auto` width is larger than a set size; if it is then it will set it as `auto` otherwise it will make the columns the set size. This helps when one field is very long and 'squishing' other fields; this will allow that long field to truncate!

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/69e920a8-7456-4428-8da3-30dca726d3d6) | ![image](https://github.com/user-attachments/assets/417598e5-21c0-41f3-b412-e2f830416063) | 

It doesn't look perfect but it definitely looks better 😌 
