### PR TITLE
ref(onboarding): Open quick start sidebar on skip onboarding

### DIFF
--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -15,6 +15,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import testableTransition from 'sentry/utils/testableTransition';
 import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
+import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import GenericFooter from './genericFooter';
 
@@ -31,6 +32,8 @@ export default function FirstEventFooter({
   onClickSetupLater,
   isLast,
 }: FirstEventFooterProps) {
+  const {activateSidebar} = useOnboardingSidebar();
+
   const source = 'targeted_onboarding_first_event_footer';
 
   const getSecondaryCta = useCallback(() => {
@@ -83,6 +86,7 @@ export default function FirstEventFooter({
             organization,
             source,
           });
+          activateSidebar();
         }}
         to={`/organizations/${organization.slug}/issues/?referrer=onboarding-first-event-footer-skip`}
       >

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -30,6 +30,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import PageCorners from 'sentry/views/onboarding/components/pageCorners';
+import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import Stepper from './components/stepper';
 import {PlatformSelection} from './platformSelection';
@@ -91,6 +92,8 @@ function Onboarding(props: Props) {
   });
 
   const cornerVariantTimeoutRed = useRef<number | undefined>(undefined);
+
+  const {activateSidebar} = useOnboardingSidebar();
 
   useEffect(() => {
     return () => {
@@ -326,6 +329,7 @@ function Onboarding(props: Props) {
             source,
           });
           onboardingContext.setData({...onboardingContext.data, selectedSDK: undefined});
+          activateSidebar();
         }}
         to={normalizeUrl(
           `/organizations/${organization.slug}/issues/?referrer=onboarding-skip`

--- a/static/app/views/onboarding/useOnboardingSidebar.tsx
+++ b/static/app/views/onboarding/useOnboardingSidebar.tsx
@@ -1,0 +1,15 @@
+import {useCallback} from 'react';
+
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
+
+export function useOnboardingSidebar() {
+  const activateSidebar = useCallback(() => {
+    // Delay activating the onboarding panel until after the sidebar closes on route change
+    setTimeout(() => {
+      SidebarPanelStore.activatePanel(SidebarPanelKey.ONBOARDING_WIZARD);
+    }, 0);
+  }, []);
+
+  return {activateSidebar};
+}

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -15,6 +15,7 @@ import testableTransition from 'sentry/utils/testableTransition';
 import useOrganization from 'sentry/utils/useOrganization';
 import FallingError from 'sentry/views/onboarding/components/fallingError';
 import WelcomeBackground from 'sentry/views/onboarding/components/welcomeBackground';
+import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import type {StepProps} from './types';
 
@@ -50,6 +51,7 @@ function InnerAction({title, subText, cta, src}: TextWrapperProps) {
 function TargetedOnboardingWelcome(props: StepProps) {
   const organization = useOrganization();
   const onboardingContext = useContext(OnboardingContext);
+  const {activateSidebar} = useOnboardingSidebar();
 
   const source = 'targeted_onboarding';
 
@@ -79,7 +81,9 @@ function TargetedOnboardingWelcome(props: StepProps) {
       organization,
       source,
     });
-  }, [organization, source]);
+
+    activateSidebar();
+  }, [organization, source, activateSidebar]);
 
   return (
     <FallingError>


### PR DESCRIPTION
When users skip the onboarding flow, we set the sidebar’s active panel to the quick start sidebar, contributing to the issue:

- https://github.com/getsentry/sentry/issues/84062

We are using a small delay before activating the panel to allow the route change to settle first. This ensures the sidebar has time to close before the onboarding wizard is shown. This solution is the same one used in the PR:

- https://github.com/getsentry/sentry/pull/77516

https://github.com/user-attachments/assets/f38bfcae-4c53-481a-b024-470b824588d2


