### PR TITLE
ref: avoid an out-of-order teardown of auth provider

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -212,7 +212,8 @@ class BaseTestCase(Fixtures):
     @pytest.fixture(autouse=True)
     def setup_dummy_auth_provider(self):
         auth.register("dummy", DummyProvider)
-        self.addCleanup(auth.unregister, "dummy", DummyProvider)
+        yield
+        auth.unregister("dummy", DummyProvider)
 
     def tasks(self):
         return TaskRunner()


### PR DESCRIPTION
I couldn't find any breakage due to this (other that the type checker dislikes this) but as written this would do pytest setup and unittest teardown leading to jagged teardown.

<!-- Describe your PR here. -->