### PR TITLE
fix(issues): only search if not given a id's

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -254,8 +254,7 @@ def update_groups_with_search_fn(
     group_list = []
     if group_ids:
         group_list = get_group_list(organization_id, projects, group_ids)
-
-    if not group_list and not group_ids:
+    else:
         try:
             # It can raise ValidationError
             cursor_result, _ = search_fn(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -255,7 +255,7 @@ def update_groups_with_search_fn(
     if group_ids:
         group_list = get_group_list(organization_id, projects, group_ids)
 
-    if not group_list:
+    if not group_list and not group_ids:
         try:
             # It can raise ValidationError
             cursor_result, _ = search_fn(


### PR DESCRIPTION
this pr updates our issues search to only perform an additional search of all issues, if a list of issue id's is not given. right now, if `get_group_list` returns an empty list, it could default to searching which isn't what we would want, given that id's were passed in. we had a similar check in that past that got adjusted with the refactor in https://github.com/getsentry/sentry/pull/82245/
