### PR TITLE
fix(widget-builder): Make entrance/exit animations smoother

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/common/animationSettings.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/common/animationSettings.tsx
@@ -1,0 +1,4 @@
+export const animationTransitionSettings = {
+  type: 'tween',
+  duration: 0.5,
+};

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -26,6 +26,7 @@ import {
   DisplayType,
   type Widget,
 } from 'sentry/views/dashboards/types';
+import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import {
   DEFAULT_WIDGET_DRAG_POSITIONING,
   DRAGGABLE_PREVIEW_HEIGHT_PX,
@@ -300,11 +301,7 @@ export function WidgetPreviewContainer({
                     initial={{opacity: 0, x: '50%', y: 0}}
                     animate={{opacity: 1, x: 0, y: 0}}
                     exit={{opacity: 0, x: '50%', y: 0}}
-                    transition={{
-                      type: 'spring',
-                      stiffness: 500,
-                      damping: 50,
-                    }}
+                    transition={animationTransitionSettings}
                   >
                     {t('Widget Preview')}
                   </WidgetPreviewTitle>
@@ -313,11 +310,7 @@ export function WidgetPreviewContainer({
                   initial={{opacity: 0, x: '50%', y: 0}}
                   animate={{opacity: 1, x: 0, y: 0}}
                   exit={{opacity: 0, x: '50%', y: 0}}
-                  transition={{
-                    type: 'spring',
-                    stiffness: 500,
-                    damping: 50,
-                  }}
+                  transition={animationTransitionSettings}
                   style={{
                     width: isDragEnabled ? DRAGGABLE_PREVIEW_WIDTH_PX : undefined,
                     height: getPreviewHeight(),

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -21,6 +21,7 @@ import {
   DisplayType,
   type Widget,
 } from 'sentry/views/dashboards/types';
+import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
@@ -140,6 +141,7 @@ function WidgetBuilderSlideout({
       collapsed={!isOpen}
       slidePosition="left"
       data-test-id="widget-slideout"
+      transitionProps={animationTransitionSettings}
     >
       <SlideoutHeaderWrapper>
         <SlideoutTitle>{title}</SlideoutTitle>


### PR DESCRIPTION
Got some [feedback](https://www.notion.so/sentry/Animation-after-saving-widget-1768b10e4b5d80549c8bef6726374c12?pvs=4) from the bug bash saying it would be nice to have some nice animation on exit as well as entrance. I've adjusted the type of movement and the made the duration so that the animation is more prominent.

This is what it looks like now:


https://github.com/user-attachments/assets/1af250c5-812f-4253-a29f-b2f3c43e42f3

Doesn't look too different but the animation is longer and not as stiff