### PR TITLE
ref(grouping): Clarify category and `in_app` assignment

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -162,11 +162,11 @@ class Enhancements:
         """
         match_frames = [create_match_frame(frame, platform) for frame in frames]
 
-        rust_enhanced_frames = self.rust_enhancements.apply_modifications_to_frames(
+        category_and_in_app_results = self.rust_enhancements.apply_modifications_to_frames(
             match_frames, make_rust_exception_data(exception_data)
         )
 
-        for frame, (category, in_app) in zip(frames, rust_enhanced_frames):
+        for frame, (category, in_app) in zip(frames, category_and_in_app_results):
             if in_app is not None:
                 set_in_app(frame, in_app)
             if category is not None:

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -168,6 +168,8 @@ class Enhancements:
 
         for frame, (category, in_app) in zip(frames, category_and_in_app_results):
             if in_app is not None:
+                # If the `in_app` value changes as a result of this call, the original value (in
+                # integer form) will be added to `frame.data` under the key "orig_in_app"
                 set_in_app(frame, in_app)
             if category is not None:
                 set_path(frame, "data", "category", value=category)

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -153,7 +153,12 @@ class Enhancements:
         exception_data: dict[str, Any],
     ) -> None:
         """
-        This applies the frame modifications to the frames itself. This does not affect grouping.
+        Apply enhancement rules to each frame, adding a category (if any) and updating the `in_app`
+        value if necessary.
+
+        Both the category and `in_app` data will be used during grouping. The `in_app` values will
+        also be persisted in the saved event, so they can be used in the UI and when determining
+        things like suspect commits and suggested assignees.
         """
         match_frames = [create_match_frame(frame, platform) for frame in frames]
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -146,7 +146,7 @@ class Enhancements:
 
         self.rust_enhancements = merge_rust_enhancements(bases, rust_enhancements)
 
-    def apply_modifications_to_frame(
+    def apply_category_and_updated_in_app_to_frames(
         self,
         frames: Sequence[dict[str, Any]],
         platform: str,

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -197,7 +197,7 @@ def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> N
         return
     enhancements = Enhancements.from_config_string(profiling_rules)
     if "version" in profile:
-        enhancements.apply_modifications_to_frame(
+        enhancements.apply_category_and_updated_in_app_to_frames(
             profile["profile"]["frames"], profile["platform"], {}
         )
     elif profile["platform"] == "android":
@@ -209,6 +209,6 @@ def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> N
             method["function"] = method.get("name", "")
             method["abs_path"] = method.get("source_file", "")
             method["module"] = method.get("class_name", "")
-        enhancements.apply_modifications_to_frame(
+        enhancements.apply_category_and_updated_in_app_to_frames(
             profile["profile"]["methods"], profile["platform"], {}
         )

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -350,7 +350,7 @@ def normalize_stacktraces_for_grouping(
         with sentry_sdk.start_span(op=op, name="apply_modifications_to_frame"):
             for frames, stacktrace_container in zip(stacktrace_frames, stacktrace_containers):
                 # This call has a caching mechanism when the same stacktrace and rules are used
-                grouping_config.enhancements.apply_modifications_to_frame(
+                grouping_config.enhancements.apply_category_and_updated_in_app_to_frames(
                     frames, platform, stacktrace_container
                 )
 

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -97,19 +97,19 @@ def test_flipflop_inapp():
     )
 
     frames: list[dict[str, Any]] = [{}]
-    enhancement.apply_modifications_to_frame(frames, "javascript", {})
+    enhancement.apply_category_and_updated_in_app_to_frames(frames, "javascript", {})
 
     assert frames[0]["data"]["orig_in_app"] == -1  # == None
     assert frames[0]["in_app"] is False
 
     frames = [{"in_app": False}]
-    enhancement.apply_modifications_to_frame(frames, "javascript", {})
+    enhancement.apply_category_and_updated_in_app_to_frames(frames, "javascript", {})
 
     assert "data" not in frames[0]  # no changes were made
     assert frames[0]["in_app"] is False
 
     frames = [{"in_app": True}]
-    enhancement.apply_modifications_to_frame(frames, "javascript", {})
+    enhancement.apply_category_and_updated_in_app_to_frames(frames, "javascript", {})
 
     assert frames[0]["data"]["orig_in_app"] == 1  # == True
     assert frames[0]["in_app"] is False
@@ -483,7 +483,7 @@ def test_range_matching_direct():
 )
 def test_app_no_matches(frame):
     enhancements = Enhancements.from_config_string("app:no +app")
-    enhancements.apply_modifications_to_frame([frame], "native", {})
+    enhancements.apply_category_and_updated_in_app_to_frames([frame], "native", {})
     assert frame.get("in_app")
 
 


### PR DESCRIPTION
We call the rust enhancers in two different spots during ingest, first in `Enhancements.apply_modifications_to_frame` and later in `Enhancements.assemble_stacktrace_component`. There is an upcoming change to the latter, which I think will be easier to understand if it's clearer how the two functions differ, and the way in which the former sets the stage for the latter. This therefore makes a few small naming/documentation changes to make it clearer what `apply_modifications_to_frame` (now called `apply_category_and_updated_in_app_to_frames`) does and how. No behavior changes.