### PR TITLE
chore(cursor): Add .cursor/rules for frontend

### DIFF
--- a/.cursor/rules/tsx_tests.mdc
+++ b/.cursor/rules/tsx_tests.mdc
@@ -1,0 +1,25 @@
+---
+description: Rules and guidlines for running *.spec.tsx tests and writing React tests
+globs: *.spec.tsx
+---
+
+# Running *.spec.tsx tests
+
+Please run tests with command: CI=true yarn test
+For example: CI=true yarn test path/to/file.spec.tsx
+
+NOTE: `CI=true` runs jest in non-interactive mode.
+
+# React tests
+
+When writing React tests and using react-test-library, please use exports from 'sentry-test/reactTestingLibrary'. It re-exports from '@testing-library/react'. For example:
+
+```
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+```

--- a/.cursor/rules/tsx_tests.mdc
+++ b/.cursor/rules/tsx_tests.mdc
@@ -1,5 +1,5 @@
 ---
-description: Rules and guidlines for running *.spec.tsx tests and writing React tests
+description: Rules and guidelines for running *.spec.tsx tests and writing React tests
 globs: *.spec.tsx
 ---
 


### PR DESCRIPTION
Add a cursor rules file that applies to `*.spec.tsx` files as per https://docs.cursor.com/context/rules-for-ai

Example of usage without explicitly mentioning how to run and test the `*.spec.tsx` file. 

<img width="872" alt="Screenshot 2025-02-06 at 1 42 00 PM" src="https://github.com/user-attachments/assets/e87bea22-80a3-48db-ba34-0105a5639563" />
