### PR TITLE
feat(query-builder): Add support for size filters in search query builder

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2183,6 +2183,141 @@ describe('SearchQueryBuilder', function () {
       });
     });
 
+    describe('size', function () {
+      const sizeFilterKeys: TagCollection = {
+        size: {
+          key: 'size',
+          name: 'Size',
+        },
+      };
+
+      const fieldDefinitionGetter: FieldDefinitionGetter = () => ({
+        valueType: FieldValueType.SIZE,
+        kind: FieldKind.FIELD,
+      });
+
+      const sizeProps: SearchQueryBuilderProps = {
+        ...defaultProps,
+        filterKeys: sizeFilterKeys,
+        filterKeySections: [],
+        fieldDefinitionGetter,
+      };
+
+      it('new size filters start with greater than operator and default value', async function () {
+        render(<SearchQueryBuilder {...sizeProps} />);
+        await userEvent.click(getLastInput());
+        await userEvent.click(screen.getByRole('option', {name: 'size'}));
+
+        // Should start with the > operator and a value of 10ms
+        expect(
+          await screen.findByRole('row', {name: 'size:>10bytes'})
+        ).toBeInTheDocument();
+      });
+
+      it('size filters have the correct operator options', async function () {
+        render(<SearchQueryBuilder {...sizeProps} initialQuery="size:>100bytes" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: size'})
+        );
+
+        expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'is not'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '>'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '<'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '>='})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '<='})).toBeInTheDocument();
+      });
+
+      it('size filters have the correct value suggestions', async function () {
+        render(<SearchQueryBuilder {...sizeProps} initialQuery="size:>100bytes" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: size'})
+        );
+
+        // Default suggestions
+        expect(await screen.findByRole('option', {name: '10bytes'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '10kib'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '10mib'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '10gib'})).toBeInTheDocument();
+
+        // Entering a number will show unit suggestions for that value
+        await userEvent.keyboard('7');
+        expect(await screen.findByRole('option', {name: '7bytes'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '7kib'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '7mib'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '7gib'})).toBeInTheDocument();
+      });
+
+      it('size filters can change operator', async function () {
+        render(<SearchQueryBuilder {...sizeProps} initialQuery="size:>10bytes" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: size'})
+        );
+
+        await userEvent.click(await screen.findByRole('option', {name: '<='}));
+
+        expect(
+          await screen.findByRole('row', {name: 'size:<=10bytes'})
+        ).toBeInTheDocument();
+      });
+
+      it('size filters do not allow invalid values', async function () {
+        render(<SearchQueryBuilder {...sizeProps} initialQuery="size:>10bytes" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: size'})
+        );
+
+        await userEvent.keyboard('a{Enter}');
+
+        // Should have the same value because "a" is not a numeric value
+        expect(screen.getByRole('row', {name: 'size:>10bytes'})).toBeInTheDocument();
+
+        await userEvent.keyboard('{Backspace}7kib{Enter}');
+
+        // Should accept "7kib" as a valid value
+        expect(await screen.findByRole('row', {name: 'size:>7kib'})).toBeInTheDocument();
+      });
+
+      it('size filters will add a default unit to entered numbers', async function () {
+        render(<SearchQueryBuilder {...sizeProps} initialQuery="size:>10bytes" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: size'})
+        );
+
+        await userEvent.keyboard('7{Enter}');
+
+        // Should accept "7" and add "bytes" as the default unit
+        expect(
+          await screen.findByRole('row', {name: 'size:>7bytes'})
+        ).toBeInTheDocument();
+      });
+
+      it('keeps previous value when confirming empty value', async function () {
+        const mockOnChange = jest.fn();
+        render(
+          <SearchQueryBuilder
+            {...sizeProps}
+            onChange={mockOnChange}
+            initialQuery="size:>10bytes"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: size'})
+        );
+        await userEvent.clear(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        );
+        await userEvent.keyboard('{enter}');
+
+        // Should have the same value
+        expect(
+          await screen.findByRole('row', {name: 'size:>10bytes'})
+        ).toBeInTheDocument();
+        expect(mockOnChange).not.toHaveBeenCalled();
+      });
+    });
+
     describe('percentage', function () {
       const percentageFilterKeys: TagCollection = {
         rate: {

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/duration/parser.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/duration/parser.tsx
@@ -6,7 +6,7 @@ type DurationTokenValue = {
 };
 
 /**
- * This parser is specifically meant for parsing the value of a duartion filter.
+ * This parser is specifically meant for parsing the value of a duration filter.
  * This should mostly mirror the grammar used for search syntax, but is a little
  * more lenient. This parser still returns a valid result if the duration does
  * not contain a unit which can be used to help create a valid duration or show

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/size/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/size/grammar.pegjs
@@ -1,0 +1,13 @@
+value = size_format
+
+size_format
+  = value:numeric
+    unit:size_unit? {
+      return {value, unit}
+    }
+
+size_unit = bit_unit / byte_unit
+
+bit_unit  = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
+byte_unit  = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
+numeric   = [0-9]+ ("." [0-9]*)? { return text(); }

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/size/parser.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/size/parser.tsx
@@ -1,0 +1,21 @@
+import grammar from './grammar.pegjs';
+
+type SizeTokenValue = {
+  value: string;
+  unit?: string;
+};
+
+/**
+ * This parser is specifically meant for parsing the value of a size filter.
+ * This should mostly mirror the grammar used for search syntax, but is a little
+ * more lenient. This parser still returns a valid result if the size does
+ * not contain a unit which can be used to help create a valid size or show
+ * search suggestions.
+ */
+export function parseFilterValueSize(query: string): SizeTokenValue | null {
+  try {
+    return grammar.parse(query);
+  } catch (e) {
+    return null;
+  }
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/size.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/size.tsx
@@ -1,0 +1,51 @@
+import {parseFilterValueSize} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/size/parser';
+import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
+
+const SIZE_UNIT_SUGGESTIONS = ['bytes', 'kib', 'mib', 'gib'] as const;
+
+const DEFAULT_SIZE_SUGGESTIONS: SuggestionSection[] = [
+  {
+    sectionText: '',
+    suggestions: SIZE_UNIT_SUGGESTIONS.map(unit => ({value: `10${unit}`})),
+  },
+];
+
+export function getSizeSuggestions(
+  inputValue: string,
+  token: TokenResult<Token.FILTER>
+): SuggestionSection[] {
+  if (!inputValue) {
+    const currentValue =
+      token.value.type === Token.VALUE_DURATION ? token.value.value : null;
+
+    if (!currentValue) {
+      return DEFAULT_SIZE_SUGGESTIONS;
+    }
+
+    return [
+      {
+        sectionText: '',
+        suggestions: SIZE_UNIT_SUGGESTIONS.map(unit => ({
+          value: `${currentValue}${unit}`,
+        })),
+      },
+    ];
+  }
+
+  const parsed = parseFilterValueSize(inputValue);
+
+  if (parsed) {
+    return [
+      {
+        sectionText: '',
+        suggestions: SIZE_UNIT_SUGGESTIONS.map(unit => ({
+          value: `${parsed.value}${unit}`,
+        })),
+      },
+    ];
+  }
+
+  // If the value doesn't contain any valid number or duration, don't show any suggestions
+  return [];
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
@@ -6,6 +6,7 @@ import {DEFAULT_BOOLEAN_SUGGESTIONS} from 'sentry/components/searchQueryBuilder/
 import {getRelativeDateSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
 import {getDurationSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/duration';
 import {getNumericSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric';
+import {getSizeSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/size';
 import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 import {FieldValueType} from 'sentry/utils/fields';
@@ -28,6 +29,8 @@ export function getValueSuggestions({
       return getNumericSuggestions(filterValue);
     case FieldValueType.DURATION:
       return getDurationSuggestions(filterValue, token);
+    case FieldValueType.SIZE:
+      return getSizeSuggestions(filterValue, token);
     case FieldValueType.PERCENTAGE:
       return [];
     case FieldValueType.BOOLEAN:

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
@@ -1,6 +1,7 @@
 import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
 import {parseFilterValueDuration} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/duration/parser';
 import {parseFilterValuePercentage} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/percentage/parser';
+import {parseFilterValueSize} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/size/parser';
 import {escapeTagValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {DEFAULT_BOOLEAN_SUGGESTIONS} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean';
 import {getRelativeDateSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
@@ -78,6 +79,17 @@ export function cleanFilterValue({
       // Default to ms if no unit is provided
       if (!parsed.unit) {
         return `${parsed.value}ms`;
+      }
+      return value;
+    }
+    case FieldValueType.SIZE: {
+      const parsed = parseFilterValueSize(value);
+      if (!parsed) {
+        return null;
+      }
+      // Default to ms if no unit is provided
+      if (!parsed.unit) {
+        return `${parsed.value}bytes`;
       }
       return value;
     }

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -54,6 +54,8 @@ export function getDefaultValueForValueType(valueType: FieldValueType | null): s
       return '-24h';
     case FieldValueType.DURATION:
       return '10ms';
+    case FieldValueType.SIZE:
+      return '10bytes';
     case FieldValueType.PERCENTAGE:
       return '0.5';
     case FieldValueType.STRING:
@@ -122,6 +124,7 @@ export function getInitialFilterText(
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:
+    case FieldValueType.SIZE:
     case FieldValueType.PERCENTAGE:
       return `${keyText}:>${defaultValue}`;
     case FieldValueType.STRING:

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -28,6 +28,7 @@ function getSearchConfigFromKeys(
     dateKeys: new Set<string>(),
     durationKeys: new Set<string>(),
     percentageKeys: new Set<string>(),
+    sizeKeys: new Set<string>(),
   } satisfies Partial<SearchConfig>;
 
   for (const key in keys) {
@@ -54,6 +55,9 @@ function getSearchConfigFromKeys(
         break;
       case FieldValueType.DURATION:
         config.durationKeys.add(key);
+        break;
+      case FieldValueType.SIZE:
+        config.sizeKeys.add(key);
         break;
       default:
         break;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -383,7 +383,9 @@ export class TokenConverter {
     isNumeric: (key: string) =>
       this.config.numericKeys.has(key) ||
       isMeasurement(key) ||
-      isSpanOperationBreakdownField(key),
+      isSpanOperationBreakdownField(key) ||
+      this.keyValidation.isDuration(key) ||
+      this.keyValidation.isSize(key),
     isBoolean: (key: string) => this.config.booleanKeys.has(key),
     isPercentage: (key: string) => this.config.percentageKeys.has(key),
     isDate: (key: string) => this.config.dateKeys.has(key),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -203,6 +203,12 @@ export enum SpanOpBreakdown {
   SPANS_UI = 'spans.ui',
 }
 
+export enum SpanHttpField {
+  HTTP_DECODED_RESPONSE_CONTENT_LENGTH = 'http.decoded_response_content_length',
+  HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
+  HTTP_RESPONSE_TRANSFER_SIZE = 'http.response_transfer_size',
+}
+
 export enum AggregationKey {
   COUNT = 'count',
   COUNT_UNIQUE = 'count_unique',
@@ -1798,9 +1804,28 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   },
 };
 
+const SPAN_HTTP_FIELD_DEFINITIONS: Record<SpanHttpField, FieldDefinition> = {
+  [SpanHttpField.HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: {
+    desc: t('Content length of the decoded response'),
+    kind: FieldKind.MEASUREMENT,
+    valueType: FieldValueType.SIZE,
+  },
+  [SpanHttpField.HTTP_RESPONSE_CONTENT_LENGTH]: {
+    desc: t('Content length of the response'),
+    kind: FieldKind.MEASUREMENT,
+    valueType: FieldValueType.SIZE,
+  },
+  [SpanHttpField.HTTP_RESPONSE_TRANSFER_SIZE]: {
+    desc: t('Transfer size of the response'),
+    kind: FieldKind.MEASUREMENT,
+    valueType: FieldValueType.SIZE,
+  },
+};
+
 const SPAN_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   ...EVENT_FIELD_DEFINITIONS,
   ...SPAN_AGGREGATION_FIELDS,
+  ...SPAN_HTTP_FIELD_DEFINITIONS,
 };
 
 export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [

--- a/static/app/views/metrics/utils/index.spec.tsx
+++ b/static/app/views/metrics/utils/index.spec.tsx
@@ -152,6 +152,7 @@ describe('ensureQuotedTextFilters', () => {
     expect(
       ensureQuotedTextFilters('transaction.duration:100', {
         numericKeys: new Set([]),
+        durationKeys: new Set([]),
       })
     ).toBe('transaction.duration:"100"');
   });


### PR DESCRIPTION
Support for size filters was partially there but not fully complete. This brings it on par with the other types.