### PR TITLE
✨ feat(threads): Create Notification Action threads repository

### DIFF
--- a/src/sentry/integrations/repository/notification_action.py
+++ b/src/sentry/integrations/repository/notification_action.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from datetime import datetime
+from logging import Logger, getLogger
+
+from django.db.models import Q
+
+from sentry.integrations.repository.base import (
+    BaseNewNotificationMessage,
+    BaseNotificationMessage,
+    NotificationMessageValidationError,
+)
+from sentry.models.group import Group
+from sentry.notifications.models.notificationmessage import NotificationMessage
+from sentry.workflow_engine.models import Action
+
+_default_logger: Logger = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NotificationActionNotificationMessage(BaseNotificationMessage):
+    action: Action | None = None
+    group: Group | None = None
+    open_period_start: datetime | None = None
+
+    @classmethod
+    def from_model(cls, instance: NotificationMessage) -> NotificationActionNotificationMessage:
+        return NotificationActionNotificationMessage(
+            id=instance.id,
+            error_code=instance.error_code,
+            error_details=instance.error_details,
+            message_identifier=instance.message_identifier,
+            parent_notification_message_id=(
+                instance.parent_notification_message.id
+                if instance.parent_notification_message
+                else None
+            ),
+            action=instance.action,
+            group=instance.group,
+            open_period_start=instance.open_period_start,
+            date_added=instance.date_added,
+        )
+
+
+class NotificationActionNotificationMessageValidationError(NotificationMessageValidationError):
+    pass
+
+
+class ActionAndGroupActionValidationError(NotificationActionNotificationMessageValidationError):
+    message = "both action and group need to exist together with a reference"
+
+
+@dataclass
+class NewNotificationActionNotificationMessage(BaseNewNotificationMessage):
+    action_id: int | None = None
+    group_id: int | None = None
+    open_period_start: datetime | None = None
+
+    def get_validation_error(self) -> Exception | None:
+        error = super().get_validation_error()
+        if error is not None:
+            return error
+
+        if self.message_identifier is not None:
+            # If a message_identifier exists, that means a successful notification happened for a rule action and fire
+            # This means that neither of them can be empty
+            if self.action_id is None or self.group_id is None:
+                return ActionAndGroupActionValidationError()
+
+        # We can create a NotificationMessage if it has both, or neither, of action and group.
+        # The following is an XNOR check for action and group
+        if (self.action_id is not None) != (self.group_id is not None):
+            return ActionAndGroupActionValidationError()
+
+        return None
+
+
+class NotificationActionNotificationMessageRepository:
+    """
+    Repository class that is responsible for querying the data store for notification messages in relation to notification actions.
+    """
+
+    _model = NotificationMessage
+
+    def __init__(self, logger: Logger) -> None:
+        self._logger: Logger = logger
+
+    @classmethod
+    def default(cls) -> NotificationActionNotificationMessageRepository:
+        return cls(logger=_default_logger)
+
+    @classmethod
+    def _parent_notification_message_base_filter(cls) -> Q:
+        """
+        Returns the query used to filter the notification messages for parent notification messages.
+        Parent notification messages are notification message instances without a parent notification message itself,
+        and where the error code is null.
+        """
+        return Q(parent_notification_message__isnull=True, error_code__isnull=True)
+
+    def get_parent_notification_message(
+        self,
+        action: Action,
+        group: Group,
+        open_period_start: datetime | None = None,
+    ) -> NotificationActionNotificationMessage | None:
+        """
+        Returns the parent notification message if it exists, otherwise returns None.
+        Will raise an exception if the query fails and logs the error with associated data.
+        """
+        try:
+            base_filter = self._parent_notification_message_base_filter()
+            instance: NotificationMessage = (
+                self._model.objects.filter(base_filter)
+                .filter(
+                    action=action,
+                    group=group,
+                    open_period_start=open_period_start,
+                )
+                .latest("date_added")
+            )
+            return NotificationActionNotificationMessage.from_model(instance=instance)
+        except NotificationMessage.DoesNotExist:
+            return None
+        except Exception as e:
+            self._logger.exception(
+                "Failed to get parent notification for issue rule",
+                exc_info=e,
+                extra={
+                    "action": action,
+                    "group": group,
+                },
+            )
+            raise
+
+    def create_notification_message(
+        self, data: NewNotificationActionNotificationMessage
+    ) -> NotificationActionNotificationMessage:
+        if (error := data.get_validation_error()) is not None:
+            raise error
+
+        try:
+            instance = self._model.objects.create(
+                action_id=data.action_id,
+                group_id=data.group_id,
+                open_period_start=data.open_period_start,
+                error_details=data.error_details,
+                error_code=data.error_code,
+                message_identifier=data.message_identifier,
+                parent_notification_message_id=data.parent_notification_message_id,
+            )
+            return NotificationActionNotificationMessage.from_model(instance=instance)
+        except Exception as e:
+            self._logger.exception(
+                "failed to create new notification action notification message",
+                exc_info=e,
+                extra=data.__dict__,
+            )
+            raise
+
+    def get_all_parent_notification_messages_by_filters(
+        self,
+        action_ids: list[int] | None = None,
+        group_ids: list[int] | None = None,
+        open_period_start: datetime | None = None,
+    ) -> Generator[NotificationActionNotificationMessage]:
+        """
+        If no filters are passed, then all parent notification objects are returned.
+
+        Because an unbounded amount of parent notification objects can be returned, this method leverages generator to
+        control the usage of memory in the application.
+        It is up to the caller to iterate over all the data, or store in memory if they need all objects concurrently.
+        """
+        action_id_filter = Q(action__id__in=action_ids) if action_ids else Q()
+        group_id_filter = Q(group__id__in=group_ids) if group_ids else Q()
+        open_period_start_filter = (
+            Q(open_period_start=open_period_start) if open_period_start else Q()
+        )
+
+        query = self._model.objects.filter(
+            action_id_filter & group_id_filter & open_period_start_filter
+        ).filter(self._parent_notification_message_base_filter())
+
+        try:
+            for instance in query:
+                yield NotificationActionNotificationMessage.from_model(instance=instance)
+        except Exception as e:
+            self._logger.exception(
+                "Failed to get parent notifications on filters",
+                exc_info=e,
+                extra=filter.__dict__,
+            )
+            raise

