### PR TITLE
ref(dashboards): Move padding control into `WidgetLayout`

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -333,6 +333,7 @@ function WidgetCard(props: Props) {
             onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
             borderless={props.borderless}
             forceDescriptionTooltip={props.forceDescriptionTooltip}
+            noVisualizationPadding
           >
             <WidgetCardChartContainer
               location={location}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -14,8 +14,6 @@ import {
   DEFAULT_FIELD,
   MISSING_DATA_MESSAGE,
   NON_FINITE_NUMBER_MESSAGE,
-  X_GUTTER,
-  Y_GUTTER,
 } from '../common/settings';
 import type {StateProps} from '../common/types';
 
@@ -95,5 +93,4 @@ const BigNumberResizeWrapper = styled('div')`
 const LoadingPlaceholder = styled('span')`
   color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
   font-size: ${p => p.theme.fontSizeLarge};
-  padding: ${Y_GUTTER} ${X_GUTTER};
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -15,8 +15,6 @@ import type {
   Thresholds,
 } from 'sentry/views/dashboards/widgets/common/types';
 
-import {X_GUTTER, Y_GUTTER} from '../common/settings';
-
 import {ThresholdsIndicator} from './thresholdsIndicator';
 
 export interface BigNumberWidgetVisualizationProps {
@@ -143,7 +141,7 @@ function Wrapper({children}: any) {
 
 const AutoResizeParent = styled('div')`
   position: absolute;
-  inset: ${Y_GUTTER} ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
+  inset: 0;
 
   color: ${p => p.theme.headingColor};
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -40,7 +40,9 @@ export default storyBook(WidgetFrame, story => {
             <WidgetFrame
               title="Count"
               description="This counts up the amount of something that happens."
-            />
+            >
+              <p>Lorem whoopsie, feed me pickles please I am lacking in probiotics</p>
+            </WidgetFrame>
           </NormalWidget>
           <NormalWidget>
             <WidgetFrame

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -30,6 +30,7 @@ export interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
   badgeProps?: BadgeProps | BadgeProps[];
   borderless?: boolean;
   children?: React.ReactNode;
+  noVisualizationPadding?: boolean;
   onFullScreenViewClick?: () => void | Promise<void>;
   title?: string;
   warnings?: string[];
@@ -155,6 +156,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
           </ErrorBoundary>
         )
       }
+      noVisualizationPadding={props.noVisualizationPadding}
     />
   );
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {defined} from 'sentry/utils';
 import {
   WidgetFrame,
@@ -10,7 +8,7 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {MISSING_DATA_MESSAGE, X_GUTTER, Y_GUTTER} from '../common/settings';
+import {MISSING_DATA_MESSAGE} from '../common/settings';
 import type {StateProps} from '../common/types';
 import {LoadingPanel} from '../widgetLayout/loadingPanel';
 
@@ -54,23 +52,16 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
       onRetry={props.onRetry}
     >
       {defined(timeseries) && (
-        <TimeSeriesWrapper>
-          <TimeSeriesWidgetVisualization
-            visualizationType={props.visualizationType}
-            timeseries={timeseries}
-            releases={props.releases}
-            aliases={props.aliases}
-            dataCompletenessDelay={props.dataCompletenessDelay}
-            timeseriesSelection={props.timeseriesSelection}
-            onTimeseriesSelectionChange={props.onTimeseriesSelectionChange}
-          />
-        </TimeSeriesWrapper>
+        <TimeSeriesWidgetVisualization
+          visualizationType={props.visualizationType}
+          timeseries={timeseries}
+          releases={props.releases}
+          aliases={props.aliases}
+          dataCompletenessDelay={props.dataCompletenessDelay}
+          timeseriesSelection={props.timeseriesSelection}
+          onTimeseriesSelectionChange={props.onTimeseriesSelectionChange}
+        />
       )}
     </WidgetFrame>
   );
 }
-
-const TimeSeriesWrapper = styled('div')`
-  flex-grow: 1;
-  padding: 0 ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
-`;

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
@@ -72,7 +72,7 @@ import {WidgetTitle} from './widgetTitle';
   Visualization={
     <LineChartWidgetVisualization timeseries={[sampleDurationTimeSeries]} />
   }
-  Footer={<p>This data is incomplete!</p>}
+  Footer={<span>This data is incomplete!</span>}
 />
 
         `}
@@ -94,7 +94,7 @@ import {WidgetTitle} from './widgetTitle';
             Visualization={
               <LineChartWidgetVisualization timeseries={[sampleDurationTimeSeries]} />
             }
-            Footer={<p>This data is incomplete!</p>}
+            Footer={<span>This data is incomplete!</span>}
           />
         </SmallSizingWindow>
       </Fragment>

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -13,6 +13,9 @@ export interface WidgetLayoutProps {
   ariaLabel?: string;
   forceShowActions?: boolean;
   height?: number;
+  noFooterPadding?: boolean;
+  noHeaderPadding?: boolean;
+  noVisualizationPadding?: boolean;
 }
 
 export function WidgetLayout(props: WidgetLayoutProps) {
@@ -22,16 +25,20 @@ export function WidgetLayout(props: WidgetLayoutProps) {
       height={props.height}
       forceShowActions={props.forceShowActions}
     >
-      <Header>
+      <Header noPadding={props.noHeaderPadding}>
         {props.Title && <Fragment>{props.Title}</Fragment>}
         {props.Actions && <TitleHoverItems>{props.Actions}</TitleHoverItems>}
       </Header>
 
       {props.Visualization && (
-        <VisualizationWrapper>{props.Visualization}</VisualizationWrapper>
+        <VisualizationWrapper noPadding={props.noVisualizationPadding}>
+          {props.Visualization}
+        </VisualizationWrapper>
       )}
 
-      {props.Footer && <FooterWrapper>{props.Footer}</FooterWrapper>}
+      {props.Footer && (
+        <FooterWrapper noPadding={props.noFooterPadding}>{props.Footer}</FooterWrapper>
+      )}
     </Frame>
   );
 }
@@ -81,25 +88,26 @@ const Frame = styled('div')<{forceShowActions?: boolean; height?: number}>`
   }`}
 `;
 
-const Header = styled('div')`
+const Header = styled('div')<{noPadding?: boolean}>`
   display: flex;
   align-items: center;
   height: calc(${HEADER_HEIGHT} + ${Y_GUTTER});
   flex-shrink: 0;
   gap: ${space(0.75)};
-  padding: ${X_GUTTER} ${Y_GUTTER} 0 ${X_GUTTER};
+  padding: ${p => (p.noPadding ? 0 : `${Y_GUTTER} ${X_GUTTER} 0 ${X_GUTTER}`)};
 `;
 
-const VisualizationWrapper = styled('div')`
+const VisualizationWrapper = styled('div')<{noPadding?: boolean}>`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   min-height: 0;
   position: relative;
-  padding: 0;
+  padding: ${p => (p.noPadding ? 0 : `0 ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER}`)};
 `;
 
-const FooterWrapper = styled('div')`
+const FooterWrapper = styled('div')<{noPadding?: boolean}>`
   margin: 0;
   border-top: 1px solid ${p => p.theme.border};
+  padding: ${p => (p.noPadding ? 0 : `${space(1)} ${X_GUTTER} ${space(1)} ${X_GUTTER}`)};
 `;

--- a/static/app/views/projectDetail/projectScoreCards/actionWrapper.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/actionWrapper.tsx
@@ -3,5 +3,5 @@ import styled from '@emotion/styled';
 import {space} from 'sentry/styles/space';
 
 export const ActionWrapper = styled('div')`
-  padding: ${space(2)};
+  padding: ${space(1)} 0 0 0;
 `;


### PR DESCRIPTION
This is a re-do of https://github.com/getsentry/sentry/pull/83744 but this time without the mistake. In short

- right now, the padding around a widget's visualization is up to the widget. It's not specified in the visualization _or_ in the frame. This makes it hard to enforce consistent padding in other places
- in this PR, the control of padding is given to `WidgetLayout`, which will set up correct padding
- on the off-chance (actually kind of common) that visualization padding is not needed, the parent can specify `noVisualizationPadding`

The `noVisualizationPadding` approach is a little gross, but it solves the current need and I'll circle back to automatic padding control in the near future. For now, this makes it easier for custom usage to get correct padding out-of-the-box, and splits the responsibilities more sensibly.
