### PR TITLE
fix(theme): Allow go to definition for theme.breakpoint

### DIFF
--- a/static/app/utils/metrics/useBreakpoints.spec.tsx
+++ b/static/app/utils/metrics/useBreakpoints.spec.tsx
@@ -4,7 +4,7 @@ import {checkBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
 
 describe('checkBreakpoints', () => {
   it('returns true for active breakpoints', () => {
-    const breakpoints: Theme['breakpoints'] = {
+    const breakpoints: Record<keyof Theme['breakpoints'], string> = {
       xsmall: '0px',
       small: '0px',
       medium: '1px',

--- a/static/app/utils/metrics/useBreakpoints.tsx
+++ b/static/app/utils/metrics/useBreakpoints.tsx
@@ -8,7 +8,7 @@ import {useInstantRef} from 'sentry/utils/metrics';
 
 type Breakpoint = keyof Theme['breakpoints'];
 export function checkBreakpoints(
-  breakpoints: Theme['breakpoints'],
+  breakpoints: Record<Breakpoint, string>,
   width: number
 ): Record<Breakpoint, boolean> {
   return Object.entries(breakpoints).reduce(

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -839,18 +839,16 @@ const buttonPaddingSizes: ButtonPaddingSizes = {
 };
 
 type Breakpoint = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge';
-type Breakpoints = {
-  [key in Breakpoint]: string;
-};
+type Breakpoints = Record<Breakpoint, string>;
 
-const breakpoints: Breakpoints = {
+const breakpoints = {
   xsmall: '500px',
   small: '800px',
   medium: '992px',
   large: '1200px',
   xlarge: '1440px',
   xxlarge: '2560px',
-} as const;
+} as const satisfies Breakpoints;
 
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 type Sizes = {


### PR DESCRIPTION
Allows you to go directly to the definition for theme.breakpoins.large where before it would only take you to theme.breakpoints

before
![image](https://github.com/user-attachments/assets/e2fa9baa-67c6-4fca-9d3a-0b9ffe530595)

after
![image](https://github.com/user-attachments/assets/51c704eb-77da-408f-a1f7-f654eeb4c490)
