### PR TITLE
ref(dashboards): Update `TimeseriesData` types to always include `meta`

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -37,6 +37,7 @@ describe('BigNumberWidget', () => {
             fields: {
               'p95(span.duration)': 'number',
             },
+            units: {},
           }}
         />
       );
@@ -53,6 +54,7 @@ describe('BigNumberWidget', () => {
             fields: {
               'count()': 'number',
             },
+            units: {},
           }}
         />
       );
@@ -88,6 +90,7 @@ describe('BigNumberWidget', () => {
             fields: {
               'max(timestamp)': 'string',
             },
+            units: {},
           }}
         />
       );
@@ -146,6 +149,7 @@ describe('BigNumberWidget', () => {
             fields: {
               'count()': 'integer',
             },
+            units: {},
           }}
         />
       );

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -128,6 +128,7 @@ export default storyBook(BigNumberWidget, story => {
                 fields: {
                   'count()': 'integer',
                 },
+                units: {},
               }}
             />
           </SmallWidget>
@@ -228,6 +229,7 @@ export default storyBook(BigNumberWidget, story => {
                 fields: {
                   'http_rate(500)': 'percentage',
                 },
+                units: {},
               }}
             />
           </SmallWidget>
@@ -242,6 +244,7 @@ export default storyBook(BigNumberWidget, story => {
                 fields: {
                   'http_rate(200)': 'percentage',
                 },
+                units: {},
               }}
             />
           </SmallWidget>

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -1,8 +1,8 @@
 import type {ThresholdsConfig} from '../../widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
 export type Meta = {
-  fields: Record<string, string>;
-  units?: Record<string, string | null>;
+  fields: Record<string, string | null>;
+  units: Record<string, string | null>;
 };
 
 type TableRow = Record<string, number | string | undefined>;
@@ -17,8 +17,8 @@ export type TimeSeriesItem = {
 export type TimeseriesData = {
   data: TimeSeriesItem[];
   field: string;
+  meta: Meta;
   color?: string;
-  meta?: Meta;
 };
 
 export type ErrorProp = Error | string;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/splitSeriesIntoCompleteAndIncomplete.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/splitSeriesIntoCompleteAndIncomplete.spec.tsx
@@ -30,6 +30,14 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
           timestamp: '2024-10-24T15:56:00.000Z',
         },
       ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': 'millisecond',
+        },
+      },
     };
 
     const [completeSerie, incompleteSerie] = splitSeriesIntoCompleteAndIncomplete(
@@ -76,6 +84,14 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
           timestamp: '2024-10-24T15:58:20.000Z',
         },
       ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': 'millisecond',
+        },
+      },
     };
 
     const [completeSerie, incompleteSerie] = splitSeriesIntoCompleteAndIncomplete(
@@ -130,6 +146,14 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
           timestamp: '2024-10-24T15:59:00.000Z',
         },
       ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': 'millisecond',
+        },
+      },
     };
 
     const [completeSerie, incompleteSerie] = splitSeriesIntoCompleteAndIncomplete(
@@ -191,6 +215,14 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
           timestamp: '2024-10-24T15:00:00.000Z',
         },
       ],
+      meta: {
+        fields: {
+          'p99(span.duration)': 'duration',
+        },
+        units: {
+          'p99(span.duration)': 'millisecond',
+        },
+      },
     };
 
     const [completeSerie, incompleteSerie] = splitSeriesIntoCompleteAndIncomplete(

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -31,7 +31,7 @@ export interface MetricTimeseriesRow {
 }
 
 export type DiscoverSeries = Series & {
-  meta?: EventsMetaType;
+  meta: EventsMetaType;
 };
 
 interface UseMetricsSeriesOptions<Fields> {

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
@@ -150,6 +150,7 @@ export function ProjectAnrScoreCard({
         fields: {
           'anr_rate()': 'percentage',
         },
+        units: {},
       }}
       actions={[
         {

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -134,6 +134,7 @@ function ProjectApdexScoreCard(props: Props) {
         fields: {
           'apdex()': 'number',
         },
+        units: {},
       }}
       preferredPolarity="+"
       isLoading={isLoading}

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -156,6 +156,7 @@ function ProjectStabilityScoreCard(props: Props) {
         fields: {
           [`${props.field}()`]: 'percentage',
         },
+        units: {},
       }}
       preferredPolarity="+"
       isLoading={isLoading}

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -168,6 +168,7 @@ function ProjectVelocityScoreCard(props: Props) {
         fields: {
           'count()': 'number',
         },
+        units: {},
       }}
       preferredPolarity="+"
       isLoading={isLoading}


### PR DESCRIPTION
As of recent changes to the backend, all timeseries requests to the backend return the `meta` property. Here I am updating the types to make future code simpler. I can also remove redundant checks sometime soon in another PR.
