### PR TITLE
feat(nav): Remove button labels for footer items

### DIFF
--- a/static/app/components/nav/constants.tsx
+++ b/static/app/components/nav/constants.tsx
@@ -6,7 +6,7 @@ export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-co
 export const NAV_GROUP_LABELS: Record<PrimaryNavGroup, string> = {
   [PrimaryNavGroup.ISSUES]: t('Issues'),
   [PrimaryNavGroup.EXPLORE]: t('Explore'),
-  [PrimaryNavGroup.DASHBOARDS]: t('Dashboards'),
+  [PrimaryNavGroup.DASHBOARDS]: t('Boards'),
   [PrimaryNavGroup.INSIGHTS]: t('Insights'),
   [PrimaryNavGroup.SETTINGS]: t('Settings'),
 };


### PR DESCRIPTION
Removes labels for the items in the footer (request from vu/rachel)

![CleanShot 2025-02-06 at 15 35 54@2x](https://github.com/user-attachments/assets/4899ee14-b0f6-47a4-a39b-cbe849ab37fe)
