### PR TITLE
feat(replay): Add an error message when network response body is blob

### DIFF
--- a/static/app/views/replays/detail/network/details/content.tsx
+++ b/static/app/views/replays/detail/network/details/content.tsx
@@ -73,6 +73,13 @@ export default function NetworkDetailsContent(props: Props) {
           {output === Output.BODY_PARSE_ERROR && (
             <ParseError>{t('The SDK was unable to parse the response body.')}</ParseError>
           )}
+          {output === Output.UNPARSEABLE_BODY_TYPE && (
+            <ParseError>
+              {t(
+                'This request body contains an unsupported type and was not captured. For example, blobs are unsupported as they are not human-readable.'
+              )}
+            </ParseError>
+          )}
           {output === Output.BODY_PARSE_TIMEOUT && (
             <ParseError>
               {t(

--- a/static/app/views/replays/detail/network/details/getOutputType.tsx
+++ b/static/app/views/replays/detail/network/details/getOutputType.tsx
@@ -9,6 +9,7 @@ export enum Output {
   BODY_SKIPPED = 'body_skipped',
   BODY_PARSE_ERROR = 'body_parse_error',
   BODY_PARSE_TIMEOUT = 'body_parse_timeout',
+  UNPARSEABLE_BODY_TYPE = 'unparseable_body_type',
   DATA = 'data',
 }
 
@@ -53,6 +54,11 @@ export default function getOutputType({isSetup, item, visibleTab}: Args): Output
 
   if (respWarnings?.includes('BODY_PARSE_TIMEOUT')) {
     return Output.BODY_PARSE_TIMEOUT;
+  }
+
+  if (respWarnings?.includes('UNPARSEABLE_BODY_TYPE')) {
+    // Differs from BODY_PARSE_ERROR in that we did not attempt to parse it
+    return Output.UNPARSEABLE_BODY_TYPE;
   }
 
   if (isReqUrlSkipped || isRespUrlSkipped) {


### PR DESCRIPTION
SDK sends an `UNPARSEABLE_BODY_TYPE` warning but the UI does not handle it. This component defaults incorrectly defaults to SDK instructions when a warning type is not explicitly handled, we should refactor to make a generic error message.
