### PR TITLE
fix(issues): Move event id dropdown position

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -141,7 +141,8 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
                   {getShortEventId(event.id)}
                 </EventIdDropdownButton>
               )}
-              position="bottom"
+              position="bottom-start"
+              offset={2}
               size="xs"
               items={[
                 {

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -142,7 +142,7 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
                 </EventIdDropdownButton>
               )}
               position="bottom-start"
-              offset={2}
+              offset={4}
               size="xs"
               items={[
                 {


### PR DESCRIPTION
left aligns the dropdown. bring it a little closer

before
![image](https://github.com/user-attachments/assets/6db35bd1-6b33-41a8-afbd-7f05b70896ca)


after
![image](https://github.com/user-attachments/assets/5c44908f-4276-4213-be38-68427f2b6931)

