### PR TITLE
:sparkles: fea(aci): util to migrate sentry apps

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -439,7 +439,7 @@ class SentryAppActionTranslator(BaseActionTranslator):
         )
 
         if sentry_app_installation:
-            return sentry_app_installation[0].sentry_app.id
+            return str(sentry_app_installation[0].sentry_app.id)
         else:
             raise ValueError("Sentry app installation not found")
 

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -443,7 +443,7 @@ class SentryAppActionTranslator(BaseActionTranslator):
         else:
             raise ValueError("Sentry app installation not found")
 
-    def get_sanitized_data(self) -> SentryAppDataBlob:
+    def get_sanitized_data(self) -> dict[str, Any]:
         data = SentryAppDataBlob()
         if settings := self.action.get("settings"):
             for setting in settings:

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -439,9 +439,10 @@ class SentryAppActionTranslator(BaseActionTranslator):
         )
 
         if sentry_app_installation:
+            assert len(sentry_app_installation) == 1
             return str(sentry_app_installation[0].sentry_app.id)
-        else:
-            raise ValueError("Sentry app installation not found")
+
+        raise ValueError("Sentry app installation not found")
 
     def get_sanitized_data(self) -> dict[str, Any]:
         data = SentryAppDataBlob()
@@ -465,7 +466,9 @@ class DataBlob:
 
 @dataclass
 class SlackDataBlob(DataBlob):
-    """SlackDataBlob is a specific type that represents the data blob for a Slack notification action."""
+    """
+    SlackDataBlob is a specific type that represents the data blob for a Slack notification action.
+    """
 
     tags: str = ""
     notes: str = ""
@@ -482,14 +485,18 @@ class DiscordDataBlob(DataBlob):
 
 @dataclass
 class OnCallDataBlob(DataBlob):
-    """OnCallDataBlob is a specific type that represents the data blob for a PagerDuty or Opsgenie notification action."""
+    """
+    OnCallDataBlob is a specific type that represents the data blob for a PagerDuty or Opsgenie notification action.
+    """
 
     priority: str = ""
 
 
 @dataclass
 class TicketDataBlob(DataBlob):
-    """TicketDataBlob is a specific type that represents the data blob for a ticket creation action."""
+    """
+    TicketDataBlob is a specific type that represents the data blob for a ticket creation action.
+    """
 
     # This is dynamic and can whatever customer config the customer setup on GitHub
     dynamic_form_fields: list[dict] = field(default_factory=list)
@@ -518,7 +525,10 @@ class AzureDevOpsDataBlob(TicketDataBlob):
 
 @dataclass
 class SentryAppFormConfigDataBlob(DataBlob):
-    """Represents a single form config field for a Sentry App."""
+    """
+    SentryAppFormConfigDataBlob represents a single form config field for a Sentry App.
+    name is the name of the form field, and value is the value of the form field.
+    """
 
     name: str = ""
     value: str = ""
@@ -526,13 +536,17 @@ class SentryAppFormConfigDataBlob(DataBlob):
 
 @dataclass
 class SentryAppDataBlob(DataBlob):
-    """Represents a Sentry App notification action."""
+    """
+    Represents a Sentry App notification action.
+    """
 
     settings: list[SentryAppFormConfigDataBlob] = field(default_factory=list)
 
 
 @dataclass
 class EmailDataBlob(DataBlob):
-    """EmailDataBlob represents the data blob for an email notification action."""
+    """
+    EmailDataBlob represents the data blob for an email notification action.
+    """
 
     fallthroughType: str = ""

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -7,6 +9,7 @@ from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
+from sentry.sentry_apps.services.app import app_service
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.action import Action
 
@@ -64,7 +67,7 @@ class BaseActionTranslator(ABC):
         return None
 
     @property
-    def blob_type(self) -> type["DataBlob"] | None:
+    def blob_type(self) -> type[DataBlob] | None:
         """Return the blob type for this action, if any"""
         return None
 
@@ -134,7 +137,7 @@ class SlackActionTranslator(BaseActionTranslator):
         return self.action.get("channel")
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return SlackDataBlob
 
 
@@ -161,7 +164,7 @@ class DiscordActionTranslator(BaseActionTranslator):
         return self.action.get("channel_id")
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return DiscordDataBlob
 
 
@@ -220,7 +223,7 @@ class PagerDutyActionTranslator(BaseActionTranslator):
         return self.action.get("service")
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return OnCallDataBlob
 
 
@@ -252,7 +255,7 @@ class OpsgenieActionTranslator(BaseActionTranslator):
         return self.action.get("team")
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return OnCallDataBlob
 
 
@@ -273,7 +276,7 @@ class TicketActionTranslator(BaseActionTranslator, ABC):
 class GitHubActionTranslatorBase(TicketActionTranslator):
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return GitHubDataBlob
 
 
@@ -298,7 +301,7 @@ class AzureDevOpsActionTranslator(TicketActionTranslator):
     action_type = Action.Type.AZURE_DEVOPS
 
     @property
