### PR TITLE
feat(icons): Add double chevron

### DIFF
--- a/static/app/icons/iconChevron.tsx
+++ b/static/app/icons/iconChevron.tsx
@@ -14,9 +14,7 @@ const CHEVRON_PATH = (
   <path d="M14,11.75a.74.74,0,0,1-.53-.22L8,6.06,2.53,11.53a.75.75,0,0,1-1.06-1.06l6-6a.75.75,0,0,1,1.06,0l6,6a.75.75,0,0,1,0,1.06A.74.74,0,0,1,14,11.75Z" />
 );
 
-function getChevronPath(props: Props) {
-  const {isCircled = false, isDouble = false} = props;
-
+function getChevronPath({isCircled, isDouble}: Pick<Props, 'isCircled' | 'isDouble'>) {
   if (isCircled) {
     return (
       <Fragment>
@@ -39,7 +37,7 @@ function getChevronPath(props: Props) {
 }
 
 const IconChevron = forwardRef<SVGSVGElement, Props>(
-  ({direction = 'up', ...props}, ref) => {
+  ({isDouble, isCircled, direction = 'up', ...props}, ref) => {
     const theme = useTheme();
 
     return (
@@ -55,7 +53,7 @@ const IconChevron = forwardRef<SVGSVGElement, Props>(
             : undefined
         }
       >
-        {getChevronPath(props)}
+        {getChevronPath({isDouble, isCircled})}
       </SvgIcon>
     );
   }

--- a/static/app/icons/iconChevron.tsx
+++ b/static/app/icons/iconChevron.tsx
@@ -7,10 +7,39 @@ import {SvgIcon} from './svgIcon';
 interface Props extends SVGIconProps {
   direction?: 'up' | 'right' | 'down' | 'left';
   isCircled?: boolean;
+  isDouble?: boolean;
+}
+
+const CHEVRON_PATH = (
+  <path d="M14,11.75a.74.74,0,0,1-.53-.22L8,6.06,2.53,11.53a.75.75,0,0,1-1.06-1.06l6-6a.75.75,0,0,1,1.06,0l6,6a.75.75,0,0,1,0,1.06A.74.74,0,0,1,14,11.75Z" />
+);
+
+function getChevronPath(props: Props) {
+  const {isCircled = false, isDouble = false} = props;
+
+  if (isCircled) {
+    return (
+      <Fragment>
+        <path d="M8,16a8,8,0,1,1,8-8A8,8,0,0,1,8,16ZM8,1.53A6.47,6.47,0,1,0,14.47,8,6.47,6.47,0,0,0,8,1.53Z" />
+        <path d="M11.12,9.87a.73.73,0,0,1-.53-.22L8,7.07,5.41,9.65a.74.74,0,0,1-1.06,0,.75.75,0,0,1,0-1.06L7.47,5.48a.74.74,0,0,1,1.06,0l3.12,3.11a.75.75,0,0,1,0,1.06A.74.74,0,0,1,11.12,9.87Z" />
+      </Fragment>
+    );
+  }
+
+  if (isDouble) {
+    return (
+      <Fragment>
+        <g transform="translate(0 -4)">{CHEVRON_PATH}</g>
+        <g transform="translate(0 4)">{CHEVRON_PATH}</g>
+      </Fragment>
+    );
+  }
+
+  return CHEVRON_PATH;
 }
 
 const IconChevron = forwardRef<SVGSVGElement, Props>(
-  ({isCircled = false, direction = 'up', ...props}, ref) => {
+  ({direction = 'up', ...props}, ref) => {
     const theme = useTheme();
 
     return (
@@ -26,14 +55,7 @@ const IconChevron = forwardRef<SVGSVGElement, Props>(
             : undefined
         }
       >
-        {isCircled ? (
-          <Fragment>
-            <path d="M8,16a8,8,0,1,1,8-8A8,8,0,0,1,8,16ZM8,1.53A6.47,6.47,0,1,0,14.47,8,6.47,6.47,0,0,0,8,1.53Z" />
-            <path d="M11.12,9.87a.73.73,0,0,1-.53-.22L8,7.07,5.41,9.65a.74.74,0,0,1-1.06,0,.75.75,0,0,1,0-1.06L7.47,5.48a.74.74,0,0,1,1.06,0l3.12,3.11a.75.75,0,0,1,0,1.06A.74.74,0,0,1,11.12,9.87Z" />
-          </Fragment>
-        ) : (
-          <path d="M14,11.75a.74.74,0,0,1-.53-.22L8,6.06,2.53,11.53a.75.75,0,0,1-1.06-1.06l6-6a.75.75,0,0,1,1.06,0l6,6a.75.75,0,0,1,0,1.06A.74.74,0,0,1,14,11.75Z" />
-        )}
+        {getChevronPath(props)}
       </SvgIcon>
     );
   }

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -271,12 +271,14 @@ const SECTIONS: TSection[] = [
           'expand',
           'collapse',
           'arrow',
+          'double',
         ],
-        additionalProps: ['isCircled', 'direction'],
+        additionalProps: ['isCircled', 'direction', 'isDouble'],
         name: 'Chevron',
         defaultProps: {
           isCircled: false,
           direction: 'left',
+          isDouble: false,
         },
       },
       {
@@ -332,6 +334,38 @@ const SECTIONS: TSection[] = [
         name: 'Chevron',
         defaultProps: {
           isCircled: true,
+          direction: 'down',
+        },
+      },
+      {
+        id: 'chevron-isDouble-direction-left',
+        name: 'Chevron',
+        defaultProps: {
+          isDouble: true,
+          direction: 'left',
+        },
+      },
+      {
+        id: 'chevron-isDouble-direction-right',
+        name: 'Chevron',
+        defaultProps: {
+          isDouble: true,
+          direction: 'right',
+        },
+      },
+      {
+        id: 'chevron-isDouble-direction-up',
+        name: 'Chevron',
+        defaultProps: {
+          isDouble: true,
+          direction: 'up',
+        },
+      },
+      {
+        id: 'chevron-isDouble-direction-down',
+        name: 'Chevron',
+        defaultProps: {
+          isDouble: true,
           direction: 'down',
         },
       },

--- a/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
@@ -27,8 +27,7 @@ export function ToggleSidebar({size = 'lg'}: {size?: 'lg' | 'sm'}) {
           org_streamline_only: organization.streamlineOnly ?? undefined,
         }}
       >
-        <LeftChevron direction={direction} />
-        <RightChevron direction={direction} />
+        <Chevron direction={direction} isDouble size="xs" />
       </ToggleButton>
     </ToggleContainer>
   );
@@ -53,16 +52,10 @@ const ToggleButton = styled(Button)`
   width: calc(100% - ${space(0.5)} + 1px);
   outline: 0;
   min-height: unset;
-`;
-
-const LeftChevron = styled(IconChevron)`
-  position: absolute;
   color: ${p => p.theme.subText};
-  height: 10px;
-  width: 10px;
-  left: ${space(0.75)};
 `;
 
-const RightChevron = styled(LeftChevron)`
-  left: ${space(1.5)};
+const Chevron = styled(IconChevron)`
+  position: absolute;
+  left: ${space(0.75)};
 `;


### PR DESCRIPTION
Used in a couple designs but we did not have an icon for it. Added an `isDouble` prop to IconChevron. Replaced the custom usage in issue details.

![CleanShot 2025-02-05 at 11 13 33](https://github.com/user-attachments/assets/2e8ff75f-657c-4096-85d3-d146661bf887)

Issue details:

![CleanShot 2025-02-05 at 11 14 51](https://github.com/user-attachments/assets/3c6a1339-1fa2-4d41-a945-df9ca1b08c27)
