### PR TITLE
fix(admin): reload page after submitting superuser modal form

### DIFF
--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -38,6 +38,7 @@ const ACTIONS: Action[] = [
     action: () =>
       openSudo({
         isSuperuser: true,
+        needsReload: true,
       }),
   },
 


### PR DESCRIPTION
previously the form would gaslight you into thinking it didn't submit successfully, but really the page just needs to be reloaded

https://github.com/user-attachments/assets/0edc8182-310f-42fa-89a7-96e61ae5746e

