### PR TITLE
feat(events): Increase character limit on title

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -1,5 +1,6 @@
 from warnings import warn
 
+from sentry import options
 from sentry.utils.safe import get_path
 from sentry.utils.strings import strip, truncatechars
 
@@ -48,7 +49,11 @@ class DefaultEvent(BaseEvent):
         )
 
         if message:
-            title = truncatechars(message.splitlines()[0], 256)
+            if options.get("sentry.save-event.title-char-limit-256.enabled"):
+                truncate_to = 256
+            else:
+                truncate_to = 100
+            title = truncatechars(message.splitlines()[0], truncate_to)
         else:
             title = "<unlabeled event>"
 

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -48,7 +48,7 @@ class DefaultEvent(BaseEvent):
         )
 
         if message:
-            title = truncatechars(message.splitlines()[0], 100)
+            title = truncatechars(message.splitlines()[0], 256)
         else:
             title = "<unlabeled event>"
 

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -77,7 +77,7 @@ class ErrorEvent(BaseEvent):
         if title is not None:
             value = metadata.get("value")
             if value:
-                title += f": {truncatechars(value.splitlines()[0], 100)}"
+                title += f": {truncatechars(value.splitlines()[0], 256)}"
 
         return title or metadata.get("function") or "<unknown>"
 

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import Any
 
+from sentry import options
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
 
@@ -76,8 +77,12 @@ class ErrorEvent(BaseEvent):
         title = metadata.get("type")
         if title is not None:
             value = metadata.get("value")
+            if options.get("sentry.save-event.title-char-limit-256.enabled"):
+                truncate_to = 256
+            else:
+                truncate_to = 100
             if value:
-                title += f": {truncatechars(value.splitlines()[0], 256)}"
+                title += f": {truncatechars(value.splitlines()[0], truncate_to)}"
 
         return title or metadata.get("function") or "<unknown>"
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3008,3 +3008,11 @@ register(
     default=0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Increases event title character limit
+register(
+    "sentry.save-event.title-char-limit-256.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest import TestCase
 
 from sentry.eventtypes.error import ErrorEvent
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 class GetMetadataTest(TestCase):
@@ -89,6 +90,7 @@ class GetMetadataTest(TestCase):
         }
 
 
+@django_db_all
 class GetTitleTest(TestCase):
     def test_none_value(self):
         inst = ErrorEvent()

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -35,6 +35,7 @@ from tests.sentry.grouping import (
 dummy_project = Mock(id=11211231)
 
 
+@django_db_all
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
 @override_options({"grouping.experiments.parameterization.uniq_id": 0})
 @pytest.mark.parametrize(
@@ -187,6 +188,7 @@ def _assert_and_snapshot_results(
     )
 
 
+@django_db_all
 class GroupHashMetadataTest(TestCase):
     def test_check_grouphashes_for_positive_fingerprint_match(self):
         grouphash1 = GroupHash.objects.create(hash="dogs", project_id=self.project.id)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -22,6 +22,7 @@ from tests.sentry.grouping import (
 )
 
 
+@django_db_all
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
 @override_options({"grouping.experiments.parameterization.uniq_id": 0})
 @pytest.mark.parametrize(
@@ -106,6 +107,7 @@ def _assert_and_snapshot_results(
     )
 
 
+@django_db_all
 # TODO: This can be deleted after Jan 2025, when affected events have aged out
 def test_old_event_with_no_fingerprint_rule_text():
     variant = CustomFingerprintVariant(


### PR DESCRIPTION
Event titles get truncated at 100 characters. It's one of the default columns
on discover, so we'd like to have a better user experience and increase
character count. 256 chars seems reasonable while keeping title bounded.

![Screenshot 2025-02-06 at 10 22 51 AM](https://github.com/user-attachments/assets/356d88fe-edab-4301-96e3-bd98df335b11)

Implications:
- this will affect discover/dashboard queries that group by title and have titles that were previously truncated (they will make 2 different groups - shorter, before truncation value and longer, after truncation value till they go out of retention)