### PR TITLE
:mag: nit: fix and improve logging around slack activity notifs

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -124,14 +124,21 @@ class SlackService:
         If the group is not associated with an activity, return early as there's nothing to do.
         If the user is not associated with an activity, return early as we only care about user activities.
         """
+        log_params = {
+            "activity_id": activity.id,
+            "activity_type": activity.type,
+            "project_id": activity.project.id,
+        }
+
         if activity.group is None:
             self._logger.info(
                 "no group associated on the activity, nothing to do",
-                extra={
-                    "activity_id": activity.id,
-                },
+                extra=log_params,
             )
             return None
+
+        log_params["group_id"] = activity.group.id
+        log_params["organization_id"] = activity.group.organization.id
 
         uptime_resolved_notification = (
             activity.type == ActivityType.SET_RESOLVED.value
@@ -141,9 +148,7 @@ class SlackService:
         if activity.user_id is None and not uptime_resolved_notification:
             self._logger.info(
                 "machine/system updates are ignored at this time, nothing to do",
-                extra={
-                    "activity_id": activity.id,
-                },
+                extra=log_params,
             )
             return None
 
@@ -156,11 +161,7 @@ class SlackService:
         ):
             self._logger.info(
                 "feature is turned off for this organization",
-                extra={
-                    "activity_id": activity.id,
-                    "organization_id": organization_id,
-                    "project_id": activity.project.id,
-                },
+                extra=log_params,
             )
             return None
         # The same message is sent to all the threads, so this needs to only happen once
@@ -168,9 +169,7 @@ class SlackService:
         if not notification_to_send:
             self._logger.info(
                 "notification to send is invalid",
-                extra={
-                    "activity_id": activity.id,
-                },
+                extra=log_params,
             )
             return None
 
@@ -181,11 +180,7 @@ class SlackService:
         if integration is None:
             self._logger.info(
                 "no integration found for activity",
-                extra={
-                    "activity_id": activity.id,
-                    "organization_id": organization_id,
-                    "project_id": activity.project.id,
-                },
+                extra=log_params,
             )
             return None
 
@@ -201,6 +196,7 @@ class SlackService:
                     "activity_id": activity.id,
                     "group_id": activity.group.id,
                     "project_id": activity.project.id,
+                    "organization_id": activity.group.organization.id,
                 }
             )
 

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -126,7 +126,6 @@ class SlackService:
         """
         log_params = {
             "activity_id": activity.id,
-            "activity_type": activity.type,
             "project_id": activity.project.id,
         }
 

--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -24,18 +24,18 @@ _TASK_QUEUED_METRIC = (
 )
 def send_activity_notifications_to_slack_threads(activity_id) -> None:
     log_params = {"activity_id": activity_id}
-    _default_logger.debug("async processing for activity", extra=log_params)
+    _default_logger.info("async processing for activity", extra=log_params)
 
     try:
         activity = Activity.objects.get(pk=activity_id)
     except Activity.DoesNotExist:
-        _default_logger.debug("activity does not exist", extra=log_params)
+        _default_logger.info("activity does not exist", extra=log_params)
         return
 
     organization = Organization.objects.get_from_cache(id=activity.project.organization_id)
     log_params["organization_id"] = organization.id
 
-    _default_logger.debug("attempting to send notifications", extra=log_params)
+    _default_logger.info("attempting to send notifications", extra=log_params)
     slack_service = SlackService.default()
     try:
         slack_service.notify_all_threads_for_activity(activity=activity)
@@ -54,7 +54,7 @@ def send_activity_notifications_to_slack_threads(activity_id) -> None:
             sample_rate=1.0,
         )
 
-    _default_logger.debug("task finished for sending notifications", extra=log_params)
+    _default_logger.info("task finished for sending notifications", extra=log_params)
 
 
 def activity_created_receiver(instance, created, **kwargs) -> None:
@@ -62,9 +62,9 @@ def activity_created_receiver(instance, created, **kwargs) -> None:
     If an activity is created for an issue, this will trigger, and we can kick off an async process
     """
     log_params = {"activity_id": instance.id, "activity_object_created": created}
-    _default_logger.debug("receiver for activity event", extra=log_params)
+    _default_logger.info("receiver for activity event", extra=log_params)
     if not created:
-        _default_logger.debug("instance is not created, skipping post processing", extra=log_params)
+        _default_logger.info("instance is not created, skipping post processing", extra=log_params)
         return
 
     transaction.on_commit(

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -101,7 +101,10 @@ class TestNotifyAllThreadsForActivity(TestCase):
             self.service.notify_all_threads_for_activity(activity=self.activity)
             mock_logger.info.assert_called_with(
                 "no group associated on the activity, nothing to do",
-                extra={"activity_id": self.activity.id},
+                extra={
+                    "activity_id": self.activity.id,
+                    "project_id": self.activity.project.id,
+                },
             )
 
     def test_none_user_id(self):
@@ -111,7 +114,12 @@ class TestNotifyAllThreadsForActivity(TestCase):
             self.service.notify_all_threads_for_activity(activity=self.activity)
             mock_logger.info.assert_called_with(
                 "machine/system updates are ignored at this time, nothing to do",
-                extra={"activity_id": self.activity.id},
+                extra={
+                    "activity_id": self.activity.id,
+                    "project_id": self.activity.project.id,
+                    "group_id": self.activity.group.id,
+                    "organization_id": self.organization.id,
+                },
             )
 
     def test_disabled_option(self):
@@ -125,8 +133,9 @@ class TestNotifyAllThreadsForActivity(TestCase):
                 "feature is turned off for this organization",
                 extra={
                     "activity_id": self.activity.id,
-                    "organization_id": self.organization.id,
                     "project_id": self.activity.project.id,
+                    "group_id": self.activity.group.id,
+                    "organization_id": self.organization.id,
                 },
             )
 
@@ -137,7 +146,13 @@ class TestNotifyAllThreadsForActivity(TestCase):
         with mock.patch.object(self.service, "_logger") as mock_logger:
             self.service.notify_all_threads_for_activity(activity=self.activity)
             mock_logger.info.assert_called_with(
-                "notification to send is invalid", extra={"activity_id": self.activity.id}
+                "notification to send is invalid",
+                extra={
+                    "activity_id": self.activity.id,
+                    "project_id": self.activity.project.id,
+                    "group_id": self.activity.group.id,
+                    "organization_id": self.organization.id,
+                },
             )
 
     def test_no_integration(self):
@@ -150,8 +165,9 @@ class TestNotifyAllThreadsForActivity(TestCase):
                 "no integration found for activity",
                 extra={
                     "activity_id": self.activity.id,
-                    "organization_id": self.organization.id,
                     "project_id": self.activity.project.id,
+                    "group_id": self.activity.group.id,
+                    "organization_id": self.organization.id,
                 },
             )
 


### PR DESCRIPTION
confirmed by SRE: `logger.debug` doesn't make it way to gcp, so those logs are just lost. we need them in order to debug some issues around activity notifs.

i also added improved the logging inside the service so we get more context in the log.