### PR TITLE
fix(dashboards): Cache project for ondemand evaluation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -828,20 +828,23 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         )
         current_widget_specs = get_current_widget_specs(organization)
 
-        if ondemand_feature:
-            for new_query in new_queries:
-                query_cardinality = all(
-                    check_field_cardinality(
-                        new_query.columns, organization, max_cardinality_allowed
-                    ).values()
-                )
-                set_or_create_on_demand_state(
-                    new_query,
-                    organization,
-                    query_cardinality,
-                    ondemand_feature,
-                    current_widget_specs,
-                )
+        if not ondemand_feature:
+            # If the org does not have the on-demand feature, we don't need to check cardinality
+            return
+
+        for new_query in new_queries:
+            query_cardinality = all(
+                check_field_cardinality(
+                    new_query.columns, organization, max_cardinality_allowed
+                ).values()
+            )
+            set_or_create_on_demand_state(
+                new_query,
+                organization,
+                query_cardinality,
+                ondemand_feature,
+                current_widget_specs,
+            )
 
     def update_widget(self, widget, data, order):
         prev_layout = widget.detail.get("layout") if widget.detail else None

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -828,15 +828,20 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         )
         current_widget_specs = get_current_widget_specs(organization)
 
-        for new_query in new_queries:
-            query_cardinality = all(
-                check_field_cardinality(
-                    new_query.columns, organization, max_cardinality_allowed
-                ).values()
-            )
-            set_or_create_on_demand_state(
-                new_query, organization, query_cardinality, ondemand_feature, current_widget_specs
-            )
+        if ondemand_feature:
+            for new_query in new_queries:
+                query_cardinality = all(
+                    check_field_cardinality(
+                        new_query.columns, organization, max_cardinality_allowed
+                    ).values()
+                )
+                set_or_create_on_demand_state(
+                    new_query,
+                    organization,
+                    query_cardinality,
+                    ondemand_feature,
+                    current_widget_specs,
+                )
 
     def update_widget(self, widget, data, order):
         prev_layout = widget.detail.get("layout") if widget.detail else None

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -828,10 +828,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         )
         current_widget_specs = get_current_widget_specs(organization)
 
-        if not ondemand_feature:
-            # If the org does not have the on-demand feature, we don't need to check cardinality
-            return
-
         for new_query in new_queries:
             query_cardinality = all(
                 check_field_cardinality(

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -50,7 +50,7 @@ def _get_widget_processing_batch_key() -> str:
 
 
 def _get_project_for_query_cache_key(organization: Organization) -> str:
-    return f"project_for_query:{organization.id}"
+    return f"on-demand-project-spec:{organization.id}"
 
 
 def get_field_cardinality_cache_key(

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -253,10 +253,10 @@ def _get_widget_on_demand_specs(
     """
     Saves on-demand state for a widget query.
     """
-    # This can just be the first project we find, since spec hashes should not be project
-    # dependent. If spec hashes become project dependent then this may need to change.
     project_for_query = cache.get(_get_project_for_query_cache_key(organization), None)
-    if not project_for_query:
+    if not cache.has_key(_get_project_for_query_cache_key(organization)):
+        # This can just be the first project we find, since spec hashes should not be project
+        # dependent. If spec hashes become project dependent then this may need to change.
         project_for_query = Project.objects.filter(organization=organization).first()
         cache.set(
             _get_project_for_query_cache_key(organization),

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -49,6 +49,10 @@ def _get_widget_processing_batch_key() -> str:
     return "on-demand-metrics:widgets:currently-processing-batch"
 
 
+def _get_project_for_query_cache_key(organization: Organization) -> str:
+    return f"project_for_query:{organization.id}"
+
+
 def get_field_cardinality_cache_key(
     query_column: str, organization: Organization, widget_cache_key: str
 ) -> str:
@@ -251,10 +255,10 @@ def _get_widget_on_demand_specs(
     """
     # This can just be the first project we find, since spec hashes should not be project
     # dependent. If spec hashes become project dependent then this may need to change.
-    project_for_query = cache.get(f"project_for_query:{organization.id}", None)
+    project_for_query = cache.get(_get_project_for_query_cache_key(organization), None)
     if not project_for_query:
         project_for_query = Project.objects.filter(organization=organization).first()
-        cache.set(f"project_for_query:{organization.id}", project_for_query, timeout=3600)
+        cache.set(_get_project_for_query_cache_key(organization), project_for_query, timeout=3600)
 
     if not project_for_query:
         return []

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -258,7 +258,11 @@ def _get_widget_on_demand_specs(
     project_for_query = cache.get(_get_project_for_query_cache_key(organization), None)
     if not project_for_query:
         project_for_query = Project.objects.filter(organization=organization).first()
-        cache.set(_get_project_for_query_cache_key(organization), project_for_query, timeout=3600)
+        cache.set(
+            _get_project_for_query_cache_key(organization),
+            project_for_query,
+            timeout=_COLUMN_CARDINALITY_TTL,
+        )
 
     if not project_for_query:
         return []

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -251,7 +251,10 @@ def _get_widget_on_demand_specs(
     """
     # This can just be the first project we find, since spec hashes should not be project
     # dependent. If spec hashes become project dependent then this may need to change.
-    project_for_query = Project.objects.filter(organization=organization).first()
+    project_for_query = cache.get(f"project_for_query:{organization.id}", None)
+    if not project_for_query:
+        project_for_query = Project.objects.filter(organization=organization).first()
+        cache.set(f"project_for_query:{organization.id}", project_for_query, timeout=3600)
 
     if not project_for_query:
         return []


### PR DESCRIPTION
Querying for the project for each widget query was incurring ~1s of time, and since it doesn't matter what project we use, cache it for the org if we get one.