### PR TITLE
fix(widget-builder): Aggregate selector dropdown misplaced

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize.tsx
@@ -511,6 +511,7 @@ function Visualize({error, setError}: VisualizeProps) {
                           disabled={aggregateOptions.length <= 1}
                           options={aggregateOptions}
                           value={parseFunction(stringFields?.[index] ?? '')?.name ?? ''}
+                          position="bottom-end"
                           onChange={aggregateSelection => {
                             const isNone = aggregateSelection.value === NONE;
                             const newFields = cloneDeep(fields);


### PR DESCRIPTION
Figured out why the aggregate selector was randomly showing up in a weird position after switching from one to two selectors. We needed to set a position relative to the selector. Small one line change but i'm no longer annoyed yay!



https://github.com/user-attachments/assets/75e439e8-ebd7-4d3b-8190-ef664b560f89


