### PR TITLE
ref(autofix): Move unit test option

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
@@ -152,32 +152,4 @@ describe('AutofixChanges', () => {
       })
     );
   });
-
-  it('passes correct analytics props for Add Tests button', () => {
-    MockApiClient.addMockResponse({
-      url: '/issues/123/autofix/setup/?check_write_access=true',
-      method: 'GET',
-      body: {
-        genAIConsent: {ok: true},
-        integration: {ok: true},
-        githubWriteIntegration: {
-          repos: [{ok: true, owner: 'owner', name: 'hello-world', id: 100}],
-        },
-      },
-    });
-
-    render(<AutofixChanges {...defaultProps} />);
-    screen.getByText('Add Tests').click();
-
-    const addTestsButtonCall = mockButton.mock.calls.find(
-      call => call[0]?.analyticsEventKey === 'autofix.add_tests_clicked'
-    );
-    expect(addTestsButtonCall?.[0]).toEqual(
-      expect.objectContaining({
-        analyticsEventKey: 'autofix.add_tests_clicked',
-        analyticsEventName: 'Autofix: Add Tests Clicked',
-        analyticsParams: {group_id: '123'},
-      })
-    );
-  });
 });

--- a/static/app/components/events/autofix/autofixChanges.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.spec.tsx
@@ -100,7 +100,6 @@ describe('AutofixChanges', () => {
     expect(screen.getByText('Add error handling')).toBeInTheDocument();
     expect(screen.getByText('owner/hello-world')).toBeInTheDocument();
 
-    expect(screen.getByRole('button', {name: 'Add Tests'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Check Out Locally'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Draft PR'})).toBeInTheDocument();
   });

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -9,13 +9,11 @@ import ButtonBar from 'sentry/components/buttonBar';
 import ClippedBox from 'sentry/components/clippedBox';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
