### PR TITLE
feat(workflow_engine): Add metrics for the processing funnel in workflow_engine

### DIFF
--- a/src/sentry/workflow_engine/processors/data_packet.py
+++ b/src/sentry/workflow_engine/processors/data_packet.py
@@ -11,6 +11,21 @@ def process_data_packets(
     """
     This method ties the two main pre-processing methods together to process
     the incoming data and create issue occurrences.
+
+    This is the general entry point for the workflow engine. It will create
+    a metric pipline with the following metrics:
+    - sentry.workflow_engine.process_data_sources
+        - sentry.workflow_engine.process_data_sources.detectors
+        - sentry.workflow_engine.process_data_sources.no_detectors
+    - sentry.workflow_engine.process_detectors
+        - sentry.workflow_engine.process_detectors.triggered
+    - sentry.workflow_engine.process_workflows
+        - sentry.workflow_engine.process_workflows.triggered_workflows
+        - sentry.workflow_engine.process_workflows.triggered_actions
+
+    This metric funnel can be used to monitor the health of the workflow engine.
+    TODO - saponifi3d - Create a monitoring dashboard for the workflow engine and link it here
+         - the dashboard should show the funnel as we process data.
     """
     processed_sources = process_data_sources(data_packets, query_type)
 

--- a/src/sentry/workflow_engine/processors/data_packet.py
+++ b/src/sentry/workflow_engine/processors/data_packet.py
@@ -14,14 +14,14 @@ def process_data_packets(
 
     This is the general entry point for the workflow engine. It will create
     a metric pipline with the following metrics:
-    - sentry.workflow_engine.process_data_sources
-        - sentry.workflow_engine.process_data_sources.detectors
-        - sentry.workflow_engine.process_data_sources.no_detectors
-    - sentry.workflow_engine.process_detectors
-        - sentry.workflow_engine.process_detectors.triggered
-    - sentry.workflow_engine.process_workflows
-        - sentry.workflow_engine.process_workflows.triggered_workflows
-        - sentry.workflow_engine.process_workflows.triggered_actions
+    - workflow_engine.process_data_sources
+        - workflow_engine.process_data_sources.detectors
+        - workflow_engine.process_data_sources.no_detectors
+    - workflow_engine.process_detectors
+        - workflow_engine.process_detectors.triggered
+    - workflow_engine.process_workflows
+        - workflow_engine.process_workflows.triggered_workflows
+        - workflow_engine.process_workflows.triggered_actions
 
     This metric funnel can be used to monitor the health of the workflow engine.
     TODO - saponifi3d - Create a monitoring dashboard for the workflow engine and link it here

--- a/src/sentry/workflow_engine/processors/data_packet.py
+++ b/src/sentry/workflow_engine/processors/data_packet.py
@@ -13,7 +13,7 @@ def process_data_packets(
     the incoming data and create issue occurrences.
 
     This is the general entry point for the workflow engine. It will create
-    a metric pipline with the following metrics:
+    a metric pipeline with the following metrics:
     - workflow_engine.process_data_sources
         - workflow_engine.process_data_sources.detectors
         - workflow_engine.process_data_sources.no_detectors

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 
 import sentry_sdk
 from django.db.models import Prefetch
@@ -34,6 +35,14 @@ def process_data_sources(
         if detectors:
             data_packet_tuple = (packet, detectors)
             result.append(data_packet_tuple)
+
+            detector_metrics = Counter(detector.type for detector in detectors)
+            for detector_type, count in detector_metrics.items():
+                metrics.incr(
+                    "workflow_engine.process_data_sources.detectors",
+                    count,
+                    tags={"detector_type": detector_type},
+                )
 
             metrics.incr(
                 "workflow_engine.process_data_sources.detectors",

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -14,7 +14,7 @@ def process_data_sources(
 ) -> list[tuple[DataPacket, list[Detector]]]:
     metrics.incr("sentry.workflow_engine.process_data_sources", tags={"query_type": query_type})
 
-    # TODO - change data_source.query_id to be a string to support UUIDs
+    # TODO - saponifi3d - change data_source.query_id to be a string to support UUIDs
     data_packet_ids = {int(packet.query_id) for packet in data_packets}
 
     # Fetch all data sources and associated detectors for the given data packets
@@ -34,6 +34,12 @@ def process_data_sources(
         if detectors:
             data_packet_tuple = (packet, detectors)
             result.append(data_packet_tuple)
+
+            metrics.incr(
+                "sentry.workflow_engine.process_data_sources.detectors",
+                len(detectors),
+                tags={"detector_type": detectors[0].type},
+            )
         else:
             logger.warning(
                 "No detectors found", extra={"query_id": packet.query_id, "query_type": query_type}

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -12,13 +12,13 @@ logger = logging.getLogger("sentry.workflow_engine.process_data_source")
 def process_data_sources(
     data_packets: list[DataPacket], query_type: str
 ) -> list[tuple[DataPacket, list[Detector]]]:
-    metrics.incr("sentry.workflow_engine.process_data_sources", tags={"query_type": query_type})
+    metrics.incr("workflow_engine.process_data_sources", tags={"query_type": query_type})
 
     # TODO - saponifi3d - change data_source.query_id to be a string to support UUIDs
     data_packet_ids = {int(packet.query_id) for packet in data_packets}
 
     # Fetch all data sources and associated detectors for the given data packets
-    with sentry_sdk.start_span(op="sentry.workflow_engine.process_data_sources.fetch_data_sources"):
+    with sentry_sdk.start_span(op="workflow_engine.process_data_sources.fetch_data_sources"):
         data_sources = DataSource.objects.filter(
             query_id__in=data_packet_ids, type=query_type
         ).prefetch_related(Prefetch("detectors"))
@@ -36,7 +36,7 @@ def process_data_sources(
             result.append(data_packet_tuple)
 
             metrics.incr(
-                "sentry.workflow_engine.process_data_sources.detectors",
+                "workflow_engine.process_data_sources.detectors",
                 len(detectors),
                 tags={"detector_type": detectors[0].type},
             )
@@ -45,7 +45,7 @@ def process_data_sources(
                 "No detectors found", extra={"query_id": packet.query_id, "query_type": query_type}
             )
             metrics.incr(
-                "sentry.workflow_engine.process_data_sources.no_detectors",
+                "workflow_engine.process_data_sources.no_detectors",
                 tags={"query_type": query_type},
             )
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -5,6 +5,7 @@ import logging
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
+from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector import DetectorEvaluationResult
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.types import DetectorGroupKey, WorkflowJob
@@ -12,7 +13,7 @@ from sentry.workflow_engine.types import DetectorGroupKey, WorkflowJob
 logger = logging.getLogger(__name__)
 
 
-# TODO - cache these by evt.group_id? :thinking:
+# TODO - saponifi3d - cache these by evt.group_id? :thinking:
 def get_detector_by_event(job: WorkflowJob) -> Detector:
     evt = job["event"]
     issue_occurrence = evt.occurrence
@@ -27,6 +28,7 @@ def get_detector_by_event(job: WorkflowJob) -> Detector:
 
 def create_issue_occurrence_from_result(result: DetectorEvaluationResult):
     occurrence, status_change = None, None
+
     if isinstance(result.result, IssueOccurrence):
         occurrence = result.result
         payload_type = PayloadType.OCCURRENCE
@@ -42,7 +44,6 @@ def create_issue_occurrence_from_result(result: DetectorEvaluationResult):
     )
 
 
-# TODO - Add metrics / logging here
 def process_detectors(
     data_packet: DataPacket, detectors: list[Detector]
 ) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]]:
@@ -54,15 +55,22 @@ def process_detectors(
         if not handler:
             continue
 
-        # TODO add metric here for detector processing
+        metrics.incr(
+            "sentry.workflow_engine.process_detector",
+            tags={"detector_type": detector.type},
+        )
+
         detector_results = handler.evaluate(data_packet)
 
         for result in detector_results.values():
             if result.result is not None:
+                metrics.incr(
+                    "sentry.workflow_engine.process_detector.triggered",
+                    tags={"detector_type": detector.type},
+                )
                 create_issue_occurrence_from_result(result)
 
         if detector_results:
-            # TODO - Add metrics / logging here for successful result
             results.append((detector, detector_results))
 
         # Now that we've processed all results for this detector, commit any state changes

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -13,12 +13,12 @@ from sentry.workflow_engine.types import DetectorGroupKey, WorkflowJob
 logger = logging.getLogger(__name__)
 
 
-# TODO - saponifi3d - cache these by evt.group_id? :thinking:
 def get_detector_by_event(job: WorkflowJob) -> Detector:
     evt = job["event"]
     issue_occurrence = evt.occurrence
 
     if issue_occurrence is None:
+        # TODO - @saponifi3d - check to see if there's a way to confirm these are for the error detector
         detector = Detector.objects.get(project_id=evt.project_id, type=ErrorGroupType.slug)
     else:
         detector = Detector.objects.get(id=issue_occurrence.evidence_data.get("detector_id", None))

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -56,7 +56,7 @@ def process_detectors(
             continue
 
         metrics.incr(
-            "sentry.workflow_engine.process_detector",
+            "workflow_engine.process_detector",
             tags={"detector_type": detector.type},
         )
 
@@ -65,7 +65,7 @@ def process_detectors(
         for result in detector_results.values():
             if result.result is not None:
                 metrics.incr(
-                    "sentry.workflow_engine.process_detector.triggered",
+                    "workflow_engine.process_detector.triggered",
                     tags={"detector_type": detector.type},
                 )
                 create_issue_occurrence_from_result(result)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -153,12 +153,11 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
     ):
         actions = evaluate_workflows_action_filters(triggered_workflows, job)
 
-        if actions:
-            metrics.incr(
-                "workflow_engine.process_workflows.triggered_actions",
-                len(actions),
-                tags={"detector_type": detector.type},
-            )
+        metrics.incr(
+            "workflow_engine.process_workflows.triggered_actions",
+            len(actions),
+            tags={"detector_type": detector.type},
+        )
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):
         for action in actions:

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
 from sentry.snuba.models import SnubaQuery
-from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.processors import process_data_sources
 from sentry.workflow_engine.registry import data_source_type_registry
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
-class TestProcessDataSources(TestCase):
+class TestProcessDataSources(BaseWorkflowTest):
     def create_snuba_query(self, **kwargs):
         return SnubaQuery.objects.create(
             type=SnubaQuery.Type.ERROR.value,

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -118,3 +118,16 @@ class TestProcessDataSources(BaseWorkflowTest):
                 "workflow_engine.process_data_sources.no_detectors",
                 tags={"query_type": "test3"},
             )
+
+    def test_metrics_for_many_detectors(self):
+        self.detector_three = self.create_detector(name="test_detector3")
+        self.ds1.detectors.add(self.detector_three)
+
+        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
+            process_data_sources(self.data_packets, "test")
+
+            mock_incr.assert_any_call(
+                "workflow_engine.process_data_sources.detectors",
+                2,
+                tags={"detector_type": self.detector_one.type},
+            )

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -97,7 +97,7 @@ class TestProcessDataSources(BaseWorkflowTest):
             process_data_sources(self.data_packets, "test")
 
             mock_incr.assert_any_call(
-                "sentry.workflow_engine.process_data_sources", tags={"query_type": "test"}
+                "workflow_engine.process_data_sources", tags={"query_type": "test"}
             )
 
     def test_metrics_are_sent_for_detector_types(self):
@@ -105,7 +105,7 @@ class TestProcessDataSources(BaseWorkflowTest):
             process_data_sources(self.data_packets, "test")
 
             mock_incr.assert_any_call(
-                "sentry.workflow_engine.process_data_sources.detectors",
+                "workflow_engine.process_data_sources.detectors",
                 1,
                 tags={"detector_type": self.detector_one.type},
             )
@@ -115,6 +115,6 @@ class TestProcessDataSources(BaseWorkflowTest):
             process_data_sources(self.data_packets, "test3")
 
             mock_incr.assert_any_call(
-                "sentry.workflow_engine.process_data_sources.no_detectors",
+                "workflow_engine.process_data_sources.no_detectors",
                 tags={"query_type": "test3"},
             )

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -146,6 +146,38 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             )
         assert results == []
 
+    def test_sending_metric_before_evaluating(self):
+        detector = self.create_detector(type=self.handler_type.slug)
+        data_packet = self.build_data_packet()
+
+        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
+            process_detectors(data_packet, [detector])
+
+            mock_incr.assert_called_once_with(
+                "sentry.workflow_engine.process_detector",
+                tags={"detector_type": detector.type},
+            )
+
+    def test_sending_metric_with_results(self):
+        detector = self.create_detector(type=self.update_handler_type.slug)
+        data_packet = self.build_data_packet()
+
+        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
+            process_detectors(data_packet, [detector])
+
+            mock_incr.assert_any_call(
+                "sentry.workflow_engine.process_detector.triggered",
+                tags={"detector_type": detector.type},
+            )
+
+    def test_doesnt_send_metric(self):
+        detector = self.create_detector(type=self.no_handler_type.slug)
+        data_packet = self.build_data_packet()
+
+        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
+            process_detectors(data_packet, [detector])
+            mock_incr.assert_not_called()
+
 
 class TestKeyBuilders(unittest.TestCase):
     def build_handler(self, detector: Detector | None = None) -> MockDetectorStateHandler:

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -154,7 +154,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             process_detectors(data_packet, [detector])
 
             mock_incr.assert_called_once_with(
-                "sentry.workflow_engine.process_detector",
+                "workflow_engine.process_detector",
                 tags={"detector_type": detector.type},
             )
 
@@ -166,7 +166,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             process_detectors(data_packet, [detector])
 
             mock_incr.assert_any_call(
-                "sentry.workflow_engine.process_detector.triggered",
+                "workflow_engine.process_detector.triggered",
                 tags={"detector_type": detector.type},
             )
 


### PR DESCRIPTION
## Description
Creates a standardize pipeline of metrics for the workflow_engine platform.

The funnel:
- workflow_engine.process_data_sources
  - workflow_engine.process_data_sources.detectors
  - workflow_engine.process_data_sources.no_detectors
-  workflow_engine.process_detectors
  - workflow_engine.process_detectors.triggered
- workflow_engine.process_workflows
  - workflow_engine.process_workflows.triggered_workflows
  - workflow_engine.process_workflows.triggered_actions
  
 ---
 
 This will allow us to track and split each processing layer by detector type. So we can say "we're processing this many metric alerts vs issues alerts" or if there's an outage we'll be able to see where the processing is failing (getting the data, evaluating the data, or notifying the user) -- all of this data will be split-able by detector type (product lines).

Once these metrics are in, we'll create a dashboard to illustrate the data flow in the platform.