### PR TITLE
ref(dashboards): Remove duplicated `SeriesWithOrdering` type

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -1,7 +1,6 @@
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
-import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,
@@ -62,8 +61,6 @@ const DEFAULT_FIELD: QueryFieldValue = {
   function: ['count', '', undefined, undefined],
   kind: FieldValueKind.FUNCTION,
 };
-
-export type SeriesWithOrdering = [order: number, series: Series];
 
 export const ErrorsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats,

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -8,7 +8,6 @@ import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
-import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,
@@ -92,8 +91,6 @@ const DEFAULT_FIELD: QueryFieldValue = {
   function: ['count', '', undefined, undefined],
   kind: FieldValueKind.FUNCTION,
 };
-
-export type SeriesWithOrdering = [order: number, series: Series];
 
 export const ErrorsAndTransactionsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats,

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -1,7 +1,6 @@
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
-import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,
@@ -66,8 +65,6 @@ const DEFAULT_FIELD: QueryFieldValue = {
   function: ['count', '', undefined, undefined],
   kind: FieldValueKind.FUNCTION,
 };
-
-export type SeriesWithOrdering = [order: number, series: Series];
 
 export const TransactionsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats,

--- a/static/app/views/dashboards/utils/transformEventsResponseToSeries.tsx
+++ b/static/app/views/dashboards/utils/transformEventsResponseToSeries.tsx
@@ -5,9 +5,10 @@ import type {
   MultiSeriesEventsStats,
 } from 'sentry/types/organization';
 
-import type {SeriesWithOrdering} from '../datasetConfig/errorsAndTransactions';
 import type {WidgetQuery} from '../types';
 import {transformSeries} from '../widgetCard/widgetQueries';
+
+type SeriesWithOrdering = [order: number, series: Series];
 
 import {
   isEventsStats,


### PR DESCRIPTION
We don't need 3 of these, and they don't need to be exported either.
