### PR TITLE
feat(explore): Render numeric tags without the explicit tag syntax

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -41,7 +41,7 @@ function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
       <AggregateKeyVisual token={token} />
     </div>
   ) : (
-    <div>{getKeyName(token.key, {showExplicitTagPrefix: true})}</div>
+    <div>{getKeyName(token.key)}</div>
   );
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -17,6 +17,7 @@ import type {
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {prettifyTagKey} from 'sentry/utils/discover/fields';
 
 type AggregateKeyProps = {
   filterRef: React.RefObject<HTMLDivElement>;
@@ -28,7 +29,7 @@ type AggregateKeyProps = {
 
 export function AggregateKeyVisual({token}: {token: AggregateFilter}) {
   const fnName = getKeyName(token.key);
-  const fnParams = token.key.args?.text ?? '';
+  const fnParams = prettifyTagKey(token.key.args?.text ?? '');
 
   return (
     <Fragment>

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
@@ -57,9 +57,11 @@ export function FilterKey({item, state, token, onActiveChange}: FilterKeyProps) 
     );
   }
 
+  const keyName = getKeyName(token.key);
+
   return (
     <KeyButton
-      aria-label={t('Edit key for filter: %s', getKeyName(token.key))}
+      aria-label={t('Edit key for filter: %s', keyName)}
       onClick={() => {
         setIsEditing(true);
         onActiveChange(true);
@@ -68,7 +70,7 @@ export function FilterKey({item, state, token, onActiveChange}: FilterKeyProps) 
       {...filterButtonProps}
     >
       <InteractionStateLayer />
-      {token.key.text}
+      {keyName}
     </KeyButton>
   );
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -37,7 +37,8 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
 
   const currentFilterValueType = getFilterValueType(
     token,
-    getFieldDefinition(getKeyName(token.key))
+    getFieldDefinition(getKeyName(token.key, {showExplicitTagPrefix: true})) ||
+      getFieldDefinition(getKeyName(token.key))
   );
 
   const handleSelectKey = useCallback(

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -10,6 +10,7 @@ import {FunctionDescription} from 'sentry/components/searchQueryBuilder/tokens/f
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue';
 import type {AggregateFilter} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
+import {prettifyTagKey} from 'sentry/utils/discover/fields';
 import {FieldKind, FieldValueType} from 'sentry/utils/fields';
 
 type ParametersComboboxProps = {
@@ -120,7 +121,7 @@ function useParameterSuggestions({
                   FieldValueType.STRING,
               })
             )
-            .map(col => ({value: col.key, label: col.key}));
+            .map(col => ({value: col.key, label: prettifyTagKey(col.key)}));
         }
 
         return potentialColumns
@@ -129,7 +130,7 @@ function useParameterSuggestions({
               getFieldDefinition(col.key)?.valueType ?? FieldValueType.STRING
             )
           )
-          .map(col => ({value: col.key, label: col.key}));
+          .map(col => ({value: col.key, label: prettifyTagKey(col.key)}));
       }
       case 'value':
         if (parameterDefinition.options) {
@@ -178,6 +179,7 @@ export function SearchQueryBuilderParametersCombobox({
   const inputRef = useRef<HTMLInputElement>(null);
   const {dispatch} = useSearchQueryBuilder();
   const [inputValue, setInputValue] = useState(() => getInitialInputValue(token));
+
   const {selectionIndex, updateSelectionIndex} = useSelectionIndex({
     inputRef,
     inputValue,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -306,9 +306,10 @@ function useFilterSuggestions({
   token: TokenResult<Token.FILTER>;
 }) {
   const keyName = getKeyName(token.key);
+  const fullKeyName = getKeyName(token.key, {showExplicitTagPrefix: true});
   const {getFieldDefinition, getTagValues, filterKeys} = useSearchQueryBuilder();
-  const key: Tag | undefined = filterKeys[keyName];
-  const fieldDefinition = getFieldDefinition(keyName);
+  const key: Tag | undefined = filterKeys[fullKeyName] || filterKeys[keyName];
+  const fieldDefinition = getFieldDefinition(fullKeyName) || getFieldDefinition(keyName);
   const predefinedValues = useMemo(
     () =>
       getPredefinedValues({
@@ -491,7 +492,8 @@ export function SearchQueryBuilderValueCombobox({
     wrapperRef: topLevelWrapperRef,
   } = useSearchQueryBuilder();
   const keyName = getKeyName(token.key);
-  const fieldDefinition = getFieldDefinition(keyName);
+  const fullKeyName = getKeyName(token.key, {showExplicitTagPrefix: true});
+  const fieldDefinition = getFieldDefinition(fullKeyName) || getFieldDefinition(keyName);
   const canSelectMultipleValues = tokenSupportsMultipleValues(
     token,
     filterKeys,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -17,6 +17,7 @@ import type {
 import {t} from 'sentry/locale';
 import type {RecentSearch, Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import {prettifyTagKey} from 'sentry/utils/discover/fields';
 import {type FieldDefinition, FieldKind} from 'sentry/utils/fields';
 import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 
@@ -59,7 +60,7 @@ export function getKeyLabel(
     return `${tag.key}()`;
   }
 
-  return tag.key;
+  return prettifyTagKey(tag.key);
 }
 
 export function createSection(

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -681,6 +681,7 @@ export class TokenConverter {
    */
   predicateFilter = <T extends FilterType>(type: T, key: FilterMap[T]['key']) => {
     const keyName = getKeyName(key);
+    const fullKeyName = getKeyName(key, {showExplicitTagPrefix: true});
     const aggregateKey = key as ReturnType<TokenConverter['tokenKeyAggregate']>;
 
     const {isNumeric, isDuration, isBoolean, isDate, isPercentage, isSize} =
@@ -692,21 +693,21 @@ export class TokenConverter {
     switch (type) {
       case FilterType.NUMERIC:
       case FilterType.NUMERIC_IN:
-        return isNumeric(keyName);
+        return isNumeric(fullKeyName) || isNumeric(keyName);
 
       case FilterType.DURATION:
-        return isDuration(keyName);
+        return isDuration(fullKeyName) || isDuration(keyName);
 
       case FilterType.SIZE:
-        return isSize(keyName);
+        return isSize(fullKeyName) || isSize(keyName);
 
       case FilterType.BOOLEAN:
-        return isBoolean(keyName);
+        return isBoolean(fullKeyName) || isBoolean(keyName);
 
       case FilterType.DATE:
       case FilterType.RELATIVE_DATE:
       case FilterType.SPECIFIC_DATE:
-        return isDate(keyName);
+        return isDate(fullKeyName) || isDate(keyName);
 
       case FilterType.AGGREGATE_DURATION:
         return checkAggregate(isDuration);
@@ -834,11 +835,12 @@ export class TokenConverter {
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&
-      !this.config.supportedTags[getKeyName(key)]
+      !this.config.supportedTags[getKeyName(key)] &&
+      !this.config.supportedTags[getKeyName(key, {showExplicitTagPrefix: true})]
     ) {
       return {
         type: InvalidReason.INVALID_KEY,
-        reason: t('Invalid key. "%s" is not a supported search key.', key.text),
+        reason: t('Invalid key. "%s" is not a supported search key.', getKeyName(key)),
       };
     }
 

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -253,9 +253,10 @@ export const getKeyName = (
         ? `${key.name.value}(${key.args ? key.args.text : ''})`
         : key.name.value;
     case Token.KEY_EXPLICIT_NUMBER_TAG:
-      // number tags always need to be expressed with the
-      // explicit tag prefix + type
-      return key.text;
+      if (showExplicitTagPrefix) {
+        return key.text;
+      }
+      return key.key.value;
     case Token.KEY_EXPLICIT_STRING_TAG:
       if (showExplicitTagPrefix) {
         return key.text;


### PR DESCRIPTION
This hides away an implementation detail that requires users to type in `tags[...,number]` in order to search for numeric tags. It renders as just the tag name in the search bar but uses the full syntax under the hood.

# Screenshots

## Before

![Screenshot 2025-02-03 at 6 01 03 PM](https://github.com/user-attachments/assets/1050cfae-5590-4060-84bf-ac0489a09309)

## After

![Screenshot 2025-02-03 at 6 01 37 PM](https://github.com/user-attachments/assets/7355ae01-1136-430f-b1a5-4e512fb7d521)
