### PR TITLE
:recycle: ref(noa): fail loudly when action can't be migrated

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -10,7 +10,7 @@ from sentry.workflow_engine.typings.notification_action import (
 logger = logging.getLogger(__name__)
 
 
-def build_notification_actions_from_rule_data_actions(
+def translate_rule_data_actions_to_notification_actions(
     actions: list[dict[str, Any]]
 ) -> list[Action]:
     """
@@ -73,6 +73,22 @@ def build_notification_actions_from_rule_data_actions(
         )
 
         notification_actions.append(notification_action)
+
+    return notification_actions
+
+
+def build_notification_actions_from_rule_data_actions(
+    actions: list[dict[str, Any]]
+) -> list[Action]:
+    """
+    Builds notification actions from action field in Rule's data blob.
+    Will only create actions that are valid, and log any errors before skipping the action.
+
+    :param actions: list of action data (Rule.data.actions)
+    :return: list of notification actions (Action)
+    """
+
+    notification_actions = translate_rule_data_actions_to_notification_actions(actions)
 
     # Bulk create the actions
     Action.objects.bulk_create(notification_actions)

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1,6 +1,8 @@
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from sentry.eventstore.models import GroupEvent
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
@@ -164,8 +166,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 0
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
         # Assert the logger was called with the correct arguments
         mock_logger.assert_called_with(
@@ -183,8 +185,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 0
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
         # Assert the logger was called with the correct arguments
         mock_logger.assert_called_with(
@@ -276,13 +278,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        # Only 2 actions should be created, the first one is malformed
-        assert len(actions) == 2
-
-        self.assert_actions_migrated_correctly(
-            actions, action_data[1:], "workspace", "channel_id", "channel"
-        )
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
         # Assert the logger was called with the correct arguments
         mock_logger.assert_called_with(
@@ -293,8 +290,6 @@ class TestNotificationActionMigrationUtils(TestCase):
                 "missing_fields": ["channel_id", "channel"],
             },
         )
-
-        self.assert_actions_migrated_correctly(actions, action_data[1:])
 
     def test_discord_action_migration(self):
         action_data = [
@@ -336,12 +331,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 1
-
-        self.assert_actions_migrated_correctly(
-            actions, action_data[1:], "server", "channel_id", None
-        )
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
         # Assert the logger was called with the correct arguments
         mock_logger.assert_called_with(
@@ -397,12 +388,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 1
-
-        self.assert_actions_migrated_correctly(
-            actions, action_data[1:], "team", "channel_id", "channel"
-        )
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
         # Assert the logger was called with the correct arguments
         mock_logger.assert_called_with(
@@ -465,10 +452,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 1
-
-        self.assert_actions_migrated_correctly(actions, action_data[1:], "account", "service", None)
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_opsgenie_action_migration(self):
         action_data = [
@@ -521,10 +506,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 1
-
-        self.assert_actions_migrated_correctly(actions, action_data[1:], "account", "team", None)
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_github_action_migration(self):
         # Includes both, Github and Github Enterprise. We currently don't have any rules configured for Github Enterprise.
@@ -763,8 +746,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 0
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_azure_devops_migration(self):
         action_data = [
@@ -920,8 +903,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 0
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_email_migration(self):
         action_data: list[dict[str, Any]] = [
@@ -1000,11 +983,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 1
-        self.assert_actions_migrated_correctly(
-            actions, [action_data[2]], None, "targetIdentifier", None, "targetType"
-        )
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_plugin_action_migration(self):
         action_data = [
@@ -1086,8 +1066,8 @@ class TestNotificationActionMigrationUtils(TestCase):
             },
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 0
+        with pytest.raises(ValueError):
+            build_notification_actions_from_rule_data_actions(action_data)
 
     def test_action_types(self):
         """Test that all registered action translators have the correct action type set."""


### PR DESCRIPTION
instead of just logging and continuing, lets raise loudly and let the caller handle the error.

closes https://getsentry.atlassian.net/browse/ACI-130