### PR TITLE
feat(aci): query snuba in delayed workflow processing

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -33,7 +33,8 @@ class BaseEventFrequencyConditionHandler(ABC):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = STANDARD_INTERVALS
 
     @classmethod
-    def base_handler(cls) -> type["BaseEventFrequencyConditionHandler"]:
+    @abstractmethod
+    def get_base_handler(cls) -> type["BaseEventFrequencyConditionHandler"]:
         # frequency and percent conditions can share the same base handler to query Snuba
         raise NotImplementedError
 

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
-from typing import Any, Literal, Self, TypedDict
+from typing import Any, ClassVar, Literal, Self, TypedDict
 
 from django.db.models import QuerySet
 
@@ -30,15 +30,16 @@ class _QSTypedDict(TypedDict):
 
 
 class BaseEventFrequencyConditionHandler(ABC):
-    @property
+    intervals: ClassVar[dict[str, tuple[str, timedelta]]] = STANDARD_INTERVALS
+
+    def __call__(self) -> None:
+        pass
+
+    @classmethod
     @abstractmethod
-    def base_handler(self) -> Self:
+    def base_handler(cls) -> type[Self]:
         # frequency and percent conditions can share the same base handler to query Snuba
         raise NotImplementedError
-
-    @property
-    def intervals(self) -> dict[str, tuple[str, timedelta]]:
-        return STANDARD_INTERVALS
 
     def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
         """

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_base_handler.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
-from typing import Any, ClassVar, Literal, Self, TypedDict
+from typing import Any, ClassVar, Literal, TypedDict
 
 from django.db.models import QuerySet
 
@@ -32,12 +32,8 @@ class _QSTypedDict(TypedDict):
 class BaseEventFrequencyConditionHandler(ABC):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = STANDARD_INTERVALS
 
-    def __call__(self) -> None:
-        pass
-
     @classmethod
-    @abstractmethod
-    def base_handler(cls) -> type[Self]:
+    def base_handler(cls) -> type["BaseEventFrequencyConditionHandler"]:
         # frequency and percent conditions can share the same base handler to query Snuba
         raise NotImplementedError
 
@@ -69,7 +65,7 @@ class BaseEventFrequencyConditionHandler(ABC):
         model: TSDBModel,
         start: datetime,
         end: datetime,
-        environment_id: int,
+        environment_id: int | None,
         referrer_suffix: str,
     ) -> Mapping[int, int]:
         result: Mapping[int, int] = tsdb_function(
@@ -93,7 +89,7 @@ class BaseEventFrequencyConditionHandler(ABC):
         organization_id: int,
         start: datetime,
         end: datetime,
-        environment_id: int,
+        environment_id: int | None,
         referrer_suffix: str,
     ) -> dict[int, int]:
         batch_totals: dict[int, int] = defaultdict(int)
@@ -142,7 +138,7 @@ class BaseEventFrequencyConditionHandler(ABC):
 
     @abstractmethod
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
+        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
         """
         Abstract method that specifies how to query Snuba for multiple groups
@@ -154,7 +150,7 @@ class BaseEventFrequencyConditionHandler(ABC):
         self,
         duration: timedelta,
         group_ids: set[int],
-        environment_id: int,
+        environment_id: int | None,
         current_time: datetime,
         comparison_interval: timedelta | None,
     ) -> dict[int, int]:

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -20,21 +20,22 @@ class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     def get_base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
         return EventFrequencyConditionHandler
 
+    @classmethod
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
+        cls, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
-        category_group_ids = self.get_group_ids_by_category(groups)
-        organization_id = self.get_value_from_groups(groups, "project__organization_id")
+        category_group_ids = cls.get_group_ids_by_category(groups)
+        organization_id = cls.get_value_from_groups(groups, "project__organization_id")
 
         if not organization_id:
             return batch_sums
 
         def get_result(model: TSDBModel, group_ids: list[int]) -> dict[int, int]:
