### PR TITLE
feat(aci): issue alert dual update in API

### DIFF
--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -4,9 +4,11 @@ from attr import dataclass
 from django.db import router, transaction
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.types.actor import Actor
+from sentry.workflow_engine.migration_helpers.rule import update_migrated_issue_alert
 
 
 @dataclass
@@ -35,6 +37,12 @@ class ProjectRuleUpdater:
             self._update_conditions()
             self._update_frequency()
             self.rule.save()
+
+            if features.has(
+                "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
+            ):
+                # TODO(cathy): handle errors from broken actions
+                update_migrated_issue_alert(self.rule)
             return self.rule
 
     def _update_name(self) -> None:

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -14,7 +14,6 @@ from slack_sdk.web import SlackResponse
 
 from sentry.api.endpoints.project_rules import get_max_alerts
 from sentry.constants import ObjectStatus
-from sentry.grouping.grouptype import ErrorGroupType
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
@@ -25,14 +24,6 @@ from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
 from sentry.users.models.user import User
-from sentry.workflow_engine.models import (
-    Action,
-    AlertRuleDetector,
-    AlertRuleWorkflow,
-    DataConditionGroupAction,
-    WorkflowDataConditionGroup,
-)
-from sentry.workflow_engine.models.data_condition import Condition
 
 
 class ProjectRuleBaseTestCase(APITestCase):
@@ -407,56 +398,6 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         self.run_test(
             actions=self.notify_event_action, conditions=self.first_seen_condition, environment=None
         )
-        assert AlertRuleWorkflow.objects.all().count() == 0
-        assert AlertRuleDetector.objects.all().count() == 0
-
-    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
-    def test_dual_create_workflow_engine(self):
-        filters = [
-            {
-                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
-                "key": "foo",
-                "match": "is",
-            }
-        ]
-        expected_filters = deepcopy(filters)
-        expected_filters[0]["value"] = ""
-        expected_conditions = self.first_seen_condition + expected_filters
-        response = self.run_test(
-            actions=self.notify_event_action,
-            filters=filters,
-            conditions=self.first_seen_condition,
-            expected_conditions=expected_conditions,
-            environment=None,
-        )
-
-        rule_id = response.data["id"]
-        alert_rule_detector = AlertRuleDetector.objects.get(rule_id=rule_id)
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule_id)
-
-        detector = alert_rule_detector.detector
-        assert detector.project_id == self.project.id
-        assert detector.type == ErrorGroupType.slug
-
-        workflow = alert_rule_workflow.workflow
-        when_dcg = workflow.when_condition_group
-        assert when_dcg
-        assert when_dcg.logic_type == "any-short"
-        assert len(when_dcg.conditions.all()) == 1
-
-        data_condition = list(when_dcg.conditions.all())[0]
-        assert data_condition.type == Condition.FIRST_SEEN_EVENT
-
-        action_filter = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
-        assert action_filter.logic_type == "any-short"
-
-        assert len(action_filter.conditions.all()) == 1
-        data_condition = list(action_filter.conditions.all())[0]
-        assert data_condition.type == Condition.TAGGED_EVENT
-        assert data_condition.comparison == {"key": "foo", "match": "is"}
-
-        action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
-        assert action.type == Action.Type.PLUGIN
 
     @with_feature("organizations:rule-create-edit-confirm-notification")
     @patch(

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -1,7 +1,17 @@
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
 from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.actor import Actor
+from sentry.workflow_engine.models import (
+    Action,
+    AlertRuleDetector,
+    AlertRuleWorkflow,
+    DataConditionGroupAction,
+    WorkflowDataConditionGroup,
+)
+from sentry.workflow_engine.models.data_condition import Condition
 
 
 class TestProjectRuleCreator(TestCase):
@@ -61,3 +71,72 @@ class TestProjectRuleCreator(TestCase):
             "filter_match": "any",
             "frequency": 5,
         }
