### PR TITLE
theme: standardize radiuses

### DIFF
--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -441,7 +441,7 @@ export default Menu;
 const StyledInput = styled(Input)`
   flex: 1;
   border: 1px solid transparent;
-  border-radius: calc(${p => p.theme.panelBorderRadius} - 1px);
+  border-radius: calc(${p => p.theme.borderRadius} - 1px);
   &,
   &:focus,
   &:active,
@@ -497,7 +497,7 @@ const InputWrapper = styled('div')`
   display: flex;
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p =>
-    `calc(${p.theme.panelBorderRadius} - 1px) calc(${p.theme.panelBorderRadius} - 1px) 0 0`};
+    `calc(${p.theme.borderRadius} - 1px) calc(${p.theme.borderRadius} - 1px) 0 0`};
   align-items: center;
 `;
 

--- a/static/app/components/dropdownBubble.tsx
+++ b/static/app/components/dropdownBubble.tsx
@@ -44,7 +44,7 @@ const getMenuBorderRadius = ({
   width,
   theme,
 }: DropdownBubbleProps & {theme: Theme}) => {
-  const radius = theme.panelBorderRadius;
+  const radius = theme.borderRadius;
   if (!blendCorner || detached) {
     return css`
       border-radius: ${radius};

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -299,7 +299,7 @@ const Modal = styled(motion.div)`
 
 const Content = styled('div')`
   background: ${p => p.theme.background};
