### PR TITLE
feat(issue-details): All check-ins page enabled for uptime

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2043,6 +2043,10 @@ function buildRoutes() {
         component={make(() => import('sentry/views/issueDetails/groupOpenPeriods'))}
       />
       <Route
+        path={TabPaths[Tab.CHECK_INS]}
+        component={make(() => import('sentry/views/issueDetails/groupCheckIns'))}
+      />
+      <Route
         path={TabPaths[Tab.TAGS]}
         component={make(() => import('sentry/views/issueDetails/groupTags/groupTagsTab'))}
       />

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -29,7 +29,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
       eventUnits: t('Check-ins'),
       resolution: t('Resolved'),
     },
-    allEventsPath: Tab.EVENTS,
+    allEventsPath: Tab.CHECK_INS,
     attachments: {enabled: false},
     resources: null,
     autofix: false,

--- a/static/app/views/issueDetails/groupCheckIns.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.tsx
@@ -88,8 +88,8 @@ function GroupCheckIns() {
   return (
     <EventListTable
       title={t('All Check-ins')}
-      tableUnits={t('check-ins')}
       pagination={{
+        tableUnits: t('check-ins'),
         links,
         pageCount,
         nextDisabled,

--- a/static/app/views/issueDetails/groupCheckIns.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.tsx
@@ -21,6 +21,7 @@ import type {User} from 'sentry/types/user';
 import {parseCursor} from 'sentry/utils/cursor';
 import {getShortEventId} from 'sentry/utils/events';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -28,7 +29,7 @@ import {useUser} from 'sentry/utils/useUser';
 import {
   type UptimeCheckIn,
   useUptimeCheckIns,
-} from 'sentry/views/issueDetails/queries/useUptimeCheckins';
+} from 'sentry/views/issueDetails/queries/useUptimeCheckIns';
 import {
   EventListHeader,
   EventListHeaderItem,
@@ -70,6 +71,8 @@ function GroupCheckIns() {
       orgSlug: organization.slug,
       projectSlug: group?.project.slug ?? '',
       uptimeAlertId: uptimeAlertId ?? '',
+      cursor: decodeScalar(location.query.cursor),
+      limit: 50,
     },
     {enabled: isUptimeAlert}
   );

--- a/static/app/views/issueDetails/groupCheckIns.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.tsx
@@ -1,0 +1,216 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import Duration from 'sentry/components/duration';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import TimeSince from 'sentry/components/timeSince';
+import {IconChevron} from 'sentry/icons/iconChevron';
+import {t, tct} from 'sentry/locale';
+import {parseCursor} from 'sentry/utils/cursor';
+import {getShortEventId} from 'sentry/utils/events';
+import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+import {useUser} from 'sentry/utils/useUser';
+import {
+  EventListHeader,
+  EventListHeaderItem,
+  EventListTitle,
+  StreamlineEventsTable,
+} from 'sentry/views/issueDetails/streamline/eventList';
+import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
+
+interface CheckInDisplayData {
+  duration: number;
+  env: string;
+  method: string;
+  statusCode: string;
+  time: string;
+  trace: string;
+}
+
+function GroupCheckIns() {
+  const {groupId} = useParams<{groupId: string}>();
+  const location = useLocation();
+  const user = useUser();
+
+  const {
+    isPending: isEventPending,
+    isError: isEventError,
+    refetch: refetchEvent,
+  } = useGroupEvent({
+    groupId,
+    eventId: user.options.defaultIssueEvent,
+  });
+
+  if (isEventError) {
+    return <LoadingError onRetry={refetchEvent} />;
+  }
+
+  if (isEventPending) {
+    return <LoadingIndicator />;
+  }
+
+  // TODO(leander): Fetch this data from the backend
+  const data: CheckInDisplayData[] = [];
+
+  // TODO(leander): Parse the page links from the backend response
+  const links = parseLinkHeader('');
+  const previousDisabled = links.previous?.results === false;
+  const nextDisabled = links.next?.results === false;
+  const currentCursor = parseCursor(location.query?.cursor);
+  const start = Math.max(currentCursor?.offset ?? 1, 1);
+  const pageCount = data.length;
+  // TODO(leander): Update this to use the actual total count
+  const totalCount = 500;
+
+  return (
+    <StreamlineEventsTable>
+      <EventListHeader>
+        <EventListTitle>{t('All Check-ins')}</EventListTitle>
+        <EventListHeaderItem>
+          {pageCount === 0
+            ? null
+            : tct('Showing [start]-[end] of [count] matching check-ins', {
+                start: start.toLocaleString(),
+                end: ((currentCursor?.offset ?? 0) + pageCount).toLocaleString(),
+                count: (totalCount ?? 0).toLocaleString(),
+              })}
+        </EventListHeaderItem>
+        <EventListHeaderItem>
+          <ButtonBar gap={0.25}>
+            <GrayLinkButton
+              aria-label={t('Previous Page')}
+              borderless
+              size="xs"
+              icon={<IconChevron direction="left" />}
+              to={{
+                ...location,
+                query: {
+                  ...location.query,
+                  cursor: links.previous?.cursor,
+                },
+              }}
+              disabled={isEventPending || previousDisabled}
+            />
+            <GrayLinkButton
+              aria-label={t('Next Page')}
+              borderless
+              size="xs"
+              icon={<IconChevron direction="right" />}
+              to={{
+                ...location,
+                query: {
+                  ...location.query,
+                  cursor: links.next?.cursor,
+                },
+              }}
+              disabled={isEventPending || nextDisabled}
+            />
+          </ButtonBar>
+        </EventListHeaderItem>
+      </EventListHeader>
+      <GridEditable
+        isLoading={isEventPending}
+        data={data}
+        columnOrder={[
+          {key: 'time', width: COL_WIDTH_UNDEFINED, name: t('Time')},
+          {key: 'statusCode', width: 115, name: t('Status Code')},
+          {key: 'method', width: 100, name: t('Method')},
+          {key: 'duration', width: 110, name: t('Duration')},
+          {key: 'env', width: COL_WIDTH_UNDEFINED, name: t('Environment')},
+          {key: 'trace', width: 100, name: t('Trace')},
+        ]}
+        columnSortBy={[]}
+        grid={{
+          renderHeadCell: (col: GridColumnOrder) => <Cell>{col.name}</Cell>,
+          renderBodyCell: (column, dataRow) => (
+            <CheckInBodyCell column={column} dataRow={dataRow} />
+          ),
+        }}
+      />
+    </StreamlineEventsTable>
+  );
+}
+
+function CheckInBodyCell({
+  dataRow,
+  column,
+}: {
+  column: GridColumnOrder<string>;
+  dataRow: CheckInDisplayData;
+}) {
+  const theme = useTheme();
+  const columnKey = column.key as keyof CheckInDisplayData;
+  const cellData = dataRow[columnKey];
+
+  if (!cellData) {
+    return <Cell />;
+  }
+
+  switch (columnKey) {
+    case 'time':
+      return (
+        <Cell>
+          <TimeSince date={new Date(cellData)} />
+        </Cell>
+      );
+    case 'duration':
+      if (typeof cellData === 'number') {
+        return (
+          <Cell>
+            <Duration seconds={cellData / 100000} abbreviation />
+          </Cell>
+        );
+      }
+      return <Cell>{cellData}</Cell>;
+    case 'statusCode':
+      const statusCodeFirstDigit = String(cellData)?.[0];
+      switch (statusCodeFirstDigit) {
+        case '2':
+          return <Cell style={{color: theme.successText}}>{cellData}</Cell>;
+        case '3':
+          return <Cell style={{color: theme.warningText}}>{cellData}</Cell>;
+        case '4':
+        case '5':
+          return <Cell style={{color: theme.errorText}}>{cellData}</Cell>;
+        default:
+          return <Cell>{cellData}</Cell>;
+      }
+    case 'trace':
+      return (
+        <LinkCell to={`/performance/trace/${cellData}`}>
+          {getShortEventId(String(cellData))}
+        </LinkCell>
+      );
+    default:
+      return <Cell>{dataRow[columnKey]}</Cell>;
+  }
+}
+
+const Cell = styled('span')`
+  text-align: left;
+  width: 100%;
+`;
+
+const LinkCell = styled(Link)`
+  text-decoration: underline;
+  text-decoration-color: ${p => p.theme.subText};
+  cursor: pointer;
+  text-decoration-style: dotted;
+`;
+
+const GrayLinkButton = styled(LinkButton)`
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeightNormal};
+`;
+
+export default GroupCheckIns;

--- a/static/app/views/issueDetails/groupOpenPeriods.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.tsx
@@ -11,6 +11,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {useParams} from 'sentry/utils/useParams';
+import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTable';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
 interface OpenPeriodDisplayData {
@@ -79,21 +80,23 @@ function IssueOpenPeriodsList() {
   };
 
   return (
-    <GridEditable
-      isLoading={isGroupPending}
-      data={data}
-      columnOrder={[
-        {key: 'title', width: COL_WIDTH_UNDEFINED, name: t('Title')},
-        {key: 'start', width: COL_WIDTH_UNDEFINED, name: t('Start')},
-        {key: 'end', width: COL_WIDTH_UNDEFINED, name: t('End')},
-        {key: 'duration', width: COL_WIDTH_UNDEFINED, name: t('Duration')},
-      ]}
-      columnSortBy={[]}
-      grid={{
-        renderHeadCell,
-        renderBodyCell,
-      }}
-    />
+    <EventListTable title={t('All Open Periods')} pagination={{enabled: false}}>
+      <GridEditable
+        isLoading={isGroupPending}
+        data={data}
+        columnOrder={[
+          {key: 'title', width: COL_WIDTH_UNDEFINED, name: t('Title')},
+          {key: 'start', width: COL_WIDTH_UNDEFINED, name: t('Start')},
+          {key: 'end', width: COL_WIDTH_UNDEFINED, name: t('End')},
+          {key: 'duration', width: COL_WIDTH_UNDEFINED, name: t('Duration')},
+        ]}
+        columnSortBy={[]}
+        grid={{
+          renderHeadCell,
+          renderBodyCell,
+        }}
+      />
+    </EventListTable>
   );
 }
 

--- a/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
+++ b/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
@@ -1,0 +1,49 @@
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+
+interface UptimeCheckInsParameters {
+  orgSlug: string;
+  projectSlug: string;
+  uptimeAlertId: string;
+}
+
+export interface UptimeCheckIn {
+  checkStatus: 'success' | 'failure' | 'missed_window';
+  checkStatusReason: string;
+  durationMs: number;
+  environment: string;
+  projectUptimeSubscriptionId: number;
+  region: string;
+  scheduledCheckTime: string;
+  // This hasn't been implemented on the backend yet
+  statusCode: string;
+  timestamp: string;
+  traceId: string;
+  uptimeCheckId: string;
+  uptimeSubscriptionId: number;
+}
+
+export function makeUptimeCheckInsQueryKey({
+  orgSlug,
+  projectSlug,
+  uptimeAlertId,
+}: UptimeCheckInsParameters): ApiQueryKey {
+  return [
+    `/organizations/${orgSlug}/${projectSlug}/uptime-alert/${uptimeAlertId}/checks/`,
+    {query: {per_page: 50}},
+  ];
+}
+
+export function useUptimeCheckIns(
+  params: UptimeCheckInsParameters,
+  options: Partial<UseApiQueryOptions<UptimeCheckIn[]>> = {}
+) {
+  return useApiQuery<UptimeCheckIn[]>(makeUptimeCheckInsQueryKey(params), {
+    staleTime: 10000,
+    retry: false,
+    ...options,
+  });
+}

--- a/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
+++ b/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
@@ -8,6 +8,8 @@ interface UptimeCheckInsParameters {
   orgSlug: string;
   projectSlug: string;
   uptimeAlertId: string;
+  cursor?: string;
+  limit?: number;
 }
 
 export interface UptimeCheckIn {
@@ -30,10 +32,12 @@ export function makeUptimeCheckInsQueryKey({
   orgSlug,
   projectSlug,
   uptimeAlertId,
+  cursor,
+  limit,
 }: UptimeCheckInsParameters): ApiQueryKey {
   return [
     `/organizations/${orgSlug}/${projectSlug}/uptime-alert/${uptimeAlertId}/checks/`,
-    {query: {per_page: 50}},
+    {query: {per_page: limit, cursor}},
   ];
 }
 
@@ -41,6 +45,7 @@ export function useUptimeCheckIns(
   params: UptimeCheckInsParameters,
   options: Partial<UseApiQueryOptions<UptimeCheckIn[]>> = {}
 ) {
+  // TODO(Leander): Add querying and sorting, when the endpoint supports it
   return useApiQuery<UptimeCheckIn[]>(makeUptimeCheckInsQueryKey(params), {
     staleTime: 10000,
     retry: false,

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -170,7 +170,7 @@ export function EventList({group}: EventListProps) {
   );
 }
 
-const EventListHeader = styled('div')`
+export const EventListHeader = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto auto;
   gap: ${space(1.5)};
@@ -184,19 +184,19 @@ const EventListHeader = styled('div')`
   border-radius: ${p => p.theme.borderRadiusTop};
 `;
 
-const EventListTitle = styled('div')`
+export const EventListTitle = styled('div')`
   color: ${p => p.theme.textColor};
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-const EventListHeaderItem = styled('div')`
+export const EventListHeaderItem = styled('div')`
   color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-const StreamlineEventsTable = styled('div')`
+export const StreamlineEventsTable = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
 

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -1,22 +1,9 @@
 import {useState} from 'react';
-import {css, useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
-import {LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {
-  GridBodyCell,
-  GridHead,
-  GridHeadCell,
-  GridResizer,
-  GridRow,
-} from 'sentry/components/gridEditable/styles';
-import Panel from 'sentry/components/panels/panel';
 import {IconChevron} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {t} from 'sentry/locale';
 import {type Group, IssueType} from 'sentry/types/group';
-import {parseCursor} from 'sentry/utils/cursor';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -24,6 +11,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {useEventColumns} from 'sentry/views/issueDetails/allEventsTable';
 import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/groupEvents';
+import {
+  EventListTable,
+  Header,
+  HeaderItem,
+  PaginationButton,
+  PaginationText,
+  Title,
+} from 'sentry/views/issueDetails/streamline/eventListTable';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import EventsTable from 'sentry/views/performance/transactionSummary/transactionEvents/eventsTable';
 
@@ -33,7 +28,6 @@ interface EventListProps {
 
 export function EventList({group}: EventListProps) {
   const referrer = 'issue_details.streamline_list';
-  const theme = useTheme();
   const location = useLocation();
   const organization = useOrganization();
   const routes = useRoutes();
@@ -75,17 +69,12 @@ export function EventList({group}: EventListProps) {
     eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
   }
 
-  const grayText = css`
-    color: ${theme.subText};
-    font-weight: ${theme.fontWeightNormal};
-  `;
-
   const isRegressionIssue =
     group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
     group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION;
 
   return (
-    <StreamlineEventsTable>
+    <EventListTable pagination={{enabled: false}}>
       <EventsTable
         eventView={eventView}
         location={location}
@@ -111,31 +100,24 @@ export function EventList({group}: EventListProps) {
           const links = parseLinkHeader(pageLinks);
           const previousDisabled = links.previous?.results === false;
           const nextDisabled = links.next?.results === false;
-          const currentCursor = parseCursor(location.query?.cursor);
-          const start = Math.max(currentCursor?.offset ?? 1, 1);
 
           return (
-            <EventListHeader>
-              <EventListTitle>{t('All Events')}</EventListTitle>
-              <EventListHeaderItem>
-                {isPending || pageEventsCount === 0
-                  ? null
-                  : tct('Showing [start]-[end] of [count] matching events', {
-                      start: start.toLocaleString(),
-                      end: (
-                        (currentCursor?.offset ?? 0) + pageEventsCount
-                      ).toLocaleString(),
-                      count: (totalEventsCount ?? 0).toLocaleString(),
-                    })}
-              </EventListHeaderItem>
-              <EventListHeaderItem>
+            <Header>
+              <Title>{t('All Events')}</Title>
+              <HeaderItem>
+                <PaginationText
+                  pageCount={pageEventsCount}
+                  totalCount={totalEventsCount}
+                  tableUnits={t('events')}
+                />
+              </HeaderItem>
+              <HeaderItem>
                 <ButtonBar gap={0.25}>
-                  <LinkButton
+                  <PaginationButton
                     aria-label={t('Previous Page')}
                     borderless
                     size="xs"
                     icon={<IconChevron direction="left" />}
-                    css={grayText}
                     to={{
                       ...location,
                       query: {
@@ -145,12 +127,11 @@ export function EventList({group}: EventListProps) {
                     }}
                     disabled={isPending || previousDisabled}
                   />
-                  <LinkButton
+                  <PaginationButton
                     aria-label={t('Next Page')}
                     borderless
                     size="xs"
                     icon={<IconChevron direction="right" />}
-                    css={grayText}
                     to={{
                       ...location,
                       query: {
@@ -161,104 +142,11 @@ export function EventList({group}: EventListProps) {
                     disabled={isPending || nextDisabled}
                   />
                 </ButtonBar>
-              </EventListHeaderItem>
-            </EventListHeader>
+              </HeaderItem>
+            </Header>
           );
         }}
       />
-    </StreamlineEventsTable>
+    </EventListTable>
   );
 }
-
-export const EventListHeader = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: ${space(1.5)};
-  align-items: center;
-  padding: ${space(1)} ${space(1)} ${space(1)} ${space(1.5)};
-  background: ${p => p.theme.background};
-  border-bottom: 1px solid ${p => p.theme.translucentBorder};
-  position: sticky;
-  top: 0;
-  z-index: ${p => p.theme.zIndex.header};
-  border-radius: ${p => p.theme.borderRadiusTop};
-`;
-
-export const EventListTitle = styled('div')`
-  color: ${p => p.theme.textColor};
-  font-weight: ${p => p.theme.fontWeightBold};
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-export const EventListHeaderItem = styled('div')`
-  color: ${p => p.theme.subText};
-  font-weight: ${p => p.theme.fontWeightNormal};
-  font-size: ${p => p.theme.fontSizeSmall};
-`;
-
-export const StreamlineEventsTable = styled('div')`
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-
-  ${Panel} {
-    border: 0;
-    margin-bottom: 0;
-  }
-
-  ${GridHead} {
-    min-height: unset;
-    font-size: ${p => p.theme.fontSizeMedium};
-    ${GridResizer} {
-      height: 36px;
-    }
-  }
-
-  ${GridHeadCell} {
-    height: 36px;
-    padding: 0 ${space(1.5)};
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    text-transform: none;
-    border-width: 0 1px 0 0;
-    border-style: solid;
-    border-image: linear-gradient(
-        to bottom,
-        transparent,
-        transparent 30%,
-        ${p => p.theme.border} 30%,
-        ${p => p.theme.border} 70%,
-        transparent 70%,
-        transparent
-      )
-      1;
-    &:last-child {
-      border: 0;
-    }
-    &:first-child {
-      padding-left: ${space(1.5)};
-    }
-  }
-
-  ${GridBodyCell} {
-    min-height: unset;
-    padding: ${space(1)} ${space(1.5)};
-    font-size: ${p => p.theme.fontSizeMedium};
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  ${GridRow} {
-    td:nth-child(2) {
-      padding-left: ${space(1.5)};
-    }
-
-    td:not(:nth-child(2)) {
-      a {
-        color: ${p => p.theme.textColor};
-        text-decoration: underline;
-        text-decoration-color: ${p => p.theme.border};
-      }
-    }
-  }
-`;

--- a/static/app/views/issueDetails/streamline/eventListTable.tsx
+++ b/static/app/views/issueDetails/streamline/eventListTable.tsx
@@ -1,0 +1,221 @@
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {
+  GridBodyCell,
+  GridHead,
+  GridHeadCell,
+  GridResizer,
+  GridRow,
+} from 'sentry/components/gridEditable/styles';
+import Panel from 'sentry/components/panels/panel';
+import {IconChevron} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {parseCursor} from 'sentry/utils/cursor';
+import type parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {useLocation} from 'sentry/utils/useLocation';
+
+interface EventListTableProps {
+  /**
+   * Should contain a <GridEditable /> to apply the streamlined styles
+   */
+  children: React.ReactNode;
+  /**
+   * The unit of the table, e.g. "events", "check-ins", "open periods", etc.
+   */
+  tableUnits: string;
+  title: React.ReactNode;
+  pagination?: {
+    links?: ReturnType<typeof parseLinkHeader>;
+    /**
+     * Whether the next page link is disabled
+     */
+    nextDisabled?: boolean;
+    /**
+     * Number of results displayed on the current page
+     */
+    pageCount?: number;
+    /**
+     * Whether the previous page link is disabled
+     */
+    previousDisabled?: boolean;
+    /**
+     * The total number of results for this table across all pages
+     */
+    totalCount?: number;
+  };
+}
+
+export function EventListTable({
+  children,
+  pagination,
+  tableUnits,
+  title,
+}: EventListTableProps) {
+  const location = useLocation();
+  const {
+    links,
+    pageCount = 0,
+    totalCount,
+    nextDisabled,
+    previousDisabled,
+  } = pagination ?? {};
+  const currentCursor = parseCursor(location.query?.cursor);
+  const start = Math.max(currentCursor?.offset ?? 1, 1);
+
+  const paginationText = defined(totalCount)
+    ? tct('Showing [start]-[end] of [count] matching [tableUnits]', {
+        start: start.toLocaleString(),
+        end: ((currentCursor?.offset ?? 0) + pageCount).toLocaleString(),
+        count: totalCount.toLocaleString(),
+        tableUnits,
+      })
+    : tct('Showing [start]-[end] matching [tableUnits]', {
+        start: start.toLocaleString(),
+        end: ((currentCursor?.offset ?? 0) + pageCount).toLocaleString(),
+        tableUnits,
+      });
+
+  return (
+    <StreamlineGridEditable>
+      <Header>
+        <Title>{title}</Title>
+        <HeaderItem>{pageCount !== 0 ? paginationText : null}</HeaderItem>
+        <HeaderItem>
+          <ButtonBar gap={0.25}>
+            <PaginationButton
+              aria-label={t('Previous Page')}
+              borderless
+              size="xs"
+              icon={<IconChevron direction="left" />}
+              to={{
+                ...location,
+                query: {
+                  ...location.query,
+                  cursor: links?.previous?.cursor,
+                },
+              }}
+              disabled={previousDisabled}
+            />
+            <PaginationButton
+              aria-label={t('Next Page')}
+              borderless
+              size="xs"
+              icon={<IconChevron direction="right" />}
+              to={{
+                ...location,
+                query: {
+                  ...location.query,
+                  cursor: links?.next?.cursor,
+                },
+              }}
+              disabled={nextDisabled}
+            />
+          </ButtonBar>
+        </HeaderItem>
+      </Header>
+      {children}
+    </StreamlineGridEditable>
+  );
+}
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: ${space(1.5)};
+  align-items: center;
+  padding: ${space(1)} ${space(1)} ${space(1)} ${space(1.5)};
+  background: ${p => p.theme.background};
+  border-bottom: 1px solid ${p => p.theme.translucentBorder};
+  position: sticky;
+  top: 0;
+  z-index: ${p => p.theme.zIndex.header};
+  border-radius: ${p => p.theme.borderRadiusTop};
+`;
+
+const Title = styled('div')`
+  color: ${p => p.theme.textColor};
+  font-weight: ${p => p.theme.fontWeightBold};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const HeaderItem = styled('div')`
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const StreamlineGridEditable = styled('div')`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+
+  ${Panel} {
+    border: 0;
+    margin-bottom: 0;
+  }
+
+  ${GridHead} {
+    min-height: unset;
+    font-size: ${p => p.theme.fontSizeMedium};
+    ${GridResizer} {
+      height: 36px;
+    }
+  }
+
+  ${GridHeadCell} {
+    height: 36px;
+    padding: 0 ${space(1.5)};
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    text-transform: none;
+    border-width: 0 1px 0 0;
+    border-style: solid;
+    border-image: linear-gradient(
+        to bottom,
+        transparent,
+        transparent 30%,
+        ${p => p.theme.border} 30%,
+        ${p => p.theme.border} 70%,
+        transparent 70%,
+        transparent
+      )
+      1;
+    &:last-child {
+      border: 0;
+    }
+    &:first-child {
+      padding-left: ${space(1.5)};
+    }
+  }
+
+  ${GridBodyCell} {
+    min-height: unset;
+    padding: ${space(1)} ${space(1.5)};
+    font-size: ${p => p.theme.fontSizeMedium};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  ${GridRow} {
+    td:nth-child(2) {
+      padding-left: ${space(1.5)};
+    }
+
+    td:not(:nth-child(2)) {
+      a {
+        color: ${p => p.theme.textColor};
+        text-decoration: underline;
+        text-decoration-color: ${p => p.theme.border};
+      }
+    }
+  }
+`;
+
+const PaginationButton = styled(LinkButton)`
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeightNormal};
+`;


### PR DESCRIPTION
Pagination and some useful tool tips show up. I think it's worth revising the timestamp tooltip per some conversations on slack, but I will circle back to that later on for now so I can move onto some main page changes.

<img width="910" alt="image" src="https://github.com/user-attachments/assets/24b22aaf-f825-4d2b-bb9e-aff54d952167" />

Also applies the new styling to the open period page

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/5253078a-40f5-49f7-945d-5998c3fc4bde" />