+
+        assert not AlertRuleDetector.objects.filter(rule_id=rule.id).exists()
+        assert not AlertRuleWorkflow.objects.filter(rule_id=rule.id).exists()
+
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    def test_dual_create_workflow_engine(self):
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            },
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "key": "foo",
+                "match": "is",
+            },
+        ]
+
+        rule = ProjectRuleCreator(
+            name="New Cool Rule",
+            owner=Actor.from_id(user_id=self.user.id),
+            project=self.project,
+            action_match="any",
+            filter_match="all",
+            conditions=conditions,
+            environment=self.environment.id,
+            actions=[
+                {
+                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                    "name": "Send a notification (for all legacy integrations)",
+                }
+            ],
+            frequency=5,
+        ).run()
+
+        rule_id = rule.id
+        alert_rule_detector = AlertRuleDetector.objects.get(rule_id=rule_id)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule_id)
+
+        detector = alert_rule_detector.detector
+        assert detector.project_id == self.project.id
+        assert detector.type == ErrorGroupType.slug
+
+        workflow = alert_rule_workflow.workflow
+        assert workflow.config["frequency"] == 5
+        assert workflow.owner_user_id == self.user.id
+        assert workflow.owner_team_id is None
+        assert workflow.environment_id == self.environment.id
+
+        when_dcg = workflow.when_condition_group
+        assert when_dcg
+        assert when_dcg.logic_type == "any-short"
+        assert len(when_dcg.conditions.all()) == 1
+
+        data_condition = list(when_dcg.conditions.all())[0]
+        assert data_condition.type == Condition.FIRST_SEEN_EVENT
+
+        action_filter = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        assert action_filter.logic_type == "all"
+
+        assert len(action_filter.conditions.all()) == 1
+        data_condition = list(action_filter.conditions.all())[0]
+        assert data_condition.type == Condition.TAGGED_EVENT
+        assert data_condition.comparison == {"key": "foo", "match": "is"}
+
+        action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
+        assert action.type == Action.Type.PLUGIN

--- a/tests/sentry/projects/project_rules/test_updater.py
+++ b/tests/sentry/projects/project_rules/test_updater.py
@@ -1,8 +1,19 @@
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.projects.project_rules.updater import ProjectRuleUpdater
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.actor import Actor
 from sentry.users.models.user import User
+from sentry.workflow_engine.migration_helpers.rule import migrate_issue_alert
+from sentry.workflow_engine.models import (
+    Action,
+    AlertRuleDetector,
+    AlertRuleWorkflow,
+    DataConditionGroupAction,
+    WorkflowDataConditionGroup,
+)
+from sentry.workflow_engine.models.data_condition import Condition
 
 
 class TestUpdater(TestCase):
@@ -104,3 +115,72 @@ class TestUpdater(TestCase):
         self.updater.frequency = 5
         self.updater.run()
         assert self.rule.data["frequency"] == 5
+
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    def test_dual_create_workflow_engine(self):
+        migrate_issue_alert(self.rule, user_id=self.user.id)
+
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            },
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "key": "foo",
+                "match": "is",
+            },
+        ]
+        new_user_id = self.create_user().id
+
+        ProjectRuleUpdater(
+            rule=self.rule,
+            name="Updated Rule",
+            owner=Actor.from_id(new_user_id),
+            project=self.project,
+            action_match="all",
+            filter_match="any",
+            conditions=conditions,
+            environment=None,
+            actions=[
+                {
+                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                    "name": "Send a notification (for all legacy integrations)",
+                }
+            ],
+            frequency=5,
+        ).run()
+
+        alert_rule_detector = AlertRuleDetector.objects.get(rule_id=self.rule.id)
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=self.rule.id)
+
+        detector = alert_rule_detector.detector
+        assert detector.project_id == self.project.id
+        assert detector.type == ErrorGroupType.slug
+
+        workflow = alert_rule_workflow.workflow
+        assert workflow.config["frequency"] == 5
+        assert workflow.owner_user_id == new_user_id
+        assert workflow.owner_team_id is None
+        assert workflow.environment is None
+
+        when_dcg = workflow.when_condition_group
+        assert when_dcg
+        assert when_dcg.logic_type == "all"
+        assert len(when_dcg.conditions.all()) == 1
+
+        data_condition = list(when_dcg.conditions.all())[0]
+        assert data_condition.type == Condition.FIRST_SEEN_EVENT
+
+        action_filter = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        assert action_filter.logic_type == "any-short"
+
+        assert len(action_filter.conditions.all()) == 1
+        data_condition = list(action_filter.conditions.all())[0]
+        assert data_condition.type == Condition.TAGGED_EVENT
+        assert data_condition.comparison == {"key": "foo", "match": "is"}
+
+        action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
+        assert action.type == Action.Type.PLUGIN

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -1,3 +1,6 @@
+import pytest
+from jsonschema.exceptions import ValidationError
+
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
@@ -7,9 +10,7 @@ from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.rules.filters.latest_release import LatestReleaseFilter
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack
-from sentry.types.actor import Actor
 from sentry.workflow_engine.migration_helpers.rule import (
-    UpdatedIssueAlertData,
     delete_migrated_issue_alert,
     migrate_issue_alert,
     update_migrated_issue_alert,
@@ -58,6 +59,8 @@ class RuleMigrationHelpersTest(APITestCase):
             filter_match="any",
             action_data=action_data,
         )
+        self.issue_alert.data["frequency"] = 5
+        self.issue_alert.save()
 
     def test_create_issue_alert(self):
         migrate_issue_alert(self.issue_alert, self.user.id)
