### PR TITLE
ref(issue-guides-content): Add quick start pendo item to issue

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -66,6 +66,13 @@ export default function getGuidesContent(
               and triage through issue management tools like Jira. `
           ),
         },
+        {
+          title: t('Quick Setup'),
+          target: 'onboarding_sidebar',
+          description: t(
+            'Walk through this guide to get the most out of Sentry right away.'
+          ),
+        },
       ],
     },
     {

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -1,8 +1,9 @@
-import {Fragment, useCallback, useContext, useEffect} from 'react';
+import {useCallback, useContext, useEffect} from 'react';
 import type {Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {OnboardingSidebar} from 'sentry/components/onboardingWizard/sidebar';
 import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
@@ -115,7 +116,7 @@ export function OnboardingStatus({
   }
 
   return (
-    <Fragment>
+    <GuideAnchor target="onboarding_sidebar" position="right">
       <Container
         role="button"
         aria-label={label}
@@ -166,7 +167,7 @@ export function OnboardingStatus({
           beyondBasicsTasks={beyondBasicsTasks}
         />
       )}
-    </Fragment>
+    </GuideAnchor>
   );
 }
 


### PR DESCRIPTION
To make the quick start more visible, we're adding a Pendo quick start guide item to the issue content.



https://github.com/user-attachments/assets/f45ecd3d-9c92-4e39-b989-2e8b1ce6f569



contributes to 

- https://github.com/getsentry/sentry/issues/84062