### PR TITLE
ref(aci): prepare to process delayed detector trigger groups

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -141,7 +141,7 @@ def fetch_data_condition_groups(
     Fetch DataConditionGroups with enabled detectors/workflows
     """
 
-    return DataConditionGroup.objects.filter(id__in=dcg_ids)
+    return list(DataConditionGroup.objects.filter(id__in=dcg_ids))
 
 
 def generate_unique_queries(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -12,7 +12,6 @@ from sentry.models.project import Project
 from sentry.rules.conditions.event_frequency import COMPARISON_INTERVALS
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.utils import json
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.utils.safe import safe_execute
 from sentry.workflow_engine.handlers.condition.slow_condition_query_handlers import (
@@ -31,6 +30,10 @@ from sentry.workflow_engine.types import DataConditionHandlerType
 logger = logging.getLogger("sentry.workflow_engine.processors.delayed_workflow")
 
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
+
+DataConditionGroupGroups = dict[int, set[int]]
+DataConditionGroupWorkflow = dict[int, int]
+DataConditionGroupDetector = dict[int, int]
 
 
 @dataclass(frozen=True)
@@ -74,56 +77,58 @@ def fetch_group_to_event_data(
 
 def get_dcg_group_workflow_detector_data(
     workflow_event_dcg_data: dict[str, str]
-) -> tuple[dict[int, set[int]], dict[int, int], dict[int, int], list[Any]]:
+) -> tuple[DataConditionGroupGroups, DataConditionGroupWorkflow, DataConditionGroupDetector]:
     """
     Parse the data in the buffer hash, which is in the form of {workflow/detector_id}:{event_id}:{dcg_id, ..., dcg_id}:{dcg_type}
     """
 
-    dcg_to_groups: dict[int, set[int]] = defaultdict(set)
-    dcg_to_workflow: dict[int, int] = {}
-    dcg_to_detector: dict[int, int] = {}
-    all_event_data = []
+    dcg_to_groups: DataConditionGroupGroups = defaultdict(set)
+    dcg_to_workflow: DataConditionGroupWorkflow = {}
+    dcg_to_detector: DataConditionGroupDetector = {}
 
     for workflow_event_dcg, instance_data in workflow_event_dcg_data.items():
         data = workflow_event_dcg.split(":")
         dcg_type = data[3]  # TODO: use dcg_type to split WHEN and IF DCGs
 
-        dcg_has_detector = dcg_type == DataConditionHandlerType.DETECTOR_TRIGGER
-        workflow_or_detector_id = int(data[0])
         event_id = int(data[1])
         dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
-        event_data = json.loads(instance_data)
 
         for dcg_id in dcg_ids:
             dcg_to_groups[dcg_id].add(event_id)
-            if dcg_has_detector:
-                dcg_to_detector[dcg_id] = workflow_or_detector_id
-            else:
-                dcg_to_workflow[dcg_id] = workflow_or_detector_id
-            all_event_data.append(event_data)  # used in bulk fetching events from Snuba
 
-    return dcg_to_groups, dcg_to_workflow, dcg_to_detector, all_event_data
+            target_dict = (
+                dcg_to_detector
+                if dcg_type == DataConditionHandlerType.DETECTOR_TRIGGER
+                else dcg_to_workflow
+            )
+            target_dict[dcg_id] = int(data[0])
+
+    return dcg_to_groups, dcg_to_workflow, dcg_to_detector
 
 
-def fetch_workflows_detectors_envs(
+def fetch_workflows_envs(
     workflow_ids: list[int],
-    detector_ids: list[int],
-) -> tuple[dict[int, Workflow], dict[int, Detector], dict[int, int | None]]:
+) -> tuple[dict[int, Workflow], dict[int, int | None]]:
     workflows_to_envs: dict[int, int | None] = {}
     workflow_ids_to_workflows: dict[int, Workflow] = {}
-    detector_ids_to_detectors: dict[int, Detector] = {}
 
     workflows = list(Workflow.objects.filter(id__in=workflow_ids))
-    detectors = list(Detector.objects.filter(id__in=detector_ids))
 
     for workflow in workflows:
         workflows_to_envs[workflow.id] = workflow.environment.id if workflow.environment else None
         workflow_ids_to_workflows[workflow.id] = workflow
 
+    return workflow_ids_to_workflows, workflows_to_envs
+
+
+def fetch_detectors(detector_ids: list[int]) -> dict[int, Detector]:
+    detector_ids_to_detectors: dict[int, Detector] = {}
+    detectors = list(Detector.objects.filter(id__in=detector_ids))
+
     for detector in detectors:
         detector_ids_to_detectors[detector.id] = detector
 
-    return workflow_ids_to_workflows, detector_ids_to_detectors, workflows_to_envs
+    return detector_ids_to_detectors
 
 
 def fetch_active_data_condition_groups(
@@ -275,14 +280,13 @@ def process_delayed_workflows(
     workflow_event_dcg_data = fetch_group_to_event_data(project_id, Workflow, batch_key)
 
     # Get mappings from DataConditionGroups to other info
-    dcg_to_groups, dcg_to_workflow, dcg_to_detector, _ = get_dcg_group_workflow_detector_data(
+    dcg_to_groups, dcg_to_workflow, dcg_to_detector = get_dcg_group_workflow_detector_data(
         workflow_event_dcg_data
     )
-    workflow_ids_to_workflows, detector_ids_to_detectors, workflows_to_envs = (
-        fetch_workflows_detectors_envs(
-            list(dcg_to_workflow.values()), list(dcg_to_detector.values())
-        )
+    workflow_ids_to_workflows, workflows_to_envs = fetch_workflows_envs(
+        list(dcg_to_workflow.values())
     )
+    detector_ids_to_detectors = fetch_detectors(list(dcg_to_detector.values()))
     data_condition_groups = fetch_active_data_condition_groups(
         list(dcg_to_groups.keys()),
         dcg_to_workflow,

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -34,6 +34,9 @@ COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
 DataConditionGroupGroups = dict[int, set[int]]
 DataConditionGroupWorkflow = dict[int, int]
 DataConditionGroupDetector = dict[int, int]
+WorkflowMapping = dict[int, Workflow]
+WorkflowEnvMapping = dict[int, int | None]
+DetectorMapping = dict[int, Detector]
 
 
 @dataclass(frozen=True)
@@ -108,9 +111,9 @@ def get_dcg_group_workflow_detector_data(
 
 def fetch_workflows_envs(
     workflow_ids: list[int],
-) -> tuple[dict[int, Workflow], dict[int, int | None]]:
-    workflows_to_envs: dict[int, int | None] = {}
-    workflow_ids_to_workflows: dict[int, Workflow] = {}
+) -> tuple[WorkflowMapping, WorkflowEnvMapping]:
+    workflows_to_envs: WorkflowEnvMapping = {}
+    workflow_ids_to_workflows: WorkflowMapping = {}
 
     workflows = list(Workflow.objects.filter(id__in=workflow_ids))
 
@@ -121,8 +124,8 @@ def fetch_workflows_envs(
     return workflow_ids_to_workflows, workflows_to_envs
 
 
-def fetch_detectors(detector_ids: list[int]) -> dict[int, Detector]:
-    detector_ids_to_detectors: dict[int, Detector] = {}
+def fetch_detectors(detector_ids: list[int]) -> DetectorMapping:
+    detector_ids_to_detectors: DetectorMapping = {}
     detectors = list(Detector.objects.filter(id__in=detector_ids))
 
     for detector in detectors:
@@ -133,10 +136,10 @@ def fetch_detectors(detector_ids: list[int]) -> dict[int, Detector]:
 
 def fetch_active_data_condition_groups(
     dcg_ids: list[int],
-    dcg_to_workflow: dict[int, int],
-    dcg_to_detector: dict[int, int],
-    workflow_ids_to_workflows: dict[int, Workflow],
-    detector_ids_to_detectors: dict[int, Detector],
+    dcg_to_workflow: DataConditionGroupWorkflow,
+    dcg_to_detector: DataConditionGroupDetector,
+    workflow_ids_to_workflows: WorkflowMapping,
+    detector_ids_to_detectors: DetectorMapping,
 ) -> list[DataConditionGroup]:
     """
     Fetch DataConditionGroups with enabled detectors/workflows
@@ -210,9 +213,9 @@ def generate_unique_queries(
 
 def get_condition_query_groups(
     data_condition_groups: list[DataConditionGroup],
-    dcg_to_groups: dict[int, set[int]],
-    dcg_to_workflow: dict[int, int],
-    workflows_to_envs: dict[int, int | None],
+    dcg_to_groups: DataConditionGroupGroups,
+    dcg_to_workflow: DataConditionGroupWorkflow,
+    workflows_to_envs: WorkflowEnvMapping,
 ) -> dict[UniqueConditionQuery, set[int]]:
     """
     Map unique condition queries to the group IDs that need to checked for that query.

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -101,7 +101,7 @@ def get_dcg_group_workflow_detector_data(
         )
 
         for dcg_id in dcg_ids:
-            dcg_to_groups[dcg_id].add(data[1])
+            dcg_to_groups[dcg_id].add(int(data[1]))
             target_dict[dcg_id] = int(data[0])
 
     return dcg_to_groups, dcg_to_workflow, dcg_to_detector

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -89,21 +89,19 @@ def get_dcg_group_workflow_detector_data(
     dcg_to_workflow: DataConditionGroupWorkflow = {}
     dcg_to_detector: DataConditionGroupDetector = {}
 
-    for workflow_event_dcg, instance_data in workflow_event_dcg_data.items():
+    for workflow_event_dcg, _ in workflow_event_dcg_data.items():
         data = workflow_event_dcg.split(":")
         dcg_type = data[3]  # TODO: use dcg_type to split WHEN and IF DCGs
 
-        event_id = int(data[1])
         dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
+        target_dict = (
+            dcg_to_detector
+            if dcg_type == DataConditionHandlerType.DETECTOR_TRIGGER
+            else dcg_to_workflow
+        )
 
         for dcg_id in dcg_ids:
-            dcg_to_groups[dcg_id].add(event_id)
-
-            target_dict = (
-                dcg_to_detector
-                if dcg_type == DataConditionHandlerType.DETECTOR_TRIGGER
-                else dcg_to_workflow
-            )
+            dcg_to_groups[dcg_id].add(data[1])
             target_dict[dcg_id] = int(data[0])
 
     return dcg_to_groups, dcg_to_workflow, dcg_to_detector

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -216,9 +216,9 @@ def get_condition_query_groups(
     for dcg in data_condition_groups:
         slow_conditions = get_slow_conditions(dcg)
         for condition in slow_conditions:
-            for condition_query in generate_unique_queries(
-                condition, workflows_to_envs[dcg_to_workflow[dcg.id]]
-            ):
+            workflow_id = dcg_to_workflow.get(dcg.id)
+            workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
+            for condition_query in generate_unique_queries(condition, workflow_env):
                 condition_groups[condition_query].update(dcg_to_groups[dcg.id])
     return condition_groups
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -18,7 +18,7 @@ from sentry.workflow_engine.handlers.condition.slow_condition_query_handlers imp
     BaseEventFrequencyQueryHandler,
     slow_condition_query_handler_registry,
 )
-from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector, Workflow
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Workflow
 from sentry.workflow_engine.models.data_condition import (
     PERCENT_CONDITIONS,
     SLOW_CONDITIONS,
@@ -34,7 +34,6 @@ COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
 DataConditionGroupGroups = dict[int, set[int]]
 WorkflowMapping = dict[int, Workflow]
 WorkflowEnvMapping = dict[int, int | None]
-DetectorMapping = dict[int, Detector]
 
 
 @dataclass(frozen=True)
@@ -117,16 +116,6 @@ def fetch_workflows_envs(
         workflow_ids_to_workflows[workflow.id] = workflow
 
     return workflow_ids_to_workflows, workflows_to_envs
-
-
-def fetch_detectors(detector_ids: list[int]) -> DetectorMapping:
-    detector_ids_to_detectors: DetectorMapping = {}
-    detectors = list(Detector.objects.filter(id__in=detector_ids))
-
-    for detector in detectors:
-        detector_ids_to_detectors[detector.id] = detector
-
-    return detector_ids_to_detectors
 
 
 def fetch_data_condition_groups(
@@ -268,9 +257,6 @@ def process_delayed_workflows(
     dcg_to_workflow.update(trigger_type_to_dcg_model[DataConditionHandlerType.ACTION_FILTER])
 
     _, workflows_to_envs = fetch_workflows_envs(list(dcg_to_workflow.values()))
-    _ = fetch_detectors(
-        list(trigger_type_to_dcg_model[DataConditionHandlerType.DETECTOR_TRIGGER].values())
-    )
     data_condition_groups = fetch_data_condition_groups(list(dcg_to_groups.keys()))
 
     _ = get_condition_query_groups(

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -23,7 +23,6 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     DataConditionGroupGroups,
     DataConditionGroupWorkflow,
     UniqueConditionQuery,
-    fetch_active_data_condition_groups,
     fetch_detectors,
     fetch_group_to_event_data,
     fetch_workflows_envs,
@@ -261,31 +260,6 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
         assert detector_ids_to_detectors == {
             self.detector.id: self.detector,
         }
-
-    def test_fetch_active_data_condition_groups(self):
-        workflow_ids_to_workflows = {
-            self.workflow1.id: self.workflow1,
-            self.workflow2.id: self.workflow2,
-        }
-        self.dcg_to_groups[self.detector_dcg.id] = {self.group1.id}
-
-        active_dcgs = fetch_active_data_condition_groups(
-            list(self.dcg_to_groups.keys()),
-            self.dcg_to_workflow,
-            self.dcg_to_detector,
-            workflow_ids_to_workflows,
-            {self.detector.id: self.detector},
-        )
-        assert set(active_dcgs) == set(
-            self.workflow1_dcgs + self.workflow2_dcgs + [self.detector_dcg]
-        )
-
-        self.workflow1.update(enabled=False)
-        self.detector.update(enabled=False)
-        active_dcgs = fetch_active_data_condition_groups(
-            list(self.dcg_to_groups.keys()), self.dcg_to_workflow, {}, workflow_ids_to_workflows, {}
-        )
-        assert set(active_dcgs) == set(self.workflow2_dcgs)
 
 
 class TestDelayedWorkflowQueries(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -22,7 +22,6 @@ from sentry.workflow_engine.models.data_condition import (
 from sentry.workflow_engine.processors.delayed_workflow import (
     DataConditionGroupGroups,
     UniqueConditionQuery,
-    fetch_detectors,
     fetch_group_to_event_data,
     fetch_workflows_envs,
     generate_unique_queries,
@@ -266,15 +265,6 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
         assert workflow_ids_to_workflows == {
             self.workflow1.id: self.workflow1,
             self.workflow2.id: self.workflow2,
-        }
-
-    def test_fetch_detectors(self):
-        detector_ids = list(
-            self.trigger_type_to_dcg_model[DataConditionHandlerType.DETECTOR_TRIGGER].values()
-        )
-        detector_ids_to_detectors = fetch_detectors(detector_ids)
-        assert detector_ids_to_detectors == {
-            self.detector.id: self.detector,
         }
 
 

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -19,6 +19,9 @@ from sentry.workflow_engine.models.data_condition import (
     Condition,
 )
 from sentry.workflow_engine.processors.delayed_workflow import (
+    DataConditionGroupDetector,
+    DataConditionGroupGroups,
+    DataConditionGroupWorkflow,
     UniqueConditionQuery,
     fetch_active_data_condition_groups,
     fetch_detectors,
@@ -82,17 +85,17 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
             f"{self.workflow4.id}:{self.group4.id}:{self.workflow4_dcgs[1].id}:{DataConditionHandlerType.ACTION_FILTER}",
         }
 
-        self.dcg_to_groups = {dcg.id: {self.group1.id} for dcg in self.workflow1_dcgs} | {
-            dcg.id: {self.group2.id} for dcg in self.workflow2_dcgs
-        }
-        self.dcg_to_workflow = {dcg.id: self.workflow1.id for dcg in self.workflow1_dcgs} | {
-            dcg.id: self.workflow2.id for dcg in self.workflow2_dcgs
-        }
+        self.dcg_to_groups: DataConditionGroupGroups = {
+            dcg.id: {self.group1.id} for dcg in self.workflow1_dcgs
+        } | {dcg.id: {self.group2.id} for dcg in self.workflow2_dcgs}
+        self.dcg_to_workflow: DataConditionGroupWorkflow = {
+            dcg.id: self.workflow1.id for dcg in self.workflow1_dcgs
+        } | {dcg.id: self.workflow2.id for dcg in self.workflow2_dcgs}
 
         self.detector = Detector.objects.get(project_id=self.project.id, type=ErrorGroupType.slug)
         self.detector_dcg = self.create_data_condition_group()
         self.detector.update(workflow_condition_group=self.detector_dcg)
-        self.dcg_to_detector = {self.detector_dcg.id: self.detector.id}
+        self.dcg_to_detector: DataConditionGroupDetector = {self.detector_dcg.id: self.detector.id}
 
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -21,8 +21,9 @@ from sentry.workflow_engine.models.data_condition import (
 from sentry.workflow_engine.processors.delayed_workflow import (
     UniqueConditionQuery,
     fetch_active_data_condition_groups,
+    fetch_detectors,
     fetch_group_to_event_data,
-    fetch_workflows_detectors_envs,
+    fetch_workflows_envs,
     generate_unique_queries,
     get_condition_group_results,
     get_condition_query_groups,
@@ -231,21 +232,17 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
         self.dcg_to_groups[self.detector_dcg.id] = {self.group1.id}
 
         buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        dcg_to_groups, dcg_to_workflow, dcg_to_detector, all_event_data = (
-            get_dcg_group_workflow_detector_data(buffer_data)
+        dcg_to_groups, dcg_to_workflow, dcg_to_detector = get_dcg_group_workflow_detector_data(
+            buffer_data
         )
 
         assert dcg_to_groups == self.dcg_to_groups
         assert dcg_to_workflow == self.dcg_to_workflow
         assert dcg_to_detector == self.dcg_to_detector
-        assert all_event_data.count({"event_id": self.event1.event_id, "occurrence_id": None}) == 3
-        assert all_event_data.count({"event_id": self.event2.event_id, "occurrence_id": None}) == 2
 
-    def test_fetch_workflows_detectors_envs(self):
-        workflow_ids_to_workflows, detector_ids_to_detectors, workflows_to_envs = (
-            fetch_workflows_detectors_envs(
-                list(self.dcg_to_workflow.values()), list(self.dcg_to_detector.values())
-            )
+    def test_fetch_workflows_envs(self):
+        workflow_ids_to_workflows, workflows_to_envs = fetch_workflows_envs(
+            list(self.dcg_to_workflow.values())
         )
         assert workflows_to_envs == {
             self.workflow1.id: self.environment.id,
@@ -255,6 +252,9 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
             self.workflow1.id: self.workflow1,
             self.workflow2.id: self.workflow2,
         }
+
+    def test_fetch_detectors(self):
+        detector_ids_to_detectors = fetch_detectors(list(self.dcg_to_detector.values()))
         assert detector_ids_to_detectors == {
             self.detector.id: self.detector,
         }


### PR DESCRIPTION
We should be able to process delayed conditions that are enqueued from anywhere in workflow engine. The types of `DataConditionGroups` are encapsulated in `DataConditionHandlerType` and will be enqueued alongside the workflow_id OR detector_id. We can use the type to determine whether we are dealing with a detector or workflow.

This PR adds prepping data for querying for enqueued `Detector` `DataConditionGroups`. We need to check if the respective detectors are enabled in order to query Snuba for the relevant data.

NOTE: we currently do not have any slow conditions in the detector. But we can handle it for future cases.