### PR TITLE
fix(grouping): Make system frames not contribute to app variant

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -176,6 +176,7 @@ class Enhancements:
 
     def assemble_stacktrace_component(
         self,
+        variant_name: str,
         frame_components: list[FrameGroupingComponent],
         frames: list[dict[str, Any]],
         platform: str | None,

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -205,15 +205,61 @@ class Enhancements:
         # to Seer
         frame_counts: Counter[str] = Counter()
 
+        # Update frame components with results from rust
         for py_component, rust_component in zip(frame_components, rust_components):
-            py_component.update(contributes=rust_component.contributes, hint=rust_component.hint)
+            # TODO: Remove the first condition once we get rid of the legacy config
+            if (
+                not (self.bases and self.bases[0].startswith("legacy"))
+                and variant_name == "app"
+                and not py_component.in_app
+            ):
+                # System frames should never contribute in the app variant, so force
+                # `contribtues=False`, regardless of the rust results. Use the rust hint if it
+                # explains the `in_app` value (but not if it explains the `contributing` value,
+                # because we're ignoring that)
+                #
+                # TODO: Right now, if stacktrace rules have modified both the `in_app` and
+                # `contributes` values, then the hint you get back from the rust enhancers depends
+                # on the order in which those changes happened, which in turn depends on both the
+                # order of stacktrace rules and the order of the actions within a stacktrace rule.
+                # Ideally we'd get both hints back.
+                hint = (
+                    rust_component.hint
+                    if rust_component.hint and rust_component.hint.startswith("marked out of app")
+                    else py_component.hint
+                )
+                py_component.update(contributes=False, hint=hint)
+            else:
+                py_component.update(
+                    contributes=rust_component.contributes, hint=rust_component.hint
+                )
+
+            # Add this frame to our tally
             key = f"{"in_app" if py_component.in_app else "system"}_{"contributing" if py_component.contributes else "non_contributing"}_frames"
             frame_counts[key] += 1
 
+        # Because of the special case above, in which we ignore the rust-derived `contributes` value
+        # for certain frames, it's possible for the rust-derived `contributes` value for the overall
+        # stacktrace to be wrong, too (if in the process of ignoring rust we turn a stacktrace with
+        # at least one contributing frame into one without any). So we need to special-case here as
+        # well.
+        #
+        # TODO: Remove the first condition once we get rid of the legacy config
+        if (
+            not (self.bases and self.bases[0].startswith("legacy"))
+            and variant_name == "app"
+            and frame_counts["in_app_contributing_frames"] == 0
+        ):
+            stacktrace_contributes = False
+            stacktrace_hint = None
+        else:
+            stacktrace_contributes = rust_results.contributes
+            stacktrace_hint = rust_results.hint
+
         stacktrace_component = StacktraceGroupingComponent(
             values=frame_components,
-            hint=rust_results.hint,
-            contributes=rust_results.contributes,
+            hint=stacktrace_hint,
+            contributes=stacktrace_contributes,
             frame_counts=frame_counts,
         )
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -192,6 +192,10 @@ class Enhancements:
 
         rust_components = [RustComponent(contributes=c.contributes) for c in frame_components]
 
+        # Modify the rust components by applying +group/-group rules and getting hints for both
+        # those changes and the `in_app` changes applied by earlier in the ingestion process by
+        # `apply_category_and_updated_in_app_to_frames`. Also, get `hint` and `contributes` values
+        # for the overall stacktrace (returned in `rust_results`).
         rust_results = self.rust_enhancements.assemble_stacktrace_component(
             match_frames, make_rust_exception_data(exception_data), rust_components
         )

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -448,7 +448,7 @@ def stacktrace_legacy(
         prev_frame = frame
 
     stacktrace_component = context.config.enhancements.assemble_stacktrace_component(
-        frame_components, frames_for_filtering, event.platform
+        variant_name, frame_components, frames_for_filtering, event.platform
     )
     stacktrace_component.update(contributes=contributes, hint=hint)
     return {variant_name: stacktrace_component}

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -464,6 +464,7 @@ def _single_stacktrace_variant(
         )
 
     stacktrace_component = context.config.enhancements.assemble_stacktrace_component(
+        variant_name,
         frame_components,
         frames_for_filtering,
         event.platform,

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:41:17.184133+00:00'
+created: '2025-01-30T21:45:36.771348+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,13 +24,29 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    hash: "161ce02ecc5d6685a72e8e520ab726b3"
     contributing component: exception
     component:
       app*
         exception*
           stacktrace*
-            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "dogpark.js"
+              function*
+                "playFetch"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"
+  system*
+    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          stacktrace*
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:41:17.269522+00:00'
+created: '2025-01-30T21:45:36.965256+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "in_app"
+  "stacktrace_type": "system"
 }
 ---
 metrics with tags: {
@@ -18,19 +18,19 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "in_app"
+    "stacktrace_type": "system"
   }
 }
 ---
 contributing variants:
-  app*
+  system*
     hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
     contributing component: exception
     component:
-      app*
+      system*
         exception*
           stacktrace*
-            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:41:01.822552+00:00'
+created: '2025-01-30T21:46:13.738334+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,13 +24,29 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    hash: "161ce02ecc5d6685a72e8e520ab726b3"
     contributing component: exception
     component:
       app*
         exception*
           stacktrace*
-            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "dogpark.js"
+              function*
+                "playFetch"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"
+  system*
+    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          stacktrace*
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:41:01.889599+00:00'
+created: '2025-01-30T21:46:13.879780+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "in_app"
+  "stacktrace_type": "system"
 }
 ---
 metrics with tags: {
@@ -18,19 +18,19 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "in_app"
+    "stacktrace_type": "system"
   }
 }
 ---
 contributing variants:
