### PR TITLE
feat(taskworker): Loadbalance workers onto brokers

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -274,6 +274,7 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 
 @run.command()
 @click.option("--rpc-host", help="The hostname for the taskworker-rpc", default="127.0.0.1:50051")
+@click.option("--num-brokers", help="Number of brokers available to connect to", default=1)
 @click.option("--autoreload", is_flag=True, default=False, help="Enable autoreloading.")
 @click.option(
     "--max-task-count", help="Number of tasks this worker should run before exiting", default=10000
@@ -295,7 +296,12 @@ def taskworker(**options: Any) -> None:
 
 
 def run_taskworker(
-    rpc_host: str, max_task_count: int, namespace: str | None, concurrency: int, **options: Any
+    rpc_host: str,
+    num_brokers: int,
+    max_task_count: int,
+    namespace: str | None,
+    concurrency: int,
+    **options: Any,
 ) -> None:
     """
     taskworker factory that can be reloaded
@@ -305,6 +311,7 @@ def run_taskworker(
     with managed_bgtasks(role="taskworker"):
         worker = TaskWorker(
             rpc_host=rpc_host,
+            num_brokers=num_brokers,
             max_task_count=max_task_count,
             namespace=namespace,
             concurrency=concurrency,

--- a/src/sentry/taskworker/client.py
+++ b/src/sentry/taskworker/client.py
@@ -1,4 +1,6 @@
 import logging
+import random
+from datetime import datetime
 
 import grpc
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
@@ -18,12 +20,25 @@ class TaskworkerClient:
     Taskworker RPC client wrapper
     """
 
-    def __init__(self, host: str) -> None:
-        self._host = host
+    def __init__(self, host: str, num_brokers: int) -> None:
+        self._host = self.loadbalance(host, num_brokers)
 
         # TODO(taskworker) Need to support xds bootstrap file
         self._channel = grpc.insecure_channel(self._host)
         self._stub = ConsumerServiceStub(self._channel)
+
+    def loadbalance(self, host: str, num_brokers: int) -> str:
+        """
+        This function can be used to determine which broker a particular taskworker should connect to.
+        Currently it selects a random broker and connects to it.
+
+        This assumes that the passed in port is of the form broker:port, where broker corresponds to the
+        headless service of the brokers.
+        """
+        domain, port = host.split(":")
+        random.seed(datetime.now().microsecond)
+        broker_index = random.randint(0, num_brokers - 1)
+        return f"{domain}-{broker_index}:{port}"
 
     def get_task(self, namespace: str | None = None) -> TaskActivation | None:
         """

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -232,6 +232,7 @@ class TaskWorker:
     def __init__(
         self,
         rpc_host: str,
+        num_brokers: int,
         max_task_count: int | None = None,
         namespace: str | None = None,
         concurrency: int = 1,
@@ -243,7 +244,7 @@ class TaskWorker:
         self._max_task_count = max_task_count
         self._namespace = namespace
         self._concurrency = concurrency
-        self.client = TaskworkerClient(rpc_host)
+        self.client = TaskworkerClient(rpc_host, num_brokers)
         self._child_tasks: multiprocessing.Queue[TaskActivation] = multiprocessing.Queue(
             maxsize=(concurrency * 10)
         )

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -90,7 +90,7 @@ def test_get_task_ok():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.get_task()
 
         assert result
@@ -115,7 +115,7 @@ def test_get_task_with_namespace():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.get_task(namespace="testing")
 
         assert result
@@ -131,7 +131,7 @@ def test_get_task_not_found():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.get_task()
 
         assert result is None
@@ -145,7 +145,7 @@ def test_get_task_failure():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         with pytest.raises(grpc.RpcError):
             client.get_task()
 
@@ -167,7 +167,7 @@ def test_update_task_ok_with_next():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.update_task(
             "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
         )
@@ -192,7 +192,7 @@ def test_update_task_ok_with_next_namespace():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.update_task(
             "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace="testing")
         )
@@ -208,7 +208,7 @@ def test_update_task_ok_no_next():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.update_task(
             "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
         )
@@ -223,7 +223,7 @@ def test_update_task_not_found():
     )
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient("localhost:50051")
+        client = TaskworkerClient("localhost:50051", 1)
         result = client.update_task(
             "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
         )

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -62,7 +62,7 @@ class TestTaskWorker(TestCase):
         assert example_tasks.at_most_once_task
 
     def test_fetch_task(self) -> None:
-        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", max_task_count=100)
+        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", num_brokers=1, max_task_count=100)
         with mock.patch.object(taskworker.client, "get_task") as mock_get:
             mock_get.return_value = SIMPLE_TASK
 
@@ -73,7 +73,7 @@ class TestTaskWorker(TestCase):
         assert task.id == SIMPLE_TASK.id
 
     def test_fetch_no_task(self) -> None:
-        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", max_task_count=100)
+        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", num_brokers=1, max_task_count=100)
         with mock.patch.object(taskworker.client, "get_task") as mock_get:
             mock_get.return_value = None
             task = taskworker.fetch_task()
@@ -83,7 +83,7 @@ class TestTaskWorker(TestCase):
 
     def test_run_once_no_next_task(self) -> None:
         max_runtime = 5
-        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", max_task_count=1)
+        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", num_brokers=1, max_task_count=1)
         with mock.patch.object(taskworker, "client") as mock_client:
             mock_client.get_task.return_value = SIMPLE_TASK
             # No next_task returned
@@ -108,7 +108,7 @@ class TestTaskWorker(TestCase):
         # Cover the scenario where update_task returns the next task which should
         # be processed.
         max_runtime = 5
-        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", max_task_count=1)
+        taskworker = TaskWorker(rpc_host="127.0.0.1:50051", num_brokers=1, max_task_count=1)
         with mock.patch.object(taskworker, "client") as mock_client:
 
             def update_task_response(*args, **kwargs):


### PR DESCRIPTION
The way that gRPC and k8s do load balance isn't giving the system the properties required:
1) Evenly distributed workers across brokers
2) Sticky sessions between workers and brokers

In order to make that happen, have each taskworker client randomly pick a specific taskbroker to 
connect to. This currently relies on the taskbroker hostnames aligning with how a k8s headless 
service would generate the hostnames. In the future it can have a more sophisticated algorithm.