### PR TITLE
feat(aci): query snuba in delayed workflow processing take 2

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -10,6 +10,46 @@ from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult, WorkflowJob
 
 
+class BaseEventFrequencyCountHandler:
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
+            "value": {"type": "integer", "minimum": 0},
+        },
+        "required": ["interval", "value"],
+        "additionalProperties": False,
+    }
+
+    @staticmethod
+    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
+        if len(value.get("snuba_results", [])) != 1:
+            return False
+        return value["snuba_results"][0] > comparison["value"]
+
+
+class BaseEventFrequencyPercentHandler:
+    comparison_json_schema = {
+        "type": "object",
+        "properties": {
+            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
+            "value": {"type": "integer", "minimum": 0},
+            "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
+        },
+        "required": ["interval", "value", "comparison_interval"],
+        "additionalProperties": False,
+    }
+
+    @staticmethod
+    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
+        if len(value.get("snuba_results", [])) != 2:
+            return False
+        return (
+            percent_increase(value["snuba_results"][0], value["snuba_results"][1])
+            > comparison["value"]
+        )
+
+
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
 @condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 class EventFrequencyCountHandler(DataConditionHandler[WorkflowJob]):

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -10,46 +10,6 @@ from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult, WorkflowJob
 
 
-class BaseEventFrequencyCountHandler:
-    comparison_json_schema = {
-        "type": "object",
-        "properties": {
-            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
-            "value": {"type": "integer", "minimum": 0},
-        },
-        "required": ["interval", "value"],
-        "additionalProperties": False,
-    }
-
-    @staticmethod
-    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
-        if len(value.get("snuba_results", [])) != 1:
-            return False
-        return value["snuba_results"][0] > comparison["value"]
-
-
-class BaseEventFrequencyPercentHandler:
-    comparison_json_schema = {
-        "type": "object",
-        "properties": {
-            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
-            "value": {"type": "integer", "minimum": 0},
-            "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
-        },
-        "required": ["interval", "value", "comparison_interval"],
-        "additionalProperties": False,
-    }
-
-    @staticmethod
-    def evaluate_value(value: WorkflowJob, comparison: Any) -> DataConditionResult:
-        if len(value.get("snuba_results", [])) != 2:
-            return False
-        return (
-            percent_increase(value["snuba_results"][0], value["snuba_results"][1])
-            > comparison["value"]
-        )
-
-
 @condition_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
 @condition_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 class EventFrequencyCountHandler(DataConditionHandler[WorkflowJob]):

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,15 +1,20 @@
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
+
+from django.utils import timezone
 
 from sentry import buffer
 from sentry.db import models
 from sentry.models.project import Project
+from sentry.rules.conditions.event_frequency import COMPARISON_INTERVALS
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
 from sentry.utils.registry import NoRegistrationExistsError
+from sentry.utils.safe import safe_execute
 from sentry.workflow_engine.handlers.condition.slow_condition_query_handlers import (
     BaseEventFrequencyQueryHandler,
     slow_condition_query_handler_registry,
@@ -24,13 +29,15 @@ from sentry.workflow_engine.models.data_condition_group import get_slow_conditio
 
 logger = logging.getLogger("sentry.workflow_engine.processors.delayed_workflow")
 
+COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
+
 
 @dataclass(frozen=True)
 class UniqueConditionQuery:
     """
-    Represents all the data that uniquely identifies a condition class and its
+    Represents all the data that uniquely identifies a condition and its
     single respective Snuba query that must be made. Multiple instances of the
-    same condition class can share the single query.
+    same condition can share a single query.
     """
 
     handler: type[BaseEventFrequencyQueryHandler]
@@ -192,6 +199,36 @@ def get_condition_query_groups(
             ):
                 condition_groups[condition_query].update(dcg_to_groups[dcg.id])
     return condition_groups
+
+
+def get_condition_group_results(
+    queries_to_groups: dict[UniqueConditionQuery, set[int]]
+) -> dict[UniqueConditionQuery, dict[int, int]]:
+    condition_group_results = {}
+    current_time = timezone.now()
+
+    for unique_condition, group_ids in queries_to_groups.items():
+        handler = unique_condition.handler()
+
+        _, duration = handler.intervals[unique_condition.interval]
+
+        comparison_interval: timedelta | None = None
+        if unique_condition.comparison_interval is not None:
+            comparison_interval = COMPARISON_INTERVALS_VALUES.get(
+                unique_condition.comparison_interval
+            )
+
+        result = safe_execute(
+            handler.get_rate_bulk,
+            duration=duration,
+            group_ids=group_ids,
+            environment_id=unique_condition.environment_id,
+            current_time=current_time,
+            comparison_interval=comparison_interval,
+        )
+        condition_group_results[unique_condition] = result or {}
+
+    return condition_group_results
 
 
 @instrumented_task(


### PR DESCRIPTION
Take 2

In delayed workflow processing, query Snuba for the results of the `UniqueConditionQueries` for the group ids that share the same query (interval, environment_id, comparison_interval).

Use the `get_rate_bulk` function on the condition handler to do so.