### PR TITLE
:bug: fix(threads): send system workflow notification in slack threads

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -133,7 +133,12 @@ class SlackService:
             )
             return None
 
-        if activity.user_id is None and activity.group.issue_category != GroupCategory.UPTIME:
+        uptime_resolved_notification = (
+            activity.type == ActivityType.SET_RESOLVED.value
+            and activity.group.issue_category == GroupCategory.UPTIME
+        )
+
+        if activity.user_id is None and not uptime_resolved_notification:
             self._logger.info(
                 "machine/system updates are ignored at this time, nothing to do",
                 extra={

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -133,7 +133,7 @@ class SlackService:
             )
             return None
 
-        if activity.user_id is None:
+        if activity.user_id is None and activity.group.issue_category != GroupCategory.UPTIME:
             self._logger.info(
                 "machine/system updates are ignored at this time, nothing to do",
                 extra={

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -241,6 +241,67 @@ class TestNotifyAllThreadsForActivity(TestCase):
         mock_handle.assert_called()
         assert mock_handle.call_args.kwargs["parent_notification"] == parent_notification_2
 
+    @with_feature("organizations:slack-threads-refactor-uptime")
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch("sentry.integrations.slack.service.SlackService._handle_parent_notification")
+    def test_handle_parent_notification_with_open_period_uptime_resolved(
+        self, mock_handle, mock_record
+    ) -> None:
+        group = self.create_group(type=UptimeDomainCheckFailure.type_id)
+
+        activity = Activity.objects.create(
+            group=group,
+            project=self.project,
+            type=ActivityType.SET_IGNORED.value,
+            user_id=None,
+            data={"ignoreUntilEscalating": True},
+        )
+
+        rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=group,
+            event_id=456,
+            notification_uuid=str(uuid4()),
+        )
+
+        # "older" parent notification
+        parent_notification_1_message = NotificationMessage.objects.create(
+            id=123,
+            date_added=timezone.now(),
+            message_identifier="1a2s3d",
+            rule_action_uuid=self.rule_action_uuid,
+            rule_fire_history=rule_fire_history,
+            open_period_start=timezone.now() - timedelta(minutes=1),
+        )
+        parent_notification_1 = IssueAlertNotificationMessage.from_model(
+            parent_notification_1_message
+        )
+
+        self.service.notify_all_threads_for_activity(activity=activity)
+
+        mock_handle.assert_called()
+        assert mock_handle.call_args.kwargs["parent_notification"] == parent_notification_1
+
+        # "newer" parent notification
+        parent_notification_2_message = NotificationMessage.objects.create(
+            id=124,
+            date_added=timezone.now(),
+            message_identifier="1a2s3d",
+            rule_action_uuid=self.rule_action_uuid,
+            rule_fire_history=rule_fire_history,
+            open_period_start=timezone.now(),
+        )
+        parent_notification_2 = IssueAlertNotificationMessage.from_model(
+            parent_notification_2_message
+        )
+
+        self.service.notify_all_threads_for_activity(activity=activity)
+
+        # Should only return the "newer" parent notification
+        mock_handle.assert_called()
+        assert mock_handle.call_args.kwargs["parent_notification"] == parent_notification_2
+
 
 class TestHandleParentNotification(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -252,7 +252,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
         activity = Activity.objects.create(
             group=group,
             project=self.project,
-            type=ActivityType.SET_IGNORED.value,
+            type=ActivityType.SET_RESOLVED.value,
             user_id=None,
             data={"ignoreUntilEscalating": True},
         )


### PR DESCRIPTION
for uptime issues, we want to send workflow notifications the system creates (it resolves an uptime issue for example) in the thread. i still need to think through the entire behavior for all issue types so just gating this to uptime for now.


