### PR TITLE
:recycle: ref: refactor slack service and decompose functions

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -36,6 +36,7 @@ from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
 from sentry.integrations.utils.common import get_active_integration_for_organization
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
+from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
@@ -85,6 +86,10 @@ class RuleDataError(Exception):
     pass
 
 
+class ActionDataError(Exception):
+    pass
+
+
 class SlackService:
     """
     Slack service is the main entry point for all business logic related to Slack.
@@ -97,12 +102,12 @@ class SlackService:
 
     def __init__(
         self,
-        notification_message_repository: IssueAlertNotificationMessageRepository,
+        issue_alert_repository: IssueAlertNotificationMessageRepository,
         message_block_builder: BlockSlackMessageBuilder,
         activity_thread_notification_handlers: dict[ActivityType, type[ActivityNotification]],
         logger: Logger,
     ) -> None:
-        self._notification_message_repository = notification_message_repository
+        self._issue_alert_repository = issue_alert_repository
         self._slack_block_builder = message_block_builder
         self._activity_thread_notification_handlers = activity_thread_notification_handlers
         self._logger = logger
@@ -110,7 +115,7 @@ class SlackService:
     @classmethod
     def default(cls) -> SlackService:
         return SlackService(
-            notification_message_repository=get_default_issue_alert_repository(),
+            issue_alert_repository=get_default_issue_alert_repository(),
             message_block_builder=BlockSlackMessageBuilder(),
             activity_thread_notification_handlers=DEFAULT_SUPPORTED_ACTIVITY_THREAD_NOTIFICATION_HANDLERS,
             logger=_default_logger,
@@ -151,10 +156,12 @@ class SlackService:
             )
             return None
 
-        organization_id = activity.group.organization.id
+        organization = activity.group.organization
+        organization_id = organization.id
+
         # If the feature is turned off for the organization, exit early as there's nothing to do
         if not OrganizationOption.objects.get_value(
-            organization=activity.group.organization,
+            organization=organization,
             key="sentry:issue_alerts_thread_flag",
             default=ISSUE_ALERTS_THREAD_DEFAULT,
         ):
@@ -185,6 +192,20 @@ class SlackService:
 
         slack_client = SlackSdkClient(integration_id=integration.id)
 
+        self._notify_all_threads_for_activity(
+            activity=activity,
+            group=activity.group,
+            notification_to_send=notification_to_send,
+            client=slack_client,
+        )
+
+    def _notify_all_threads_for_activity(
+        self,
+        activity: Activity,
+        group: Group,
+        notification_to_send: str,
+        client: SlackSdkClient,
+    ) -> None:
         # Get all parent notifications, which will have the message identifier to use to reply in a thread
         with MessagingInteractionEvent(
             interaction_type=MessagingInteractionType.GET_PARENT_NOTIFICATION,
@@ -193,9 +214,9 @@ class SlackService:
             lifecycle.add_extras(
                 {
                     "activity_id": activity.id,
-                    "group_id": activity.group.id,
+                    "group_id": group.id,
                     "project_id": activity.project.id,
-                    "organization_id": activity.group.organization.id,
+                    "organization_id": group.organization.id,
                 }
             )
 
@@ -203,21 +224,25 @@ class SlackService:
             if (
                 features.has(
                     "organizations:slack-threads-refactor-uptime",
-                    activity.group.project.organization,
+                    group.organization,
                 )
-                and activity.group.issue_category == GroupCategory.UPTIME
+                and group.issue_category == GroupCategory.UPTIME
             ):
                 use_open_period_start = True
-                open_period_start = open_period_start_for_group(activity.group)
-                parent_notifications = self._notification_message_repository.get_all_parent_notification_messages_by_filters(
-                    group_ids=[activity.group.id],
-                    project_ids=[activity.project.id],
-                    open_period_start=open_period_start,
+                open_period_start = open_period_start_for_group(group)
+                parent_notifications = (
+                    self._issue_alert_repository.get_all_parent_notification_messages_by_filters(
+                        group_ids=[group.id],
+                        project_ids=[activity.project.id],
+                        open_period_start=open_period_start,
+                    )
                 )
             else:
-                parent_notifications = self._notification_message_repository.get_all_parent_notification_messages_by_filters(
-                    group_ids=[activity.group.id],
-                    project_ids=[activity.project.id],
+                parent_notifications = (
+                    self._issue_alert_repository.get_all_parent_notification_messages_by_filters(
+                        group_ids=[group.id],
+                        project_ids=[activity.project.id],
+                    )
                 )
 
         # We don't wrap this in a lifecycle because _handle_parent_notification is already wrapped in a lifecycle
@@ -233,8 +258,8 @@ class SlackService:
                         "activity_id": activity.id,
                         "parent_notification_id": parent_notification.id,
                         "notification_to_send": notification_to_send,
-                        "integration_id": integration.id,
-                        "group_id": activity.group.id,
+                        "integration_id": client.integration_id,
+                        "group_id": group.id,
                         "project_id": activity.project.id,
                     }
                 )
@@ -242,7 +267,7 @@ class SlackService:
                     self._handle_parent_notification(
                         parent_notification=parent_notification,
                         notification_to_send=notification_to_send,
-                        client=slack_client,
+                        client=client,
                     )
                 except Exception as err:
                     if isinstance(err, SlackApiError):
@@ -252,7 +277,7 @@ class SlackService:
 
         if use_open_period_start and parent_notification_count != 1:
             sentry_sdk.capture_message(
-                f"slack.notify_all_threads_for_activity.multiple_parent_notifications_for_single_open_period Activity: {activity.id}, Group: {activity.group.id}, Project: {activity.project.id}, Integration: {integration.id}, Parent Notification Count: {parent_notification_count}"
+                f"slack.notify_all_threads_for_activity.multiple_parent_notifications_for_single_open_period Activity: {activity.id}, Group: {group.id}, Project: {activity.project.id}, Integration: {client.integration_id}, Parent Notification Count: {parent_notification_count}"
             )
             self._logger.error(
                 "multiple parent notifications found for single open period",
@@ -293,8 +318,27 @@ class SlackService:
                 f"failed to get channel_id for rule {rule.id} and rule action {parent_notification.rule_action_uuid}"
             )
 
+        if not parent_notification.message_identifier:
+            raise RuleDataError(
+                f"parent notification {parent_notification.id} does not have a message_identifier"
+            )
+
+        self._send_notification_to_slack_channel(
+            channel_id=channel_id,
+            message_identifier=parent_notification.message_identifier,
+            notification_to_send=notification_to_send,
+            client=client,
+        )
+
+    def _send_notification_to_slack_channel(
+        self,
+        channel_id: str,
+        message_identifier: str,
+        notification_to_send: str,
+        client: SlackSdkClient,
+    ) -> None:
         block = self._slack_block_builder.get_markdown_block(text=notification_to_send)
-        payload = {"channel": channel_id, "thread_ts": parent_notification.message_identifier}
+        payload = {"channel": channel_id, "thread_ts": message_identifier}
         slack_payload = self._slack_block_builder._build_blocks(
             block, fallback_text=notification_to_send
         )
@@ -305,7 +349,7 @@ class SlackService:
 
         client.chat_postMessage(
             channel=channel_id,
-            thread_ts=parent_notification.message_identifier,
+            thread_ts=message_identifier,
             text=notification_to_send,
             blocks=json_blocks,
         )


### PR DESCRIPTION
i refactoring this service by decomposing into functions so that it is easier to feature flag the logic when i integrate my notification action updates in a pr thats coming up.

no logic change, just moving things around