### PR TITLE
:sparkles: feat(aci): Invoke Rule Registry from Notification Action

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/__init__.py
+++ b/src/sentry/workflow_engine/handlers/action/__init__.py
@@ -2,4 +2,4 @@ __all__ = [
     "NotificationActionHandler",
 ]
 
-from .notification import NotificationActionHandler
+from .notification.notification import NotificationActionHandler

--- a/src/sentry/workflow_engine/handlers/action/__init__.py
+++ b/src/sentry/workflow_engine/handlers/action/__init__.py
@@ -2,4 +2,4 @@ __all__ = [
     "NotificationActionHandler",
 ]
 
-from .notification.notification import NotificationActionHandler
+from .notification.handler import NotificationActionHandler

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -14,6 +14,10 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowJob
 logger = logging.getLogger(__name__)
 
 
+class NotificationHandlerException(Exception):
+    pass
+
+
 class LegacyRegistryInvoker(ABC):
     """
     Abstract base class that defines the interface for notification handlers.
@@ -63,11 +67,13 @@ class IssueAlertRegistryInvoker(LegacyRegistryInvoker):
                 action.type,
                 extra={"action_id": action.id},
             )
-        except Exception:
+            raise
+        except Exception as e:
             logger.exception(
                 "Error invoking issue alert handler",
                 extra={"action_id": action.id},
             )
+            raise NotificationHandlerException(e)
 
 
 @group_type_notification_registry.register(MetricIssuePOC.slug)

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
 from typing import Any
 
@@ -19,12 +20,13 @@ from sentry.workflow_engine.typings.notification_action import DiscordDataBlob
 logger = logging.getLogger(__name__)
 
 
-class BaseIssueAlertHandler:
+class BaseIssueAlertHandler(ABC):
     """
     Base class for invoking the legacy issue alert registry.
     """
 
     @staticmethod
+    @abstractmethod
     def build_rule_action_blob(
         action: Action,
     ) -> dict[str, Any]:
@@ -47,7 +49,7 @@ class BaseIssueAlertHandler:
         """
 
         rule = Rule(
-            id=detector.id,
+            id=action.id,
             project=detector.project,
             label=detector.name,
             data={"actions": [cls.build_rule_action_blob(action)]},

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -40,17 +40,24 @@ class BaseIssueAlertHandler(ABC):
         cls,
         action: Action,
         detector: Detector,
+        job: WorkflowJob,
     ) -> Rule:
         """
         Creates a Rule instance from the Action model.
         :param action: Action
         :param detector: Detector
+        :param job: WorkflowJob
         :return: Rule instance
         """
