### PR TITLE
feat(grouping): Add contributing system frames test inputs

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/contributing_system_and_app_frames.json
+++ b/tests/sentry/grouping/grouping_inputs/contributing_system_and_app_frames.json
@@ -1,0 +1,39 @@
+{
+  "_grouping": {
+    "enhancements": "stack.function:runApp -app -group \n stack.function:handleRequest -app +group \n stack.function:recordMetrics +app -group \n stack.function:playFetch +app +group"
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "FailedToFetchError",
+        "value": "FailedToFetchError: Charlie didn't bring the ball back!",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "runApp",
+              "filename": "/node_modules/express/app.js",
+              "context_line": "return server.serve(port);"
+            },
+            {
+              "function": "handleRequest",
+              "filename": "/node_modules/express/router.js",
+              "context_line": "return handler(request);"
+            },
+            {
+              "function": "recordMetrics",
+              "filename": "/dogApp/metrics.js",
+              "context_line": "return withMetrics(handler, metricName, tags);"
+            },
+            {
+              "function": "playFetch",
+              "filename": "/dogApp/dogpark.js",
+              "context_line": "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "platform": "javascript",
+  "sdk": {"name": "sentry.javascript.nextjs", "version": "12.31.12"}
+}

--- a/tests/sentry/grouping/grouping_inputs/contributing_system_frames.json
+++ b/tests/sentry/grouping/grouping_inputs/contributing_system_frames.json
@@ -1,0 +1,34 @@
+{
+  "_grouping": {
+    "enhancements": "stack.function:runApp -app -group \n stack.function:handleRequest -app +group \n stack.function:recordMetrics +app -group"
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "FailedToFetchError",
+        "value": "FailedToFetchError: Charlie didn't bring the ball back!",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "runApp",
+              "filename": "/node_modules/express/app.js",
+              "context_line": "return server.serve(port);"
+            },
+            {
+              "function": "handleRequest",
+              "filename": "/node_modules/express/router.js",
+              "context_line": "return handler(request);"
+            },
+            {
+              "function": "recordMetrics",
+              "filename": "/dogApp/metrics.js",
+              "context_line": "return withMetrics(handler, metricName, tags);"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "platform": "javascript",
+  "sdk": {"name": "sentry.javascript.nextjs", "version": "12.31.12"}
+}

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,44 @@
+---
+created: '2025-01-30T21:40:29.945093+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "eb1c9a5ad0bb12f57d30dd08ee542d47"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          stacktrace*
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "/node_modules/express/router.js"
+              context-line*
+                "return handler(request);"
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "/dogApp/dogpark.js"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_frames.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-01-30T21:40:30.030946+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "1421f48adc6007aa7243ba9c380835b4"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          stacktrace*
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "/node_modules/express/router.js"
+              context-line*
+                "return handler(request);"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,48 @@
+---
+created: '2025-01-30T21:41:17.184133+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "in_app"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "in_app"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "router.js"
+              function*
+                "handleRequest"
+              context-line*
+                "return handler(request);"
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "dogpark.js"
+              function*
+                "playFetch"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_frames.pysnap
@@ -1,0 +1,41 @@
+---
+created: '2025-01-30T21:41:17.269522+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "in_app"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "in_app"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "router.js"
+              function*
+                "handleRequest"
+              context-line*
+                "return handler(request);"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,48 @@
+---
+created: '2025-01-30T21:41:01.822552+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "in_app"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "in_app"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "router.js"
+              function*
+                "handleRequest"
+              context-line*
+                "return handler(request);"
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "dogpark.js"
+              function*
+                "playFetch"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_frames.pysnap
@@ -1,0 +1,41 @@
+---
+created: '2025-01-30T21:41:01.889599+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "in_app"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "in_app"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "router.js"
+              function*
+                "handleRequest"
+              context-line*
+                "return handler(request);"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,48 @@
+---
+created: '2025-01-30T21:40:46.962385+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "in_app"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "in_app"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "router.js"
+              function*
+                "handleRequest"
+              context-line*
+                "return handler(request);"
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "dogpark.js"
+              function*
+                "playFetch"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,0 +1,41 @@
+---
+created: '2025-01-30T21:40:47.031377+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "in_app"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "in_app"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+              filename*
+                "router.js"
+              function*
+                "handleRequest"
+              context-line*
+                "return handler(request);"
+          type*
+            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,84 @@
+---
+created: '2025-01-30T21:38:38.352402+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "/node_modules/express/app.js"
+            context-line*
+              "return server.serve(port);"
+            function (function name is not used if context-line is available)
+              "runApp"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "/node_modules/express/router.js"
+            context-line*
+              "return handler(request);"
+            function (function name is not used if context-line is available)
+              "handleRequest"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "/dogApp/metrics.js"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+            function (function name is not used if context-line is available)
+              "recordMetrics"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "/dogApp/dogpark.js"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+            function (function name is not used if context-line is available)
+              "playFetch"
+        type*
+          "FailedToFetchError"
+        value (stacktrace and type take precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: "eb1c9a5ad0bb12f57d30dd08ee542d47"
+  contributing component: exception
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "/node_modules/express/app.js"
+            context-line*
+              "return server.serve(port);"
+            function (function name is not used if context-line is available)
+              "runApp"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "/node_modules/express/router.js"
+            context-line*
+              "return handler(request);"
+            function (function name is not used if context-line is available)
+              "handleRequest"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "/dogApp/metrics.js"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+            function (function name is not used if context-line is available)
+              "recordMetrics"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "/dogApp/dogpark.js"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+            function (function name is not used if context-line is available)
+              "playFetch"
+        type*
+          "FailedToFetchError"
+        value (stacktrace and type take precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_frames.pysnap
@@ -1,0 +1,70 @@
+---
+created: '2025-01-30T21:38:38.444808+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "/node_modules/express/app.js"
+            context-line*
+              "return server.serve(port);"
+            function (function name is not used if context-line is available)
+              "runApp"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "/node_modules/express/router.js"
+            context-line*
+              "return handler(request);"
+            function (function name is not used if context-line is available)
+              "handleRequest"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "/dogApp/metrics.js"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+            function (function name is not used if context-line is available)
+              "recordMetrics"
+        type*
+          "FailedToFetchError"
+        value (stacktrace and type take precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: "1421f48adc6007aa7243ba9c380835b4"
+  contributing component: exception
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "/node_modules/express/app.js"
+            context-line*
+              "return server.serve(port);"
+            function (function name is not used if context-line is available)
+              "runApp"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "/node_modules/express/router.js"
+            context-line*
+              "return handler(request);"
+            function (function name is not used if context-line is available)
+              "handleRequest"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "/dogApp/metrics.js"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+            function (function name is not used if context-line is available)
+              "recordMetrics"
+        type*
+          "FailedToFetchError"
+        value (stacktrace and type take precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,84 @@
+---
+created: '2025-01-30T21:38:17.979729+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "dogpark.js"
+            function*
+              "playFetch"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  component:
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "dogpark.js"
+            function*
+              "playFetch"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_frames.pysnap
@@ -1,0 +1,70 @@
+---
+created: '2025-01-30T21:38:18.144167+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  component:
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,84 @@
+---
+created: '2025-01-30T21:37:56.171192+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "dogpark.js"
+            function*
+              "playFetch"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  component:
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "dogpark.js"
+            function*
+              "playFetch"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_frames.pysnap
@@ -1,0 +1,70 @@
+---
+created: '2025-01-30T21:37:56.373019+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  component:
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,0 +1,84 @@
+---
+created: '2025-01-30T21:37:24.805215+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "dogpark.js"
+            function*
+              "playFetch"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  component:
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            filename*
+              "dogpark.js"
+            function*
+              "playFetch"
+            context-line*
+              "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,0 +1,70 @@
+---
+created: '2025-01-30T21:37:24.936142+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  contributing component: null
+  component:
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
+        stacktrace*
+          frame (ignored by stack trace rule (function:runApp -app -group))
+            filename*
+              "app.js"
+            function*
+              "runApp"
+            context-line*
+              "return server.serve(port);"
+          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            filename*
+              "router.js"
+            function*
+              "handleRequest"
+            context-line*
+              "return handler(request);"
+          frame (ignored by stack trace rule (function:recordMetrics +app -group))
+            filename*
+              "metrics.js"
+            function*
+              "recordMetrics"
+            context-line*
+              "return withMetrics(handler, metricName, tags);"
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"


### PR DESCRIPTION
Right now we have a bug in our grouping code which makes system frames count towards the `in_app` hash if they're the subject of `+group` enhancement rules, either from us or the user. To illustrate the fix which is coming, this adds two grouping inputs demonstrating the broken behavior.

In both inputs, there is a frame (the `handleRequest` frame) like the one described above, and in the resulting newstyle snapshots, that frame is marked with a `*` even in the app variant, meaning it's contributing. Once the fix is in, that will change. (The effect is somewhat different in the legacy snapshots, but the legacy code is going to disappear in any case, so that isn't a problem.)