### PR TITLE
fix(dynamic-sampling): fix integrity error for deleted projects in DS on AM3

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1051,8 +1051,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         rebalanced_projects = calculate_sample_rates_of_projects(
             org_id, projects_with_tx_count_and_rates
         )
-        # get all active projects associated with the org
-        # filter rebalanced_projects by those where the project actually exists
         project_ids = Project.objects.filter(organization_id=org_id).values_list("id", flat=True)
 
         if rebalanced_projects is not None:

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1053,11 +1053,11 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         )
         # get all active projects associated with the org
         # filter rebalanced_projects by those where the project actually exists
-        project_ids = Project.objects.filter(organization_id=org_id).values("id").distinct()
+        project_ids = Project.objects.filter(organization_id=org_id).values_list("id", flat=True)
 
         if rebalanced_projects is not None:
             for rebalanced_item in rebalanced_projects:
-                if rebalanced_item.id in project_ids:
+                if int(rebalanced_item.id) in project_ids:
                     ProjectOption.objects.create_or_update(
                         project_id=rebalanced_item.id,
                         key="sentry:target_sample_rate",

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1053,9 +1053,11 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             org_id, projects_with_tx_count_and_rates
         )
 
-        project_ids = Project.objects.filter(
-            organization_id=org_id, status=ObjectStatus.ACTIVE
-        ).values_list("id", flat=True)
+        project_ids = set(
+            Project.objects.filter(organization_id=org_id, status=ObjectStatus.ACTIVE).values_list(
+                "id", flat=True
+            )
+        )
 
         if rebalanced_projects is not None:
             for rebalanced_item in rebalanced_projects:

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -65,6 +65,7 @@ from sentry.constants import (
     SENSITIVE_FIELDS_DEFAULT,
     TARGET_SAMPLE_RATE_DEFAULT,
     UPTIME_AUTODETECTION,
+    ObjectStatus,
 )
 from sentry.datascrubbing import validate_pii_config_update, validate_pii_selectors
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
@@ -90,6 +91,7 @@ from sentry.models.avatars.organization_avatar import OrganizationAvatar
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization, OrganizationStatus
+from sentry.models.project import Project
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import (
     RpcOrganization,
@@ -1050,7 +1052,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         rebalanced_projects = calculate_sample_rates_of_projects(
             org_id, projects_with_tx_count_and_rates
         )
-        project_ids = [project.id for project in self.get_projects(request, organization)]
+
+        project_ids = Project.objects.filter(
+            organization_id=org_id, status=ObjectStatus.ACTIVE
+        ).values_list("id", flat=True)
 
         if rebalanced_projects is not None:
             for rebalanced_item in rebalanced_projects:


### PR DESCRIPTION
The method _compute_project_target_sample_rate that is called in the OrganizationDetailsEndpoint currently queries metrics for all projects that ingested data in the past 30d. When a project is deleted, but had ingested data in the prior 30 day period, this causes an error when writing the ProjectOption, because the project_id cannot be found. 
This PR:
- reproduces the error in a test
- fixes the error by filtering the rebalanced projects for existing ones before committing them to the database

- Closes https://github.com/getsentry/projects/issues/666
- Fixes [SENTRY-3NBS](https://sentry.sentry.io/issues/6272894699/)