+        workflow = job.get("workflow")
+        environment_id = None
+        if workflow and workflow.environment:
+            environment_id = workflow.environment.id
 
         rule = Rule(
             id=action.id,
             project=detector.project,
+            environment_id=environment_id,
             label=detector.name,
             data={"actions": [cls.build_rule_action_blob(action)]},
             status=ObjectStatus.ACTIVE,
@@ -114,7 +121,7 @@ class BaseIssueAlertHandler(ABC):
             notification_uuid = str(uuid.uuid4())
 
             # Create a rule
-            rule = cls.create_rule_instance_from_action(action, detector)
+            rule = cls.create_rule_instance_from_action(action, detector, job)
 
             # Get the futures
             futures = cls.get_rule_futures(job, rule, notification_uuid)

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -82,7 +82,7 @@ class BaseIssueAlertHandler:
     ) -> None:
         """
         This method will execute the futures.
-        Based off of proccess_rules in post_process.py
+        Based off of process_rules in post_process.py
         """
         with sentry_sdk.start_span(
             op="workflow_engine.handlers.action.notification.issue_alert.execute_futures"
@@ -100,9 +100,9 @@ class BaseIssueAlertHandler:
         """
         This method will create a rule instance from the Action model, and then invoke the legacy registry.
         This method encompases the following logic in our legacy system:
-        1. post_proccess proccess_rules calls rule_processor.apply
+        1. post_process process_rules calls rule_processor.apply
         2. activate_downstream_actions
-        3. execute_futures (also in post_process proccess_rules)
+        3. execute_futures (also in post_process process_rules)
         """
 
         with sentry_sdk.start_span(

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -1,0 +1,123 @@
+import logging
+import uuid
+from abc import ABC, abstractmethod
+
+import sentry_sdk
+
+from sentry.constants import ObjectStatus
+from sentry.models.rule import Rule, RuleSource
+from sentry.rules.actions.base import instantiate_action
+from sentry.types.rules import RuleFuture
+from sentry.utils.registry import Registry
+from sentry.utils.safe import safe_execute
+from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.types import WorkflowJob
+from sentry.workflow_engine.typings.notification_action import DiscordDataBlob
+
+logger = logging.getLogger(__name__)
+
+
+class BaseIssueAlertHandler(ABC):
+    """
+    Base class for invoking the legacy issue alert registry.
+    """
+
+    @abstractmethod
+    def build_rule_action_blob(
+        self,
+        action: Action,
+    ) -> dict:
+        """
+        Build the rule action blob from the Action model.
+        """
+        raise NotImplementedError
+
+    def create_rule_instance_from_action(
+        self,
+        action: Action,
+        detector: Detector,
+    ) -> Rule:
+        """
+        Creates a Rule instance from the Action model.
+        :param action: Action
+        :param detector: Detector
+        :return: Rule instance
+        """
+
+        rule = Rule(
+            id=detector.id,
+            project=detector.project,
+            label=detector.name,
+            data={"actions": [self.build_rule_action_blob(action)]},
+            status=ObjectStatus.ACTIVE,
+            source=RuleSource.ISSUE,
+        )
+
+        return rule
+
+    def invoke_legacy_registry(
+        self,
+        job: WorkflowJob,
+        action: Action,
+        detector: Detector,
+    ) -> None:
+        """
+        This method will create a rule instance from the Action model, and then invoke the legacy registry.
+        """
+
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry"
+        ):
+            # Create a notification uuid
+            notification_uuid = str(uuid.uuid4())
+
+            # Create a rule
+            rule = self.create_rule_instance_from_action(action, detector)
+
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry.instantiate_action"
+        ):
+            # This should only have one action
+            action_data = rule.data.get("actions", [])
+            assert len(action_data) == 1
+
+            action_inst = instantiate_action(rule, action_data)
+            if not action_inst:
+                logger.error(
+                    "Failed to instantiate action",
+                    extra={"detector_id": detector.id, "action_id": action.id},
+                )
+                raise ValueError(
+                    f"Failed to instantiate action {action.id} for detector {detector.id}"
+                )
+
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry.instantiate_action.safe_execute"
+        ):
+            results = safe_execute(
+                action_inst.after,
+                event=job["event"],
+                notification_uuid=notification_uuid,
+            )
+        if results is None:
+            raise ValueError("Action %s did not return any futures", action.id)
+
+        for future in results:
+            rule_future = RuleFuture(rule=rule, kwargs=future.kwargs)
+            # Send the notification
+            safe_execute(future.callback, job["event"], [rule_future])
+
+
+issue_alert_handler_registry = Registry[BaseIssueAlertHandler]()
+
+
+@issue_alert_handler_registry.register(Action.Type.DISCORD)
+class DiscordIssueAlertHandler(BaseIssueAlertHandler):
+    def build_rule_action_blob(self, action: Action) -> dict:
+        blob = DiscordDataBlob(**action.data)
+        return {
+            "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
+            "server": action.integration_id,
+            "channel_id": action.target_identifier,
+            "tags": blob.tags,
+        }

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -1,12 +1,14 @@
 import logging
 import uuid
-from abc import ABC, abstractmethod
+from collections.abc import Callable, Collection, Sequence
+from typing import Any
 
 import sentry_sdk
 
 from sentry.constants import ObjectStatus
+from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule, RuleSource
-from sentry.rules.actions.base import instantiate_action
+from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.types.rules import RuleFuture
 from sentry.utils.registry import Registry
 from sentry.utils.safe import safe_execute
@@ -17,23 +19,23 @@ from sentry.workflow_engine.typings.notification_action import DiscordDataBlob
 logger = logging.getLogger(__name__)
 
 
-class BaseIssueAlertHandler(ABC):
+class BaseIssueAlertHandler:
     """
     Base class for invoking the legacy issue alert registry.
     """
 