-  app*
+  system*
     hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
     contributing component: exception
     component:
-      app*
+      system*
         exception*
           stacktrace*
-            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:40:46.962385+00:00'
+created: '2025-01-30T21:46:37.831164+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,13 +24,29 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    hash: "161ce02ecc5d6685a72e8e520ab726b3"
     contributing component: exception
     component:
       app*
         exception*
           stacktrace*
-            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+              filename*
+                "dogpark.js"
+              function*
+                "playFetch"
+              context-line*
+                "raise FailedToFetchError('Charlie didn't bring the ball back!');"
+          type*
+            "FailedToFetchError"
+  system*
+    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          stacktrace*
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:40:47.031377+00:00'
+created: '2025-01-30T21:46:37.985114+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "in_app"
+  "stacktrace_type": "system"
 }
 ---
 metrics with tags: {
@@ -18,19 +18,19 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "in_app"
+    "stacktrace_type": "system"
   }
 }
 ---
 contributing variants:
-  app*
+  system*
     hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
     contributing component: exception
     component:
-      app*
+      system*
         exception*
           stacktrace*
-            frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-01-30T21:38:17.979729+00:00'
+created: '2025-01-30T21:48:30.179389+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  hash: "161ce02ecc5d6685a72e8e520ab726b3"
   contributing component: exception
   component:
     app*
@@ -17,7 +17,7 @@ app:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+          frame (non app frame)
             filename*
               "router.js"
             function*
@@ -44,11 +44,11 @@ app:
           "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -app -group))
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_frames.pysnap
@@ -1,15 +1,15 @@
 ---
-created: '2025-01-30T21:38:18.144167+00:00'
+created: '2025-01-30T21:48:30.270003+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
-  contributing component: exception
+  hash: null
+  contributing component: null
   component:
-    app*
-      exception*
-        stacktrace*
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by stack trace rule (function:runApp -app -group))
             filename*
               "app.js"
@@ -17,7 +17,7 @@ app:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+          frame (non app frame)
             filename*
               "router.js"
             function*
@@ -33,15 +33,15 @@ app:
               "return withMetrics(handler, metricName, tags);"
         type*
           "FailedToFetchError"
-        value (ignored because stacktrace takes precedence)
+        value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -app -group))
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_and_app_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-01-30T21:37:56.171192+00:00'
+created: '2025-01-30T21:48:09.575427+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  hash: "161ce02ecc5d6685a72e8e520ab726b3"
   contributing component: exception
   component:
     app*
@@ -17,7 +17,7 @@ app:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+          frame (non app frame)
             filename*
               "router.js"
             function*
@@ -44,11 +44,11 @@ app:
           "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -app -group))
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/contributing_system_frames.pysnap
@@ -1,15 +1,15 @@
 ---
-created: '2025-01-30T21:37:56.373019+00:00'
+created: '2025-01-30T21:48:09.726306+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
-  contributing component: exception
+  hash: null
+  contributing component: null
   component:
-    app*
-      exception*
-        stacktrace*
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by stack trace rule (function:runApp -app -group))
             filename*
               "app.js"
@@ -17,7 +17,7 @@ app:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+          frame (non app frame)
             filename*
               "router.js"
             function*
