### PR TITLE
fix(dashboards): Skip load last used page filters

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1176,6 +1176,7 @@ class DashboardDetail extends Component<Props, State> {
       <SentryDocumentTitle title={dashboard.title} orgSlug={organization.slug}>
         <PageFiltersContainer
           disablePersistence
+          skipLoadLastUsed
           defaultSelection={{
             datetime: {
               start: null,

--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -14,6 +14,7 @@ function WidgetBuilderFilterBar() {
   const {selection} = usePageFilters();
   return (
     <PageFiltersContainer
+      skipLoadLastUsed
       disablePersistence
       defaultSelection={{
         datetime: {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -1147,6 +1147,8 @@ function WidgetBuilder({
         defaultSelection={{
           datetime: {start: null, end: null, utc: null, period: DEFAULT_STATS_PERIOD},
         }}
+        disablePersistence
+        skipLoadLastUsed
       >
         <OnRouteLeave message={UNSAVED_CHANGES_MESSAGE} when={onRouteLeave} />
         <CustomMeasurementsProvider organization={organization} selection={selection}>


### PR DESCRIPTION
Skips loading the last used options. This option is important for dashboards because we always override the page filters with the dashboard settings and the ones persisted on other pages do not apply.

Also closes JAVASCRIPT-2XRE

To verify the fix, go to Discover, set a project, go to a dashboard with "All Projects" or "My Projects" selected and open the widget builder. It will override the page filters and put the Discover project in the URL on prod, this will make it so it does not.