### PR TITLE
chore(slack): add `restricted_action` halt error category

### DIFF
--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -18,6 +18,7 @@ SLACK_SDK_ERROR_CATEGORIES = (
     CHANNEL_ARCHIVED := SlackSdkErrorCategory("is_archived"),
     MODAL_NOT_FOUND := SlackSdkErrorCategory("not_found"),
     RATE_LIMITED := SlackSdkErrorCategory("ratelimited"),
+    RESTRICTED_ACTION := SlackSdkErrorCategory("restricted_action"),
 )
 
 """
@@ -28,6 +29,7 @@ SLACK_SDK_HALT_ERROR_CATEGORIES = (
     CHANNEL_NOT_FOUND,
     CHANNEL_ARCHIVED,
     RATE_LIMITED,
+    RESTRICTED_ACTION,
 )
 
 _CATEGORIES_BY_MESSAGE = {c.message: c for c in SLACK_SDK_ERROR_CATEGORIES}


### PR DESCRIPTION
According to https://api.slack.com/methods/chat.postMessage, `restricted_action` error means a workspace preference prevents the authenticated user from posting, which should be categorized as a halt