### PR TITLE
feat(react-native): Exclude `_callSuper` functions from in-app and grouping by default

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -392,6 +392,10 @@ module:core-js/** -app -group
 module:regenerator-runtime/** -app -group
 module:tslib/** -app -group
 
+## react-native
+### babel
+family:javascript function:_callSuper -app -group
+
 ## node
 function:runMicrotasks -app -group
 function:queueMicrotask -app -group


### PR DESCRIPTION
- fixes https://github.com/getsentry/sentry-react-native/issues/4076

- RN tooling doesn't supply correct source maps to the original internal JS source files. The `_callSuper` calls should not be considered for grouping nor in-app.
