### PR TITLE
fix(tempest): Make `poll_tempest` not propagate trace

### DIFF
--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -44,7 +44,7 @@ def poll_tempest(**kwargs):
     soft_time_limit=55,
     time_limit=60,
 )
-def fetch_latest_item_id(credentials_id: int) -> None:
+def fetch_latest_item_id(credentials_id: int, **kwargs) -> None:
     # FIXME: Try catch this later
     credentials = TempestCredentials.objects.select_related("project").get(id=credentials_id)
     project_id = credentials.project.id
@@ -109,7 +109,7 @@ def fetch_latest_item_id(credentials_id: int) -> None:
     soft_time_limit=55,
     time_limit=60,
 )
-def poll_tempest_crashes(credentials_id: int) -> None:
+def poll_tempest_crashes(credentials_id: int, **kwargs) -> None:
     credentials = TempestCredentials.objects.select_related("project").get(id=credentials_id)
     project_id = credentials.project.id
     org_id = credentials.project.organization_id

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -26,9 +26,15 @@ def poll_tempest(**kwargs):
     # FIXME: Once we have more traffic this needs to be done smarter.
     for credentials in TempestCredentials.objects.all():
         if credentials.latest_fetched_item_id is None:
-            fetch_latest_item_id.delay(credentials.id)
+            fetch_latest_item_id.apply_async(
+                kwargs={"credentials_id": credentials.id},
+                headers={"sentry-propagate-traces": False},
+            )
         else:
-            poll_tempest_crashes.delay(credentials.id)
+            poll_tempest_crashes.apply_async(
+                kwargs={"credentials_id": credentials.id},
+                headers={"sentry-propagate-traces": False},
+            )
 
 
 @instrumented_task(

--- a/tests/sentry/tempest/test_tempest.py
+++ b/tests/sentry/tempest/test_tempest.py
@@ -143,9 +143,11 @@ class TempestTasksTest(TestCase):
 
         poll_tempest()
 
-        # Should call fetch_latest_item_id.delay() and not poll_tempest_crashes
-        mock_fetch_latest.delay.assert_called_once_with(self.credentials.id)
-        mock_poll_crashes.delay.assert_not_called()
+        # Should call fetch_latest_item_id and not poll_tempest_crashes
+        mock_fetch_latest.apply_async.assert_called_once_with(
+            kwargs={"credentials_id": 10}, headers={"sentry-propagate-traces": False}
+        )
+        mock_poll_crashes.apply_async.assert_not_called()
 
     @patch("sentry.tempest.tasks.fetch_latest_item_id")
     @patch("sentry.tempest.tasks.poll_tempest_crashes")
@@ -156,9 +158,11 @@ class TempestTasksTest(TestCase):
 
         poll_tempest()
 
-        # Should call poll_tempest_crashes.delay() and not fetch_latest_item_id
-        mock_poll_crashes.delay.assert_called_once_with(self.credentials.id)
-        mock_fetch_latest.delay.assert_not_called()
+        # Should call poll_tempest_crashes and not fetch_latest_item_id
+        mock_poll_crashes.apply_async.assert_called_once_with(
+            kwargs={"credentials_id": 11}, headers={"sentry-propagate-traces": False}
+        )
+        mock_fetch_latest.apply_async.assert_not_called()
 
     def test_tempest_project_key(self):
         project = self.create_project()

--- a/tests/sentry/tempest/test_tempest.py
+++ b/tests/sentry/tempest/test_tempest.py
@@ -145,7 +145,8 @@ class TempestTasksTest(TestCase):
 
         # Should call fetch_latest_item_id and not poll_tempest_crashes
         mock_fetch_latest.apply_async.assert_called_once_with(
-            kwargs={"credentials_id": 10}, headers={"sentry-propagate-traces": False}
+            kwargs={"credentials_id": self.credentials.id},
+            headers={"sentry-propagate-traces": False},
         )
         mock_poll_crashes.apply_async.assert_not_called()
 
@@ -160,7 +161,8 @@ class TempestTasksTest(TestCase):
 
         # Should call poll_tempest_crashes and not fetch_latest_item_id
         mock_poll_crashes.apply_async.assert_called_once_with(
-            kwargs={"credentials_id": 11}, headers={"sentry-propagate-traces": False}
+            kwargs={"credentials_id": self.credentials.id},
+            headers={"sentry-propagate-traces": False},
         )
         mock_fetch_latest.apply_async.assert_not_called()
 


### PR DESCRIPTION
Good point brought up by Jan: Currently the trace from `poll_tempest` propagates to each of the celery tasks called inside it. This would cause a ginormous trace in the case where we loop over a lot of orgs which is not desirable. As such we used the strategy outlined in this [documentation](https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces) to avoid the propagation of the trace to the individual celery tasks.