-    @abstractmethod
+    @staticmethod
     def build_rule_action_blob(
-        self,
         action: Action,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         Build the rule action blob from the Action model.
         """
         raise NotImplementedError
 
+    @classmethod
     def create_rule_instance_from_action(
-        self,
+        cls,
         action: Action,
         detector: Detector,
     ) -> Rule:
@@ -48,21 +50,59 @@ class BaseIssueAlertHandler(ABC):
             id=detector.id,
             project=detector.project,
             label=detector.name,
-            data={"actions": [self.build_rule_action_blob(action)]},
+            data={"actions": [cls.build_rule_action_blob(action)]},
             status=ObjectStatus.ACTIVE,
             source=RuleSource.ISSUE,
         )
 
         return rule
 
+    @staticmethod
+    def get_rule_futures(
+        job: WorkflowJob,
+        rule: Rule,
+        notification_uuid: str,
+    ) -> Collection[tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]]:
+        """
+        This method will collect the futures from the activate_downstream_actions method.
+        Based off of rule_processor.apply in rules/processing/processor.py
+        """
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry.activate_downstream_actions"
+        ):
+            grouped_futures = activate_downstream_actions(rule, job["event"], notification_uuid)
+            return grouped_futures.values()
+
+    @staticmethod
+    def execute_futures(
+        job: WorkflowJob,
+        futures: Collection[
+            tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
+        ],
+    ) -> None:
+        """
+        This method will execute the futures.
+        Based off of proccess_rules in post_process.py
+        """
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.issue_alert.execute_futures"
+        ):
+            for callback, futures in futures:
+                safe_execute(callback, job["event"], futures)
+
+    @classmethod
     def invoke_legacy_registry(
-        self,
+        cls,
         job: WorkflowJob,
         action: Action,
         detector: Detector,
     ) -> None:
         """
         This method will create a rule instance from the Action model, and then invoke the legacy registry.
+        This method encompases the following logic in our legacy system:
+        1. post_proccess proccess_rules calls rule_processor.apply
+        2. activate_downstream_actions
+        3. execute_futures (also in post_process proccess_rules)
         """
 
         with sentry_sdk.start_span(
@@ -72,40 +112,13 @@ class BaseIssueAlertHandler(ABC):
             notification_uuid = str(uuid.uuid4())
 
             # Create a rule
-            rule = self.create_rule_instance_from_action(action, detector)
+            rule = cls.create_rule_instance_from_action(action, detector)
 
-        with sentry_sdk.start_span(
-            op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry.instantiate_action"
-        ):
-            # This should only have one action
-            action_data = rule.data.get("actions", [])
-            assert len(action_data) == 1
+            # Get the futures
+            futures = cls.get_rule_futures(job, rule, notification_uuid)
 
-            action_inst = instantiate_action(rule, action_data)
-            if not action_inst:
-                logger.error(
-                    "Failed to instantiate action",
-                    extra={"detector_id": detector.id, "action_id": action.id},
-                )
-                raise ValueError(
-                    f"Failed to instantiate action {action.id} for detector {detector.id}"
-                )
-
-        with sentry_sdk.start_span(
-            op="workflow_engine.handlers.action.notification.issue_alert.invoke_legacy_registry.instantiate_action.safe_execute"
-        ):
-            results = safe_execute(
-                action_inst.after,
-                event=job["event"],
-                notification_uuid=notification_uuid,
-            )
-        if results is None:
-            raise ValueError("Action %s did not return any futures", action.id)
-
-        for future in results:
-            rule_future = RuleFuture(rule=rule, kwargs=future.kwargs)
-            # Send the notification
-            safe_execute(future.callback, job["event"], [rule_future])
+            # Execute the futures
+            cls.execute_futures(job, futures)
 
 
 issue_alert_handler_registry = Registry[BaseIssueAlertHandler]()
@@ -113,7 +126,8 @@ issue_alert_handler_registry = Registry[BaseIssueAlertHandler]()
 
 @issue_alert_handler_registry.register(Action.Type.DISCORD)
 class DiscordIssueAlertHandler(BaseIssueAlertHandler):
-    def build_rule_action_blob(self, action: Action) -> dict:
+    @staticmethod
+    def build_rule_action_blob(action: Action) -> dict[str, Any]:
         blob = DiscordDataBlob(**action.data)
         return {
             "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",

--- a/src/sentry/workflow_engine/handlers/action/notification/notification.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/notification.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import MetricIssuePOC
@@ -13,12 +14,13 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowJob
 logger = logging.getLogger(__name__)
 
 
-class LegacyRegistryInvoker:
+class LegacyRegistryInvoker(ABC):
     """
     Abstract base class that defines the interface for notification handlers.
     """
 
     @staticmethod
+    @abstractmethod
     def handle_workflow_action(job: WorkflowJob, action: Action, detector: Detector) -> None:
         """
         Implement this method to handle the specific notification logic for your handler.

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -1,0 +1,114 @@
+import uuid
+from unittest import mock
+
+import pytest
+
+from sentry.constants import ObjectStatus
+from sentry.models.rule import Rule, RuleSource
+from sentry.workflow_engine.handlers.action.notification.issue_alert import (
+    BaseIssueAlertHandler,
+    DiscordIssueAlertHandler,
+)
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowJob
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class TestBaseIssueAlertHandler(BaseWorkflowTest):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project)
+        self.action = Action(type=Action.Type.DISCORD)
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.job = WorkflowJob(event=self.group_event)
+
+        class TestHandler(BaseIssueAlertHandler):
+            def build_rule_action_blob(self, action: Action) -> dict:
+                return {"test": "data"}
+
+        self.handler = TestHandler()
+
+    def test_create_rule_instance_from_action(self):
+        """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
+        rule = self.handler.create_rule_instance_from_action(self.action, self.detector)
+
+        assert isinstance(rule, Rule)
+        assert rule.id == self.detector.id
+        assert rule.project == self.detector.project
+        assert rule.label == self.detector.name
+        assert rule.data == {"actions": [{"test": "data"}]}
+        assert rule.status == ObjectStatus.ACTIVE
+        assert rule.source == RuleSource.ISSUE
+
+    @mock.patch("sentry.workflow_engine.handlers.action.notification.issue_alert.safe_execute")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.issue_alert.instantiate_action"
+    )
+    @mock.patch("uuid.uuid4")
+    def test_invoke_legacy_registry(self, mock_uuid, mock_instantiate_action, mock_safe_execute):
+        """Test that invoke_legacy_registry correctly processes the action"""
+        mock_uuid.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        mock_action = mock.Mock()
+        mock_instantiate_action.return_value = mock_action
+        mock_future = mock.Mock()
+        mock_safe_execute.side_effect = [[mock_future], None]  # Return for after, then for callback
+
+        self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+
+        # Verify action instantiation
+        mock_instantiate_action.assert_called_once()
+
+        # Verify after method called with correct args
+        mock_safe_execute.assert_any_call(
+            mock_action.after,
+            event=self.job["event"],
+            notification_uuid="12345678-1234-5678-1234-567812345678",
+        )
+
+        # Verify callback execution
+        mock_safe_execute.assert_any_call(mock_future.callback, self.job["event"], mock.ANY)
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.issue_alert.instantiate_action",
+        return_value=None,
+    )
+    def test_invoke_legacy_registry_no_action(self, mock_instantiate_action):
+        """Test that invoke_legacy_registry raises an error if no action is found"""
+        with pytest.raises(ValueError):
+            self.handler.invoke_legacy_registry(self.job, self.action, self.detector)
+
+
+class TestDiscordIssueAlertHandler(BaseWorkflowTest):
+    def setUp(self):
+        super().setUp()
+        self.handler = DiscordIssueAlertHandler()
+        self.action = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            target_identifier="channel456",
+            data={"tags": "environment,user,my_tag"},
+        )
+
+    def test_build_rule_action_blob(self):
+        """Test that build_rule_action_blob creates correct Discord action data"""
+        blob = self.handler.build_rule_action_blob(self.action)
+
+        assert blob == {
+            "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
+            "server": "1234567890",
+            "channel_id": "channel456",
+            "tags": "environment,user,my_tag",
+        }
+
+    def test_build_rule_action_blob_no_tags(self):
+        """Test that build_rule_action_blob handles missing tags"""
+        self.action.data = {}
+        blob = self.handler.build_rule_action_blob(self.action)
+
+        assert blob == {
+            "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
+            "server": "1234567890",
+            "channel_id": "channel456",
+            "tags": "",
+        }

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -96,6 +96,10 @@ class TestDiscordIssueAlertHandler(BaseWorkflowTest):
             target_identifier="channel456",
             data={"tags": "environment,user,my_tag"},
         )
+        # self.project = self.create_project()
+        # self.detector = self.create_detector(project=self.project)
+        # self.group, self.event, self.group_event = self.create_group_event()
+        # self.job = WorkflowJob(event=self.group_event)
 
     def test_build_rule_action_blob(self):
         """Test that build_rule_action_blob creates correct Discord action data"""

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -43,7 +43,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         rule = self.handler.create_rule_instance_from_action(self.action, self.detector)
 
         assert isinstance(rule, Rule)
-        assert rule.id == self.detector.id
+        assert rule.id == self.action.id
         assert rule.project == self.detector.project
         assert rule.label == self.detector.name
         assert rule.data == {

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -47,6 +47,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.id == self.action.id
         assert rule.project == self.detector.project
         assert rule.environment_id is not None
+        assert self.workflow.environment is not None
         assert rule.environment_id == self.workflow.environment.id
         assert rule.label == self.detector.name
         assert rule.data == {

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -40,7 +40,9 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         NotificationActionHandler.execute(self.job, self.action, self.detector)
 
         mock_registry_get.assert_called_once_with(ErrorGroupType.slug)
-        mock_handler.assert_called_once_with(self.job, self.action, self.detector)
+        mock_handler.handle_workflow_action.assert_called_once_with(
+            self.job, self.action, self.detector
+        )
 
     @mock.patch(
         "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get"
@@ -56,7 +58,9 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         NotificationActionHandler.execute(self.job, self.action, self.detector)
 
         mock_registry_get.assert_called_once_with(MetricIssuePOC.slug)
-        mock_handler.assert_called_once_with(self.job, self.action, self.detector)
+        mock_handler.handle_workflow_action.assert_called_once_with(
+            self.job, self.action, self.detector
+        )
 
     @mock.patch(
         "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get",

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -1,10 +1,14 @@
 from unittest import mock
 
+import pytest
+
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import MetricIssuePOC
 from sentry.utils.registry import NoRegistrationExistsError
-from sentry.workflow_engine.handlers.action.notification.notification import (
+from sentry.workflow_engine.handlers.action.notification.handler import (
+    IssueAlertRegistryInvoker,
     NotificationActionHandler,
+    NotificationHandlerException,
 )
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowJob
@@ -27,7 +31,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         # Test passes if no exception is raised
 
     @mock.patch(
-        "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get"
+        "sentry.workflow_engine.handlers.action.notification.handler.group_type_notification_registry.get"
     )
     def test_execute_error_group_type(self, mock_registry_get):
         """Test that execute calls correct handler for ErrorGroupType"""
@@ -45,7 +49,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         )
 
     @mock.patch(
-        "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get"
+        "sentry.workflow_engine.handlers.action.notification.handler.group_type_notification_registry.get"
     )
     def test_execute_metric_alert_type(self, mock_registry_get):
         """Test that execute calls correct handler for MetricIssuePOC"""
@@ -63,10 +67,10 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         )
 
     @mock.patch(
-        "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get",
+        "sentry.workflow_engine.handlers.action.notification.handler.group_type_notification_registry.get",
         side_effect=NoRegistrationExistsError,
     )
-    @mock.patch("sentry.workflow_engine.handlers.action.notification.notification.logger")
+    @mock.patch("sentry.workflow_engine.handlers.action.notification.handler.logger")
     def test_execute_unknown_group_type(self, mock_logger, mock_registry_get):
         """Test that execute does nothing when detector has no group_type"""
         NotificationActionHandler.execute(self.job, self.action, self.detector)
@@ -75,4 +79,42 @@ class TestNotificationActionHandler(BaseWorkflowTest):
             "No notification handler found for detector type: %s",
             self.detector.type,
             extra={"detector_id": self.detector.id, "action_id": self.action.id},
+        )
+
+
+class TestIssueAlertRegistryInvoker(BaseWorkflowTest):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project)
+        self.action = Action(type=Action.Type.DISCORD)
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.job = WorkflowJob({"event": self.group_event})
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.handler.issue_alert_handler_registry.get"
+    )
+    def test_handle_workflow_action_no_handler(self, mock_registry_get):
+        """Test that handle_workflow_action raises NoRegistrationExistsError when no handler exists"""
+        mock_registry_get.side_effect = NoRegistrationExistsError()
+
+        with pytest.raises(NoRegistrationExistsError):
+            IssueAlertRegistryInvoker.handle_workflow_action(self.job, self.action, self.detector)
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.action.notification.handler.issue_alert_handler_registry.get"
+    )
+    @mock.patch("sentry.workflow_engine.handlers.action.notification.handler.logger")
+    def test_handle_workflow_action_general_exception(self, mock_logger, mock_registry_get):
+        """Test that handle_workflow_action wraps general exceptions in NotificationHandlerException"""
+        mock_handler = mock.Mock()
+        mock_handler.invoke_legacy_registry.side_effect = Exception("Something went wrong")
+        mock_registry_get.return_value = mock_handler
+
+        with pytest.raises(NotificationHandlerException):
+            IssueAlertRegistryInvoker.handle_workflow_action(self.job, self.action, self.detector)
+
+        mock_logger.exception.assert_called_once_with(
+            "Error invoking issue alert handler",
+            extra={"action_id": self.action.id},
         )

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -27,7 +27,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         # Test passes if no exception is raised
 
     @mock.patch(
-        "sentry.workflow_engine.handlers.action.notification.group_type_notification_registry.get"
+        "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get"
     )
     def test_execute_error_group_type(self, mock_registry_get):
         """Test that execute calls correct handler for ErrorGroupType"""
@@ -43,7 +43,7 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         mock_handler.assert_called_once_with(self.job, self.action, self.detector)
 
     @mock.patch(
-        "sentry.workflow_engine.handlers.action.notification.group_type_notification_registry.get"
+        "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get"
     )
     def test_execute_metric_alert_type(self, mock_registry_get):
         """Test that execute calls correct handler for MetricIssuePOC"""
@@ -59,10 +59,10 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         mock_handler.assert_called_once_with(self.job, self.action, self.detector)
 
     @mock.patch(
-        "sentry.workflow_engine.handlers.action.notification.group_type_notification_registry.get",
+        "sentry.workflow_engine.handlers.action.notification.notification.group_type_notification_registry.get",
         side_effect=NoRegistrationExistsError,
     )
-    @mock.patch("sentry.workflow_engine.handlers.action.notification.logger")
+    @mock.patch("sentry.workflow_engine.handlers.action.notification.notification.logger")
     def test_execute_unknown_group_type(self, mock_logger, mock_registry_get):
         """Test that execute does nothing when detector has no group_type"""
         NotificationActionHandler.execute(self.job, self.action, self.detector)

--- a/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_notification_action.py
@@ -3,7 +3,9 @@ from unittest import mock
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import MetricIssuePOC
 from sentry.utils.registry import NoRegistrationExistsError
-from sentry.workflow_engine.handlers.action.notification import NotificationActionHandler
+from sentry.workflow_engine.handlers.action.notification.notification import (
+    NotificationActionHandler,
+)
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowJob
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest


### PR DESCRIPTION
This PR introduces a new ABC which we will inherit and create new handlers to invoke the legacy issue alert registry.

Basically after the notification action determines that it needs to invoke the issue alert registry (rule registry), it will call `BaseIssueAlertHandler.invoke_legacy_registry` which will shape the data into a rule instance and then `safe_execute` the callback returned by the `RuleFuture`. 

the method mentioned above is based on
https://github.com/getsentry/sentry/blob/aa95456c77e51b21e920107af33d3e79f05d4f79/src/sentry/rules/processing/processor.py#L147-L184

[spec](https://www.notion.so/sentry/Alerts-Create-Issues-Notification-Action-NOA-1268b10e4b5d805b967ed2655c962db6#1268b10e4b5d812aaa59e13c96a04abd)

closes https://getsentry.atlassian.net/browse/ACI-150