### PR TITLE
fix(widget-builder): Change release interval fidelity to medium

### DIFF
--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -217,8 +217,8 @@ function getReleasesSeriesRequest(
     displayType,
     {start, end, period},
     '5m',
-    // requesting low fidelity for release sort because metrics api can't return 100 rows of high fidelity series data
-    isCustomReleaseSorting ? 'low' : undefined
+    // requesting medium fidelity for release sort because metrics api can't return 100 rows of high fidelity series data
+    isCustomReleaseSorting ? 'medium' : undefined
   );
 
   return getReleasesRequest(

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -179,7 +179,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
           groupBy: ['release'],
           includeSeries: 1,
           includeTotals: 1,
-          interval: '12h',
+          interval: '1h',
           per_page: 100,
           project: [1],
           query: ' release:be1ddfb18126dd2cbde26bfe75488503280e716e',


### PR DESCRIPTION
On certain release group-bys and sort-bys users were getting an error saying the interval should divide one day on requests that had a stats period of over 60 days. Low fidelity was making any stats period range over 60 days use an interval of 2 days which was giving us this error. I changed the releases dataset to use medium fidelity instead of low to ensure the interval wasn't greater than a day. 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7a0892c4-c6a8-4dce-b728-619134a0bbe7) | ![image](https://github.com/user-attachments/assets/0837bcc9-b0c0-440c-b6c2-41887d2532bc) | 