### PR TITLE
storybook: fix titles

### DIFF
--- a/static/app/components/alert.stories.tsx
+++ b/static/app/components/alert.stories.tsx
@@ -10,7 +10,7 @@ import {IconClose, IconDelete, IconSad, IconSentry, IconStar} from 'sentry/icons
 import storyBook from 'sentry/stories/storyBook';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 
-export default storyBook(Alert, story => {
+export default storyBook('Alert', story => {
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/alertLink.stories.tsx
+++ b/static/app/components/alertLink.stories.tsx
@@ -6,7 +6,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import {IconSentry} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(AlertLink, story => {
+export default storyBook('AlertLink', story => {
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/alerts/pageBanner.stories.tsx
+++ b/static/app/components/alerts/pageBanner.stories.tsx
@@ -10,7 +10,7 @@ import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {IconBroadcast} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(PageBanner, story => {
+export default storyBook('PageBanner', story => {
   const storiesButton = (
     <LinkButton
       external

--- a/static/app/components/avatar/avatarList.stories.tsx
+++ b/static/app/components/avatar/avatarList.stories.tsx
@@ -20,7 +20,7 @@ function useLoadedMembers() {
   return {members, loadMore, ...rest};
 }
 
-export default storyBook(AvatarList, story => {
+export default storyBook('AvatarList', story => {
   story('Default', () => {
     const {members, fetching} = useLoadedMembers();
 

--- a/static/app/components/avatar/seenByList.stories.tsx
+++ b/static/app/components/avatar/seenByList.stories.tsx
@@ -20,7 +20,7 @@ function useLoadedMembers() {
   return {members, loadMore, ...rest};
 }
 
-export default storyBook(SeenByList, story => {
+export default storyBook('SeenByList', story => {
   story('Default', () => {
     const {members, fetching} = useLoadedMembers();
 

--- a/static/app/components/badge/alertBadge.stories.tsx
+++ b/static/app/components/badge/alertBadge.stories.tsx
@@ -5,7 +5,7 @@ import Matrix from 'sentry/components/stories/matrix';
 import storyBook from 'sentry/stories/storyBook';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 
-export default storyBook(AlertBadge, story => {
+export default storyBook('AlertBadge', story => {
   story('Default', () => <AlertBadge />);
 
   const props = {

--- a/static/app/components/badge/badge.stories.tsx
+++ b/static/app/components/badge/badge.stories.tsx
@@ -3,7 +3,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SideBySide from 'sentry/components/stories/sideBySide';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(Badge, story => {
+export default storyBook('Badge', story => {
   story('Default', () => (
     <SideBySide>
       <Badge text="Text Prop" />

--- a/static/app/components/badge/deployBadge.stories.tsx
+++ b/static/app/components/badge/deployBadge.stories.tsx
@@ -12,7 +12,7 @@ const deploy: Deploy = {
   id: '6348842',
 };
 
-export default storyBook(DeployBadge, story => {
+export default storyBook('DeployBadge', story => {
   story('Renders with a link', () => (
     <DeployBadge deploy={deploy} orgSlug="sentry" version="1.2.3" projectId={1} />
   ));

--- a/static/app/components/badge/featureBadge.stories.tsx
+++ b/static/app/components/badge/featureBadge.stories.tsx
@@ -6,7 +6,7 @@ import Matrix from 'sentry/components/stories/matrix';
 import SideBySide from 'sentry/components/stories/sideBySide';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(FeatureBadge, story => {
+export default storyBook('FeatureBadge', story => {
   story('Types', () => (
     <SideBySide>
       <FeatureBadge type="alpha" />

--- a/static/app/components/badge/groupPriority.stories.tsx
+++ b/static/app/components/badge/groupPriority.stories.tsx
@@ -10,7 +10,7 @@ import {PriorityLevel} from 'sentry/types/group';
 
 const PRIORITIES = [PriorityLevel.HIGH, PriorityLevel.MEDIUM, PriorityLevel.LOW];
 
-export const Badge = storyBook(GroupPriorityBadge, story => {
+export const Badge = storyBook('GroupPriorityBadge', story => {
   story('Default', () => (
     <SideBySide>
       {PRIORITIES.map(priority => (
@@ -20,7 +20,7 @@ export const Badge = storyBook(GroupPriorityBadge, story => {
   ));
 });
 
-export const Dropdown = storyBook(GroupPriorityDropdown, story => {
+export const Dropdown = storyBook('GroupPriorityDropdown', story => {
   story('Default', () => {
     const [value, setValue] = useState(PriorityLevel.MEDIUM);
 

--- a/static/app/components/badge/tag.stories.tsx
+++ b/static/app/components/badge/tag.stories.tsx
@@ -9,7 +9,7 @@ import {IconCheckmark, IconFire, IconSentry, IconStar} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 
-export default storyBook(Tag, story => {
+export default storyBook('Tag', story => {
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/button.stories.tsx
+++ b/static/app/components/button.stories.tsx
@@ -12,6 +12,7 @@ import types from '!!type-loader!sentry/components/button';
 
 export default storyBook('Button', (story, APIReference) => {
   APIReference(types.Button);
+
   story('Default', () => {
     return <Button>Default Button</Button>;
   });

--- a/static/app/components/buttonBar.stories.tsx
+++ b/static/app/components/buttonBar.stories.tsx
@@ -3,7 +3,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import Matrix from 'sentry/components/stories/matrix';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(ButtonBar, story => {
+export default storyBook('ButtonBar', story => {
   story('Default', () => (
     <ButtonBar>
       <Button>One</Button>

--- a/static/app/components/charts/groupStatusChart.stories.tsx
+++ b/static/app/components/charts/groupStatusChart.stories.tsx
@@ -31,7 +31,7 @@ const stats: readonly TimeseriesValue[] = [
   [1715637600, 82],
 ];
 
-export default storyBook(GroupStatusChart, story => {
+export default storyBook('GroupStatusChart', story => {
   story('Default', () => {
     return (
       <GraphContainer>

--- a/static/app/components/checkInTimeline/checkInTimeline.stories.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.stories.tsx
@@ -79,7 +79,7 @@ function generateMockTickData(
     .filter(([ts, _]) => ts <= timeWindowConfig.end.getTime() / 1000);
 }
 
-export default storyBook(CheckInTimeline, story => {
+export default storyBook('CheckInTimeline', story => {
   story('Simple', () => {
     const elementRef = useRef<HTMLDivElement>(null);
     const {width: timelineWidth} = useDimensions<HTMLDivElement>({elementRef});

--- a/static/app/components/clippedBox.stories.tsx
+++ b/static/app/components/clippedBox.stories.tsx
@@ -12,7 +12,7 @@ import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook(ClippedBox, story => {
+export default storyBook('ClippedBox', story => {
   story('Default', () => (
     <Fragment>
       <p>

--- a/static/app/components/codeSnippet.stories.tsx
+++ b/static/app/components/codeSnippet.stories.tsx
@@ -7,7 +7,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import {IconStar} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(CodeSnippet, story => {
+export default storyBook('CodeSnippet', story => {
   story('Defaults', () => (
     <Fragment>
       <p>

--- a/static/app/components/collapsePanel.stories.tsx
+++ b/static/app/components/collapsePanel.stories.tsx
@@ -8,7 +8,7 @@ import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(CollapsePanel, story => {
+export default storyBook('CollapsePanel', story => {
   story('Basics', () => (
     <Fragment>
       <p>

--- a/static/app/components/collapsible.stories.tsx
+++ b/static/app/components/collapsible.stories.tsx
@@ -8,7 +8,7 @@ import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(Collapsible, story => {
+export default storyBook('Collapsible', story => {
   story('Default', () => (
     <Fragment>
       <p>

--- a/static/app/components/compactSelect/composite.stories.tsx
+++ b/static/app/components/compactSelect/composite.stories.tsx
@@ -44,7 +44,7 @@ const ADJ_OPTIONS = [
   {value: 'awesome', label: 'awesome'},
 ];
 
-export default storyBook(CompositeSelect, story => {
+export default storyBook('CompositeSelect', story => {
   story('Introduction', () => {
     return (
       <Fragment>

--- a/static/app/components/compactSelect/index.stories.tsx
+++ b/static/app/components/compactSelect/index.stories.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import storyBook from 'sentry/stories/storyBook';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 
-export default storyBook(CompactSelect, story => {
+export default storyBook('CompactSelect', story => {
   story('Basics', () => {
     return (
       <Fragment>

--- a/static/app/components/confirm.stories.tsx
+++ b/static/app/components/confirm.stories.tsx
@@ -11,7 +11,7 @@ import SideBySide from 'sentry/components/stories/sideBySide';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook(Confirm, story => {
+export default storyBook('Confirm', story => {
   story('Triggers', () => {
     const [state, setState] = useState('empty');
 

--- a/static/app/components/container/negativeSpaceContainer.stories.tsx
+++ b/static/app/components/container/negativeSpaceContainer.stories.tsx
@@ -7,7 +7,7 @@ import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceCon
 import JSXNode from 'sentry/components/stories/jsxNode';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(NegativeSpaceContainer, story => {
+export default storyBook('NegativeSpaceContainer', story => {
   story('Empty', () => (
     <Fragment>
       <p>

--- a/static/app/components/copyToClipboardButton.stories.tsx
+++ b/static/app/components/copyToClipboardButton.stories.tsx
@@ -10,7 +10,7 @@ import {IconLink} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 
-export default storyBook(CopyToClipboardButton, story => {
+export default storyBook('CopyToClipboardButton', story => {
   story('Basic', () => (
     <Fragment>
       <p>

--- a/static/app/components/duration/duration.stories.tsx
+++ b/static/app/components/duration/duration.stories.tsx
@@ -1,7 +1,7 @@
 import Duration from 'sentry/components/duration/duration';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(Duration, story => {
+export default storyBook('Duration', story => {
   story('Default format ("hh:mm:ss.sss")', () => (
     <ul>
       <li>

--- a/static/app/components/emptyStateWarning.stories.tsx
+++ b/static/app/components/emptyStateWarning.stories.tsx
@@ -6,7 +6,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook(EmptyStateWarning, story => {
+export default storyBook('EmptyStateWarning', story => {
   story('Default', () => (
     <Fragment>
       <p>

--- a/static/app/components/events/contexts/contextIcon.stories.tsx
+++ b/static/app/components/events/contexts/contextIcon.stories.tsx
@@ -6,7 +6,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook(ContextIcon, story => {
+export default storyBook('ContextIcon', story => {
   story('All', () => (
     <Grid
       style={{

--- a/static/app/components/forms/fields/index.stories.tsx
+++ b/static/app/components/forms/fields/index.stories.tsx
@@ -22,7 +22,7 @@ import SeparatorField from './separatorField';
 import TextareaField from './textareaField';
 import TextField from './textField';
 
-export default storyBook(Form, story => {
+export default storyBook('Form', story => {
   story('Available fields', () => {
     const {projects} = useProjects();
 

--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -17,7 +17,7 @@ interface ExampleDataItem {
   name: string;
 }
 
-export default storyBook(GridEditable, story => {
+export default storyBook('GridEditable', story => {
   const columns: Array<GridColumnOrder<keyof ExampleDataItem>> = [
     {key: 'category', name: 'Platform Category'},
     {key: 'name', name: 'Platform Name'},

--- a/static/app/components/guidedSteps/guidedSteps.stories.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.stories.tsx
@@ -9,7 +9,7 @@ import JSXNode from 'sentry/components/stories/jsxNode';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(GuidedSteps, story => {
+export default storyBook('GuidedSteps', story => {
   story('Default', () => (
     <Fragment>
       <p>

--- a/static/app/components/idBadge/index.stories.tsx
+++ b/static/app/components/idBadge/index.stories.tsx
@@ -13,7 +13,7 @@ import SideBySide from '../stories/sideBySide';
 import type {OrganizationBadgeProps} from './organizationBadge';
 import IdBadge from '.';
 
-export default storyBook(IdBadge, story => {
+export default storyBook('IdBadge', story => {
   story('Props', () => {
     const org = useOrganization();
 

--- a/static/app/components/interactionStateLayer.stories.tsx
+++ b/static/app/components/interactionStateLayer.stories.tsx
@@ -9,7 +9,7 @@ import JSXNode from './stories/jsxNode';
 import SideBySide from './stories/sideBySide';
 import InteractionStateLayer from './interactionStateLayer';
 
-export default storyBook(InteractionStateLayer, story => {
+export default storyBook('InteractionStateLayer', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/components/loadingError.stories.tsx
+++ b/static/app/components/loadingError.stories.tsx
@@ -7,7 +7,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(LoadingError, story => {
+export default storyBook('LoadingError', story => {
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/loadingIndicator.stories.tsx
+++ b/static/app/components/loadingIndicator.stories.tsx
@@ -1,7 +1,7 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(LoadingIndicator, story => {
+export default storyBook('LoadingIndicator', story => {
   story('Default', () => <LoadingIndicator />);
 
   story('Mini', () => <LoadingIndicator mini />);

--- a/static/app/components/loadingTriangle.stories.tsx
+++ b/static/app/components/loadingTriangle.stories.tsx
@@ -2,7 +2,7 @@ import LoadingTriangle from 'sentry/components/loadingTriangle';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(LoadingTriangle, story => {
+export default storyBook('LoadingTriangle', story => {
   story('Default', () => (
     <SizingWindow style={{height: '150px'}}>
       <LoadingTriangle />

--- a/static/app/components/logoSentry.stories.tsx
+++ b/static/app/components/logoSentry.stories.tsx
@@ -2,7 +2,7 @@ import LogoSentry from 'sentry/components/logoSentry';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(LogoSentry, story => {
+export default storyBook('LogoSentry', story => {
   story('Default', () => (
     <SizingWindow>
       <LogoSentry />

--- a/static/app/components/nav/secondary.stories.tsx
+++ b/static/app/components/nav/secondary.stories.tsx
@@ -8,7 +8,7 @@ import {SecondarySidebar} from 'sentry/components/nav/secondarySidebar';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook(SecondaryNav, story => {
+export default storyBook('SecondaryNav', story => {
   story('Basics (WIP)', () => {
     const [activeItem, setActiveItem] = useState<string | null>('product-area-1');
 

--- a/static/app/components/onboardingPanel.stories.tsx
+++ b/static/app/components/onboardingPanel.stories.tsx
@@ -11,7 +11,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(OnboardingPanel, story => {
+export default storyBook('OnboardingPanel', story => {
   story('Basics', () => {
     return (
       <Fragment>

--- a/static/app/components/progrssBar.stories.tsx
+++ b/static/app/components/progrssBar.stories.tsx
@@ -2,7 +2,7 @@ import ProgressBar from 'sentry/components/progressBar';
 import Matrix from 'sentry/components/stories/matrix';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(ProgressBar, story => {
+export default storyBook('ProgressBar', story => {
   story('Default', () => (
     <Matrix
       propMatrix={{

--- a/static/app/components/questionTooltip.stories.tsx
+++ b/static/app/components/questionTooltip.stories.tsx
@@ -7,7 +7,7 @@ import JSXProperty from 'sentry/components/stories/jsxProperty';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook(QuestionTooltip, story => {
+export default storyBook('QuestionTooltip', story => {
   story('Basics', () => {
     return (
       <Fragment>

--- a/static/app/components/replays/alerts/missingReplayAlert.stories.tsx
+++ b/static/app/components/replays/alerts/missingReplayAlert.stories.tsx
@@ -1,6 +1,6 @@
 import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(MissingReplayAlert, story => {
+export default storyBook('MissingReplayAlert', story => {
   story('All', () => <MissingReplayAlert orgSlug="MY-ORG" />);
 });

--- a/static/app/components/replays/alerts/replayUnsupportedAlert.stories.tsx
+++ b/static/app/components/replays/alerts/replayUnsupportedAlert.stories.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ReplayUnsupportedAlert from 'sentry/components/replays/alerts/replayUnsupportedAlert';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(ReplayUnsupportedAlert, story => {
+export default storyBook('ReplayUnsupportedAlert', story => {
   story('All', () => {
     return (
       <Fragment>

--- a/static/app/components/replays/player/replayCurrentTime.stories.tsx
+++ b/static/app/components/replays/player/replayCurrentTime.stories.tsx
@@ -8,7 +8,7 @@ import ReplayPlayPauseButton from 'sentry/components/replays/player/replayPlayPa
 import SideBySide from 'sentry/components/stories/sideBySide';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(ReplayCurrentTime, story => {
+export default storyBook('ReplayCurrentTime', story => {
   story('Default', () => {
     function Example() {
       return (

--- a/static/app/components/replays/player/replayPlayPauseButton.stories.tsx
+++ b/static/app/components/replays/player/replayPlayPauseButton.stories.tsx
@@ -8,7 +8,7 @@ import ReplayPlayPauseButton from 'sentry/components/replays/player/replayPlayPa
 import JSXNode from 'sentry/components/stories/jsxNode';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(ReplayPlayer, story => {
+export default storyBook('ReplayPlayer', story => {
   story('Default', () => {
     function Example() {
       return (

--- a/static/app/components/replays/player/replayPlayer.stories.tsx
+++ b/static/app/components/replays/player/replayPlayer.stories.tsx
@@ -12,7 +12,7 @@ import storyBook from 'sentry/stories/storyBook';
 import {useReplayPlayerState} from 'sentry/utils/replays/playback/providers/replayPlayerStateContext';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 
-export default storyBook(ReplayPlayer, story => {
+export default storyBook('ReplayPlayer', story => {
   story('Default', () => {
     function Example() {
       return (

--- a/static/app/components/replays/player/replayPlayerMeasurer.stories.tsx
+++ b/static/app/components/replays/player/replayPlayerMeasurer.stories.tsx
@@ -6,7 +6,7 @@ import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(ReplayPlayerMeasurer, story => {
+export default storyBook('ReplayPlayerMeasurer', story => {
   story('measure=both, the default, container has fixed height', () => {
     function Example() {
       return (

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
@@ -15,7 +15,7 @@ import {
   useReplayPrefs,
 } from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 
-export default storyBook(ReplayPreferenceDropdown, story => {
+export default storyBook('ReplayPreferenceDropdown', story => {
   story('Default - LocalStorageReplayPreferences', () => {
     return (
       <Fragment>

--- a/static/app/components/scrollCarousel.stories.tsx
+++ b/static/app/components/scrollCarousel.stories.tsx
@@ -8,7 +8,7 @@ import {space} from 'sentry/styles/space';
 
 import {ScrollCarousel} from './scrollCarousel';
 
-export default storyBook(ScrollCarousel, story => {
+export default storyBook('ScrollCarousel', story => {
   story('Default', () => (
     <Fragment>
       <p>

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -118,7 +118,7 @@ const getTagValues = (): Promise<string[]> => {
   });
 };
 
-export default storyBook(SearchQueryBuilder, story => {
+export default storyBook('SearchQueryBuilder', story => {
   story('Getting started', () => {
     return (
       <Fragment>

--- a/static/app/components/segmentedControl.stories.tsx
+++ b/static/app/components/segmentedControl.stories.tsx
@@ -7,7 +7,7 @@ import SideBySide from 'sentry/components/stories/sideBySide';
 import {IconStats} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(SegmentedControl, story => {
+export default storyBook('SegmentedControl', story => {
   story('Default', () => (
     <Fragment>
       <p>

--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -9,7 +9,7 @@ import SideBySide from 'sentry/components/stories/sideBySide';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(StructuredEventData, story => {
+export default storyBook('StructuredEventData', story => {
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -9,7 +9,7 @@ import type {TabListProps, TabsProps} from 'sentry/components/tabs';
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook(Tabs, story => {
+export default storyBook('Tabs', story => {
   const TABS = [
     {key: 'one', label: 'One', content: 'This is the first Panel.'},
     {key: 'two', label: 'Two', content: 'This is the second panel'},

--- a/static/app/stories/storyBook.tsx
+++ b/static/app/stories/storyBook.tsx
@@ -14,7 +14,7 @@ type SetupFunction = (
 ) => void;
 
 export default function storyBook(
-  bookContext: string | React.ComponentType<any>,
+  title: string,
   setup: SetupFunction
 ): StoryRenderFunction {
   const stories: Array<{
@@ -40,11 +40,10 @@ export default function storyBook(
   return function RenderStory() {
     return (
       <Fragment>
-        <BookTitle bookContext={bookContext} />
+        <StoryTitle>{title}</StoryTitle>
         {stories.map(({name, render}, i) => (
           <Story key={i} name={name} render={render} />
         ))}
-
         {APIDocumentation.map((documentation, i) => (
           <StoryTypes key={i} types={documentation} />
         ))}
@@ -62,18 +61,6 @@ function Story(props: {name: string; render: StoryRenderFunction}) {
       <StoryTitle>{props.name}</StoryTitle>
       {isOneChild ? children : <SideBySide>{children}</SideBySide>}
     </StorySection>
-  );
-}
-
-function BookTitle(props: {bookContext: string | React.ComponentType<any>}) {
-  const {bookContext} = props;
-  if (typeof bookContext === 'string') {
-    return <StoryTitle>{bookContext}</StoryTitle>;
-  }
-  return (
-    <StoryTitle>
-      <code>{`<${bookContext.displayName ?? bookContext.name ?? bookContext.constructor.name}/>`}</code>
-    </StoryTitle>
   );
 }
 

--- a/static/app/views/dashboards/widgetCard/autoSizedText.stories.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.stories.tsx
@@ -6,7 +6,7 @@ import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 
-export default storyBook(AutoSizedText, story => {
+export default storyBook('AutoSizedText', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.stories.tsx
@@ -17,7 +17,7 @@ import {AreaChartWidget} from './areaChartWidget';
 import sampleLatencyTimeSeries from './sampleLatencyTimeSeries.json';
 import sampleSpanDurationTimeSeries from './sampleSpanDurationTimeSeries.json';
 
-export default storyBook(AreaChartWidget, story => {
+export default storyBook('AreaChartWidget', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.stories.tsx
@@ -15,7 +15,7 @@ import {BarChartWidget} from './barChartWidget';
 import sampleLatencyTimeSeries from './sampleLatencyTimeSeries.json';
 import sampleSpanDurationTimeSeries from './sampleSpanDurationTimeSeries.json';
 
-export default storyBook(BarChartWidget, story => {
+export default storyBook('BarChartWidget', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -8,7 +8,7 @@ import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
 
-export default storyBook(BigNumberWidget, story => {
+export default storyBook('BigNumberWidget', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -8,7 +8,7 @@ import {t, tct} from 'sentry/locale';
 import storyBook from 'sentry/stories/storyBook';
 import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
-export default storyBook(WidgetFrame, story => {
+export default storyBook('WidgetFrame', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -37,7 +37,7 @@ const sampleDurationTimeSeries2 = {
   },
 };
 
-export default storyBook(LineChartWidget, story => {
+export default storyBook('LineChartWidget', story => {
   story('Getting Started', () => {
     return (
       <Fragment>

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
@@ -14,7 +14,7 @@ import {WidgetDescription} from './widgetDescription';
 import {WidgetLayout} from './widgetLayout';
 import {WidgetTitle} from './widgetTitle';
 
-export default storyBook(WidgetLayout, story => {
+export default storyBook('WidgetLayout', story => {
   story('Getting Started', () => {
     return (
       <Fragment>


### PR DESCRIPTION
Titles broke with the removal of babel display name plugin. This PR switches the API to use manually defined titles instead