### PR TITLE
fix(explore): Clear cursor on certain explore navigation

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/groupBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/groupBys.tsx
@@ -32,6 +32,9 @@ export function updateLocationWithGroupBys(
 ) {
   if (defined(groupBys)) {
     location.query.groupBy = groupBys;
+
+    // make sure to clear the cursor every time the query is updated
+    delete location.query.cursor;
   } else if (groupBys === null) {
     delete location.query.groupBy;
   }

--- a/static/app/views/explore/contexts/pageParamsContext/mode.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/mode.tsx
@@ -26,6 +26,9 @@ export function updateLocationWithMode(
 ) {
   if (defined(mode)) {
     location.query.mode = mode;
+
+    // make sure to clear the cursor every time the query is updated
+    delete location.query.cursor;
   } else if (mode === null) {
     delete location.query.mode;
   }

--- a/static/app/views/explore/contexts/pageParamsContext/query.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/query.tsx
@@ -17,6 +17,9 @@ export function updateLocationWithQuery(
 ) {
   if (defined(query)) {
     location.query.query = query;
+
+    // make sure to clear the cursor every time the query is updated
+    delete location.query.cursor;
   } else if (query === null) {
     delete location.query.query;
   }

--- a/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
@@ -84,6 +84,9 @@ export function updateLocationWithSortBys(
     location.query.sort = sortBys.map(sortBy =>
       sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
     );
+
+    // make sure to clear the cursor every time the query is updated
+    delete location.query.cursor;
   } else if (sortBys === null) {
     delete location.query.sort;
   }


### PR DESCRIPTION
When changing selections in explore, we need to make sure to reset the cursor back to the first page in some cases.