### PR TITLE
feat(taskworker) Add CLI option to control prefetch queue size

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -284,6 +284,11 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 )
 @click.option("--concurrency", help="Number of child worker processes to create.", default=1)
 @click.option(
+    "--prefetch-multiplier",
+    help="How many tasks to keep in the child worker Queue. Multiplied by --concurrency",
+    default=3,
+)
+@click.option(
     "--namespace", help="The dedicated task namespace that taskworker operates on", default=None
 )
 @log_options()
@@ -304,6 +309,7 @@ def run_taskworker(
     max_task_count: int,
     namespace: str | None,
     concurrency: int,
+    prefetch_multiplier: int,
     **options: Any,
 ) -> None:
     """
@@ -318,6 +324,7 @@ def run_taskworker(
             max_task_count=max_task_count,
             namespace=namespace,
             concurrency=concurrency,
+            prefetch_multiplier=prefetch_multiplier,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -236,6 +236,7 @@ class TaskWorker:
         max_task_count: int | None = None,
         namespace: str | None = None,
         concurrency: int = 1,
+        prefetch_multiplier: int = 3,
         **options: dict[str, Any],
     ) -> None:
         self.options = options
@@ -245,11 +246,13 @@ class TaskWorker:
         self._namespace = namespace
         self._concurrency = concurrency
         self.client = TaskworkerClient(rpc_host, num_brokers)
+
+        queue_size = concurrency * prefetch_multiplier
         self._child_tasks: multiprocessing.Queue[TaskActivation] = multiprocessing.Queue(
-            maxsize=(concurrency * 10)
+            maxsize=queue_size
         )
         self._processed_tasks: multiprocessing.Queue[ProcessingResult] = multiprocessing.Queue(
-            maxsize=(concurrency * 10)
+            maxsize=queue_size
         )
         self._children: list[multiprocessing.Process] = []
         self._shutdown_event = multiprocessing.Event()


### PR DESCRIPTION
Control the size of the worker Queue buffer via a CLI option so that we can test different values in a sandbox.
