### PR TITLE
fix(issue-details): Remove extra divider from tags preview

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -86,14 +86,11 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
           <GraphSection>
             <EventGraph event={event} group={group} style={{flex: 1}} />
             {issueTypeConfig.header.tagDistribution.enabled && (
-              <Fragment>
-                <SectionDivider />
-                <IssueTagsPreview
-                  groupId={group.id}
-                  environments={environments}
-                  project={project}
-                />
-              </Fragment>
+              <IssueTagsPreview
+                groupId={group.id}
+                environments={environments}
+                project={project}
+              />
             )}
           </GraphSection>
         )}
@@ -195,13 +192,6 @@ const OccurrenceSummarySection = styled(OccurrenceSummary)`
   &:not(:first-child) {
     border-top: 1px solid ${p => p.theme.translucentBorder};
   }
-`;
-
-const SectionDivider = styled('div')`
-  border-left: 1px solid ${p => p.theme.translucentBorder};
-  display: flex;
-  align-items: center;
-  margin: ${space(1)};
 `;
 
 const PageErrorBoundary = styled(ErrorBoundary)`

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -252,9 +252,12 @@ export default function IssueTagsPreview({
 
   if (isPending || isHighlightPending) {
     return (
-      <IssueTagPreviewSection>
-        <Placeholder width="240px" height="100px" />
-      </IssueTagPreviewSection>
+      <Fragment>
+        <SectionDivider />
+        <IssueTagPreviewSection>
+          <Placeholder width="240px" height="100px" />
+        </IssueTagPreviewSection>
+      </Fragment>
     );
   }
 
@@ -267,14 +270,17 @@ export default function IssueTagsPreview({
   }
 
   return (
-    <IssueTagPreviewSection>
-      <TagsPreview>
-        {tagsToPreview.map(tag => (
-          <TagPreviewProgressBar key={tag.key} tag={tag} groupId={groupId} />
-        ))}
-      </TagsPreview>
-      <IssueTagButton tags={tagsToPreview} />
-    </IssueTagPreviewSection>
+    <Fragment>
+      <SectionDivider />
+      <IssueTagPreviewSection>
+        <TagsPreview>
+          {tagsToPreview.map(tag => (
+            <TagPreviewProgressBar key={tag.key} tag={tag} groupId={groupId} />
+          ))}
+        </TagsPreview>
+        <IssueTagButton tags={tagsToPreview} />
+      </IssueTagPreviewSection>
+    </Fragment>
   );
 }
 
@@ -402,4 +408,11 @@ const HorizontalIssueTagsButton = styled(LinkButton)`
   span {
     white-space: unset;
   }
+`;
+
+const SectionDivider = styled('div')`
+  border-left: 1px solid ${p => p.theme.translucentBorder};
+  display: flex;
+  align-items: center;
+  margin: ${space(1)};
 `;


### PR DESCRIPTION
this pr fixes an issue with the updated tags preview where when you search, an extra divider appeared next to the graph

before:
<img width="110" alt="Screenshot 2025-01-31 at 4 50 36 PM" src="https://github.com/user-attachments/assets/686620bd-ba87-4b8f-b2b5-9e3076398ff0" />

after: 
<img width="88" alt="Screenshot 2025-01-31 at 4 50 30 PM" src="https://github.com/user-attachments/assets/fd314635-969b-40fe-81f7-bfa9664a1727" />
