### PR TITLE
ref(auto_source_code_config): Clean up for upcoming change

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -37,10 +37,9 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
-from sentry.issues.auto_source_code_config.code_mapping import RepoTree
 from sentry.models.repository import Repository
 from sentry.organizations.absolute_url import generate_organization_url
-from sentry.organizations.services.organization import RpcOrganizationSummary, organization_service
+from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import Pipeline, PipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -285,29 +284,6 @@ class GitHubIntegration(
         except ApiError:
             return False
         return True
-
-    # XXX: To be removed after we switch over to the new repo trees integration code
-    def get_trees_for_org_old(self, cache_seconds: int = 3600 * 24) -> dict[str, RepoTree]:
-        trees: dict[str, RepoTree] = {}
-        domain_name = self.model.metadata["domain_name"]
-        extra = {"metadata": self.model.metadata}
-        if domain_name.find("github.com/") == -1:
-            logger.warning("We currently only support github.com domains.", extra=extra)
-            return trees
-
-        gh_org = domain_name.split("github.com/")[1]
-        extra.update({"gh_org": gh_org})
-        org_exists = organization_service.check_organization_by_id(
-            id=self.org_integration.organization_id, only_visible=False
-        )
-        if not org_exists:
-            logger.error(
-                "No organization information was found. Continuing execution.", extra=extra
-            )
-        else:
-            trees = self.get_client().get_trees_for_org_deprecate(gh_org, cache_seconds)
-
-        return trees
 
     def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
         resp = self.get_client().search_issues(query)

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -1,1 +1,3 @@
 SUPPORTED_INTEGRATIONS = ["github"]
+# Any new languages should also require updating the stacktraceLink.tsx and repo_trees.py SUPPORTED_EXTENSIONS
+SUPPORTED_LANGUAGES = ["javascript", "python", "node", "ruby", "php", "go", "csharp"]

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -1,0 +1,1 @@
+SUPPORTED_INTEGRATIONS = ["github"]

--- a/src/sentry/issues/auto_source_code_config/errors.py
+++ b/src/sentry/issues/auto_source_code_config/errors.py
@@ -1,2 +1,0 @@
-class InstallationNotFoundError(Exception):
-    pass

--- a/src/sentry/issues/auto_source_code_config/errors.py
+++ b/src/sentry/issues/auto_source_code_config/errors.py
@@ -1,0 +1,2 @@
+class InstallationNotFoundError(Exception):
+    pass

--- a/src/sentry/issues/auto_source_code_config/integration_utils.py
+++ b/src/sentry/issues/auto_source_code_config/integration_utils.py
@@ -1,0 +1,26 @@
+from sentry.constants import ObjectStatus
+from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.services.integration import integration_service
+from sentry.models.organization import Organization
+
+from .constants import SUPPORTED_INTEGRATIONS
+from .errors import InstallationNotFoundError
+
+
+def get_installation(organization: Organization) -> IntegrationInstallation:
+    integrations = integration_service.get_integrations(
+        organization_id=organization.id,
+        providers=SUPPORTED_INTEGRATIONS,
+        status=ObjectStatus.ACTIVE,
+    )
+    if len(integrations) == 0:
+        raise InstallationNotFoundError
+
+    # XXX: We only operate on the first integration for an organization.
+    integration = integrations[0]
+    installation = integration.get_installation(organization_id=organization.id)
+
+    if not installation:
+        raise InstallationNotFoundError
+
+    return installation

--- a/src/sentry/issues/auto_source_code_config/integration_utils.py
+++ b/src/sentry/issues/auto_source_code_config/integration_utils.py
@@ -4,7 +4,10 @@ from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 
 from .constants import SUPPORTED_INTEGRATIONS
-from .errors import InstallationNotFoundError
+
+
+class InstallationNotFoundError(Exception):
+    pass
 
 
 def get_installation(organization: Organization) -> IntegrationInstallation:

--- a/src/sentry/issues/auto_source_code_config/stacktraces.py
+++ b/src/sentry/issues/auto_source_code_config/stacktraces.py
@@ -1,0 +1,40 @@
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.db.models.fields.node import NodeData
+from sentry.utils.safe import get_path
+
+logger = logging.getLogger(__name__)
+
+
+def identify_stacktrace_paths(data: NodeData) -> list[str]:
+    """
+    Get the stacktrace_paths from the event data.
+    """
+    stacktraces = get_stacktrace(data)
+    stacktrace_paths = set()
+    for stacktrace in stacktraces:
+        try:
+            frames = stacktrace["frames"]
+            paths = {
+                frame["filename"]
+                for frame in frames
+                if frame and frame.get("in_app") and frame.get("filename")
+            }
+            stacktrace_paths.update(paths)
+        except Exception:
+            logger.exception("Error getting filenames for project.")
+    return list(stacktrace_paths)
+
+
+def get_stacktrace(data: NodeData) -> list[Mapping[str, Any]]:
+    exceptions = get_path(data, "exception", "values", filter=True)
+    if exceptions:
+        return [e["stacktrace"] for e in exceptions if get_path(e, "stacktrace", "frames")]
+
+    stacktrace = data.get("stacktrace")
+    if stacktrace and stacktrace.get("frames"):
+        return [stacktrace]
+
+    return []

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -20,8 +20,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.locking import UnableToAcquireLock
 
-from .errors import InstallationNotFoundError
-from .integration_utils import get_installation
+from .integration_utils import InstallationNotFoundError, get_installation
 from .stacktraces import identify_stacktrace_paths
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from sentry_sdk import set_tag, set_user
 
 from sentry import eventstore
-from sentry.constants import ObjectStatus
-from sentry.db.models.fields.node import NodeData
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.integrations.services.integration import RpcOrganizationIntegration, integration_service
 from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionEvent,
     SCMIntegrationInteractionType,
@@ -23,7 +19,10 @@ from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.locking import UnableToAcquireLock
-from sentry.utils.safe import get_path
+
+from .errors import InstallationNotFoundError
+from .integration_utils import get_installation
+from .stacktraces import identify_stacktrace_paths
 
 logger = logging.getLogger(__name__)
 
@@ -66,15 +65,16 @@ def process_event(project_id: int, group_id: int, event_id: str) -> None:
     if not stacktrace_paths:
         return
 
-    installation, organization_integration = get_installation(org)
-    if not installation or not organization_integration:
+    try:
+        installation = get_installation(org)
+    except InstallationNotFoundError:
         logger.info("No installation or organization integration found.", extra=extra)
         return
 
     trees = get_trees_for_org(installation, org, extra)
     trees_helper = CodeMappingTreesHelper(trees)
     code_mappings = trees_helper.generate_code_mappings(stacktrace_paths)
-    set_project_codemappings(code_mappings, organization_integration, project)
+    set_project_codemappings(code_mappings, installation, project)
 
 
 def process_error(error: ApiError, extra: dict[str, Any]) -> None:
@@ -152,71 +152,19 @@ def get_trees_for_org(
         return trees
 
 
-def identify_stacktrace_paths(data: NodeData) -> list[str]:
-    """
-    Get the stacktrace_paths from the event data.
-    """
-    stacktraces = get_stacktrace(data)
-    stacktrace_paths = set()
-    for stacktrace in stacktraces:
-        try:
-            frames = stacktrace["frames"]
-            paths = {
-                frame["filename"]
-                for frame in frames
-                if frame and frame.get("in_app") and frame.get("filename")
-            }
-            stacktrace_paths.update(paths)
-        except Exception:
-            logger.exception("Error getting filenames for project.")
-    return list(stacktrace_paths)
-
-
-def get_stacktrace(data: NodeData) -> list[Mapping[str, Any]]:
-    exceptions = get_path(data, "exception", "values", filter=True)
-    if exceptions:
-        return [e["stacktrace"] for e in exceptions if get_path(e, "stacktrace", "frames")]
-
-    stacktrace = data.get("stacktrace")
-    if stacktrace and stacktrace.get("frames"):
-        return [stacktrace]
-
-    return []
-
-
-def get_installation(
-    organization: Organization,
-) -> tuple[IntegrationInstallation | None, RpcOrganizationIntegration | None]:
-    integrations = integration_service.get_integrations(
-        organization_id=organization.id,
-        providers=["github"],
-        status=ObjectStatus.ACTIVE,
-    )
-    if len(integrations) == 0:
-        return None, None
-
-    # XXX: We only operate on the first integration for an organization.
-    integration = integrations[0]
-    organization_integration = integration_service.get_organization_integration(
-        integration_id=integration.id, organization_id=organization.id
-    )
-    if not organization_integration:
-        return None, None
-
-    installation = integration.get_installation(organization_id=organization.id)
-
-    return installation, organization_integration
-
-
 def set_project_codemappings(
     code_mappings: list[CodeMapping],
-    organization_integration: RpcOrganizationIntegration,
+    installation: IntegrationInstallation,
     project: Project,
 ) -> None:
     """
     Given a list of code mappings, create a new repository project path
     config for each mapping.
     """
+    organization_integration = installation.org_integration
+    if not organization_integration:
+        raise InstallationNotFoundError
+
     organization_id = organization_integration.organization_id
     for code_mapping in code_mappings:
         repository = (

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -994,7 +994,7 @@ def process_code_mappings(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
-    from sentry.issues.auto_source_code_config.code_mapping import SUPPORTED_LANGUAGES
+    from sentry.issues.auto_source_code_config.constants import SUPPORTED_LANGUAGES
     from sentry.tasks.auto_source_code_config import auto_source_code_config
 
     try:

--- a/tests/sentry/issues/auto_source_code_config/test_task.py
+++ b/tests/sentry/issues/auto_source_code_config/test_task.py
@@ -8,11 +8,8 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.source_code_management.repo_trees import RepoAndBranch, RepoTree
 from sentry.issues.auto_source_code_config.code_mapping import CodeMapping
-from sentry.issues.auto_source_code_config.task import (
-    DeriveCodeMappingsErrorReason,
-    identify_stacktrace_paths,
-    process_event,
-)
+from sentry.issues.auto_source_code_config.stacktraces import identify_stacktrace_paths
+from sentry.issues.auto_source_code_config.task import DeriveCodeMappingsErrorReason, process_event
 from sentry.models.organization import OrganizationStatus
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -21,7 +21,7 @@ from sentry.eventstream.types import EventStreamEventType
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.source_code_management.commit_context import CommitInfo, FileBlameInfo
-from sentry.issues.auto_source_code_config.code_mapping import SUPPORTED_LANGUAGES
+from sentry.issues.auto_source_code_config.constants import SUPPORTED_LANGUAGES
 from sentry.issues.grouptype import (
     FeedbackGroup,
     GroupCategory,


### PR DESCRIPTION
`get_installation` is used by the derive-code-mappings endpoints and we should have its module for it.

This also simplifies the logic of it.