### PR TITLE
feat(eap): Migrate Transaction Summary samples list to EAP

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -216,6 +216,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-chart-interpolation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable consecutive http performance issue type
     manager.add("organizations:performance-consecutive-http-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    manager.add("organizations:performance-core-otel-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:performance-db-main-thread-detector", OrganizationFeature, api_expose=False)
     # Enable Discover Saved Query dataset selector
     manager.add("organizations:performance-discover-dataset-selector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -216,7 +216,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-chart-interpolation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable consecutive http performance issue type
     manager.add("organizations:performance-consecutive-http-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    manager.add("organizations:performance-core-otel-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:performance-db-main-thread-detector", OrganizationFeature, api_expose=False)
     # Enable Discover Saved Query dataset selector
     manager.add("organizations:performance-discover-dataset-selector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -189,9 +189,13 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
     hasDatasetSelector(organization) &&
     eventView.dataset === DiscoverDatasets.TRANSACTIONS;
 
-  const query = isTransactionsDataset
+  let query = isTransactionsDataset
     ? appendEventTypeCondition(eventView.getQuery())
     : eventView.getQuery();
+
+  if (organization.features.includes('performance-transaction-summary-eap')) {
+    query = query.replace(/\bis_transaction:true\b/i, 'event.type:transaction');
+  }
 
   const isTransactionQueryMissing =
     getQueryDatasource(query)?.source !== Datasource.TRANSACTION &&

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -372,7 +372,6 @@ type SpecialFields = {
   device: SpecialField;
   'error.handled': SpecialField;
   id: SpecialField;
-  span_id: SpecialField;
   issue: SpecialField;
   'issue.id': SpecialField;
   minidump: SpecialField;
@@ -382,6 +381,7 @@ type SpecialFields = {
   replayId: SpecialField;
   'span.description': SpecialField;
   'span.status_code': SpecialField;
+  span_id: SpecialField;
   team_key_transaction: SpecialField;
   'timestamp.to_day': SpecialField;
   'timestamp.to_hour': SpecialField;

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -372,6 +372,7 @@ type SpecialFields = {
   device: SpecialField;
   'error.handled': SpecialField;
   id: SpecialField;
+  span_id: SpecialField;
   issue: SpecialField;
   'issue.id': SpecialField;
   minidump: SpecialField;
@@ -489,6 +490,17 @@ const SPECIAL_FIELDS: SpecialFields = {
     sortField: 'id',
     renderFunc: data => {
       const id: string | unknown = data?.id;
+      if (typeof id !== 'string') {
+        return null;
+      }
+
+      return <Container>{getShortEventId(id)}</Container>;
+    },
+  },
+  span_id: {
+    sortField: 'span_id',
+    renderFunc: data => {
+      const id: string | unknown = data?.span_id;
       if (typeof id !== 'string') {
         return null;
       }

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -54,11 +54,12 @@ export const useOurlogs = <Fields extends Array<keyof OurlogsFields>>(
 
 export const useEAPSpans = <Fields extends EAPSpanProperty[]>(
   options: UseMetricsOptions<Fields> = {},
-  referrer: string
+  referrer: string,
+  useRpc?: boolean
 ) => {
   return useDiscover<Fields, EAPSpanResponse>(
     options,
-    DiscoverDatasets.SPANS_EAP,
+    useRpc ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_EAP,
     referrer
   );
 };

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -106,7 +106,7 @@ export type SpanStringFields =
   | 'user.username'
   | 'user.ip'
   | 'replay.id'
-  | 'profile_id'
+  | 'profile.id'
   | 'profiler.id'
   | 'thread.id';
 

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -100,6 +100,7 @@ export type SpanStringFields =
   | 'project'
   | 'messaging.destination.name'
   | 'user'
+  | 'user.display'
   | 'user.id'
   | 'user.email'
   | 'user.username'

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -62,6 +62,8 @@ export enum SpanMetricsField {
   CLIENT_ADDRESS = 'client.address',
   BROWSER_NAME = 'browser.name',
   USER_GEO_SUBREGION = 'user.geo.subregion',
+  PRECISE_START_TS = 'precise.start_ts',
+  PRECISE_FINISH_TS = 'precise.finish_ts',
 }
 
 export type SpanNumberFields =
@@ -73,7 +75,9 @@ export type SpanNumberFields =
   | SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH
   | SpanMetricsField.HTTP_RESPONSE_TRANSFER_SIZE
   | SpanMetricsField.MESSAGING_MESSAGE_RECEIVE_LATENCY
-  | SpanMetricsField.CACHE_ITEM_SIZE;
+  | SpanMetricsField.CACHE_ITEM_SIZE
+  | SpanMetricsField.PRECISE_START_TS
+  | SpanMetricsField.PRECISE_FINISH_TS;
 
 export type SpanStringFields =
   | 'span_id'
@@ -95,7 +99,15 @@ export type SpanStringFields =
   | 'span.ai.pipeline.group'
   | 'project'
   | 'messaging.destination.name'
-  | 'user';
+  | 'user'
+  | 'user.id'
+  | 'user.email'
+  | 'user.username'
+  | 'user.ip'
+  | 'replay.id'
+  | 'profile_id'
+  | 'profiler.id'
+  | 'thread.id';
 
 export type SpanMetricsQueryFilters = {
   [Field in SpanStringFields]?: string;

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -105,7 +105,7 @@ export type SpanStringFields =
   | 'user.email'
   | 'user.username'
   | 'user.ip'
-  | 'replay.id'
+  | 'replayId'
   | 'profile.id'
   | 'profiler.id'
   | 'thread.id';

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -20,6 +20,7 @@ import type EventView from 'sentry/utils/discover/eventView';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -30,11 +31,10 @@ import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {type EAPSpanResponse, ModuleName} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
-  SpanOperationBreakdownFilter,
   filterToField,
+  SpanOperationBreakdownFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 // TODO: When supported, also add span operation breakdown as a field
 type Row = Pick<
@@ -111,8 +111,8 @@ const CURSOR_NAME = 'serviceEntrySpansCursor';
 type Props = {
   eventView: EventView;
   handleDropdownChange: (k: string) => void;
-  totalValues: Record<string, number> | null;
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
+  totalValues: Record<string, number> | null;
   transactionName: string;
   showViewSampledEventsButton?: boolean;
   supportsInvestigationRule?: boolean;

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -20,7 +20,6 @@ import type EventView from 'sentry/utils/discover/eventView';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -30,11 +30,10 @@ import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {type EAPSpanResponse, ModuleName} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
-  SpanOperationBreakdownFilter,
   filterToField,
+  SpanOperationBreakdownFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 // TODO: When supported, also add span operation breakdown as a field
 type Row = Pick<
@@ -111,8 +110,8 @@ const CURSOR_NAME = 'serviceEntrySpansCursor';
 type Props = {
   eventView: EventView;
   handleDropdownChange: (k: string) => void;
-  totalValues: Record<string, number> | null;
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
+  totalValues: Record<string, number> | null;
   transactionName: string;
   showViewSampledEventsButton?: boolean;
   supportsInvestigationRule?: boolean;
@@ -131,7 +130,6 @@ export function ServiceEntrySpansTable({
   const organization = useOrganization();
   const {projects} = useProjects();
   const navigate = useNavigate();
-  console.dir(totalValues);
 
   const projectSlug = projects.find(p => p.id === `${eventView.project}`)?.slug;
   const cursor = decodeScalar(location.query?.[CURSOR_NAME]);
@@ -139,15 +137,6 @@ export function ServiceEntrySpansTable({
     spanOperationBreakdownFilter,
     p95: totalValues?.['p95()'] ?? 0,
   });
-
-  console.dir(selected);
-  if (selected.query?.[0]) {
-    // const [key, value] = selected.query[0];
-    // const newQuery = new MutableSearch(eventView.query);
-    // newQuery.addFilterValue(key, value);
-    // eventView.query = newQuery.formatString();
-    // console.dir(eventView.query);
-  }
 
   const {
     data: tableData,

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -116,11 +116,6 @@ export function ServiceEntrySpansTable({
 
   const projectSlug = projects.find(p => p.id === `${eventView.project}`)?.slug;
 
-  const sortOrder = decodeScalar(
-    location.query.showTransactions,
-    TransactionFilterOptions.SLOW
-  ) as TransactionFilterOptions;
-
   const {
     data: tableData,
     isLoading,
@@ -146,6 +141,7 @@ export function ServiceEntrySpansTable({
         'precise.start_ts',
         'precise.finish_ts',
       ],
+      sorts: [selected.sort],
       limit: LIMIT,
     },
     'api.performance.service-entry-spans-table',

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -40,7 +40,7 @@ type Row = Pick<
   | 'trace'
   | 'timestamp'
   | 'replay.id'
-  | 'profile_id'
+  | 'profile.id'
   | 'profiler.id'
   | 'thread.id'
   | 'precise.start_ts'
@@ -54,7 +54,7 @@ type Column = GridColumnHeader<
   | 'trace'
   | 'timestamp'
   | 'replay.id'
-  | 'profile_id'
+  | 'profile.id'
 >;
 
 const COLUMN_ORDER: Column[] = [
@@ -89,7 +89,7 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'profile_id',
+    key: 'profile.id',
     name: t('Profile'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -135,7 +135,7 @@ export function ServiceEntrySpansTable({
         'trace',
         'timestamp',
         'replay.id',
-        'profile_id',
+        'profile.id',
         'profiler.id',
         'thread.id',
         'precise.start_ts',
@@ -209,20 +209,21 @@ function renderBodyCell(
     );
   }
 
-  if (column.key === 'profile_id') {
+  if (column.key === 'profile.id') {
+    console.dir(row);
     return (
       <div>
         <LinkButton
           size="xs"
           icon={<IconProfiling size="xs" />}
           to={{
-            pathname: `/organizations/${organization.slug}/profiling/profile/${projectSlug}/${row.profile_id}/flamegraph/`,
+            pathname: `/organizations/${organization.slug}/profiling/profile/${projectSlug}/${row['profile.id']}/flamegraph/`,
             query: {
               referrer: 'performance',
             },
           }}
           aria-label={t('View Profile')}
-          disabled={!row.profile_id}
+          disabled={!row['profile.id']}
         ></LinkButton>
       </div>
     );

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -51,6 +51,11 @@ type Column = GridColumnHeader<
 
 const COLUMN_ORDER: Column[] = [
   {
+    key: 'trace',
+    name: t('Trace ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
     key: 'span_id',
     name: t('Span ID'),
     width: COL_WIDTH_UNDEFINED,
@@ -63,11 +68,6 @@ const COLUMN_ORDER: Column[] = [
   {
     key: 'span.duration',
     name: t('Total Duration'),
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'trace',
-    name: t('Trace ID'),
     width: COL_WIDTH_UNDEFINED,
   },
   {

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -1,22 +1,21 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
-import {Fragment} from 'react';
+
 import {LinkButton} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import type {DropdownOption} from 'sentry/components/discover/transactionsList';
-
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   type GridColumnHeader,
 } from 'sentry/components/gridEditable';
 import {IconPlay, IconProfiling} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -25,7 +24,6 @@ import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spa
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {type EAPSpanResponse, ModuleName} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
-import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
 // TODO: When supported, also add span operation breakdown as a field
 type Row = Pick<
@@ -39,7 +37,7 @@ type Row = Pick<
   | 'span.duration'
   | 'trace'
   | 'timestamp'
-  | 'replay.id'
+  | 'replayId'
   | 'profile.id'
   | 'profiler.id'
   | 'thread.id'
@@ -53,7 +51,7 @@ type Column = GridColumnHeader<
   | 'span.duration'
   | 'trace'
   | 'timestamp'
-  | 'replay.id'
+  | 'replayId'
   | 'profile.id'
 >;
 
@@ -84,7 +82,7 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'replay.id',
+    key: 'replayId',
     name: t('Replay'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -99,9 +97,9 @@ const LIMIT = 5;
 
 type Props = {
   eventView: EventView;
+  handleDropdownChange: (k: string) => void;
   options: DropdownOption[];
   selected: DropdownOption;
-  handleDropdownChange: (k: string) => void;
 };
 
 export function ServiceEntrySpansTable({
@@ -134,7 +132,7 @@ export function ServiceEntrySpansTable({
         'span.duration',
         'trace',
         'timestamp',
-        'replay.id',
+        'replayId',
         'profile.id',
         'profiler.id',
         'thread.id',
@@ -224,26 +222,26 @@ function renderBodyCell(
           }}
           aria-label={t('View Profile')}
           disabled={!row['profile.id']}
-        ></LinkButton>
+        />
       </div>
     );
   }
 
-  if (column.key === 'replay.id') {
+  if (column.key === 'replayId') {
     return (
       <div>
         <LinkButton
           size="xs"
           icon={<IconPlay size="xs" />}
           to={{
-            pathname: `/organizations/${organization.slug}/replays/${row['replay.id']}/`,
+            pathname: `/organizations/${organization.slug}/replays/${row['replayId']}/`,
             query: {
               referrer: 'performance',
             },
           }}
-          disabled={!row['replay.id']}
+          disabled={!row['replayId']}
           aria-label={t('View Replay')}
-        ></LinkButton>
+        />
       </div>
     );
   }

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -1,23 +1,24 @@
 import type {Location} from 'history';
+import {LinkButton} from 'sentry/components/button';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   type GridColumnHeader,
 } from 'sentry/components/gridEditable';
+import {IconPlay, IconProfiling} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type EventView from 'sentry/utils/discover/eventView';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
-
-import {ModuleName, type EAPSpanResponse} from 'sentry/views/insights/types';
-import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Organization} from 'sentry/types/organization';
+import type EventView from 'sentry/utils/discover/eventView';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
-import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import useProjects from 'sentry/utils/useProjects';
+import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
+import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {type EAPSpanResponse, ModuleName} from 'sentry/views/insights/types';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 // TODO: When supported, also add span operation breakdown as a field
 type Row = Pick<
@@ -174,11 +175,49 @@ function renderBodyCell(
         projectSlug={projectSlug ?? ''}
         traceId={row.trace}
         timestamp={row.timestamp}
-        transactionId={row['span_id']}
-        spanId={row['span_id']}
+        transactionId={row.span_id}
+        spanId={row.span_id}
         source={TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY}
         location={location}
       />
+    );
+  }
+
+  if (column.key === 'profile_id') {
+    return (
+      <div>
+        <LinkButton
+          size="xs"
+          icon={<IconProfiling size="xs" />}
+          to={{
+            pathname: `/organizations/${organization.slug}/profiling/profile/${projectSlug}/${row.profile_id}/flamegraph/`,
+            query: {
+              referrer: 'performance',
+            },
+          }}
+          aria-label={t('View Profile')}
+          disabled={!row.profile_id}
+        ></LinkButton>
+      </div>
+    );
+  }
+
+  if (column.key === 'replay.id') {
+    return (
+      <div>
+        <LinkButton
+          size="xs"
+          icon={<IconPlay size="xs" />}
+          to={{
+            pathname: `/organizations/${organization.slug}/replays/${row['replay.id']}/`,
+            query: {
+              referrer: 'performance',
+            },
+          }}
+          disabled={!row['replay.id']}
+          aria-label={t('View Replay')}
+        ></LinkButton>
+      </div>
     );
   }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -278,11 +278,9 @@ function OTelSummaryContentInner({
           />
           <ServiceEntrySpansTable
             eventView={transactionsListEventView}
+            spanOperationBreakdownFilter={spanOperationBreakdownFilter}
             handleDropdownChange={handleTransactionsListSortChange}
-            {...getOTelTransactionsListSort(location, {
-              p95: totalValues?.['p95()'] ?? 0,
-              spanOperationBreakdownFilter,
-            })}
+            totalValues={totalValues}
             transactionName={transactionName}
             supportsInvestigationRule
             showViewSampledEventsButton
@@ -761,67 +759,6 @@ function SummaryContent({
   );
 }
 
-function getOTelFilterOptions({
-  p95,
-  spanOperationBreakdownFilter,
-}: {
-  p95: number;
-  spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
-}): DropdownOption[] {
-  if (spanOperationBreakdownFilter === SpanOperationBreakdownFilter.NONE) {
-    return [
-      {
-        sort: {kind: 'asc', field: 'span.duration'},
-        value: TransactionFilterOptions.FASTEST,
-        label: t('Fastest Transactions'),
-      },
-      {
-        query: p95 > 0 ? [['span.duration', `<=${p95.toFixed(0)}`]] : undefined,
-        sort: {kind: 'desc', field: 'span.duration'},
-        value: TransactionFilterOptions.SLOW,
-        label: t('Slow Transactions (p95)'),
-      },
-      {
-        sort: {kind: 'desc', field: 'span.duration'},
-        value: TransactionFilterOptions.OUTLIER,
-        label: t('Outlier Transactions (p100)'),
-      },
-      {
-        sort: {kind: 'desc', field: 'timestamp'},
-        value: TransactionFilterOptions.RECENT,
-        label: t('Recent Transactions'),
-      },
-    ];
-  }
-
-  const field = filterToField(spanOperationBreakdownFilter)!;
-  const operationName = spanOperationBreakdownFilter;
-
-  return [
-    {
-      sort: {kind: 'asc', field},
-      value: TransactionFilterOptions.FASTEST,
-      label: t('Fastest %s Operations', operationName),
-    },
-    {
-      query: p95 > 0 ? [['transaction.duration', `<=${p95.toFixed(0)}`]] : undefined,
-      sort: {kind: 'desc', field},
-      value: TransactionFilterOptions.SLOW,
-      label: t('Slow %s Operations (p95)', operationName),
-    },
-    {
-      sort: {kind: 'desc', field},
-      value: TransactionFilterOptions.OUTLIER,
-      label: t('Outlier %s Operations (p100)', operationName),
-    },
-    {
-      sort: {kind: 'desc', field: 'timestamp'},
-      value: TransactionFilterOptions.RECENT,
-      label: t('Recent Transactions'),
-    },
-  ];
-}
-
 function getFilterOptions({
   p95,
   spanOperationBreakdownFilter,
@@ -888,19 +825,6 @@ function getTransactionsListSort(
   options: {p95: number; spanOperationBreakdownFilter: SpanOperationBreakdownFilter}
 ): {options: DropdownOption[]; selected: DropdownOption} {
   const sortOptions = getFilterOptions(options);
-  const urlParam = decodeScalar(
-    location.query.showTransactions,
-    TransactionFilterOptions.SLOW
-  );
-  const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0]!;
-  return {selected: selectedSort, options: sortOptions};
-}
-
-export function getOTelTransactionsListSort(
-  location: Location,
-  options: {p95: number; spanOperationBreakdownFilter: SpanOperationBreakdownFilter}
-): {options: DropdownOption[]; selected: DropdownOption} {
-  const sortOptions = getOTelFilterOptions(options);
   const urlParam = decodeScalar(
     location.query.showTransactions,
     TransactionFilterOptions.SLOW

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -343,7 +343,9 @@ function OTelSummaryContentInner({
               p95: totalValues?.['p95()'] ?? 0,
               spanOperationBreakdownFilter,
             })}
+            transactionName={transactionName}
             supportsInvestigationRule
+            showViewSampledEventsButton
           />
           <TransactionsList
             location={location}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -100,7 +100,6 @@ function OTelSummaryContentInner({
   onChangeFilter,
 }: Props) {
   const navigate = useNavigate();
-  const mepDataContext = useMEPDataContext();
   const domainViewFilters = useDomainViewFilters();
 
   const handleSearch = useCallback(
@@ -138,14 +137,6 @@ function OTelSummaryContentInner({
 
     navigate(target);
   }
-
-  const trailingItems = useMemo(() => {
-    if (!canUseTransactionMetricsData(organization, mepDataContext)) {
-      return <MetricsWarningIcon />;
-    }
-
-    return null;
-  }, [organization, mepDataContext]);
 
   const hasPerformanceChartInterpolation = organization.features.includes(
     'performance-chart-interpolation'
@@ -246,7 +237,6 @@ function OTelSummaryContentInner({
         searchSource="transaction_summary"
         disableLoadingTags // already loaded by the parent component
         filterKeyMenuWidth={420}
-        trailingItems={trailingItems}
       />
     );
   }

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -336,7 +336,14 @@ function OTelSummaryContentInner({
             withoutZerofill={hasPerformanceChartInterpolation}
             project={project}
           />
-          <ServiceEntrySpansTable eventView={transactionsListEventView} />
+          <ServiceEntrySpansTable
+            eventView={transactionsListEventView}
+            handleDropdownChange={handleTransactionsListSortChange}
+            {...getOTelTransactionsListSort(location, {
+              p95: totalValues?.['p95()'] ?? 0,
+              spanOperationBreakdownFilter,
+            })}
+          />
           <TransactionsList
             location={location}
             organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -70,6 +70,7 @@ import StatusBreakdown from './statusBreakdown';
 import SuspectSpans from './suspectSpans';
 import {TagExplorer} from './tagExplorer';
 import UserStats from './userStats';
+import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
 
 type Props = {
   error: QueryError | null;
@@ -335,6 +336,7 @@ function OTelSummaryContentInner({
             withoutZerofill={hasPerformanceChartInterpolation}
             project={project}
           />
+          <ServiceEntrySpansTable eventView={transactionsListEventView} />
           <TransactionsList
             location={location}
             organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -343,6 +343,7 @@ function OTelSummaryContentInner({
               p95: totalValues?.['p95()'] ?? 0,
               spanOperationBreakdownFilter,
             })}
+            supportsInvestigationRule
           />
           <TransactionsList
             location={location}
@@ -986,7 +987,7 @@ function getTransactionsListSort(
   return {selected: selectedSort, options: sortOptions};
 }
 
-function getOTelTransactionsListSort(
+export function getOTelTransactionsListSort(
   location: Location,
   options: {p95: number; spanOperationBreakdownFilter: SpanOperationBreakdownFilter}
 ): {options: DropdownOption[]; selected: DropdownOption} {

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -39,6 +39,7 @@ import {updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import Tags from 'sentry/views/discover/tags';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
 import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
   PERCENTILE as VITAL_PERCENTILE,
@@ -70,7 +71,6 @@ import StatusBreakdown from './statusBreakdown';
 import SuspectSpans from './suspectSpans';
 import {TagExplorer} from './tagExplorer';
 import UserStats from './userStats';
-import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
 
 type Props = {
   error: QueryError | null;

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -340,8 +340,8 @@ function generateEventView({
   const query = decodeScalar(location.query.query, '');
   const conditions = new MutableSearch(query);
 
-  const usingOTel = organization.features.includes('performance-core-otel-support');
-  if (usingOTel) {
+  const isEAP = organization.features.includes('performance-transaction-summary-eap');
+  if (isEAP) {
     conditions.setFilterValues('is_transaction', ['true']);
     conditions.setFilterValues(
       'transaction.method',
@@ -359,7 +359,7 @@ function generateEventView({
     }
   });
 
-  const fields = usingOTel
+  const fields = isEAP
     ? [
         'id',
         'user.email',
@@ -380,7 +380,7 @@ function generateEventView({
       fields,
       query: conditions.formatString(),
       projects: [],
-      dataset: usingOTel ? DiscoverDatasets.SPANS_EAP_RPC : undefined,
+      dataset: isEAP ? DiscoverDatasets.SPANS_EAP_RPC : undefined,
     },
     location
   );

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -127,7 +127,7 @@ function OTelOverviewContentWrapper(props: ChildProps) {
   const mepContext = useMEPDataContext();
 
   const queryData = useDiscoverQuery({
-    eventView: getTotalsEventView(organization, eventView),
+    eventView: getEAPTotalsEventView(organization, eventView),
     orgSlug: organization.slug,
     location,
     transactionThreshold,
@@ -457,6 +457,24 @@ function getTotalsEventView(
         }) as Column
     ),
   ]);
+}
+
+function getEAPTotalsEventView(
+  _organization: Organization,
+  eventView: EventView
+): EventView {
+  const totalsColumns: QueryFieldValue[] = [
+    {
+      kind: 'function',
+      function: ['p95', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['count_unique', 'user', undefined, undefined],
+    },
+  ];
+
+  return eventView.withColumns([...totalsColumns]);
 }
 
 export default withPageFilters(withProjects(withOrganization(TransactionOverview)));

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -69,7 +69,7 @@ function TransactionOverview(props: Props) {
     });
   }, [selection, organization, api]);
 
-  const isOTel = organization.features.includes('performance-core-otel-support');
+  const isEAP = organization.features.includes('performance-transaction-summary-eap');
 
   return (
     <MEPSettingProvider>
@@ -80,9 +80,7 @@ function TransactionOverview(props: Props) {
         tab={Tab.TRANSACTION_SUMMARY}
         getDocumentTitle={getDocumentTitle}
         generateEventView={generateEventView}
-        childComponent={
-          isOTel ? OTelCardinalityLoadingWrapper : CardinalityLoadingWrapper
-        }
+        childComponent={isEAP ? EAPCardinalityLoadingWrapper : CardinalityLoadingWrapper}
       />
     </MEPSettingProvider>
   );
@@ -98,7 +96,7 @@ function CardinalityLoadingWrapper(props: ChildProps) {
   return <OverviewContentWrapper {...props} />;
 }
 
-function OTelCardinalityLoadingWrapper(props: ChildProps) {
+function EAPCardinalityLoadingWrapper(props: ChildProps) {
   const mepCardinalityContext = useMetricsCardinalityContext();
 
   if (mepCardinalityContext.isLoading) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -10,9 +10,10 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import type {QueryFieldValue} from 'sentry/utils/discover/fields';
+import type {Column, QueryFieldValue} from 'sentry/utils/discover/fields';
 import {isAggregateField} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import type {WebVital} from 'sentry/utils/fields';
 import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {
   getIsMetricsDataFromResults,
@@ -31,6 +32,10 @@ import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {
+  PERCENTILE as VITAL_PERCENTILE,
+  VITAL_GROUPS,
+} from 'sentry/views/performance/transactionSummary/transactionVitals/constants';
 
 import {addRoutePerformanceContext} from '../../utils';
 import {
@@ -402,10 +407,10 @@ function getTotalsEventView(
   _organization: Organization,
   eventView: EventView
 ): EventView {
-  // const vitals = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce((keys: WebVital[], vs) => {
-  //   vs.forEach(vital => keys.push(vital));
-  //   return keys;
-  // }, []);
+  const vitals = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce((keys: WebVital[], vs) => {
+    vs.forEach(vital => keys.push(vital));
+    return keys;
+  }, []);
 
   const totalsColumns: QueryFieldValue[] = [
     {
@@ -416,41 +421,41 @@ function getTotalsEventView(
       kind: 'function',
       function: ['count_unique', 'user', undefined, undefined],
     },
-    // {
-    //   kind: 'function',
-    //   function: ['failure_rate', '', undefined, undefined],
-    // },
-    // {
-    //   kind: 'function',
-    //   function: ['tpm', '', undefined, undefined],
-    // },
-    // {
-    //   kind: 'function',
-    //   function: ['count_miserable', 'user', undefined, undefined],
-    // },
-    // {
-    //   kind: 'function',
-    //   function: ['user_misery', '', undefined, undefined],
-    // },
-    // {
-    //   kind: 'function',
-    //   function: ['apdex', '', undefined, undefined],
-    // },
-    // {
-    //   kind: 'function',
-    //   function: ['sum', 'transaction.duration', undefined, undefined],
-    // },
+    {
+      kind: 'function',
+      function: ['failure_rate', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['tpm', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['count_miserable', 'user', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['user_misery', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['apdex', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['sum', 'transaction.duration', undefined, undefined],
+    },
   ];
 
   return eventView.withColumns([
     ...totalsColumns,
-    // ...vitals.map(
-    //   vital =>
-    //     ({
-    //       kind: 'function',
-    //       function: ['percentile', vital, VITAL_PERCENTILE.toString(), undefined],
-    //     }) as Column
-    // ),
+    ...vitals.map(
+      vital =>
+        ({
+          kind: 'function',
+          function: ['percentile', vital, VITAL_PERCENTILE.toString(), undefined],
+        }) as Column
+    ),
   ]);
 }
 


### PR DESCRIPTION
Updates the samples list table in the Transaction Summary page of Performance and Insights to use EAP. This change is hidden behind a feature flag, so it will not impact users in production. At the moment, this change breaks the rest of the components on the Transaction Summary page, but I will gradually migrate the rest of the components to work with EAP as well.

This PR includes some changes that decouple the samples table from the rest of the page and does some cleanup so that the code is easier to read and is less prone to strange side effects.

![image](https://github.com/user-attachments/assets/e5ef0729-0830-48ef-8477-42009a128191)



TODO in followups:

- [ ] Add unit tests
- [ ] Fix p95 dropdown option (it currently shows the same as p100)
- [ ] Update the Sample Events page to use the same EAP-powered component