### PR TITLE
fix(page-filters): Remove utc if stats period is present

### DIFF
--- a/static/app/components/organizations/pageFilters/parse.spec.tsx
+++ b/static/app/components/organizations/pageFilters/parse.spec.tsx
@@ -176,6 +176,45 @@ describe('normalizeDateTimeParams', function () {
   it('does not return default statsPeriod if `allowEmptyPeriod` option is passed', function () {
     expect(normalizeDateTimeParams({}, {allowEmptyPeriod: true})).toEqual({});
   });
+
+  it('should parse utc when it is defined', function () {
+    expect(
+      normalizeDateTimeParams({
+        utc: 'true',
+        start: '2019-10-01T00:00:00',
+        end: '2019-10-02T00:00:00',
+      })
+    ).toEqual({
+      utc: 'true',
+      start: '2019-10-01T00:00:00.000',
+      end: '2019-10-02T00:00:00.000',
+    });
+    expect(
+      normalizeDateTimeParams({
+        utc: 'false',
+        start: '2019-10-01T00:00:00',
+        end: '2019-10-02T00:00:00',
+      })
+    ).toEqual({
+      utc: 'false',
+      start: '2019-10-01T00:00:00.000',
+      end: '2019-10-02T00:00:00.000',
+    });
+    expect(
+      normalizeDateTimeParams({
+        utc: 'invalid',
+        start: '2019-10-01T00:00:00',
+        end: '2019-10-02T00:00:00',
+      })
+    ).toEqual({
+      utc: 'false',
+      start: '2019-10-01T00:00:00.000',
+      end: '2019-10-02T00:00:00.000',
+    });
+
+    expect(normalizeDateTimeParams({utc: null})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({utc: undefined})).toEqual({statsPeriod: '14d'});
+  });
 });
 
 describe('parseStatsPeriod', function () {

--- a/static/app/components/organizations/pageFilters/parse.spec.tsx
+++ b/static/app/components/organizations/pageFilters/parse.spec.tsx
@@ -169,31 +169,12 @@ describe('normalizeDateTimeParams', function () {
         statsPeriod: '14d',
       })
     ).toEqual({
-      utc: 'true',
       statsPeriod: '90d',
     });
   });
 
   it('does not return default statsPeriod if `allowEmptyPeriod` option is passed', function () {
     expect(normalizeDateTimeParams({}, {allowEmptyPeriod: true})).toEqual({});
-  });
-
-  it('should parse utc when it is defined', function () {
-    expect(normalizeDateTimeParams({utc: 'true'})).toEqual({
-      utc: 'true',
-      statsPeriod: '14d',
-    });
-    expect(normalizeDateTimeParams({utc: 'false'})).toEqual({
-      utc: 'false',
-      statsPeriod: '14d',
-    });
-    expect(normalizeDateTimeParams({utc: 'invalid'})).toEqual({
-      utc: 'false',
-      statsPeriod: '14d',
-    });
-
-    expect(normalizeDateTimeParams({utc: null})).toEqual({statsPeriod: '14d'});
-    expect(normalizeDateTimeParams({utc: undefined})).toEqual({statsPeriod: '14d'});
   });
 });
 

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -262,7 +262,7 @@ export function normalizeDateTimeParams(
     end: coercedPeriod ? null : dateTimeEnd ?? null,
     // coerce utc into a string (it can be both: a string representation from
     // router, or a boolean from time range picker)
-    utc: getUtcValue(pageUtc ?? utc),
+    utc: coercedPeriod ? null : getUtcValue(pageUtc ?? utc),
     ...otherParams,
   };
 

--- a/static/app/utils/discover/eventView.spec.tsx
+++ b/static/app/utils/discover/eventView.spec.tsx
@@ -1348,7 +1348,6 @@ describe('EventView.getEventsAPIPayload()', function () {
     expect(eventView.getEventsAPIPayload(location)).toEqual({
       project: [],
       environment: [],
-      utc: 'true',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -1383,7 +1382,6 @@ describe('EventView.getEventsAPIPayload()', function () {
     expect(eventView.getEventsAPIPayload(location)).toEqual({
       project: ['1234'],
       environment: ['staging'],
-      utc: 'true',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -1406,7 +1404,6 @@ describe('EventView.getEventsAPIPayload()', function () {
     expect(eventView.getEventsAPIPayload(location2)).toEqual({
       project: ['1234'],
       environment: ['staging'],
-      utc: 'true',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -1439,7 +1436,6 @@ describe('EventView.getEventsAPIPayload()', function () {
     expect(eventView.getEventsAPIPayload(location)).toEqual({
       project: ['1234'],
       environment: ['staging'],
-      utc: 'true',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -1461,7 +1457,6 @@ describe('EventView.getEventsAPIPayload()', function () {
     expect(eventView.getEventsAPIPayload(location2)).toEqual({
       project: ['1234'],
       environment: ['staging'],
-      utc: 'true',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -1650,7 +1645,6 @@ describe('EventView.getFacetsAPIPayload()', function () {
     expect(eventView.getFacetsAPIPayload(location)).toEqual({
       project: [],
       environment: [],
-      utc: 'true',
       statsPeriod: '14d',
 
       query: 'event.type:csp',

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -27,7 +27,7 @@ describe('DatabaseSpanSummaryPage', function () {
         period: '10d',
         start: null,
         end: null,
-        utc: false,
+        utc: null,
       },
       environments: [],
       projects: [],
@@ -313,7 +313,6 @@ describe('DatabaseSpanSummaryPage', function () {
           shortIdLookup: 1,
           project: [],
           statsPeriod: '10d',
-          utc: 'false',
         },
       })
     );


### PR DESCRIPTION
Forces utc=null if the time filters use statsperiod (instead of start,end). This is causing unexpected issues in Issue Views when we are trying to detect unsaved changes. 