### PR TITLE
feat(insights): highlight insights on sidebar when on transaction summary

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -278,6 +278,7 @@ function Sidebar() {
             {hasNewNav ? 'Perf.' : t('Performance')}
           </GuideAnchor>
         }
+        active={hasPerfLandingRemovalFlag ? false : undefined}
         to={`${getPerformanceBaseUrl(organization.slug, view)}/`}
         id="performance"
       />
@@ -437,6 +438,11 @@ function Sidebar() {
         label={DOMAIN_VIEW_BASE_TITLE}
         id="insights-domains"
         initiallyExpanded
+        active={
+          hasPerfLandingRemovalFlag
+            ? location.pathname.includes(`/${DOMAIN_VIEW_BASE_URL}/summary`)
+            : undefined
+        }
         exact={!shouldAccordionFloat}
       >
         <SidebarItem

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -315,9 +315,12 @@ function SidebarItem({
 SidebarItem.displayName = 'SidebarItem';
 
 export function isItemActive(
-  item: Pick<SidebarItemProps, 'to' | 'label'>,
+  item: Pick<SidebarItemProps, 'to' | 'label' | 'active'>,
   exact?: boolean
 ): boolean {
+  if (typeof item.active === 'boolean') {
+    return item.active;
+  }
   // take off the query params for matching
   const toPathWithoutReferrer = item?.to?.split('?')[0];
   if (!toPathWithoutReferrer) {


### PR DESCRIPTION
Work for #84021 

1. When you land on a transaction summary page external to a domain view, we should highlight Insights.
<img width="742" alt="image" src="https://github.com/user-attachments/assets/79a7427c-5969-4dff-a774-e8d780d08b81" />

2. https://github.com/getsentry/sentry/pull/84117 introduced a bug where both performance and a domain view would highlight (see screenshot below), this PR ensures the redirect introduced in that PR results in only the domain view highlighting
<img width="266" alt="image" src="https://github.com/user-attachments/assets/baef1eff-9366-42e2-8e4f-2cbe1cb823ec" />
