### PR TITLE
:recycle: ref(aci): migrate sentry app webhooks to sentry app

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -26,7 +26,11 @@ class FieldMapping:
 
 
 class BaseActionTranslator(ABC):
-    action_type: ClassVar[Action.Type]
+    @property
+    @abstractmethod
+    def action_type(self) -> Action.Type:
+        pass
+
     # Represents the mapping of a target field to a source field {target_field: FieldMapping}
     field_mappings: ClassVar[dict[str, FieldMapping]] = {}
 
@@ -114,7 +118,9 @@ issue_alert_action_translator_registry = Registry[type[BaseActionTranslator]](
     "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
 )
 class SlackActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.SLACK
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.SLACK
 
     @property
     def required_fields(self) -> list[str]:
@@ -145,7 +151,9 @@ class SlackActionTranslator(BaseActionTranslator):
     "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction"
 )
 class DiscordActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.DISCORD
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.DISCORD
 
     @property
     def required_fields(self) -> list[str]:
@@ -172,7 +180,9 @@ class DiscordActionTranslator(BaseActionTranslator):
     "sentry.integrations.msteams.notify_action.MsTeamsNotifyServiceAction"
 )
 class MSTeamsActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.MSTEAMS
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.MSTEAMS
 
     @property
     def required_fields(self) -> list[str]:
@@ -194,12 +204,19 @@ class MSTeamsActionTranslator(BaseActionTranslator):
     def target_display(self) -> str | None:
         return self.action.get("channel")
 
+    @property
+    def blob_type(self) -> type[DataBlob]:
+        return OnCallDataBlob
+
 
 @issue_alert_action_translator_registry.register(
     "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction"
 )
 class PagerDutyActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.PAGERDUTY
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.PAGERDUTY
+
     field_mappings = {
         "priority": FieldMapping(
             source_field="severity", default_value=str(PAGERDUTY_DEFAULT_SEVERITY)
@@ -231,7 +248,10 @@ class PagerDutyActionTranslator(BaseActionTranslator):
     "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction"
 )
 class OpsgenieActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.OPSGENIE
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.OPSGENIE
+
     field_mappings = {
         "priority": FieldMapping(
             source_field="priority", default_value=str(OPSGENIE_DEFAULT_PRIORITY)
@@ -284,21 +304,27 @@ class GitHubActionTranslatorBase(TicketActionTranslator):
     "sentry.integrations.github.notify_action.GitHubCreateTicketAction"
 )
 class GitHubActionTranslator(GitHubActionTranslatorBase):
-    action_type = Action.Type.GITHUB
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.GITHUB
 
 
 @issue_alert_action_translator_registry.register(
     "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction"
 )
 class GitHubEnterpriseActionTranslator(GitHubActionTranslatorBase):
-    action_type = Action.Type.GITHUB_ENTERPRISE
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.GITHUB_ENTERPRISE
 
 
 @issue_alert_action_translator_registry.register(
     "sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction"
 )
 class AzureDevOpsActionTranslator(TicketActionTranslator):
-    action_type = Action.Type.AZURE_DEVOPS
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.AZURE_DEVOPS
 
     @property
     def blob_type(self) -> type[DataBlob]:
@@ -307,7 +333,9 @@ class AzureDevOpsActionTranslator(TicketActionTranslator):
 
 @issue_alert_action_translator_registry.register("sentry.mail.actions.NotifyEmailAction")
 class EmailActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.EMAIL
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.EMAIL
 
     @property
     def required_fields(self) -> list[str]:
@@ -363,7 +391,9 @@ class EmailActionTranslator(BaseActionTranslator):
     "sentry.rules.actions.notify_event.NotifyEventAction"
 )
 class PluginActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.PLUGIN
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.PLUGIN
 
     @property
     def required_fields(self) -> list[str]:
@@ -392,15 +422,32 @@ class PluginActionTranslator(BaseActionTranslator):
     "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
 )
 class WebhookActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.WEBHOOK
+    def __init__(self, action: dict[str, Any]):
+        super().__init__(action)
+        # Fetch the sentry app id using app_service
+        # If the app exists, we should heal this action as a SentryAppAction
+        # Based on sentry/rules/actions/notify_event_service.py
+        if service := self.action.get("service"):
+            self.sentry_app = app_service.get_sentry_app_by_slug(slug=service)
+        else:
+            self.sentry_app = None
+
+    @property
+    def action_type(self) -> Action.Type:
+        if self.sentry_app:
+            return Action.Type.SENTRY_APP
+        else:
+            return Action.Type.WEBHOOK
+
+    @property
+    def target_type(self) -> ActionTarget | None:
+        if self.sentry_app:
+            return ActionTarget.SENTRY_APP
+        return None
 
     @property
     def required_fields(self) -> list[str]:
         return ["service"]
-
-    @property
-    def target_type(self) -> ActionTarget | None:
-        return None
 
     @property
     def integration_id(self) -> int | None:
