### PR TITLE
fix(widget-builder): Add error messaging to threshold fields

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -93,4 +93,28 @@ describe('Thresholds', () => {
       {replace: true}
     );
   });
+
+  it('displays error', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Thresholds
+          dataType="duration"
+          dataUnit="millisecond"
+          error={{thresholds: {max1: 'error on max 1', max2: 'error on max 2'}}}
+        />
+      </WidgetBuilderProvider>,
+      {
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              thresholds: '{"max_values":{"max1":-200,"max2":100},"unit":"millisecond"}',
+            },
+          }),
+        }),
+      }
+    );
+
+    expect(await screen.findByText('error on max 1')).toBeInTheDocument();
+    expect(await screen.findByText('error on max 2')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -11,7 +11,19 @@ import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/co
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
-function ThresholdsSection({dataType, dataUnit}: {dataType?: string; dataUnit?: string}) {
+type ThresholdsSectionProps = {
+  dataType?: string;
+  dataUnit?: string;
+  error?: Record<string, any>;
+  setError?: (error: Record<string, any>) => void;
+};
+
+function ThresholdsSection({
+  dataType,
+  dataUnit,
+  error,
+  setError,
+}: ThresholdsSectionProps) {
   const {state, dispatch} = useWidgetBuilderContext();
   return (
     <Fragment>
@@ -55,6 +67,8 @@ function ThresholdsSection({dataType, dataUnit}: {dataType?: string; dataUnit?: 
             newThresholds = undefined;
           }
 
+          setError?.({...error, thresholds: {[maxKey]: ''}});
+
           dispatch({
             type: BuilderStateAction.SET_THRESHOLDS,
             payload: newThresholds,
@@ -71,8 +85,7 @@ function ThresholdsSection({dataType, dataUnit}: {dataType?: string; dataUnit?: 
         }}
         dataType={dataType}
         dataUnit={dataUnit}
-        // TODO: Add errors
-        errors={{}}
+        errors={error?.thresholds}
       />
     </Fragment>
   );

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -200,6 +200,8 @@ function WidgetBuilderSlideout({
                 <ThresholdsSection
                   dataType={thresholdMetaState?.dataType}
                   dataUnit={thresholdMetaState?.dataUnit}
+                  error={error}
+                  setError={setError}
                 />
               </Section>
             )}


### PR DESCRIPTION
we forgot to put error messages in the threshold fields whooops! Now we have it lol

![image](https://github.com/user-attachments/assets/4f3442d7-13af-4462-aa43-a09e50c614c1)
![image](https://github.com/user-attachments/assets/cf8419bf-3117-4f2d-bd89-8a8a89fadf02)

