### PR TITLE
fix(metric-issues): Fix the status check for open periods

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1090,9 +1090,12 @@ def get_open_periods_for_group(
         query_end = timezone.now()
 
     query_limit = limit * 2 if limit else None
+    # Filter to REGRESSION and RESOLVED activties to find the bounds of each open period.
+    # The only UNRESOLVED activity we would care about is the first UNRESOLVED activity for the group creation,
+    # but we don't create an entry for that .
     activities = Activity.objects.filter(
         group=group,
-        type__in=[ActivityType.SET_UNRESOLVED.value, ActivityType.SET_RESOLVED.value],
+        type__in=[ActivityType.SET_REGRESSION.value, ActivityType.SET_RESOLVED.value],
         datetime__gte=query_start,
         datetime__lte=query_end,
     ).order_by("-datetime")[:query_limit]
@@ -1118,7 +1121,7 @@ def get_open_periods_for_group(
     for activity in activities:
         if activity.type == ActivityType.SET_RESOLVED.value:
             end = activity.datetime
-        elif activity.type == ActivityType.SET_UNRESOLVED.value:
+        elif activity.type == ActivityType.SET_REGRESSION.value:
             start = activity.datetime
             if end is not None:
                 open_periods.append(

--- a/tests/sentry/issues/endpoints/test_group_open_periods.py
+++ b/tests/sentry/issues/endpoints/test_group_open_periods.py
@@ -96,7 +96,7 @@ class GroupOpenPeriodsTest(APITestCase):
         Activity.objects.create(
             group=self.group,
             project=self.group.project,
-            type=ActivityType.SET_UNRESOLVED.value,
+            type=ActivityType.SET_REGRESSION.value,
             datetime=unresolved_time,
         )
 
@@ -147,7 +147,7 @@ class GroupOpenPeriodsTest(APITestCase):
         Activity.objects.create(
             group=self.group,
             project=self.group.project,
-            type=ActivityType.SET_UNRESOLVED.value,
+            type=ActivityType.SET_REGRESSION.value,
             datetime=unresolved_time,
         )
 


### PR DESCRIPTION
Fix the logic to calculate open periods to look for SET_REGRESSION activities instead of SET_UNRESOLVED. Since we don't track an activity for the first time an issue is created and marked unresolved, we can look at only the regressions and resolutions.