### PR TITLE
feat(nav): Display secondary nav in mobile menu

### DIFF
--- a/static/app/components/nav/constants.tsx
+++ b/static/app/components/nav/constants.tsx
@@ -1,0 +1,12 @@
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
+import {t} from 'sentry/locale';
+
+export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-collapsed';
+
+export const NAV_GROUP_LABELS: Record<PrimaryNavGroup, string> = {
+  [PrimaryNavGroup.ISSUES]: t('Issues'),
+  [PrimaryNavGroup.EXPLORE]: t('Explore'),
+  [PrimaryNavGroup.DASHBOARDS]: t('Dashboards'),
+  [PrimaryNavGroup.INSIGHTS]: t('Insights'),
+  [PrimaryNavGroup.SETTINGS]: t('Settings'),
+};

--- a/static/app/components/nav/context.tsx
+++ b/static/app/components/nav/context.tsx
@@ -1,9 +1,10 @@
 import {createContext, useContext, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 
 import {NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY} from 'sentry/components/nav/constants';
 import {NavLayout, type PrimaryNavGroup} from 'sentry/components/nav/types';
-import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import useMedia from 'sentry/utils/useMedia';
 
 export interface NavContext {
   activeGroup: PrimaryNavGroup | null;
@@ -36,26 +37,21 @@ export function NavContextProvider({children}: {children: React.ReactNode}) {
   );
   const [secondaryNavEl, setSecondaryNavEl] = useState<HTMLElement | null>(null);
   const [activeGroup, setActiveGroup] = useState<PrimaryNavGroup | null>(null);
-  const screen = useBreakpoints();
+
+  const theme = useTheme();
+  const isMobile = useMedia(`(max-width: ${theme.breakpoints.medium})`);
 
   const value = useMemo(
     () => ({
       secondaryNavEl,
       setSecondaryNavEl,
-      layout: screen.medium ? NavLayout.SIDEBAR : NavLayout.MOBILE,
+      layout: isMobile ? NavLayout.MOBILE : NavLayout.SIDEBAR,
       isCollapsed,
       setIsCollapsed,
       activeGroup,
       setActiveGroup,
     }),
-    [
-      screen.medium,
-      secondaryNavEl,
-      isCollapsed,
-      setIsCollapsed,
-      activeGroup,
-      setActiveGroup,
-    ]
+    [secondaryNavEl, isMobile, isCollapsed, setIsCollapsed, activeGroup]
   );
 
   return <NavContext.Provider value={value}>{children}</NavContext.Provider>;

--- a/static/app/components/nav/context.tsx
+++ b/static/app/components/nav/context.tsx
@@ -1,13 +1,28 @@
 import {createContext, useContext, useMemo, useState} from 'react';
 
+import {NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY} from 'sentry/components/nav/constants';
+import {NavLayout, type PrimaryNavGroup} from 'sentry/components/nav/types';
+import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+
 export interface NavContext {
+  activeGroup: PrimaryNavGroup | null;
+  isCollapsed: boolean;
+  layout: NavLayout;
   secondaryNavEl: HTMLElement | null;
+  setActiveGroup: (group: PrimaryNavGroup | null) => void;
+  setIsCollapsed: (isCollapsed: boolean) => void;
   setSecondaryNavEl: (el: HTMLElement | null) => void;
 }
 
 const NavContext = createContext<NavContext>({
   secondaryNavEl: null,
   setSecondaryNavEl: () => {},
+  layout: NavLayout.SIDEBAR,
+  isCollapsed: false,
+  setIsCollapsed: () => {},
+  activeGroup: null,
+  setActiveGroup: () => {},
 });
 
 export function useNavContext(): NavContext {
@@ -15,11 +30,32 @@ export function useNavContext(): NavContext {
 }
 
 export function NavContextProvider({children}: {children: React.ReactNode}) {
+  const [isCollapsed, setIsCollapsed] = useLocalStorageState(
+    NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY,
+    false
+  );
   const [secondaryNavEl, setSecondaryNavEl] = useState<HTMLElement | null>(null);
+  const [activeGroup, setActiveGroup] = useState<PrimaryNavGroup | null>(null);
+  const screen = useBreakpoints();
 
   const value = useMemo(
-    () => ({secondaryNavEl, setSecondaryNavEl}),
-    [secondaryNavEl, setSecondaryNavEl]
+    () => ({
+      secondaryNavEl,
+      setSecondaryNavEl,
+      layout: screen.medium ? NavLayout.SIDEBAR : NavLayout.MOBILE,
+      isCollapsed,
+      setIsCollapsed,
+      activeGroup,
+      setActiveGroup,
+    }),
+    [
+      screen.medium,
+      secondaryNavEl,
+      isCollapsed,
+      setIsCollapsed,
+      activeGroup,
+      setActiveGroup,
+    ]
   );
 
   return <NavContext.Provider value={value}>{children}</NavContext.Provider>;

--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -13,6 +13,7 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 import Nav from 'sentry/components/nav';
 import {NavContextProvider} from 'sentry/components/nav/context';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
 
 const ALL_AVAILABLE_FEATURES = [
   'insights-entry-points',
@@ -39,11 +40,12 @@ describe('Nav', function () {
     render(
       <NavContextProvider>
         <Nav />
-        <SecondaryNav>
+        <SecondaryNav group={PrimaryNavGroup.ISSUES}>
           <SecondaryNav.Item to="/organizations/org-slug/issues/foo/">
             Foo
           </SecondaryNav.Item>
         </SecondaryNav>
+        <div id="main" />
       </NavContextProvider>,
       {
         organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
@@ -105,6 +107,56 @@ describe('Nav', function () {
       const link = screen.getByRole('link', {name: 'Foo'});
       expect(link).toHaveAttribute('aria-current', 'page');
       expect(link).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('mobile navigation', function () {
+    beforeEach(() => {
+      // Need useMedia() to return true for isMobile query
+      window.matchMedia = jest.fn().mockImplementation(query => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+    });
+
+    it('renders mobile navigation on small screen sizes', async function () {
+      renderNav();
+
+      // Should have a top-level header element with a home link and menu button
+      expect(screen.getByRole('link', {name: 'Sentry Home'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Open main menu'})).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Open main menu'}));
+
+      // Should first render the active secondary navigation
+      expect(
+        await screen.findByRole('navigation', {name: 'Secondary Navigation'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Foo'})).toBeInTheDocument();
+
+      // Clicking back should render the primary navigation
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Back to primary navigation'})
+      );
+      expect(
+        screen.getByRole('navigation', {name: 'Primary Navigation'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Issues'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Explore'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Boards'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Insights'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Stats'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Settings'})).toBeInTheDocument();
+
+      // Tapping one of the primary navigation items should close the menu
+      await userEvent.click(screen.getByRole('link', {name: 'Explore'}));
+      expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/nav/index.tsx
+++ b/static/app/components/nav/index.tsx
@@ -1,13 +1,18 @@
 import styled from '@emotion/styled';
 
+import {useNavContext} from 'sentry/components/nav/context';
 import MobileTopbar from 'sentry/components/nav/mobileTopbar';
 import {Sidebar} from 'sentry/components/nav/sidebar';
-import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
+import {NavLayout} from 'sentry/components/nav/types';
 
 function Nav() {
-  const screen = useBreakpoints();
+  const {layout} = useNavContext();
 
-  return <NavContainer>{screen.medium ? <Sidebar /> : <MobileTopbar />}</NavContainer>;
+  return (
+    <NavContainer>
+      {layout === NavLayout.SIDEBAR ? <Sidebar /> : <MobileTopbar />}
+    </NavContainer>
+  );
 }
 
 const NavContainer = styled('div')`

--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -2,19 +2,24 @@ import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
+import Link from 'sentry/components/links/link';
 import {useNavContext} from 'sentry/components/nav/context';
 import {PrimaryNavigationItems} from 'sentry/components/nav/primary';
 import {SecondaryMobile} from 'sentry/components/nav/secondaryMobile';
 import {IconClose, IconMenu, IconSentry} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import theme from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type ActiveView = 'primary' | 'secondary' | 'closed';
 
 function MobileTopbar() {
   const {activeGroup} = useNavContext();
   const location = useLocation();
+  const organization = useOrganization();
   const [view, setView] = useState<ActiveView>('closed');
   /** Sync menu state with `body` attributes */
   useLayoutEffect(() => {
@@ -30,19 +35,28 @@ function MobileTopbar() {
 
   return (
     <Topbar>
-      <a href="/">
+      <HomeLink
+        to={`/organizations/${organization.slug}/issues/`}
+        aria-label={t('Sentry Home')}
+      >
         <IconSentry />
-      </a>
-      <button onClick={handleClick}>
-        {view === 'closed' ? <IconMenu width={16} /> : <IconClose width={16} />}
-      </button>
+      </HomeLink>
+      <MenuButton
+        onClick={handleClick}
+        icon={view === 'closed' ? <IconMenu /> : <IconClose />}
+        aria-label={view === 'closed' ? t('Open main menu') : t('Close main menu')}
+        size="sm"
+        borderless
+      />
       {view !== 'closed' ? (
-        <OverlayPortal>
+        <NavigationOverlayPortal
+          label={view === 'primary' ? t('Primary Navigation') : t('Secondary Navigation')}
+        >
           {view === 'primary' ? <PrimaryNavigationItems /> : null}
           {view === 'secondary' ? (
             <SecondaryMobile handleClickBack={() => setView('primary')} />
           ) : null}
-        </OverlayPortal>
+        </NavigationOverlayPortal>
       ) : null}
     </Topbar>
   );
@@ -68,11 +82,20 @@ function updateNavStyleAttributes(view: ActiveView) {
   }
 }
 
-function OverlayPortal({children}: any) {
-  return createPortal(<Overlay>{children}</Overlay>, document.body);
+function NavigationOverlayPortal({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
+  return createPortal(
+    <NavigationOverlay aria-label={label}>{children}</NavigationOverlay>,
+    document.body
+  );
 }
 
-const Topbar = styled('div')`
+const Topbar = styled('header')`
   height: 40px;
   width: 100vw;
   padding: ${space(0.5)} ${space(1.5)} ${space(0.5)} ${space(1)};
@@ -86,34 +109,31 @@ const Topbar = styled('div')`
   position: sticky;
   top: 0;
   z-index: ${theme.zIndex.sidebar};
+`;
+
+const HomeLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 ${space(2)};
+  margin: -${space(1)};
 
   svg {
-    display: block;
-    width: var(--size);
-    height: var(--size);
-    color: currentColor;
-  }
-  button {
-    all: initial;
-    --size: ${space(2)};
-  }
-  a {
-    --size: ${space(3)};
-  }
-  a,
-  button {
-    color: rgba(255, 255, 255, 0.85);
-    padding: ${space(1)};
-    margin: -${space(1)};
-    cursor: pointer;
-
-    &:hover {
-      color: white;
-    }
+    color: ${p => p.theme.white};
+    width: ${space(3)};
+    height: ${space(3)};
   }
 `;
 
-const Overlay = styled('div')`
+const MenuButton = styled(Button)`
+  color: ${p => p.theme.white};
+
+  &:hover {
+    color: ${p => p.theme.white};
+  }
+`;
+
+const NavigationOverlay = styled('nav')`
   position: fixed;
   top: 40px;
   right: 0;

--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -276,7 +276,7 @@ const SidebarItemWrapper = styled('li')`
     height: 40px;
     gap: ${space(1.5)};
     align-items: center;
-    padding: auto ${space(1.5)};
+    padding: 0 ${space(1.5)};
     color: var(--color, currentColor);
     font-size: ${p => p.theme.fontSizeMedium};
     font-weight: ${p => p.theme.fontWeightNormal};

--- a/static/app/components/nav/secondary.stories.tsx
+++ b/static/app/components/nav/secondary.stories.tsx
@@ -5,6 +5,7 @@ import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceCon
 import {NavContextProvider} from 'sentry/components/nav/context';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {SecondarySidebar} from 'sentry/components/nav/secondarySidebar';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import storyBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
@@ -16,7 +17,7 @@ export default storyBook('SecondaryNav', story => {
       <Container>
         <NavContextProvider>
           <SecondarySidebar />
-          <SecondaryNav>
+          <SecondaryNav group={PrimaryNavGroup.ISSUES}>
             <SecondaryNav.Body>
               <SecondaryNav.Section>
                 <SecondaryNav.Item

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -1,17 +1,20 @@
-import type {ReactNode} from 'react';
+import {type ReactNode, useLayoutEffect} from 'react';
 import {createPortal} from 'react-dom';
 import type {To} from 'react-router-dom';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link, {type LinkProps} from 'sentry/components/links/link';
 import {useNavContext} from 'sentry/components/nav/context';
+import {NavLayout, type PrimaryNavGroup} from 'sentry/components/nav/types';
 import {isLinkActive} from 'sentry/components/nav/utils';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 
 type SecondaryNavProps = {
   children: ReactNode;
+  group: PrimaryNavGroup;
 };
 
 interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
@@ -25,8 +28,16 @@ interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
   isActive?: boolean;
 }
 
-export function SecondaryNav({children}: SecondaryNavProps) {
-  const {secondaryNavEl} = useNavContext();
+export function SecondaryNav({children, group}: SecondaryNavProps) {
+  const {secondaryNavEl, setActiveGroup} = useNavContext();
+
+  useLayoutEffect(() => {
+    setActiveGroup(group);
+
+    return () => {
+      setActiveGroup(null);
+    };
+  }, [group, setActiveGroup]);
 
   if (!secondaryNavEl) {
     return null;
@@ -36,7 +47,9 @@ export function SecondaryNav({children}: SecondaryNavProps) {
 }
 
 SecondaryNav.Body = function SecondaryNavBody({children}: {children: ReactNode}) {
-  return <Body>{children}</Body>;
+  const {layout} = useNavContext();
+
+  return <Body layout={layout}>{children}</Body>;
 };
 
 SecondaryNav.Section = function SecondaryNavSection({
@@ -46,10 +59,12 @@ SecondaryNav.Section = function SecondaryNavSection({
   children: ReactNode;
   title?: ReactNode;
 }) {
+  const {layout} = useNavContext();
+
   return (
     <Section>
       <SectionSeparator />
-      {title && <SectionTitle>{title}</SectionTitle>}
+      {title && <SectionTitle layout={layout}>{title}</SectionTitle>}
       {children}
     </Section>
   );
@@ -63,8 +78,9 @@ SecondaryNav.Item = function SecondaryNavItem({
   ...linkProps
 }: SecondaryNavItemProps) {
   const location = useLocation();
-
   const isActive = incomingIsActive || isLinkActive(to, location.pathname, {end});
+
+  const {layout} = useNavContext();
 
   return (
     <Item
@@ -72,6 +88,7 @@ SecondaryNav.Item = function SecondaryNavItem({
       to={to}
       aria-current={isActive ? 'page' : undefined}
       aria-selected={isActive}
+      layout={layout}
     >
       <InteractionStateLayer hasSelectedBackground={isActive} />
       {children}
@@ -80,12 +97,20 @@ SecondaryNav.Item = function SecondaryNavItem({
 };
 
 SecondaryNav.Footer = function SecondaryNavFooter({children}: {children: ReactNode}) {
-  return <Footer>{children}</Footer>;
+  const {layout} = useNavContext();
+
+  return <Footer layout={layout}>{children}</Footer>;
 };
 
-const Body = styled('div')`
+const Body = styled('div')<{layout: NavLayout}>`
   padding: ${space(1)};
   overflow-y: auto;
+
+  ${p =>
+    p.layout === NavLayout.MOBILE &&
+    css`
+      padding: 0 0 ${space(1)} 0;
+    `}
 `;
 
 const Section = styled('div')`
@@ -96,11 +121,17 @@ const Section = styled('div')`
   }
 `;
 
-const SectionTitle = styled('div')`
+const SectionTitle = styled('div')<{layout: NavLayout}>`
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.subText};
   padding: 0 ${space(1.5)};
   margin: ${space(2)} 0 ${space(0.5)} 0;
+
+  ${p =>
+    p.layout === NavLayout.MOBILE &&
+    css`
+      padding: 0 ${space(1.5)} 0 48px;
+    `}
 `;
 
 const SectionSeparator = styled('hr')`
@@ -112,7 +143,7 @@ const SectionSeparator = styled('hr')`
   border: none;
 `;
 
-const Item = styled(Link)`
+const Item = styled(Link)<{layout: NavLayout}>`
   position: relative;
   display: flex;
   padding: 5px ${space(1.5)};
@@ -142,9 +173,22 @@ const Item = styled(Link)`
     width: initial;
     height: initial;
   }
+
+  ${p =>
+    p.layout === NavLayout.MOBILE &&
+    css`
+      padding: 0 ${space(1.5)} 0 48px;
+      border-radius: 0;
+    `}
 `;
 
-const Footer = styled('div')`
+const Footer = styled('div')<{layout: NavLayout}>`
   padding: ${space(1)} ${space(1.5)};
   border-top: 1px solid ${p => p.theme.innerBorder};
+
+  ${p =>
+    p.layout === NavLayout.MOBILE &&
+    css`
+      padding: ${space(1)} 0;
+    `}
 `;

--- a/static/app/components/nav/secondaryMobile.tsx
+++ b/static/app/components/nav/secondaryMobile.tsx
@@ -4,6 +4,7 @@ import {Button} from 'sentry/components/button';
 import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {useNavContext} from 'sentry/components/nav/context';
 import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type Props = {
@@ -19,7 +20,7 @@ export function SecondaryMobile({handleClickBack}: Props) {
         <Button
           onClick={handleClickBack}
           icon={<IconChevron direction="left" />}
-          aria-label="Back"
+          aria-label={t('Back to primary navigation')}
           size="xs"
           borderless
         />
@@ -44,7 +45,7 @@ const SecondaryMobileWrapper = styled('div')`
   grid-template-rows: auto 1fr;
 `;
 
-const GroupHeader = styled('div')`
+const GroupHeader = styled('h2')`
   grid-area: header;
   position: sticky;
   top: 0;
@@ -54,6 +55,7 @@ const GroupHeader = styled('div')`
   align-items: center;
   padding: ${space(2)} ${space(1)};
   gap: ${space(1)};
+  margin: 0;
 `;
 
 const ContentWrapper = styled('div')`

--- a/static/app/components/nav/secondaryMobile.tsx
+++ b/static/app/components/nav/secondaryMobile.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
+import {useNavContext} from 'sentry/components/nav/context';
+import {IconChevron} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+
+type Props = {
+  handleClickBack: () => void;
+};
+
+export function SecondaryMobile({handleClickBack}: Props) {
+  const {setSecondaryNavEl, activeGroup} = useNavContext();
+
+  return (
+    <SecondaryMobileWrapper>
+      <GroupHeader>
+        <Button
+          onClick={handleClickBack}
+          icon={<IconChevron direction="left" />}
+          aria-label="Back"
+          size="xs"
+          borderless
+        />
+        <HeaderLabel>{activeGroup ? NAV_GROUP_LABELS[activeGroup] : ''}</HeaderLabel>
+      </GroupHeader>
+      <ContentWrapper ref={setSecondaryNavEl} />
+    </SecondaryMobileWrapper>
+  );
+}
+
+const SecondaryMobileWrapper = styled('div')`
+  position: relative;
+  border-right: 1px solid ${p => p.theme.translucentGray200};
+  background: ${p => p.theme.surface300};
+  height: 100%;
+  overflow-y: auto;
+
+  display: grid;
+  grid-template-areas:
+    'header'
+    'content';
+  grid-template-rows: auto 1fr;
+`;
+
+const GroupHeader = styled('div')`
+  grid-area: header;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: ${p => p.theme.background};
+  display: flex;
+  align-items: center;
+  padding: ${space(2)} ${space(1)};
+  gap: ${space(1)};
+`;
+
+const ContentWrapper = styled('div')`
+  grid-area: content;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  flex-direction: column;
+`;
+
+const HeaderLabel = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+`;

--- a/static/app/components/nav/types.tsx
+++ b/static/app/components/nav/types.tsx
@@ -1,0 +1,12 @@
+export enum NavLayout {
+  MOBILE = 'mobile',
+  SIDEBAR = 'sidebar',
+}
+
+export enum PrimaryNavGroup {
+  ISSUES = 'issues',
+  DASHBOARDS = 'dashboards',
+  EXPLORE = 'explorer',
+  INSIGHTS = 'insights',
+  SETTINGS = 'settings',
+}

--- a/static/app/views/explore/navigation.tsx
+++ b/static/app/views/explore/navigation.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -22,7 +23,7 @@ export default function ExploreNavigation({children}: Props) {
   // TODO(malwilley): Move other products under the /explore/ route
   return (
     <Fragment>
-      <SecondaryNav>
+      <SecondaryNav group={PrimaryNavGroup.EXPLORE}>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <Feature features="performance-trace-explorer">

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -37,7 +38,7 @@ export default function InsightsNavigation({children}: InsightsNavigationProps) 
 
   return (
     <Fragment>
-      <SecondaryNav>
+      <SecondaryNav group={PrimaryNavGroup.INSIGHTS}>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/projects/`}>

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -21,7 +22,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
 
   return (
     <Fragment>
-      <SecondaryNav>
+      <SecondaryNav group={PrimaryNavGroup.ISSUES}>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={baseUrl}>{t('All')}</SecondaryNav.Item>

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {space} from 'sentry/styles/space';
 import SettingsNavigationGroup from 'sentry/views/settings/components/settingsNavigationGroup';
 import SettingsNavigationGroupDeprecated from 'sentry/views/settings/components/settingsNavigationGroupDeprecated';
@@ -40,7 +41,7 @@ function SettingsSecondaryNavigation({
   const navWithHooks = navigationObjects.concat(hookConfigs);
 
   return (
-    <SecondaryNav>
+    <SecondaryNav group={PrimaryNavGroup.SETTINGS}>
       <SecondaryNav.Body>
         {navWithHooks.map(config => (
           <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

- Adds the secondary nav menu to the mobile menu when you first tap the hamburger menu
- In order to display the header title, adds `activeGroup` state to the navigation context (also need to add a prop to `<SecondaryNavigation />` and update callsites
- Adds `layout` to the nav context so components can render differently based on the current layout (mobile or sidebar)

Before:

![CleanShot 2025-02-04 at 15 56 38](https://github.com/user-attachments/assets/f2b2ff81-4dbf-4b87-b5d0-4944694907aa)

After:

https://github.com/user-attachments/assets/b5a51f38-0706-4e49-b89c-a80490443978

