### PR TITLE
chore: upgrade sentry-kafka-schemas

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.19.9
-sentry-kafka-schemas>=1.0.2
+sentry-kafka-schemas>=1.0.3
 sentry-ophio==1.0.0
 sentry-protos>=0.1.58
 sentry-redis-tools>=0.1.7

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sentry-devenv==1.14.2
 sentry-forked-django-stubs==5.1.2.post1
 sentry-forked-djangorestframework-stubs==3.15.2.post2
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.0.2
+sentry-kafka-schemas==1.0.3
 sentry-ophio==1.0.0
 sentry-protos==0.1.58
 sentry-redis-tools==0.1.7

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.19.9
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.0.2
+sentry-kafka-schemas==1.0.3
 sentry-ophio==1.0.0
 sentry-protos==0.1.58
 sentry-redis-tools==0.1.7


### PR DESCRIPTION
primarily for new uptime failure types added in https://github.com/getsentry/sentry-kafka-schemas/pull/377