-            return self.get_chunked_result(
+            return cls.get_chunked_result(
                 tsdb_function=tsdb.backend.get_sums,
                 model=model,
                 group_ids=group_ids,

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Self
 
 from sentry import tsdb
 from sentry.issues.constants import get_issue_tsdb_group_model
@@ -17,12 +16,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
-    @classmethod
-    def base_handler(cls) -> type[Self]:
-        return cls
-
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
+        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
@@ -61,7 +56,9 @@ class EventFrequencyCountHandler(
     BaseEventFrequencyCountHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    pass
+    @classmethod
+    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+        return EventFrequencyConditionHandler
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
@@ -70,4 +67,6 @@ class EventFrequencyPercentHandler(
     BaseEventFrequencyPercentHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    pass
+    @classmethod
+    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+        return EventFrequencyConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -16,6 +16,10 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
+    @classmethod
+    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+        return EventFrequencyConditionHandler
+
     def batch_query(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
@@ -56,9 +60,7 @@ class EventFrequencyCountHandler(
     BaseEventFrequencyCountHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    @classmethod
-    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
-        return EventFrequencyConditionHandler
+    pass
 
 
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
@@ -67,6 +69,4 @@ class EventFrequencyPercentHandler(
     BaseEventFrequencyPercentHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    @classmethod
-    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
-        return EventFrequencyConditionHandler
+    pass

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -17,9 +17,9 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
-    @property
-    def base_handler(self) -> Self:
-        return self
+    @classmethod
+    def base_handler(cls) -> type[Self]:
+        return cls
 
     def batch_query(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -17,7 +17,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 class EventFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     @classmethod
-    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+    def get_base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
         return EventFrequencyConditionHandler
 
     def batch_query(

--- a/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Self
 
 from sentry import tsdb
 from sentry.issues.constants import get_issue_tsdb_user_group_model
@@ -17,12 +16,8 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
-    @classmethod
-    def base_handler(cls) -> type[Self]:
-        return cls
-
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int
+        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
@@ -61,7 +56,9 @@ class EventUniqueUserFrequencyCountHandler(
     BaseEventFrequencyCountHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    pass
+    @classmethod
+    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+        return EventUniqueUserFrequencyConditionHandler
 
 
 @condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
@@ -70,4 +67,6 @@ class EventUniqueUserFrequencyPercentHandler(
     BaseEventFrequencyPercentHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    pass
+    @classmethod
+    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+        return EventUniqueUserFrequencyConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
@@ -17,9 +17,9 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
-    @property
-    def base_handler(self) -> Self:
-        return self
+    @classmethod
+    def base_handler(cls) -> type[Self]:
+        return cls
 
     def batch_query(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int

--- a/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
@@ -16,6 +16,10 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
+    @classmethod
+    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+        return EventUniqueUserFrequencyConditionHandler
+
     def batch_query(
         self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
@@ -56,9 +60,7 @@ class EventUniqueUserFrequencyCountHandler(
     BaseEventFrequencyCountHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    @classmethod
-    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
-        return EventUniqueUserFrequencyConditionHandler
+    pass
 
 
 @condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
@@ -67,6 +69,4 @@ class EventUniqueUserFrequencyPercentHandler(
     BaseEventFrequencyPercentHandler,
     DataConditionHandler[WorkflowJob],
 ):
-    @classmethod
-    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
-        return EventUniqueUserFrequencyConditionHandler
+    pass

--- a/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
@@ -17,7 +17,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
     @classmethod
-    def base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
+    def get_base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
         return EventUniqueUserFrequencyConditionHandler
 
     def batch_query(

--- a/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_unique_user_frequency_handlers.py
@@ -16,25 +16,27 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowJob
 
 
 class EventUniqueUserFrequencyConditionHandler(BaseEventFrequencyConditionHandler):
+
     @classmethod
     def get_base_handler(cls) -> type[BaseEventFrequencyConditionHandler]:
         return EventUniqueUserFrequencyConditionHandler
 
+    @classmethod
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
+        cls, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
             "id", "type", "project_id", "project__organization_id"
         )
-        category_group_ids = self.get_group_ids_by_category(groups)
-        organization_id = self.get_value_from_groups(groups, "project__organization_id")
+        category_group_ids = cls.get_group_ids_by_category(groups)
+        organization_id = cls.get_value_from_groups(groups, "project__organization_id")
 
         if not organization_id:
             return batch_sums
 
         def get_result(model: TSDBModel, group_ids: list[int]) -> dict[int, int]:
-            return self.get_chunked_result(
+            return cls.get_chunked_result(
                 tsdb_function=tsdb.backend.get_distinct_counts_totals,
                 model=model,
                 group_ids=group_ids,

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -40,7 +40,7 @@ class UniqueConditionQuery:
     same condition class can share the single query.
     """
 
-    handler: BaseEventFrequencyConditionHandler
+    handler: type[BaseEventFrequencyConditionHandler]
     interval: str
     environment_id: int | None
     comparison_interval: str | None = None

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -165,7 +165,7 @@ def generate_unique_queries(
     if not (isinstance(handler, type) and issubclass(handler, BaseEventFrequencyConditionHandler)):
         return []
 
-    base_handler = handler.base_handler  # type: ignore[attr-defined]
+    base_handler = handler.get_base_handler()  # type: ignore[attr-defined]
 
     unique_queries = [
         UniqueConditionQuery(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -165,7 +165,7 @@ def generate_unique_queries(
     if not (isinstance(handler, type) and issubclass(handler, BaseEventFrequencyConditionHandler)):
         return []
 
-    base_handler = handler.get_base_handler()  # type: ignore[attr-defined]
+    base_handler = handler.base_handler  # type: ignore[attr-defined]
 
     unique_queries = [
         UniqueConditionQuery(
@@ -224,7 +224,7 @@ def get_condition_group_results(
             )
 
         result = safe_execute(
-            handler().get_rate_bulk,
+            handler.get_rate_bulk,
             duration=duration,
             group_ids=group_ids,
             environment_id=unique_condition.environment_id,

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -165,7 +165,7 @@ def generate_unique_queries(
     if not (isinstance(handler, type) and issubclass(handler, BaseEventFrequencyConditionHandler)):
         return []
 
-    base_handler = handler.base_handler()  # type: ignore[attr-defined]
+    base_handler = handler.get_base_handler()  # type: ignore[attr-defined]
 
     unique_queries = [
         UniqueConditionQuery(

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,4 +1,7 @@
 from dataclasses import asdict
+from datetime import timedelta
+
+import pytest
 
 from sentry import buffer
 from sentry.eventstore.models import Event
@@ -6,18 +9,24 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.rules.conditions.event_frequency import ComparisonType
 from sentry.rules.processing.delayed_processing import fetch_project
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import json
-from sentry.workflow_engine.models import DataConditionGroup, Detector, Workflow
-from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector, Workflow
+from sentry.workflow_engine.models.data_condition import (
+    PERCENT_CONDITIONS,
+    SLOW_CONDITIONS,
+    Condition,
+)
 from sentry.workflow_engine.processors.delayed_workflow import (
     UniqueConditionQuery,
     fetch_active_data_condition_groups,
     fetch_group_to_event_data,
     fetch_workflows_and_environments,
     generate_unique_queries,
+    get_condition_group_results,
     get_condition_query_groups,
     get_dcg_group_workflow_data,
 )
@@ -26,6 +35,7 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
+pytestmark = pytest.mark.sentry_metrics
 
 
 class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
@@ -356,3 +366,108 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
         assert result[count_query] == {self.group.id, group2.id}  # count and percent condition
         assert result[percent_only_query] == {self.group.id}
         assert result[different_query] == {group3.id}
+
+
+class TestGetSnubaResults(BaseWorkflowTest):
+    def create_events(self, comparison_type: ComparisonType) -> Event:
+        # Create current events for the first query
+        event = self.create_event(self.project.id, FROZEN_TIME, "group-1", self.environment.name)
+        self.create_event(self.project.id, FROZEN_TIME, "group-1", self.environment.name)
+        if comparison_type == ComparisonType.PERCENT:
+            # Create a past event for the second query
+            self.create_event(
+                self.project.id,
+                FROZEN_TIME - timedelta(hours=1, minutes=10),
+                "group-1",
+                self.environment.name,
+            )
+        return event
+
+    def create_condition_groups(
+        self, data_conditions: list[DataCondition]
+    ) -> tuple[dict[UniqueConditionQuery, set[int]], int, list[UniqueConditionQuery]]:
+        condition_groups = {}
+        all_unique_queries = []
+        for data_condition in data_conditions:
+            unique_queries = generate_unique_queries(data_condition, self.environment.id)
+            comparison_type = (
+                ComparisonType.PERCENT
+                if Condition(data_condition.type) in PERCENT_CONDITIONS
+                else ComparisonType.COUNT
+            )
+            event = self.create_events(comparison_type)
+            assert event.group
+            group = event.group
+            condition_groups.update({query: {event.group.id} for query in unique_queries})
+            all_unique_queries.extend(unique_queries)
+        return condition_groups, group.id, all_unique_queries
+
+    def create_event_frequency_condition(
+        self, type: Condition | None = Condition.EVENT_FREQUENCY_COUNT
+    ) -> DataCondition:
+        if type not in SLOW_CONDITIONS:
+            raise ValueError(f"{type} is not a slow condition")
+
+        comparison = {"interval": "1h", "value": 100}
+
+        if type in PERCENT_CONDITIONS:
+            comparison["comparison_interval"] = "15m"
+
+        return self.create_data_condition(
+            type=type,
+            comparison=comparison,
+            condition_result=True,
+        )
+
+    def test_empty_condition_groups(self):
+        assert get_condition_group_results({}) == {}
+
+    def test_count_comparison_condition(self):
+        dc = self.create_event_frequency_condition()
+        condition_groups, group_id, unique_queries = self.create_condition_groups([dc])
+
+        results = get_condition_group_results(condition_groups)
+        assert results == {
+            unique_queries[0]: {group_id: 2},
+        }
+
+    def test_percent_comparison_condition(self):
+        dc = self.create_event_frequency_condition(type=Condition.EVENT_FREQUENCY_PERCENT)
+        condition_groups, group_id, unique_queries = self.create_condition_groups([dc])
+        results = get_condition_group_results(condition_groups)
+
+        present_percent_query, offset_percent_query = unique_queries
+
+        assert results == {
+            present_percent_query: {group_id: 2},
+            offset_percent_query: {group_id: 1},
+        }
+
+    def test_count_percent_conditions_together(self):
+        """
+        Test that a percent and count condition are processed as expected.
+        """
+        count_dc = self.create_event_frequency_condition()
+        percent_dc = self.create_event_frequency_condition(type=Condition.EVENT_FREQUENCY_PERCENT)
+        condition_groups, group_id, unique_queries = self.create_condition_groups(
+            [count_dc, percent_dc]
+        )
+
+        results = get_condition_group_results(condition_groups)
+
+        count_query, present_percent_query, offset_percent_query = unique_queries
+        # The count query and first percent query should be identical
+        count_information = asdict(count_query)
+        del count_information["handler"]
+
+        present_percent_information = asdict(present_percent_query)
+        del present_percent_information["handler"]
+
+        assert count_information == present_percent_information
+
+        # We should only query twice b/c the count query and first percent query
+        # share a single scan.
+        assert results == {
+            count_query: {group_id: 4},
+            offset_percent_query: {group_id: 1},
+        }


### PR DESCRIPTION
In delayed workflow processing, query Snuba for the results of the `UniqueConditionQueries` for the group ids that share the same query (interval, `environment_id`, `comparison_interval`).

Use the `get_rate_bulk` function on the condition handler to do so.