### PR TITLE
feat(nav): Add redirects to new routes

### DIFF
--- a/static/app/components/nav/useRedirectNavV2Routes.spec.tsx
+++ b/static/app/components/nav/useRedirectNavV2Routes.spec.tsx
@@ -1,0 +1,145 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
+
+const mockUsingCustomerDomain = jest.fn();
+
+jest.mock('sentry/constants', () => {
+  const sentryConstant = jest.requireActual('sentry/constants');
+  return {
+    ...sentryConstant,
+
+    get USING_CUSTOMER_DOMAIN() {
+      return mockUsingCustomerDomain();
+    },
+  };
+});
+
+describe('useRedirectNavV2Routes', () => {
+  function TestComponent({
+    oldPathPrefix,
+    newPathPrefix,
+  }: {
+    newPathPrefix: `/${string}`;
+    oldPathPrefix: `/${string}`;
+  }) {
+    const redirectPath = useRedirectNavV2Routes({
+      oldPathPrefix,
+      newPathPrefix,
+    });
+
+    return <div>{redirectPath ?? 'no redirect'}</div>;
+  }
+
+  const organization = OrganizationFixture({
+    slug: 'org-slug',
+    features: ['navigation-sidebar-v2'],
+  });
+
+  describe('customer domain', () => {
+    beforeEach(() => {
+      mockUsingCustomerDomain.mockReturnValue(true);
+    });
+
+    it('should not redirect if no navigation v2', () => {
+      render(
+        <TestComponent oldPathPrefix="/projects/" newPathPrefix="/insights/projects/" />,
+        {
+          organization: OrganizationFixture({
+            slug: 'org-slug',
+            features: [],
+          }),
+          disableRouterMocks: true,
+          initialRouterConfig: {
+            location: {
+              pathname: '/projects/123/',
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('no redirect')).toBeInTheDocument();
+    });
+
+    it('should redirect on match', () => {
+      render(
+        <TestComponent oldPathPrefix="/projects/" newPathPrefix="/insights/projects/" />,
+        {
+          organization,
+          disableRouterMocks: true,
+          initialRouterConfig: {
+            location: {
+              pathname: '/projects/123/',
+              query: {foo: 'bar'},
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('/insights/projects/123/?foo=bar')).toBeInTheDocument();
+    });
+
+    it('should not redirect if no match', () => {
+      render(
+        <TestComponent oldPathPrefix="/projects/" newPathPrefix="/insights/projects/" />,
+        {
+          organization,
+          disableRouterMocks: true,
+          initialRouterConfig: {
+            location: {
+              pathname: '/other-projects/123/',
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('no redirect')).toBeInTheDocument();
+    });
+  });
+
+  describe('non-customer domain', () => {
+    beforeEach(() => {
+      mockUsingCustomerDomain.mockReturnValue(false);
+    });
+
+    it('should redirect on match', () => {
+      render(
+        <TestComponent oldPathPrefix="/projects/" newPathPrefix="/insights/projects/" />,
+        {
+          organization,
+          disableRouterMocks: true,
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/projects/123/',
+              query: {foo: 'bar'},
+            },
+          },
+        }
+      );
+
+      expect(
+        screen.getByText('/organizations/org-slug/insights/projects/123/?foo=bar')
+      ).toBeInTheDocument();
+    });
+
+    it('should not redirect if no match', () => {
+      render(
+        <TestComponent oldPathPrefix="/projects/" newPathPrefix="/insights/projects/" />,
+        {
+          organization,
+          disableRouterMocks: true,
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/other-projects/123/',
+              query: {foo: 'bar'},
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('no redirect')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/components/nav/useRedirectNavV2Routes.tsx
+++ b/static/app/components/nav/useRedirectNavV2Routes.tsx
@@ -1,0 +1,64 @@
+import {useLocation} from 'react-router-dom';
+
+import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type Props = {
+  newPathPrefix: `/${string}`;
+  oldPathPrefix: `/${string}`;
+};
+
+function useShouldRedirect(oldPathPrefix: `/${string}`) {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  if (USING_CUSTOMER_DOMAIN) {
+    return location.pathname.startsWith(oldPathPrefix);
+  }
+
+  return location.pathname.startsWith(
+    `/organizations/${organization.slug}${oldPathPrefix}`
+  );
+}
+
+/**
+ * Helps determine if we are on a legacy route and should redirect to the new route.
+ * Some products have been moved under new groups, such as feedback -> issues/feedback
+ * and discover -> explore/discover. When the v2 navigation is enabled, we need to
+ * enforce the new routes.
+ *
+ * Example:
+ *
+ * /feedback/123 -> /issues/feedback/123/
+ * /issues/feedback/123/ -> null (no redirect)
+ */
+export function useRedirectNavV2Routes({
+  oldPathPrefix,
+  newPathPrefix,
+}: Props): string | null {
+  const location = useLocation();
+  const organization = useOrganization();
+  const hasNavigationV2 = organization.features.includes('navigation-sidebar-v2');
+  const shouldRedirect = useShouldRedirect(oldPathPrefix);
+
+  if (!hasNavigationV2 || !shouldRedirect) {
+    return null;
+  }
+
+  if (USING_CUSTOMER_DOMAIN) {
+    return (
+      location.pathname.replace(new RegExp(`^${oldPathPrefix}`), newPathPrefix) +
+      location.search +
+      location.hash
+    );
+  }
+
+  return (
+    location.pathname.replace(
+      new RegExp(`^/organizations/${organization.slug}${oldPathPrefix}`),
+      `/organizations/${organization.slug}${newPathPrefix}`
+    ) +
+    location.search +
+    location.hash
+  );
+}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1466,7 +1466,11 @@ function buildRoutes() {
   );
   const releasesRoutes = (
     <Fragment>
-      <Route path="/releases/" withOrgPath>
+      <Route
+        path="/releases/"
+        component={make(() => import('sentry/views/releases/index'))}
+        withOrgPath
+      >
         {releasesChildRoutes}
       </Route>
       <Redirect
@@ -2001,7 +2005,12 @@ function buildRoutes() {
       <Route path="discover/" component={make(() => import('sentry/views/discover'))}>
         {discoverChildRoutes}
       </Route>
-      <Route path="releases/">{releasesChildRoutes}</Route>
+      <Route
+        path="releases/"
+        component={make(() => import('sentry/views/releases/index'))}
+      >
+        {releasesChildRoutes}
+      </Route>
       <Route path="logs/" component={make(() => import('sentry/views/explore/logs'))} />
     </Route>
   );

--- a/static/app/views/discover/index.tsx
+++ b/static/app/views/discover/index.tsx
@@ -1,7 +1,9 @@
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import Redirect from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -12,6 +14,15 @@ type Props = {
 };
 
 function DiscoverContainer({organization, children}: Props) {
+  const redirectPath = useRedirectNavV2Routes({
+    oldPathPrefix: '/discover/',
+    newPathPrefix: '/explore/discover/',
+  });
+
+  if (redirectPath) {
+    return <Redirect to={redirectPath} />;
+  }
+
   function renderNoAccess() {
     return (
       <Layout.Page withPadding>

--- a/static/app/views/feedback/index.tsx
+++ b/static/app/views/feedback/index.tsx
@@ -2,7 +2,9 @@ import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import Redirect from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,6 +15,15 @@ type Props = RouteComponentProps<{}, {}> & {
 
 export default function FeedbackContainer({children}: Props) {
   const organization = useOrganization();
+
+  const redirectPath = useRedirectNavV2Routes({
+    oldPathPrefix: '/feedback/',
+    newPathPrefix: '/issues/feedback/',
+  });
+
+  if (redirectPath) {
+    return <Redirect to={redirectPath} />;
+  }
 
   return (
     <Feature

--- a/static/app/views/profiling/index.tsx
+++ b/static/app/views/profiling/index.tsx
@@ -1,7 +1,9 @@
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import Redirect from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -13,6 +15,15 @@ type Props = {
 
 function ProfilingContainer({children}: Props) {
   const organization = useOrganization();
+
+  const redirectPath = useRedirectNavV2Routes({
+    oldPathPrefix: '/profiling/',
+    newPathPrefix: '/explore/profiling/',
+  });
+
+  if (redirectPath) {
+    return <Redirect to={redirectPath} />;
+  }
 
   return (
     <Feature

--- a/static/app/views/projects/index.tsx
+++ b/static/app/views/projects/index.tsx
@@ -1,3 +1,6 @@
+import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
+import Redirect from 'sentry/components/redirect';
+
 import {GettingStartedWithProjectContextProvider} from './gettingStartedWithProjectContext';
 
 type Props = {
@@ -5,6 +8,15 @@ type Props = {
 };
 
 export default function Projects({children}: Props) {
+  const redirectPath = useRedirectNavV2Routes({
+    oldPathPrefix: '/projects/',
+    newPathPrefix: '/insights/projects/',
+  });
+
+  if (redirectPath) {
+    return <Redirect to={redirectPath} />;
+  }
+
   return (
     <GettingStartedWithProjectContextProvider>
       {children}

--- a/static/app/views/releases/index.tsx
+++ b/static/app/views/releases/index.tsx
@@ -1,24 +1,20 @@
 import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
-import NoProjectMessage from 'sentry/components/noProjectMessage';
 import Redirect from 'sentry/components/redirect';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = RouteComponentProps<{}, {}> & {
   children: React.ReactNode;
 };
 
-export default function ReplaysContainer({children}: Props) {
-  const organization = useOrganization();
-
+export default function ReleasesContainer({children}: Props) {
   const redirectPath = useRedirectNavV2Routes({
-    oldPathPrefix: '/replays/',
-    newPathPrefix: '/explore/replays/',
+    oldPathPrefix: '/releases/',
+    newPathPrefix: '/explore/releases/',
   });
 
   if (redirectPath) {
     return <Redirect to={redirectPath} />;
   }
 
-  return <NoProjectMessage organization={organization}>{children}</NoProjectMessage>;
+  return children;
 }

--- a/static/app/views/traces/index.tsx
+++ b/static/app/views/traces/index.tsx
@@ -1,6 +1,8 @@
 import Feature from 'sentry/components/acl/feature';
+import {useRedirectNavV2Routes} from 'sentry/components/nav/useRedirectNavV2Routes';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import Redirect from 'sentry/components/redirect';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export const TRACE_EXPLORER_DOCS_URL = 'https://docs.sentry.io/product/explore/traces/';
@@ -11,6 +13,15 @@ interface Props {
 
 export default function TracesPage({children}: Props) {
   const organization = useOrganization();
+
+  const redirectPath = useRedirectNavV2Routes({
+    oldPathPrefix: '/traces/',
+    newPathPrefix: '/explore/traces/',
+  });
+
+  if (redirectPath) {
+    return <Redirect to={redirectPath} />;
+  }
 
   return (
     <Feature

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -281,7 +281,7 @@ function parseLocationConfig(location: LocationConfig | undefined): InitialEntry
     const queryString = qs.stringify(location.query);
     return {
       pathname: location.pathname,
-      search: queryString,
+      search: queryString ? `?${queryString}` : '',
     };
   }
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

Adds a new hook `useRedirectNavV2Routes()` and uses it in the top-level route components for each page thats needs the redirect.

When the feature flag is enabled, this will return a redirect to the new location. Otherwise it will do nothing.