@@ -33,15 +33,15 @@ app:
               "return withMetrics(handler, metricName, tags);"
         type*
           "FailedToFetchError"
-        value (ignored because stacktrace takes precedence)
+        value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -app -group))
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-01-30T21:37:24.805215+00:00'
+created: '2025-01-30T21:49:11.496007+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  hash: "161ce02ecc5d6685a72e8e520ab726b3"
   contributing component: exception
   component:
     app*
@@ -17,7 +17,7 @@ app:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+          frame (non app frame)
             filename*
               "router.js"
             function*
@@ -44,11 +44,11 @@ app:
           "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -app -group))
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,15 +1,15 @@
 ---
-created: '2025-01-30T21:37:24.936142+00:00'
+created: '2025-01-30T21:49:11.604093+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
-  contributing component: exception
+  hash: null
+  contributing component: null
   component:
-    app*
-      exception*
-        stacktrace*
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by stack trace rule (function:runApp -app -group))
             filename*
               "app.js"
@@ -17,7 +17,7 @@ app:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (un-ignored by stack trace rule (function:handleRequest -app +group))
+          frame (non app frame)
             filename*
               "router.js"
             function*
@@ -33,15 +33,15 @@ app:
               "return withMetrics(handler, metricName, tags);"
         type*
           "FailedToFetchError"
-        value (ignored because stacktrace takes precedence)
+        value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -app -group))
             filename*

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -117,20 +117,35 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        for variant_name in ["app", "system"]:
-            exception_component = variants[variant_name].component.values[0]
-            assert isinstance(exception_component, ExceptionGroupingComponent)
-            stacktrace_component = find_given_child_component(
-                exception_component, StacktraceGroupingComponent
-            )
-            assert stacktrace_component
+        system_exception_component = variants["system"].component.values[0]
+        assert isinstance(system_exception_component, ExceptionGroupingComponent)
+        system_stacktrace_component = find_given_child_component(
+            system_exception_component, StacktraceGroupingComponent
+        )
+        assert system_stacktrace_component
 
-            assert stacktrace_component.frame_counts == Counter(
-                system_non_contributing_frames=11,
-                system_contributing_frames=21,
-                in_app_non_contributing_frames=12,
-                in_app_contributing_frames=31,
-            )
+        assert system_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=11,
+            system_contributing_frames=21,
+            in_app_non_contributing_frames=12,
+            in_app_contributing_frames=31,
+        )
+
+        # In the app variant, there's no such thing as a contributing system frame, so all the
+        # system frames count as non-contributing
+        app_exception_component = variants["app"].component.values[0]
+        assert isinstance(app_exception_component, ExceptionGroupingComponent)
+        app_stacktrace_component = find_given_child_component(
+            app_exception_component, StacktraceGroupingComponent
+        )
+        assert app_stacktrace_component
+
+        assert app_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=32,
+            system_contributing_frames=0,
+            in_app_non_contributing_frames=12,
+            in_app_contributing_frames=31,
+        )
 
     def test_stacktrace_component_tallies_frame_types_not_all_types_present(self):
         self.event.data["exception"]["values"][0]["stacktrace"] = {
@@ -142,20 +157,35 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        for variant_name in ["app", "system"]:
-            exception_component = variants[variant_name].component.values[0]
-            assert isinstance(exception_component, ExceptionGroupingComponent)
-            stacktrace_component = find_given_child_component(
-                exception_component, StacktraceGroupingComponent
-            )
-            assert stacktrace_component
+        system_exception_component = variants["system"].component.values[0]
+        assert isinstance(system_exception_component, ExceptionGroupingComponent)
+        system_stacktrace_component = find_given_child_component(
+            system_exception_component, StacktraceGroupingComponent
+        )
+        assert system_stacktrace_component
 
-            assert stacktrace_component.frame_counts == Counter(
-                system_non_contributing_frames=0,
-                system_contributing_frames=20,
-                in_app_non_contributing_frames=0,
-                in_app_contributing_frames=13,
-            )
+        assert system_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=0,
+            system_contributing_frames=20,
+            in_app_non_contributing_frames=0,
+            in_app_contributing_frames=13,
+        )
+
+        # In the app variant, there's no such thing as a contributing system frame, so all the
+        # system frames count as non-contributing
+        app_exception_component = variants["app"].component.values[0]
+        assert isinstance(app_exception_component, ExceptionGroupingComponent)
+        app_stacktrace_component = find_given_child_component(
+            app_exception_component, StacktraceGroupingComponent
+        )
+        assert app_stacktrace_component
+
+        assert app_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=20,
+            system_contributing_frames=0,
+            in_app_non_contributing_frames=0,
+            in_app_contributing_frames=13,
+        )
 
     def test_exception_component_uses_stacktrace_frame_counts(self):
         self.event.data["exception"]["values"][0]["stacktrace"] = {
@@ -170,21 +200,37 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        for variant_name in ["app", "system"]:
-            exception_component = variants[variant_name].component.values[0]
-            assert isinstance(exception_component, ExceptionGroupingComponent)
-            stacktrace_component = find_given_child_component(
-                exception_component, StacktraceGroupingComponent
-            )
-            assert stacktrace_component
+        system_exception_component = variants["system"].component.values[0]
+        assert isinstance(system_exception_component, ExceptionGroupingComponent)
+        system_stacktrace_component = find_given_child_component(
+            system_exception_component, StacktraceGroupingComponent
+        )
+        assert system_stacktrace_component
 
-            assert stacktrace_component.frame_counts == Counter(
-                system_non_contributing_frames=4,
-                system_contributing_frames=15,
-                in_app_non_contributing_frames=9,
-                in_app_contributing_frames=8,
-            )
-            assert exception_component.frame_counts == stacktrace_component.frame_counts
+        assert system_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=4,
+            system_contributing_frames=15,
+            in_app_non_contributing_frames=9,
+            in_app_contributing_frames=8,
+        )
+        assert system_exception_component.frame_counts == system_stacktrace_component.frame_counts
+
+        # In the app variant, there's no such thing as a contributing system frame, so all the
+        # system frames count as non-contributing
+        app_exception_component = variants["app"].component.values[0]
+        assert isinstance(app_exception_component, ExceptionGroupingComponent)
+        app_stacktrace_component = find_given_child_component(
+            app_exception_component, StacktraceGroupingComponent
+        )
+        assert app_stacktrace_component
+
+        assert app_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=19,
+            system_contributing_frames=0,
+            in_app_non_contributing_frames=9,
+            in_app_contributing_frames=8,
+        )
+        assert app_exception_component.frame_counts == app_stacktrace_component.frame_counts
 
     def test_threads_component_uses_stacktrace_frame_counts(self):
         self.event.data["threads"] = self.event.data.pop("exception")
