### PR TITLE
styles(explore): Ensure explore toolbar dropdown is not cropped

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -282,6 +282,7 @@ const Body = styled(Layout.Body)<{withToolbar: boolean}>`
       p.withToolbar
         ? `grid-template-columns: 300px minmax(100px, auto);`
         : `grid-template-columns: 0px minmax(100px, auto);`}
+    grid-template-rows: auto 1fr;
     align-content: start;
     gap: ${space(2)} ${p => (p.withToolbar ? `${space(2)}` : '0px')};
     transition: 700ms;
@@ -301,7 +302,9 @@ const TopSection = styled('div')`
 `;
 
 const SideSection = styled('aside')`
-  overflow: hidden;
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    overflow: hidden;
+  }
 `;
 
 const MainContent = styled('div')`


### PR DESCRIPTION
- Give the toolbar the remaining space on the page for larger view ports
- Remove unecessary `overflow: hidden` on smaller view ports, it's only needed for collapsing the toolbar