### PR TITLE
fix(uptime): Consider underscan buckets when filtering MAXIMUM_BUCKETS

### DIFF
--- a/static/app/components/checkInTimeline/checkInTooltip.spec.tsx
+++ b/static/app/components/checkInTimeline/checkInTooltip.spec.tsx
@@ -23,6 +23,7 @@ const tickConfig: TimeWindowConfig = {
     interval: 0,
     timelineUnderscanWidth: 0,
     totalBuckets: 0,
+    underscanPeriod: 0,
   },
   showUnderscanHelp: false,
 };

--- a/static/app/components/checkInTimeline/types.tsx
+++ b/static/app/components/checkInTimeline/types.tsx
@@ -38,6 +38,12 @@ export interface RollupConfig {
    * How many total number of buckets are we fitting into our timeline
    */
   totalBuckets: number;
+  /**
+   * When there is an underscan we also will likely want to query the
+   * additional time range for that underscan, this is the additional period of
+   * time that the underscan represents in seconds.
+   */
+  underscanPeriod: number;
 }
 
 export interface TimeWindowConfig {

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
@@ -19,6 +19,8 @@ describe('getConfigFromTimeRange', function () {
         interval: 15,
         timelineUnderscanWidth: 0,
         totalBuckets: 20,
+        underscanBuckets: 0,
+        underscanPeriod: 0,
       },
       showUnderscanHelp: false,
       intervals: {
@@ -45,6 +47,8 @@ describe('getConfigFromTimeRange', function () {
         interval: 60,
         timelineUnderscanWidth: 77,
         totalBuckets: 1446,
+        underscanBuckets: 154,
+        underscanPeriod: 9240,
       },
       showUnderscanHelp: false,
       intervals: {
@@ -71,6 +75,8 @@ describe('getConfigFromTimeRange', function () {
         interval: 900,
         timelineUnderscanWidth: 20,
         totalBuckets: 60,
+        underscanBuckets: 1,
+        underscanPeriod: 900,
       },
       intervals: {
         normalMarkerInterval: 120,
@@ -98,6 +104,8 @@ describe('getConfigFromTimeRange', function () {
         interval: 1800,
         timelineUnderscanWidth: 56,
         totalBuckets: 1488,
+        underscanBuckets: 112,
+        underscanPeriod: 201600,
       },
       // 5 days in between each time label
       intervals: {
@@ -126,6 +134,8 @@ describe('getConfigFromTimeRange', function () {
         interval: 900,
         timelineUnderscanWidth: 16,
         totalBuckets: 56,
+        underscanBuckets: 1,
+        underscanPeriod: 900,
       },
       showUnderscanHelp: false,
       intervals: {

--- a/static/app/components/checkInTimeline/utils/mergeBuckets.spec.tsx
+++ b/static/app/components/checkInTimeline/utils/mergeBuckets.spec.tsx
@@ -19,6 +19,7 @@ describe.skip('mergeBucketsWithStats', function () {
     interval: 0,
     timelineUnderscanWidth: 0,
     totalBuckets: 0,
+    underscanPeriod: 0,
   };
 
   it('does not generate ticks less than 3px width', function () {

--- a/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
@@ -20,18 +20,15 @@ interface Options {
  * Fetches Uptime Monitor stats
  */
 export function useUptimeMonitorStats({ruleIds, timeWindowConfig}: Options) {
-  const {start, end, timelineWidth, rollupConfig} = timeWindowConfig;
+  const {start, end, rollupConfig} = timeWindowConfig;
 
-  // Add the underscan to our selection time
-  const additionalInterval =
-    (rollupConfig.timelineUnderscanWidth / rollupConfig.bucketPixels) *
-    rollupConfig.interval;
-
-  // XXX(epurkhiser): We are dropping 1 bucket worth of data on the right side
-  // to account for the fact that this bucket is actually over-scan becauase
-  // the query on the backend is inclusive.
   const until =
-    Math.floor(end.getTime() / 1000) + additionalInterval - rollupConfig.interval;
+    Math.floor(end.getTime() / 1000) +
+    rollupConfig.underscanPeriod -
+    // XXX(epurkhiser): We are dropping 1 bucket worth of data on the right
+    // side to account for the fact that this bucket is actually over-scan
+    // becauase the query on the backend is inclusive.
+    rollupConfig.interval;
 
   const selectionQuery = {
     since: Math.floor(start.getTime() / 1000),
@@ -57,7 +54,7 @@ export function useUptimeMonitorStats({ruleIds, timeWindowConfig}: Options) {
     ],
     {
       staleTime: 0,
-      enabled: timelineWidth > 0,
+      enabled: rollupConfig.totalBuckets > 0,
     }
   );
 }

--- a/static/app/views/monitors/utils/useMonitorStats.tsx
+++ b/static/app/views/monitors/utils/useMonitorStats.tsx
@@ -20,18 +20,15 @@ interface Options {
  * Fetches Monitor stats
  */
 export function useMonitorStats({monitors, timeWindowConfig}: Options) {
-  const {start, end, timelineWidth, rollupConfig} = timeWindowConfig;
+  const {start, end, rollupConfig} = timeWindowConfig;
 
-  // Add the underscan to our selection time
-  const additionalInterval =
-    (rollupConfig.timelineUnderscanWidth / rollupConfig.bucketPixels) *
-    rollupConfig.interval;
-
-  // XXX(epurkhiser): We are dropping 1 bucket worth of data on the right side
-  // to account for the fact that this bucket is actually over-scan becauase
-  // the query on the backend is inclusive.
   const until =
-    Math.floor(end.getTime() / 1000) + additionalInterval - rollupConfig.interval;
+    Math.floor(end.getTime() / 1000) +
+    rollupConfig.underscanPeriod -
+    // XXX(epurkhiser): We are dropping 1 bucket worth of data on the right
+    // side to account for the fact that this bucket is actually over-scan
+    // becauase the query on the backend is inclusive.
+    rollupConfig.interval;
 
   const selectionQuery = {
     since: Math.floor(start.getTime() / 1000),
@@ -58,7 +55,7 @@ export function useMonitorStats({monitors, timeWindowConfig}: Options) {
     ],
     {
       staleTime: 0,
-      enabled: timelineWidth > 0,
+      enabled: rollupConfig.totalBuckets > 0,
     }
   );
 }


### PR DESCRIPTION
This ensure we don't try and query for more buckets than the `MAXIMUM_BUCKETS` limit.