### PR TITLE
chore(seer grouping): Remove old excess frames check debug logging

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -9,7 +9,6 @@ from sentry import options
 from sentry import ratelimits as ratelimiter
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.eventstore.models import Event
-from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
@@ -201,25 +200,8 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
 
 
 def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant]) -> bool:
-    # For purposes of a temporary debug log - will be removed as soon as the mysterious behavior
-    # is sorted
-    logger_extra = {
-        "event_id": event.event_id,
-        "project_id": event.project_id,
-        "platform": event.platform,
-        "has_too_many_frames_result": has_too_many_contributing_frames(
-            event, variants, ReferrerOptions.INGEST, record_metrics=False
-        ),
-    }
-    _, contributing_component = get_contributing_variant_and_component(variants)
-    if contributing_component is not None and hasattr(contributing_component, "frame_counts"):
-        logger_extra["frame_counts"] = contributing_component.frame_counts
-
     stacktrace_string = get_stacktrace_string_with_metrics(
-        get_grouping_info_from_variants(variants),
-        event.platform,
-        ReferrerOptions.INGEST,
-        logger_extra=logger_extra,
+        get_grouping_info_from_variants(variants), event.platform, ReferrerOptions.INGEST
     )
     if not stacktrace_string:
         if stacktrace_string == "":

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -312,7 +312,6 @@ def has_too_many_contributing_frames(
     event: Event | GroupEvent,
     variants: dict[str, BaseVariant],
     referrer: ReferrerOptions,
-    record_metrics: bool = True,
 ) -> bool:
     platform = event.platform
     shared_tags = {"referrer": referrer.value, "platform": platform}
@@ -340,12 +339,11 @@ def has_too_many_contributing_frames(
     # with the existing data, we turn off the filter for them (instead their stacktraces will be
     # truncated)
     if platform in EVENT_PLATFORMS_BYPASSING_FRAME_COUNT_CHECK:
-        if record_metrics:
-            metrics.incr(
-                "grouping.similarity.frame_count_filter",
-                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={**shared_tags, "outcome": "bypass"},
-            )
+        metrics.incr(
+            "grouping.similarity.frame_count_filter",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={**shared_tags, "outcome": "bypass"},
+        )
         return False
 
     stacktrace_type = "in_app" if contributing_variant.variant_name == "app" else "system"
@@ -353,20 +351,18 @@ def has_too_many_contributing_frames(
     shared_tags["stacktrace_type"] = stacktrace_type
 
     if contributing_component.frame_counts[key] > MAX_FRAME_COUNT:
-        if record_metrics:
-            metrics.incr(
-                "grouping.similarity.frame_count_filter",
-                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={**shared_tags, "outcome": "block"},
-            )
-        return True
-
-    if record_metrics:
         metrics.incr(
             "grouping.similarity.frame_count_filter",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={**shared_tags, "outcome": "pass"},
+            tags={**shared_tags, "outcome": "block"},
         )
+        return True
+
+    metrics.incr(
+        "grouping.similarity.frame_count_filter",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={**shared_tags, "outcome": "pass"},
+    )
     return False
 
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -269,10 +269,7 @@ def is_base64_encoded_frame(frame_dict: Mapping[str, Any]) -> bool:
 
 
 def get_stacktrace_string_with_metrics(
-    data: dict[str, Any],
-    platform: str | None,
-    referrer: ReferrerOptions,
-    logger_extra: dict[str, Any] | None = None,
+    data: dict[str, Any], platform: str | None, referrer: ReferrerOptions
 ) -> str | None:
     stacktrace_string = None
     sample_rate = options.get("seer.similarity.metrics_sample_rate")
@@ -286,12 +283,6 @@ def get_stacktrace_string_with_metrics(
             tags={"platform": platform, "referrer": referrer},
         )
         if referrer == ReferrerOptions.INGEST:
-            # Temporary log to debug how we're still landing here, which we shouldn't be anymore
-            logger.info(
-                "record_did_call_seer_metric.over-threshold-frames",
-                extra=logger_extra,
-            )
-
             record_did_call_seer_metric(call_made=False, blocker="over-threshold-frames")
     except Exception:
         logger.exception("Unexpected exception in stacktrace string formatting")


### PR DESCRIPTION
This removes the temporary logs added in https://github.com/getsentry/sentry/pull/83082, now that we've finished debugging the problem (landing in the old excess frames logic when we shouldn't). It also removes the `record_metrics` parameter from `has_too_many_contributing_frames` which that PR added in order to keep the logging from messing up our DD numbers.