-    def blob_type(self) -> type["DataBlob"]:
+    def blob_type(self) -> type[DataBlob]:
         return AzureDevOpsDataBlob
 
 
@@ -409,6 +412,50 @@ class WebhookActionTranslator(BaseActionTranslator):
         return self.action.get("service")
 
 
+@issue_alert_action_translator_registry.register(
+    "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
+)
+class SentryAppActionTranslator(BaseActionTranslator):
+    action_type = Action.Type.SENTRY_APP
+
+    @property
+    def required_fields(self) -> list[str]:
+        return ["sentryAppInstallationUuid"]
+
+    @property
+    def target_type(self) -> ActionTarget | None:
+        return ActionTarget.SENTRY_APP
+
+    @property
+    def integration_id(self) -> int | None:
+        return None
+
+    @property
+    def target_identifier(self) -> str | None:
+        # Fetch the sentry app id using app_service
+        # Based on sentry/rules/actions/sentry_apps/notify_event.py
+        sentry_app_installation = app_service.get_many(
+            filter=dict(uuids=[self.action.get("sentryAppInstallationUuid")])
+        )
+
+        if sentry_app_installation:
+            return sentry_app_installation[0].sentry_app.id
+        else:
+            raise ValueError("Sentry app installation not found")
+
+    def get_sanitized_data(self) -> SentryAppDataBlob:
+        data = SentryAppDataBlob()
+        if settings := self.action.get("settings"):
+            for setting in settings:
+                data.settings.append(SentryAppFormConfigDataBlob(**setting))
+
+        return dataclasses.asdict(data)
+
+    @property
+    def blob_type(self) -> type[DataBlob]:
+        return SentryAppDataBlob
+
+
 @dataclass
 class DataBlob:
     """DataBlob is a generic type that represents the data blob for a notification action."""
@@ -467,6 +514,21 @@ class AzureDevOpsDataBlob(TicketDataBlob):
 
     project: str = ""
     work_item_type: str = ""
+
+
+@dataclass
+class SentryAppFormConfigDataBlob(DataBlob):
+    """Represents a single form config field for a Sentry App."""
+
+    name: str = ""
+    value: str = ""
+
+
+@dataclass
+class SentryAppDataBlob(DataBlob):
+    """Represents a Sentry App notification action."""
+
+    settings: list[SentryAppFormConfigDataBlob] = field(default_factory=list)
 
 
 @dataclass

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -338,7 +338,7 @@ class EmailActionTranslator(BaseActionTranslator):
         return None
 
     @property
-    def blob_type(self) -> type["DataBlob"] | None:
+    def blob_type(self) -> type[DataBlob] | None:
         target_type = self.action.get("targetType")
         if target_type == ActionTargetType.ISSUE_OWNERS.value:
             return EmailDataBlob

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -439,7 +439,7 @@ class SentryAppActionTranslator(BaseActionTranslator):
         )
 
         if sentry_app_installation:
-            assert len(sentry_app_installation) == 1
+            assert len(sentry_app_installation) == 1, "Expected exactly one sentry app installation"
             return str(sentry_app_installation[0].sentry_app.id)
 
         raise ValueError("Sentry app installation not found")

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1,6 +1,8 @@
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from sentry.eventstore.models import GroupEvent
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
@@ -1262,3 +1264,162 @@ class TestNotificationActionMigrationUtils(TestCase):
                 f"Action {action_data['id']} has incorrect type after migration. "
                 f"Expected {expected_type}, got {actions[0].type}"
             )
