### PR TITLE
feat(issue-details): Add uptime specific data for header

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2057,8 +2057,8 @@ function buildRoutes() {
         component={make(() => import('sentry/views/issueDetails/groupOpenPeriods'))}
       />
       <Route
-        path={TabPaths[Tab.CHECK_INS]}
-        component={make(() => import('sentry/views/issueDetails/groupCheckIns'))}
+        path={TabPaths[Tab.UPTIME_CHECKS]}
+        component={make(() => import('sentry/views/issueDetails/groupUptimeChecks'))}
       />
       <Route
         path={TabPaths[Tab.TAGS]}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -697,10 +697,7 @@ export type PerformanceDetectorData = {
   issueType?: IssueType;
 };
 
-type EventEvidenceDisplay = {
-  /**
-   * Used for alerting, probably not useful for the UI
-   */
+export type EventEvidenceDisplay = {
   important: boolean;
   name: string;
   value: string;

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -72,7 +72,7 @@ export type IssueTypeConfig = {
       type: 'discover-events' | 'checkin-timeline' | 'detector-history';
     };
     occurrenceSummary: DisabledWithReasonConfig & {
-      duration?: boolean;
+      downtime?: boolean;
     };
     tagDistribution: DisabledWithReasonConfig;
   };

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -26,7 +26,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
       ctaText: t('View alert details'),
     },
     customCopy: {
-      eventUnits: t('Check-ins'),
+      eventUnits: t('Events'),
       resolution: t('Resolved'),
     },
     pages: {

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -18,7 +18,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
       filterBar: {enabled: true, fixedEnvironment: true},
       graph: {enabled: true, type: 'checkin-timeline'},
       tagDistribution: {enabled: false},
-      occurrenceSummary: {enabled: true, duration: true},
+      occurrenceSummary: {enabled: true, downtime: true},
     },
     detector: {
       enabled: true,

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -30,7 +30,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
       resolution: t('Resolved'),
     },
     pages: {
-      landingPage: Tab.CHECK_INS,
+      landingPage: Tab.EVENTS,
       events: {enabled: false},
       openPeriods: {enabled: false},
       checkIns: {enabled: true},

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -30,7 +30,7 @@ import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTabl
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 
-function GroupCheckIns() {
+export default function GroupUptimeChecks() {
   const organization = useOrganization();
   const {groupId} = useParams<{groupId: string}>();
   const location = useLocation();
@@ -87,9 +87,9 @@ function GroupCheckIns() {
 
   return (
     <EventListTable
-      title={t('All Check-ins')}
+      title={t('All Uptime Checks')}
       pagination={{
-        tableUnits: t('check-ins'),
+        tableUnits: t('uptime checks'),
         links,
         pageCount,
         nextDisabled,
@@ -257,5 +257,3 @@ const LabelledTooltip = styled('div')`
   text-align: left;
   margin: 0;
 `;
-
-export default GroupCheckIns;

--- a/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
+++ b/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
@@ -36,7 +36,7 @@ export function makeUptimeCheckInsQueryKey({
   limit,
 }: UptimeCheckInsParameters): ApiQueryKey {
   return [
-    `/organizations/${orgSlug}/${projectSlug}/uptime-alert/${uptimeAlertId}/checks/`,
+    `/projects/${orgSlug}/${projectSlug}/uptime-alert/${uptimeAlertId}/checks/`,
     {query: {per_page: limit, cursor}},
   ];
 }

--- a/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
+++ b/static/app/views/issueDetails/queries/useUptimeCheckIns.tsx
@@ -36,7 +36,7 @@ export function makeUptimeCheckInsQueryKey({
   limit,
 }: UptimeCheckInsParameters): ApiQueryKey {
   return [
-    `/projects/${orgSlug}/${projectSlug}/uptime-alert/${uptimeAlertId}/checks/`,
+    `/projects/${orgSlug}/${projectSlug}/uptime/${uptimeAlertId}/checks/`,
     {query: {per_page: limit, cursor}},
   ];
 }

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -7,6 +7,8 @@ import {
   useReducer,
 } from 'react';
 
+import type {DetectorDetails} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
+
 export const enum SectionKey {
   /**
    * Trace timeline or linked error
@@ -95,6 +97,7 @@ export interface IssueDetailsContextType extends IssueDetailsState {
 
 export const IssueDetailsContext = createContext<IssueDetailsContextType>({
   sectionData: {},
+  detectorDetails: {},
   isSidebarOpen: true,
   navScrollMargin: 0,
   eventCount: 0,
@@ -106,6 +109,10 @@ export function useIssueDetails() {
 }
 
 export interface IssueDetailsState {
+  /**
+   * Detector details for the current issue
+   */
+  detectorDetails: DetectorDetails;
   /**
    * Allows updating the event count based on the date/time/environment filters.
    */
@@ -147,11 +154,17 @@ type UpdateSidebarAction = {
   type: 'UPDATE_SIDEBAR_STATE';
 };
 
+type UpdateDetectorDetailsAction = {
+  detectorDetails: DetectorDetails;
+  type: 'UPDATE_DETECTOR_DETAILS';
+};
+
 export type IssueDetailsActions =
   | UpdateEventSectionAction
   | UpdateNavScrollMarginAction
   | UpdateEventCountAction
-  | UpdateSidebarAction;
+  | UpdateSidebarAction
+  | UpdateDetectorDetailsAction;
 
 function updateEventSection(
   state: IssueDetailsState,
@@ -176,6 +189,7 @@ function updateEventSection(
 export function useIssueDetailsReducer() {
   const initialState: IssueDetailsState = {
     sectionData: {},
+    detectorDetails: {},
     isSidebarOpen: true,
     eventCount: 0,
     navScrollMargin: 0,
@@ -192,6 +206,8 @@ export function useIssueDetailsReducer() {
           return updateEventSection(state, action.key, action.config ?? {});
         case 'UPDATE_EVENT_COUNT':
           return {...state, eventCount: action.count};
+        case 'UPDATE_DETECTOR_DETAILS':
+          return {...state, detectorDetails: action.detectorDetails};
         default:
           return state;
       }

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -128,7 +128,7 @@ describe('EventDetailsHeader', () => {
     expect(screen.queryByText('Duration')).not.toBeInTheDocument();
   });
 
-  it('renders timeline summary if enabled', async function () {
+  it('renders occurrence summary if enabled', async function () {
     render(
       <EventDetailsHeader
         {...defaultProps}
@@ -136,11 +136,21 @@ describe('EventDetailsHeader', () => {
           issueCategory: IssueCategory.UPTIME,
           issueType: IssueType.UPTIME_DOMAIN_FAILURE,
         })}
+        event={EventFixture({
+          occurrence: {
+            evidenceDisplay: [
+              {name: 'Status Code', value: '500'},
+              {name: 'Failure reason', value: 'bad things'},
+            ],
+          },
+        })}
       />,
       {organization, router}
     );
-    expect(await screen.findByTestId('event-graph-loading')).not.toBeInTheDocument();
-
-    expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(await screen.findByText('Downtime')).toBeInTheDocument();
+    expect(screen.getByText('Status Code')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument();
+    expect(screen.getByText('Reason')).toBeInTheDocument();
+    expect(screen.getByText('bad things')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -100,7 +100,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
           </GraphSection>
         )}
         {issueTypeConfig.header.occurrenceSummary.enabled && (
-          <OccurrenceSummarySection group={group} />
+          <OccurrenceSummarySection group={group} event={event} />
         )}
       </FilterContainer>
     </PageErrorBoundary>
@@ -133,7 +133,7 @@ function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
       title={t('This issue only occurs in a single environment')}
       css={environmentCss}
     >
-      {eventEnvironment}
+      {eventEnvironment ?? t('All Envs')}
     </Button>
   ) : (
     <EnvironmentPageFilter

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -15,14 +15,18 @@ import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
 import {
   EventSearch,
   useEventQuery,
 } from 'sentry/views/issueDetails/streamline/eventSearch';
+import {IssueCheckInTimeline} from 'sentry/views/issueDetails/streamline/issueCheckInTimeline';
 import IssueTagsPreview from 'sentry/views/issueDetails/streamline/issueTagsPreview';
 import {MetricIssueChart} from 'sentry/views/issueDetails/streamline/metricIssueChart';
 import {OccurrenceSummary} from 'sentry/views/issueDetails/streamline/occurrenceSummary';
+import {getDetectorDetails} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
 import {ToggleSidebar} from 'sentry/views/issueDetails/streamline/sidebar/toggleSidebar';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
@@ -33,11 +37,29 @@ interface EventDetailsHeaderProps {
 }
 
 export function EventDetailsHeader({group, event, project}: EventDetailsHeaderProps) {
+  const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
   const environments = useEnvironmentsFromUrl();
   const searchQuery = useEventQuery({groupId: group.id});
   const issueTypeConfig = getConfigForIssueType(group, project);
+  const {dispatch} = useIssueDetails();
+
+  useEffect(() => {
+    if (event) {
+      // Since detector details are identical across the issue but only provided at the event level,
+      // we need to persist the details in state to prevent breakage when an event is unloaded.
+      const detectorDetails = getDetectorDetails({
+        event,
+        organization,
+        project,
+      });
+      dispatch({
+        type: 'UPDATE_DETECTOR_DETAILS',
+        detectorDetails,
+      });
+    }
+  }, [event, organization, project, dispatch]);
 
   const searchText = t(
     'Filter %s\u2026',
@@ -85,10 +107,14 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
         )}
         {issueTypeConfig.header.graph.enabled && (
           <GraphSection>
-            {issueTypeConfig.header.graph.type === 'detector-history' ? (
-              <MetricIssueChart group={group} project={project} event={event} />
-            ) : (
+            {issueTypeConfig.header.graph.type === 'discover-events' && (
               <EventGraph event={event} group={group} style={{flex: 1}} />
+            )}
+            {issueTypeConfig.header.graph.type === 'detector-history' && (
+              <MetricIssueChart group={group} project={project} event={event} />
+            )}
+            {issueTypeConfig.header.graph.type === 'checkin-timeline' && (
+              <IssueCheckInTimeline event={event} group={group} project={project} />
             )}
             {issueTypeConfig.header.tagDistribution.enabled && (
               <IssueTagsPreview

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -114,7 +114,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
               <MetricIssueChart group={group} project={project} event={event} />
             )}
             {issueTypeConfig.header.graph.type === 'checkin-timeline' && (
-              <IssueCheckInTimeline event={event} group={group} project={project} />
+              <IssueCheckInTimeline />
             )}
             {issueTypeConfig.header.tagDistribution.enabled && (
               <IssueTagsPreview

--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -43,6 +43,7 @@ describe('EventNavigation', () => {
         tags: {key: SectionKey.TAGS},
         replay: {key: SectionKey.REPLAY},
       },
+      detectorDetails: {},
       eventCount: 0,
       isSidebarOpen: true,
       navScrollMargin: 0,

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -77,7 +77,9 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
     [Tab.USER_FEEDBACK]: t('Feedback'),
   };
 
-  const isListView = [Tab.CHECK_INS, Tab.EVENTS, Tab.OPEN_PERIODS].includes(currentTab);
+  const isListView = [Tab.UPTIME_CHECKS, Tab.EVENTS, Tab.OPEN_PERIODS].includes(
+    currentTab
+  );
 
   return (
     <EventNavigationWrapper role="navigation">
@@ -213,14 +215,14 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
             {issueTypeConfig.pages.checkIns.enabled && (
               <LinkButton
                 to={{
-                  pathname: `${baseUrl}${TabPaths[Tab.CHECK_INS]}`,
+                  pathname: `${baseUrl}${TabPaths[Tab.UPTIME_CHECKS]}`,
                   query: location.query,
                 }}
                 size="xs"
-                analyticsEventKey="issue_details.all_check_ins_clicked"
-                analyticsEventName="Issue Details: All Check-ins Clicked"
+                analyticsEventKey="issue_details.all_uptime_checks_clicked"
+                analyticsEventName="Issue Details: All Uptime Checks Clicked"
               >
-                {t('All Check-ins')}
+                {t('All Uptime Checks')}
               </LinkButton>
             )}
           </Fragment>

--- a/static/app/views/issueDetails/streamline/eventTitle.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.spec.tsx
@@ -36,6 +36,7 @@ describe('EventNavigation', () => {
         tags: {key: SectionKey.TAGS},
         replay: {key: SectionKey.REPLAY},
       },
+      detectorDetails: {},
       eventCount: 0,
       isSidebarOpen: true,
       navScrollMargin: 0,
@@ -58,6 +59,7 @@ describe('EventNavigation', () => {
   it('does not show jump to sections by default', () => {
     jest.mocked(useIssueDetails).mockReturnValue({
       sectionData: {},
+      detectorDetails: {},
       eventCount: 0,
       isSidebarOpen: true,
       navScrollMargin: 0,

--- a/static/app/views/issueDetails/streamline/issueCheckInTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCheckInTimeline.tsx
@@ -1,0 +1,77 @@
+import {useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
+import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
+import {
+  GridLineLabels,
+  GridLineOverlay,
+} from 'sentry/components/checkInTimeline/gridLines';
+import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
+import {space} from 'sentry/styles/space';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import {
+  checkStatusPrecedent,
+  statusToText,
+  tickStyle,
+} from 'sentry/views/insights/uptime/timelineConfig';
+import {useUptimeMonitorStats} from 'sentry/views/insights/uptime/utils/useUptimeMonitorStats';
+import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
+
+export function IssueCheckInTimeline() {
+  const {detectorDetails} = useIssueDetails();
+  const {detectorId, detectorType} = detectorDetails;
+  const elementRef = useRef<HTMLDivElement>(null);
+  const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
+  const timelineWidth = useDebouncedValue(containerWidth, 500);
+  const timeWindowConfig = useTimeWindowConfig({timelineWidth});
+
+  const {data: uptimeStats, isPending} = useUptimeMonitorStats({
+    ruleIds: detectorType === 'uptime_monitor' && detectorId ? [detectorId] : [],
+    timeWindowConfig,
+  });
+
+  return (
+    <ChartContainer>
+      <TimelineWidthTracker ref={elementRef} />
+      <IssueGridLineOverlay
+        stickyCursor
+        allowZoom
+        showCursor
+        timeWindowConfig={timeWindowConfig}
+      />
+      <GridLineLabels timeWindowConfig={timeWindowConfig} />
+      {isPending ? (
+        <CheckInPlaceholder />
+      ) : (
+        <CheckInTimeline
+          bucketedData={detectorId ? uptimeStats?.[detectorId] ?? [] : []}
+          statusLabel={statusToText}
+          statusStyle={tickStyle}
+          statusPrecedent={checkStatusPrecedent}
+          timeWindowConfig={timeWindowConfig}
+        />
+      )}
+    </ChartContainer>
+  );
+}
+
+const ChartContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+  min-height: 104px;
+  width: 100%;
+  position: relative;
+`;
+
+const IssueGridLineOverlay = styled(GridLineOverlay)`
+  position: absolute;
+  width: 100%;
+`;
+
+const TimelineWidthTracker = styled('div')`
+  position: absolute;
+  width: 100%;
+`;

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -3,14 +3,19 @@ import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
 import {DowntimeDuration} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
+import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Event, EventEvidenceDisplay} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getDetectorDetails} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
 
 interface OccurrenceSummaryProps {
   group: Group;
   className?: string;
+  event?: Event;
 }
 
 /**
@@ -18,7 +23,8 @@ interface OccurrenceSummaryProps {
  * the occurence. For example, we display 'check-ins' in uptime issues, but the occrurence is a
  * status change from success to failure.
  */
-export function OccurrenceSummary({group, className}: OccurrenceSummaryProps) {
+export function OccurrenceSummary({group, event, className}: OccurrenceSummaryProps) {
+  const organization = useOrganization();
   const issueTypeConfig = getConfigForIssueType(group, group.project);
 
   if (!issueTypeConfig.header.occurrenceSummary.enabled) {
@@ -27,16 +33,68 @@ export function OccurrenceSummary({group, className}: OccurrenceSummaryProps) {
 
   const items: React.ReactNode[] = [];
 
-  if (issueTypeConfig.header.occurrenceSummary.duration) {
+  if (issueTypeConfig.header.occurrenceSummary.downtime) {
     items.push(
       <Flex column>
-        <ItemTitle>{t('Duration')}</ItemTitle>
+        <ItemTitle>{t('Downtime')}</ItemTitle>
         <ItemValue>
           <DowntimeDuration group={group} />
         </ItemValue>
       </Flex>
     );
   }
+
+  if (event) {
+    const {detectorPath, detectorType, detectorId} = getDetectorDetails({
+      event,
+      organization,
+      project: group.project,
+    });
+
+    if (detectorType === 'metric_alert' && detectorPath) {
+      items.push(
+        <Flex column>
+          <ItemTitle>{t('Alert ID')}</ItemTitle>
+          <ItemLink to={detectorPath}>{detectorId}</ItemLink>
+        </Flex>
+      );
+    }
+
+    if (['cron_monitor', 'uptime_monitor'].includes(detectorType ?? '') && detectorPath) {
+      items.push(
+        <Flex column>
+          <ItemTitle>{t('Monitor ID')}</ItemTitle>
+          <ItemLink to={detectorPath}>{detectorId}</ItemLink>
+        </Flex>
+      );
+    }
+  }
+
+  const evidenceMap = event?.occurrence?.evidenceDisplay?.reduce<
+    Record<string, EventEvidenceDisplay>
+  >((map, eed) => {
+    map[eed.name] = eed;
+    return map;
+  }, {});
+
+  if (evidenceMap?.['Status Code']) {
+    items.push(
+      <Flex column>
+        <ItemTitle>{t('Status Code')}</ItemTitle>
+        <ItemValue>{evidenceMap['Status Code'].value}</ItemValue>
+      </Flex>
+    );
+  }
+
+  if (evidenceMap?.['Failure reason']) {
+    items.push(
+      <Flex column>
+        <ItemTitle>{t('Reason')}</ItemTitle>
+        <ItemValue>{evidenceMap['Failure reason'].value}</ItemValue>
+      </Flex>
+    );
+  }
+
   // TODO(Leander): Add last successful check-in when the data is available
   // TODO(Leander): Add Incident ID when the data is available
 
@@ -58,4 +116,12 @@ const ItemTitle = styled('div')`
 const ItemValue = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: ${p => p.theme.fontWeightNormal};
+`;
+
+const ItemLink = styled(Link)`
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeLarge};
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: ${p => p.theme.subText};
 `;

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -99,7 +99,7 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
   // TODO(Leander): Add Incident ID when the data is available
 
   return items.length > 0 ? (
-    <Flex align="center" gap={space(4)} className={className}>
+    <Flex align="start" gap={space(4)} className={className}>
       {items.map((item, i) => (
         <Fragment key={i}>{item}</Fragment>
       ))}
@@ -116,6 +116,7 @@ const ItemTitle = styled('div')`
 const ItemValue = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: ${p => p.theme.fontWeightNormal};
+  max-width: 400px;
 `;
 
 const ItemLink = styled(Link)`

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -13,7 +13,9 @@ import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar/
 
 interface DetectorDetails {
   description?: string;
+  detectorId?: string;
   detectorPath?: string;
+  detectorType?: 'metric_alert' | 'cron_monitor' | 'uptime_monitor';
 }
 
 export function getDetectorDetails({
@@ -33,6 +35,8 @@ export function getDetectorDetails({
   const metricAlertRuleId = event?.contexts?.metric_alert?.alert_rule_id;
   if (metricAlertRuleId) {
     return {
+      detectorType: 'metric_alert',
+      detectorId: metricAlertRuleId,
       detectorPath: `/organizations/${organization.slug}/alerts/rules/details/${metricAlertRuleId}/`,
       // TODO(issues): We can probably enrich this description with details from the alert itself.
       description: t(
@@ -44,6 +48,8 @@ export function getDetectorDetails({
   const cronSlug = event?.tags?.find(({key}) => key === 'monitor.slug')?.value;
   if (cronSlug) {
     return {
+      detectorType: 'cron_monitor',
+      detectorId: cronSlug,
       detectorPath: `/organizations/${organization.slug}/alerts/rules/crons/${project.slug}/${cronSlug}/details/`,
       description: t(
         'This issue was created by a cron monitor. View the monitor details to learn more.'
@@ -54,6 +60,8 @@ export function getDetectorDetails({
   const uptimeAlertRuleId = event?.tags?.find(tag => tag?.key === 'uptime_rule')?.value;
   if (uptimeAlertRuleId) {
     return {
+      detectorType: 'uptime_monitor',
+      detectorId: uptimeAlertRuleId,
       detectorPath: `/organizations/${organization.slug}/alerts/rules/uptime/${project.slug}/${uptimeAlertRuleId}/details/`,
       // TODO(issues): Update this to mention detectors when that language is user-facing
       description: t(

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -8,10 +8,10 @@ import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import useOrganization from 'sentry/utils/useOrganization';
+import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 
-interface DetectorDetails {
+export interface DetectorDetails {
   description?: string;
   detectorId?: string;
   detectorPath?: string;
@@ -75,18 +75,10 @@ export function getDetectorDetails({
   };
 }
 
-export function DetectorSection({
-  event,
-  group,
-  project,
-}: {
-  event: Event;
-  group: Group;
-  project: Project;
-}) {
-  const organization = useOrganization();
-  const {detectorPath, description} = getDetectorDetails({event, organization, project});
+export function DetectorSection({group, project}: {group: Group; project: Project}) {
   const issueConfig = getConfigForIssueType(group, project);
+  const {detectorDetails} = useIssueDetails();
+  const {detectorPath, description} = detectorDetails;
 
   if (!detectorPath) {
     return null;

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -88,10 +88,10 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
         </Fragment>
       )}
       {/* Currently, we require events for displaying detector details */}
-      {event && issueTypeConfig.detector.enabled && (
+      {issueTypeConfig.detector.enabled && (
         <Fragment>
           <StyledBreak />
-          <DetectorSection event={event} group={group} project={project} />
+          <DetectorSection group={group} project={project} />
         </Fragment>
       )}
     </Side>

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -87,7 +87,6 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
           <MergedIssuesSidebarSection />
         </Fragment>
       )}
-      {/* Currently, we require events for displaying detector details */}
       {issueTypeConfig.detector.enabled && (
         <Fragment>
           <StyledBreak />

--- a/static/app/views/issueDetails/types.tsx
+++ b/static/app/views/issueDetails/types.tsx
@@ -9,7 +9,7 @@ export enum Tab {
   SIMILAR_ISSUES = 'similar-issues',
   REPLAYS = 'Replays',
   OPEN_PERIODS = 'open-periods',
-  CHECK_INS = 'check-ins',
+  UPTIME_CHECKS = 'uptime-checks',
 }
 
 export const TabPaths: Record<Tab, string> = {
@@ -23,5 +23,5 @@ export const TabPaths: Record<Tab, string> = {
   [Tab.SIMILAR_ISSUES]: 'similar/',
   [Tab.REPLAYS]: 'replays/',
   [Tab.OPEN_PERIODS]: 'open-periods/',
-  [Tab.CHECK_INS]: 'check-ins/',
+  [Tab.UPTIME_CHECKS]: 'uptime-checks/',
 };


### PR DESCRIPTION
Get a first draft of a working header for uptime issues:

<img width="978" alt="image" src="https://github.com/user-attachments/assets/9ffc96b4-3bf0-4dab-8329-3b654419cc62" />


A few things:
- The graph doesn't reflect new designs quite yet, it's just in there for now to be useful, we can style afterward
- The wording in the selector has been reverted to 'Events'. I will change it to check-ins once we have a single check-in view, because it is currently a misnomer.
- The occurrence data under the graph is being populated from `event.occurrence`
- A bit of a refactor to add `detectorDetails` to the `useIssueDetails` shared context. This will ensure that unloading an event (with a query, or with a new date range) doesn't unload the detector, as those _should_ be at the issue level, but aren't currently. 
