### PR TITLE
ref(frontend-workflow): Increase jest timeout minutes

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -82,7 +82,7 @@ jobs:
     # If you change the runs-on image, you must also change the runner in jest-balance.yml
     # so that the balancer runs in the same environment as the tests.
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 35
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)


### PR DESCRIPTION
This is a bandage solution to fix [this](https://github.com/getsentry/sentry/actions/runs/13150634047/job/36701757426) until we can make our tests more efficient or find a better alternative