### PR TITLE
ref(ourlogs): Add option for breadcrumb extraction count

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -522,6 +522,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Control number of breadcrumbs converted to OurLogs
+register(
+    "relay.ourlogs-breadcrumb-extraction.max-breadcrumbs-converted",
+    default=100,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Extract spans only from a random fraction of transactions.
 #

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -22,6 +22,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.metric-bucket-distribution-encodings",
     "relay.metric-stats.rollout-rate",
     "relay.ourlogs-breadcrumb-extraction.sample-rate",
+    "relay.ourlogs-breadcrumb-extraction.max-breadcrumbs-converted",
     "relay.span-extraction.sample-rate",
     "relay.span-normalization.allowed_hosts",
     "relay.drop-transaction-attachments",


### PR DESCRIPTION
### Summary
Adds an option for max breadcrumbs per event.

Needed for https://github.com/getsentry/relay/pull/4479
