### PR TITLE
chore(issues): Create fewer events in test

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4175,7 +4175,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_bulk_resolve(self) -> None:
         self.login_as(user=self.user)
 
-        for i in range(200):
+        for i in range(101):
             self.store_event(
                 data={
                     "fingerprint": [i],


### PR DESCRIPTION
This is one of our slowest tests, saving almost half as many events should improve performance since the test doesn't actually rely on needing as many events as it saves.

[Before](https://app.codecov.io/gh/getsentry/sentry/tests/master?term=tests.sentry.issues.endpoints.test_organization_group_index.GroupUpdateTest%3A%3Atest_bulk_resolve): 30.152s
[After](https://app.codecov.io/gh/getsentry/sentry/tests/mrduncan%2Fspeed-up-test?term=tests.sentry.issues.endpoints.test_organization_group_index.GroupUpdateTest%3A%3Atest_bulk_resolve): 15.764s