+
+    def test_sentry_app_action_migration(self):
+        self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application",
+            is_alertable=True,
+        )
+
+        install = self.create_sentry_app_installation(
+            slug="test-application", organization=self.organization
+        )
+
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "sentryAppInstallationUuid": install.uuid,
+                "settings": [
+                    {
+                        "name": "opsgenieResponders",
+                        "value": '[{ "id": "8132bcc6-e697-44b2-8b61-c044803f9e6e", "type": "team" }]',
+                    },
+                    {
+                        "name": "tagsToInclude",
+                        "value": "environment",
+                    },
+                    {"name": "opsgeniePriority", "value": "P2"},
+                ],
+                "hasSchemaFormConfig": True,
+                "formFields": {
+                    "type": "alert-rule-settings",
+                    "uri": "/sentry/alert-rule-integration",
+                    "required_fields": [
+                        {
+                            "name": "opsgenieResponders",
+                            "label": "Opsgenie Responders",
+                            "type": "textarea",
+                        }
+                    ],
+                    "optional_fields": [
+                        {"name": "tagsToInclude", "label": "Tags to include", "type": "text"},
+                        {
+                            "name": "opsgeniePriority",
+                            "label": "Opsgenie Alert Priority",
+                            "type": "select",
+                            "options": [
+                                ["P1", "P1"],
+                                ["P2", "P2"],
+                                ["P3", "P3"],
+                                ["P4", "P4"],
+                                ["P5", "P5"],
+                            ],
+                            "choices": [
+                                ["P1", "P1"],
+                                ["P2", "P2"],
+                                ["P3", "P3"],
+                                ["P4", "P4"],
+                                ["P5", "P5"],
+                            ],
+                        },
+                    ],
+                },
+                "uuid": "55429e64-ce1a-46d5-bdff-e3f2fdf415b1",
+                "_sentry_app": [
+                    ["id", 1],
+                    ["scope_list", ["event:read"]],
+                    ["application_id", 1],
+                    [
+                        "application",
+                        [
+                            ["id", 1],
+                        ],
+                    ],
+                ],
+            },
+            # Simple webhook sentry app
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "sentryAppInstallationUuid": install.uuid,
+                "settings": [
+                    {"name": "destination", "value": "slack"},
+                    {"name": "systemid", "value": "test-system"},
+                ],
+                "hasSchemaFormConfig": True,
+                "uuid": "a37dd837-d709-4d67-9442-b23d068a5b43",
+            },
+            # Custom webhook sentry app with team selection
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "sentryAppInstallationUuid": install.uuid,
+                "settings": [
+                    {"name": "team", "value": "team-a"},
+                    {"name": "severity", "value": "sev2"},
+                ],
+                "hasSchemaFormConfig": True,
+                "uuid": "5b6d5bba-b3ba-40d5-b3e0-9b5f567ad277",
+                "formFields": {
+                    "type": "alert-rule-settings",
+                    "uri": "/v1/ticket",
+                    "required_fields": [
+                        {
+                            "type": "select",
+                            "label": "Team",
+                            "name": "team",
+                            "options": [
+                                ["unknown", "Automatic"],
+                                ["team-a", "Team A"],
+                                ["team-b", "Team B"],
+                            ],
+                            "choices": [
+                                ["unknown", "Automatic"],
+                                ["team-a", "Team A"],
+                                ["team-b", "Team B"],
+                            ],
+                        },
+                        {
+                            "type": "select",
+                            "label": "Severity",
+                            "name": "severity",
+                            "options": [
+                                ["sev1", "Severity 1"],
+                                ["sev2", "Severity 2"],
+                                ["sev3", "Severity 3"],
+                            ],
+                            "choices": [
+                                ["sev1", "Severity 1"],
+                                ["sev2", "Severity 2"],
+                                ["sev3", "Severity 3"],
+                            ],
+                        },
+                    ],
+                },
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        assert len(actions) == len(action_data)
+        self.assert_actions_migrated_correctly(actions, action_data, None, None, None)
+
+        # Verify that action type is set correctly
+        for action in actions:
+            assert action.type == Action.Type.SENTRY_APP
+            assert action.target_identifier == install.id
+
+    def test_sentry_app_migration_with_form_config(self):
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "sentryAppInstallationUuid": "fake-uuid",
+                "settings": [
+                    {"name": "destination", "value": "slack"},
+                    {"name": "systemid", "value": "test-system"},
+                ],
+                "hasSchemaFormConfig": True,
+                "uuid": "a37dd837-d709-4d67-9442-b23d068a5b43",
+            },
+        ]
+
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1405,7 +1405,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         # Verify that action type is set correctly
         for action in actions:
             assert action.type == Action.Type.SENTRY_APP
-            assert action.target_identifier == install.id
+            assert action.target_identifier == str(install.id)
 
     def test_sentry_app_migration_with_form_config(self):
         action_data = [

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1266,7 +1266,7 @@ class TestNotificationActionMigrationUtils(TestCase):
             )
 
     def test_sentry_app_action_migration(self):
-        self.create_sentry_app(
+        app = self.create_sentry_app(
             organization=self.organization,
             name="Test Application",
             is_alertable=True,
@@ -1405,7 +1405,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         # Verify that action type is set correctly
         for action in actions:
             assert action.type == Action.Type.SENTRY_APP
-            assert action.target_identifier == str(install.id)
+            assert action.target_identifier == str(app.id)
 
     def test_sentry_app_migration_with_form_config(self):
         action_data = [


### PR DESCRIPTION
migration util for sentry apps.

for sentry apps, we should only need to save the sentry app id (which we will get from the installation uuid), and the settings list which should contain the form field values the user configured.

follow up pr coming to match the metric alert migration with this.

closes https://getsentry.atlassian.net/browse/ACI-103