### PR TITLE
ref(seer grouping): Make hybrid fingerprints compatible with Seer

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1287,7 +1287,7 @@ def assign_event_to_group(
         # If we still haven't found a group, ask Seer for a match (if enabled for the project)
         else:
             seer_matched_grouphash = maybe_check_seer_for_matching_grouphash(
-                event, primary.variants, all_grouphashes
+                event, primary.grouphashes[0], primary.variants, all_grouphashes
             )
 
             if seer_matched_grouphash:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -121,6 +121,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Allow creating `GroupHashMetadata` records
     manager.add("organizations:grouphash-metadata-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Allow events with hybrid fingerprints to be sent to Seer for grouping
+    manager.add("organizations:grouping-hybrid-fingerprint-seer-usage", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -216,7 +216,7 @@ def get_or_create_grouphashes(
     hashes: Sequence[str],
     grouping_config: str,
 ) -> list[GroupHash]:
-    is_secondary = grouping_config != project.get_option("sentry:grouping_config")
+    is_secondary = grouping_config == project.get_option("sentry:secondary_grouping_config")
     grouphashes: list[GroupHash] = []
 
     # The only utility of secondary hashes is to link new primary hashes to an existing group.

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -292,7 +292,10 @@ def get_seer_similar_issues(
 
 
 def maybe_check_seer_for_matching_grouphash(
-    event: Event, variants: dict[str, BaseVariant], all_grouphashes: list[GroupHash]
+    event: Event,
+    event_grouphash: GroupHash,
+    variants: dict[str, BaseVariant],
+    all_grouphashes: list[GroupHash],
 ) -> GroupHash | None:
     seer_matched_grouphash = None
 

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -234,6 +234,7 @@ def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant])
 
 def get_seer_similar_issues(
     event: Event,
+    event_grouphash: GroupHash,
     variants: dict[str, BaseVariant],
     num_neighbors: int = 1,
 ) -> tuple[dict[str, Any], GroupHash | None]:
@@ -305,7 +306,9 @@ def maybe_check_seer_for_matching_grouphash(
         try:
             # If no matching group is found in Seer, we'll still get back result
             # metadata, but `seer_matched_grouphash` will be None
-            seer_response_data, seer_matched_grouphash = get_seer_similar_issues(event, variants)
+            seer_response_data, seer_matched_grouphash = get_seer_similar_issues(
+                event, event_grouphash, variants
+            )
         except Exception as e:  # Insurance - in theory we shouldn't ever land here
             sentry_sdk.capture_exception(
                 e, tags={"event": event.event_id, "project": event.project.id}

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -26,7 +26,7 @@ from sentry.seer.similarity.utils import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_feature
 from sentry.testutils.helpers.options import override_options
 
 
@@ -140,7 +140,51 @@ class ShouldCallSeerTest(TestCase):
             ):
                 assert should_call_seer_for_grouping(self.event, self.variants) is expected_result
 
-    def test_obeys_customized_fingerprint_check(self) -> None:
+    @with_feature({"organizations:grouping-hybrid-fingerprint-seer-usage": True})
+    def test_obeys_custom_fingerprint_check_flag_on(self) -> None:
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
+
+        default_fingerprint_event = Event(
+            project_id=self.project.id,
+            event_id="11212012123120120415201309082013",
+            data={**self.event_data, "fingerprint": ["{{ default }}"]},
+        )
+        custom_fingerprint_event = Event(
+            project_id=self.project.id,
+            event_id="04152013090820131121201212312012",
+            data={**self.event_data, "fingerprint": ["charlie"]},
+        )
+        built_in_fingerprint_event = Event(
+            project_id=self.project.id,
+            event_id="09082013112120121231201204152013",
+            data={
+                **self.event_data,
+                "fingerprint": ["failedtofetcherror"],
+                "_fingerprint_info": {
+                    "matched_rule": {
+                        "is_builtin": True,
+                        "matchers": [["type", "FailedToFetchError"]],
+                        "fingerprint": ["failedtofetcherror"],
+                        "text": 'type:"FailedToFetchError" -> "failedtofetcherror"',
+                    }
+                },
+            },
+        )
+
+        for event, expected_result in [
+            (default_fingerprint_event, True),
+            (custom_fingerprint_event, False),
+            (built_in_fingerprint_event, False),
+        ]:
+
+            assert (
+                should_call_seer_for_grouping(event, event.get_grouping_variants())
+                is expected_result
+            ), f'Case with fingerprint {event.data["fingerprint"]} failed.'
+
+    # TODO: Delete this once the hybrid fingerprint + seer change is fully rolled out
+    @with_feature({"organizations:grouping-hybrid-fingerprint-seer-usage": False})
+    def test_obeys_customized_fingerprint_check_flag_off(self) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
         default_fingerprint_event = Event(
@@ -236,7 +280,7 @@ class GetSeerSimilarIssuesTest(TestCase):
         num_frames: int = 1,
         stacktrace_string: str | None = None,
         fingerprint: list[str] | None = None,
-    ) -> tuple[Event, dict[str, BaseVariant], str]:
+    ) -> tuple[Event, dict[str, BaseVariant], GroupHash, str]:
         error_type = "FailedToFetchError"
         error_value = "Charlie didn't bring the ball back"
         event = Event(
@@ -278,13 +322,13 @@ class GetSeerSimilarIssuesTest(TestCase):
             stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants(variants))
         event.data["stacktrace_string"] = stacktrace_string
 
-        return (event, variants, stacktrace_string)
+        return (event, variants, grouphash, stacktrace_string)
 
     @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
     def test_sends_expected_data_to_seer(self, mock_get_similarity_data: MagicMock) -> None:
-        new_event, new_variants, new_stacktrace_string = self.create_new_event()
+        new_event, new_variants, new_grouphash, new_stacktrace_string = self.create_new_event()
 
-        get_seer_similar_issues(new_event, new_variants)
+        get_seer_similar_issues(new_event, new_grouphash, new_variants)
 
         mock_get_similarity_data.assert_called_with(
             {
@@ -307,7 +351,7 @@ class GetSeerSimilarIssuesTest(TestCase):
         ).first()
         assert existing_event.group_id
 
-        new_event, new_variants, _ = self.create_new_event()
+        new_event, new_variants, new_grouphash, _ = self.create_new_event()
 
         seer_result_data = SeerSimilarIssueData(
             parent_hash=existing_hash,
@@ -325,13 +369,13 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "results": [asdict(seer_result_data)],
             }
 
-            assert get_seer_similar_issues(new_event, new_variants) == (
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 expected_metadata,
                 existing_grouphash,
             )
 
     def test_no_parent_group_found(self) -> None:
-        new_event, new_variants, _ = self.create_new_event()
+        new_event, new_variants, new_grouphash, _ = self.create_new_event()
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
@@ -342,7 +386,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "results": [],
             }
 
-            assert get_seer_similar_issues(new_event, new_variants) == (
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 expected_metadata,
                 None,
             )
@@ -382,12 +426,12 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
                 "platform": "python",
             },
         )
