### PR TITLE
feat(insights): use sdk to show frontend/mobile/backend transactions

### DIFF
--- a/static/app/utils/project/useSelectedProjectsHaveField.tsx
+++ b/static/app/utils/project/useSelectedProjectsHaveField.tsx
@@ -6,7 +6,7 @@ import type {Project} from 'sentry/types/project';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 
-function getSelectedProjectList(
+export function getSelectedProjectList(
   selectedProjects: PageFilters['projects'],
   projects: Project[]
 ) {

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -123,14 +123,14 @@ function BackendOverviewPage() {
     ...new Set([...FRONTEND_OVERVIEW_PAGE_OPS, ...BACKEND_OVERVIEW_PAGE_OPS]),
   ];
 
-  const frontendSelectedProjects: Project[] = getSelectedProjectList(
+  const selectedFrontendProjects: Project[] = getSelectedProjectList(
     selection.projects,
     projects
   ).filter((project): project is Project =>
     Boolean(project?.platform && FRONTEND_PLATFORMS.includes(project.platform))
   );
 
-  const mobileSelectedProjects: Project[] = getSelectedProjectList(
+  const selectedMobileProjects: Project[] = getSelectedProjectList(
     selection.projects,
     projects
   ).filter((project): project is Project =>
@@ -139,11 +139,17 @@ function BackendOverviewPage() {
 
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addFilterValues('!transaction.op', disallowedOps);
-  // TODO - make this a not condtion
-  existingQuery.addFilterValues('project', [
-    ...frontendSelectedProjects.map(project => project.id),
-    ...mobileSelectedProjects.map(project => project.id),
-  ]);
+
+  if (selectedFrontendProjects.length > 0 || selectedMobileProjects.length > 0) {
+    existingQuery.addFilterValue(
+      '!project.id',
+      `[${[
+        ...selectedFrontendProjects.map(project => project.id),
+        ...selectedMobileProjects.map(project => project.id),
+      ]}]`
+    );
+  }
+
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -12,6 +12,7 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import {tct} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
@@ -19,10 +20,12 @@ import {
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
+import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
@@ -32,8 +35,14 @@ import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
-import {OVERVIEW_PAGE_ALLOWED_OPS as FRONTEND_OVERVIEW_PAGE_OPS} from 'sentry/views/insights/pages/frontend/settings';
-import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS} from 'sentry/views/insights/pages/mobile/settings';
+import {
+  FRONTEND_PLATFORMS,
+  OVERVIEW_PAGE_ALLOWED_OPS as FRONTEND_OVERVIEW_PAGE_OPS,
+} from 'sentry/views/insights/pages/frontend/settings';
+import {
+  MOBILE_PLATFORMS,
+  OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS,
+} from 'sentry/views/insights/pages/mobile/settings';
 import {
   generateBackendPerformanceEventView,
   USER_MISERY_TOOLTIP,
@@ -83,6 +92,7 @@ function BackendOverviewPage() {
   const navigate = useNavigate();
   const {teams} = useUserTeams();
   const mepSetting = useMEPSettingContext();
+  const {selection} = usePageFilters();
 
   const withStaticFilters = canUseMetricsData(organization);
   const eventView = generateBackendPerformanceEventView(
@@ -113,8 +123,27 @@ function BackendOverviewPage() {
     ...new Set([...FRONTEND_OVERVIEW_PAGE_OPS, ...BACKEND_OVERVIEW_PAGE_OPS]),
   ];
 
+  const frontendSelectedProjects: Project[] = getSelectedProjectList(
+    selection.projects,
+    projects
+  ).filter((project): project is Project =>
+    Boolean(project?.platform && FRONTEND_PLATFORMS.includes(project.platform))
+  );
+
+  const mobileSelectedProjects: Project[] = getSelectedProjectList(
+    selection.projects,
+    projects
+  ).filter((project): project is Project =>
+    Boolean(project?.platform && MOBILE_PLATFORMS.includes(project.platform))
+  );
+
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addFilterValues('!transaction.op', disallowedOps);
+  // TODO - make this a not condtion
+  existingQuery.addFilterValues('project', [
+    ...frontendSelectedProjects.map(project => project.id),
+    ...mobileSelectedProjects.map(project => project.id),
+  ]);
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -1,0 +1,215 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import FrontendOverviewPage from 'sentry/views/insights/pages/frontend/frontendOverviewPage';
+
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useOrganization');
+jest.mock('sentry/utils/useProjects');
+jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
+
+const organization = OrganizationFixture({features: ['performance-view']});
+const pageFilterSelection = PageFiltersFixture({
+  projects: [1, 2],
+  datetime: {
+    period: '14d',
+    start: null,
+    end: null,
+    utc: false,
+  },
+});
+const projects = [
+  ProjectFixture({id: '1', platform: 'javascript-react'}),
+  ProjectFixture({id: '2', platform: undefined}),
+];
+
+let mainTableApiCall: jest.Mock;
+
+describe('FrontendOverviewPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  describe('data fetching', () => {
+    it('fetches correct data with unkown + frontend platform', async () => {
+      render(<FrontendOverviewPage />);
+
+      expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(
+        'Frontend'
+      );
+      expect(mainTableApiCall).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query:
+              '( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) OR project.id:[1] event.type:transaction',
+          }),
+        })
+      );
+    });
+
+    it('fetches correct data with unknown platform', async () => {
+      jest.mocked(usePageFilters).mockReturnValue({
+        isReady: true,
+        desyncedFilters: new Set(),
+        pinnedFilters: new Set(),
+        shouldPersist: true,
+        selection: {
+          projects: [2],
+          datetime: pageFilterSelection.datetime,
+          environments: [],
+        },
+      });
+      render(<FrontendOverviewPage />);
+
+      expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(
+        'Frontend'
+      );
+      expect(mainTableApiCall).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query:
+              '( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) event.type:transaction',
+          }),
+        })
+      );
+    });
+  });
+});
+
+const setupMocks = () => {
+  mainTableApiCall = MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/events/',
+    body: {
+      data: [],
+      meta: {
+        fields: {
+          'transaction.op': 'string',
+          transaction: 'string',
+          project: 'string',
+          team_key_transaction: 'boolean',
+          'p95(transaction.duration)': 'duration',
+          'p75(transaction.duration)': 'duration',
+          'tpm()': 'rate',
+          'p50(transaction.duration)': 'duration',
+          'user_misery()': 'number',
+          'count_unique(user)': 'integer',
+          'count_miserable(user)': 'integer',
+        },
+        units: {
+          'transaction.op': null,
+          transaction: null,
+          project: null,
+          team_key_transaction: null,
+          'p95(transaction.duration)': 'millisecond',
+          'p75(transaction.duration)': 'millisecond',
+          'tpm()': '1/minute',
+          'p50(transaction.duration)': 'millisecond',
+          'user_misery()': null,
+          'count_unique(user)': null,
+          'count_miserable(user)': null,
+        },
+        isMetricsData: true,
+        isMetricsExtractedData: false,
+        tips: {},
+        datasetReason: 'unchanged',
+        dataset: 'metrics',
+      },
+    },
+    match: [MockApiClient.matchQuery({referrer: 'api.performance.landing-table'})],
+  });
+  mainTableApiCall = MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/events/',
+    body: {
+      data: [],
+    },
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/events-stats/',
+    body: {
+      data: [],
+      meta: {
+        fields: {
+          'transaction.op': 'string',
+          transaction: 'string',
+          project: 'string',
+          team_key_transaction: 'boolean',
+          'p95(transaction.duration)': 'duration',
+          'p75(transaction.duration)': 'duration',
+          'tpm()': 'rate',
+          'p50(transaction.duration)': 'duration',
+          'user_misery()': 'number',
+          'count_unique(user)': 'integer',
+          'count_miserable(user)': 'integer',
+        },
+        units: {
+          'transaction.op': null,
+          transaction: null,
+          project: null,
+          team_key_transaction: null,
+          'p95(transaction.duration)': 'millisecond',
+          'p75(transaction.duration)': 'millisecond',
+          'tpm()': '1/minute',
+          'p50(transaction.duration)': 'millisecond',
+          'user_misery()': null,
+          'count_unique(user)': null,
+          'count_miserable(user)': null,
+        },
+        isMetricsData: true,
+        isMetricsExtractedData: false,
+        tips: {},
+        datasetReason: 'unchanged',
+        dataset: 'metrics',
+      },
+    },
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/events-histogram/',
+    body: {data: [], meta: []},
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/key-transactions-list/',
+    body: [],
+  });
+
+  jest.mocked(useLocation).mockReturnValue({
+    pathname: '/insights/backend/http/',
+    search: '',
+    query: {statsPeriod: '10d', 'span.domain': 'git', project: '1'},
+    hash: '',
+    state: undefined,
+    action: 'PUSH',
+    key: '',
+  });
+
+  jest.mocked(useOrganization).mockReturnValue(organization);
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: pageFilterSelection,
+  });
+  jest.mocked(useProjects).mockReturnValue({
+    projects,
+    fetchError: null,
+    hasMore: false,
+    initiallyLoaded: true,
+    onSearch: () => Promise.resolve(),
+    reloadProjects: jest.fn(),
+    placeholders: [],
+    fetching: false,
+  });
+  jest.mocked(useOnboardingProject).mockReturnValue(undefined);
+};

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -114,7 +114,7 @@ function FrontendOverviewPage() {
 
   const doubleChartRowEventView = eventView.clone(); // some of the double chart rows rely on span metrics, so they can't be queried the same way
 
-  const frontendSelectedProjects: Project[] = getSelectedProjectList(
+  const selectedFrontendProjects: Project[] = getSelectedProjectList(
     selection.projects,
     projects
   ).filter((project): project is Project =>
@@ -124,10 +124,13 @@ function FrontendOverviewPage() {
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
   // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
-  existingQuery.addFilterValue(
-    'project.id',
-    `[${frontendSelectedProjects.map(({id}) => id).join(',')}]`
-  );
+  if (selectedFrontendProjects.length > 0) {
+    existingQuery.addOp('OR');
+    existingQuery.addFilterValue(
+      'project.id',
+      `[${selectedFrontendProjects.map(({id}) => id).join(',')}]`
+    );
+  }
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -12,6 +12,7 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import {tct} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
@@ -19,10 +20,12 @@ import {
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
+import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
@@ -33,6 +36,7 @@ import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOve
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {
   FRONTEND_LANDING_TITLE,
+  FRONTEND_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {
@@ -82,6 +86,7 @@ function FrontendOverviewPage() {
   const navigate = useNavigate();
   const {teams} = useUserTeams();
   const mepSetting = useMEPSettingContext();
+  const {selection} = usePageFilters();
 
   const withStaticFilters = canUseMetricsData(organization);
   const eventView = generateFrontendOtherPerformanceEventView(
@@ -89,6 +94,8 @@ function FrontendOverviewPage() {
     withStaticFilters,
     organization
   );
+
+  const sharedProps = {eventView, location, organization, withStaticFilters};
 
   // TODO - this should come from MetricsField / EAP fields
   eventView.fields = [
@@ -107,8 +114,20 @@ function FrontendOverviewPage() {
 
   const doubleChartRowEventView = eventView.clone(); // some of the double chart rows rely on span metrics, so they can't be queried the same way
 
+  const frontendSelectedProjects: Project[] = getSelectedProjectList(
+    selection.projects,
+    projects
+  ).filter((project): project is Project =>
+    Boolean(project?.platform && FRONTEND_PLATFORMS.includes(project.platform))
+  );
+
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
+  // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
+  existingQuery.addFilterValue(
+    'project.id',
+    `[${frontendSelectedProjects.map(({id}) => id).join(',')}]`
+  );
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;
@@ -136,8 +155,6 @@ function FrontendOverviewPage() {
     doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES);
     doubleChartRowCharts.unshift(PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES);
   }
-
-  const sharedProps = {eventView, location, organization, withStaticFilters};
 
   const getFreeTextFromQuery = (query: string) => {
     const conditions = new MutableSearch(query);

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -1,4 +1,6 @@
+import {frontend} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const FRONTEND_LANDING_SUB_PATH = 'frontend';
@@ -13,3 +15,10 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
 ];
 
 export const MODULES = [ModuleName.VITAL, ModuleName.HTTP, ModuleName.RESOURCE];
+
+// Mirrors `FRONTEND` in src/sentry/utils/platform_categories.py, except shared platforms are removed
+export const FRONTEND_PLATFORMS: PlatformKey[] = frontend.filter(
+  platform =>
+    // Next, Remix and Sveltekit have both, frontend and backend transactions.
+    !['javascript-nextjs', 'javascript-remix', 'javascript-sveltekit'].includes(platform)
+);

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -105,7 +105,7 @@ function MobileOverviewPage() {
 
   const doubleChartRowEventView = eventView.clone(); // some of the double chart rows rely on span metrics, so they can't be queried the same way
 
-  const mobileSelectedProjects: Project[] = getSelectedProjectList(
+  const selectedMobileProjects: Project[] = getSelectedProjectList(
     selection.projects,
     projects
   ).filter((project): project is Project =>
@@ -114,10 +114,14 @@ function MobileOverviewPage() {
 
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
-  existingQuery.addFilterValue(
-    'project.id',
-    `[${mobileSelectedProjects.map(({id}) => id).join(',')}]`
-  );
+  if (selectedMobileProjects.length > 0) {
+    existingQuery.addOp('OR');
+    existingQuery.addFilterValue(
+      'project.id',
+      `[${selectedMobileProjects.map(({id}) => id).join(',')}]`
+    );
+  }
+
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -9,6 +9,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
+import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
@@ -16,10 +17,12 @@ import {
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
+import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
@@ -30,6 +33,7 @@ import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOve
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {
   MOBILE_LANDING_TITLE,
+  MOBILE_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
 import {
@@ -83,6 +87,7 @@ function MobileOverviewPage() {
   const navigate = useNavigate();
   const {teams} = useUserTeams();
   const mepSetting = useMEPSettingContext();
+  const {selection} = usePageFilters();
 
   const withStaticFilters = canUseMetricsData(organization);
 
@@ -100,8 +105,19 @@ function MobileOverviewPage() {
 
   const doubleChartRowEventView = eventView.clone(); // some of the double chart rows rely on span metrics, so they can't be queried the same way
 
+  const mobileSelectedProjects: Project[] = getSelectedProjectList(
+    selection.projects,
+    projects
+  ).filter((project): project is Project =>
+    Boolean(project?.platform && MOBILE_PLATFORMS.includes(project.platform))
+  );
+
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addFilterValue(
+    'project.id',
+    `[${mobileSelectedProjects.map(({id}) => id).join(',')}]`
+  );
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/mobile/settings.ts
+++ b/static/app/views/insights/pages/mobile/settings.ts
@@ -1,4 +1,6 @@
+import {mobile} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const MOBILE_LANDING_SUB_PATH = 'mobile';
@@ -24,3 +26,6 @@ export const MODULES = [
   ModuleName.MOBILE_VITALS,
   ModuleName.MOBILE_UI,
 ];
+
+// Mirrors `FRONTEND` in src/sentry/utils/platform_categories.py, except shared platforms are removed
+export const MOBILE_PLATFORMS: PlatformKey[] = [...mobile];

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -294,13 +294,18 @@ class _Table extends Component<Props, State> {
       if (dataRow.hasOwnProperty('transaction.op')) {
         existingQuery.removeFilter('!transaction.op');
         existingQuery.removeFilter('transaction.op');
-        summaryView.query = existingQuery.formatString();
         if (dataRow['transaction.op']) {
           summaryView.additionalConditions.setFilterValues('transaction.op', [
             dataRow['transaction.op'] as string,
           ]);
         }
       }
+
+      // This is carried forward from the insight overview pages
+      existingQuery.removeFilter('project.id');
+      existingQuery.removeFilter('!project.id');
+
+      summaryView.query = existingQuery.formatString();
       summaryView.query = summaryView.getQueryWithAdditionalConditions();
       if (isUnparameterizedRow && !this.unparameterizedMetricSet) {
         this.sendUnparameterizedAnalytic(project);


### PR DESCRIPTION
See the notion doc in https://github.com/getsentry/team-visibility/issues/22 for more details.

Currently domain views filter by transaction.op only to determine frontend/backend/mobile data. However, for custom transactions, this doesn't work well. You would expect a frontend project, to show all transactions (regardless if custom), on a frontend overview page.

To help resolve this, we add an additional OR condition, and query on projects of certain SDKs, depending on domain.