### PR TITLE
ref(quick-start): Add animation to the progress bar ring

### DIFF
--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -127,7 +127,7 @@ export function OnboardingStatus({
         }}
       >
         <ProgressRing
-          animateText
+          animate
           textCss={() => css`
             font-size: ${theme.fontSizeMedium};
             font-weight: ${theme.fontWeightBold};


### PR DESCRIPTION
Adds animation not only to the text but also to the progress ring.


https://github.com/user-attachments/assets/a2a22e82-dce2-42d0-ad80-5101ddf5db04

contributes to:

- https://github.com/getsentry/sentry/issues/84062