### PR TITLE
fix(replay): Disable pointer events when resizing replay panels

### DIFF
--- a/static/app/components/splitPanel.tsx
+++ b/static/app/components/splitPanel.tsx
@@ -204,7 +204,11 @@ const SplitPanelContainer = styled('div')<{
   overflow: auto;
   grid-template-${p => p.orientation}: ${p => p.size} auto 1fr;
 
-  &.disable-iframe-pointer iframe {
+  /*
+   * This is more specific, with <code>&&</code> than the foundational rule:
+   * <code>&[data-inspectable='true'] .replayer-wrapper > iframe</code>
+   */
+  &&.disable-iframe-pointer iframe {
     pointer-events: none !important;
   }
 `;


### PR DESCRIPTION
There was always some CSS to disable pointer-events when the replay view was resizing, but it broke a little while ago because of CSS selector specificity

The fixes selectors look like this:
 
![fixed](https://github.com/user-attachments/assets/010ac479-47e9-4061-b4d2-c3d3796c3d2d)

Fixes #78977