### PR TITLE
fix(admin): add RouterProvider to superuser access form

### DIFF
--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {logout} from 'sentry/actionCreators/account';
@@ -194,7 +195,7 @@ class SuperuserStaffAccessForm extends Component<Props, State> {
       return null;
     }
 
-    return (
+    const FormContent = (
       <ThemeAndStyleProvider>
         {this.props.hasStaff ? (
           isLoading ? (
@@ -244,6 +245,15 @@ class SuperuserStaffAccessForm extends Component<Props, State> {
         )}
       </ThemeAndStyleProvider>
     );
+
+    const router = createBrowserRouter([
+      {
+        path: '*',
+        element: FormContent,
+      },
+    ]);
+
+    return <RouterProvider router={router} />;
   }
 }
 

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, useState} from 'react';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import styled from '@emotion/styled';
 
@@ -35,7 +35,7 @@ type State = {
   superuserReason: string;
 };
 
-class SuperuserStaffAccessForm extends Component<Props, State> {
+class SuperuserStaffAccessFormContent extends Component<Props, State> {
   constructor(props: any) {
     super(props);
     this.authUrl = this.props.hasStaff ? '/staff-auth/' : '/auth/';
@@ -195,7 +195,7 @@ class SuperuserStaffAccessForm extends Component<Props, State> {
       return null;
     }
 
-    const FormContent = (
+    return (
       <ThemeAndStyleProvider>
         {this.props.hasStaff ? (
           isLoading ? (
@@ -245,16 +245,21 @@ class SuperuserStaffAccessForm extends Component<Props, State> {
         )}
       </ThemeAndStyleProvider>
     );
+  }
+}
 
-    const router = createBrowserRouter([
+const FormWithApi = withApi(SuperuserStaffAccessFormContent);
+
+export default function SuperuserStaffAccessForm({api, hasStaff}: Props) {
+  const [router] = useState(() =>
+    createBrowserRouter([
       {
         path: '*',
-        element: FormContent,
+        element: <FormWithApi api={api} hasStaff={hasStaff} />,
       },
-    ]);
-
-    return <RouterProvider router={router} />;
-  }
+    ])
+  );
+  return <RouterProvider router={router} />;
 }
 
 const StyledAlert = styled(Alert)`
@@ -265,5 +270,3 @@ const BackWrapper = styled('div')`
   width: 100%;
   margin-left: ${space(4)};
 `;
-
-export default withApi(SuperuserStaffAccessForm);

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -250,12 +250,12 @@ class SuperuserStaffAccessFormContent extends Component<Props, State> {
 
 const FormWithApi = withApi(SuperuserStaffAccessFormContent);
 
-export default function SuperuserStaffAccessForm({api, hasStaff}: Props) {
+export default function SuperuserStaffAccessForm({hasStaff}: Props) {
   const [router] = useState(() =>
     createBrowserRouter([
       {
         path: '*',
-        element: <FormWithApi api={api} hasStaff={hasStaff} />,
+        element: <FormWithApi hasStaff={hasStaff} />,
       },
     ])
   );


### PR DESCRIPTION
trying to access _admin was broken locally because it didn't have a RouterProvider (since the superuser access form gets rendered directly from a django view)

<img width="794" alt="Screenshot 2025-02-05 at 4 31 42 PM" src="https://github.com/user-attachments/assets/8cb81f99-2408-49a8-9a5e-f1bf599eca1c" />
