### PR TITLE
feat(nav): Duplicate alerts route under /issues/alerts/

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2086,6 +2086,9 @@ function buildRoutes() {
         {issueTabs}
         <Route path={`${TabPaths[Tab.EVENTS]}:eventId/`}>{issueTabs}</Route>
       </Route>
+      <Route path="alerts/" component={make(() => import('sentry/views/alerts'))}>
+        {alertChildRoutes({forCustomerDomain: true})}
+      </Route>
       {traceViewRoute}
     </Route>
   );

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -32,10 +32,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
           </SecondaryNav.Section>
         </SecondaryNav.Body>
         <SecondaryNav.Footer>
-          {/* TODO(malwilley): Move alerts under the /issues/ route */}
-          <SecondaryNav.Item to={`/organizations/${organization.slug}/alerts/`}>
-            {t('Alerts')}
-          </SecondaryNav.Item>
+          <SecondaryNav.Item to={`${baseUrl}/alerts/`}>{t('Alerts')}</SecondaryNav.Item>
         </SecondaryNav.Footer>
       </SecondaryNav>
       {children}


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84016

Since alerts will live under the issues, this makes it to that alerts are rendered under `/issues/alerts/` as well. Existing links and redirects will be changed at a later point.