### PR TITLE
ref(workflow_engine): Implementation of DataSource query_id to source_id

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -390,7 +390,7 @@ class SubscriptionProcessor:
             self.subscription.project.organization,
         ):
             data_packet = DataPacket[QuerySubscriptionUpdate](
-                query_id=str(self.subscription.id), packet=subscription_update
+                source_id=str(self.subscription.id), packet=subscription_update
             )
             process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
 

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -150,7 +150,9 @@ class QuerySubscriptionDataSourceHandler(DataSourceTypeHandler[QuerySubscription
         data_sources: list[DataSource],
     ) -> dict[int, QuerySubscription | None]:
         qs_lookup = {
-            qs.id: qs
-            for qs in QuerySubscription.objects.filter(id__in=[ds.query_id for ds in data_sources])
+            str(qs.id): qs
+            for qs in QuerySubscription.objects.filter(
+                id__in=[int(ds.source_id) for ds in data_sources]
+            )
         }
-        return {ds.id: qs_lookup.get(ds.query_id) for ds in data_sources}
+        return {ds.id: qs_lookup.get(ds.source_id) for ds in data_sources}

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2129,17 +2129,17 @@ class Factories:
     @assume_test_silo_mode(SiloMode.REGION)
     def create_data_source(
         organization: Organization | None = None,
-        query_id: int | None = None,
+        source_id: str | None = None,
         type: str | None = None,
         **kwargs,
     ) -> DataSource:
         if organization is None:
             organization = Factories.create_organization()
-        if query_id is None:
-            query_id = random.randint(1, 10000)
+        if source_id is None:
+            source_id = str(random.randint(1, 10000))
         if type is None:
             type = data_source_type_registry.get_key(QuerySubscriptionDataSourceHandler)
-        return DataSource.objects.create(organization=organization, query_id=query_id, type=type)
+        return DataSource.objects.create(organization=organization, source_id=source_id, type=type)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -62,8 +62,8 @@ class DataSourceSerializer(Serializer):
         self, obj: DataSource, attrs: Mapping[str, Any], user, **kwargs
     ) -> dict[str, Any]:
         return {
-            "id": obj.id,
-            "organizationId": obj.organization_id,
+            "id": str(obj.id),
+            "organizationId": str(obj.organization_id),
             "type": obj.type,
             "sourceId": str(obj.source_id),
             "queryObj": attrs["query_obj"],

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -62,10 +62,10 @@ class DataSourceSerializer(Serializer):
         self, obj: DataSource, attrs: Mapping[str, Any], user, **kwargs
     ) -> dict[str, Any]:
         return {
-            "id": str(obj.id),
-            "organizationId": str(obj.organization_id),
+            "id": obj.id,
+            "organizationId": obj.organization_id,
             "type": obj.type,
-            "queryId": str(obj.query_id),
+            "sourceId": str(obj.source_id),
             "queryObj": attrs["query_obj"],
         }
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -55,7 +55,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
             data_source = data_source_creator.create()
             detector_data_source = DataSource.objects.create(
                 organization_id=self.context["project"].organization_id,
-                query_id=data_source.id,
+                source_id=data_source.id,
                 type=validated_data["data_source"]["data_source_type"],
             )
             for condition in validated_data["data_conditions"]:

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -333,7 +333,7 @@ def create_data_source(
         return None
     return DataSource.objects.create(
         organization_id=organization_id,
-        query_id=query_subscription.id,
+        source_id=str(query_subscription.id),
         type="snuba_query_subscription",
     )
 
@@ -651,7 +651,7 @@ def get_data_source(alert_rule: AlertRule) -> DataSource | None:
     try:
         data_source = DataSource.objects.get(
             organization=organization,
-            query_id=query_subscription.id,
+            source_id=query_subscription.id,
             type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
         )
     except DataSource.DoesNotExist:

--- a/src/sentry/workflow_engine/models/data_source.py
+++ b/src/sentry/workflow_engine/models/data_source.py
@@ -23,8 +23,7 @@ T = TypeVar("T")
 
 @dataclasses.dataclass
 class DataPacket(Generic[T]):
-    # TODO - @saponifi3d - update this to source_id to match, when implementing
-    query_id: str
+    source_id: str
     packet: T
 
 

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -10,6 +10,7 @@ from sentry.workflow_engine.models import DataPacket, DataSource, Detector
 logger = logging.getLogger("sentry.workflow_engine.process_data_source")
 
 
+# TODO - @saponifi3d - change the text choices to an enum
 def process_data_sources(
     data_packets: list[DataPacket], query_type: str
 ) -> list[tuple[DataPacket, list[Detector]]]:

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -15,22 +15,21 @@ def process_data_sources(
 ) -> list[tuple[DataPacket, list[Detector]]]:
     metrics.incr("workflow_engine.process_data_sources", tags={"query_type": query_type})
 
-    # TODO - saponifi3d - change data_source.query_id to be a string to support UUIDs
-    data_packet_ids = {int(packet.query_id) for packet in data_packets}
+    data_packet_ids = {packet.source_id for packet in data_packets}
 
     # Fetch all data sources and associated detectors for the given data packets
     with sentry_sdk.start_span(op="workflow_engine.process_data_sources.fetch_data_sources"):
         data_sources = DataSource.objects.filter(
-            query_id__in=data_packet_ids, type=query_type
+            source_id__in=data_packet_ids, type=query_type
         ).prefetch_related(Prefetch("detectors"))
 
-    # Build a lookup dict for query_id to detectors
-    query_id_to_detectors = {int(ds.query_id): list(ds.detectors.all()) for ds in data_sources}
+    # Build a lookup dict for source_id to detectors
+    source_id_to_detectors = {ds.source_id: list(ds.detectors.all()) for ds in data_sources}
 
     # Create the result tuples
     result = []
     for packet in data_packets:
-        detectors = query_id_to_detectors.get(int(packet.query_id))
+        detectors = source_id_to_detectors.get(packet.source_id)
 
         if detectors:
             data_packet_tuple = (packet, detectors)
@@ -51,7 +50,8 @@ def process_data_sources(
             )
         else:
             logger.warning(
-                "No detectors found", extra={"query_id": packet.query_id, "query_type": query_type}
+                "No detectors found",
+                extra={"source_id": packet.source_id, "query_type": query_type},
             )
             metrics.incr(
                 "workflow_engine.process_data_sources.no_detectors",

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2959,7 +2959,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     def test_process_data_packets_called(self, mock_process_data_packets):
         rule = self.rule
         detector = self.create_detector(name="hojicha", type=MetricAlertFire.slug)
-        data_source = self.create_data_source(query_id=self.sub.id)
+        data_source = self.create_data_source(source_id=str(self.sub.id))
         data_source.detectors.set([detector])
         self.send_update(rule, 10)
         assert mock_process_data_packets.call_count == 1
@@ -2968,7 +2968,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             == DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
         )
         data_packet_list = mock_process_data_packets.call_args_list[0][0][0]
-        assert data_packet_list[0].query_id == str(self.sub.id)
+        assert data_packet_list[0].source_id == str(self.sub.id)
         assert data_packet_list[0].packet["values"] == {"data": [{"some_col_name": 10}]}
 
 

--- a/tests/sentry/snuba/test_models.py
+++ b/tests/sentry/snuba/test_models.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
+from unittest import mock
 
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
-from sentry.snuba.subscriptions import create_snuba_query
+from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 
 
@@ -22,3 +23,51 @@ class SnubaQueryEventTypesTest(TestCase):
             SnubaQueryEventType.EventType.DEFAULT,
             SnubaQueryEventType.EventType.ERROR,
         }
