### PR TITLE
ref(forms): Remove function variants in FormGroupProps

### DIFF
--- a/static/app/components/forms/fieldGroup/index.tsx
+++ b/static/app/components/forms/fieldGroup/index.tsx
@@ -51,10 +51,7 @@ function FieldGroup({
     style,
   } = props;
 
-  const isVisible = typeof visible === 'function' ? visible(props) : visible;
-  const isDisabled = typeof disabled === 'function' ? disabled(props) : disabled;
-
-  if (!isVisible) {
+  if (!visible) {
     return null;
   }
 
@@ -62,7 +59,6 @@ function FieldGroup({
     <ControlState error={error} isSaving={isSaving} isSaved={isSaved} />
   );
 
-  const helpElement = typeof help === 'function' ? help(props) : help;
   const shouldRenderLabel = !hideLabel && !!label;
 
   // Provide an `aria-label` to the FieldDescription label if our label is a
@@ -83,32 +79,32 @@ function FieldGroup({
       style={style}
     >
       <FieldDescription
-        displayNone={!shouldRenderLabel && !helpElement}
+        displayNone={!shouldRenderLabel && !help}
         inline={inline}
         htmlFor={id}
         aria-label={ariaLabel}
       >
         {shouldRenderLabel && (
-          <FieldLabel disabled={isDisabled}>
+          <FieldLabel disabled={disabled}>
             <span>
               {label}
               {required && <FieldRequiredBadge />}
             </span>
-            {helpElement && showHelpInTooltip && (
+            {help && showHelpInTooltip && (
               <FieldQuestion>
                 <QuestionTooltip
                   position="top"
                   size="sm"
                   {...(showHelpInTooltip !== true ? showHelpInTooltip : {})}
-                  title={helpElement}
+                  title={help}
                 />
               </FieldQuestion>
             )}
           </FieldLabel>
         )}
-        {helpElement && !showHelpInTooltip && (
+        {help && !showHelpInTooltip && (
           <FieldHelp id={helpId} stacked={stacked} inline={inline}>
-            {helpElement}
+            {help}
           </FieldHelp>
         )}
       </FieldDescription>

--- a/static/app/components/forms/fieldGroup/types.tsx
+++ b/static/app/components/forms/fieldGroup/types.tsx
@@ -23,11 +23,11 @@ export interface FieldGroupProps {
   /**
    * Should field be disabled?
    */
-  disabled?: boolean | ((props: FieldGroupProps) => boolean);
+  disabled?: boolean;
   /**
    * Produces a question tooltip on the field, explaining why it is disabled
    */
-  disabledReason?: React.ReactNode | ((props: FieldGroupProps) => React.ReactNode);
+  disabledReason?: React.ReactNode;
   /**
    * Display the  error indicator
    */
@@ -46,7 +46,7 @@ export interface FieldGroupProps {
   /**
    * Help or description of the field
    */
-  help?: React.ReactNode | ((props: FieldGroupProps) => React.ReactNode);
+  help?: React.ReactNode;
   /**
    * Hide the fields control state
    */
@@ -109,7 +109,7 @@ export interface FieldGroupProps {
   /**
    * Should field be visible
    */
-  visible?: boolean | ((props: FieldGroupProps) => boolean);
+  visible?: boolean;
 }
 
 /**

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -386,14 +386,9 @@ function FormField(props: FormFieldProps) {
                 const error = model.getError(name);
                 const value = model.getValue(name);
 
-                const isVisible =
-                  typeof fieldProps.visible === 'function'
-                    ? fieldProps.visible({...props, ...fieldProps} as ResolvedProps)
-                    : true;
-
                 return (
                   <Fragment>
-                    {isVisible
+                    {fieldProps.visible
                       ? selectionInfoFunction({...fieldProps, error, value})
                       : null}
                   </Fragment>


### PR DESCRIPTION
We already override these props on form fields with function variants, there's no need to allow for these to be functions in the form fields themselves.