### PR TITLE
:wrench: chore: add ecosystem to notification builder and threads codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -378,6 +378,8 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/integrations/                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
 /src/sentry/mail/                                                    @getsentry/alerts-notifications
 /src/sentry/notifications/                                           @getsentry/alerts-notifications
+/src/sentry/notifications/models/                                    @getsentry/ecosystem
+/src/sentry/notifications/notifications/                             @getsentry/ecosystem
 /src/sentry/pipeline/                                                @getsentry/ecosystem
 /src/sentry/plugins/                                                 @getsentry/ecosystem
 /src/sentry/shared_integrations/                                     @getsentry/ecosystem


### PR DESCRIPTION
logic for our notification builders for slack and email as well as models for threading all live under the notifications folder which the ecosystem regularly interacts with.
