### PR TITLE
perf(profiling): Use has condition for has:thread.id condition

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1320,7 +1320,13 @@ class BaseQueryBuilder:
 
         # Handle checks for existence
         if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
-            if is_tag or is_attr or is_context or name in self.config.non_nullable_keys:
+            if is_context and name in self.config.nullable_context_keys:
+                return Condition(
+                    Function("has", [Column("contexts.key"), lhs.key]),
+                    Op(search_filter.operator),
+                    0,
+                )
+            elif is_tag or is_attr or is_context or name in self.config.non_nullable_keys:
                 return Condition(lhs, Op(search_filter.operator), value)
             elif is_measurement(name):
                 # Measurements can be a `Column` (e.g., `"lcp"`) or a `Function` (e.g., `"frames_frozen_rate"`). In either cause, since they are nullable, return a simple null check

--- a/src/sentry/search/events/datasets/base.py
+++ b/src/sentry/search/events/datasets/base.py
@@ -18,6 +18,7 @@ from sentry.search.events.types import SelectType, WhereType
 class DatasetConfig(abc.ABC):
     custom_threshold_columns: set[str] = set()
     non_nullable_keys: set[str] = set()
+    nullable_context_keys: set[str] = set()
     missing_function_error: ClassVar[type[Exception]] = InvalidSearchQuery
     optimize_wildcard_searches = False
     subscriptables_with_index: set[str] = set()

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -107,6 +107,7 @@ class DiscoverDatasetConfig(DatasetConfig):
         "user_misery()",
     }
     non_nullable_keys = {"event.type"}
+    nullable_context_keys = {"thread.id"}
     use_entity_prefix_for_fields: bool = False
 
     def __init__(self, builder: BaseQueryBuilder):


### PR DESCRIPTION
The `has:thread.id` condition currently queries the `contexts.key` and `contexts.value` column. To speed it up, rewrite the query so it only needs the `contexts.key` column.