### PR TITLE
chore(explore): Add tooltip to explore project badge

### DIFF
--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -157,6 +157,7 @@ function SpanDescriptionRenderer(data: EventData) {
             <ProjectBadge
               project={project ? project : {slug: data.project}}
               avatarSize={16}
+              avatarProps={{hasTooltip: true, tooltip: project.slug}}
               hideName
             />
           )}


### PR DESCRIPTION
This adds the tooltip for project name back to the badge.