+
+
+class QuerySubscriptionDataSourceHandlerTest(TestCase):
+    def setUp(self):
+        self.snuba_query = create_snuba_query(
+            SnubaQuery.Type.ERROR,
+            Dataset.Events,
+            "release:123",
+            "count()",
+            timedelta(minutes=10),
+            timedelta(minutes=1),
+            None,
+            [SnubaQueryEventType.EventType.DEFAULT, SnubaQueryEventType.EventType.ERROR],
+        )
+
+        self.subscription = create_snuba_subscription(
+            self.project,
+            "test_data_source_handler",
+            self.snuba_query,
+        )
+
+        self.data_source = self.create_data_source(
+            type="snuba_query_subscription",
+            source_id=str(self.subscription.id),
+        )
+
+    def test_bulk_get_query_object(self):
+        result = QuerySubscriptionDataSourceHandler.bulk_get_query_object([self.data_source])
+        assert result[self.data_source.id] == self.subscription
+
+    def test_bulk_get_query_object__incorrect_data_source(self):
+        self.ds_with_invalid_subscription_id = self.create_data_source(
+            type="snuba_query_subscription",
+            source_id="not_int",
+        )
+
+        with mock.patch("sentry.snuba.models.logger.exception") as mock_logger:
+            data_sources = [self.data_source, self.ds_with_invalid_subscription_id]
+            result = QuerySubscriptionDataSourceHandler.bulk_get_query_object(data_sources)
+            assert result[self.data_source.id] == self.subscription
+
+            mock_logger.assert_called_once_with(
+                "Invalid DataSource.source_id fetching subscriptions",
+                extra={
+                    "id": self.ds_with_invalid_subscription_id.id,
+                    "source_id": self.ds_with_invalid_subscription_id.source_id,
+                },
+            )

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -130,7 +130,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
         assert data_source.organization_id == self.organization.id
 
         # Verify query subscription