@@ -409,6 +456,9 @@ class WebhookActionTranslator(BaseActionTranslator):
     @property
     def target_identifier(self) -> str | None:
         # The service field identifies the webhook
+        # If the webhook goes to a sentry app, then we should identify the sentry app by id
+        if self.sentry_app:
+            return str(self.sentry_app.id)
         return self.action.get("service")
 
 
@@ -416,7 +466,9 @@ class WebhookActionTranslator(BaseActionTranslator):
     "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
 )
 class SentryAppActionTranslator(BaseActionTranslator):
-    action_type = Action.Type.SENTRY_APP
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.SENTRY_APP
 
     @property
     def required_fields(self) -> list[str]:
@@ -530,6 +582,12 @@ class SentryAppFormConfigDataBlob(DataBlob):
     name is the name of the form field, and value is the value of the form field.
     """
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]):
+        if not isinstance(data.get("name"), str) or not isinstance(data.get("value"), str):
+            raise ValueError("Sentry app config must contain name and value keys")
+        return cls(name=data["name"], value=data["value"])
+
     name: str = ""
     value: str = ""
 
@@ -541,6 +599,12 @@ class SentryAppDataBlob(DataBlob):
     """
 
     settings: list[SentryAppFormConfigDataBlob] = field(default_factory=list)
+
+    @classmethod
+    def from_list(cls, data: list[dict[str, Any]] | None):
+        if data is None:
+            return cls()
+        return cls(settings=[SentryAppFormConfigDataBlob.from_dict(setting) for setting in data])
 
 
 @dataclass

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1073,10 +1073,11 @@ class TestNotificationActionMigrationUtils(TestCase):
         ]
 
         actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == 2
+        assert len(actions) == 1
         assert actions[0].type == Action.Type.SENTRY_APP
         assert actions[0].target_identifier == str(app.id)
         assert actions[0].target_type == ActionTarget.SENTRY_APP
+        assert actions[0].data == {}
 
     def test_webhook_action_migration_malformed(self):
         action_data = [

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1058,6 +1058,26 @@ class TestNotificationActionMigrationUtils(TestCase):
         actions = build_notification_actions_from_rule_data_actions(action_data)
         self.assert_actions_migrated_correctly(actions, action_data, None, "service", None)
 
+    def test_webhook_action_migration_to_sentry_app(self):
+        app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application",
+            is_alertable=True,
+        )
+
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+                "service": app.slug,
+            },
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        assert len(actions) == 2
+        assert actions[0].type == Action.Type.SENTRY_APP
+        assert actions[0].target_identifier == str(app.id)
+        assert actions[0].target_type == ActionTarget.SENTRY_APP
+
     def test_webhook_action_migration_malformed(self):
         action_data = [
             {
@@ -1120,9 +1140,11 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         for registry_id, expected_type in test_cases:
             translator_class = issue_alert_action_translator_registry.get(registry_id)
-            assert translator_class.action_type == expected_type, (
+            # Create an instance with empty action data
+            translator = translator_class({"id": registry_id})
+            assert translator.action_type == expected_type, (
                 f"Action translator {registry_id} has incorrect action type. "
-                f"Expected {expected_type}, got {translator_class.action_type}"
+                f"Expected {expected_type}, got {translator.action_type}"
             )
 
     def test_action_type_in_migration(self):


### PR DESCRIPTION
a bit of an interesting one:

so i was working on cleaning up some metric alert migration for action and found that for AlertRuleTriggerActions configured as "sentry apps", they actually contain 2 classes - sentry apps (duh) and webhooks. webhooks are basically sentry apps where we don't send any additional data.

on the other hand issue alerts aren't as well abstracted. we have 2 different controllers that differentiate between webhooks and sentry apps.

the webhook action handler is a little scuffed, first attempting to fetch a sentry app by slug, then trying plugins:
https://github.com/getsentry/sentry/blob/76d4f816f8cc193b00337d912bae3c085be4b982/src/sentry/rules/actions/notify_event_service.py#L150-L158

whats to note is that if it finds a sentry app, it uses the same function as the sentry app handler to send a notification
https://github.com/getsentry/sentry/blob/76d4f816f8cc193b00337d912bae3c085be4b982/src/sentry/rules/actions/notify_event_service.py#L155

https://github.com/getsentry/sentry/blob/76d4f816f8cc193b00337d912bae3c085be4b982/src/sentry/rules/actions/sentry_apps/notify_event.py#L147-L151


what this means is we can actually move these webhooks configured for issue alerts to sentry apps (we actually need to so actions are alert type agnostic). this pr checks if the webhook action configured is a sentry app. if it is, it will translate it to a sentry app.

in the NOA, we will actually use the Sentry App Handler instead of the webhook handler. this will give us a deprecation path where we can remove the scuffed logic to fetch both sentry apps and plugins -- instead we would just have to fetch plugins.



a todo for the future: look into seeing if i can combine webhook and plugin actions

for those interested, the overall flow for this would look like:
![image](https://github.com/user-attachments/assets/77fdb2e1-229c-4006-a798-742e800e9af6)