### PR TITLE
feat(aci): add EventUniqueUserFrequencyConditionHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -28,7 +28,7 @@ from .event_attribute_handler import EventAttributeConditionHandler
 from .event_created_by_detector_handler import EventCreatedByDetectorConditionHandler
 from .event_frequency_handlers import EventFrequencyCountHandler, EventFrequencyPercentHandler
 from .event_seen_count_handler import EventSeenCountConditionHandler
-from .event_user_frequency_handlers import (
+from .event_unique_user_frequency_handlers import (
     EventUniqueUserFrequencyCountHandler,
     EventUniqueUserFrequencyPercentHandler,
 )

--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -3,6 +3,8 @@ __all__ = [
     "EventFrequencyCountHandler",
     "EventFrequencyPercentHandler",
     "EventSeenCountConditionHandler",
+    "EventUniqueUserFrequencyCountHandler",
+    "EventUniqueUserFrequencyPercentHandler",
     "ReappearedEventConditionHandler",
     "RegressionEventConditionHandler",
     "ExistingHighPriorityIssueConditionHandler",
@@ -26,6 +28,10 @@ from .event_attribute_handler import EventAttributeConditionHandler
 from .event_created_by_detector_handler import EventCreatedByDetectorConditionHandler
 from .event_frequency_handlers import EventFrequencyCountHandler, EventFrequencyPercentHandler
 from .event_seen_count_handler import EventSeenCountConditionHandler
+from .event_user_frequency_handlers import (
+    EventUniqueUserFrequencyCountHandler,
+    EventUniqueUserFrequencyPercentHandler,
+)
 from .existing_high_priority_issue_handler import ExistingHighPriorityIssueConditionHandler
 from .first_seen_event_handler import FirstSeenEventConditionHandler
 from .issue_category_handler import IssueCategoryConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -9,10 +9,17 @@ from django.db.models import QuerySet
 
 from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.models.group import Group
-from sentry.rules.conditions.event_frequency import SNUBA_LIMIT
+from sentry.rules.conditions.event_frequency import (
+    COMPARISON_INTERVALS,
+    PERCENT_INTERVALS,
+    SNUBA_LIMIT,
+    STANDARD_INTERVALS,
+    percent_increase,
+)
 from sentry.tsdb.base import TSDBModel
 from sentry.utils.iterators import chunked
 from sentry.utils.snuba import options_override
+from sentry.workflow_engine.types import DataConditionResult, WorkflowJob
 
 
 class _QSTypedDict(TypedDict):
@@ -30,9 +37,8 @@ class BaseEventFrequencyConditionHandler(ABC):
         raise NotImplementedError
 
     @property
-    @abstractmethod
     def intervals(self) -> dict[str, tuple[str, timedelta]]:
-        raise NotImplementedError
+        return STANDARD_INTERVALS
 
     def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
         """
@@ -172,3 +178,47 @@ class BaseEventFrequencyConditionHandler(ABC):
                 environment_id=environment_id,
             )
         return result
+
+
+class BaseEventFrequencyCountHandler:
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
+            "value": {"type": "integer", "minimum": 0},
+        },
+        "required": ["interval", "value"],
+        "additionalProperties": False,
+    }
+
+    @staticmethod
+    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
+        if len(value.get("snuba_results", [])) != 1:
+            return False
+        return value["snuba_results"][0] > comparison["value"]
+
+
+class BaseEventFrequencyPercentHandler:
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
+            "value": {"type": "integer", "minimum": 0},
+            "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
+        },
+        "required": ["interval", "value", "comparison_interval"],
+        "additionalProperties": False,
+    }
+
+    @property
+    def intervals(self) -> dict[str, tuple[str, timedelta]]:
+        return PERCENT_INTERVALS
+
+    @staticmethod
+    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
+        if len(value.get("snuba_results", [])) != 2:
+            return False
+        return (
+            percent_increase(value["snuba_results"][0], value["snuba_results"][1])
+            > comparison["value"]
+        )

--- a/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Self
 
 from sentry import tsdb
-from sentry.issues.constants import get_issue_tsdb_group_model
+from sentry.issues.constants import get_issue_tsdb_user_group_model
 from sentry.models.group import Group
 from sentry.tsdb.base import TSDBModel
 from sentry.workflow_engine.handlers.condition.event_frequency_base_handler import (
@@ -47,7 +47,7 @@ class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandle
             )
 
         for category, issue_ids in category_group_ids.items():
-            model = get_issue_tsdb_group_model(
+            model = get_issue_tsdb_user_group_model(
                 category
             )  # TODO: may need to update logic for crons, metric issues, uptime
             batch_sums.update(get_result(model, issue_ids))

--- a/src/sentry/workflow_engine/handlers/condition/event_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_user_frequency_handlers.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
-class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
+class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     @property
     def base_handler(self) -> Self:
         return self
@@ -36,14 +36,14 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
 
         def get_result(model: TSDBModel, group_ids: list[int]) -> dict[int, int]:
             return self.get_chunked_result(
-                tsdb_function=tsdb.backend.get_sums,
+                tsdb_function=tsdb.backend.get_distinct_counts_totals,
                 model=model,
                 group_ids=group_ids,
                 organization_id=organization_id,
                 start=start,
                 end=end,
                 environment_id=environment_id,
-                referrer_suffix="batch_alert_event_frequency",
+                referrer_suffix="batch_alert_event_uniq_user_frequency",
             )
 
         for category, issue_ids in category_group_ids.items():
@@ -55,18 +55,18 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
         return batch_sums
 
 
-@condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
-class EventFrequencyCountHandler(
-    EventFrequencyConditionHandler,
+@condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
+class EventUniqueUserFrequencyCountHandler(
+    EventUniqueUserFrequencyConditionHandler,
     BaseEventFrequencyCountHandler,
     DataConditionHandler[WorkflowJob],
 ):
     pass
 
 
-@condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
-class EventFrequencyPercentHandler(
-    EventFrequencyConditionHandler,
+@condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
+class EventUniqueUserFrequencyPercentHandler(
+    EventUniqueUserFrequencyConditionHandler,
     BaseEventFrequencyPercentHandler,
     DataConditionHandler[WorkflowJob],
 ):

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from django.utils import timezone
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
-from sentry.rules.base import RuleBase
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -23,11 +22,6 @@ class ConditionTestCase(BaseWorkflowTest):
 
     @property
     def condition(self) -> Condition:
-        raise NotImplementedError
-
-    @property
-    def rule_cls(self) -> type[RuleBase]:
-        # for mapping purposes, can delete later
         raise NotImplementedError
 
     @property

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -20,7 +20,6 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 class TestEventFrequencyCountCondition(ConditionTestCase):
     condition = Condition.EVENT_FREQUENCY_COUNT
-    rule_cls = EventFrequencyCondition
     payload = {
         "interval": "1h",
         "id": EventFrequencyCondition.id,
@@ -81,12 +80,12 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
 
 class TestEventFrequencyPercentCondition(ConditionTestCase):
     condition = Condition.EVENT_FREQUENCY_PERCENT
-    rule_cls = EventFrequencyCondition
     payload = {
         "interval": "1h",
         "id": EventFrequencyCondition.id,
         "value": 1000,
         "comparisonType": ComparisonType.PERCENT,
+        "comparisonInterval": "1d",
     }
 
     def setUp(self):
@@ -111,7 +110,6 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         self.assert_does_not_pass(dc, self.job)
 
     def test_dual_write_percent(self):
-        self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_unique_user_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_unique_user_frequency_handlers.py
@@ -39,7 +39,7 @@ class TestEventUniqueUserFrequencyPercentCondition(TestEventFrequencyPercentCond
     }
 
 
-class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
+class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
     handler = EventFrequencyCountHandler
 
     def test_batch_query_user(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_unique_user_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_unique_user_frequency_handlers.py
@@ -1,0 +1,64 @@
+import pytest
+
+from sentry.rules.conditions.event_frequency import (
+    ComparisonType,
+    EventUniqueUserFrequencyCondition,
+)
+from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
+    EventFrequencyCountHandler,
+)
+from sentry.workflow_engine.models.data_condition import Condition
+from tests.sentry.workflow_engine.handlers.condition.test_base import EventFrequencyQueryTestBase
+from tests.sentry.workflow_engine.handlers.condition.test_event_frequency_handlers import (
+    TestEventFrequencyCountCondition,
+    TestEventFrequencyPercentCondition,
+)
+
+pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
+
+
+class TestEventUniqueUserFrequencyCountCondition(TestEventFrequencyCountCondition):
+    condition = Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
+    payload = {
+        "interval": "1h",
+        "id": EventUniqueUserFrequencyCondition.id,
+        "value": 1000,
+        "comparisonType": ComparisonType.COUNT,
+    }
+
+
+class TestEventUniqueUserFrequencyPercentCondition(TestEventFrequencyPercentCondition):
+    condition = Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT
+    payload = {
+        "interval": "1h",
+        "id": EventUniqueUserFrequencyCondition.id,
+        "value": 1000,
+        "comparisonType": ComparisonType.PERCENT,
+        "comparisonInterval": "1d",
+    }
+
+
+class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
+    handler = EventFrequencyCountHandler
+
+    def test_batch_query_user(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 1,
+            self.perf_event.group_id: 1,
+        }
+
+        batch_query = self.handler().batch_query(
+            group_ids={self.event3.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment2.id,
+        )
+        assert batch_query == {self.event3.group_id: 1}

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_unique_user_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_unique_user_frequency_handlers.py
@@ -5,8 +5,8 @@ from sentry.rules.conditions.event_frequency import (
     EventUniqueUserFrequencyCondition,
 )
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.handlers.condition.event_frequency_handlers import (
-    EventFrequencyCountHandler,
+from sentry.workflow_engine.handlers.condition.event_unique_user_frequency_handlers import (
+    EventUniqueUserFrequencyConditionHandler,
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.workflow_engine.handlers.condition.test_base import EventFrequencyQueryTestBase
@@ -40,7 +40,7 @@ class TestEventUniqueUserFrequencyPercentCondition(TestEventFrequencyPercentCond
 
 
 class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
-    handler = EventFrequencyCountHandler
+    handler = EventUniqueUserFrequencyConditionHandler
 
     def test_batch_query_user(self):
         batch_query = self.handler().batch_query(


### PR DESCRIPTION
Add condition handler for `EventUniqueUserFrequencyCondition`. This consists of a count condition AND a percent condition.

1. Add condition handler
2. Add translator to create `DataCondition` from existing issue alert payload
3. Add tests

I noticed that all count conditions have the same method of evaluation + comparison schema, and same for percent conditions, so I refactored those commonalities into shared classes. The only thing that is different between different kinds of overarching conditions (e.g. `EventFrequency` vs `EventUniqueUserFrequency`) is the way we query Snuba, which is encapsulated in the `batch_query` function.