-import {useUpdateInsightCard} from 'sentry/components/events/autofix/autofixInsightCards';
 import {AutofixSetupWriteAccessModal} from 'sentry/components/events/autofix/autofixSetupWriteAccessModal';
 import {
   type AutofixChangesStep,
   type AutofixCodebaseChange,
   AutofixStatus,
-  AutofixStepType,
 } from 'sentry/components/events/autofix/types';
 import {
   makeAutofixQueryKey,
@@ -417,22 +415,6 @@ export function AutofixChanges({
   const data = useAutofixData({groupId});
   const [isBusy, setIsBusy] = useState(false);
 
-  const {mutate: sendFeedbackOnChanges} = useUpdateInsightCard({groupId, runId});
-
-  const handleAddTests = () => {
-    const planStep = data?.steps?.[data.steps.length - 2];
-    if (!planStep || planStep.type !== AutofixStepType.DEFAULT) {
-      return;
-    }
-
-    sendFeedbackOnChanges({
-      step_index: planStep.index,
-      retain_insight_card_index: planStep.insights.length - 1,
-      message:
-        'Please write a unit test that reproduces the issue to make sure it is fixed. Put it in the appropriate test file in the codebase. If there is none, create one.',
-    });
-  };
-
   if (step.status === 'ERROR' || data?.status === 'ERROR') {
     return (
       <Content>
@@ -482,18 +464,6 @@ export function AutofixChanges({
               </HeaderText>
               {!prsMade && (
                 <ButtonBar gap={1}>
-                  {!branchesMade && (
-                    <Button
-                      size="sm"
-                      onClick={handleAddTests}
-                      disabled={isBusy}
-                      analyticsEventName="Autofix: Add Tests Clicked"
-                      analyticsEventKey="autofix.add_tests_clicked"
-                      analyticsParams={{group_id: groupId}}
-                    >
-                      {t('Add Tests')}
-                    </Button>
-                  )}
                   {!branchesMade ? (
                     <SetupAndCreateBranchButton
                       changes={step.changes}

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -640,6 +640,8 @@ const FileName = styled('div')`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  direction: rtl;
+  text-align: left;
 `;
 
 const DiffContainer = styled('div')`

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -8,6 +8,7 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ClippedBox from 'sentry/components/clippedBox';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {
   type AutofixRepository,
   type AutofixSolutionTimelineEvent,
@@ -19,7 +20,14 @@ import {
   type AutofixResponse,
   makeAutofixQueryKey,
 } from 'sentry/components/events/autofix/useAutofix';
-import {IconClose, IconEdit, IconEllipsis, IconFix} from 'sentry/icons';
+import {
+  IconCheckmark,
+  IconChevron,
+  IconClose,
+  IconEdit,
+  IconEllipsis,
+  IconFix,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
@@ -37,9 +45,12 @@ export function useSelectSolution({groupId, runId}: {groupId: string; runId: str
   return useMutation({
     mutationFn: (
       params:
-        | {}
+        | {
+            mode: 'all' | 'fix' | 'test';
+          }
         | {
             customSolution: string;
+            mode: 'all' | 'fix' | 'test';
           }
     ) => {
       return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
@@ -51,12 +62,14 @@ export function useSelectSolution({groupId, runId}: {groupId: string; runId: str
                 payload: {
                   type: 'select_solution',
                   custom_solution: params.customSolution,
+                  mode: params.mode,
                 },
               }
             : {
                 run_id: runId,
                 payload: {
                   type: 'select_solution',
+                  mode: params.mode,
                 },
               },
       });
@@ -306,8 +319,6 @@ function AutofixSolutionDisplay({
     );
   }
 
-  const showCodeButton = isEditing || !solutionSelected;
-
   return (
     <SolutionContainer>
       <ClippedBox clipHeight={408}>
@@ -335,24 +346,66 @@ function AutofixSolutionDisplay({
                 {isEditing ? <IconClose size="sm" /> : <IconEdit size="sm" />}
               </EditButton>
             </ButtonBar>
-            {showCodeButton && (
+            <ButtonBar merged>
               <Button
                 size="sm"
-                priority="primary"
+                priority={solutionSelected ? 'default' : 'primary'}
                 busy={isPending}
                 onClick={() => {
                   if (isEditing) {
                     if (userCustomSolution.trim()) {
-                      handleContinue({customSolution: userCustomSolution.trim()});
+                      handleContinue({
+                        customSolution: userCustomSolution.trim(),
+                        mode: 'fix',
+                      });
                     }
                   } else {
-                    handleContinue({});
+                    handleContinue({
+                      mode: 'fix',
+                    });
                   }
                 }}
               >
                 {t('Code It Up')}
               </Button>
-            )}
+              <DropdownMenu
+                items={[
+                  {
+                    key: 'fix',
+                    label: 'Write the fix',
+                    details: 'Autofix will implement this solution.',
+                    onAction: () => handleContinue({mode: 'fix'}),
+                    leadingItems: <IconCheckmark size="sm" color="purple300" />,
+                  },
+                  {
+                    key: 'test',
+                    label: 'Write a reproduction test',
+                    details:
+                      'Autofix will write a unit test to reproduce the issue and validate future fixes.',
+                    onAction: () => handleContinue({mode: 'test'}),
+                    leadingItems: <div style={{width: 16}} />,
+                  },
+                  {
+                    key: 'all',
+                    label: 'Write both',
+                    details:
+                      'Autofix will implement this solution and a test to validate the issue is fixed.',
+                    onAction: () => handleContinue({mode: 'all'}),
+                    leadingItems: <div style={{width: 16}} />,
+                  },
+                ]}
+                position="bottom-end"
+                trigger={triggerProps => (
+                  <DropdownButton
+                    size="sm"
+                    priority={solutionSelected ? 'default' : 'primary'}
+                    {...triggerProps}
+                  >
+                    <IconChevron direction="down" size="xs" />
+                  </DropdownButton>
+                )}
+              />
+            </ButtonBar>
           </ButtonBar>
         </HeaderWrapper>
         <Content>
@@ -469,4 +522,15 @@ const EditButton = styled(Button)`
 
 const CustomSolutionPadding = styled('div')`
   padding: ${space(1)} ${space(0.25)} ${space(2)} ${space(0.25)};
+`;
+
+const DropdownButton = styled(Button)`
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -1px;
+  position: relative;
+
+  &:hover {
+    z-index: 1;
+  }
 `;


### PR DESCRIPTION
Moves the unit testing option to a specific option in a dropdown attached to the "Code it up" button. The button itself defaults to just the fix.

The Seer change should go in first.

<img width="654" alt="Screenshot 2025-02-06 at 9 48 06 AM" src="https://github.com/user-attachments/assets/a1a3564c-4621-493d-8c6c-6e2ce8b6f50e" />
<img width="675" alt="Screenshot 2025-02-06 at 9 46 55 AM" src="https://github.com/user-attachments/assets/59f77631-e993-4ca4-90c8-f9467c7f0c2a" />

