### PR TITLE
chore(insights): Remove frontend Web Vitals flag checks

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.tsx
@@ -5,7 +5,6 @@ import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Series} from 'sentry/types/echarts';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
 import {
@@ -16,7 +15,6 @@ import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import {applyStaticWeightsToTimeseries} from 'sentry/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries';
 import {getWeights} from 'sentry/views/insights/browser/webVitals/utils/getWeights';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import type {SubregionCode} from 'sentry/views/insights/types';
@@ -51,14 +49,10 @@ export function PerformanceScoreBreakdownChart({
   browserTypes,
   subregions,
 }: Props) {
-  const organization = useOrganization();
   const theme = useTheme();
   const segmentColors = [...(theme.charts.getColorPalette(3) ?? []).slice(0, 5)];
 
   const pageFilters = usePageFilters();
-  const handleMissingWebVitals = organization.features.includes(
-    'performance-vitals-handle-missing-webvitals'
-  );
 
   const {data: timeseriesData, isLoading: isTimeseriesLoading} =
     useProjectWebVitalsScoresTimeseriesQuery({transaction, browserTypes, subregions});
@@ -68,10 +62,7 @@ export function PerformanceScoreBreakdownChart({
   const performanceScoreSubtext = (period && DEFAULT_RELATIVE_PERIODS[period]) ?? '';
   const chartSeriesOrder = ORDER;
 
-  const weightedTimeseriesData = applyStaticWeightsToTimeseries(
-    organization,
-    timeseriesData
-  );
+  const weightedTimeseriesData = applyStaticWeightsToTimeseries(timeseriesData);
 
   const weightedTimeseries = formatTimeSeriesResultsToChartData(
     weightedTimeseriesData,
@@ -92,13 +83,9 @@ export function PerformanceScoreBreakdownChart({
     chartSeriesOrder
   );
 
-  const weights = handleMissingWebVitals
-    ? getWeights(
-        ORDER.filter(webVital =>
-          timeseriesData[webVital].some(series => series.value > 0)
-        )
-      )
-    : PERFORMANCE_SCORE_WEIGHTS;
+  const weights = getWeights(
+    ORDER.filter(webVital => timeseriesData[webVital].some(series => series.value > 0))
+  );
 
   return (
     <StyledChartPanel title={t('Score Breakdown')}>

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -17,7 +17,6 @@ import type {
   WebVitals,
 } from 'sentry/views/insights/browser/webVitals/types';
 import {getWeights} from 'sentry/views/insights/browser/webVitals/utils/getWeights';
-import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 
 import {getFormattedDuration} from './webVitalMeters';
@@ -163,11 +162,7 @@ function PerformanceScoreRingWithTooltips({
     });
   }
 
-  const weights = organization.features.includes(
-    'performance-vitals-handle-missing-webvitals'
-  )
-    ? getWeights(ORDER.filter(webVital => projectScore[`${webVital}Score`]))
-    : PERFORMANCE_SCORE_WEIGHTS;
+  const weights = getWeights(ORDER.filter(webVital => projectScore[`${webVital}Score`]));
 
   const commonWebVitalLabelProps = {
     organization,

--- a/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.spec.tsx
@@ -1,10 +1,7 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {applyStaticWeightsToTimeseries} from 'sentry/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries';
 
 describe('applyStaticWeightsToTimeseries', function () {
   it('updates timeseries scores with static weighing', function () {
-    const organization = OrganizationFixture();
     const timeseriesData = {
       lcp: [
         {name: '2024-07-01T00:00:00.000Z', value: 90},
@@ -31,7 +28,7 @@ describe('applyStaticWeightsToTimeseries', function () {
         {name: '2024-07-02T00:00:00.000Z', value: 50},
       ],
     };
-    const result = applyStaticWeightsToTimeseries(organization, timeseriesData);
+    const result = applyStaticWeightsToTimeseries(timeseriesData);
     expect(result).toEqual({
       lcp: [
         {name: '2024-07-01T00:00:00.000Z', value: 90 * 0.3},

--- a/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/applyStaticWeightsToTimeseries.tsx
@@ -1,26 +1,17 @@
-import type {Organization} from 'sentry/types/organization';
 import type {WebVitalsScoreBreakdown} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import {getWeights} from 'sentry/views/insights/browser/webVitals/utils/getWeights';
-import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/insights/browser/webVitals/utils/scoreThresholds';
 
 // Returns a weighed score timeseries with each interval calculated from applying hardcoded weights to unweighted scores
-export function applyStaticWeightsToTimeseries(
-  organization: Organization,
-  timeseriesData: WebVitalsScoreBreakdown
-) {
-  const weights = organization.features.includes(
-    'performance-vitals-handle-missing-webvitals'
-  )
-    ? getWeights(
-        Object.keys(timeseriesData)
-          .filter(key => key !== 'total')
-          .filter(key =>
-            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            timeseriesData[key].some((series: any) => series.value > 0)
-          ) as WebVitals[]
-      )
-    : PERFORMANCE_SCORE_WEIGHTS;
+export function applyStaticWeightsToTimeseries(timeseriesData: WebVitalsScoreBreakdown) {
+  const weights = getWeights(
+    Object.keys(timeseriesData)
+      .filter(key => key !== 'total')
+      .filter(key =>
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        timeseriesData[key].some((series: any) => series.value > 0)
+      ) as WebVitals[]
+  );
   return {
     ...Object.keys(weights).reduce((acc, webVital) => {
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -62,10 +62,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
 
   const order = ORDER;
 
-  const weightedTimeseriesData = applyStaticWeightsToTimeseries(
-    props.organization,
-    timeseriesData
-  );
+  const weightedTimeseriesData = applyStaticWeightsToTimeseries(timeseriesData);
 
   const getAreaChart = () => {
     const segmentColors = (theme.charts.getColorPalette(3) ?? []).slice(0, 5);


### PR DESCRIPTION
Removes frontend flag checks on `performance-vitals-handle-missing-webvitals` since it's been GA'd