### PR TITLE
ref: use a normal AnonymousUser for system token user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ module = [
     "sentry.api.serializers.models.event",
     "sentry.auth.helper",
     "sentry.auth.provider",
-    "sentry.auth.system",
     "sentry.db.mixin",
     "sentry.db.postgres.base",
     "sentry.discover.endpoints.discover_key_transactions",

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -416,7 +416,7 @@ class UserAuthTokenAuthentication(StandardAuthentication):
         if token.is_expired():
             raise AuthenticationFailed("Token expired")
 
-        if user and hasattr(user, "is_active") and not user.is_active:
+        if not isinstance(token, SystemToken) and user and not user.is_active:
             raise AuthenticationFailed("User inactive or deleted")
 
         if application_is_inactive:

--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -79,9 +79,7 @@ class SystemToken:
 
     @cached_property
     def user(self) -> AnonymousUser:
-        user = AnonymousUser()
-        user.is_active = True
-        return user
+        return AnonymousUser()
 
     def get_allowed_origins(self) -> list[str]:
         return []


### PR DESCRIPTION
as far as I can tell is_active is not used (if it was it would violate the type system anyway since that can narrow to User) and the user value is immediately converted to an AuthenticatedToken HC model via user id

<!-- Describe your PR here. -->