### PR TITLE
feat(insights): make perf to insights banner red

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -92,7 +92,7 @@ export function PerformanceLanding(props: Props) {
     handleTrendsClick,
     onboardingProject,
   } = props;
-  const {setPageInfo, pageAlert} = usePageAlert();
+  const {setPageError, pageAlert} = usePageAlert();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
   const {slug} = organization;
 
@@ -134,9 +134,9 @@ export function PerformanceLanding(props: Props) {
 
   useEffect(() => {
     if (performanceMovingAlert && pageAlert?.message !== performanceMovingAlert) {
-      setPageInfo(performanceMovingAlert);
+      setPageError(performanceMovingAlert);
     }
-  }, [pageAlert?.message, performanceMovingAlert, setPageInfo]);
+  }, [pageAlert?.message, performanceMovingAlert, setPageError]);
 
   useEffect(() => {
     if (hasMounted.current) {


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/84021

Makes the banner red so that it draws more eyes, will merge this when we have the green light from product.
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/093f7219-7ca6-4b77-8f2e-b66e1c34f554" />
