### PR TITLE
♻️ ref: migrate sentry app webhooks to sentry app

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 from typing import Any
 
@@ -10,6 +11,8 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
+from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.integrations.services.integration import integration_service
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.users.services.user import RpcUser
@@ -30,6 +33,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.typings.notification_action import OnCallDataBlob, SentryAppDataBlob
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +81,50 @@ def get_action_type(alert_rule_trigger_action: AlertRuleTriggerAction) -> str | 
             return None
     else:
         return Action.Type.EMAIL
+
+
+def build_action_data_blob(
+    alert_rule_trigger_action: AlertRuleTriggerAction, action_type: Action.Type
+) -> dict:
+    # if the action is a Sentry app, we need to get the Sentry app installation ID
+    if action_type == Action.Type.SENTRY_APP:
+        return (
+            dataclasses.asdict(
+                SentryAppDataBlob(
+                    settings=alert_rule_trigger_action.sentry_app_config,
+                )
+            )
+            if alert_rule_trigger_action.sentry_app_config
+            else {}
+        )
+    elif action_type in (Action.Type.OPSGENIE, Action.Type.PAGERDUTY):
+        default_priority = (
+            OPSGENIE_DEFAULT_PRIORITY
+            if action_type == Action.Type.OPSGENIE
+            else PAGERDUTY_DEFAULT_SEVERITY
+        )
+
+        if not alert_rule_trigger_action.sentry_app_config:
+            return {"priority": default_priority}
+
+        priority = alert_rule_trigger_action.sentry_app_config.get("priority", default_priority)
+        return dataclasses.asdict(OnCallDataBlob(priority=priority))
+    else:
+        return {
+            "type": alert_rule_trigger_action.type,
+            "sentry_app_id": alert_rule_trigger_action.sentry_app_id,
+            "sentry_app_config": alert_rule_trigger_action.sentry_app_config,
+        }
+
+
+def get_target_identifier(
+    alert_rule_trigger_action: AlertRuleTriggerAction, action_type: Action.Type
+) -> str:
+    return (
+        str(alert_rule_trigger_action.sentry_app_id)
+        if action_type == Action.Type.SENTRY_APP
+        else alert_rule_trigger_action.target_identifier
+    )
 
 
 def get_detector_trigger(
@@ -147,17 +195,15 @@ def migrate_metric_action(
         )
         return None
 
-    data = {
-        "type": alert_rule_trigger_action.type,
-        "sentry_app_id": alert_rule_trigger_action.sentry_app_id,
-        "sentry_app_config": alert_rule_trigger_action.sentry_app_config,
-    }
+    data = build_action_data_blob(alert_rule_trigger_action, action_type)
+    target_identifier = get_target_identifier(alert_rule_trigger_action, action_type)
+
     action = Action.objects.create(
         type=action_type,
         data=data,
         integration_id=alert_rule_trigger_action.integration_id,
         target_display=alert_rule_trigger_action.target_display,
-        target_identifier=alert_rule_trigger_action.target_identifier,
+        target_identifier=target_identifier,
         target_type=alert_rule_trigger_action.target_type,
     )
     data_condition_group_action = DataConditionGroupAction.objects.create(

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -136,14 +136,16 @@ def build_action_data_blob(
 
 def get_target_identifier(
     alert_rule_trigger_action: AlertRuleTriggerAction, action_type: Action.Type
-) -> str:
+) -> str | None:
     if action_type == Action.Type.SENTRY_APP:
         # Ensure we have a valid sentry_app_id
         if not alert_rule_trigger_action.sentry_app_id:
-            return ""
+            raise InvalidActionType(
+                f"sentry_app_id is required for Sentry App actions for alert rule trigger action {alert_rule_trigger_action.id}",
+            )
         return str(alert_rule_trigger_action.sentry_app_id)
     # Ensure we have a valid target_identifier
-    return alert_rule_trigger_action.target_identifier or ""
+    return alert_rule_trigger_action.target_identifier
 
 
 def get_detector_trigger(

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -757,12 +757,16 @@ class DualWriteAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
             sentry_app=self.sentry_app,
             alert_rule_trigger=self.critical_trigger,
-            sentry_app_config={
-                "settings": {
+            sentry_app_config=[
+                {
                     "name": "foo",
                     "value": "bar",
                 },
-            },
+                {
+                    "name": "bufo",
+                    "value": "bot",
+                },
+            ],
         )
 
         aarta_opsgenie_with_config = self.create_alert_rule_trigger_action(
@@ -783,6 +787,13 @@ class DualWriteAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             aarta_sentry_app_with_config, Action.Type.SENTRY_APP
         )
         assert_alert_rule_trigger_action_migrated(aarta_opsgenie_with_config, Action.Type.OPSGENIE)
+
+        # broken config, should raise an error
+        aarta_sentry_app_with_config.sentry_app_config = {
+            "priority": "p2",
+        }
+        with pytest.raises(ValueError):
+            migrate_metric_action(aarta_sentry_app_with_config)
 
     @mock.patch("sentry.workflow_engine.migration_helpers.alert_rule.logger")
     def test_dual_write_metric_alert_trigger_action_no_type(self, mock_logger):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -14,6 +14,8 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
+from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.silo.base import SiloMode
 from sentry.snuba.models import QuerySubscription
@@ -169,6 +171,39 @@ def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_
     assert DataConditionGroupAction.objects.filter(
         action_id=action.id,
     ).exists()
+
+    # Additional checks for Sentry app actions
+    if action_type == Action.Type.SENTRY_APP:
+        # Verify target_identifier is the string representation of sentry_app_id
+        assert action.target_identifier == str(alert_rule_trigger_action.sentry_app_id)
+
+        # Verify data blob has correct structure for Sentry apps
+        if not alert_rule_trigger_action.sentry_app_config:
+            assert action.data == {}
+        else:
+            assert action.data == {
+                "settings": alert_rule_trigger_action.sentry_app_config,
+            }
+
+    if action_type == Action.Type.OPSGENIE:
+        if not alert_rule_trigger_action.sentry_app_config:
+            assert action.data == {
+                "priority": OPSGENIE_DEFAULT_PRIORITY,
+            }
+        else:
+            assert action.data == {
+                "priority": alert_rule_trigger_action.sentry_app_config["priority"],
+            }
+
+    if action_type == Action.Type.PAGERDUTY:
+        if not alert_rule_trigger_action.sentry_app_config:
+            assert action.data == {
+                "priority": PAGERDUTY_DEFAULT_SEVERITY,
+            }
+        else:
+            assert action.data == {
+                "priority": alert_rule_trigger_action.sentry_app_config["priority"],
+            }
 
 
 class BaseMetricAlertMigrationTest(APITestCase, BaseWorkflowTest):
@@ -687,7 +722,6 @@ class DualWriteAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
         )
 
         self.alert_rule_trigger_action_sentry_app = self.create_alert_rule_trigger_action(
-            target_identifier=self.sentry_app.id,
             type=AlertRuleTriggerAction.Type.SENTRY_APP,
             target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
             sentry_app=self.sentry_app,
@@ -716,6 +750,39 @@ class DualWriteAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
         assert_alert_rule_trigger_action_migrated(
             self.alert_rule_trigger_action_sentry_app, Action.Type.SENTRY_APP
         )
+
+        # add some additional checks for sentry app and opsgenie actions to test with config
+        aarta_sentry_app_with_config = self.create_alert_rule_trigger_action(
+            type=AlertRuleTriggerAction.Type.SENTRY_APP,
+            target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
+            sentry_app=self.sentry_app,
+            alert_rule_trigger=self.critical_trigger,
+            sentry_app_config={
+                "settings": {
+                    "name": "foo",
+                    "value": "bar",
+                },
+            },
+        )
+
+        aarta_opsgenie_with_config = self.create_alert_rule_trigger_action(
+            target_identifier=self.og_team["id"],
+            type=AlertRuleTriggerAction.Type.OPSGENIE,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=self.integration,
+            alert_rule_trigger=self.critical_trigger,
+            sentry_app_config={
+                "priority": "p2",
+            },
+        )
+
+        migrate_metric_action(aarta_sentry_app_with_config)
+        migrate_metric_action(aarta_opsgenie_with_config)
+
+        assert_alert_rule_trigger_action_migrated(
+            aarta_sentry_app_with_config, Action.Type.SENTRY_APP
+        )
+        assert_alert_rule_trigger_action_migrated(aarta_opsgenie_with_config, Action.Type.OPSGENIE)
 
     @mock.patch("sentry.workflow_engine.migration_helpers.alert_rule.logger")
     def test_dual_write_metric_alert_trigger_action_no_type(self, mock_logger):


### PR DESCRIPTION
this consolidates the configuration of the data blob for `sentry_apps`, and on call integrations.

### sentry_app
instead of 
```
{
	"sentry_app_config": {
		"settings": {
			"blah"	
	}
	}
}
```

we match the blob to how its built for issue alerts:
```
{
		"settings": {
			"blah"	
	}
}
```

this is similar for on call integrations, where we go from 
```
{
	"sentry_app_config": {
		"priority": "p1"
}
```

to 

```
{
	"priority": "p1"
}
```