### PR TITLE
chore: Bump platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "moment-timezone": "0.5.44",
     "papaparse": "^5.3.2",
     "peggy": "^4.1.1",
-    "platformicons": "^7.0.4",
+    "platformicons": "^8.0.0",
     "po-catalog-loader": "2.1.0",
     "prettier": "3.3.2",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,7 +3469,6 @@
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-3.1.1.tgz#f84ce1b2484f39568fcab2a007567efdca98b421"
   integrity sha512-PsHM8q7PfLeToQgNwPwbkySRWCPY59ymuzvG0vE8wceduS6JM6kGbwBU8gRXHn6aOohwpdmwMJuBdBtXQhS6Jg==
-
   dependencies:
     "@sentry/bundler-plugin-core" "3.1.1"
     unplugin "1.0.1"
@@ -9860,10 +9859,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-7.0.4.tgz#1e5df8b79478e11381dced9df45e129da172f89e"
-  integrity sha512-ld6YQ8CwUYScEp9qUW34tHq68nguzS7tTIYAW6TV64h/v8G1FqlKJ2eUZXMK/BSds8Vs+buV06NZX1r3Wm1kiw==
+platformicons@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.0.tgz#36fea256b6ac2f32f792a18529116efa8ffc3a67"
+  integrity sha512-mY8YP3DzL8x2PRwFV61Lrc1HM/g9ZiQqThPjde/hMgqV8jnKAwZpCYVpg/9O6j2uYgokBIeaYrZMDArX3ok+lA==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
This PR bumps the platformicons dependency to version [8.0.0](https://www.npmjs.com/package/platformicons/v/8.0.0), based on the changes introduced in the [PR](https://github.com/getsentry/platformicons/pull/198).
