### PR TITLE
feat(uptime): clamp data past epoch time

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2363,9 +2363,17 @@ class UptimeCheckSnubaTestCase(TestCase):
         )
         assert response.status_code == 200
 
-    def store_snuba_uptime_check(self, subscription_id: str | None, check_status: str):
-        scheduled_time = datetime.now() - timedelta(minutes=5)
-        timestamp = scheduled_time + timedelta(seconds=1)
+    def store_snuba_uptime_check(
+        self,
+        subscription_id: str | None,
+        check_status: str,
+        scheduled_check_time: datetime | None = None,
+    ):
+        if scheduled_check_time is None:
+            scheduled_check_time = datetime.now() - timedelta(minutes=5)
+
+        timestamp = scheduled_check_time + timedelta(seconds=1)
+
         http_status = 200 if check_status == "success" else random.choice([408, 500, 502, 503, 504])
 
         self.store_uptime_check(
@@ -2377,7 +2385,7 @@ class UptimeCheckSnubaTestCase(TestCase):
                 "environment": "production",
                 "subscription_id": subscription_id,
                 "guid": str(uuid.uuid4()),
-                "scheduled_check_time_ms": int(scheduled_time.timestamp() * 1000),
+                "scheduled_check_time_ms": int(scheduled_check_time.timestamp() * 1000),
                 "actual_check_time_ms": int(timestamp.timestamp() * 1000),
                 "duration_ms": random.randint(1, 1000),
                 "status": check_status,

--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -74,7 +74,7 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
 
         try:
             eap_response = self._make_eap_request(
-                organization, projects, subscription_ids, timerange_args
+                organization, projects, subscription_ids, timerange_args, epoch_cutoff
             )
         except Exception:
             logger.exception("Error making EAP RPC request for uptime check stats")
@@ -139,10 +139,15 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
         projects: list[Project],
         subscription_ids: list[str],
         timerange_args: StatsArgsDict,
+        epoch_cutoff: datetime.datetime | None,
     ) -> TimeSeriesResponse:
 
+        eap_query_start = timerange_args["start"]
+        if epoch_cutoff and epoch_cutoff > timerange_args["start"]:
+            eap_query_start = epoch_cutoff
+
         start_timestamp = Timestamp()
-        start_timestamp.FromDatetime(timerange_args["start"])
+        start_timestamp.FromDatetime(eap_query_start)
         end_timestamp = Timestamp()
         end_timestamp.FromDatetime(timerange_args["end"])
         request = TimeSeriesRequest(


### PR DESCRIPTION
this PR makes it so on the check index and stats endpoint, we don't let any data be queried past the specified epoch cutoff date. can remove after 90 days from epoch cutoff date