-        GroupHash.objects.create(
+        new_grouphash = GroupHash.objects.create(
             project=self.project, group=new_event.group, hash=new_event.get_primary_hash()
         )
         group_hashes = list(GroupHash.objects.filter(project_id=self.project.id))
         maybe_check_seer_for_matching_grouphash(
-            new_event, new_event.get_grouping_variants(), group_hashes
+            new_event, new_grouphash, new_event.get_grouping_variants(), group_hashes
         )
 
         mock_get_similarity_data.assert_called_with(
@@ -444,12 +488,12 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
             },
         )
 
-        GroupHash.objects.create(
+        new_grouphash = GroupHash.objects.create(
             project=self.project, group=new_event.group, hash=new_event.get_primary_hash()
         )
         group_hashes = list(GroupHash.objects.filter(project_id=self.project.id))
         maybe_check_seer_for_matching_grouphash(
-            new_event, new_event.get_grouping_variants(), group_hashes
+            new_event, new_grouphash, new_event.get_grouping_variants(), group_hashes
         )
 
         sample_rate = options.get("seer.similarity.metrics_sample_rate")
@@ -503,12 +547,12 @@ class TestMaybeCheckSeerForMatchingGroupHash(TestCase):
             },
         )
 
-        GroupHash.objects.create(
+        new_grouphash = GroupHash.objects.create(
             project=self.project, group=new_event.group, hash=new_event.get_primary_hash()
         )
         group_hashes = list(GroupHash.objects.filter(project_id=self.project.id))
         maybe_check_seer_for_matching_grouphash(
-            new_event, new_event.get_grouping_variants(), group_hashes
+            new_event, new_grouphash, new_event.get_grouping_variants(), group_hashes
         )
 
         mock_get_similarity_data.assert_called_with(


### PR DESCRIPTION
Currently, if an event has a hybrid fingerprint (a fingerprint including both `{{ default }}` and a custom value), we don't send it to Seer, because we don't want to override the custom grouping the user has chosen to do. That said, the whole point of hybrid fingerprints (as opposed to fully custom ones) is that the user wants grouping to happen as normal before their custom grouping is applied. If using Seer is now part of "normal grouping," it follows that it should be included in the preliminary step when grouping events with hybrid fingerprints. This PR makes that change (albeit behind a new `organizations:grouping-hybrid-fingerprint-seer-usage` feature flag).

The key insight here was provided by @JoshFerge: Rather than trying to insert a Seer call into the middle of the process of combining default grouping values with custom ones to get an initial hash value, we can achieve the same effect by considering the custom values twice: once when calculating the hash, and again when evaluating the Seer result. With the hash, we're matching on the two pieces (normal grouping, custom fingerprint) combined into a single value. With Seer, we can match on the two pieces individually, and the totality of the result is the same. In concrete terms, this means that for events with hybrid fingerprints, the Seer result only "counts" if the custom pieces match as well.

Note: In order to compare the two fingerprints, we rely on the resolved fingerprint value stored in grouphash metadata. (For the incoming event, it's important to use its grouphash and not the fingerprint in the event itself, because in the event, fingerprint variables like `{{ message }}` and `{{ transaction }}` appear in their raw, unevaluated form. That fingerprint _is_ enough to determine hybrid-ness, though, so we use it for that to avoid having to make an extra database request.) This reliance on metadata means this feature will only be as good as the data that backs it up, and will therefore produce limited results until we backfill metadata for all hashes.