@@ -69,7 +72,7 @@ class RuleMigrationHelpersTest(APITestCase):
         assert workflow.name == self.issue_alert.label
         assert self.issue_alert.project
         assert workflow.organization_id == self.issue_alert.project.organization.id
-        assert workflow.config == {"frequency": 30}
+        assert workflow.config == {"frequency": 5}
 
         detector = Detector.objects.get(id=issue_alert_detector.detector.id)
         assert detector.name == "Error Detector"
@@ -131,26 +134,33 @@ class RuleMigrationHelpersTest(APITestCase):
                 "id": LatestReleaseFilter.id,
             },
         ]
-        payload: UpdatedIssueAlertData = {
-            "name": "hello world",
-            "owner": Actor.from_id(user_id=self.user.id),
-            "environment": self.environment.id,
-            "action_match": "none",
-            "filter_match": "all",
-            "actions": [
-                {
-                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                    "uuid": "test-uuid",
-                }
-            ],
-            "conditions": conditions_payload,
-            "frequency": 60,
-        }
-        update_migrated_issue_alert(self.issue_alert, payload)
+        rule_data = self.issue_alert.data
+        rule_data.update(
+            {
+                "action_match": "none",
+                "filter_match": "all",
+                "conditions": conditions_payload,
+                "frequency": 60,
+                "actions": [
+                    {
+                        "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                        "uuid": "test-uuid",
+                    }
+                ],
+            }
+        )
+
+        self.issue_alert.update(
+            label="hello world",
+            owner_user_id=self.user.id,
+            environment_id=self.environment.id,
+            data=rule_data,
+        )
+        update_migrated_issue_alert(self.issue_alert)
 
         issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
         workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
-        assert workflow.name == payload["name"]
+        assert workflow.name == self.issue_alert.label
         assert self.issue_alert.project
         assert workflow.organization_id == self.issue_alert.project.organization.id
         assert workflow.config == {"frequency": 60}
@@ -184,24 +194,37 @@ class RuleMigrationHelpersTest(APITestCase):
 
     def test_required_fields_only(self):
         migrate_issue_alert(self.issue_alert, self.user.id)
-        payload: UpdatedIssueAlertData = {
-            "name": "hello world",
-            "owner": None,
-            "environment": None,
-            "conditions": [],
-            "action_match": "none",
-            "filter_match": None,
-            "actions": [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
-            "frequency": None,
-        }
-        update_migrated_issue_alert(self.issue_alert, payload)
+        # None fields are not updated
+
+        rule_data = self.issue_alert.data
+        rule_data.update(
+            {
+                "action_match": "none",
+                "conditions": [],
+                "actions": [
+                    {
+                        "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                        "uuid": "test-uuid",
+                    }
+                ],
+            }
+        )
+
+        self.issue_alert.update(
+            label="hello world",
+            owner_user_id=None,
+            owner_team_id=None,
+            environment_id=None,
+            data=rule_data,
+        )
+        update_migrated_issue_alert(self.issue_alert)
 
         issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
         workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
         assert workflow.environment is None
         assert workflow.owner_user_id is None
         assert workflow.owner_team_id is None
-        assert workflow.config == {"frequency": workflow.DEFAULT_FREQUENCY}
+        assert workflow.config == {"frequency": 5}  # not migrated
 
         assert workflow.when_condition_group
         assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.NONE
@@ -213,6 +236,13 @@ class RuleMigrationHelpersTest(APITestCase):
         assert if_dcg.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
         filters = DataCondition.objects.filter(condition_group=if_dcg)
         assert filters.count() == 0
+
+    def test_invalid_frequency(self):
+        migrate_issue_alert(self.issue_alert, self.user.id)
+        self.issue_alert.data["frequency"] = -1
+        self.issue_alert.save()
+        with pytest.raises(ValidationError):
+            update_migrated_issue_alert(self.issue_alert)
 
     def test_delete_issue_alert(self):
         migrate_issue_alert(self.issue_alert, self.user.id)


### PR DESCRIPTION
Add feature-flagged updating of workflow engine models when an issue alert is updated in the API.

This PR also includes some refactoring to account for the fact that our PUT API operates like a PATCH, meaning if you don't pass in a certain attribute of the `Rule`, we don't update it. `environment_id` is an outlier in that we do update the field if it's `None`, because `Rule.environment_id` can be null. This observation is based on the `ProjectUpdater` class implementation.

I also refactored the `update_migrated_alert_rule` function to purely pull from the recently updated `Rule` instead of a `TypedDict` of updated data, this is easier because we can more easily map parts of the `Rule` to `Workflow` than `request.data`.