### PR TITLE
fix(issues): Support group pluginActions integrations

### DIFF
--- a/static/app/components/feedback/list/issueTrackingSignals.tsx
+++ b/static/app/components/feedback/list/issueTrackingSignals.tsx
@@ -20,6 +20,12 @@ interface Props {
 }
 
 function getPluginNames(pluginIssue: PluginIssueComponent | PluginActionComponent) {
+  if (Array.isArray(pluginIssue.props.plugin)) {
+    return {
+      name: pluginIssue.props.plugin[0],
+      icon: '',
+    };
+  }
   return {
     name: pluginIssue.props.plugin.name ?? '',
     icon: pluginIssue.props.plugin.slug ?? '',

--- a/static/app/components/group/externalIssuesList/hooks/types.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/types.tsx
@@ -35,6 +35,10 @@ export interface ExternalIssueAction {
    * Helps differentiate between actions with the same name
    */
   nameSubText?: string;
+  /**
+   * Used with pluginActions to link to specific url
+   */
+  to?: string;
 }
 
 /**

--- a/static/app/components/group/externalIssuesList/hooks/usePluginExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/usePluginExternalIssues.tsx
@@ -22,8 +22,7 @@ export function usePluginExternalIssues({
 
   const result: GroupIntegrationIssueResult = {integrations: [], linkedIssues: []};
 
-  const combinedPlugins = [...group.pluginIssues, ...group.pluginActions];
-  for (const plugin of combinedPlugins) {
+  for (const plugin of group.pluginIssues) {
     const displayIcon = getIntegrationIcon(plugin.id, 'sm');
     const displayName = plugin.name || plugin.title;
     if (plugin.issue) {
@@ -95,6 +94,24 @@ export function usePluginExternalIssues({
         ],
       });
     }
+  }
+
+  for (const [title, action] of group.pluginActions) {
+    result.integrations.push({
+      key: `${title}-${action}`,
+      displayName: title,
+      displayIcon: getIntegrationIcon(title, 'sm'),
+      actions: [
+        {
+          id: `${title}-${action}`,
+          name: action,
+          to: action,
+          onClick: () => {
+            // Do nothing
+          },
+        },
+      ],
+    });
   }
 
   return result;

--- a/static/app/components/group/externalIssuesList/index.tsx
+++ b/static/app/components/group/externalIssuesList/index.tsx
@@ -58,8 +58,8 @@ export default function ExternalIssueList({group, event, project}: Props) {
       <ExternalIssueActions {...props} />
     ),
     'plugin-action': ({plugin}: PluginActionComponent['props']) => (
-      <IssueSyncListElement externalIssueLink={(plugin as any)[1]}>
-        {(plugin as any)[0]}
+      <IssueSyncListElement externalIssueLink={plugin[1]}>
+        {plugin[0]}
       </IssueSyncListElement>
     ),
     'plugin-issue': (props: PluginIssueComponent['props']) => (

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -822,7 +822,7 @@ export interface BaseGroup {
   participants: Array<UserParticipant | TeamParticipant>;
   permalink: string;
   platform: PlatformKey;
-  pluginActions: TitledPlugin[];
+  pluginActions: Array<[title: string, actionLink: string]>;
   pluginContexts: any[]; // TODO(ts)
   pluginIssues: TitledPlugin[];
   priority: PriorityLevel;

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueList.spec.tsx
@@ -229,4 +229,30 @@ describe('ExternalIssueList', () => {
     // Item with name matching integration name should only show subtext
     expect(screen.getByRole('menuitemradio', {name: 'example.com'})).toBeInTheDocument();
   });
+
+  it('should render links to group.pluginActions', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
+      body: [],
+    });
+
+    const groupWithPluginActions = GroupFixture({
+      pluginActions: [['Create Redmine Issue', '/path/to/redmine']],
+    });
+    render(
+      <ExternalIssueList event={event} group={groupWithPluginActions} project={project} />
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Create Redmine Issue'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Create Redmine Issue'})).toHaveAttribute(
+      'href',
+      '/path/to/redmine'
+    );
+  });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueList.tsx
@@ -127,16 +127,33 @@ export function ExternalIssueList({group, event, project}: ExternalIssueListProp
                 };
 
                 if (integration.actions.length === 1) {
+                  const action = integration.actions[0]!;
                   return (
                     <ErrorBoundary key={integration.key} mini>
-                      <IssueActionButton
-                        {...sharedButtonProps}
-                        disabled={integration.disabled}
-                        title={
-                          integration.disabled ? integration.disabledText : undefined
-                        }
-                        onClick={integration.actions[0]!.onClick}
-                      />
+                      {action.to ? (
+                        // Exclusively used for group.pluginActions
+                        <IssueActionLinkButton
+                          size="zero"
+                          icon={integration.displayIcon}
+                          disabled={integration.disabled}
+                          title={
+                            integration.disabled ? integration.disabledText : undefined
+                          }
+                          onClick={action.onClick}
+                          to={action.to}
+                        >
+                          <IssueActionName>{integration.displayName}</IssueActionName>
+                        </IssueActionLinkButton>
+                      ) : (
+                        <IssueActionButton
+                          {...sharedButtonProps}
+                          disabled={integration.disabled}
+                          title={
+                            integration.disabled ? integration.disabledText : undefined
+                          }
+                          onClick={action.onClick}
+                        />
+                      )}
                     </ErrorBoundary>
                   );
                 }
@@ -201,6 +218,15 @@ const LinkedIssue = styled(LinkButton)`
 `;
 
 const IssueActionButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  padding: ${space(0.5)} ${space(0.75)};
+  border: 1px dashed ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  font-weight: normal;
+`;
+
+const IssueActionLinkButton = styled(LinkButton)`
   display: flex;
   align-items: center;
   padding: ${space(0.5)} ${space(0.75)};


### PR DESCRIPTION
Correct types for group pluginActions and correctly render them in the new integrations sidebar. Types were based off of these in the backend https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/group_stream.py#L53

fixes JAVASCRIPT-2XKY

![image](https://github.com/user-attachments/assets/baebeb15-776a-48fb-bc03-ce7290f19236)

