### PR TITLE
fix(taskworker) Fix scheduling slow + fast tasks

### DIFF
--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -90,6 +90,12 @@ class ScheduleEntry:
         # Secondary sorting for heapq when remaining time is the same
         return self.fullname < other.fullname
 
+    def __repr__(self) -> str:
+        last_run = self._last_run.isoformat() if self._last_run else None
+        remaining_seconds = self.remaining_seconds()
+
+        return f"<ScheduleEntry fullname={self.fullname} last_run={last_run} remaining_seconds={remaining_seconds}>"
+
     @property
     def fullname(self) -> str:
         return self._task.fullname

--- a/src/sentry/taskworker/scheduler/schedules.py
+++ b/src/sentry/taskworker/scheduler/schedules.py
@@ -127,20 +127,22 @@ class CrontabSchedule(Schedule):
         # If last run is in the past, see if the next runtime
         # is in the future.
         if last_run < now:
-            next_run = self._advance(last_run)
+            next_run = self._advance(last_run + timedelta(minutes=1))
             # Our next runtime is in the future, or now
             if next_run >= now:
                 return int(next_run.timestamp() - now.timestamp())
 
             # still in the past, we missed an interval :(
+            missed = next_run
             next_run = self._advance(now)
             logger.warning(
                 "taskworker.scheduler.missed_interval",
                 extra={
                     "task": self._name,
-                    "last_run": last_run,
-                    "now": now,
-                    "next_run": next_run,
+                    "last_run": last_run.isoformat(),
+                    "missed": missed.isoformat(),
+                    "now": now.isoformat(),
+                    "next_run": next_run.isoformat(),
                 },
             )
             return int(next_run.timestamp() - now.timestamp())

--- a/tests/sentry/taskworker/scheduler/test_runner.py
+++ b/tests/sentry/taskworker/scheduler/test_runner.py
@@ -245,3 +245,76 @@ def test_schedulerunner_tick_multiple_tasks(
             assert sleep_time == 120
 
         assert mock_send.call_count == 3
+
+
+def test_schedulerunner_tick_fast_and_slow(
+    taskregistry: TaskRegistry, run_storage: RunStorage
+) -> None:
+    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set.add(
+        {
+            "task": "test:valid",
+            "schedule": timedelta(seconds=30),
+        }
+    )
+    schedule_set.add(
+        {
+            "task": "test:second",
+            "schedule": crontab(minute="*/2"),
+        }
+    )
+
+    namespace = taskregistry.get("test")
+    with patch.object(namespace, "send_task") as mock_send:
+        with freeze_time("2025-01-24 14:25:00"):
+            sleep_time = schedule_set.tick()
+            assert sleep_time == 30
+
+        called = extract_sent_tasks(mock_send)
+        assert called == ["second", "valid"]
+
+        run_storage.delete("test:valid")
+        with freeze_time("2025-01-24 14:25:30"):
+            sleep_time = schedule_set.tick()
+            assert sleep_time == 30
+
+        called = extract_sent_tasks(mock_send)
+        assert called == ["second", "valid", "valid"]
+
+        run_storage.delete("test:valid")
+        run_storage.delete("test:second")
+        with freeze_time("2025-01-24 14:26:01"):
+            sleep_time = schedule_set.tick()
+            assert sleep_time == 30
+
+        called = extract_sent_tasks(mock_send)
+        assert called == ["second", "valid", "valid", "second", "valid"]
+
+        run_storage.delete("test:valid")
+        with freeze_time("2025-01-24 14:26:31"):
+            sleep_time = schedule_set.tick()
+            assert sleep_time == 30
+
+        called = extract_sent_tasks(mock_send)
+        assert called == ["second", "valid", "valid", "second", "valid", "valid"]
+
+        run_storage.delete("test:valid")
+        with freeze_time("2025-01-24 14:27:01"):
+            sleep_time = schedule_set.tick()
+            assert sleep_time == 30
+
+        assert run_storage.read("test:valid")
+        called = extract_sent_tasks(mock_send)
+        assert called == [
+            "second",
+            "valid",
+            "valid",
+            "second",
+            "valid",
+            "valid",
+            "valid",
+        ]
+
+
+def extract_sent_tasks(mock: Mock) -> list[str]:
+    return [call[0][0].taskname for call in mock.call_args_list]

--- a/tests/sentry/taskworker/scheduler/test_schedules.py
+++ b/tests/sentry/taskworker/scheduler/test_schedules.py
@@ -112,9 +112,15 @@ def test_crontabschedule_remaining_seconds() -> None:
         five_min_ago = timezone.now()
         assert schedule.remaining_seconds(five_min_ago) == 300
 
+    # Later in the minute. crontabs only have minute precision.
     with freeze_time("2025-01-24 14:25:59"):
         five_min_ago = timezone.now()
         assert schedule.remaining_seconds(five_min_ago) == 300
+
+    # It isn't time yet, as we're mid interval
+    with freeze_time("2025-01-24 14:23:10"):
+        three_min_ago = timezone.now() - timedelta(minutes=3)
+        assert schedule.remaining_seconds(three_min_ago) == 120
 
     # 14:19 was 1 min late, we missed a beat but we're currently on time.
     with freeze_time("2025-01-24 14:25:10"):


### PR DESCRIPTION
Fix an issue where fast `timedelta()` based tasks would result in slower crontabs from not being spawned. Before starting each tick, we need to update the schedule heap to ensure slower tasks get moved to the top of the heap and don't miss their interval.