### PR TITLE
✨ feat(aci): update `AlertRuleTriggerAction` migration for sentryapps

### DIFF
--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -157,6 +157,16 @@ def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_
         action_id=action.id,
     ).exists()
 
+    # Additional checks for Sentry app actions
+    if action_type == Action.Type.SENTRY_APP:
+        # Verify target_identifier is the string representation of sentry_app_id
+        assert action.target_identifier == str(alert_rule_trigger_action.sentry_app_id)
+
+        # Verify data blob has correct structure for Sentry apps
+        assert action.data == {
+            "settings": alert_rule_trigger_action.sentry_app_config,
+        }
+
 
 class BaseMetricAlertMigrationTest(APITestCase, BaseWorkflowTest):
     """


### PR DESCRIPTION
this requires https://github.com/getsentry/sentry/pull/84426 to be merged.

this pr consolidates the configuration for sentry apps for both issue alerts and metric alerts.

the main changes are we save the sentry_app_id in `target_identifier` and instead of saving the config in the "data_blob" itself, we use the dataclass i defined earlier and save it under the "settings" key.