### PR TITLE
chore(settings): Hide legacy rate limits page when disabled

### DIFF
--- a/static/app/views/settings/organizationRateLimits/organizationRateLimits.spec.tsx
+++ b/static/app/views/settings/organizationRateLimits/organizationRateLimits.spec.tsx
@@ -28,6 +28,7 @@ describe('Organization Rate Limits', function () {
     );
 
   beforeEach(function () {
+    organization.features = ['legacy-rate-limits'];
     MockApiClient.clearMockResponses();
   });
 
@@ -108,5 +109,14 @@ describe('Organization Rate Limits', function () {
         },
       })
     );
+  });
+
+  it('renders disabled message if organization does not have legacy rate limits', function () {
+    organization.features = [];
+    renderComponent();
+
+    expect(
+      screen.getByText('Legacy rate limits are not available in this organization.')
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationRateLimits/organizationRateLimits.tsx
+++ b/static/app/views/settings/organizationRateLimits/organizationRateLimits.tsx
@@ -5,7 +5,7 @@ import EmptyMessage from 'sentry/components/emptyMessage';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import RangeField from 'sentry/components/forms/fields/rangeField';
 import Form from 'sentry/components/forms/form';
-import Link from 'sentry/components/links/link';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
 import PanelAlert from 'sentry/components/panels/panelAlert';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -63,8 +63,8 @@ function OrganizationRateLimit({organization}: OrganizationRateLimitProps) {
             `See our [link:Billing Quota Management] docs for more information about managing your organization's quota.`,
             {
               link: (
-                <Link
-                  to="https://docs.sentry.io/pricing/quotas/"
+                <ExternalLink
+                  href="https://docs.sentry.io/pricing/quotas/"
                   aria-label={t('Billing Quota Management')}
                 />
               ),

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 from django.utils import timezone
 
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
 
@@ -17,6 +18,7 @@ class OrganizationRateLimitsTest(AcceptanceTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
         self.path = f"/organizations/{self.org.slug}/rate-limits/"
+        OrganizationOption.objects.set_value(self.org, "sentry:project-rate-limit", 80)
 
     @patch("sentry.quotas.get_maximum_quota", Mock(return_value=(100, 60)))
     def test_with_rate_limits(self):


### PR DESCRIPTION
Link in sidenav was already hidden in https://github.com/getsentry/sentry/issues/65625

![image](https://github.com/user-attachments/assets/f2ed037a-6e43-4ab6-b345-f3394a641064)
