### PR TITLE
fix(widget-builder): Do not await dashboard save on submit

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -16,7 +16,6 @@ import {
   addErrorMessage,
   addLoadingMessage,
   addSuccessMessage,
-  clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
@@ -821,7 +820,6 @@ class DashboardDetail extends Component<Props, State> {
         // If we're not in edit mode, send a request to update the dashboard
         addLoadingMessage(t('Saving widget'));
         this.handleUpdateWidgetList(newWidgets);
-        clearIndicators();
       } else {
         // If we're in edit mode, update the edit state
         this.onUpdateWidget(newWidgets);

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -795,13 +795,7 @@ class DashboardDetail extends Component<Props, State> {
     );
   };
 
-  handleSaveWidget = async ({
-    index,
-    widget,
-  }: {
-    index: number | undefined;
-    widget: Widget;
-  }) => {
+  handleSaveWidget = ({index, widget}: {index: number | undefined; widget: Widget}) => {
     if (
       !this.props.organization.features.includes('dashboards-widget-builder-redesign')
     ) {
@@ -826,7 +820,7 @@ class DashboardDetail extends Component<Props, State> {
       if (!this.isEditingDashboard) {
         // If we're not in edit mode, send a request to update the dashboard
         addLoadingMessage(t('Saving widget'));
-        await this.handleUpdateWidgetList(newWidgets);
+        this.handleUpdateWidgetList(newWidgets);
         clearIndicators();
       } else {
         // If we're in edit mode, update the edit state

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -635,7 +635,11 @@ class DashboardDetail extends Component<Props, State> {
               },
             })
           );
-        } else {
+        } else if (
+          !organization.features.includes('dashboards-widget-builder-redesign')
+        ) {
+          // If we're not using the new widget builder, we need to replace the URL to
+          // ensure we're navigating back to the dashboard
           browserHistory.replace(
             normalizeUrl({
               pathname: `/organizations/${organization.slug}/dashboard/${dashboard.id}/`,


### PR DESCRIPTION
We have the validation request for a widget, so if the validate doesn't pass we shouldn't have to wait on the dashboard save. This makes saving the widget feel more responsive.

Also removes the `clearIndicators` call so it doesn't wipe out the "Dashboard updated" success toast.