### PR TITLE
:sparkles: feat(aci): migration util for plugins

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -42,7 +42,7 @@ class BaseActionTranslator(ABC):
 
     @property
     @abstractmethod
-    def target_type(self) -> ActionTarget:
+    def target_type(self) -> ActionTarget | None:
         """Return the target type for this action"""
         pass
 

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -48,7 +48,7 @@ class BaseActionTranslator(ABC):
 
     @property
     @abstractmethod
-    def integration_id(self) -> Any | None:
+    def integration_id(self) -> int | None:
         """Return the integration ID for this action, if any"""
         pass
 
@@ -299,6 +299,35 @@ class AzureDevOpsActionTranslator(TicketActionTranslator):
     @property
     def blob_type(self) -> type["DataBlob"]:
         return AzureDevOpsDataBlob
+
+
+@issue_alert_action_translator_registry.register(
+    "sentry.rules.actions.notify_event.NotifyEventAction"
+)
+class PluginActionTranslator(BaseActionTranslator):
+    action_type = Action.Type.PLUGIN
+
+    @property
+    def required_fields(self) -> list[str]:
+        # NotifyEventAction doesn't appear to have any required fields
+        # beyond the standard id and uuid
+        return []
+
+    @property
+    def target_type(self) -> None:
+        # This appears to be a generic plugin notification
+        # so we'll use SPECIFIC as the target type
+        return None
+
+    @property
+    def integration_id(self) -> None:
+        # Plugin actions don't have an integration ID
+        return None
+
+    @property
+    def blob_type(self) -> None:
+        # Plugin actions don't need any additional data storage
+        return None
 
 
 @dataclass

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -891,6 +891,41 @@ class TestNotificationActionMigrationUtils(TestCase):
         actions = build_notification_actions_from_rule_data_actions(action_data)
         assert len(actions) == 0
 
+    def test_plugin_action_migration(self):
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "c792d184-81db-419f-8ab2-83baef1216f4",
+            },
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "0202a169-326b-4575-8887-afe69cc58040",
+            },
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "ad671f12-6bb7-4b9d-a4fe-f32e985fe08e",
+            },
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "efe1841d-d33a-460a-8d65-7697893ec7f1",
+            },
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "8c0c2fc9-5d89-4974-9d3c-31b1d602a065",
+            },
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "e63c387c-94f4-4284-bef8-c08b218654a3",
+            },
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "uuid": "0269d028-9466-4826-8ab9-18cd47fb08d2",
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        self.assert_actions_migrated_correctly(actions, action_data, None, None, None)
+
     def test_action_types(self):
         """Test that all registered action translators have the correct action type set."""
         test_cases = [


### PR DESCRIPTION
migration util for plugins. dirty simple cause it doesn't contain any additional info