### PR TITLE
chore(seer grouping): Remove redundant empty stacktrace string check

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -229,22 +229,6 @@ def get_seer_similar_issues(
         get_stacktrace_string(get_grouping_info_from_variants(variants)),
     )
 
-    if not stacktrace_string:
-        # TODO: remove this log once we've confirmed it isn't happening
-        logger.info(
-            "get_seer_similar_issues.empty_stacktrace",
-            extra={
-                "event_id": event.event_id,
-                "project_id": event.project.id,
-                "stacktrace_string": stacktrace_string,
-            },
-        )
-        similar_issues_metadata_empty = {
-            "results": [],
-            "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-        }
-        return (similar_issues_metadata_empty, None)
-
     request_data: SimilarIssuesEmbeddingsRequest = {
         "event_id": event.event_id,
         "hash": event_hash,

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -320,34 +320,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                 None,
             )
 
-    @patch("sentry.grouping.ingest.seer.logger")
-    def test_returns_no_grouphash_and_empty_metadata_if_empty_stacktrace(
-        self, mock_logger: MagicMock
-    ) -> None:
-        expected_metadata = {
-            "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
-            "results": [],
-        }
-
-        for stacktrace in ["", None]:
-            self.new_event.data["stacktrace_string"] = ""
-            with patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-                return_value=[],
-            ):
-                assert get_seer_similar_issues(self.new_event, self.variants) == (
-                    expected_metadata,
-                    None,
-                )
-            mock_logger.info.assert_called_with(
-                "get_seer_similar_issues.empty_stacktrace",
-                extra={
-                    "event_id": self.new_event.event_id,
-                    "project_id": self.new_event.project.id,
-                    "stacktrace_string": "",
-                },
-            )
-
 
 class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
 


### PR DESCRIPTION
This removes the code in `get_seer_similar_issues` checking for an empty stacktrace string now that we have a separate helper (`_has_empty_stacktrace_string`) to do that, which is called in `should_call_seer_for_grouping`. (We can confirm that this code is never getting hit because we never see any instances of the included log getting triggered.) It also removes the associated test.