### PR TITLE
feat(aci): get unique condition queries in delayed workflow processing

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, Self, TypedDict
 
 from django.db.models import QuerySet
 
@@ -23,6 +23,12 @@ class _QSTypedDict(TypedDict):
 
 
 class BaseEventFrequencyConditionHandler(ABC):
+    @property
+    @abstractmethod
+    def base_handler(self) -> type[Self]:
+        # frequency and percent conditions can share the same base handler to query Snuba
+        raise NotImplementedError
+
     @property
     @abstractmethod
     def intervals(self) -> dict[str, tuple[str, timedelta]]:

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -25,7 +25,7 @@ class _QSTypedDict(TypedDict):
 class BaseEventFrequencyConditionHandler(ABC):
     @property
     @abstractmethod
-    def base_handler(self) -> type[Self]:
+    def base_handler(self) -> Self:
         # frequency and percent conditions can share the same base handler to query Snuba
         raise NotImplementedError
 

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Self
 
 from sentry import tsdb
 from sentry.issues.constants import get_issue_tsdb_group_model
@@ -21,7 +21,7 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionResu
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     @property
-    def base_handler(self) -> type[BaseEventFrequencyConditionHandler]:
+    def base_handler(self) -> Self:
         return self
 
     @property

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -21,6 +21,10 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionResu
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     @property
+    def base_handler(self) -> type[BaseEventFrequencyConditionHandler]:
+        return self
+
+    @property
     def intervals(self) -> dict[str, tuple[str, timedelta]]:
         return STANDARD_INTERVALS
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -65,16 +65,19 @@ CONDITION_OPS = {
     Condition.NOT_EQUAL: operator.ne,
 }
 
-SLOW_CONDITIONS = [
-    Condition.EVENT_FREQUENCY_COUNT,
+PERCENT_CONDITIONS = [
     Condition.EVENT_FREQUENCY_PERCENT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
     Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
-    Condition.PERCENT_SESSIONS_COUNT,
     Condition.PERCENT_SESSIONS_PERCENT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
     Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT,
 ]
+
+SLOW_CONDITIONS = [
+    Condition.EVENT_FREQUENCY_COUNT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+    Condition.PERCENT_SESSIONS_COUNT,
+    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
+] + PERCENT_CONDITIONS
 
 
 T = TypeVar("T")
@@ -151,8 +154,8 @@ class DataCondition(DefaultFieldsModel):
         return self.get_condition_result() if result else None
 
 
-def is_slow_condition(cond: DataCondition) -> bool:
-    return Condition(cond.type) in SLOW_CONDITIONS
+def is_slow_condition(condition: DataCondition) -> bool:
+    return Condition(condition.type) in SLOW_CONDITIONS
 
 
 @receiver(pre_save, sender=DataCondition)

--- a/src/sentry/workflow_engine/models/data_condition_group.py
+++ b/src/sentry/workflow_engine/models/data_condition_group.py
@@ -5,6 +5,8 @@ from django.db import models
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, region_silo_model, sane_repr
 from sentry.db.models.manager.base import BaseManager
+from sentry.workflow_engine.models import DataCondition
+from sentry.workflow_engine.models.data_condition import is_slow_condition
 
 
 @region_silo_model
@@ -33,3 +35,10 @@ class DataConditionGroup(DefaultFieldsModel):
 
     logic_type = models.CharField(max_length=200, choices=Type.choices, default=Type.ANY)
     organization = models.ForeignKey("sentry.Organization", on_delete=models.CASCADE)
+
+
+def get_slow_conditions(dcg: DataConditionGroup) -> list[DataCondition]:
+    """
+    Get all conditions that are considered slow for a given data condition group
+    """
+    return [condition for condition in dcg.conditions.all() if is_slow_condition(condition)]

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -346,7 +346,7 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
             self.workflow_filters.id: self.workflow.id,
             other_workflow_filters.id: self.workflow.id,
         }
-        workflows_to_envs = {self.workflow.id: None}
+        workflows_to_envs: dict[int, int | None] = {self.workflow.id: None}
 
         result = get_condition_query_groups(dcgs, dcg_to_groups, dcg_to_workflow, workflows_to_envs)
 

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -92,10 +92,9 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
     def create_project_event_freq_workflow(
         self, project: Project, environment: Environment | None = None
     ) -> tuple[Workflow, list[DataConditionGroup]]:
-        if not Detector.objects.filter(project_id=project.id, type=ErrorGroupType.slug).exists():
-            detector = self.create_detector(project=project, type=ErrorGroupType.slug)
-        else:
-            detector = Detector.objects.get(project_id=project.id, type=ErrorGroupType.slug)
+        detector, _ = Detector.objects.get_or_create(
+            project_id=project.id, type=ErrorGroupType.slug, defaults={"config": {}}
+        )
 
         workflow_trigger_group = self.create_data_condition_group(
             logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT


### PR DESCRIPTION
Get unique conditions in delayed processing for workflows.

We do this by creating `UniqueConditionQuery` objects (similar to existing delayed processing) that represent a single unique query to Snuba. These include the `handler` (for querying Snuba via `get_rate_bulk`), `interval`, `environment_id`, and optional `comparison_interval`. Note that `group` is not here because multiple groups can share these same values in the query, and we can get the results for multiple groups at once.

Count frequency conditions will have 1 query, and percent frequency conditions will have 2. They can overlap if the fields in `condition.comparison` only differ via the `comparison_interval` (count frequency conditions don't have this, percent frequency do), which could generate a shared query.
