### PR TITLE
ref: ensure request.auth is set for internal rpc requests too

### DIFF
--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -54,7 +54,7 @@ class AuthenticationMiddleware(MiddlewareMixin):
         if request.path.startswith("/api/0/internal/rpc/"):
             # Avoid doing RPC authentication when we're already
             # in an RPC request.
-            request.user = AnonymousUser()
+            request.user, request.auth = AnonymousUser(), None
             return
 
         auth = get_authorization_header(request).split()


### PR DESCRIPTION
<!-- Describe your PR here. -->