### PR TITLE
feat(uptime): Add alert for uptime monitoring data storage acknowledgment

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {autorun} from 'mobx';
 import {Observer} from 'mobx-react';
 
+import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import FieldWrapper from 'sentry/components/forms/fieldGroup/fieldWrapper';
@@ -261,6 +262,16 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
               flexibleControlStateSize
             />
           </ConfigurationPanel>
+          <Alert type="muted" showIcon>
+            {tct(
+              'By enabling uptime monitoring, you acknowledge that uptime check data may be stored outside your selected data region. [link:Learn more].',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/organization/data-storage-location/#data-stored-in-us" />
+                ),
+              }
+            )}
+          </Alert>
           <Observer>
             {() => (
               <HTTPSnippet


### PR DESCRIPTION
Adds an alert to the uptime form acknowledging that enabling uptime monitoring, data might be stored outside of the organization's region.

<img src="https://github.com/user-attachments/assets/a56d188f-ee2d-4af2-baa6-67b0278d5b5e" width="600">