@@ -200,21 +246,37 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        for variant_name in ["app", "system"]:
-            threads_component = variants[variant_name].component.values[0]
-            assert isinstance(threads_component, ThreadsGroupingComponent)
-            stacktrace_component = find_given_child_component(
-                threads_component, StacktraceGroupingComponent
-            )
-            assert stacktrace_component
+        system_threads_component = variants["system"].component.values[0]
+        assert isinstance(system_threads_component, ThreadsGroupingComponent)
+        system_stacktrace_component = find_given_child_component(
+            system_threads_component, StacktraceGroupingComponent
+        )
+        assert system_stacktrace_component
 
-            assert stacktrace_component.frame_counts == Counter(
-                system_non_contributing_frames=20,
-                system_contributing_frames=12,
-                in_app_non_contributing_frames=20,
-                in_app_contributing_frames=13,
-            )
-            assert threads_component.frame_counts == stacktrace_component.frame_counts
+        assert system_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=20,
+            system_contributing_frames=12,
+            in_app_non_contributing_frames=20,
+            in_app_contributing_frames=13,
+        )
+        assert system_threads_component.frame_counts == system_stacktrace_component.frame_counts
+
+        # In the app variant, there's no such thing as a contributing system frame, so all the
+        # system frames count as non-contributing
+        app_threads_component = variants["app"].component.values[0]
+        assert isinstance(app_threads_component, ThreadsGroupingComponent)
+        app_stacktrace_component = find_given_child_component(
+            app_threads_component, StacktraceGroupingComponent
+        )
+        assert app_stacktrace_component
+
+        assert app_stacktrace_component.frame_counts == Counter(
+            system_non_contributing_frames=32,
+            system_contributing_frames=0,
+            in_app_non_contributing_frames=20,
+            in_app_contributing_frames=13,
+        )
+        assert app_threads_component.frame_counts == app_stacktrace_component.frame_counts
 
     def test_chained_exception_component_sums_stacktrace_frame_counts(self):
         self.event.data["exception"]["values"] = [
@@ -241,30 +303,58 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        for variant_name in ["app", "system"]:
-            chained_exception_component = variants[variant_name].component.values[0]
-            assert isinstance(chained_exception_component, ChainedExceptionGroupingComponent)
-            exception_components = chained_exception_component.values
-            assert [
-                exception_component.frame_counts for exception_component in exception_components
-            ] == [
-                Counter(
-                    system_non_contributing_frames=11,
-                    system_contributing_frames=21,
-                    in_app_non_contributing_frames=12,
-                    in_app_contributing_frames=31,
-                ),
-                Counter(
-                    system_non_contributing_frames=4,
-                    system_contributing_frames=15,
-                    in_app_non_contributing_frames=9,
-                    in_app_contributing_frames=8,
-                ),
-            ]
+        system_chained_exception_component = variants["system"].component.values[0]
+        assert isinstance(system_chained_exception_component, ChainedExceptionGroupingComponent)
+        system_exception_components = system_chained_exception_component.values
+        assert [
+            exception_component.frame_counts for exception_component in system_exception_components
+        ] == [
+            Counter(
+                system_non_contributing_frames=11,
+                system_contributing_frames=21,
+                in_app_non_contributing_frames=12,
+                in_app_contributing_frames=31,
+            ),
+            Counter(
+                system_non_contributing_frames=4,
+                system_contributing_frames=15,
+                in_app_non_contributing_frames=9,
+                in_app_contributing_frames=8,
+            ),
+        ]
 
-            assert chained_exception_component.frame_counts == Counter(
-                system_non_contributing_frames=15,
-                system_contributing_frames=36,
-                in_app_non_contributing_frames=21,
-                in_app_contributing_frames=39,
-            )
+        assert system_chained_exception_component.frame_counts == Counter(
+            system_non_contributing_frames=15,
+            system_contributing_frames=36,
+            in_app_non_contributing_frames=21,
+            in_app_contributing_frames=39,
+        )
+
+        # In the app variant, there's no such thing as a contributing system frame, so all the
+        # system frames count as non-contributing
+        app_chained_exception_component = variants["app"].component.values[0]
+        assert isinstance(app_chained_exception_component, ChainedExceptionGroupingComponent)
+        app_exception_components = app_chained_exception_component.values
+        assert [
+            exception_component.frame_counts for exception_component in app_exception_components
+        ] == [
+            Counter(
+                system_non_contributing_frames=32,
+                system_contributing_frames=0,
+                in_app_non_contributing_frames=12,
+                in_app_contributing_frames=31,
+            ),
+            Counter(
+                system_non_contributing_frames=19,
+                system_contributing_frames=0,
+                in_app_non_contributing_frames=9,
+                in_app_contributing_frames=8,
+            ),
+        ]
+
+        assert app_chained_exception_component.frame_counts == Counter(
+            system_non_contributing_frames=51,
+            system_contributing_frames=0,
+            in_app_non_contributing_frames=21,
+            in_app_contributing_frames=39,
+        )

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 from unittest import mock
 
 import pytest
 
+from sentry.grouping.component import FrameGroupingComponent, StacktraceGroupingComponent
 from sentry.grouping.enhancer import (
     Enhancements,
     is_valid_profiling_action,
@@ -13,6 +16,7 @@ from sentry.grouping.enhancer import (
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import _cached, create_match_frame
+from sentry.testutils.cases import TestCase
 
 
 def dump_obj(obj):
@@ -563,3 +567,290 @@ family:javascript,native -group
 )
 def test_keep_profiling_rules(test_input, expected):
     assert keep_profiling_rules(test_input) == expected
+
+
+@dataclass
+class DummyRustComponent:
+    contributes: bool | None
+    hint: str | None
+
+
+@dataclass
+class DummyRustAssembleResult:
+    contributes: bool | None
+    hint: str | None
+
+
+DummyRustExceptionData = dict[str, bytes | None]
+DummyRustFrame = dict[str, Any]
+
+
+class MockRustEnhancements:
+    def __init__(
+        self,
+        frame_results: Sequence[tuple[bool, str | None]],
+        stacktrace_results: tuple[bool, str | None] = (True, None),
+    ):
+        self.frame_results = frame_results
+        self.stacktrace_results = stacktrace_results
+
+    def assemble_stacktrace_component(
+        self,
+        _match_frames: list[DummyRustFrame],
+        _exception_data: DummyRustExceptionData,
+        rust_components: list[DummyRustComponent],
+    ) -> DummyRustAssembleResult:
+        # The real (rust) version of this function modifies the components in
+        # `rust_components` in place, but that's not possible from python, so instead we
+        # replace the contents of the list with our own components
+        dummy_rust_components = [
+            DummyRustComponent(contributes, hint) for contributes, hint in self.frame_results
+        ]
+        rust_components[:] = dummy_rust_components
+
+        return DummyRustAssembleResult(*self.stacktrace_results)
+
+
+def in_app_frame(contributes: bool, hint: str | None) -> FrameGroupingComponent:
+    return FrameGroupingComponent(values=[], in_app=True, contributes=contributes, hint=hint)
+
+
+def system_frame(contributes: bool, hint: str | None) -> FrameGroupingComponent:
+    return FrameGroupingComponent(values=[], in_app=False, contributes=contributes, hint=hint)
+
+
+class AssembleStacktraceComponentTest(TestCase):
+    def assert_frame_values_match_expected(
+        self,
+        stacktrace_component: StacktraceGroupingComponent,
+        expected_frame_results: Sequence[tuple[bool, str | None]],
+    ) -> None:
+        num_frames = len(stacktrace_component.values)
+        assert len(expected_frame_results) == num_frames
+
+        for i, frame_component, (expected_contributes, expected_hint) in zip(
+            range(num_frames),
+            stacktrace_component.values,
+            expected_frame_results,
+        ):
+            assert (
+                frame_component.contributes is expected_contributes
+            ), f"frame {i} has incorrect `contributes` value"
+
+            assert frame_component.hint == expected_hint, f"frame {i} has incorrect `hint` value"
+
+    def test_uses_results_from_rust_enhancers_simple(self):
+        """
+        Test that the `contributing` and `hint` results from the rust enhancers are used for both
+        frame and stacktrace components.
+        """
+        frame_components = [
+            # All four types of frames (all combos of app vs system, contributing vs not), twice
+            # each because in each case there are three possible hints rust could send back
+            in_app_frame(contributes=True, hint=None),
+            in_app_frame(contributes=True, hint=None),
+            in_app_frame(contributes=False, hint=None),
+            in_app_frame(contributes=False, hint=None),
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=False, hint=None),
+            system_frame(contributes=False, hint=None),
+        ]
+
+        rust_frame_results = [
+            # All of these change the `contributes` value of their respective frames, to show that
+            # it's the rust value which gets used in the end. Note that in the cases where the hint
+            # is about the in-app-ness of the frame, it means that both a `+/-group` rule applied
+            # and a `+/-app` rule applied, with the latter second, such that its "marked in/out of
+            # app" hint overwrote the "ignored/unignored" hint. Note that egardless of the hint, the
+            # first value in each tuple is a `contributes` value, not an `in_app` value.
+            (False, "ignored by stacktrace rule (...)"),
+            (False, "marked in-app by stacktrace rule (...)"),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, "marked in-app by stacktrace rule (...)"),
+            (False, "ignored by stacktrace rule (...)"),
+            (False, "marked out of app by stacktrace rule (...)"),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, "marked out of app by stacktrace rule (...)"),
+        ]
+
+        enhancements = Enhancements.from_config_string("")
+        mock_rust_enhancements = MockRustEnhancements(
+            frame_results=rust_frame_results,
+            stacktrace_results=(True, "some stacktrace hint"),
+        )
+
+        with mock.patch.object(enhancements, "rust_enhancements", mock_rust_enhancements):
+            stacktrace_component = enhancements.assemble_stacktrace_component(
+                variant_name="system",
+                frame_components=frame_components,
+                frames=[{}] * 8,
+                platform="javascript",
+                exception_data={},
+            )
+
+            self.assert_frame_values_match_expected(
+                stacktrace_component, expected_frame_results=rust_frame_results
+            )
+
+            assert stacktrace_component.contributes is True
+            assert stacktrace_component.hint == "some stacktrace hint"
+
+    def test_always_marks_app_variant_system_frames_non_contributing(self):
+        """
+        Test that the rust results are used or ignored as appropriate when handling the app variant,
+        and are always used when handling the system variant.
+        """
+        app_variant_frame_components = [
+            system_frame(contributes=False, hint="non app frame"),
+            system_frame(contributes=False, hint="non app frame"),
+            system_frame(contributes=False, hint="non app frame"),
+            system_frame(contributes=False, hint="non app frame"),
+            system_frame(contributes=False, hint="non app frame"),
+            system_frame(contributes=False, hint="non app frame"),
+        ]
+        system_variant_frame_components = [
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=True, hint=None),
+            system_frame(contributes=True, hint=None),
+        ]
+
+        rust_frame_results = [
+            # All the possible results which could be sent back for system frames (IOW, everything
+            # but "marked in-app"). See more detail about possible hints in both the
+            # `Enhancements.assemble_stacktrace_component` code and the `test_simple` test above.
+            (False, "ignored by stacktrace rule (...)"),
+            (False, "marked out of app by stacktrace rule (...)"),
+            (False, None),
+            (True, "un-ignored by stacktrace rule (...)"),
+            (True, "marked out of app by stacktrace rule (...)"),
+            (True, None),
+        ]
+
+        app_expected_frame_results = [
+            # None of the frames contributes, because they're all out of app, and the rust hint is
+            # only used when it relates to a `-app` rule.
+            (False, "non app frame"),
+            (False, "marked out of app by stacktrace rule (...)"),
+            (False, "non app frame"),
+            (False, "non app frame"),
+            (False, "marked out of app by stacktrace rule (...)"),
+            (False, "non app frame"),
+        ]
+        # The system variant just takes its values straight from rust
+        system_expected_frame_results = rust_frame_results
+
+        enhancements = Enhancements.from_config_string("")
+        mock_rust_enhancements = MockRustEnhancements(frame_results=rust_frame_results)
+
+        with mock.patch.object(enhancements, "rust_enhancements", mock_rust_enhancements):
+            app_stacktrace_component = enhancements.assemble_stacktrace_component(
+                variant_name="app",
+                frame_components=app_variant_frame_components,
+                frames=[{}] * 6,
+                platform="javascript",
+                exception_data={},
+            )
+            system_stacktrace_component = enhancements.assemble_stacktrace_component(
+                variant_name="system",
+                frame_components=system_variant_frame_components,
+                frames=[{}] * 6,
+                platform="javascript",
+                exception_data={},
+            )
+
+            self.assert_frame_values_match_expected(
+                app_stacktrace_component, expected_frame_results=app_expected_frame_results
+            )
+            self.assert_frame_values_match_expected(
+                system_stacktrace_component, expected_frame_results=system_expected_frame_results
+            )
+
+    def test_marks_app_stacktrace_non_contributing_if_no_in_app_frames(self):
+        """
+        Test that if frame special-casing for the app variant results in no contributing frames, the
+        stacktrace is marked non-contributing.
+        """
+        frame_components = [
+            # All possibilities (all combos of app vs system, contributing vs not) except a
+            # contributing system frame, since that will never be passed to
+            # `assemble_stacktrace_component` when dealing with the app variant
+            system_frame(contributes=False, hint="non app frame"),
+            in_app_frame(contributes=False, hint="ignored due to recursion"),
+            in_app_frame(contributes=True, hint=None),
+        ]
+
+        # With these results, there will still be a contributing frame in the end
+        rust_frame_results1 = [
+            (True, "un-ignored by stacktrace rule (...)"),
+            (False, None),
+            (True, None),
+        ]
+        # With these results, there won't
+        rust_frame_results2 = [
+            (True, "un-ignored by stacktrace rule (...)"),
+            (False, None),
+            (False, "ignored by stacktrace rule (...)"),
+        ]
+
+        # In both cases, the first frame doesn't contribute because it's a system frame, even though
+        # the rust results say it should
+        expected_frame_results1 = [
+            (False, "non app frame"),
+            (False, "ignored due to recursion"),
+            (True, None),
+        ]
+        expected_frame_results2 = [
+            (False, "non app frame"),
+            (False, "ignored due to recursion"),
+            (False, "ignored by stacktrace rule (...)"),
+        ]
+
+        enhancements1 = Enhancements.from_config_string("")
+        mock_rust_enhancements1 = MockRustEnhancements(
+            frame_results=rust_frame_results1, stacktrace_results=(True, None)
+        )
+        enhancements2 = Enhancements.from_config_string("")
+        mock_rust_enhancements2 = MockRustEnhancements(
+            frame_results=rust_frame_results2, stacktrace_results=(True, None)
+        )
+
+        # In this case, even after we force the system frame not to contribute, we'll still have
+        # another contributing frame, so we'll use rust's `contributing: True` for the stacktrace
+        # component.
+        with mock.patch.object(enhancements1, "rust_enhancements", mock_rust_enhancements1):
+            stacktrace_component1 = enhancements1.assemble_stacktrace_component(
+                variant_name="app",
+                frame_components=frame_components,
+                frames=[{}] * 3,
+                platform="javascript",
+                exception_data={},
+            )
+
+            self.assert_frame_values_match_expected(
+                stacktrace_component1, expected_frame_results=expected_frame_results1
+            )
+
+            assert stacktrace_component1.contributes is True
+            assert stacktrace_component1.hint is None
+
+        # In this case, once we force the system frame not to contribute, we won't have any
+        # contributing frames, so we'll force `contributing: False` for the stacktrace component.
+        with mock.patch.object(enhancements2, "rust_enhancements", mock_rust_enhancements2):
+            stacktrace_component2 = enhancements2.assemble_stacktrace_component(
+                variant_name="app",
+                frame_components=frame_components,
+                frames=[{}] * 3,
+                platform="javascript",
+                exception_data={},
+            )
+
+            self.assert_frame_values_match_expected(
+                stacktrace_component2, expected_frame_results=expected_frame_results2
+            )
+
+            assert stacktrace_component2.contributes is False
+            assert stacktrace_component2.hint is None

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -1052,7 +1052,6 @@ class HasTooManyFramesTest(TestCase):
             is False  # Not flagged as too many because only in-app frames are counted
         )
 
