### PR TITLE
feat(dashboards): Improve `WidgetLayout` `Caption` prop

### DIFF
--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
@@ -72,7 +72,7 @@ import {WidgetTitle} from './widgetTitle';
   Visualization={
     <LineChartWidgetVisualization timeseries={[sampleDurationTimeSeries]} />
   }
-  Caption={<p>This data is incomplete!</p>}
+  Footer={<p>This data is incomplete!</p>}
 />
 
         `}
@@ -94,7 +94,7 @@ import {WidgetTitle} from './widgetTitle';
             Visualization={
               <LineChartWidgetVisualization timeseries={[sampleDurationTimeSeries]} />
             }
-            Caption={<p>This data is incomplete!</p>}
+            Footer={<p>This data is incomplete!</p>}
           />
         </SmallSizingWindow>
       </Fragment>

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -100,7 +100,6 @@ const VisualizationWrapper = styled('div')`
 `;
 
 const FooterWrapper = styled('div')`
-  padding: ${space(0.5)} ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
   margin: 0;
   border-top: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -102,4 +102,5 @@ const VisualizationWrapper = styled('div')`
 const FooterWrapper = styled('div')`
   padding: ${space(0.5)} ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
   margin: 0;
+  border-top: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -7,7 +7,7 @@ import {MIN_HEIGHT, MIN_WIDTH, X_GUTTER, Y_GUTTER} from '../common/settings';
 
 export interface WidgetLayoutProps {
   Actions?: React.ReactNode;
-  Caption?: React.ReactNode;
+  Footer?: React.ReactNode;
   Title?: React.ReactNode;
   Visualization?: React.ReactNode;
   ariaLabel?: string;
@@ -31,7 +31,7 @@ export function WidgetLayout(props: WidgetLayoutProps) {
         <VisualizationWrapper>{props.Visualization}</VisualizationWrapper>
       )}
 
-      {props.Caption && <CaptionWrapper>{props.Caption}</CaptionWrapper>}
+      {props.Footer && <FooterWrapper>{props.Footer}</FooterWrapper>}
     </Frame>
   );
 }
@@ -99,7 +99,7 @@ const VisualizationWrapper = styled('div')`
   padding: 0;
 `;
 
-const CaptionWrapper = styled('div')`
+const FooterWrapper = styled('div')`
   padding: ${space(0.5)} ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
   margin: 0;
 `;


### PR DESCRIPTION
Very minor! Padding will be back in an upcoming PR

- **Rename `Caption` to `Footer`**
- **Add footer border**
- **Remove padding**
