### PR TITLE
fix(anomaly detection): restore correct alert reasons for anomaly detection alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -82,7 +82,7 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
           #{incident.identifier}
         </Link>
       </Cell>
-      <Cell>
+      {/* <Cell>
         {incident.alertRule.comparisonDelta ? (
           <Fragment>
             {alertName} {curentTrigger?.alertThreshold}%
@@ -104,6 +104,43 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
               ? t('above')
               : t('below')}{' '}
             {curentTrigger?.alertThreshold} {t('in')} {timeWindow}
+          </Fragment>
+        )}
+      </Cell> */}
+      <Cell>
+        {/* If an alert rule is a % comparison based detection type */}
+        {incident.alertRule.detectionType !== 'dynamic' &&
+          incident.alertRule.comparisonDelta && (
+            <Fragment>
+              {alertName} {curentTrigger?.alertThreshold}%
+              {t(
+                ' %s in %s compared to the ',
+                incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
+                  ? t('higher')
+                  : t('lower'),
+                timeWindow
+              )}
+              {COMPARISON_DELTA_OPTIONS.find(
+                ({value}) => value === incident.alertRule.comparisonDelta
+              )?.label ?? COMPARISON_DELTA_OPTIONS[0]?.label}
+            </Fragment>
+          )}
+        {/* If an alert rule is a static detection type */}
+        {incident.alertRule.detectionType !== 'dynamic' &&
+          !incident.alertRule.comparisonDelta && (
+            <Fragment>
+              {alertName}{' '}
+              {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
+                ? t('above')
+                : t('below')}{' '}
+              {curentTrigger?.alertThreshold || '_'} {t('within')} {timeWindow}
+            </Fragment>
+          )}
+        {/* If an alert rule is a dynamic detection type */}
+        {incident.alertRule.detectionType === 'dynamic' && (
+          <Fragment>
+            {t('Detected an anomaly in the query for ')}
+            {alertName}
           </Fragment>
         )}
       </Cell>

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -82,31 +82,6 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
           #{incident.identifier}
         </Link>
       </Cell>
-      {/* <Cell>
-        {incident.alertRule.comparisonDelta ? (
-          <Fragment>
-            {alertName} {curentTrigger?.alertThreshold}%
-            {t(
-              ' %s in %s compared to the ',
-              incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
-                ? t('higher')
-                : t('lower'),
-              timeWindow
-            )}
-            {COMPARISON_DELTA_OPTIONS.find(
-              ({value}) => value === incident.alertRule.comparisonDelta
-            )?.label ?? COMPARISON_DELTA_OPTIONS[0]?.label}
-          </Fragment>
-        ) : (
-          <Fragment>
-            {alertName}{' '}
-            {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
-              ? t('above')
-              : t('below')}{' '}
-            {curentTrigger?.alertThreshold} {t('in')} {timeWindow}
-          </Fragment>
-        )}
-      </Cell> */}
       <Cell>
         {/* If an alert rule is a % comparison based detection type */}
         {incident.alertRule.detectionType !== 'dynamic' &&
@@ -133,7 +108,7 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
               {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
                 ? t('above')
                 : t('below')}{' '}
-              {curentTrigger?.alertThreshold || '_'} {t('within')} {timeWindow}
+              {curentTrigger?.alertThreshold} {t('in')} {timeWindow}
             </Fragment>
           )}
         {/* If an alert rule is a dynamic detection type */}


### PR DESCRIPTION
The code to display anomaly detection alert trigger reasons was removed during a refactor. Restore the code that displays the correct reason. Note: the original code that generates reasons for anomaly detection alerts was introduced in https://github.com/getsentry/sentry/pull/77331.

Before:
![Screenshot 2025-01-31 at 3 36 38 PM](https://github.com/user-attachments/assets/0887d5fb-a088-4f0a-83aa-3436ff013608)

After:
![Screenshot 2025-01-31 at 3 36 30 PM](https://github.com/user-attachments/assets/9b2a6c16-e2f6-4a4b-8865-d803ca5bdcba)
