### PR TITLE
chore(uptime): Stop pushing configs to Kafka

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -20,7 +20,7 @@ from sentry.conf.api_pagination_allowlist_do_not_modify import (
     SENTRY_API_PAGINATION_ALLOWLIST_DO_NOT_MODIFY,
 )
 from sentry.conf.types.celery import SplitQueueSize, SplitQueueTaskRoute
-from sentry.conf.types.kafka_definition import ConsumerDefinition, Topic
+from sentry.conf.types.kafka_definition import ConsumerDefinition
 from sentry.conf.types.logging_config import LoggingConfig
 from sentry.conf.types.role_dict import RoleDict
 from sentry.conf.types.sdk_config import ServerSdkConfig
@@ -3465,7 +3465,6 @@ UPTIME_REGIONS = [
     UptimeRegionConfig(
         slug="default",
         name="Default Region",
-        config_topic=Topic.UPTIME_CONFIGS,
         config_redis_cluster=SENTRY_UPTIME_DETECTOR_CLUSTER,
         enabled=True,
     ),

--- a/src/sentry/conf/types/uptime.py
+++ b/src/sentry/conf/types/uptime.py
@@ -11,7 +11,10 @@ class UptimeRegionConfig:
 
     slug: str
     name: str
-    config_topic: Topic
     enabled: bool
+    # TODO: Remove once we've removed config that relies on this
+    config_topic: Topic | None = None
     # Temporarily defaulted for backwards compat
     config_redis_cluster: str = "default"
+    # Prefix we'll add to keys in the redis config. Currently just used in tests
+    config_redis_key_prefix: str = ""

--- a/src/sentry/uptime/config_producer.py
+++ b/src/sentry/uptime/config_producer.py
@@ -4,8 +4,6 @@ import logging
 from uuid import UUID
 
 import msgpack
-from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from django.conf import settings
 from redis import StrictRedis
 from rediscluster import RedisCluster
@@ -13,33 +11,16 @@ from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.utils import redis
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
 UPTIME_CONFIGS_CODEC: Codec[CheckConfig] = get_topic_codec(Topic.UPTIME_CONFIGS)
 
 
-def _get_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.UPTIME_CONFIGS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
-
-
-_configs_producer = SingletonProducer(_get_producer)
-
-
 def produce_config(destination_region_slug: str, config: CheckConfig):
-    _produce_to_kafka(
-        destination_region_slug,
-        UUID(config["subscription_id"]),
-        UPTIME_CONFIGS_CODEC.encode(config),
-    )
     _send_to_redis(
         destination_region_slug,
         UUID(config["subscription_id"]),
@@ -48,40 +29,19 @@ def produce_config(destination_region_slug: str, config: CheckConfig):
 
 
 def produce_config_removal(destination_region_slug: str, subscription_id: str):
-    _produce_to_kafka(destination_region_slug, UUID(subscription_id), None)
     _send_to_redis(destination_region_slug, UUID(subscription_id), None)
-
-
-def _produce_to_kafka(
-    destination_region_slug: str, subscription_id: UUID, value: bytes | None
-) -> None:
-    region_config = get_region_config(destination_region_slug)
-    if region_config is None:
-        logger.error(
-            "Attempted to create uptime subscription with invalid region slug",
-            extra={"region_slug": destination_region_slug, "subscription_id": subscription_id},
-        )
-        return
-
-    topic = get_topic_definition(region_config.config_topic)["real_topic_name"]
-    payload = KafkaPayload(
-        subscription_id.bytes,
-        # Typically None is not allowed for the arroyo payload, but in this
-        # case None produces a null value aka a tombstone.
-        value,  # type: ignore[arg-type]
-        [],
-    )
-    result = _configs_producer.produce(ArroyoTopic(topic), payload)
-    result.result()
 
 
 def get_partition_from_subscription_id(subscription_id: UUID) -> int:
     return int(subscription_id) % settings.UPTIME_CONFIG_PARTITIONS
 
 
-def get_partition_keys(subscription_id: UUID) -> tuple[str, str]:
+def get_partition_keys(subscription_id: UUID, config: UptimeRegionConfig) -> tuple[str, str]:
     partition = get_partition_from_subscription_id(subscription_id)
-    return f"uptime:configs:{partition}", f"uptime:updates:{partition}"
+    return (
+        f"{config.config_redis_key_prefix}uptime:configs:{partition}",
+        f"{config.config_redis_key_prefix}uptime:updates:{partition}",
+    )
 
 
 def _send_to_redis(
@@ -95,12 +55,8 @@ def _send_to_redis(
         )
         return
 
-    partition = get_partition_from_subscription_id(subscription_id)
     key = subscription_id.hex
-
-    config_key = f"uptime:configs:{partition}"
-    update_key = f"uptime:updates:{partition}"
-
+    config_key, update_key = get_partition_keys(subscription_id, region_config)
     cluster: RedisCluster | StrictRedis = redis.redis_clusters.get_binary(
         region_config.config_redis_cluster
     )

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.test import TestCase, override_settings
 
-from sentry.conf.types.kafka_definition import Topic
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.uptime.subscriptions.regions import get_active_region_configs, get_region_config
 
@@ -12,22 +11,22 @@ class TestBase(TestCase):
             UptimeRegionConfig(
                 slug="us",
                 name="United States",
-                config_topic=Topic("uptime-results"),
                 config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="us",
                 enabled=True,
             ),
             UptimeRegionConfig(
                 slug="eu",
                 name="Europe",
-                config_topic=Topic("uptime-configs"),
                 config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="eu",
                 enabled=False,
             ),
             UptimeRegionConfig(
                 slug="ap",
                 name="Asia Pacific",
-                config_topic=Topic("monitors-clock-tasks"),
                 config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="ap",
                 enabled=True,
             ),
         ]

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.test import override_settings
 from pytest import raises
 
-from sentry.conf.types.kafka_definition import Topic
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.quotas.base import SeatAssignmentResult
@@ -274,22 +273,22 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             UptimeRegionConfig(
                 slug="region1",
                 name="Region 1",
-                config_topic=Topic.UPTIME_CONFIGS,
                 config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="r1",
                 enabled=True,
             ),
             UptimeRegionConfig(
                 slug="region2",
                 name="Region 2",
-                config_topic=Topic.UPTIME_RESULTS,
                 config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="r2",
                 enabled=True,
             ),
             UptimeRegionConfig(
                 slug="region3",
                 name="Region 3",
-                config_topic=Topic.MONITORS_CLOCK_TASKS,
                 config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="r3",
                 enabled=False,  # This one shouldn't be associated
             ),
         ]


### PR DESCRIPTION
All checkers are running redis now, so we can stop pushing configs to Kafka.

Also fixes the tests since they weren't really testing regions well - added a key prefix so that we can have something like regions on the same local redis.

<!-- Describe your PR here. -->