### PR TITLE
:mag: nit: only capture sentry message when there is more than 1 parent notif

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -250,7 +250,7 @@ class SlackService:
                     else:
                         lifecycle.record_failure(err)
 
-        if use_open_period_start and parent_notification_count != 1:
+        if use_open_period_start and parent_notification_count > 1:
             sentry_sdk.capture_message(
                 f"slack.notify_all_threads_for_activity.multiple_parent_notifications_for_single_open_period Activity: {activity.id}, Group: {activity.group.id}, Project: {activity.project.id}, Integration: {integration.id}, Parent Notification Count: {parent_notification_count}"
             )


### PR DESCRIPTION
should reduce frequency of https://sentry.sentry.io/issues/6276673474/events/c06a595a5d2a4b8d955940326a89f401/ so it only captures when we have more than 1 parent notification