### PR TITLE
fix(issues): Make event timestamp tooltip hoverable

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -165,7 +165,7 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
             />
             <StyledTimeSince
               tooltipBody={<EventCreatedTooltip event={event} />}
-              tooltipProps={{maxWidth: 300}}
+              tooltipProps={{maxWidth: 300, isHoverable: true}}
               date={event.dateCreated ?? event.dateReceived}
               css={grayText}
               aria-label={t('Event timestamp')}


### PR DESCRIPTION
Matching behavior from old layout
