### PR TITLE
fix(rpc): Remove incorrect group by in other series

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -288,7 +288,7 @@ def run_top_events_timeseries_query(
         params,
         query_string,
         y_axes,
-        groupby_columns_without_project,
+        [],  # in the other series, we want eveything in a single group, so remove the group by
         referrer,
         config,
         granularity_secs,


### PR DESCRIPTION
When making the request for the other series, make sure to remove the group by otherwise the results will split all remaining data into groups. This is both wrong and likely to cause OOMs in clickhouse.