### PR TITLE
feat(tempest): Transition form logs to spans

### DIFF
--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -64,33 +64,12 @@ def fetch_latest_item_id(credentials_id: int) -> None:
                 credentials.message = "Seems like the provided credentials are invalid"
                 credentials.message_type = MessageType.ERROR
                 credentials.save(update_fields=["message", "message_type"])
-
-                logger.info(
-                    "invalid_credentials",
-                    extra={
-                        "org_id": org_id,
-                        "project_id": project_id,
-                        "client_id": client_id,
-                        "status_code": response.status_code,
-                        "response_text": result,
-                    },
-                )
                 return
+
             elif result["error"]["type"] == "ip_not_allowlisted":
                 credentials.message = "Seems like our IP is not allow-listed"
                 credentials.message_type = MessageType.ERROR
                 credentials.save(update_fields=["message", "message_type"])
-
-                logger.info(
-                    "ip_not_allowlisted",
-                    extra={
-                        "org_id": org_id,
-                        "project_id": project_id,
-                        "client_id": client_id,
-                        "status_code": response.status_code,
-                        "response_text": result,
-                    },
-                )
                 return
 
         # Default in case things go wrong

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
 import requests
+import sentry_sdk
 from django.conf import settings
 from requests import Response
 
@@ -93,7 +94,7 @@ def fetch_latest_item_id(credentials_id: int) -> None:
                 return
 
         # Default in case things go wrong
-        logger.info(
+        logger.error(
             "Fetching the latest item id failed.",
             extra={
                 "org_id": org_id,
@@ -105,7 +106,7 @@ def fetch_latest_item_id(credentials_id: int) -> None:
         )
 
     except Exception as e:
-        logger.info(
+        logger.exception(
             "Fetching the latest item id failed.",
             extra={
                 "org_id": org_id,
@@ -165,7 +166,7 @@ def poll_tempest_crashes(credentials_id: int) -> None:
         credentials.latest_fetched_item_id = result["latest_id"]
         credentials.save(update_fields=["latest_fetched_item_id"])
     except Exception as e:
-        logger.info(
+        logger.exception(
             "Fetching the crashes failed.",
             extra={
                 "org_id": org_id,
@@ -193,14 +194,9 @@ def fetch_latest_id_from_tempest(
         json=payload,
     )
 
-    logger.info(
-        "Tempest API response",
-        extra={
-            "status_code": response.status_code,
-            "response_text": response.text,
-            "endpoint": "/latest-id",
-        },
-    )
+    span = sentry_sdk.get_current_span()
+    if span is not None:
+        span.set_extra("response_text", response.text)
 
     return response
 
@@ -234,13 +230,8 @@ def fetch_items_from_tempest(
         timeout=time_out,
     )
 
-    logger.info(
-        "Tempest API response",
-        extra={
-            "status_code": response.status_code,
-            "response_text": response.text,
-            "endpoint": "/crashes",
-        },
-    )
+    span = sentry_sdk.get_current_span()
+    if span is not None:
+        span.set_extra("response_text", response.text)
 
     return response

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -175,7 +175,7 @@ def fetch_latest_id_from_tempest(
 
     span = sentry_sdk.get_current_span()
     if span is not None:
-        span.set_extra("response_text", response.text)
+        span.set_data("response_text", response.text)
 
     return response
 
@@ -211,6 +211,6 @@ def fetch_items_from_tempest(
 
     span = sentry_sdk.get_current_span()
     if span is not None:
-        span.set_extra("response_text", response.text)
+        span.set_data("response_text", response.text)
 
     return response


### PR DESCRIPTION
With spans now working for Tempest this attempts to log the relevant information in such a way that it shows up alongside the spans.