### PR TITLE
fix(eap): Allow numeric filters for size keys

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -630,6 +630,7 @@ class SearchVisitor(NodeVisitor):
             or is_span_op_breakdown(key)
             or self.get_field_type(key) in ["number", "integer"]
             or self.is_duration_key(key)
+            or self.is_size_key(key)
         )
 
     def is_duration_key(self, key):

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1628,6 +1628,7 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
                     "http.response_content_length",
                     "http.response_transfer_size",
                 ],
+                "query": "http.decoded_response_content_length:>0 http.response_content_length:>0 http.response_transfer_size:>0",
                 "project": self.project.id,
                 "dataset": self.dataset,
                 "allowAggregateConditions": "0",


### PR DESCRIPTION
Size keys should allow to be filtered as numbers.