-        query_sub = QuerySubscription.objects.get(id=data_source.query_id)
+        query_sub = QuerySubscription.objects.get(id=int(data_source.source_id))
         assert query_sub.project == self.project
         assert query_sub.snuba_query.type == SnubaQuery.Type.ERROR.value
         assert query_sub.snuba_query.dataset == Dataset.Events.value

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -85,8 +85,8 @@ class TestDetectorSerializer(TestCase):
             "dateUpdated": detector.date_updated,
             "dataSources": [
                 {
-                    "id": data_source.id,
-                    "organizationId": self.organization.id,
+                    "id": str(data_source.id),
+                    "organizationId": str(self.organization.id),
                     "type": type_name,
                     "sourceId": str(subscription.id),
                     "queryObj": {
@@ -168,8 +168,8 @@ class TestDataSourceSerializer(TestCase):
         result = serialize(data_source)
 
         assert result == {
-            "id": data_source.id,
-            "organizationId": self.organization.id,
+            "id": str(data_source.id),
+            "organizationId": str(self.organization.id),
             "type": type_name,
             "sourceId": str(subscription.id),
             "queryObj": {

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -71,12 +71,11 @@ class TestDetectorSerializer(TestCase):
         data_source = self.create_data_source(
             organization=self.organization,
             type=type_name,
-            query_id=subscription.id,
+            source_id=str(subscription.id),
         )
         data_source.detectors.set([detector])
 
         result = serialize(detector)
-        # print("result: ", result)
         assert result == {
             "id": str(detector.id),
             "projectId": str(detector.project_id),
@@ -86,10 +85,10 @@ class TestDetectorSerializer(TestCase):
             "dateUpdated": detector.date_updated,
             "dataSources": [
                 {
-                    "id": str(data_source.id),
-                    "organizationId": str(self.organization.id),
+                    "id": data_source.id,
+                    "organizationId": self.organization.id,
                     "type": type_name,
-                    "queryId": str(subscription.id),
+                    "sourceId": str(subscription.id),
                     "queryObj": {
                         "id": str(subscription.id),
                         "snubaQuery": {
@@ -108,13 +107,13 @@ class TestDetectorSerializer(TestCase):
             "conditionGroup": {
                 "id": str(condition_group.id),
                 "organizationId": str(self.organization.id),
-                "logicType": DataConditionGroup.Type.ANY,
+                "logicType": DataConditionGroup.Type.ANY.value,
                 "conditions": [
                     {
                         "id": str(condition.id),
                         "condition": Condition.GREATER.value,
                         "comparison": 100,
-                        "result": DetectorPriorityLevel.HIGH,
+                        "result": DetectorPriorityLevel.HIGH.value,
                     }
                 ],
                 "actions": [
@@ -159,19 +158,20 @@ class TestDataSourceSerializer(TestCase):
         subscription = create_snuba_subscription(
             self.project, INCIDENTS_SNUBA_SUBSCRIPTION_TYPE, snuba_query
         )
+
         data_source = self.create_data_source(
             organization=self.organization,
             type=type_name,
-            query_id=subscription.id,
+            source_id=str(subscription.id),
         )
 
         result = serialize(data_source)
 
         assert result == {
-            "id": str(data_source.id),
-            "organizationId": str(self.organization.id),
+            "id": data_source.id,
+            "organizationId": self.organization.id,
             "type": type_name,
-            "queryId": str(subscription.id),
+            "sourceId": str(subscription.id),
             "queryObj": {
                 "id": str(subscription.id),
                 "snubaQuery": {

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -316,7 +316,7 @@ class TestMetricAlertsDetectorValidator(TestCase):
         )
         assert data_source.organization_id == self.project.organization_id
 
-        query_sub = QuerySubscription.objects.get(id=data_source.query_id)
+        query_sub = QuerySubscription.objects.get(id=data_source.source_id)
         assert query_sub.project == self.project
         assert query_sub.type == INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -89,7 +89,7 @@ def assert_alert_rule_migrated(alert_rule, project_id):
 
     query_subscription = QuerySubscription.objects.get(snuba_query=alert_rule.snuba_query.id)
     data_source = DataSource.objects.get(
-        organization_id=alert_rule.organization_id, query_id=query_subscription.id
+        organization_id=alert_rule.organization_id, source_id=str(query_subscription.id)
     )
     assert data_source.type == "snuba_query_subscription"
     detector_state = DetectorState.objects.get(detector=detector)
@@ -206,7 +206,7 @@ class BaseMetricAlertMigrationTest(APITestCase, BaseWorkflowTest):
         query_subscription = QuerySubscription.objects.get(snuba_query=metric_alert.snuba_query)
         data_source = self.create_data_source(
             organization=self.organization,
-            query_id=query_subscription.id,
+            source_id=str(query_subscription.id),
             type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
         )
         detector_data_condition_group = self.create_data_condition_group(

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -28,15 +28,17 @@ class TestProcessDataSources(BaseWorkflowTest):
         self.detector_one = self.create_detector(name="test_detector1")
         self.detector_two = self.create_detector(name="test_detector2", type="metric_alert_fire")
 
-        self.ds1 = self.create_data_source(query_id=self.query.id, type="test")
+        self.ds1 = self.create_data_source(source_id=self.query.id, type="test")
         self.ds1.detectors.set([self.detector_one])
 
-        self.ds2 = self.create_data_source(query_id=self.query_two.id, type="test")
+        self.ds2 = self.create_data_source(source_id=self.query_two.id, type="test")
         self.ds2.detectors.set([self.detector_two])
 
-        self.packet = DataPacket[dict](self.query.id, {"query_id": self.query.id, "foo": "bar"})
+        self.packet = DataPacket[dict](
+            str(self.query.id), {"source_id": self.query.id, "foo": "bar"}
+        )
         self.packet_two = DataPacket[dict](
-            self.query_two.id, {"query_id": self.query_two.id, "foo": "baz"}
+            str(self.query_two.id), {"source_id": self.query_two.id, "foo": "baz"}
         )
 
         self.data_packets = [self.packet, self.packet_two]

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -24,9 +24,9 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         super().setUp()
 
     def build_data_packet(self, **kwargs):
-        query_id = "1234"
+        source_id = "1234"
         return DataPacket[dict](
-            query_id, {"query_id": query_id, "group_vals": {"group_1": 6}, **kwargs}
+            source_id, {"source_id": source_id, "group_vals": {"group_1": 6}, **kwargs}
         )
 
     def test(self):

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -134,7 +134,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         }
 
         data_source = self.create_data_source(
-            query_id=subscription_update["subscription_id"],
+            source_id=str(subscription_update["subscription_id"]),
             organization=self.organization,
         )
 
@@ -153,7 +153,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
         # Create a data_packet from the update for testing
         data_packet = DataPacket[QuerySubscriptionUpdate](
-            query_id=subscription_update["subscription_id"],
+            source_id=str(subscription_update["subscription_id"]),
             packet=subscription_update,
         )
 


### PR DESCRIPTION
## Description
Based on: https://github.com/getsentry/sentry/pull/84655

Updates the code for the migration from query_id to source_id.

Next PR in series will complete the db model updates.