### PR TITLE
ref: move sentry.{features,options}.rollout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -432,6 +432,7 @@ module = [
     "sentry.nodestore.filesystem.backend",
     "sentry.nodestore.models",
     "sentry.notifications.services.*",
+    "sentry.options.rollout",
     "sentry.organizations.*",
     "sentry.ownership.*",
     "sentry.plugins.base.response",

--- a/src/sentry/features/rollout.py
+++ b/src/sentry/features/rollout.py
@@ -1,26 +1,4 @@
-from __future__ import annotations
+# TODO: update callers to reference the new location
+from sentry.options.rollout import in_random_rollout, in_rollout_group
 
-import hashlib
-import random
-
-from sentry import options
-
-
-def in_random_rollout(option_name: str) -> bool:
-    """
-    Determine if the current operation is in a random % based rollout
-    group governed by an option with `option_name`.
-    """
-    return random.random() < options.get(option_name)
-
-
-def in_rollout_group(option_name: str, key: int | str) -> bool:
-    """
-    Determine if the current `key` expression is in a deterministic % based rollout
-    group governed by an option with `option_name`
-    """
-    if isinstance(key, str):
-        int_key = int(hashlib.md5(key.encode("utf8")).hexdigest(), base=16)
-    else:
-        int_key = key
-    return (int_key % 100000) / 100000 < options.get(option_name)
+__all__ = ("in_random_rollout", "in_rollout_group")

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -9,7 +9,6 @@ import sentry_sdk
 
 from sentry import features, options
 from sentry.exceptions import HashDiscarded
-from sentry.features.rollout import in_random_rollout
 from sentry.grouping.api import (
     NULL_GROUPING_CONFIG,
     BackgroundGroupingConfigLoader,
@@ -28,6 +27,7 @@ from sentry.grouping.ingest.grouphash_metadata import (
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
+from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
 from sentry.utils.metrics import MutableTags
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from sentry import analytics
 from sentry.eventstore.models import Event
-from sentry.features.rollout import in_rollout_group
 from sentry.grouping.component import MessageGroupingComponent
 from sentry.grouping.parameterization import Parameterizer, UniqueIdExperiment
 from sentry.grouping.strategies.base import (
@@ -13,6 +12,7 @@ from sentry.grouping.strategies.base import (
     strategy,
 )
 from sentry.interfaces.message import Message
+from sentry.options.rollout import in_rollout_group
 from sentry.utils import metrics
 
 

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -8,7 +8,6 @@ import sentry_sdk
 from django.conf import settings
 from rediscluster import RedisCluster
 
-from sentry.features.rollout import in_random_rollout
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.datasource import (
     HTTP_404_TAG,
@@ -16,6 +15,7 @@ from sentry.ingest.transaction_clusterer.datasource import (
     TRANSACTION_SOURCE_URL,
 )
 from sentry.models.project import Project
+from sentry.options.rollout import in_random_rollout
 from sentry.utils import redis
 from sentry.utils.safe import safe_execute
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -10,7 +10,6 @@ from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import ParseDebugIdError
 
 from sentry import options
-from sentry.features.rollout import in_random_rollout
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.lang.native.utils import (
@@ -25,6 +24,7 @@ from sentry.lang.native.utils import (
     signal_from_data,
 )
 from sentry.models.eventerror import EventError
+from sentry.options.rollout import in_random_rollout
 from sentry.stacktraces.functions import trim_function_name
 from sentry.stacktraces.processing import StacktraceInfo, find_stacktraces_in_data
 from sentry.utils import metrics

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -11,7 +11,7 @@ from sentry.db.models import (
     region_silo_model,
     sane_repr,
 )
-from sentry.features.rollout import in_random_rollout
+from sentry.options.rollout import in_random_rollout
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 

--- a/src/sentry/options/rollout.py
+++ b/src/sentry/options/rollout.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import hashlib
+import random
+
+from sentry import options
+
+
+def in_random_rollout(option_name: str) -> bool:
+    """
+    Determine if the current operation is in a random % based rollout
+    group governed by an option with `option_name`.
+    """
+    return random.random() < options.get(option_name)
+
+
+def in_rollout_group(option_name: str, key: int | str) -> bool:
+    """
+    Determine if the current `key` expression is in a deterministic % based rollout
+    group governed by an option with `option_name`
+    """
+    if isinstance(key, str):
+        int_key = int(hashlib.md5(key.encode("utf8")).hexdigest(), base=16)
+    else:
+        int_key = key
+    return (int_key % 100000) / 100000 < options.get(option_name)

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -14,7 +14,6 @@ from sentry_relay.processing import validate_sampling_condition
 from sentry import features, options
 from sentry.api.endpoints.project_transaction_threshold import DEFAULT_THRESHOLD
 from sentry.api.utils import get_date_range_from_params
-from sentry.features.rollout import in_random_rollout
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.dashboard_widget import (
     ON_DEMAND_ENABLED_KEY,
@@ -29,6 +28,7 @@ from sentry.models.transaction_threshold import (
     ProjectTransactionThresholdOverride,
     TransactionMetric,
 )
+from sentry.options.rollout import in_random_rollout
 from sentry.relay.config.experimental import TimeChecker, build_safe_config
 from sentry.relay.types import RuleCondition
 from sentry.search.events import fields

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -23,7 +23,7 @@ from snuba_sdk import (
 from sentry.api import event_search
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
-from sentry.features.rollout import in_rollout_group
+from sentry.options.rollout import in_rollout_group
 from sentry.search.events import constants
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.datasets.base import DatasetConfig

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -18,7 +18,7 @@ from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMe
 from sentry_kafka_schemas.schema_types.snuba_metrics_v1 import Metric
 
 from sentry import options
-from sentry.features.rollout import in_random_rollout
+from sentry.options.rollout import in_random_rollout
 from sentry.sentry_metrics.aggregation_option_registry import get_aggregation_options
 from sentry.sentry_metrics.configuration import MAX_INDEXED_COLUMN_LENGTH
 from sentry.sentry_metrics.consumers.indexer.common import (

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -26,10 +26,10 @@ from sentry.api.event_search import (
 from sentry.constants import DataCategory
 from sentry.discover.arithmetic import is_equation
 from sentry.exceptions import InvalidSearchQuery
-from sentry.features.rollout import in_random_rollout
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.transaction_threshold import ProjectTransactionThreshold, TransactionMetric
+from sentry.options.rollout import in_random_rollout
 from sentry.relay.types import RuleCondition
 from sentry.search.events import fields
 from sentry.search.events.builder.discover import UnresolvedQuery

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -128,7 +128,7 @@ def loads(value: str | bytes, use_rapid_json: bool = False, **kwargs: NoReturn) 
 # dumps JSON with `orjson` or the default function depending on `option_name`
 # TODO: remove this when orjson experiment is successful
 def dumps_experimental(option_name: str, data: Any) -> str:
-    from sentry.features.rollout import in_random_rollout
+    from sentry.options.rollout import in_random_rollout
 
     if in_random_rollout(option_name):
         return orjson.dumps(data).decode()

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -22,7 +22,7 @@ from sentry_sdk.utils import logger as sdk_logger
 
 from sentry import options
 from sentry.conf.types.sdk_config import SdkConfig
-from sentry.features.rollout import in_random_rollout
+from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
 from sentry.utils.db import DjangoAtomicIntegration
 from sentry.utils.flag import FlagPoleIntegration

--- a/tests/sentry/options/test_rollout.py
+++ b/tests/sentry/options/test_rollout.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 import pytest
 
 from sentry import options
-from sentry.features.rollout import in_random_rollout, in_rollout_group
+from sentry.options.rollout import in_random_rollout, in_rollout_group
 from sentry.testutils.helpers.options import override_options
 
 


### PR DESCRIPTION
resolves an import cycle between features<=>options and the rollout module has nothing to do with sentry.features

<!-- Describe your PR here. -->