### PR TITLE
ref(quick-start): Add logic to display quick start based on user visit

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -105,6 +105,7 @@ export interface Organization extends OrganizationSummary {
   };
   orgRole?: string;
   planSampleRate?: number | null;
+  quickStartDisplayStatus?: number | null;
 }
 
 export interface Team {
@@ -198,6 +199,7 @@ export interface Member {
    * User may be null when the member represents an invited member
    */
   user: User | null;
+  quickStartDisplayStatus?: number | null;
 }
 
 /**


### PR DESCRIPTION
- Add _quickStartDisplayStatus_ field to the organization types. This field is now included in the response when requesting detailed organization info.

- Introduce new logic in the _OnboardingStatus_ component to manage the visibility of the quick start guide, including updating the _quickStartDisplayStatus_ member field based on how many times the user is visiting.

- Contributes to the last point of https://github.com/getsentry/sentry/issues/84062