### PR TITLE
fix(jira-server): Removes additional validation if Jira Server API only returns a single user

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1087,10 +1087,16 @@ class JiraServerIntegration(IssueSyncIntegration):
                 total_queried_jira_users += len(possible_users)
 
                 if len(possible_users) == 1:
+                    # Assume the only user returned is a full match for the email,
+                    # as we search by username. This addresses visibility issues
+                    # in some cases where Jira server does not populate `emailAddress`
+                    # fields on user responses.
                     jira_user = possible_users[0]
                     break
 
                 for possible_user in possible_users:
+                    # Continue matching on email address, since we can't guarantee
+                    # a clean match.
                     email = possible_user.get("emailAddress")
 
                     if not email:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1063,7 +1063,7 @@ class JiraServerIntegration(IssueSyncIntegration):
             total_queried_jira_users = 0
             total_available_jira_emails = 0
             for ue in user.emails:
-                assert ue is not None, "Expected a valid user email, received empty string"
+                assert ue, "Expected a valid user email, received falsy value"
                 try:
                     possible_users = client.search_users_for_issue(external_issue.key, ue)
                 except ApiUnauthorized:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1063,6 +1063,7 @@ class JiraServerIntegration(IssueSyncIntegration):
             total_queried_jira_users = 0
             total_available_jira_emails = 0
             for ue in user.emails:
+                assert ue is not None, "Expected a valid user email, received empty string"
                 try:
                     possible_users = client.search_users_for_issue(external_issue.key, ue)
                 except ApiUnauthorized:
@@ -1084,8 +1085,13 @@ class JiraServerIntegration(IssueSyncIntegration):
                     continue
 
                 total_queried_jira_users += len(possible_users)
+
+                if len(possible_users) == 1:
+                    jira_user = possible_users[0]
+                    break
+
                 for possible_user in possible_users:
-                    email = possible_user.get("emailAddress") or possible_user.get("username")
+                    email = possible_user.get("emailAddress")
 
                     if not email:
                         continue

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -784,7 +784,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         assert assign_issue_response.request.body == b'{"name": "Alive Tofu"}'
 
     @responses.activate
-    def test_sync_assignee_outbound_no_email(self):
+    def test_sync_assignee_outbound_no_emails_for_multiple_users(self):
         user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
         external_issue = ExternalIssue.objects.create(
@@ -795,7 +795,14 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         responses.add(
             responses.GET,
             "https://jira.example.org/rest/api/2/user/assignable/search",
-            json=[{"accountId": "deadbeef123", "displayName": "Dead Beef"}],
+            json=[
+                {"accountId": "deadbeef123", "displayName": "Dead Beef", "name": "Beef"},
+                {
+                    "accountId": "alicetofu",
+                    "displayName": "Alice Tofu",
+                    "name": "Alice Tofu",
+                },
+            ],
         )
 
         with pytest.raises(IntegrationError) as e:
@@ -806,31 +813,28 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
         assert len(responses.calls) == 1
 
     @responses.activate
-    def test_sync_assignee_only_matching_username(self):
+    @patch("sentry.integrations.jira_server.integration.JiraServerClient.assign_issue")
+    def test_sync_assignee_outbound_no_email(self, mock_assign_issue):
         user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
+        fake_jira_user = {"accountId": "deadbeef123", "displayName": "Dead Beef", "name": "Beef"}
         external_issue = ExternalIssue.objects.create(
             organization_id=self.organization.id,
             integration_id=self.installation.model.id,
             key=issue_id,
         )
-        assign_issue_url = "https://jira.example.org/rest/api/2/issue/%s/assignee" % issue_id
         responses.add(
             responses.GET,
             "https://jira.example.org/rest/api/2/user/assignable/search",
-            json=[
-                {
-                    "accountId": "deadbeef123",
-                    "displayName": "Dead Beef",
-                    "username": "bob@example.com",
-                }
-            ],
+            json=[fake_jira_user],
         )
-        responses.add(responses.PUT, assign_issue_url, json={})
+
         self.installation.sync_assignee_outbound(external_issue, user)
 
-        # Assert that we properly assign the user
-        assert len(responses.calls) == 2
+        mock_assign_issue.assert_called_with(
+            issue_id,
+            "Beef",
+        )
 
     @responses.activate
     @patch("sentry.integrations.jira_server.integration.JiraServerClient.assign_issue")


### PR DESCRIPTION
Another attempted fix for Jira Server outbound sync:
- Removes the previous fallback case for username, as this likely doesn't fix anything
- Adds a new case that just accepts the first encountered user when we search by username
- Adds an assertion at the beginning of our sync flow asserting that the user we're attempting to assign to has only valid email addresses.