### PR TITLE
chore(issue-details): Show replay section off `replay_id`

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -372,9 +372,7 @@ export function EventDetailsContent({
         </Fragment>
       )}
       <EventHydrationDiff event={event} group={group} />
-      {issueTypeConfig.replays.enabled && (
-        <EventReplay event={event} group={group} projectSlug={project.slug} />
-      )}
+      <EventReplay event={event} group={group} projectSlug={project.slug} />
       {defined(eventEntries[EntryType.HPKP]) && (
         <EntryErrorBoundary type={EntryType.HPKP}>
           <Generic


### PR DESCRIPTION
this pr updates the issue details page to show the replay section off the `replay_id` instead of the config. the config is still used in a few other places so it isn't being removed, but `EventReplay` already checks for the `replay_id` which is what we want to use to determine if we show replays