### PR TITLE
ref(sidebar): Add missing organization parameter

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -104,7 +104,7 @@ function hidePanel(hash?: string) {
   SidebarPanelStore.hidePanel(hash);
 }
 
-function useOpenOnboardingSidebar(organization?: Organization) {
+function useOpenOnboardingSidebar(organization: Organization | null) {
   const onboardingContext = useContext(OnboardingContext);
   const {projects: project} = useProjects();
   const location = useLocation();
@@ -170,7 +170,7 @@ function Sidebar() {
     return HookStore.get('component:superuser-warning-excluded')[0]?.(organization);
   };
 
-  useOpenOnboardingSidebar();
+  useOpenOnboardingSidebar(organization);
 
   const toggleCollapse = useCallback(() => {
     if (collapsed) {


### PR DESCRIPTION
The following logic would never work because the organization was never passed as a parameter.

https://github.com/getsentry/sentry/blob/d210118fce94310ef5858d51efe16ee26c995a48/static/app/components/sidebar/index.tsx#L114-L125