--- a/tests/sentry/integrations/repository/notification_action/test_notification_action_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/notification_action/test_notification_action_notification_message_repository.py
@@ -1,0 +1,278 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.integrations.repository.notification_action import (
+    NewNotificationActionNotificationMessage,
+    NotificationActionNotificationMessage,
+    NotificationActionNotificationMessageRepository,
+)
+from sentry.notifications.models.notificationmessage import NotificationMessage
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+class BaseNotificationActionNotificationMessageRepositoryTest(TestCase):
+    def setUp(self) -> None:
+        self.action = self.create_action()
+        self.group = self.create_group()
+        self.parent_notification_message = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="123abc",
+        )
+        self.repository = NotificationActionNotificationMessageRepository.default()
+
+
+class TestGetParentNotificationMessage(BaseNotificationActionNotificationMessageRepositoryTest):
+    def test_returns_parent_notification_message(self) -> None:
+        instance = self.repository.get_parent_notification_message(
+            action=self.action,
+            group=self.group,
+        )
+
+        assert instance is not None
+        assert instance == NotificationActionNotificationMessage.from_model(
+            self.parent_notification_message
+        )
+
+    def test_returns_latest_parent_notification_message(self) -> None:
+        latest = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="new_later_one",
+        )
+
+        instance = self.repository.get_parent_notification_message(
+            action=self.action,
+            group=self.group,
+        )
+
+        assert instance is not None
+        assert instance == NotificationActionNotificationMessage.from_model(latest)
+
+    def test_returns_none_when_filter_does_not_exist(self) -> None:
+        different_action = self.create_action()
+        instance = self.repository.get_parent_notification_message(
+            action=different_action,
+            group=self.group,
+        )
+
+        assert instance is None
+
+    def test_when_parent_has_child(self) -> None:
+        child = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="456abc",
+            parent_notification_message=self.parent_notification_message,
+        )
+
+        assert child.id != self.parent_notification_message.id
+
+        instance = self.repository.get_parent_notification_message(
+            action=self.action,
+            group=self.group,
+        )
+
+        assert instance is not None
+        assert instance == NotificationActionNotificationMessage.from_model(
+            self.parent_notification_message
+        )
+
+    def test_returns_parent_notification_message_with_open_period_start(self) -> None:
+        open_period_start = timezone.now()
+        NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="789xyz",
+            open_period_start=open_period_start,
+        )
+
+        latest_notification = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="789xyz",
+            open_period_start=open_period_start + timedelta(seconds=1),
+        )
+
+        instance = self.repository.get_parent_notification_message(
+            action=self.action,
+            group=self.group,
+            open_period_start=open_period_start + timedelta(seconds=1),
+        )
+
+        assert instance is not None
+        assert instance == NotificationActionNotificationMessage.from_model(latest_notification)
+        assert instance.open_period_start == open_period_start + timedelta(seconds=1)
+
+
+class TestCreateNotificationMessage(BaseNotificationActionNotificationMessageRepositoryTest):
+    def test_simple(self) -> None:
+        message_identifier = "1a2b3c"
+        data = NewNotificationActionNotificationMessage(
+            action_id=self.action.id,
+            group_id=self.group.id,
+            message_identifier=message_identifier,
+        )
+
+        result = self.repository.create_notification_message(data=data)
+        assert result is not None
+        assert result.message_identifier == message_identifier
+
+    def test_with_error_details(self) -> None:
+        error_detail = {
+            "message": "message",
+            "some_nested_obj": {
+                "some_nested_key": "some_nested_value",
+                "some_array": ["some_array"],
+                "int": 203,
+            },
+        }
+        data = NewNotificationActionNotificationMessage(
+            action_id=self.action.id,
+            group_id=self.group.id,
+            error_code=405,
+            error_details=error_detail,
+        )
+
+        result = self.repository.create_notification_message(data=data)
+        assert result is not None
+        assert result.error_details == error_detail
+
+
+class TestGetAllParentNotificationMessagesByFilters(
+    BaseNotificationActionNotificationMessageRepositoryTest
+):
+    def test_returns_all_when_no_filters(self) -> None:
+        # Create additional notification messages
+        additional_notification = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="123abc",
+        )
+
+        # Call the method without any filters
+        parent_notifications = list(
+            self.repository.get_all_parent_notification_messages_by_filters()
+        )
+
+        result_ids = []
+        for parent_notification in parent_notifications:
+            result_ids.append(parent_notification.id)
+        # Check if all notification messages are returned
+        assert len(result_ids) == 2
+        assert additional_notification.id in result_ids
+        assert self.parent_notification_message.id in result_ids
+
+    def test_returns_filtered_messages_for_action_id(self) -> None:
+        # Create some notification message that should not be returned
+        different_action = self.create_action()
+        notification_message_that_should_not_be_returned = NotificationMessage.objects.create(
+            action=different_action,
+            group=self.group,
+            message_identifier="zxcvb",
+        )
+
+        # Call the method with filters specifying the specific action id
+        parent_notifications = list(
+            self.repository.get_all_parent_notification_messages_by_filters(
+                action_ids=[self.action.id]
+            )
+        )
+
+        result_ids = []
+        for parent_notification in parent_notifications:
+            result_ids.append(parent_notification.id)
+        # Check if only the notifications related to the specified action
+        assert len(result_ids) == 1
+        assert result_ids[0] == self.parent_notification_message.id
+        assert notification_message_that_should_not_be_returned.id not in result_ids
+
+    def test_returns_filtered_messages_for_group_id(self) -> None:
+        # Create some notification message that should not be returned
+        new_group = self.create_group()
+        notification_message_that_should_not_be_returned = NotificationMessage.objects.create(
+            action=self.action,
+            group=new_group,
+            message_identifier="zxcvb",
+        )
+
+        # Call the method with filters specifying the specific group id
+        parent_notifications = list(
+            self.repository.get_all_parent_notification_messages_by_filters(
+                group_ids=[self.group.id]
+            )
+        )
+
+        result_ids = []
+        for parent_notification in parent_notifications:
+            result_ids.append(parent_notification.id)
+        # Check if only the notifications related to the specified group
+        assert len(result_ids) == 1
+        assert result_ids[0] == self.parent_notification_message.id
+        assert notification_message_that_should_not_be_returned.id not in result_ids
+
+    @freeze_time("2025-01-01 00:00:00")
+    def test_returns_correct_message_when_open_period_start_is_not_none(self) -> None:
+        NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="period123",
+            open_period_start=timezone.now(),
+        )
+
+        n2 = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="period123",
+            open_period_start=timezone.now() + timedelta(seconds=1),
+        )
+
+        n3 = NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="period123",
+            open_period_start=timezone.now() + timedelta(seconds=1),
+        )
+
+        result = list(
+            self.repository.get_all_parent_notification_messages_by_filters(
+                action_ids=[self.action.id],
+                group_ids=[self.group.id],
+                open_period_start=timezone.now() + timedelta(seconds=1),
+            )
+        )
+
+        result_ids = []
+        for parent_notification in result:
+            result_ids.append(parent_notification.id)
+
+        assert len(result_ids) == 2
+        assert n3.id in result_ids
+        assert n2.id in result_ids
+
+    @freeze_time("2025-01-01 00:00:00")
+    def test_returns_none_when_open_period_start_does_not_match(self) -> None:
+        # Create notifications with different open periods
+        NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="period1",
+            open_period_start=timezone.now(),
+        )
+        NotificationMessage.objects.create(
+            action=self.action,
+            group=self.group,
+            message_identifier="period2",
+            open_period_start=timezone.now() + timedelta(days=1),
+        )
+
+        # Query with a different open period
+        instance = self.repository.get_parent_notification_message(
+            action=self.action,
+            group=self.group,
+            open_period_start=timezone.now() + timedelta(seconds=1),
+        )
+
+        assert instance is None


### PR DESCRIPTION
requires https://github.com/getsentry/sentry/pull/84498 to be merged.

this creates a notification action threads repository which we will use in the action handlers for Slack to fetch and save threads.

very similar to https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/repository/issue_alert.py, with the main difference being that we do the fetching and saving via the `Action` and `Group` FKs