-  border-radius: ${p => p.theme.modalBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
   box-shadow:
     0 0 0 1px ${p => p.theme.translucentBorder},
     ${p => p.theme.dropShadowHeavy};

--- a/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
+++ b/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
@@ -55,7 +55,7 @@ const StyledHovercardWithBodyClass = styled(HovercardWithBodyClass)`
   max-height: 300px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border-radius: ${p => p.theme.modalBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const StyledHovercard = styled(Hovercard)<{hide?: boolean}>`

--- a/static/app/components/highlightModalContainer.tsx
+++ b/static/app/components/highlightModalContainer.tsx
@@ -36,7 +36,7 @@ const PositionTopRight = styled('img')<{width: string}>`
   right: 0;
   top: 0;
   pointer-events: none;
-  border-radius: 0 ${p => p.theme.modalBorderRadius} 0 0;
+  border-radius: 0 ${p => p.theme.borderRadius} 0 0;
 `;
 
 const PositionBottomLeft = styled('img')<{width: string}>`
@@ -45,5 +45,5 @@ const PositionBottomLeft = styled('img')<{width: string}>`
   bottom: 0;
   left: 0;
   pointer-events: none;
-  border-radius: 0 0 0 ${p => p.theme.modalBorderRadius};
+  border-radius: 0 0 0 ${p => p.theme.borderRadius};
 `;

--- a/static/app/components/links/styles.tsx
+++ b/static/app/components/links/styles.tsx
@@ -1,7 +1,8 @@
 import {css, type Theme} from '@emotion/react';
 
 export const linkStyles = ({disabled, theme}: {theme: Theme; disabled?: boolean}) => css`
-  border-radius: ${theme.linkBorderRadius};
+  /* @TODO(jonasbadalic) This was defined on theme and only used here */
+  border-radius: 2px;
 
   &:focus-visible {
     box-shadow: ${theme.linkFocus} 0 0 0 2px;

--- a/static/app/components/modals/commandPalette.tsx
+++ b/static/app/components/modals/commandPalette.tsx
@@ -70,7 +70,7 @@ const InputWrapper = styled('div')`
 const StyledInput = styled(Input)`
   width: 100%;
   padding: ${space(1)};
-  border-radius: ${p => p.theme.modalBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
 
   outline: none;
   border: none;

--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -133,7 +133,7 @@ const Overlay = styled(
   )
 )`
   position: relative;
-  border-radius: ${p => p.theme.panelBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
   background: ${p => p.theme.backgroundElevated};
   box-shadow:
     0 0 0 1px ${p => p.theme.translucentBorder},

--- a/static/app/components/panels/panel.tsx
+++ b/static/app/components/panels/panel.tsx
@@ -19,7 +19,7 @@ const Panel = styled(
   {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
 )`
   background: ${p => (p.dashedBorder ? p.theme.backgroundSecondary : p.theme.background)};
-  border-radius: ${p => p.theme.panelBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
   border: 1px
     ${p => (p.dashedBorder ? 'dashed' + p.theme.gray300 : 'solid ' + p.theme.border)};
   margin-bottom: ${space(2)};

--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -33,8 +33,8 @@ const PanelHeader = styled('div')<Props>`
   font-weight: ${p => p.theme.fontWeightBold};
   text-transform: uppercase;
   border-bottom: 1px solid ${p => p.theme.border};
-  border-radius: calc(${p => p.theme.panelBorderRadius} - 1px)
-    calc(${p => p.theme.panelBorderRadius} - 1px) 0 0;
+  border-radius: calc(${p => p.theme.borderRadius} - 1px)
+    calc(${p => p.theme.borderRadius} - 1px) 0 0;
   background: ${p => p.theme.backgroundSecondary};
   line-height: 1;
   position: relative;

--- a/static/app/components/search/list.tsx
+++ b/static/app/components/search/list.tsx
@@ -136,7 +136,7 @@ export default List;
 const DropdownBox = styled('div')`
   background: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.modalBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};
   position: absolute;
   top: 36px;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -1061,8 +1061,6 @@ const commonTheme = {
   borderRadiusRight: '0 6px 6px 0',
 
   // @TODO(jonasbadalic) This should exist their respective components
-  linkBorderRadius: '2px',
-
   headerSelectorRowHeight: 44,
   headerSelectorLabelHeight: 28,
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -1061,8 +1061,6 @@ const commonTheme = {
   borderRadiusRight: '0 6px 6px 0',
 
   // @TODO(jonasbadalic) This should exist their respective components
-  panelBorderRadius: '6px',
-  modalBorderRadius: '8px',
   linkBorderRadius: '2px',
 
   headerSelectorRowHeight: 44,

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -75,7 +75,7 @@ const ToolbarPanel = styled('div')`
   align-items: flex-start;
 
   background-color: ${p => p.theme.overlayBackgroundAlpha};
-  border-radius: calc(${p => p.theme.panelBorderRadius} - 1px);
+  border-radius: calc(${p => p.theme.borderRadius} - 1px);
 `;
 
 const IconContainer = styled('div')`

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -65,7 +65,7 @@ const Frame = styled('div')<{forceShowActions?: boolean; height?: number}>`
   width: 100%;
   min-width: ${MIN_WIDTH}px;
 
-  border-radius: ${p => p.theme.panelBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
 
   background: ${p => p.theme.background};

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -77,8 +77,8 @@ const Header = styled(Sticky)`
 
   z-index: 1;
   background: ${p => p.theme.background};
-  border-top-left-radius: ${p => p.theme.panelBorderRadius};
-  border-top-right-radius: ${p => p.theme.panelBorderRadius};
+  border-top-left-radius: ${p => p.theme.borderRadius};
+  border-top-right-radius: ${p => p.theme.borderRadius};
   box-shadow: 0 1px ${p => p.theme.translucentBorder};
 
   &[data-stuck] {

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -523,7 +523,7 @@ const StickyActions = styled(Sticky)`
 
   border-bottom: 1px solid ${p => p.theme.border};
   border-top: none;
-  border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
 `;
 
 const ActionsBarContainer = styled('div')<{narrowHeader: boolean}>`
@@ -533,7 +533,7 @@ const ActionsBarContainer = styled('div')<{narrowHeader: boolean}>`
   padding-bottom: ${p => (p.narrowHeader ? space(0.5) : space(1))};
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
 `;
 
 const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -409,7 +409,7 @@ const Banner = styled('div')`
   padding: 12px;
   gap: ${space(0.5)};
   border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.panelBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
 
   background: linear-gradient(
     269.35deg,

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -179,8 +179,8 @@ const Header = styled(Sticky)`
 
   z-index: 1;
   background: ${p => p.theme.background};
-  border-top-left-radius: ${p => p.theme.panelBorderRadius};
-  border-top-right-radius: ${p => p.theme.panelBorderRadius};
+  border-top-left-radius: ${p => p.theme.borderRadius};
+  border-top-right-radius: ${p => p.theme.borderRadius};
   box-shadow: 0 1px ${p => p.theme.translucentBorder};
 
   &[data-stuck] {

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -1129,8 +1129,8 @@ const StyledJsonForm = styled(JsonForm)`
 const StyledPanelFooter = styled(PanelFooter)`
   background: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
-  border-radius: 0 0 calc(${p => p.theme.panelBorderRadius} - 1px)
-    calc(${p => p.theme.panelBorderRadius} - 1px);
+  border-radius: 0 0 calc(${p => p.theme.borderRadius} - 1px)
+    calc(${p => p.theme.borderRadius} - 1px);
 
   ${Actions} {
     padding: ${space(1.5)};

--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -166,7 +166,7 @@ const VerticalScroll = styled('main')`
  */
 const StoryMainContainer = styled(VerticalScroll)`
   background: ${p => p.theme.background};
-  border-radius: ${p => p.theme.panelBorderRadius};
+  border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
 
   grid-area: body;


### PR DESCRIPTION
Removed modal radius, panel radius and link radius from theme. I have completely removed modal radius as it was incorrectly used for things like inputs in some cases. 

We can revisit the 8px radius again in the future if necessary, but my bet is that we wont need it unless we decide to introduce other standard sizes