### PR TITLE
feat(nav): Duplicate /projects/ routes under /insights/projects/

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1041,12 +1041,8 @@ function buildRoutes() {
     </Route>
   );
 
-  const projectsRoutes = (
-    <Route
-      path="/projects/"
-      component={make(() => import('sentry/views/projects/'))}
-      withOrgPath
-    >
+  const projectsChildRoutes = (
+    <Fragment>
       <IndexRoute component={make(() => import('sentry/views/projectsDashboard'))} />
       <Route
         path="new/"
@@ -1066,6 +1062,15 @@ function buildRoutes() {
           () => import('sentry/views/projectInstall/platformOrIntegration')
         )}
       />
+    </Fragment>
+  );
+  const projectsRoutes = (
+    <Route
+      path="/projects/"
+      component={make(() => import('sentry/views/projects/'))}
+      withOrgPath
+    >
+      {projectsChildRoutes}
     </Route>
   );
 
@@ -1868,6 +1873,9 @@ function buildRoutes() {
           component={make(() => import('sentry/views/performance/trends'))}
         />
         {moduleRoutes}
+      </Route>
+      <Route path="projects/" component={make(() => import('sentry/views/projects/'))}>
+        {projectsChildRoutes}
       </Route>
     </Route>
   );

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   AI_LANDING_SUB_PATH,
@@ -39,9 +40,8 @@ export default function InsightsNavigation({children}: InsightsNavigationProps) 
       <SecondaryNav>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
-            {/* TODO(malwilley): Move projects to the /insights/projects/ route */}
-            <SecondaryNav.Item to={`/organizations/${organization.slug}/projects/`}>
-              All Projects
+            <SecondaryNav.Item to={`${baseUrl}/projects/`}>
+              {t('All Projects')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
           <SecondaryNav.Section>


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

Projects will live in `/insights/` with the new nav structure, so I'm ensuring that the components are also rendered in `/insights/projects/`. Modifying the existing links and adding redirects will happen in separate PRs

![CleanShot 2025-02-03 at 11 31 43@2x](https://github.com/user-attachments/assets/00955128-7fe6-4750-91fd-41147ad19b35)

