### PR TITLE
fix(nav): Better detection of the active link

### DIFF
--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -25,6 +25,7 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -36,6 +37,7 @@ interface SidebarItemProps {
 
 interface SidebarItemLinkProps {
   to: string;
+  activeTo?: string;
   children?: React.ReactNode;
   onClick?: MouseEventHandler<HTMLElement>;
 }
@@ -70,7 +72,12 @@ function SidebarItem({item}: SidebarItemProps) {
   if (item.to) {
     return (
       <SidebarItemWrapper>
-        <SidebarLink to={item.to} key={item.label} onClick={recordAnalytics}>
+        <SidebarLink
+          to={item.to}
+          activeTo={item.activeTo}
+          key={item.label}
+          onClick={recordAnalytics}
+        >
           {item.icon}
           <span>{item.label}</span>
         </SidebarLink>
@@ -115,9 +122,9 @@ function SidebarMenu({items, children, onClick}: SidebarItemDropdownProps) {
   );
 }
 
-function SidebarLink({children, to, onClick}: SidebarItemLinkProps) {
+function SidebarLink({children, to, activeTo = to, onClick}: SidebarItemLinkProps) {
   const location = useLocation();
-  const isActive = isLinkActive(to, location.pathname);
+  const isActive = isLinkActive(normalizeUrl(activeTo, location), location.pathname);
   const linkProps = makeLinkPropsFromTo(to);
 
   return (
@@ -226,7 +233,8 @@ export function PrimaryNavigationItems() {
             label: t('Settings'),
             icon: <IconSettings />,
             analyticsKey: 'settings',
-            to: `${prefix}/settings/${organization.slug}/`,
+            to: `/${prefix}/settings/${organization.slug}/`,
+            activeTo: `/${prefix}/settings/`,
           }}
         />
       </SidebarFooter>

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -14,9 +14,14 @@ type SecondaryNavProps = {
   children: ReactNode;
 };
 
-interface SecondaryNavItemProps extends Omit<LinkProps, 'ref'> {
+interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
   children: ReactNode;
   to: To;
+  /**
+   * When passed, will not show the link as active for descendant paths.
+   * Same as the RR6 `NavLink` `end` prop.
+   */
+  end?: boolean;
   isActive?: boolean;
 }
 
@@ -54,12 +59,12 @@ SecondaryNav.Item = function SecondaryNavItem({
   children,
   to,
   isActive: incomingIsActive,
+  end = false,
   ...linkProps
 }: SecondaryNavItemProps) {
-  const {pathname} = useLocation();
-  const isActive =
-    incomingIsActive ||
-    isLinkActive(typeof to === 'string' ? to : to.pathname ?? '/', pathname);
+  const location = useLocation();
+
+  const isActive = incomingIsActive || isLinkActive(to, location.pathname, {end});
 
   return (
     <Item

--- a/static/app/components/nav/utils.tsx
+++ b/static/app/components/nav/utils.tsx
@@ -1,3 +1,4 @@
+import type {To} from '@remix-run/router';
 import type {LocationDescriptor} from 'history';
 
 import type {FeatureProps} from 'sentry/components/acl/feature';
@@ -40,6 +41,11 @@ export interface NavSidebarItem extends NavItem {
    */
   icon: React.ReactElement;
   /**
+   * Defines the path that should be considered active for this item.
+   * Defaults to the `to` prop.
+   */
+  activeTo?: string;
+  /**
    * dropdown menu to display when this SidebarItem is clicked
    */
   dropdown?: MenuItemProps[];
@@ -68,11 +74,18 @@ export type NavConfig = NavItemLayout<NavSidebarItem>;
 
 export type NavigationItemStatus = 'inactive' | 'active' | 'active-parent';
 
-export function isLinkActive(to: string, pathname: string): boolean {
-  const normalizedTo = normalizeUrl(to);
-  const normalizedCurrent = normalizeUrl(pathname);
+export function isLinkActive(
+  to: To,
+  pathname: string,
+  options: {end?: boolean} = {end: false}
+): boolean {
+  const toPathname = normalizeUrl(typeof to === 'string' ? to : to.pathname ?? '/');
 
-  return normalizedCurrent.startsWith(normalizedTo);
+  if (options.end) {
+    return pathname === toPathname;
+  }
+
+  return pathname.startsWith(toPathname);
 }
 
 /**

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -1,7 +1,6 @@
 import type {ReactElement} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import type {LocationDescriptor} from 'history';
 
 import Badge from 'sentry/components/badge/badge';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
@@ -10,11 +9,10 @@ import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
 
 type Props = {
   label: React.ReactNode;
-  to: LocationDescriptor;
+  to: string;
   badge?: string | number | null | ReactElement;
   id?: string;
   index?: boolean;
@@ -47,10 +45,9 @@ function SettingsNavBadge({badge}: {badge: string | number | null | ReactElement
   return badge;
 }
 
-function SettingsNavItem({badge, label, id, to, ...props}: Props) {
-  // TODO(malwilley): Support `end` prop in `SecondaryNav.Item`
+function SettingsNavItem({badge, label, id, to, index, ...props}: Props) {
   return (
-    <SecondaryNav.Item to={locationDescriptorToTo(to)} {...props}>
+    <SecondaryNav.Item to={to} end={index} {...props}>
       <LabelHook id={id}>{label}</LabelHook>
       {badge ? <SettingsNavBadge badge={badge} /> : null}
     </SecondaryNav.Item>


### PR DESCRIPTION
Some small updates to ensure that active links are treated correctly. Settings links were being normalized twice which was causing issues, and needed the `end` prop to be added to SecondaryNav.Item.