-    @pytest.mark.skip(reason="wonky behavior with -app +group rules")
     def test_uses_app_or_system_variants(self):
         for frame, expected_variant_name in [
             (self.contributing_in_app_frame, "app"),


### PR DESCRIPTION
When we do grouping based on stacktrace, we actually produce two hashes, one based on the full stacktrace and one based on only the in-app frames. Right now, it's possible for non-app ("system") frames to be included in the app hash if they're subject to a `+group` stacktrace rule. 

This fixes that by checking the results which come back from the rust enhancer (which is what actually does the application of the stacktrace rules) when we're calculating the app hash and overriding them if necessary, to weed out the rogue system frames. Doing this can change a stacktrace which rust thinks has contributing frames to one which no longer does (and therefore shouldn't contribute to the hash), so we also now check the full stacktrace in the app variant and override its `contributing` value in that case.

The effects of this change are easiest to see in the `test_variants/test_event_hash_variant` newstyle snapshots. (The metadata snapshots, because they don't show both app and system variants, do show the correct changes, but in a way which is less intuitive.) 

- In both inputs([here](https://github.com/getsentry/sentry/blob/e4888e1eb290ab59dff98729f3992551bfe23f3e/tests/sentry/grouping/grouping_inputs/contributing_system_and_app_frames.json) and [here](https://github.com/getsentry/sentry/blob/e4888e1eb290ab59dff98729f3992551bfe23f3e/tests/sentry/grouping/grouping_inputs/contributing_system_frames.json)), the `handleRequest` frame from `router.js` is a system frame which has until now been counted as contributing to the app variant because of the `stack.function:handleRequest -app +group` rule.

- In `contributing_system_and_app_frames`, the app variant also has the in-app `playFetch` frame contributing, so even though the app hash changes when the `handleRequest` frame stops contributing, the app variant's stacktrace remains contributing. (Note that the hash change won't actually lead to new groups, since the old hash, which used to match the system hash, is still being produced by the system variant.)
  
  ![image](https://github.com/user-attachments/assets/9d49bdd6-9476-40cc-a460-4ffa253f1f76)

- In `contributing_system_frames`, the only contributing frame the app variant had was the `handleRequest` frame. With it now not contributing, the app variant has no contributing frames, so its stacktrace has switched from contributing to not contributing. (Again here, no new group will be formed because the system hash remains the same.)

  ![image](https://github.com/user-attachments/assets/e65b5a55-4bbd-43c8-8aef-3a9dc8631ad4)

The other effect of this change is that it fixes what is currently broken behavior in the `has_too_many_contributing_frames` [Seer utility function](https://github.com/getsentry/sentry/blob/e4888e1eb290ab59dff98729f3992551bfe23f3e/src/sentry/seer/similarity/utils.py#L320-L379). Right now, stacktraces like the one in the `contributing_system_frames` test input mistakenly count the app variant as the contributing one, and `contributing_system_frames` therefore looks to see how many in-app contributing frames there are. Frames like the `handleRequest` frame don't count in that tally, because they're not in-app, leading `has_too_many_contributing_frames` to mistakenly let through stacktraces it shouldn't. 

With this fix, we can stop skipping the `has_too_many_contributing_frames` test [demonstrating this](https://github.com/getsentry/sentry/blob/e4888e1eb290ab59dff98729f3992551bfe23f3e/tests/sentry/seer/similarity/test_utils.py#L1055-L1075). This PR also adds dedicated tests in `test_enhancer.py` (scroll down past the snapshots).

Note: Because the legacy config handles frames and stacktraces differently, this fix is limited to hash calculations using the newstyle configs.