### PR TITLE
chore(aci milestone 3): metric alert migration helper cleanup

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -139,7 +139,7 @@ def get_action_filter(
 
 def migrate_metric_action(
     alert_rule_trigger_action: AlertRuleTriggerAction,
-) -> tuple[Action, DataConditionGroupAction, ActionAlertRuleTriggerAction] | None:
+) -> tuple[Action, DataConditionGroupAction, ActionAlertRuleTriggerAction]:
     alert_rule_trigger = alert_rule_trigger_action.alert_rule_trigger
     priority = PRIORITY_MAP.get(alert_rule_trigger.label, DetectorPriorityLevel.HIGH)
     action_filter = get_action_filter(alert_rule_trigger, priority)
@@ -178,7 +178,7 @@ def migrate_metric_action(
 
 def migrate_metric_data_conditions(
     alert_rule_trigger: AlertRuleTrigger,
-) -> tuple[DataCondition, DataCondition] | None:
+) -> tuple[DataCondition, DataCondition]:
     alert_rule = alert_rule_trigger.alert_rule
     # create a data condition for the Detector's data condition group with the
     # threshold and associated priority level
@@ -257,7 +257,7 @@ def get_resolve_threshold(detector_data_condition_group: DataConditionGroup) -> 
 
 def migrate_resolve_threshold_data_conditions(
     alert_rule: AlertRule,
-) -> tuple[DataCondition, DataCondition] | None:
+) -> tuple[DataCondition, DataCondition]:
     """
     Create data conditions for the old world's "resolve" threshold. If a resolve threshold
     has been explicitly set on the alert rule, then use this as our comparison value. Otherwise,
@@ -395,19 +395,16 @@ def create_detector(
 def migrate_alert_rule(
     alert_rule: AlertRule,
     user: RpcUser | None = None,
-) -> (
-    tuple[
-        DataSource,
-        DataConditionGroup,
-        Workflow,
-        Detector,
-        DetectorState,
-        AlertRuleDetector,
-        AlertRuleWorkflow,
-        DetectorWorkflow,
-    ]
-    | None
-):
+) -> tuple[
+    DataSource,
+    DataConditionGroup,
+    Workflow,
+    Detector,
+    DetectorState,
+    AlertRuleDetector,
+    AlertRuleWorkflow,
+    DetectorWorkflow,
+]:
     organization_id = alert_rule.organization_id
     project = alert_rule.projects.get()
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -421,12 +421,14 @@ def migrate_alert_rule(
     workflow = create_workflow(alert_rule.name, organization_id, user)
 
     open_incident = (
-        Incident.objects.exclude(status=IncidentStatus.CLOSED).filter(alert_rule=alert_rule).first()
+        Incident.objects.exclude(status=IncidentStatus.CLOSED.value)
+        .filter(alert_rule=alert_rule)
+        .first()
     )
     if open_incident:
         state = (
             DetectorPriorityLevel.MEDIUM
-            if open_incident.status == IncidentStatus.WARNING
+            if open_incident.status == IncidentStatus.WARNING.value
             else DetectorPriorityLevel.HIGH
         )
     else:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -853,7 +853,7 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
 
     def test_dual_update_trigger_action_legacy_fields(self):
         updated_fields = {
-            "integration_id": self.integration.id,  # TODO: set up the integration properly and stuff
+            "integration_id": self.integration.id,
             "target_display": "freddy frog",
             "target_identifier": "freddy_frog",
             "target_type": ActionTarget.USER,

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -725,8 +725,8 @@ class DualWriteAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
         with assume_test_silo_mode_of(Integration, OrganizationIntegration):
             self.integration.update(provider="hellboy")
             self.integration.save()
-        migrated = migrate_metric_action(self.alert_rule_trigger_action_integration)
-        assert migrated is None
+        with pytest.raises(InvalidActionType):
+            migrate_metric_action(self.alert_rule_trigger_action_integration)
         mock_logger.warning.assert_called_with(
             "Could not find a matching Action.Type for the trigger action",
             extra={


### PR DESCRIPTION
Update the helpers so that all helpers raise an error on failure (as opposed to returning `None`). Also resolve a TODO to dual write detector state according to alert rule incident status.