### PR TITLE
fix(dashboards): Indicate dashboard filters are saving on click

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -134,6 +134,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 
 type State = {
   dashboardState: DashboardState;
+  isSavingDashboardFilters: boolean;
   isWidgetBuilderOpen: boolean;
   modifiedDashboard: DashboardDetails | null;
   widgetLegendState: WidgetLegendSelectionState;
@@ -255,6 +256,7 @@ class DashboardDetail extends Component<Props, State> {
       location: this.props.location,
       router: this.props.router,
     }),
+    isSavingDashboardFilters: false,
     isWidgetBuilderOpen: this.isRedesignedWidgetBuilder,
     openWidgetTemplates: undefined,
   };
@@ -1270,6 +1272,7 @@ class DashboardDetail extends Component<Props, State> {
                                 }
                                 isPreview={this.isPreview}
                                 onDashboardFilterChange={this.handleChangeFilter}
+                                shouldBusySaveButton={this.state.isSavingDashboardFilters}
                                 onCancel={() => {
                                   resetPageFilters(dashboard, location);
                                   trackAnalytics('dashboards2.filter.cancel', {
@@ -1291,6 +1294,8 @@ class DashboardDetail extends Component<Props, State> {
                                       getDashboardFiltersFromURL(location) ??
                                       (modifiedDashboard ?? dashboard).filters,
                                   };
+                                  this.setState({isSavingDashboardFilters: true});
+                                  addLoadingMessage(t('Saving dashboard filters'));
                                   updateDashboard(
                                     api,
                                     organization.slug,
@@ -1319,6 +1324,7 @@ class DashboardDetail extends Component<Props, State> {
                                         this.setState(
                                           {
                                             modifiedDashboard: null,
+                                            isSavingDashboardFilters: false,
                                           },
                                           () => {
                                             // Wait for modifiedDashboard state to update before navigating
@@ -1329,6 +1335,7 @@ class DashboardDetail extends Component<Props, State> {
                                       }
 
                                       navigateToDashboard();
+                                      this.setState({isSavingDashboardFilters: false});
                                     },
                                     // `updateDashboard` does its own error handling
                                     () => undefined

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -37,6 +37,7 @@ type FiltersBarProps = {
   dashboardPermissions?: DashboardPermissions;
   onCancel?: () => void;
   onSave?: () => void;
+  shouldBusySaveButton?: boolean;
 };
 
 export default function FiltersBar({
@@ -50,6 +51,7 @@ export default function FiltersBar({
   onCancel,
   onDashboardFilterChange,
   onSave,
+  shouldBusySaveButton,
 }: FiltersBarProps) {
   const {selection} = usePageFilters();
   const organization = useOrganization();
@@ -124,6 +126,7 @@ export default function FiltersBar({
               priority="primary"
               onClick={onSave}
               disabled={!hasEditAccess}
+              busy={shouldBusySaveButton}
             >
               {t('Save')}
             </Button>


### PR DESCRIPTION
We were getting rage clicks on the save filters button on dashboards because the save button was still active once it was clicked. I've added in a busy state while the filters are saving and put a loading message so users get visual confirmation of this.


https://github.com/user-attachments/assets/16621543-a5f1-4ba4-9153-a9b2c340d977

