### PR TITLE
fix(issue-stream): Prevent current tab count from being overridden

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -410,7 +410,7 @@ function IssueListOverview({router}: Props) {
 
   const fetchCounts = useCallback(
     (currentQueryCount: number, fetchAllCounts: boolean) => {
-      let newQueryCounts: QueryCounts = {...queryCounts};
+      const newQueryCounts: QueryCounts = {...queryCounts};
 
       const endpointParams = getEndpointParams();
       const tabQueriesWithCounts = getTabsWithCounts();
@@ -433,7 +433,7 @@ function IssueListOverview({router}: Props) {
       if (
         fetchAllCounts ||
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        !tabQueriesWithCounts.every(tabQuery => queryCounts[tabQuery] !== undefined)
+        !tabQueriesWithCounts.every(tabQuery => newQueryCounts[tabQuery] !== undefined)
       ) {
         const countsRequestParams: CountsEndpointParams = {
           ...omit(endpointParams, 'query'),
@@ -454,20 +454,17 @@ function IssueListOverview({router}: Props) {
             if (!data) {
               return;
             }
-            // Counts coming from the counts endpoint is limited to 100, for >= 100 we display 99+
-            newQueryCounts = {
-              ...queryCounts,
-              ...mapValues(data, (count: number) => ({
-                count,
-                hasMore: count > TAB_MAX_COUNT,
+            setQueryCounts({
+              ...newQueryCounts,
+              ...mapValues(data, (count: number | null) => ({
+                count: count ?? 0,
+                // Counts coming from the counts endpoint is limited to 100, for >= 100 we display 99+
+                hasMore: (count ?? 0) > TAB_MAX_COUNT,
               })),
-            };
+            });
           },
           error: () => {
             setQueryCounts({});
-          },
-          complete: () => {
-            setQueryCounts(newQueryCounts);
           },
         });
       }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/84439

When we set the query counts, we were combining the result with an old counts object which meant that the current count got lost.