### PR TITLE
fix(dashboards): Switch `Add Widget` dropdown order

### DIFF
--- a/static/app/views/dashboards/addWidget.tsx
+++ b/static/app/views/dashboards/addWidget.tsx
@@ -55,14 +55,14 @@ function AddWidget({onAddWidget, onAddWidgetFromNewWidgetBuilder}: Props) {
 
   const addWidgetDropdownItems: MenuItemProps[] = [
     {
-      key: 'from-widget-library',
-      label: t('From Widget Library'),
-      onAction: () => onAddWidgetFromNewWidgetBuilder?.(defaultDataset, true),
-    },
-    {
       key: 'create-custom-widget',
       label: t('Create Custom Widget'),
       onAction: () => onAddWidgetFromNewWidgetBuilder?.(defaultDataset, false),
+    },
+    {
+      key: 'from-widget-library',
+      label: t('From Widget Library'),
+      onAction: () => onAddWidgetFromNewWidgetBuilder?.(defaultDataset, true),
     },
   ];
 

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -167,14 +167,14 @@ function Controls({
 
   const addWidgetDropdownItems: MenuItemProps[] = [
     {
-      key: 'from-widget-library',
-      label: t('From Widget Library'),
-      onAction: () => onAddWidgetFromNewWidgetBuilder(defaultDataset, true),
-    },
-    {
       key: 'create-custom-widget',
       label: t('Create Custom Widget'),
       onAction: () => onAddWidgetFromNewWidgetBuilder(defaultDataset, false),
+    },
+    {
+      key: 'from-widget-library',
+      label: t('From Widget Library'),
+      onAction: () => onAddWidgetFromNewWidgetBuilder(defaultDataset, true),
     },
   ];
 


### PR DESCRIPTION
Just switching the add `From Widget Library` and `Create Custom Widget` order in the Add Widget dropdown. No functional changes.
