### PR TITLE
feat(projects): Allow users to see projects of other teams

### DIFF
--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -17,7 +17,7 @@ import * as projectsActions from 'sentry/actionCreators/projects';
 import ProjectsStatsStore from 'sentry/stores/projectsStatsStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Dashboard} from 'sentry/views/projectsDashboard';
+import ProjectsDashboard from 'sentry/views/projectsDashboard';
 
 jest.unmock('lodash/debounce');
 jest.mock('lodash/debounce', () => {
@@ -40,7 +40,6 @@ jest.mock('lodash/debounce', () => {
 });
 
 describe('ProjectsDashboard', function () {
-  const api = new MockApiClient();
   const org = OrganizationFixture();
   const team = TeamFixture();
   const teams = [team];
@@ -66,43 +65,14 @@ describe('ProjectsDashboard', function () {
   });
 
   describe('empty state', function () {
-    it('renders with no projects', async function () {
-      const noProjectTeams = [TeamFixture({isMember: false, projects: []})];
-
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          teams={noProjectTeams}
-          organization={org}
-          {...RouteComponentPropsFixture()}
-        />
-      );
-
-      expect(
-        await screen.findByRole('button', {name: 'Join a Team'})
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('create-project')).toBeInTheDocument();
-      expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
-    });
-
     it('renders with 1 project, with no first event', async function () {
       const projects = [ProjectFixture({teams, firstEvent: null, stats: []})];
       ProjectsStore.loadInitialData(projects);
 
       const teamsWithOneProject = [TeamFixture({projects})];
+      TeamStore.loadInitialData(teamsWithOneProject);
 
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          teams={teamsWithOneProject}
-          organization={org}
-          {...RouteComponentPropsFixture()}
-        />
-      );
+      render(<ProjectsDashboard />);
 
       expect(await screen.findByTestId('join-team')).toBeInTheDocument();
       expect(screen.getByTestId('create-project')).toBeInTheDocument();
@@ -111,7 +81,7 @@ describe('ProjectsDashboard', function () {
       ).toBeInTheDocument();
       expect(screen.getByText('My Teams')).toBeInTheDocument();
       expect(screen.getByText('Resources')).toBeInTheDocument();
-      expect(screen.getByTestId('badge-display-name')).toBeInTheDocument();
+      expect(await screen.findByTestId('badge-display-name')).toBeInTheDocument();
       expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
     });
   });
@@ -139,17 +109,8 @@ describe('ProjectsDashboard', function () {
 
       ProjectsStore.loadInitialData(projects);
       const teamsWithTwoProjects = [TeamFixture({projects})];
-
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          organization={org}
-          teams={teamsWithTwoProjects}
-          {...RouteComponentPropsFixture()}
-        />
-      );
+      TeamStore.loadInitialData(teamsWithTwoProjects);
+      render(<ProjectsDashboard />);
       expect(await screen.findByText('My Teams')).toBeInTheDocument();
       expect(screen.getAllByTestId('badge-display-name')).toHaveLength(2);
       expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
@@ -179,27 +140,15 @@ describe('ProjectsDashboard', function () {
         }),
       ]);
       const teamsWithTwoProjects = [TeamFixture({projects: teamProjects})];
+      TeamStore.loadInitialData(teamsWithTwoProjects);
 
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          organization={org}
-          teams={teamsWithTwoProjects}
-          {...RouteComponentPropsFixture()}
-        />
-      );
+      render(<ProjectsDashboard />);
       expect(await screen.findByText('My Teams')).toBeInTheDocument();
       expect(screen.getAllByTestId('badge-display-name')).toHaveLength(1);
     });
 
     it('renders all projects if open membership is enabled and user selects all teams', async function () {
-      const {
-        organization: openOrg,
-        router,
-        routerProps,
-      } = initializeOrg({
+      const {organization: openOrg, router} = initializeOrg({
         organization: {features: ['open-membership']},
         router: {
           // team='' removes the default selection of 'myteams', same as clicking "clear"
@@ -208,7 +157,6 @@ describe('ProjectsDashboard', function () {
       });
       const teamA = TeamFixture({slug: 'team1', isMember: true});
       const teamB = TeamFixture({id: '2', slug: 'team2', name: 'team2', isMember: false});
-      TeamStore.loadInitialData([teamA, teamB]);
       const teamProjects = [
         ProjectFixture({
           id: '1',
@@ -218,9 +166,9 @@ describe('ProjectsDashboard', function () {
           stats: [],
         }),
       ];
+      teamA.projects = teamProjects;
 
-      ProjectsStore.loadInitialData([
-        ...teamProjects,
+      const teamBProjects = [
         ProjectFixture({
           id: '2',
           slug: 'project2',
@@ -228,23 +176,17 @@ describe('ProjectsDashboard', function () {
           firstEvent: new Date().toISOString(),
           stats: [],
         }),
-      ]);
-      const teamsWithTwoProjects = [TeamFixture({projects: teamProjects})];
+      ];
+      teamB.projects = teamBProjects;
 
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          organization={openOrg}
-          teams={teamsWithTwoProjects}
-          {...routerProps}
-        />,
-        {
-          router,
-          organization: openOrg,
-        }
-      );
+      ProjectsStore.loadInitialData([...teamProjects, ...teamBProjects]);
+      const teamWithTwoProjects = TeamFixture({projects: teamProjects});
+      TeamStore.loadInitialData([teamWithTwoProjects, teamA, teamB]);
+
+      render(<ProjectsDashboard />, {
+        router,
+        organization: openOrg,
+      });
       expect(await screen.findByText('All Teams')).toBeInTheDocument();
       expect(screen.getAllByTestId('badge-display-name')).toHaveLength(2);
 
@@ -253,14 +195,56 @@ describe('ProjectsDashboard', function () {
       expect(screen.getByText('#team2')).toBeInTheDocument();
     });
 
-    it('renders only projects for my teams if open membership is disabled', async function () {
-      const {
-        organization: closedOrg,
+    it('renders projects for specific team that user is not a member of', async function () {
+      const openMembershipOrg = OrganizationFixture({features: ['open-membership']});
+      const teamB = TeamFixture({id: '2', slug: 'team2', name: 'team2', isMember: false});
+      const router = RouterFixture({
+        // team2 is selected
+        location: {query: {team: teamB.id}},
+      });
+
+      const teamA = TeamFixture({id: '1', slug: 'team1', name: 'team1', isMember: true});
+      const teamAProjects = [
+        ProjectFixture({
+          id: '1',
+          slug: 'project1',
+          teams: [teamA],
+          firstEvent: new Date().toISOString(),
+          stats: [],
+        }),
+      ];
+      teamA.projects = teamAProjects;
+
+      const teamBProjects = [
+        ProjectFixture({
+          id: '2',
+          slug: 'project2',
+          name: 'project2',
+          teams: [teamB],
+          firstEvent: new Date().toISOString(),
+          stats: [],
+          isMember: false,
+        }),
+      ];
+      teamB.projects = teamBProjects;
+
+      ProjectsStore.loadInitialData([...teamAProjects, ...teamBProjects]);
+      TeamStore.loadInitialData([teamA, teamB]);
+
+      render(<ProjectsDashboard />, {
         router,
-        routerProps,
-      } = initializeOrg({
+        organization: openMembershipOrg,
+      });
+      expect(await screen.findByText('#team2')).toBeInTheDocument();
+      expect(screen.getByText('project2')).toBeInTheDocument();
+      expect(screen.getAllByTestId('badge-display-name')).toHaveLength(1);
+    });
+
+    it('renders only projects for my teams if open membership is disabled', async function () {
+      const {organization: closedOrg, router} = initializeOrg({
         organization: {features: []},
         router: {
+          // All projects
           location: {query: {team: ''}},
         },
       });
@@ -274,6 +258,7 @@ describe('ProjectsDashboard', function () {
           stats: [],
         }),
       ];
+      teamA.projects = teamProjects;
 
       ProjectsStore.loadInitialData([
         ...teamProjects,
@@ -285,24 +270,19 @@ describe('ProjectsDashboard', function () {
           stats: [],
         }),
       ]);
-      const teamsWithTwoProjects = [TeamFixture({projects: teamProjects})];
+      const teamsWithTwoProjects = [
+        TeamFixture({id: '2', slug: 'team2', projects: teamProjects, isMember: false}),
+      ];
+      TeamStore.loadInitialData([...teamsWithTwoProjects, teamA]);
 
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          organization={closedOrg}
-          teams={teamsWithTwoProjects}
-          {...routerProps}
-        />,
-        {
-          router,
-          organization: closedOrg,
-        }
-      );
+      render(<ProjectsDashboard />, {
+        router,
+        organization: closedOrg,
+      });
       expect(await screen.findByText('All Teams')).toBeInTheDocument();
       expect(screen.getAllByTestId('badge-display-name')).toHaveLength(1);
+      expect(screen.getByText('project1')).toBeInTheDocument();
+      expect(screen.queryByText('project2')).not.toBeInTheDocument();
     });
 
     it('renders correct project with selected team', async function () {
@@ -336,11 +316,7 @@ describe('ProjectsDashboard', function () {
       });
 
       const teamsWithSpecificProjects = [teamC, teamD];
-
-      MockApiClient.addMockResponse({
-        url: `/organizations/${org.slug}/teams/?team=2`,
-        body: teamsWithSpecificProjects,
-      });
+      TeamStore.loadInitialData(teamsWithSpecificProjects);
 
       const projects = [
         ProjectFixture({
@@ -373,26 +349,19 @@ describe('ProjectsDashboard', function () {
         body: projects,
       });
 
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          teams={teamsWithSpecificProjects}
-          organization={org}
-          {...RouteComponentPropsFixture({
-            location: {
-              pathname: '',
-              hash: '',
-              state: '',
-              action: 'PUSH',
-              key: '',
-              query: {team: '2'},
-              search: '?team=2`',
-            },
-          })}
-        />
-      );
+      const router = RouterFixture({
+        location: {
+          pathname: '',
+          hash: '',
+          state: '',
+          action: 'PUSH',
+          key: '',
+          query: {team: '2'},
+          search: '?team=2`',
+        },
+      });
+
+      render(<ProjectsDashboard />, {router});
 
       expect(await screen.findByText('project3')).toBeInTheDocument();
       expect(screen.queryByText('project2')).not.toBeInTheDocument();
@@ -424,17 +393,8 @@ describe('ProjectsDashboard', function () {
 
       ProjectsStore.loadInitialData(projects);
       const teamsWithTwoProjects = [TeamFixture({projects})];
-
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          teams={teamsWithTwoProjects}
-          organization={org}
-          {...RouteComponentPropsFixture()}
-        />
-      );
+      TeamStore.loadInitialData(teamsWithTwoProjects);
+      render(<ProjectsDashboard />);
       await userEvent.type(
         screen.getByPlaceholderText('Search for projects by name'),
         'project2{enter}'
@@ -495,6 +455,7 @@ describe('ProjectsDashboard', function () {
 
       ProjectsStore.loadInitialData(projects);
       const teamsWithFavProjects = [TeamFixture({projects})];
+      TeamStore.loadInitialData(teamsWithFavProjects);
 
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/projects/`,
@@ -509,16 +470,7 @@ describe('ProjectsDashboard', function () {
         ],
       });
 
-      render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          organization={org}
-          teams={teamsWithFavProjects}
-          {...RouteComponentPropsFixture()}
-        />
-      );
+      render(<ProjectsDashboard />);
 
       // check that all projects are displayed
       await waitFor(() =>
@@ -577,7 +529,10 @@ describe('ProjectsDashboard', function () {
       }),
     ];
 
-    const teamsWithStatTestProjects = [TeamFixture({projects})];
+    beforeEach(function () {
+      const teamsWithStatTestProjects = [TeamFixture({projects})];
+      TeamStore.loadInitialData(teamsWithStatTestProjects);
+    });
 
     it('uses ProjectsStatsStore to load stats', async function () {
       ProjectsStore.loadInitialData(projects);
@@ -598,16 +553,7 @@ describe('ProjectsDashboard', function () {
         })),
       });
 
-      const {unmount} = render(
-        <Dashboard
-          api={api}
-          error={null}
-          loadingTeams={false}
-          teams={teamsWithStatTestProjects}
-          organization={org}
-          {...RouteComponentPropsFixture()}
-        />
-      );
+      const {unmount} = render(<ProjectsDashboard />);
 
       expect(loadStatsSpy).toHaveBeenCalledTimes(6);
       expect(mock).not.toHaveBeenCalled();
@@ -659,25 +605,6 @@ describe('ProjectsDashboard', function () {
       // Resets store when it unmounts
       unmount();
       expect(ProjectsStatsStore.getAll()).toEqual({});
-    });
-
-    it('renders an error from withTeamsForUser', function () {
-      ProjectsStore.loadInitialData(projects);
-
-      render(
-        <Dashboard
-          api={api}
-          loadingTeams={false}
-          error={Error('uhoh')}
-          organization={org}
-          teams={[]}
-          {...RouteComponentPropsFixture()}
-        />
-      );
-
-      expect(
-        screen.getByText('An error occurred while fetching your projects')
-      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -110,15 +110,13 @@ function Dashboard() {
     return <LoadingError message={t('An error occurred while fetching your projects')} />;
   }
 
-  const includeMyTeams = selectedTeams.some(team => team === 'myteams') || isAllTeams;
+  const includeMyTeams = isAllTeams || selectedTeams.some(team => team === 'myteams');
   const hasOtherTeams = selectedTeams.some(team => team !== 'myteams');
   const myTeams = includeMyTeams ? (userTeams as TeamWithProjects[]) : [];
   const otherTeams = isAllTeams
     ? allTeams
     : hasOtherTeams
-      ? (allTeams.filter(team =>
-          selectedTeams.includes(`${team.id}`)
-        ) as TeamWithProjects[])
+      ? allTeams.filter(team => selectedTeams.includes(`${team.id}`))
       : [];
   const filteredTeams = ([...myTeams, ...otherTeams] as TeamWithProjects[]).filter(
     team => {

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -28,9 +28,9 @@ import {
 } from 'sentry/utils/performanceForSentry';
 import {sortProjects} from 'sentry/utils/project/sortProjects';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import useRouter from 'sentry/utils/useRouter';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
@@ -72,7 +72,7 @@ function ProjectCardList({projects}: {projects: Project[]}) {
 }
 
 function Dashboard() {
-  const router = useRouter();
+  const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
   useEffect(() => {
@@ -150,7 +150,7 @@ function Dashboard() {
   }
 
   function handleChangeFilter(activeFilters: string[]) {
-    router.push({
+    navigate({
       pathname: location.pathname,
       query: {
         ...location.query,

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -5,7 +5,6 @@ import {withProfiler} from '@sentry/react';
 import debounce from 'lodash/debounce';
 import uniqBy from 'lodash/uniqBy';
 
-import type {Client} from 'sentry/api';
 import {LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -21,8 +20,6 @@ import {IconAdd, IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ProjectsStatsStore from 'sentry/stores/projectsStatsStore';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
 import type {Project, TeamWithProjects} from 'sentry/types/project';
 import {
   onRenderCallback,
@@ -30,25 +27,18 @@ import {
   setGroupedEntityTag,
 } from 'sentry/utils/performanceForSentry';
 import {sortProjects} from 'sentry/utils/project/sortProjects';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import useRouter from 'sentry/utils/useRouter';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {useUser} from 'sentry/utils/useUser';
-import withApi from 'sentry/utils/withApi';
-import withOrganization from 'sentry/utils/withOrganization';
-import withTeamsForUser from 'sentry/utils/withTeamsForUser';
+import {useUserTeams} from 'sentry/utils/useUserTeams';
 import TeamFilter from 'sentry/views/alerts/list/rules/teamFilter';
 
 import ProjectCard from './projectCard';
 import Resources from './resources';
 import {getTeamParams} from './utils';
-
-type Props = {
-  api: Client;
-  error: Error | null;
-  loadingTeams: boolean;
-  organization: Organization;
-  teams: TeamWithProjects[];
-} & RouteComponentProps<{}, {}>;
 
 function ProjectCardList({projects}: {projects: Project[]}) {
   const organization = useOrganization();
@@ -81,12 +71,21 @@ function ProjectCardList({projects}: {projects: Project[]}) {
   );
 }
 
-function Dashboard({teams, organization, loadingTeams, error, router, location}: Props) {
+function Dashboard() {
+  const router = useRouter();
+  const location = useLocation();
+  const organization = useOrganization();
   useEffect(() => {
     return function cleanup() {
       ProjectsStatsStore.reset();
     };
   }, []);
+  const {teams: userTeams, isLoading: loadingTeams, isError} = useUserTeams();
+  const isAllTeams = location.query.team === '';
+  const selectedTeams = getTeamParams(location.query.team ?? 'myteams');
+  const {teams: allTeams} = useTeamsById({
+    ids: selectedTeams.filter(team => team !== 'myteams'),
+  });
   const user = useUser();
   const [projectQuery, setProjectQuery] = useState('');
   const debouncedSearchQuery = useMemo(
@@ -103,40 +102,48 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
     return user.isSuperuser || isOrgAdminOrManager || isOpenMembership;
   }, [user, organization.orgRole, organization.features]);
 
-  const canUserCreateProject = canCreateProject(organization);
   if (loadingTeams || fetching) {
     return <LoadingIndicator />;
   }
 
-  if (error || fetchError) {
+  if (isError || fetchError) {
     return <LoadingError message={t('An error occurred while fetching your projects')} />;
   }
 
-  const canJoinTeam = organization.access.includes('team:read');
-  const selectedTeams = getTeamParams(location.query.team ?? 'myteams');
-  const filteredTeams =
-    selectedTeams[0] === 'myteams' || selectedTeams.length === 0
-      ? teams
-      : teams.filter(team => selectedTeams.includes(team.id));
+  const includeMyTeams = selectedTeams.some(team => team === 'myteams') || isAllTeams;
+  const hasOtherTeams = selectedTeams.some(team => team !== 'myteams');
+  const myTeams = includeMyTeams ? (userTeams as TeamWithProjects[]) : [];
+  const otherTeams = isAllTeams
+    ? allTeams
+    : hasOtherTeams
+      ? (allTeams.filter(team =>
+          selectedTeams.includes(`${team.id}`)
+        ) as TeamWithProjects[])
+      : [];
+  const filteredTeams = ([...myTeams, ...otherTeams] as TeamWithProjects[]).filter(
+    team => {
+      if (showNonMemberProjects) {
+        return true;
+      }
 
-  const filteredTeamProjects = uniqBy(
-    (filteredTeams ?? teams).flatMap(team => team.projects),
+      return team.isMember;
+    }
+  );
+
+  const currentProjects = uniqBy(
+    filteredTeams.flatMap(team => team.projects),
     'id'
   );
   setGroupedEntityTag('projects.total', 1000, projects.length);
 
-  const currentProjects =
-    // No teams are specifically selected and query parameter is present
-    // Use all projects if open membership is enabled
-    location.query.team === '' && showNonMemberProjects
-      ? projects
-      : // No teams are specifically selected - Use "myteams"
-        filteredTeamProjects;
-  const filteredProjects = (currentProjects ?? projects).filter(project =>
+  const filteredProjects = currentProjects.filter(project =>
     project.slug.includes(projectQuery)
   );
 
   const showResources = projects.length === 1 && !projects[0]!.firstEvent;
+
+  const canJoinTeam = organization.access.includes('team:read');
+  const canUserCreateProject = canCreateProject(organization);
 
   function handleSearch(searchQuery: string) {
     setProjectQuery(searchQuery);
@@ -226,11 +233,12 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
   );
 }
 
-function OrganizationDashboard(props: Props) {
+function OrganizationDashboard() {
+  const organization = useOrganization();
   return (
     <Layout.Page>
-      <NoProjectMessage organization={props.organization}>
-        <Dashboard {...props} />
+      <NoProjectMessage organization={organization}>
+        <Dashboard />
       </NoProjectMessage>
     </Layout.Page>
   );
@@ -274,7 +282,4 @@ const ProjectCards = styled('div')`
   }
 `;
 
-export {Dashboard};
-export default withApi(
-  withOrganization(withTeamsForUser(withProfiler(OrganizationDashboard)))
-);
+export default withProfiler(OrganizationDashboard);


### PR DESCRIPTION
Fixes a bug where the list of projects is blank when viewing teams the user is not a member of
![image](https://github.com/user-attachments/assets/191584ef-6a62-4006-b084-749192e39207)


fixes #84323