### PR TITLE
feat(uptime): Add check-in graph to legacy page

### DIFF
--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
@@ -1,20 +1,44 @@
-import {useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
+import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
+import {
+  GridLineLabels,
+  GridLineOverlay,
+} from 'sentry/components/checkInTimeline/gridLines';
+import {usePageFilterDates} from 'sentry/components/checkInTimeline/hooks/useMonitorDates';
+import type {TimeWindow} from 'sentry/components/checkInTimeline/types';
+import {getConfigFromTimeRange} from 'sentry/components/checkInTimeline/utils/getConfigFromTimeRange';
+import {getTimeRangeFromEvent} from 'sentry/components/checkInTimeline/utils/getTimeRangeFromEvent';
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
+import Panel from 'sentry/components/panels/panel';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {fadeIn} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import {type Group, GroupActivityType, GroupStatus} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {
+  checkStatusPrecedent,
+  statusToText,
+  tickStyle,
+} from 'sentry/views/insights/uptime/timelineConfig';
+import {useUptimeMonitorStats} from 'sentry/views/insights/uptime/utils/useUptimeMonitorStats';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {ResolutionSelector} from 'sentry/views/monitors/components/overviewTimeline/resolutionSelector';
 
 interface Props {
   event: Event;
@@ -77,8 +101,48 @@ export function DowntimeDuration({group}: {group: Group}) {
 
 export function UptimeDataSection({group, event, project}: Props) {
   const organization = useOrganization();
+  const location = useLocation();
+  const now = useMemo(() => new Date(), []);
+
   const isResolved = group.status === GroupStatus.RESOLVED;
   const alertRuleId = event.tags.find(tag => tag.key === 'uptime_rule')?.value;
+
+  const elementRef = useRef<HTMLDivElement>(null);
+  const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
+  const timelineWidth = useDebouncedValue(containerWidth, 500);
+  const timeWindow = location.query?.timeWindow as TimeWindow;
+  const {since, until} = usePageFilterDates();
+
+  const timeWindowConfig = useMemo(() => {
+    if (defined(timeWindow)) {
+      const {start, end} = getTimeRangeFromEvent(event, now, timeWindow);
+      return getConfigFromTimeRange(start, end, timelineWidth);
+    }
+    return getConfigFromTimeRange(since, until, timelineWidth);
+  }, [timeWindow, timelineWidth, since, until, event, now]);
+
+  const {data: uptimeStats, isPending} = useUptimeMonitorStats({
+    ruleIds: alertRuleId ? [alertRuleId] : [],
+    timeWindowConfig,
+  });
+  const bucketedData = alertRuleId ? uptimeStats?.[alertRuleId] ?? [] : [];
+
+  const actions = (
+    <ButtonBar gap={1}>
+      {defined(alertRuleId) && (
+        <LinkButton
+          icon={<IconSettings />}
+          size="xs"
+          to={normalizeUrl(
+            `/organizations/${organization.slug}/alerts/rules/uptime/${project.slug}/${alertRuleId}/details/`
+          )}
+        >
+          {t('Uptime Alert Rule')}
+        </LinkButton>
+      )}
+      <ResolutionSelector />
+    </ButtonBar>
+  );
 
   return (
     <InterimSection
@@ -86,27 +150,35 @@ export function UptimeDataSection({group, event, project}: Props) {
       type={SectionKey.DOWNTIME}
       help={t('Information about the detected downtime')}
       preventCollapse
-      actions={
-        alertRuleId !== undefined && (
-          <LinkButton
-            icon={<IconSettings />}
-            size="xs"
-            to={normalizeUrl(
-              `/organizations/${organization.slug}/alerts/rules/uptime/${project.slug}/${alertRuleId}/details/`
-            )}
-          >
-            {t('Uptime Alert Rule')}
-          </LinkButton>
-        )
-      }
+      actions={actions}
     >
-      {isResolved
-        ? tct('Domain was down for [duration]', {
-            duration: <DowntimeDuration group={group} />,
-          })
-        : tct('Domain has been down for [duration]', {
-            duration: <DowntimeDuration group={group} />,
-          })}
+      <Text>
+        {isResolved
+          ? tct('Domain was down for [duration]', {
+              duration: <DowntimeDuration group={group} />,
+            })
+          : tct('Domain has been down for [duration]', {
+              duration: <DowntimeDuration group={group} />,
+            })}
+      </Text>
+      <TimelineContainer>
+        <TimelineWidthTracker ref={elementRef} />
+        <StyledGridLineTimeLabels timeWindowConfig={timeWindowConfig} />
+        <GridLineOverlay timeWindowConfig={timeWindowConfig} showCursor={!isPending} />
+        {bucketedData && !isPending ? (
+          <FadeInContainer>
+            <CheckInTimeline
+              statusLabel={statusToText}
+              statusStyle={tickStyle}
+              statusPrecedent={checkStatusPrecedent}
+              timeWindowConfig={timeWindowConfig}
+              bucketedData={bucketedData}
+            />
+          </FadeInContainer>
+        ) : (
+          <CheckInPlaceholder />
+        )}
+      </TimelineContainer>
     </InterimSection>
   );
 }
@@ -120,4 +192,30 @@ const DowntimeTooltipTitle = styled('div')`
 
 const DowntimeLabel = styled('div')`
   font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const Text = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const TimelineContainer = styled(Panel)`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 40px 100px;
+  align-items: center;
+`;
+
+const StyledGridLineTimeLabels = styled(GridLineLabels)`
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const TimelineWidthTracker = styled('div')`
+  position: absolute;
+  width: 100%;
+  grid-row: 1;
+  grid-column: 0;
+`;
+
+const FadeInContainer = styled('div')`
+  animation: ${fadeIn} 500ms ease-out forwards;
 `;

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -97,7 +97,7 @@ interface Props extends React.TimeHTMLAttributes<HTMLTimeElement> {
    * extraShort:
    *   Like short but uses very short units (h, m, s)
    *
-   * NOTE: shot and extraShort do NOT currently support times in the future.
+   * NOTE: short and extraShort do NOT currently support times in the future.
    *
    * @default human
    */

--- a/static/app/utils/event/useEventCanShowReplayUpsell.tsx
+++ b/static/app/utils/event/useEventCanShowReplayUpsell.tsx
@@ -4,6 +4,7 @@ import {replayBackendPlatforms} from 'sentry/data/platformCategories';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {PlatformKey} from 'sentry/types/project';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {projectCanUpsellReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
@@ -50,7 +51,13 @@ export default function useEventCanShowReplayUpsell({
   const upsellPlatform = group?.project.platform ?? group?.platform ?? 'other';
   const upsellProjectId = group?.project.id ?? event.projectID ?? '';
 
+  // Check if this group has replays compatibility. If we don't have a group, show the upsell.
+  const groupHasReplays = group
+    ? getConfigForIssueType(group, group?.project).pages.replays.enabled
+    : true;
+
   const canShowUpsell =
+    groupHasReplays &&
     projectCanUpsellReplay(project) &&
     (!hasOrgSentReplays || replayBackendPlatforms.includes(upsellPlatform));
 

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -31,7 +31,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
     },
     pages: {
       landingPage: Tab.EVENTS,
-      events: {enabled: false},
+      events: {enabled: true},
       openPeriods: {enabled: false},
       checkIns: {enabled: true},
       attachments: {enabled: false},

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -35,7 +35,7 @@ import GroupPriority from 'sentry/views/issueDetails/groupPriority';
 import {useIssueDetailsHeader} from 'sentry/views/issueDetails/useIssueDetailsHeader';
 
 import {GroupActions} from './actions';
-import {Tab} from './types';
+import {Tab, TabPaths} from './types';
 import {getGroupReprocessingStatus} from './utils';
 
 type Props = {
@@ -171,6 +171,14 @@ export function GroupHeaderTabs({
       >
         {t('Replays')}
         <ReplayCountBadge count={replaysCount} />
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.UPTIME_CHECKS}
+        textValue={t('Uptime Checks')}
+        hidden={!issueTypeConfig.pages.checkIns.enabled}
+        to={{pathname: `${baseUrl}${TabPaths[Tab.UPTIME_CHECKS]}`, query: queryParams}}
+      >
+        {t('Uptime Checks')}
       </TabList.Item>
     </StyledTabList>
   );

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -229,7 +229,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
         )}
         {isListView && (
           <ButtonBar gap={1}>
-            {issueTypeConfig.discover.enabled && (
+            {issueTypeConfig.discover.enabled && currentTab === Tab.EVENTS && (
               <LinkButton
                 to={discoverUrl}
                 aria-label={t('Open in Discover')}

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -65,7 +65,7 @@ export function getDetectorDetails({
       detectorPath: `/organizations/${organization.slug}/alerts/rules/uptime/${project.slug}/${uptimeAlertRuleId}/details/`,
       // TODO(issues): Update this to mention detectors when that language is user-facing
       description: t(
-        'This issue was created by an uptime alert rule. After 2 consecutive failed check-ins, an open period will be created.'
+        'This issue was created by an uptime alert rule. After 3 consecutive failed check-ins, an open period will be created.'
       ),
     };
   }


### PR DESCRIPTION
Variety of small fixes for uptime issues:

- Hide the discover button on check-in list
- Correct message from 2 misses, to 3 misses
- ~~Add back the All Events button, calling it 'Downtime'~~ Gonna do this in a separate PR
- Prevent unloading the all check-ins table if the event is unloaded, and allows the check-ins tab on legacy UI
- Timestamps instead of relative times

<img width="635" alt="image" src="https://github.com/user-attachments/assets/5ecd5ba3-8ca7-422c-873e-3c9c3aec1ac2" />
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/52905863-d96b-43b8-9deb-a32f8114bdef" />

