### PR TITLE
feat(grouping): Add grouphash fingerprint helpers

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -425,3 +425,22 @@ def _get_fallback_hashing_metadata(
         reason = "other"
 
     return {"fallback_reason": reason}
+
+
+def check_grouphashes_for_positive_fingerprint_match(
+    grouphash1: GroupHash, grouphash2: GroupHash
+) -> bool:
+    """
+    Given two grouphashes, see if a) they both have associated fingerprints, and b) if their
+    resolved fingerprints match.
+
+    Returns False if either grouphash doesn't have an associated fingerprint. (In other words, both
+    fingerprints being None doesn't count as a match.)
+    """
+    fingerprint1 = grouphash1.get_associated_fingerprint()
+    fingerprint2 = grouphash2.get_associated_fingerprint()
+
+    if not fingerprint1 or not fingerprint2:
+        return False
+
+    return fingerprint1 == fingerprint2

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -43,7 +43,18 @@ def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingCompon
     return result.hexdigest()
 
 
-def get_fingerprint_type(fingerprint: list[str]) -> Literal["default", "hybrid", "custom"]:
+def get_fingerprint_type(
+    fingerprint: list[str] | None,
+) -> Literal["default", "hybrid", "custom"] | None:
+    """
+    Examine a fingerprint to determine if it's custom, hybrid, or the default fingerprint.
+
+    Accepts (and then returns) None for convenience, so the fingerprint's existence doesn't have to
+    be separately checked.
+    """
+    if not fingerprint:
+        return None
+
     return (
         "default"
         if len(fingerprint) == 1 and is_default_fingerprint_var(fingerprint[0])

--- a/src/sentry/types/grouphash_metadata.py
+++ b/src/sentry/types/grouphash_metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, TypeIs
 
 # NOTE: The structure in these metadata types is intentionaly flat, to make it easier to query in
 # Redash or BigQuery, and they are all merged into a single flat JSON blob (which is then stored in
@@ -157,3 +157,16 @@ HashingMetadata = (
     | ChecksumHashingMetadata
     | FallbackHashingMetadata
 )
+HashingMetadataWithFingerprint = (
+    FingerprintHashingMetadata
+    | SaltedMessageHashingMetadata
+    | SaltedStacktraceHashingMetadata
+    | SaltedSecurityHashingMetadata
+    | SaltedTemplateHashingMetadata
+)
+
+
+def has_fingerprint_data(
+    hashing_metadata: HashingMetadata,
+) -> TypeIs[HashingMetadataWithFingerprint]:
+    return "fingerprint" in hashing_metadata

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -8,15 +8,18 @@ import pytest
 from sentry.eventstore.models import Event
 from sentry.grouping.component import DefaultGroupingComponent, MessageGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import (
+    check_grouphashes_for_positive_fingerprint_match,
     get_hash_basis_and_metadata,
     record_grouphash_metadata_metrics,
 )
 from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.variants import ComponentVariant
+from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata, HashBasis
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 from sentry.utils import json
@@ -182,3 +185,34 @@ def _assert_and_snapshot_results(
             __file__, input_file, "test_metadata_from_variants", config_name
         ),
     )
+
+
+class GroupHashMetadataTest(TestCase):
+    def test_check_grouphashes_for_positive_fingerprint_match(self):
+        grouphash1 = GroupHash.objects.create(hash="dogs", project_id=self.project.id)
+        grouphash2 = GroupHash.objects.create(hash="are great", project_id=self.project.id)
+
+        for fingerprint1, fingerprint2, expected_result in [
+            # All combos of default, hybrid (matching or not), custom (matching or not), and missing
+            # fingerprints
+            (["{{ default }}"], ["{{ default }}"], True),
+            (["{{ default }}"], ["{{ default }}", "maisey"], False),
+            (["{{ default }}"], ["charlie"], False),
+            (["{{ default }}"], None, False),
+            (["{{ default }}", "maisey"], ["{{ default }}", "maisey"], True),
+            (["{{ default }}", "maisey"], ["{{ default }}", "charlie"], False),
+            (["{{ default }}", "maisey"], ["charlie"], False),
+            (["{{ default }}", "maisey"], None, False),
+            (["charlie"], ["charlie"], True),
+            (["charlie"], ["maisey"], False),
+            (["charlie"], None, False),
+            (None, None, False),
+        ]:
+            with (
+                patch.object(grouphash1, "get_associated_fingerprint", return_value=fingerprint1),
+                patch.object(grouphash2, "get_associated_fingerprint", return_value=fingerprint2),
+            ):
+                assert (
+                    check_grouphashes_for_positive_fingerprint_match(grouphash1, grouphash2)
+                    == expected_result
+                ), f"Case {fingerprint1}, {fingerprint2} failed"

--- a/tests/sentry/models/test_grouphash.py
+++ b/tests/sentry/models/test_grouphash.py
@@ -1,0 +1,94 @@
+from sentry.models.grouphash import GroupHash
+from sentry.models.grouphashmetadata import GroupHashMetadata
+from sentry.testutils.cases import TestCase
+from sentry.types.grouphash_metadata import (
+    FingerprintHashingMetadata,
+    SaltedStacktraceHashingMetadata,
+    StacktraceHashingMetadata,
+)
+from sentry.utils import json
+
+
+class GetAssociatedFingerprintTest(TestCase):
+    def test_simple(self):
+        raw_fingerprint = ["maisey", "charlie", "{{ message }}"]
+        resolved_fingerprint = ["maisey", "charlie", "Dogs are great!"]
+
+        hashing_metadata: FingerprintHashingMetadata = {
+            "fingerprint": json.dumps(resolved_fingerprint),
+            "fingerprint_source": "client",
+            "is_hybrid_fingerprint": False,
+            "client_fingerprint": json.dumps(raw_fingerprint),
+        }
+
+        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
+
+        assert grouphash.get_associated_fingerprint() == resolved_fingerprint
+
+    def test_hybrid_fingerprint(self):
+        """
+        Test that it works for events grouped on things other than fingerprint.
+        """
+        raw_fingerprint = ["{{ default }}", "maisey", "charlie", "{{ message }}"]
+        resolved_fingerprint = ["{{ default }}", "maisey", "charlie", "Dogs are great!"]
+
+        hashing_metadata: SaltedStacktraceHashingMetadata = {
+            "stacktrace_type": "in-app",
+            "stacktrace_location": "exception",
+            "num_stacktraces": 1,
+            "fingerprint": json.dumps(resolved_fingerprint),
+            "fingerprint_source": "client",
+            "is_hybrid_fingerprint": True,
+            "client_fingerprint": json.dumps(raw_fingerprint),
+        }
+
+        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
+
+        assert grouphash.get_associated_fingerprint() == resolved_fingerprint
+
+    def test_stringified_fingerprint(self):
+        """
+        Test handling of fingerprint metadata from back when we were stringifying rather than
+        jsonifying the fingerprint value.
+        """
+        raw_fingerprint = ["maisey", "charlie", "{{ message }}"]
+        resolved_fingerprint = ["maisey", "charlie", "Dogs are great!"]
+
+        hashing_metadata: FingerprintHashingMetadata = {
+            "fingerprint": str(resolved_fingerprint),
+            "fingerprint_source": "client",
+            "is_hybrid_fingerprint": False,
+            "client_fingerprint": str(raw_fingerprint),
+        }
+
+        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
+
+        assert grouphash.get_associated_fingerprint() is None
+
+    def test_no_metadata(self):
+        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+
+        assert grouphash.metadata is None
+        assert grouphash.get_associated_fingerprint() is None
+
+    def test_no_hashing_metadata(self):
+        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        GroupHashMetadata.objects.create(grouphash=grouphash)
+
+        assert grouphash.metadata and grouphash.metadata.hashing_metadata is None
+        assert grouphash.get_associated_fingerprint() is None
+
+    def test_no_fingerprint(self):
+        hashing_metadata: StacktraceHashingMetadata = {
+            "stacktrace_type": "in-app",
+            "stacktrace_location": "exception",
+            "num_stacktraces": 1,
+        }
+
+        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
+
+        assert grouphash.get_associated_fingerprint() is None


### PR DESCRIPTION
This adds a `GroupHash` method (`get_associated_fingerprint`) and a helper function (`check_grouphashes_for_positive_fingerprint_match`), both of which use fingerprints stored in the metadata of grouphashes generated by hybrid or custom fingerprints. It also adds a typeguard for such grouphashes, and refactors an existing fingerprint helper (`get_fingerprint_type`) to be able to handle `None` as an input.