### PR TITLE
fix(replay): Correct `getOutputType` to not use non-existant `BODY_SKIPPED` warning

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -726,7 +726,7 @@ export default class ReplayReader {
 
   isVideoReplay = () => this.getVideoEvents().length > 0;
 
-  isNetworkCaptureBodySetup = Boolean(this.getSDKOptions()?.networkCaptureBodies);
+  isNetworkCaptureBodySetup = () => Boolean(this.getSDKOptions()?.networkCaptureBodies);
 
   isNetworkDetailsSetup = memoize(() => {
     const sdkOptions = this.getSDKOptions();

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -726,9 +726,7 @@ export default class ReplayReader {
 
   isVideoReplay = () => this.getVideoEvents().length > 0;
 
-  isNetworkCaptureBodySetup = memoize(() => {
-    return Boolean(this.getSDKOptions()?.networkCaptureBodies);
-  });
+  isNetworkCaptureBodySetup = Boolean(this.getSDKOptions()?.networkCaptureBodies);
 
   isNetworkDetailsSetup = memoize(() => {
     const sdkOptions = this.getSDKOptions();

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -726,6 +726,10 @@ export default class ReplayReader {
 
   isVideoReplay = () => this.getVideoEvents().length > 0;
 
+  isNetworkCaptureBodySetup = memoize(() => {
+    return Boolean(this.getSDKOptions()?.networkCaptureBodies);
+  });
+
   isNetworkDetailsSetup = memoize(() => {
     const sdkOptions = this.getSDKOptions();
     if (sdkOptions) {

--- a/static/app/views/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/replays/detail/network/details/content.spec.tsx
@@ -322,14 +322,14 @@ describe('NetworkDetailsContent', () => {
       );
 
       it.each([
-        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchNoDataObj'},
-        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchUrlSkipped'},
-        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchEmptyBody'},
-        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchWithHeaders'},
-        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchNoDataObj'},
-        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchUrlSkipped'},
-        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchEmptyBody'},
-        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchWithHeaders'},
       ])(
         'should render the `query params` & `setup` sections when the item has no data. [$itemName]',
         ({isSetup, isCaptureBodySetup, itemName}) => {

--- a/static/app/views/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/replays/detail/network/details/content.spec.tsx
@@ -324,7 +324,6 @@ describe('NetworkDetailsContent', () => {
       it.each([
         {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
         {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
-        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'},
         {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
         {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
         {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
@@ -347,6 +346,27 @@ describe('NetworkDetailsContent', () => {
             dataSectionHeaders: ['Query String Parameters'],
             isShowingSetup: true,
             isShowingUnsupported: false,
+          });
+        }
+      );
+
+      it.each([{isSetup: true, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'}])(
+        'should render an empty `request body` when SDK option to capture network body is setup and the request body is empty.',
+        ({isSetup, isCaptureBodySetup, itemName}) => {
+          render(
+            <NetworkDetailsContent
+              {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
+              isSetup={isSetup}
+              item={mockItems[itemName as keyof typeof mockItems]}
+              visibleTab={visibleTab}
+            />
+          );
+
+          expect(queryScreenState()).toStrictEqual({
+            dataSectionHeaders: ['Query String Parameters', 'Request BodySize: 0 B'],
+            isShowingUnsupported: false,
+            isShowingSetup: false,
           });
         }
       );

--- a/static/app/views/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/replays/detail/network/details/content.spec.tsx
@@ -23,7 +23,7 @@ const [
   img,
   fetchNoDataObj,
   fetchUrlSkipped,
-  fetchBodySkipped,
+  fetchEmptyBody,
   fetchWithHeaders,
   fetchWithRespBody,
 ] = hydrateSpans(ReplayRecordFixture(), [
@@ -60,13 +60,11 @@ const [
       method: 'GET',
       statusCode: 200,
       request: {
-        // @ts-expect-error 'BODY_SKIPPED' is not assignable to type NetworkMetaWarning
-        _meta: {warnings: ['BODY_SKIPPED']},
+        _meta: {warnings: []},
         headers: {accept: 'application/json'},
       },
       response: {
-        // @ts-expect-error 'BODY_SKIPPED' is not assignable to type NetworkMetaWarning
-        _meta: {warnings: ['BODY_SKIPPED']},
+        _meta: {warnings: []},
         headers: {'content-type': 'application/json'},
       },
     },
@@ -114,7 +112,7 @@ const mockItems = {
   img: img!,
   fetchNoDataObj: fetchNoDataObj!,
   fetchUrlSkipped: fetchUrlSkipped!,
-  fetchBodySkipped: fetchBodySkipped!,
+  fetchEmptyBody: fetchEmptyBody!,
   fetchWithHeaders: fetchWithHeaders!,
   fetchWithRespBody: fetchWithRespBody!,
 };
@@ -144,14 +142,17 @@ describe('NetworkDetailsContent', () => {
 
     describe('Unsupported Operation', () => {
       it.each([
-        {isSetup: false, itemName: 'img'},
-        {isSetup: true, itemName: 'img'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'img'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'img'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'img'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'img'},
       ])(
         'should render the `general` & `unsupported` sections when the span is not FETCH or XHR and isSetup=$isSetup. [$itemName]',
-        ({isSetup}) => {
+        ({isSetup, isCaptureBodySetup}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems.img}
               visibleTab={visibleTab}
@@ -169,17 +170,23 @@ describe('NetworkDetailsContent', () => {
 
     describe('Supported Operation', () => {
       it.each([
-        {isSetup: false, itemName: 'fetchNoDataObj'},
-        {isSetup: false, itemName: 'fetchUrlSkipped'},
-        {isSetup: false, itemName: 'fetchBodySkipped'},
-        {isSetup: false, itemName: 'fetchWithHeaders'},
-        {isSetup: false, itemName: 'fetchWithRespBody'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchEmptyBody'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchWithHeaders'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchWithRespBody'},
       ])(
         'should render the `general` & `setup` sections when isSetup=false, no matter the item. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -195,15 +202,18 @@ describe('NetworkDetailsContent', () => {
       );
 
       it.each([
-        {isSetup: true, itemName: 'fetchNoDataObj'},
-        {isSetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
       ])(
         'should render the `general` & `setup` sections when the item has no data. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
               isSetup={isSetup}
+              isCaptureBodySetup={isCaptureBodySetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
             />
@@ -218,15 +228,19 @@ describe('NetworkDetailsContent', () => {
       );
 
       it.each([
-        {isSetup: true, itemName: 'fetchBodySkipped'},
-        {isSetup: true, itemName: 'fetchWithHeaders'},
-        {isSetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchWithRespBody'},
       ])(
         'should render the `general` & two `headers` sections, and always the setup section, when things are setup and the item has some data. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -248,14 +262,17 @@ describe('NetworkDetailsContent', () => {
 
     describe('Unsupported Operation', () => {
       it.each([
-        {isSetup: false, itemName: 'img'},
-        {isSetup: true, itemName: 'img'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'img'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'img'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'img'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'img'},
       ])(
         'should render the `query params` & `unsupported` sections when the span is not FETCH or XHR and isSetup=$isSetup. [$itemName]',
-        ({isSetup}) => {
+        ({isSetup, isCaptureBodySetup}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems.img}
               visibleTab={visibleTab}
@@ -273,17 +290,23 @@ describe('NetworkDetailsContent', () => {
 
     describe('Supported Operation', () => {
       it.each([
-        {isSetup: false, itemName: 'fetchNoDataObj'},
-        {isSetup: false, itemName: 'fetchUrlSkipped'},
-        {isSetup: false, itemName: 'fetchBodySkipped'},
-        {isSetup: false, itemName: 'fetchWithHeaders'},
-        {isSetup: false, itemName: 'fetchWithRespBody'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchEmptyBody'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchWithHeaders'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchWithRespBody'},
       ])(
         'should render the `query params` & `setup` sections when isSetup is false, no matter the item. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -299,16 +322,21 @@ describe('NetworkDetailsContent', () => {
       );
 
       it.each([
-        {isSetup: true, itemName: 'fetchNoDataObj'},
-        {isSetup: true, itemName: 'fetchUrlSkipped'},
-        {isSetup: true, itemName: 'fetchBodySkipped'},
-        {isSetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureSetupBody: true, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureSetupBody: false, itemName: 'fetchWithHeaders'},
       ])(
         'should render the `query params` & `setup` sections when the item has no data. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -323,12 +351,16 @@ describe('NetworkDetailsContent', () => {
         }
       );
 
-      it.each([{isSetup: true, itemName: 'fetchWithRespBody'}])(
+      it.each([
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchWithRespBody'},
+      ])(
         'should render the `query params` & `request payload` sections when things are setup and the item has some data. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -350,14 +382,17 @@ describe('NetworkDetailsContent', () => {
 
     describe('Unsupported Operation', () => {
       it.each([
-        {isSetup: false, itemName: 'img'},
-        {isSetup: true, itemName: 'img'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'img'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'img'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'img'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'img'},
       ])(
         'should render the `unsupported` section when the span is not FETCH or XHR and isSetup=$isSetup. [$itemName]',
-        ({isSetup}) => {
+        ({isSetup, isCaptureBodySetup}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems.img}
               visibleTab={visibleTab}
@@ -375,17 +410,23 @@ describe('NetworkDetailsContent', () => {
 
     describe('Supported Operation', () => {
       it.each([
-        {isSetup: false, itemName: 'fetchNoDataObj'},
-        {isSetup: false, itemName: 'fetchUrlSkipped'},
-        {isSetup: false, itemName: 'fetchBodySkipped'},
-        {isSetup: false, itemName: 'fetchWithHeaders'},
-        {isSetup: false, itemName: 'fetchWithRespBody'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: false, isCaptureBodySetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchEmptyBody'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchWithHeaders'},
+        {isSetup: false, isCaptureBodySetup: false, itemName: 'fetchWithRespBody'},
       ])(
         'should render the `setup` section when isSetup is false, no matter the item. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -401,16 +442,20 @@ describe('NetworkDetailsContent', () => {
       );
 
       it.each([
-        {isSetup: true, itemName: 'fetchNoDataObj'},
-        {isSetup: true, itemName: 'fetchUrlSkipped'},
-        {isSetup: true, itemName: 'fetchBodySkipped'},
-        {isSetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithHeaders'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchNoDataObj'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchUrlSkipped'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchEmptyBody'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchWithHeaders'},
       ])(
         'should render the `setup` section when the item has no data. [$itemName]',
-        ({isSetup, itemName}) => {
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}
@@ -425,12 +470,37 @@ describe('NetworkDetailsContent', () => {
         }
       );
 
-      it.each([{isSetup: true, itemName: 'fetchWithRespBody'}])(
-        'should render the `response body` section when things are setup and the item has some data. [$itemName]',
-        ({isSetup, itemName}) => {
+      it.each([{isSetup: true, isCaptureBodySetup: true, itemName: 'fetchEmptyBody'}])(
+        'should render an empty `response body` when SDK option to capture network body is setup and the response body is empty.',
+        ({isSetup, isCaptureBodySetup, itemName}) => {
           render(
             <NetworkDetailsContent
               {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
+              isSetup={isSetup}
+              item={mockItems[itemName as keyof typeof mockItems]}
+              visibleTab={visibleTab}
+            />
+          );
+
+          expect(queryScreenState()).toStrictEqual({
+            dataSectionHeaders: ['Response BodySize: 0 B'],
+            isShowingUnsupported: false,
+            isShowingSetup: false,
+          });
+        }
+      );
+
+      it.each([
+        {isSetup: true, isCaptureBodySetup: true, itemName: 'fetchWithRespBody'},
+        {isSetup: true, isCaptureBodySetup: false, itemName: 'fetchWithRespBody'},
+      ])(
+        'should render the `response body` section when things are setup and the item has some data. [$itemName]',
+        ({isSetup, isCaptureBodySetup, itemName}) => {
+          render(
+            <NetworkDetailsContent
+              {...basicSectionProps()}
+              isCaptureBodySetup={isCaptureBodySetup}
               isSetup={isSetup}
               item={mockItems[itemName as keyof typeof mockItems]}
               visibleTab={visibleTab}

--- a/static/app/views/replays/detail/network/details/getOutputType.tsx
+++ b/static/app/views/replays/detail/network/details/getOutputType.tsx
@@ -14,12 +14,18 @@ export enum Output {
 }
 
 type Args = {
+  isCaptureBodySetup: boolean;
   isSetup: boolean;
   item: SectionProps['item'];
   visibleTab: TabKey;
 };
 
-export default function getOutputType({isSetup, item, visibleTab}: Args): Output {
+export default function getOutputType({
+  isCaptureBodySetup,
+  isSetup,
+  item,
+  visibleTab,
+}: Args): Output {
   if (!isRequestFrame(item)) {
     return Output.UNSUPPORTED;
   }
@@ -65,14 +71,9 @@ export default function getOutputType({isSetup, item, visibleTab}: Args): Output
     return Output.URL_SKIPPED;
   }
 
-  if (['request', 'response'].includes(visibleTab)) {
-    // @ts-expect-error TS(2345): Argument of type '"BODY_SKIPPED"' is not assignabl... Remove this comment to see the full error message
-    const isReqBodySkipped = reqWarnings.includes('BODY_SKIPPED');
-    // @ts-expect-error TS(2345): Argument of type '"BODY_SKIPPED"' is not assignabl... Remove this comment to see the full error message
-    const isRespBodySkipped = respWarnings.includes('BODY_SKIPPED');
-    if (isReqBodySkipped || isRespBodySkipped) {
-      return Output.BODY_SKIPPED;
-    }
+  // Capture body is not setup (this should also imply there is no body)
+  if (['request', 'response'].includes(visibleTab) && !hasBody && !isCaptureBodySetup) {
+    return Output.BODY_SKIPPED;
   }
 
   return Output.DATA;

--- a/static/app/views/replays/detail/network/details/index.tsx
+++ b/static/app/views/replays/detail/network/details/index.tsx
@@ -9,6 +9,7 @@ import type {TabKey} from 'sentry/views/replays/detail/network/details/tabs';
 import NetworkDetailsTabs from 'sentry/views/replays/detail/network/details/tabs';
 
 type Props = {
+  isCaptureBodySetup: boolean;
   isSetup: boolean;
   item: null | SpanFrame;
   onClose: () => void;
@@ -19,6 +20,7 @@ type Props = {
 function NetworkDetails({
   isHeld,
   isSetup,
+  isCaptureBodySetup,
   item,
   onClose,
   onDoubleClick,
@@ -47,6 +49,7 @@ function NetworkDetails({
 
       <NetworkDetailsContent
         isSetup={isSetup}
+        isCaptureBodySetup={isCaptureBodySetup}
         item={item}
         projectId={projectId}
         startTimestampMs={startTimestampMs}

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -47,6 +47,7 @@ function NetworkList() {
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 
   const isNetworkDetailsSetup = Boolean(replay?.isNetworkDetailsSetup());
+  const isCaptureBodySetup = Boolean(replay?.isNetworkCaptureBodySetup());
   const networkFrames = replay?.getNetworkFrames();
   const projectId = replay?.getReplay()?.project_id;
   const startTimestampMs = replay?.getReplay()?.started_at?.getTime() || 0;
@@ -221,6 +222,7 @@ function NetworkList() {
           <NetworkDetails
             {...resizableDrawerProps}
             isSetup={isNetworkDetailsSetup}
+            isCaptureBodySetup={isCaptureBodySetup}
             // @ts-expect-error TS(7015): Element implicitly has an 'any' type because index... Remove this comment to see the full error message
             item={selectedIndex ? items[selectedIndex] : null}
             onClose={onCloseDetailsSplit}


### PR DESCRIPTION
This actually does not exist in our SDK, instead we can make the same assumption using sdk configuration options (e.g. if they have the option enabled) and if the body is empty to determine if we should show the onboarding setup.

ref: https://github.com/getsentry/sentry-javascript/pull/7953#issuecomment-1522905971
closes: https://github.com/getsentry/sentry-javascript/issues/8004
