### PR TITLE
fix(insights): adds Web Vitals loading placeholders to page overview vital meters

### DIFF
--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -28,6 +28,7 @@ import {getWebVitalScoresFromTableDataRow} from 'sentry/views/insights/browser/w
 import {useProjectWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {WebVitalMetersPlaceholder} from 'sentry/views/insights/browser/webVitals/views/webVitalsLandingPage';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
@@ -225,6 +226,7 @@ export function PageOverview() {
                   />
                 </Flex>
                 <WebVitalMetersContainer>
+                  {(isPending || isProjectScoresLoading) && <WebVitalMetersPlaceholder />}
                   <WebVitalMeters
                     projectData={pageData}
                     projectScore={projectScore}

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -145,7 +145,7 @@ export function WebVitalsLandingPage() {
   );
 }
 
-function WebVitalMetersPlaceholder() {
+export function WebVitalMetersPlaceholder() {
   return (
     <LoadingBoxContainer>
       {[...Array(WEB_VITALS_COUNT)].map((_, index) => (


### PR DESCRIPTION
Adds loading place holders to Web Vitals page overview meters to reduce layout shift. Same as Web Vitals landing page.