### PR TITLE
chore(data-scrubbing): update copy on advanced data scrubbing hint in settings

### DIFF
--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.tsx
@@ -81,7 +81,9 @@ export default function OrganizationSecurityAndPrivacyContent() {
       {showDataSecrecySettings && <DataSecrecy />}
 
       <DataScrubbing
-        additionalContext={t('These rules can be configured for each project.')}
+        additionalContext={t(
+          'Advanced data scrubbing rules can also be configured for each project.'
+        )}
         endpoint={endpoint}
         relayPiiConfig={relayPiiConfig}
         organization={organization}

--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.tsx
@@ -82,7 +82,7 @@ export default function OrganizationSecurityAndPrivacyContent() {
 
       <DataScrubbing
         additionalContext={t(
-          'Advanced data scrubbing rules can also be configured for each project.'
+          'Advanced data scrubbing rules can be configured at the organization level and will apply to all projects. Project-level rules can be configured in addition to organization-level rules.'
         )}
         endpoint={endpoint}
         relayPiiConfig={relayPiiConfig}

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -63,7 +63,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
         additionalContext={
           <span>
             {tct(
-              'Advanced data scrubbing rules can also be configured at the organization level in [linkToOrganizationSecurityAndPrivacy].',
+              'Advanced data scrubbing rules can configured for each project. These rules will be applied in addition to any organization-level rules in in [linkToOrganizationSecurityAndPrivacy].',
               {
                 linkToOrganizationSecurityAndPrivacy: (
                   <Link to={`/settings/${organization.slug}/security-and-privacy/`}>

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -63,7 +63,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
         additionalContext={
           <span>
             {tct(
-              'These rules can be configured at the organization level in [linkToOrganizationSecurityAndPrivacy].',
+              'Advanced data scrubbing rules can also be configured at the organization level in [linkToOrganizationSecurityAndPrivacy].',
               {
                 linkToOrganizationSecurityAndPrivacy: (
                   <Link to={`/settings/${organization.slug}/security-and-privacy/`}>

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -63,7 +63,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
         additionalContext={
           <span>
             {tct(
-              'Advanced data scrubbing rules can configured for each project. These rules will be applied in addition to any organization-level rules configured in [linkToOrganizationSecurityAndPrivacy].',
+              'Advanced data scrubbing rules can be configured for each project. These rules will be applied in addition to any organization-level rules configured in [linkToOrganizationSecurityAndPrivacy].',
               {
                 linkToOrganizationSecurityAndPrivacy: (
                   <Link to={`/settings/${organization.slug}/security-and-privacy/`}>

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -63,7 +63,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
         additionalContext={
           <span>
             {tct(
-              'Advanced data scrubbing rules can configured for each project. These rules will be applied in addition to any organization-level rules in in [linkToOrganizationSecurityAndPrivacy].',
+              'Advanced data scrubbing rules can configured for each project. These rules will be applied in addition to any organization-level rules in [linkToOrganizationSecurityAndPrivacy].',
               {
                 linkToOrganizationSecurityAndPrivacy: (
                   <Link to={`/settings/${organization.slug}/security-and-privacy/`}>

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -63,7 +63,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
         additionalContext={
           <span>
             {tct(
-              'Advanced data scrubbing rules can configured for each project. These rules will be applied in addition to any organization-level rules in [linkToOrganizationSecurityAndPrivacy].',
+              'Advanced data scrubbing rules can configured for each project. These rules will be applied in addition to any organization-level rules configured in [linkToOrganizationSecurityAndPrivacy].',
               {
                 linkToOrganizationSecurityAndPrivacy: (
                   <Link to={`/settings/${organization.slug}/security-and-privacy/`}>


### PR DESCRIPTION
- Reword the slightly overzealous hint, that advanced data scrubbing rules can also be configured at a different level.
- Closes https://github.com/getsentry/projects/issues/656