### PR TITLE
chore(explore): Tweaks to explore toobar

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -320,17 +320,7 @@ describe('ExploreToolbar', function () {
       {disableRouterMocks: true}
     );
 
-    const section = screen.getByTestId('section-group-by');
-
-    expect(
-      within(section).getByRole('button', {name: 'Samples not grouped'})
-    ).toBeInTheDocument();
-    expect(groupBys).toEqual(['span.op']);
-
-    // disabled in the samples mode
-    expect(
-      within(section).getByRole('button', {name: 'Samples not grouped'})
-    ).toBeDisabled();
+    expect(screen.queryByTestId('section-group-by')).not.toBeInTheDocument();
 
     // click the aggregates mode to enable
     await userEvent.click(
@@ -338,6 +328,8 @@ describe('ExploreToolbar', function () {
         name: 'Aggregates',
       })
     );
+
+    const section = screen.getByTestId('section-group-by');
 
     expect(within(section).getByRole('button', {name: 'span.op'})).toBeEnabled();
     await userEvent.click(within(section).getByRole('button', {name: 'span.op'}));

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -46,7 +46,7 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
       )}
       <ToolbarMode mode={mode} setMode={setMode} />
       <ToolbarVisualize />
-      <ToolbarGroupBy disabled={mode !== Mode.AGGREGATE} />
+      {mode === Mode.AGGREGATE && <ToolbarGroupBy />}
       <ToolbarSortBy
         fields={fields}
         groupBys={groupBys}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -202,18 +202,18 @@ export function ToolbarVisualize() {
               {parsedVisualizeGroup.map((parsedVisualize, index) => (
                 <ToolbarRow key={index}>
                   {shouldRenderLabel && <ChartLabel>{parsedVisualize.label}</ChartLabel>}
-                  <ColumnCompactSelect
-                    searchable
-                    options={fieldOptions}
-                    value={parsedVisualize.func.arguments[0]}
-                    onChange={newField => setChartField(group, index, newField)}
-                  />
                   <AggregateCompactSelect
                     options={aggregateOptions}
                     value={parsedVisualize.func.name}
                     onChange={newAggregate =>
                       setChartAggregate(group, index, newAggregate)
                     }
+                  />
+                  <ColumnCompactSelect
+                    searchable
+                    options={fieldOptions}
+                    value={parsedVisualize.func.arguments[0]}
+                    onChange={newField => setChartField(group, index, newField)}
                   />
                   <Button
                     borderless


### PR DESCRIPTION
Swap the order of visualize function and column. And hide group by in samples mode.