### PR TITLE
ref(rpc): Move confidence to meta

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -353,6 +353,11 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             if not data:
                 return {"data": [], "meta": meta}
             if "confidence" in results:
+                meta["accuracy"] = {
+                    "confidence": results["confidence"],
+                    # TODO: add sampleCount and rampleRate here
+                }
+                # Confidence being a top level key is going to be deprecated in favour of confidence being in the meta
                 return {"data": data, "meta": meta, "confidence": results["confidence"]}
             return {"data": data, "meta": meta}
 
@@ -611,6 +616,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             )
             if is_equation(query_column):
                 equations += 1
+            # TODO: confidence is being split up in the serializer right now, need to move that here once its deprecated
+            meta["accuracy"] = {"confidence": result[columns[index]]["confidence"]}
             result[columns[index]]["meta"] = meta
         # Set order if multi-axis + top events
         if "order" in event_result.data:

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -617,7 +617,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             if is_equation(query_column):
                 equations += 1
             # TODO: confidence is being split up in the serializer right now, need to move that here once its deprecated
-            meta["accuracy"] = {"confidence": result[columns[index]]["confidence"]}
+            if "confidence" in result[columns[index]]:
+                meta["accuracy"] = {"confidence": result[columns[index]]["confidence"]}
             result[columns[index]]["meta"] = meta
         # Set order if multi-axis + top events
         if "order" in event_result.data:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1644,6 +1644,9 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
             },
         ]
         assert response.data["meta"] == {
+            "accuracy": {
+                "confidence": [{}],
+            },
             "dataset": mock.ANY,
             "datasetReason": "unchanged",
             "fields": {

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -657,7 +657,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                 }
             )
             assert response.status_code == 200, response.content
-            assert response.data["meta"] == {
+            expected = {
                 "dataset": mock.ANY,
                 "datasetReason": "unchanged",
                 "fields": {
@@ -674,6 +674,11 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                     "project.name": None,
                 },
             }
+            if self.use_rpc:
+                expected["accuracy"] = {
+                    "confidence": [{}],
+                }
+            assert response.data["meta"] == expected
             assert response.data["data"] == [
                 {
                     key: pytest.approx((i + 1) / 10),
@@ -1643,10 +1648,7 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
                 "id": mock.ANY,
             },
         ]
-        assert response.data["meta"] == {
-            "accuracy": {
-                "confidence": [{}],
-            },
+        expected = {
             "dataset": mock.ANY,
             "datasetReason": "unchanged",
             "fields": {
@@ -1667,6 +1669,11 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
                 "project.name": None,
             },
         }
+        if self.use_rpc:
+            expected["accuracy"] = {
+                "confidence": [{}],
+            }
+        assert response.data["meta"] == expected
 
     def test_filtering_numeric_attr(self):
         span_1 = self.create_span(

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1810,7 +1810,8 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
 
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        confidence = response.data["confidence"]
+        meta = response.data["meta"]
+        confidence = meta["accuracy"]["confidence"]
         assert len(data) == 2
         assert len(confidence) == 2
         assert data[0]["count()"] == 10
@@ -1901,7 +1902,8 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
 
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        confidence = response.data["confidence"]
+        meta = response.data["meta"]
+        confidence = meta["accuracy"]["confidence"]
         assert len(data) == 1
         assert data[0]["avg_sample(sampling_rate)"] == pytest.approx(0.475)
         assert data[0]["min(sampling_rate)"] == pytest.approx(0.1)

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -746,9 +746,9 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
 
         for expected, actual in zip(event_counts, confidence[0:6]):
             if expected != 0:
-                assert actual[1][0]["count"] == "low"
+                assert actual["count()"] == "low"
             else:
-                assert actual[1][0]["count"] is None
+                assert actual["count()"] is None
 
     def test_confidence_is_set(self):
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -810,9 +810,9 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             assert len(confidence) == len(event_counts)
             for count, row in zip(event_counts, confidence):
                 if count == 0:
-                    assert row[1][0]["count"] is None, y_axis
+                    assert row[y_axis] is None, y_axis
                 else:
-                    assert row[1][0]["count"] in {"low", "high"}, y_axis
+                    assert row[y_axis] in {"low", "high"}, y_axis
 
     def test_extrapolation_with_multiaxis(self):
         event_counts = [6, 0, 6, 3, 0, 3]


### PR DESCRIPTION
- We're going to add sampleCount and sampleRate eventually, and we don't want all of these as top level keys. Going to move it all to meta under a new `accuracy` key
- This is the first step to just add confidence under accuracy so the frontend can update, going to do a follow up to remove the redundant data and add the sample* data