### PR TITLE
fix(insights): Update user display to also coalesce on empty string

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -109,7 +109,7 @@ export function useSpanSamplesWebVitalsQuery({
                 row[SpanIndexedField.USER_ID],
                 row[SpanIndexedField.USER_IP],
                 row[SpanIndexedField.USER],
-              ].find(field => field !== '') ?? undefined,
+              ].find(field => field && field !== '') ?? undefined,
             replayId: row[SpanIndexedField.REPLAY_ID],
             'profile.id': row[SpanIndexedField.PROFILE_ID],
             totalScore: Math.round((row[`measurements.score.total`] ?? 0) * 100),

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -103,11 +103,13 @@ export function useSpanSamplesWebVitalsQuery({
             'measurements.cls':
               row[SpanIndexedField.CLS_SCORE] > 0 ? row[SpanIndexedField.CLS] : undefined,
             'user.display':
-              row[SpanIndexedField.USER_EMAIL] ??
-              row[SpanIndexedField.USER_USERNAME] ??
-              row[SpanIndexedField.USER_ID] ??
-              row[SpanIndexedField.USER_IP] ??
-              row[SpanIndexedField.USER],
+              [
+                row[SpanIndexedField.USER_EMAIL],
+                row[SpanIndexedField.USER_USERNAME],
+                row[SpanIndexedField.USER_ID],
+                row[SpanIndexedField.USER_IP],
+                row[SpanIndexedField.USER],
+              ].find(field => field !== '') ?? undefined,
             replayId: row[SpanIndexedField.REPLAY_ID],
             'profile.id': row[SpanIndexedField.PROFILE_ID],
             totalScore: Math.round((row[`measurements.score.total`] ?? 0) * 100),

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -48,7 +48,7 @@ export type SpanSampleRow = {
   [SpanIndexedField.SPAN_SELF_TIME]: number;
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.TRACE]: string;
-  'user.display': string;
+  'user.display'?: string;
   [SpanIndexedField.INP]?: number;
   [SpanIndexedField.CLS]?: number;
   [SpanIndexedField.LCP]?: number;


### PR DESCRIPTION
The spans dataset doesn't have a `user.display` alias, so we just construct the field in the frontend. Fixes an issue where it wasn't coalescing on empty strings.