### PR TITLE
chore(replay): create a project blocklist for viewed by endpoint and filters (inc-1024)

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -490,6 +490,13 @@ register(
     default=5000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Disables viewed by queries for a list of project ids.
+register(
+    "replay.viewed-by.project-denylist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # User Feedback Options
 register(

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -124,7 +124,7 @@ def query_replay_viewed_by_ids(
 
     for project_id in project_ids:
         if project_id in options.get("replay.viewed-by.project-denylist"):
-            raise BadRequest(VIEWED_BY_DENYLIST_MSG)
+            raise BadRequest(message=VIEWED_BY_DENYLIST_MSG)
 
     return execute_query(
         query=make_full_aggregation_query(

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -23,10 +23,12 @@ from snuba_sdk.orderby import Direction, OrderBy
 
 from sentry import options
 from sentry.api.event_search import ParenExpression, SearchConfig, SearchFilter
+from sentry.api.exceptions import BadRequest
 from sentry.models.organization import Organization
 from sentry.replays.lib.query import all_values_for_tag_key
 from sentry.replays.usecases.query import (
     PREFERRED_SOURCE,
+    VIEWED_BY_DENYLIST_MSG,
     Paginators,
     execute_query,
     make_full_aggregation_query,
@@ -122,7 +124,7 @@ def query_replay_viewed_by_ids(
 
     for project_id in project_ids:
         if project_id in options.get("replay.viewed-by.project-denylist"):
-            return []
+            raise BadRequest(VIEWED_BY_DENYLIST_MSG)
 
     return execute_query(
         query=make_full_aggregation_query(

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -21,6 +21,7 @@ from snuba_sdk import (
 from snuba_sdk.expressions import Expression
 from snuba_sdk.orderby import Direction, OrderBy
 
+from sentry import options
 from sentry.api.event_search import ParenExpression, SearchConfig, SearchFilter
 from sentry.models.organization import Organization
 from sentry.replays.lib.query import all_values_for_tag_key
@@ -118,6 +119,10 @@ def query_replay_viewed_by_ids(
         project_ids = project_id
     else:
         project_ids = [project_id]
+
+    for project_id in project_ids:
+        if project_id in options.get("replay.viewed-by.project-denylist"):
+            return []
 
     return execute_query(
         query=make_full_aggregation_query(

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -53,7 +53,7 @@ NULL_VIEWED_BY_ID_VALUE = 0  # default value in clickhouse
 DEFAULT_SORT_FIELD = "started_at"
 
 VIEWED_BY_DENYLIST_MSG = (
-    "Viewed by me search has been disabled for your project due to a data irregularity."
+    "Viewed by search has been disabled for your project due to a data irregularity."
 )
 
 PREFERRED_SOURCE = Literal["aggregated", "scalar"]
@@ -235,7 +235,7 @@ def query_using_optimized_search(
         # Skip all viewed by filters if in denylist
         for search_filter in search_filters:
             if search_filter.key.name in VIEWED_BY_KEYS:
-                raise BadRequest(VIEWED_BY_DENYLIST_MSG)
+                raise BadRequest(message=VIEWED_BY_DENYLIST_MSG)
     else:
         # Translate "viewed_by_me" filters, which are aliases for "viewed_by_id"
         search_filters = handle_viewed_by_me_filters(search_filters, request_user_id)

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -2203,3 +2203,79 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             response = self.client.get(self.url)
             assert response.status_code == 200
             assert response.headers["X-Data-Source"] == "scalar-subquery"
+
+    def test_viewed_by_denylist(self):
+        project = self.create_project(teams=[self.team])
+
+        replay1_id = uuid.uuid4().hex
+        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=22)
+        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        self.store_replays(
+            mock_replay(
+                seq1_timestamp,
+                project.id,
+                replay1_id,
+                platform="javascript",
+                dist="abc123",
+                user_id="123",
+                user_email="username@example.com",
+                user_name="username123",
+                user_ip_address="127.0.0.1",
+                sdk_name="sentry.javascript.react",
+                sdk_version="6.18.10",
+                os_name="macOS",
+                os_version="15",
+                browser_name="Firefox",
+                browser_version="99",
+                device_name="Macbook",
+                device_brand="Apple",
+                device_family="Macintosh",
+                device_model="10",
+                tags={"a": "m", "b": "q", "c": "test"},
+                urls=["example.com"],
+                segment_id=0,
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                seq2_timestamp,
+                project.id,
+                replay1_id,
+                user_id=None,
+                user_name=None,
+                user_email=None,
+                ipv4=None,
+                os_name=None,
+                os_version=None,
+                browser_name=None,
+                browser_version=None,
+                device_name=None,
+                device_brand=None,
+                device_family=None,
+                device_model=None,
+                tags={"a": "n", "b": "o"},
+                error_ids=[],
+                segment_id=1,
+            )
+        )
+
+        self.store_replays(
+            mock_replay_viewed(
+                seq1_timestamp.timestamp(), project.id, replay1_id, viewed_by_id=self.user.id
+            )
+        )
+
+        with self.feature(self.features):
+            with self.options({"replay.viewed-by.project-denylist": [project.id]}):
+                for query in [
+                    f"viewed_by_id:{self.user.id}",
+                    f"seen_by_id:{self.user.id}",
+                    "viewed_by_me:true",
+                    "seen_by_me:true",
+                ]:
+                    response = self.client.get(self.url + "?field=id&query=" + query)
+                    assert response.status_code == 400
+                    assert (
+                        response.json()["detail"]["message"]
+                        == "Viewed by search has been disabled for your project due to a data irregularity."
+                    )


### PR DESCRIPTION
Ref
- https://getsentry.atlassian.net/browse/INC-1024
- All/most of problematic queries involve the viewed_by column: https://cloudlogging.app.goo.gl/qjisuZ6EqPDHF8Uh7
- Proposed approach and project list from slack thread: https://sentry.slack.com/archives/C08BB46SJQ7/p1738698577582169?thread_ts=1738698342.127569&cid=C08BB46SJQ7