### PR TITLE
ref(flags): allow onboarding to be shown for 'other' platform

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -112,7 +112,7 @@ export function EventFeatureFlagList({
     );
   }, [event]);
 
-  const hasFlags = hasFlagContext && eventFlags.length > 0;
+  const hasFlags = eventFlags.length > 0;
 
   const showCTA =
     !project.hasFlags &&

--- a/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
@@ -274,9 +274,9 @@ function OnboardingContent({
     );
   }
 
-  const doesNotSupportFeatureFlags = currentProject.platform
-    ? !featureFlagOnboardingPlatforms.concat('other').includes(currentProject.platform)
-    : true;
+  const doesNotSupportFeatureFlags =
+    !currentProject.platform ||
+    !featureFlagOnboardingPlatforms.concat('other').includes(currentProject.platform);
 
   const defaultMessage = (
     <Fragment>
@@ -290,11 +290,12 @@ function OnboardingContent({
       </StyledDefaultContent>
       <div>
         {tct(
-          'To track flag evaluations, you can use the Feature Flags SDK. It is currently available for Python and JavaScript projects. You can [link:read the docs] to learn more.',
+          'Tracking flag evaluations is not supported for [platform] yet. It is currently available for Python and JavaScript projects through the Feature Flags SDK. You can [link:read the docs] to learn more.',
           {
             link: (
               <ExternalLink href="https://docs.sentry.io/product/explore/feature-flags/" />
             ),
+            platform: currentPlatform?.name || currentProject.slug,
           }
         )}
       </div>
@@ -307,6 +308,12 @@ function OnboardingContent({
         {radioButtons}
         <FeatureFlagOtherPlatformOnboarding
           projectSlug={currentProject.slug}
+          integration={
+            // either OpenFeature or the SDK selected from the second dropdown
+            setupMode() === 'openFeature'
+              ? IntegrationOptions.OPENFEATURE
+              : sdkProvider.value
+          }
           provider={
             // dropdown value (from either dropdown)
             setupMode() === 'openFeature' ? openFeatureProvider.value : sdkProvider.value

--- a/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
@@ -7,6 +7,7 @@ import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.
 import {LinkButton} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {FeatureFlagOnboardingLayout} from 'sentry/components/events/featureFlags/featureFlagOnboardingLayout';
+import {FeatureFlagOtherPlatformOnboarding} from 'sentry/components/events/featureFlags/featureFlagOtherPlatformOnboarding';
 import {FLAG_HASH_SKIP_CONFIG} from 'sentry/components/events/featureFlags/useFeatureFlagOnboarding';
 import {
   IntegrationOptions,
@@ -14,6 +15,7 @@ import {
 } from 'sentry/components/events/featureFlags/utils';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import IdBadge from 'sentry/components/idBadge';
+import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useCurrentProjectState from 'sentry/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
@@ -273,52 +275,59 @@ function OnboardingContent({
   }
 
   const doesNotSupportFeatureFlags = currentProject.platform
-    ? !featureFlagOnboardingPlatforms.includes(currentProject.platform)
+    ? !featureFlagOnboardingPlatforms.concat('other').includes(currentProject.platform)
     : true;
 
-  if (doesNotSupportFeatureFlags) {
-    return (
-      <Fragment>
+  const defaultMessage = (
+    <Fragment>
+      <div>
+        {t(
+          'You can set up a webhook for your Feature Flag provider by visiting the settings page, to see which flags changed over time.'
+        )}
         <div>
-          {tct(
-            'Feature Flags isn’t available for your [platform] project. It is currently only available for Python and JavaScript projects.',
-            {platform: currentPlatform?.name || currentProject.slug}
-          )}
-        </div>
-        <div>
-          <LinkButton
-            size="sm"
-            href="https://docs.sentry.io/product/explore/feature-flags/"
-            external
-          >
-            {t('Go to Sentry Documentation')}
+          <LinkButton size="sm" href={`/settings/${organization.slug}/feature-flags/`}>
+            {t('Go to Feature Flag Settings')}
           </LinkButton>
         </div>
+        <br />
+        <br />
+        {tct(
+          'The Feature Flags SDK is currently available for Python and JavaScript projects. You can [link:read the docs] to learn more.',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/product/explore/feature-flags/" />
+            ),
+          }
+        )}
+      </div>
+    </Fragment>
+  );
+
+  if (currentProject.platform === 'other') {
+    return (
+      <Fragment>
+        {radioButtons}
+        <FeatureFlagOtherPlatformOnboarding
+          projectSlug={currentProject.slug}
+          provider={
+            // dropdown value (from either dropdown)
+            setupMode() === 'openFeature' ? openFeatureProvider.value : sdkProvider.value
+          }
+        />
       </Fragment>
     );
   }
 
-  // No platform, docs import failed, no DSN, or the platform doesn't have onboarding yet
-  if (!currentPlatform || !docs || !dsn || !hasDocs || !projectKeyId) {
-    return (
-      <Fragment>
-        <div>
-          {tct(
-            'Fiddlesticks. This checklist isn’t available for your [project] project yet, but for now, go to Sentry docs for installation details.',
-            {project: currentProject.slug}
-          )}
-        </div>
-        <div>
-          <LinkButton
-            size="sm"
-            href="https://docs.sentry.io/platforms/python/feature-flags/"
-            external
-          >
-            {t('Read Docs')}
-          </LinkButton>
-        </div>
-      </Fragment>
-    );
+  // Platform is not supported, no platform, docs import failed, no DSN, or the platform doesn't have onboarding yet
+  if (
+    doesNotSupportFeatureFlags ||
+    !currentPlatform ||
+    !docs ||
+    !dsn ||
+    !hasDocs ||
+    !projectKeyId
+  ) {
+    return defaultMessage;
   }
 
   return (

--- a/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/featureFlagOnboardingSidebar.tsx
@@ -280,19 +280,17 @@ function OnboardingContent({
 
   const defaultMessage = (
     <Fragment>
-      <div>
+      <StyledDefaultContent>
         {t(
-          'You can set up a webhook for your Feature Flag provider by visiting the settings page, to see which flags changed over time.'
+          'To see which feature flags changed over time, visit the settings page to set up a webhook for your Feature Flag provider.'
         )}
-        <div>
-          <LinkButton size="sm" href={`/settings/${organization.slug}/feature-flags/`}>
-            {t('Go to Feature Flag Settings')}
-          </LinkButton>
-        </div>
-        <br />
-        <br />
+        <LinkButton size="sm" href={`/settings/${organization.slug}/feature-flags/`}>
+          {t('Go to Feature Flag Settings')}
+        </LinkButton>
+      </StyledDefaultContent>
+      <div>
         {tct(
-          'The Feature Flags SDK is currently available for Python and JavaScript projects. You can [link:read the docs] to learn more.',
+          'To track flag evaluations, you can use the Feature Flags SDK. It is currently available for Python and JavaScript projects. You can [link:read the docs] to learn more.',
           {
             link: (
               <ExternalLink href="https://docs.sentry.io/product/explore/feature-flags/" />
@@ -357,6 +355,14 @@ function OnboardingContent({
     </Fragment>
   );
 }
+
+const StyledDefaultContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${space(2)};
+  margin: ${space(1)} 0;
+`;
 
 const TaskSidebarPanel = styled(SidebarPanel)`
   width: 600px;

--- a/static/app/components/events/featureFlags/featureFlagOtherPlatformOnboarding.tsx
+++ b/static/app/components/events/featureFlags/featureFlagOtherPlatformOnboarding.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import {LinkButton} from 'sentry/components/button';
+import {Flex} from 'sentry/components/container/flex';
+import OnboardingIntegrationSection from 'sentry/components/events/featureFlags/onboardingIntegrationSection';
+import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface FeatureFlagOtherPlatformOnboardingProps {
+  projectSlug: string;
+  integration?: string;
+  provider?: string;
+}
+
+export function FeatureFlagOtherPlatformOnboarding({
+  projectSlug,
+  integration = '',
+  provider = '',
+}: FeatureFlagOtherPlatformOnboardingProps) {
+  return (
+    <AuthTokenGeneratorProvider projectSlug={projectSlug}>
+      <Wrapper>
+        {
+          <Alert type="info" showIcon>
+            <Flex gap={space(3)}>
+              {t('Read the docs to learn more about setting up the Feature Flags SDK.')}
+              <LinkButton
+                href={`https://docs.sentry.io/organization/integrations/feature-flag/${provider.toLowerCase()}/`}
+                external
+              >
+                {t('Read the docs')}
+              </LinkButton>
+            </Flex>
+          </Alert>
+        }
+        <OnboardingIntegrationSection provider={provider} integration={integration} />
+      </Wrapper>
+    </AuthTokenGeneratorProvider>
+  );
+}
+
+const Wrapper = styled('div')`
+  h4 {
+    margin-bottom: 0.5em;
+  }
+  && {
+    p {
+      margin-bottom: 0;
+    }
+    h5 {
+      margin-bottom: 0;
+    }
+  }
+`;

--- a/static/app/components/events/featureFlags/featureFlagOtherPlatformOnboarding.tsx
+++ b/static/app/components/events/featureFlags/featureFlagOtherPlatformOnboarding.tsx
@@ -27,7 +27,7 @@ export function FeatureFlagOtherPlatformOnboarding({
             <Flex gap={space(3)}>
               {t('Read the docs to learn more about setting up the Feature Flags SDK.')}
               <LinkButton
-                href={`https://docs.sentry.io/organization/integrations/feature-flag/${provider.toLowerCase()}/`}
+                href={`https://docs.sentry.io/organization/integrations/feature-flag/${provider.toLowerCase()}/#evaluation-tracking/`}
                 external
               >
                 {t('Read the docs')}


### PR DESCRIPTION
allow onboarding to be shown for 'other' platform projects if the sidebar is triggered from the issue details feature flag section. we are assuming that if the sidebar is shown, then the user must have triggered it from an existing feature flag table (indicating they probably have the sdk set up already).

|   case    | BEFORE | AFTER |
| --- | -------- | ------- |
| project has `javascript` or `python` platform set | <img width="529" alt="SCR-20250203-ndgk" src="https://github.com/user-attachments/assets/6952b985-fee7-43a7-8b42-a0f090a1afc9" /> | no change |
| project has `other` platform set |  <img width="588" alt="SCR-20250203-ndar" src="https://github.com/user-attachments/assets/0a271ad6-42fa-4c58-a621-b8b7f2762626" /> |  <img width="581" alt="SCR-20250203-nepu" src="https://github.com/user-attachments/assets/bf56d4c9-9f78-4ec7-bd47-19d653cedf8b" /> |
| project has some other platform or something else is broken | same as above but with a "fiddlesticks" message | <img width="581" alt="SCR-20250203-nidb" src="https://github.com/user-attachments/assets/3c2cb804-abf0-41d4-9070-96b828623bda" /> |
