### PR TITLE
chore(issue-views): Duplicate issue views component to facilitate feature flagging

### DIFF
--- a/static/app/components/draggableTabs/draggableTabListPF.tsx
+++ b/static/app/components/draggableTabs/draggableTabListPF.tsx
@@ -1,0 +1,568 @@
+import {
+  type Dispatch,
+  Fragment,
+  type Key,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import type {AriaTabListOptions} from '@react-aria/tabs';
+import {useTabList} from '@react-aria/tabs';
+import {useCollection} from '@react-stately/collections';
+import {ListCollection} from '@react-stately/list';
+import type {TabListState, TabListStateOptions} from '@react-stately/tabs';
+import {useTabListState} from '@react-stately/tabs';
+import type {Node} from '@react-types/shared';
+import {motion, Reorder} from 'framer-motion';
+
+import {Button} from 'sentry/components/button';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import type {DraggableTabListProps} from 'sentry/components/draggableTabs/draggableTabList';
+import DropdownButton from 'sentry/components/dropdownButton';
+import {type BaseTabProps, Tab} from 'sentry/components/tabs/tab';
+import {IconAdd, IconEllipsis} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import {useDimensionsMultiple} from 'sentry/utils/useDimensionsMultiple';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {IssueViewsPFContext} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+
+import type {DraggableTabListItemProps} from './item';
+import {Item} from './item';
+
+export const TEMPORARY_TAB_KEY = 'temporary-tab';
+
+interface BaseDraggableTabListProps extends DraggableTabListProps {
+  items: DraggableTabListItemProps[];
+}
+
+function useOverflowingTabs({state}: {state: TabListState<DraggableTabListItemProps>}) {
+  const persistentTabs = [...state.collection].filter(
+    item => item.key !== TEMPORARY_TAB_KEY
+  );
+  const outerRef = useRef<HTMLDivElement>(null);
+  const addViewTempTabRef = useRef<HTMLDivElement>(null);
+  const [tabElements, setTabElements] = useState<Array<HTMLDivElement | null>>([]);
+  const {width: outerWidth} = useDimensions({elementRef: outerRef});
+  const {width: addViewTempTabWidth} = useDimensions({elementRef: addViewTempTabRef});
+  const tabsDimensions = useDimensionsMultiple({elements: tabElements});
+
+  const overflowingTabs = useMemo(() => {
+    const availableWidth = outerWidth - addViewTempTabWidth;
+
+    let totalWidth = 0;
+    const overflowing: Array<Node<DraggableTabListItemProps>> = [];
+
+    for (let i = 0; i < tabsDimensions.length; i++) {
+      totalWidth += (tabsDimensions[i]?.width ?? 0) + 1; // 1 extra pixel for the divider
+
+      const tab = persistentTabs[i];
+
+      if (totalWidth > availableWidth + 1 && tab) {
+        overflowing.push(tab);
+      }
+    }
+
+    return overflowing.filter(defined);
+  }, [outerWidth, addViewTempTabWidth, persistentTabs, tabsDimensions]);
+
+  return {
+    overflowingTabs,
+    setTabElements,
+    outerRef,
+    addViewTempTabRef,
+    persistentTabs,
+  };
+}
+
+function OverflowMenu({
+  state,
+  overflowTabs,
+}: {
+  overflowTabs: Array<Node<DraggableTabListItemProps>>;
+  state: TabListState<any>;
+}) {
+  const options = useMemo(() => {
+    return overflowTabs.map(tab => {
+      return {
+        value: tab.key,
+        label: tab.textValue,
+        textValue: tab.textValue,
+      };
+    });
+  }, [overflowTabs]);
+
+  return (
+    <CompactSelect
+      options={options}
+      multiple={false}
+      value={state.selectionManager.firstSelectedKey?.toString()}
+      onChange={opt => state.setSelectedKey(opt.value)}
+      position="bottom-end"
+      size="sm"
+      offset={4}
+      trigger={triggerProps => (
+        <OverflowMenuTrigger
+          {...triggerProps}
+          size="sm"
+          borderless
+          showChevron={false}
+          icon={<IconEllipsis />}
+          aria-label={t('More tabs')}
+        />
+      )}
+    />
+  );
+}
+
+function Tabs({
+  orientation,
+  ariaProps,
+  state,
+  className,
+  onReorder,
+  onReorderComplete,
+  tabVariant,
+  setTabRefs,
+  tabs,
+  overflowingTabs,
+  hoveringKey,
+  setHoveringKey,
+  tempTabActive,
+  editingTabKey,
+}: {
+  ariaProps: AriaTabListOptions<DraggableTabListItemProps>;
+  hoveringKey: Key | 'addView' | null;
+  onReorder: (newOrder: Array<Node<DraggableTabListItemProps>>) => void;
+  orientation: 'horizontal' | 'vertical';
+  overflowingTabs: Array<Node<DraggableTabListItemProps>>;
+  setHoveringKey: (key: Key | 'addView' | null) => void;
+  setTabRefs: Dispatch<SetStateAction<Array<HTMLDivElement | null>>>;
+  state: TabListState<DraggableTabListItemProps>;
+  tabs: Array<Node<DraggableTabListItemProps>>;
+  tempTabActive: boolean;
+  className?: string;
+  disabled?: boolean;
+  editingTabKey?: string;
+  onChange?: (key: string | number) => void;
+  onReorderComplete?: () => void;
+  tabVariant?: BaseTabProps['variant'];
+  value?: string | number;
+}) {
+  const tabListRef = useRef<HTMLDivElement>(null);
+  const {tabListProps} = useTabList({orientation, ...ariaProps}, state, tabListRef);
+
+  const values = useMemo(() => [...state.collection], [state.collection]);
+
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Only apply this while dragging, because it causes tabs to stay within the container
+  // which we do not want (we hide tabs once they overflow
+  const dragConstraints = isDragging ? tabListRef : undefined;
+
+  // @ts-expect-error TS(7006): Parameter 'tabKey' implicitly has an 'any' type.
+  const isTabDividerVisible = tabKey => {
+    // If the tab divider is succeeding or preceding the selected tab key
+    if (
+      state.selectedKey === tabKey ||
+      (state.selectedKey !== TEMPORARY_TAB_KEY &&
+        state.collection.getKeyAfter(tabKey) !== TEMPORARY_TAB_KEY &&
+        state.collection.getKeyAfter(tabKey) === state.selectedKey)
+    ) {
+      return false;
+    }
+
+    // If the tab divider is succeeding or preceding the hovering tab key
+    if (
+      hoveringKey !== TEMPORARY_TAB_KEY &&
+      (hoveringKey === tabKey || hoveringKey === state.collection.getKeyAfter(tabKey))
+    ) {
+      return false;
+    }
+
+    if (
+      tempTabActive &&
+      state.collection.getKeyAfter(tabKey) === TEMPORARY_TAB_KEY &&
+      hoveringKey === 'addView'
+    ) {
+      return false;
+    }
+
+    if (
+      tabKey !== TEMPORARY_TAB_KEY &&
+      !state.collection.getKeyAfter(tabKey) &&
+      hoveringKey === 'addView'
+    ) {
+      return false;
+    }
+
+    return true;
+  };
+
+  return (
+    <TabListWrap {...tabListProps} className={className} ref={tabListRef}>
+      <ReorderGroup axis="x" values={values} onReorder={onReorder} initial={false}>
+        {tabs.map((item, i) => (
+          <Fragment key={item.key}>
+            <TabItemWrap
+              isSelected={state.selectedKey === item.key}
+              ref={el =>
+                setTabRefs(old => {
+                  if (!el || old.includes(el)) {
+                    return old;
+                  }
+
+                  const newRefs = [...old];
+                  newRefs[i] = el;
+                  return newRefs;
+                })
+              }
+              value={item}
+              data-key={item.key}
+              dragConstraints={dragConstraints} // dragConstraints are the bounds that the tab can be dragged within
+              dragElastic={0} // Prevents the tab from being dragged outside of the dragConstraints (w/o this you can drag it outside but it'll spring back)
+              dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic=0
+              transition={{duration: 0.1}}
+              layout
+              drag={item.key !== editingTabKey} // Disable dragging if the tab is being edited
+              onDrag={() => setIsDragging(true)}
+              onDragEnd={() => {
+                setIsDragging(false);
+                onReorderComplete?.();
+              }}
+              onHoverStart={() => setHoveringKey(item.key)}
+              onHoverEnd={() => setHoveringKey(null)}
+              initial={false}
+            >
+              <Tab
+                key={item.key}
+                item={item}
+                state={state}
+                orientation={orientation}
+                overflowing={overflowingTabs.some(tab => tab.key === item.key)}
+                variant={tabVariant}
+                as="div"
+              />
+            </TabItemWrap>
+            <TabDivider
+              layout="position"
+              transition={{duration: 0.1}}
+              isVisible={isTabDividerVisible(item.key)}
+              initial={false}
+            />
+          </Fragment>
+        ))}
+      </ReorderGroup>
+    </TabListWrap>
+  );
+}
+
+function BaseDraggableTabList({
+  hideBorder = false,
+  className,
+  outerWrapStyles,
+  onReorder,
+  onReorderComplete,
+  onAddView,
+  tabVariant = 'filled',
+  ...props
+}: BaseDraggableTabListProps) {
+  const navigate = useNavigate();
+  const [hoveringKey, setHoveringKey] = useState<Key | null>(null);
+  const {rootProps, setTabListState} = useContext(IssueViewsPFContext);
+  const organization = useOrganization();
+  const {
+    value,
+    defaultValue,
+    onChange,
+    disabled,
+    orientation = 'horizontal',
+    keyboardActivation = 'manual',
+    ...otherRootProps
+  } = rootProps;
+
+  // Load up list state
+  const ariaProps = {
+    selectedKey: value,
+    defaultSelectedKey: defaultValue,
+    // @ts-expect-error TS(7006): Parameter 'key' implicitly has an 'any' type.
+    onSelectionChange: key => {
+      onChange?.(key);
+
+      // If the newly selected tab is a tab link, then navigate to the specified link
+      const linkTo = [...(props.items ?? [])].find(item => item.key === key)?.to;
+      if (!linkTo) {
+        return;
+      }
+
+      trackAnalytics('issue_views.switched_views', {
+        organization,
+      });
+
+      navigate(linkTo);
+    },
+    isDisabled: disabled,
+    keyboardActivation,
+    ...otherRootProps,
+    ...props,
+  };
+
+  const state = useTabListState(ariaProps);
+  useEffect(() => {
+    setTabListState(state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.selectedKey]);
+
+  const tempTab = [...state.collection].find(item => item.key === TEMPORARY_TAB_KEY);
+
+  const {outerRef, setTabElements, persistentTabs, overflowingTabs, addViewTempTabRef} =
+    useOverflowingTabs({state});
+
+  return (
+    <TabListOuterWrap
+      style={outerWrapStyles}
+      hideBorder={hideBorder}
+      borderStyle={state.selectedKey === TEMPORARY_TAB_KEY ? 'dashed' : 'solid'}
+      ref={outerRef}
+    >
+      <Tabs
+        orientation={orientation}
+        ariaProps={ariaProps}
+        state={state}
+        className={className}
+        onReorder={onReorder}
+        onReorderComplete={onReorderComplete}
+        tabVariant={tabVariant}
+        setTabRefs={setTabElements}
+        tabs={persistentTabs}
+        overflowingTabs={overflowingTabs}
+        hoveringKey={hoveringKey}
+        setHoveringKey={setHoveringKey}
+        tempTabActive={!!tempTab}
+        editingTabKey={props.editingTabKey}
+      />
+      <AddViewTempTabWrap ref={addViewTempTabRef}>
+        <AddViewMotionWrapper
+          onHoverStart={() => setHoveringKey('addView')}
+          onHoverEnd={() => setHoveringKey(null)}
+        >
+          <AddViewButton
+            borderless
+            size="zero"
+            onClick={onAddView}
+            analyticsEventName="Issue Views: Add View Clicked"
+            analyticsEventKey="issue_views.add_view.clicked"
+          >
+            <StyledIconAdd size="xs" />
+            {t('Add View')}
+          </AddViewButton>
+        </AddViewMotionWrapper>
+        <TabDivider
+          layout="position"
+          isVisible={
+            defined(tempTab) &&
+            state?.selectedKey !== TEMPORARY_TAB_KEY &&
+            hoveringKey !== 'addView' &&
+            hoveringKey !== TEMPORARY_TAB_KEY
+          }
+        />
+        <MotionWrapper
+          onHoverStart={() => setHoveringKey(TEMPORARY_TAB_KEY)}
+          onHoverEnd={() => setHoveringKey(null)}
+        >
+          {tempTab && (
+            <TempTabWrap>
+              <Tab
+                key={TEMPORARY_TAB_KEY}
+                item={tempTab}
+                state={state}
+                orientation={orientation}
+                overflowing={false}
+                variant={tabVariant}
+                borderStyle="dashed"
+              />
+            </TempTabWrap>
+          )}
+        </MotionWrapper>
+        {overflowingTabs.length > 0 ? (
+          <OverflowMenu state={state} overflowTabs={overflowingTabs} />
+        ) : null}
+      </AddViewTempTabWrap>
+    </TabListOuterWrap>
+  );
+}
+
+const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
+
+export interface DraggableTabListPFProps
+  extends AriaTabListOptions<DraggableTabListItemProps>,
+    TabListStateOptions<DraggableTabListItemProps> {
+  onReorder: (newOrder: Array<Node<DraggableTabListItemProps>>) => void;
+  className?: string;
+  editingTabKey?: string;
+  hideBorder?: boolean;
+  onAddView?: React.MouseEventHandler;
+  onReorderComplete?: () => void;
+  outerWrapStyles?: React.CSSProperties;
+  showTempTab?: boolean;
+  tabVariant?: BaseTabProps['variant'];
+}
+
+/**
+ * To be used as a direct child of the <Tabs /> component. See example usage
+ * in tabs.stories.js
+ */
+export function DraggableTabListPF({
+  items,
+  onAddView,
+  ...props
+}: DraggableTabListPFProps) {
+  const collection = useCollection({items, ...props}, collectionFactory);
+
+  const parsedItems = useMemo(
+    () => [...collection].map(({key, props: itemProps}) => ({key, ...itemProps})),
+    [collection]
+  );
+
+  /**
+   * List of keys of disabled items (those with a `disbled` prop) to be passed
+   * into `BaseTabList`.
+   */
+  const disabledKeys = useMemo(
+    () => parsedItems.filter(item => item.disabled).map(item => item.key),
+    [parsedItems]
+  );
+
+  return (
+    <BaseDraggableTabList
+      items={parsedItems}
+      onAddView={onAddView}
+      disabledKeys={disabledKeys}
+      {...props}
+    >
+      {item => <Item {...item} key={item.key} />}
+    </BaseDraggableTabList>
+  );
+}
+
+DraggableTabListPF.Item = Item;
+
+const TabItemWrap = styled(Reorder.Item, {
+  shouldForwardProp: prop => prop !== 'isSelected',
+})<{isSelected: boolean}>`
+  display: flex;
+  position: relative;
+  z-index: ${p => (p.isSelected ? 1 : 0)};
+`;
+
+const TempTabWrap = styled('div')`
+  display: flex;
+  position: relative;
+  line-height: 1.6;
+`;
+
+/**
+ * TabDividers are only visible around NON-selected tabs. They are not visible around the selected tab,
+ * but they still create some space and act as a gap between tabs.
+ */
+const TabDivider = styled(motion.div, {
+  shouldForwardProp: prop => prop !== 'isVisible',
+})<{isVisible: boolean}>`
+  ${p =>
+    p.isVisible &&
+    css`
+      background-color: ${p.theme.gray200};
+      height: 16px;
+      width: 1px;
+      border-radius: 6px;
+    `}
+
+  ${p => !p.isVisible && `margin-left: 1px;`}
+
+  margin-top: 1px;
+`;
+
+const TabListOuterWrap = styled('div')<{
+  borderStyle: 'dashed' | 'solid';
+  hideBorder: boolean;
+}>`
+  position: relative;
+  ${p => !p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
+  display: grid;
+  grid-template-columns: minmax(auto, max-content) minmax(max-content, 1fr);
+  bottom: -1px;
+`;
+
+const AddViewTempTabWrap = styled('div')`
+  position: relative;
+  display: grid;
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+  flex-shrink: 0;
+  grid-auto-flow: column;
+  justify-content: start;
+  align-items: center;
+`;
+
+const TabListWrap = styled('div')`
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+  overflow-x: hidden;
+`;
+
+const ReorderGroup = styled(Reorder.Group<Node<DraggableTabListItemProps>>)`
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  width: max-content;
+  position: relative;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+`;
+
+const AddViewButton = styled(Button)`
+  display: flex;
+  color: ${p => p.theme.gray300};
+  font-weight: normal;
+  border-radius: ${p => `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`};
+  padding: ${space(1)} ${space(1)};
+  height: 31px;
+  line-height: 1.4;
+`;
+
+const StyledIconAdd = styled(IconAdd)`
+  margin-right: 4px;
+`;
+
+const MotionWrapper = styled(motion.div)`
+  display: flex;
+  position: relative;
+  bottom: 1px;
+`;
+
+const AddViewMotionWrapper = styled(motion.div)`
+  display: flex;
+  position: relative;
+  margin-top: ${space(0.25)};
+`;
+
+const OverflowMenuTrigger = styled(DropdownButton)`
+  padding: ${space(0.5)} ${space(0.75)};
+  border: none;
+
+  & > span {
+    height: 26px;
+  }
+`;

--- a/static/app/views/issueList/issueViewsHeaderPF.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.spec.tsx
@@ -1,0 +1,891 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import IssueViewsIssueListHeader from 'sentry/views/issueList/issueViewsHeader';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+describe('IssueViewsHeader', () => {
+  const organization = OrganizationFixture();
+
+  const getRequestViews = [
+    {
+      id: '1',
+      name: 'High Priority',
+      query: 'priority:high',
+      querySort: IssueSortOptions.DATE,
+    },
+    {
+      id: '2',
+      name: 'Medium Priority',
+      query: 'priority:medium',
+      querySort: IssueSortOptions.DATE,
+    },
+    {
+      id: '3',
+      name: 'Low Priority',
+      query: 'priority:low',
+      querySort: IssueSortOptions.NEW,
+    },
+  ];
+
+  const defaultRouter = RouterFixture({
+    location: LocationFixture({
+      pathname: `/organizations/${organization.slug}/issues/`,
+      query: {},
+    }),
+  });
+
+  const unsavedTabRouter = RouterFixture({
+    location: LocationFixture({
+      pathname: `/organizations/${organization.slug}/issues/`,
+      query: {
+        query: 'is:unresolved',
+        viewId: getRequestViews[0]!.id,
+      },
+    }),
+  });
+
+  const queryOnlyRouter = RouterFixture({
+    location: LocationFixture({
+      pathname: `/organizations/${organization.slug}/issues/`,
+      query: {
+        query: 'is:unresolved',
+      },
+    }),
+  });
+
+  const defaultProps = {
+    organization,
+    onRealtimeChange: jest.fn(),
+    realtimeActive: false,
+    router: defaultRouter,
+    selectedProjectIds: [],
+  };
+
+  describe('CustomViewsHeader initialization and router behavior', () => {
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+      });
+    });
+
+    it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Low Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /High Priority/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      expect(
+        screen.getByRole('button', {name: 'High Priority Ellipsis Menu'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Medium Priority Ellipsis Menu'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Low Priority Ellipsis Menu'})
+      ).not.toBeInTheDocument();
+
+      expect(defaultRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: getRequestViews[0]!.query,
+            viewId: getRequestViews[0]!.id,
+            sort: getRequestViews[0]!.querySort,
+          }),
+        })
+      );
+    });
+
+    it('creates a default viewId if no id is present in the request views', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [
+          {
+            name: 'Prioritized',
+            query: 'is:unresolved issue.priority:[high, medium]',
+            querySort: IssueSortOptions.DATE,
+          },
+        ],
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Prioritized/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      expect(defaultRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'is:unresolved issue.priority:[high, medium]',
+            viewId: 'default0',
+            sort: IssueSortOptions.DATE,
+          }),
+        })
+      );
+    });
+
+    it('allows you to manually enter a query, even if you only have a default tab', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [
+          {
+            name: 'Prioritized',
+            query: 'is:unresolved issue.priority:[high, medium]',
+            querySort: IssueSortOptions.DATE,
+          },
+        ],
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
+        router: queryOnlyRouter,
+      });
+
+      expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      expect(queryOnlyRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'is:unresolved',
+            viewId: undefined,
+          }),
+        })
+      );
+    });
+
+    it('initially selects a specific tab if its viewId is present in the url', async () => {
+      const specificTabRouter = RouterFixture({
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/`,
+          query: {
+            viewId: getRequestViews[1]!.id,
+          },
+        }),
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} router={specificTabRouter} />, {
+        router: specificTabRouter,
+      });
+
+      expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      expect(specificTabRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            viewId: getRequestViews[1]!.id,
+            query: getRequestViews[1]!.query,
+            sort: getRequestViews[1]!.querySort,
+          }),
+        })
+      );
+    });
+
+    it('initially selects a temporary tab when only a query is present in the url', async () => {
+      render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
+        router: queryOnlyRouter,
+      });
+
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Low Priority/})).toBeInTheDocument();
+
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
+
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(queryOnlyRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'is:unresolved',
+          }),
+        })
+      );
+    });
+
+    it('initially selects a temporary tab if a foreign viewId and a query is present in the url', async () => {
+      const specificTabRouter = RouterFixture({
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/`,
+          query: {
+            query: 'is:unresolved',
+            viewId: 'randomViewIdThatDoesNotExist',
+          },
+        }),
+      });
+      render(<IssueViewsIssueListHeader {...defaultProps} router={specificTabRouter} />, {
+        router: specificTabRouter,
+      });
+
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
+      expect(screen.getByRole('tab', {name: /Low Priority/})).toBeInTheDocument();
+
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toBeInTheDocument();
+
+      expect(screen.getByRole('tab', {name: /Unsaved/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      // Make sure viewId is scrubbed from the url via a replace call
+      expect(specificTabRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'is:unresolved',
+            viewId: undefined,
+          }),
+        })
+      );
+    });
+
+    it('updates the unsaved changes indicator for a default tab if the query is different', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [
+          {
+            name: 'Prioritized',
+            query: 'is:unresolved issue.priority:[high, medium]',
+            querySort: IssueSortOptions.DATE,
+          },
+        ],
+      });
+
+      const defaultTabDifferentQueryRouter = RouterFixture({
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/`,
+          query: {
+            query: 'is:unresolved',
+            viewId: 'default0',
+          },
+        }),
+      });
+
+      render(
+        <IssueViewsIssueListHeader
+          {...defaultProps}
+          router={defaultTabDifferentQueryRouter}
+        />,
+        {
+          router: defaultTabDifferentQueryRouter,
+        }
+      );
+      expect(await screen.findByRole('tab', {name: /Prioritized/})).toBeInTheDocument();
+      expect(screen.getByTestId('unsaved-changes-indicator')).toBeInTheDocument();
+      expect(screen.queryByRole('tab', {name: /Unsaved/})).not.toBeInTheDocument();
+
+      expect(defaultTabDifferentQueryRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'is:unresolved',
+            viewId: 'default0',
+          }),
+        })
+      );
+    });
+  });
+
+  describe('CustomViewsHeader search query behavior', () => {
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
+      });
+    });
+
+    it('switches tabs when clicked, and updates the query params accordingly', async () => {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      await userEvent.click(await screen.findByRole('tab', {name: /Medium Priority/}));
+
+      // This test inexplicably fails on the lines below. which ensure the Medium Priority tab is selected when clicked
+      // and the High Priority tab is unselected. This behavior exists in other tests and in browser, so idk why it fails here.
+      // We still need to ensure the router works as expected, so I'm commenting these checks rather than skipping the whole test.
+      // expect(screen.getByRole('tab', {name: 'High Priority'})).toHaveAttribute(
+      //   'aria-selected',
+      //   'false'
+      // );
+      // expect(screen.getByRole('tab', {name: 'Medium Priority'})).toHaveAttribute(
+      //   'aria-selected',
+      //   'true'
+      // );
+
+      // Note that this is a push call, not a replace call
+      expect(defaultRouter.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: getRequestViews[1]!.query,
+            viewId: getRequestViews[1]!.id,
+            sort: getRequestViews[1]!.querySort,
+          }),
+        })
+      );
+    });
+
+    it('renders the unsaved changes indicator if query params contain a viewId and a non-matching query', async () => {
+      const goodViewIdChangedQueryRouter = RouterFixture({
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/`,
+          query: {
+            viewId: getRequestViews[1]!.id,
+            query: 'is:unresolved',
+          },
+        }),
+      });
+
+      render(
+        <IssueViewsIssueListHeader
+          {...defaultProps}
+          router={goodViewIdChangedQueryRouter}
+        />,
+        {router: goodViewIdChangedQueryRouter}
+      );
+
+      expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      expect(await screen.findByTestId('unsaved-changes-indicator')).toBeInTheDocument();
+
+      expect(goodViewIdChangedQueryRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            viewId: getRequestViews[1]!.id,
+            query: 'is:unresolved',
+            sort: getRequestViews[1]!.querySort,
+          }),
+        })
+      );
+    });
+
+    it('renders the unsaved changes indicator if a viewId and non-matching sort are in the query params', async () => {
+      const goodViewIdChangedSortRouter = RouterFixture({
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/`,
+          query: {
+            viewId: getRequestViews[1]!.id,
+            sort: IssueSortOptions.FREQ,
+          },
+        }),
+      });
+
+      render(
+        <IssueViewsIssueListHeader
+          {...defaultProps}
+          router={goodViewIdChangedSortRouter}
+        />,
+        {router: goodViewIdChangedSortRouter}
+      );
+
+      expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      expect(await screen.findByTestId('unsaved-changes-indicator')).toBeInTheDocument();
+
+      expect(goodViewIdChangedSortRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            viewId: getRequestViews[1]!.id,
+            query: getRequestViews[1]!.query,
+            sort: IssueSortOptions.FREQ,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('Tab ellipsis menu options', () => {
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {},
+      });
+    });
+
+    it('should render the correct set of actions for an unchanged tab', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />);
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+      );
+
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Save Changes'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Discard Changes'})
+      ).not.toBeInTheDocument();
+
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Rename'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Duplicate'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Delete'})
+      ).toBeInTheDocument();
+    });
+
+    it('should render the correct set of actions for a changed tab', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />);
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+      );
+
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Save Changes'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Discard Changes'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Rename'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Duplicate'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Delete'})
+      ).toBeInTheDocument();
+    });
+
+    it('should render the correct set of actions if only a single tab exists', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: [getRequestViews[0]],
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />);
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+      );
+
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Save Changes'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Discard Changes'})
+      ).not.toBeInTheDocument();
+
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Rename'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Duplicate'})
+      ).toBeInTheDocument();
+
+      // The delete action should be absent if only one tab exists
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Delete'})
+      ).not.toBeInTheDocument();
+    });
+
+    describe('Tab renaming', () => {
+      it('should begin editing the tab if the "Rename" ellipsis menu options is clicked', async () => {
+        const mockPutRequest = MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/group-search-views/`,
+          method: 'PUT',
+          body: getRequestViews,
+        });
+
+        render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+        await userEvent.click(
+          await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+        );
+
+        await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Rename'}));
+
+        expect(await screen.findByRole('textbox')).toHaveValue('High Priority');
+
+        await userEvent.type(
+          await screen.findByRole('textbox'),
+          '{control>}A{/control}{backspace}'
+        );
+        await userEvent.type(await screen.findByRole('textbox'), 'New Name');
+        await userEvent.type(await screen.findByRole('textbox'), '{enter}');
+
+        expect(defaultRouter.push).not.toHaveBeenCalled();
+
+        // Make sure the put request is called, and the renamed view is in the request
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
+        expect(putRequestViews).toHaveLength(3);
+        expect(putRequestViews).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: getRequestViews[0]!.id,
+              name: 'New Name',
+              query: getRequestViews[0]!.query,
+              querySort: getRequestViews[0]!.querySort,
+            }),
+          ])
+        );
+      });
+    });
+
+    describe('Tab duplication', () => {
+      it('should duplicate the tab and then select the new tab', async () => {
+        const mockPutRequest = MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/group-search-views/`,
+          method: 'PUT',
+          body: getRequestViews,
+        });
+
+        render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+        await userEvent.click(
+          await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+        );
+
+        await userEvent.click(
+          await screen.findByRole('menuitemradio', {name: 'Duplicate'})
+        );
+
+        // Make sure the put request is called, and the duplicated view is in the request
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
+        expect(putRequestViews).toHaveLength(4);
+        expect(putRequestViews).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: 'High Priority',
+              query: getRequestViews[0]!.query,
+              querySort: getRequestViews[0]!.querySort,
+            }),
+            expect.objectContaining({
+              name: 'High Priority (Copy)',
+              query: getRequestViews[0]!.query,
+              querySort: getRequestViews[0]!.querySort,
+            }),
+          ])
+        );
+
+        // Make sure the new tab is selected with a temporary viewId
+        expect(defaultRouter.push).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.objectContaining({
+              viewId: expect.stringContaining('_'),
+              query: getRequestViews[0]!.query,
+              sort: getRequestViews[0]!.querySort,
+            }),
+          })
+        );
+      });
+    });
+
+    describe('Tab deletion', () => {
+      it('should delete the tab and then select the new first tab', async () => {
+        const mockPutRequest = MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/group-search-views/`,
+          method: 'PUT',
+          body: getRequestViews,
+        });
+
+        render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+        await userEvent.click(
+          await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+        );
+
+        await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+
+        // Make sure the put request is called, and the deleted view not in the request
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
+        expect(putRequestViews).toHaveLength(2);
+        expect(putRequestViews.every).not.toEqual(
+          expect.objectContaining({id: getRequestViews[0]!.id})
+        );
+
+        // Make sure the new first tab is selected
+        expect(defaultRouter.push).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: getRequestViews[1]!.query,
+              viewId: getRequestViews[1]!.id,
+              sort: getRequestViews[1]!.querySort,
+            }),
+          })
+        );
+      });
+    });
+
+    describe('Tab saving changes', () => {
+      it('should save the changes and then select the new tab', async () => {
+        const mockPutRequest = MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/group-search-views/`,
+          method: 'PUT',
+          body: getRequestViews,
+        });
+
+        render(
+          <IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
+          {router: unsavedTabRouter}
+        );
+
+        await userEvent.click(
+          await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+        );
+
+        await userEvent.click(
+          await screen.findByRole('menuitemradio', {name: 'Save Changes'})
+        );
+
+        // Make sure the put request is called, and the saved view is in the request
+        expect(mockPutRequest).toHaveBeenCalledTimes(2);
+        const putRequestViews = mockPutRequest.mock.calls[1][1].data.views;
+        expect(putRequestViews).toHaveLength(3);
+        expect(putRequestViews).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: getRequestViews[0]!.id,
+              name: 'High Priority',
+              query: 'is:unresolved',
+              querySort: getRequestViews[0]!.querySort,
+            }),
+          ])
+        );
+
+        expect(unsavedTabRouter.push).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Tab discarding changes', () => {
+      it('should discard the changes and then select the new tab', async () => {
+        const mockPutRequest = MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/group-search-views/`,
+          method: 'PUT',
+          body: getRequestViews,
+        });
+
+        render(
+          <IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
+          {router: unsavedTabRouter}
+        );
+
+        await userEvent.click(
+          await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
+        );
+
+        await userEvent.click(
+          await screen.findByRole('menuitemradio', {name: 'Discard Changes'})
+        );
+        // Just to be safe, make sure discarding changes does not trigger the put request
+        expect(mockPutRequest).toHaveBeenCalledTimes(1);
+
+        // Make sure that the tab's original query is restored
+        expect(unsavedTabRouter.push).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: getRequestViews[0]!.query,
+              viewId: getRequestViews[0]!.id,
+              sort: getRequestViews[0]!.querySort,
+            }),
+          })
+        );
+      });
+    });
+  });
+
+  describe('Issue views query counts', () => {
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+    });
+
+    it('should render the correct count for a single view', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        query: {
+          query: getRequestViews[0]!.query,
+        },
+        body: {
+          [getRequestViews[0]!.query]: 42,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('42')).toBeInTheDocument();
+    });
+
+    it('should render the correct count for multiple views', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: getRequestViews,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        body: {
+          [getRequestViews[0]!.query]: 42,
+          [getRequestViews[1]!.query]: 6,
+          [getRequestViews[2]!.query]: 98,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('42')).toBeInTheDocument();
+      expect(screen.getByText('6')).toBeInTheDocument();
+      expect(screen.getByText('98')).toBeInTheDocument();
+    });
+
+    it('should show a max count of 99+ if the count is greater than 99', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        query: {
+          query: getRequestViews[0]!.query,
+        },
+        body: {
+          [getRequestViews[0]!.query]: 101,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('99+')).toBeInTheDocument();
+    });
+
+    it('should show stil show a 0 query count if the count is 0', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'GET',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/`,
+        method: 'PUT',
+        body: [getRequestViews[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues-count/`,
+        method: 'GET',
+        query: {
+          query: getRequestViews[0]!.query,
+        },
+        body: {
+          [getRequestViews[0]!.query]: 0,
+        },
+      });
+
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {router: defaultRouter});
+
+      expect(await screen.findByText('0')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -1,0 +1,458 @@
+import {useContext, useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import type {Node} from '@react-types/shared';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {
+  DraggableTabList,
+  TEMPORARY_TAB_KEY,
+} from 'sentry/components/draggableTabs/draggableTabList';
+import type {DraggableTabListItemProps} from 'sentry/components/draggableTabs/item';
+import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import {IconMegaphone, IconPause, IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import {useHotkeys} from 'sentry/utils/useHotkeys';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
+import {
+  generateTempViewId,
+  type IssueViewPF,
+  type IssueViewPFParams,
+  IssueViewsPF,
+  IssueViewsPFContext,
+} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {IssueViewPFTab} from 'sentry/views/issueList/issueViewsPF/issueViewTabPF';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
+
+import {IssueSortOptions} from './utils';
+
+type IssueViewsIssueListHeaderProps = {
+  onRealtimeChange: (realtime: boolean) => void;
+  realtimeActive: boolean;
+  router: InjectedRouter;
+  selectedProjectIds: number[];
+};
+
+type IssueViewsIssueListHeaderTabsContentProps = {
+  router: InjectedRouter;
+};
+
+function IssueViewsPFIssueListHeader({
+  selectedProjectIds,
+  realtimeActive,
+  onRealtimeChange,
+  router,
+}: IssueViewsIssueListHeaderProps) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const selectedProjects = projects.filter(({id}) =>
+    selectedProjectIds.includes(Number(id))
+  );
+
+  const {newViewActive} = useContext(NewTabContext);
+
+  const {data: groupSearchViews} = useFetchGroupSearchViews({
+    orgSlug: organization.slug,
+  });
+
+  const realtimeTitle = realtimeActive
+    ? t('Pause real-time updates')
+    : t('Enable real-time updates');
+
+  const openForm = useFeedbackForm();
+  const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+
+  return (
+    <Layout.Header
+      noActionWrap
+      // No viewId in the URL query means that a temp view is selected, which has a dashed border
+      borderStyle={
+        groupSearchViews && !router?.location.query.viewId ? 'dashed' : 'solid'
+      }
+    >
+      <Layout.HeaderContent>
+        <Layout.Title>
+          {t('Issues')}
+          <PageHeadingQuestionTooltip
+            docsUrl="https://docs.sentry.io/product/issues/"
+            title={t(
+              'Detailed views of errors and performance problems in your application grouped by events with a similar set of characteristics.'
+            )}
+          />
+        </Layout.Title>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions>
+        <ButtonBar gap={1}>
+          {openForm && hasNewLayout && (
+            <Button
+              size="sm"
+              aria-label="issue-stream-feedback"
+              icon={<IconMegaphone />}
+              onClick={() =>
+                openForm({
+                  messagePlaceholder: t(
+                    'How can we make the issue stream better for you?'
+                  ),
+                  tags: {
+                    ['feedback.source']: 'new_issue_stream_layout',
+                    ['feedback.owner']: 'issues',
+                  },
+                })
+              }
+            >
+              {t('Give Feedback')}
+            </Button>
+          )}
+          {!newViewActive && (
+            <Button
+              size="sm"
+              data-test-id="real-time"
+              title={realtimeTitle}
+              aria-label={realtimeTitle}
+              icon={realtimeActive ? <IconPause /> : <IconPlay />}
+              onClick={() => onRealtimeChange(!realtimeActive)}
+            />
+          )}
+        </ButtonBar>
+      </Layout.HeaderActions>
+      <StyledGlobalEventProcessingAlert projects={selectedProjects} />
+      {groupSearchViews ? (
+        <StyledIssueViews
+          router={router}
+          initialViews={groupSearchViews.map(
+            (
+              {id, name, query: viewQuery, querySort: viewQuerySort},
+              index
+            ): IssueViewPF => {
+              const tabId = id ?? `default${index.toString()}`;
+
+              return {
+                id: tabId,
+                key: tabId,
+                label: name,
+                query: viewQuery,
+                querySort: viewQuerySort,
+                isCommitted: true,
+              };
+            }
+          )}
+        >
+          <IssueViewsPFIssueListHeaderTabsContent router={router} />
+        </StyledIssueViews>
+      ) : (
+        <div style={{height: 33}} />
+      )}
+    </Layout.Header>
+  );
+}
+
+function IssueViewsPFIssueListHeaderTabsContent({
+  router,
+}: IssueViewsIssueListHeaderTabsContentProps) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const pageFilters = usePageFilters();
+  const user = useUser();
+
+  const {newViewActive, setNewViewActive} = useContext(NewTabContext);
+  const {tabListState, state, dispatch} = useContext(IssueViewsPFContext);
+  const {views, tempView} = state;
+
+  const [editingTabKey, setEditingTabKey] = useState<string | null>(null);
+
+  // TODO(msun): Use the location from useLocation instead of props router in the future
+  const queryParams = router.location.query;
+  const {query, sort, viewId, project, environment} = queryParams;
+  const queryParamsWithPageFilters = useMemo(() => {
+    return {
+      ...queryParams,
+      project: project ?? pageFilters.selection.projects,
+      environment: environment ?? pageFilters.selection.environments,
+      ...normalizeDateTimeParams(pageFilters.selection.datetime),
+    };
+  }, [
+    environment,
+    pageFilters.selection.datetime,
+    pageFilters.selection.environments,
+    pageFilters.selection.projects,
+    project,
+    queryParams,
+  ]);
+
+  // This useEffect is here temporarily to start saving user's most recently used page filters
+  // to their views. This will be removed once the frontend is updated to use a view's page filters
+  useEffect(() => {
+    dispatch({type: 'SYNC_VIEWS_TO_BACKEND'});
+
+    trackAnalytics('issue_views.page_filters_logged', {
+      user_id: user.id,
+      organization,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageFilters.selection]);
+
+  // This insane useEffect ensures that the correct tab is selected when the url updates
+  useEffect(() => {
+    // If no query, sort, or viewId is present, set the first tab as the selected tab, update query accordingly
+    if (!query && !sort && !viewId) {
+      navigate(
+        normalizeUrl({
+          ...location,
+          query: {
+            ...queryParamsWithPageFilters,
+            query: views[0]!.query,
+            sort: views[0]!.querySort,
+            viewId: views[0]!.id,
+          },
+        }),
+        {replace: true}
+      );
+      tabListState?.setSelectedKey(views[0]!.key);
+      return;
+    }
+    // if a viewId is present, check the frontend is aware of a view with that id.
+    if (viewId) {
+      const selectedView = views.find(tab => tab.id === viewId);
+      if (selectedView) {
+        // If the frontend is aware of a view with that id, check if the query/sort is different
+        // from the view's original query/sort.
+        const {query: originalQuery, querySort: originalSort} = selectedView;
+        const issueSortOption = Object.values(IssueSortOptions).includes(sort)
+          ? sort
+          : IssueSortOptions.DATE;
+
+        const newUnsavedChanges: IssueViewPFParams | undefined =
+          query === originalQuery && sort === originalSort
+            ? undefined
+            : {
+                query,
+                querySort: issueSortOption,
+              };
+        if (
+          (newUnsavedChanges && !selectedView.unsavedChanges) ||
+          selectedView.unsavedChanges?.query !== newUnsavedChanges?.query ||
+          selectedView.unsavedChanges?.querySort !== newUnsavedChanges?.querySort
+        ) {
+          // If there were no unsaved changes before, or the existing unsaved changes
+          // don't match the new query and/or sort, update the unsaved changes
+          dispatch({
+            type: 'UPDATE_UNSAVED_CHANGES',
+            unsavedChanges: newUnsavedChanges,
+          });
+        } else if (!newUnsavedChanges && selectedView.unsavedChanges) {
+          // If the query/sort are the same as the original query/sort, remove any unsaved changes
+          dispatch({type: 'UPDATE_UNSAVED_CHANGES', unsavedChanges: undefined});
+        }
+        if (!tabListState?.selectionManager.isSelected(selectedView.key)) {
+          navigate(
+            normalizeUrl({
+              ...location,
+              query: {
+                ...queryParamsWithPageFilters,
+                query: newUnsavedChanges?.query ?? selectedView.query,
+                sort: newUnsavedChanges?.querySort ?? selectedView.querySort,
+                viewId: selectedView.id,
+              },
+            }),
+            {replace: true}
+          );
+          tabListState?.setSelectedKey(selectedView.key);
+        }
+      } else {
+        // if a viewId does not exist, remove it from the query
+        tabListState?.setSelectedKey(TEMPORARY_TAB_KEY);
+        navigate(
+          normalizeUrl({
+            ...location,
+            query: {
+              ...queryParamsWithPageFilters,
+              viewId: undefined,
+            },
+          }),
+          {replace: true}
+        );
+        trackAnalytics('issue_views.shared_view_opened', {
+          organization,
+          query,
+        });
+      }
+      return;
+    }
+    if (query) {
+      if (!tabListState?.selectionManager.isSelected(TEMPORARY_TAB_KEY)) {
+        dispatch({type: 'SET_TEMP_VIEW', query, sort});
+        navigate(
+          normalizeUrl({
+            ...location,
+            query: {
+              ...queryParamsWithPageFilters,
+              viewId: undefined,
+            },
+          }),
+          {replace: true}
+        );
+        tabListState?.setSelectedKey(TEMPORARY_TAB_KEY);
+        return;
+      }
+    }
+  }, [
+    navigate,
+    organization.slug,
+    query,
+    sort,
+    viewId,
+    tabListState,
+    location,
+    queryParamsWithPageFilters,
+    views,
+    organization,
+    dispatch,
+  ]);
+
+  // This useEffect ensures the "new view" page is displayed/hidden correctly
+  useEffect(() => {
+    if (viewId?.startsWith('_')) {
+      if (views.find(tab => tab.id === viewId)?.isCommitted) {
+        return;
+      }
+      // If the user types in query manually while the new view flow is showing,
+      // then replace the add view flow with the issue stream with the query loaded,
+      // and persist the query
+      if (newViewActive && query !== '') {
+        setNewViewActive(false);
+        dispatch({
+          type: 'UPDATE_UNSAVED_CHANGES',
+          unsavedChanges: {query, querySort: sort ?? IssueSortOptions.DATE},
+          isCommitted: true,
+          syncViews: true,
+        });
+        trackAnalytics('issue_views.add_view.custom_query_saved', {
+          organization,
+          query,
+        });
+      } else {
+        setNewViewActive(true);
+      }
+    } else {
+      setNewViewActive(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewId, query]);
+
+  useHotkeys(
+    [
+      {
+        match: ['command+s', 'ctrl+s'],
+        includeInputs: true,
+        callback: () => {
+          if (views.find(tab => tab.key === tabListState?.selectedKey)?.unsavedChanges) {
+            dispatch({type: 'SAVE_CHANGES', syncViews: true});
+            addSuccessMessage(t('Changes saved to view'));
+          }
+        },
+      },
+    ],
+    [dispatch, tabListState?.selectedKey, views]
+  );
+
+  const handleCreateNewView = () => {
+    const tempId = generateTempViewId();
+    dispatch({type: 'CREATE_NEW_VIEW', tempId});
+    tabListState?.setSelectedKey(tempId);
+    navigate({
+      ...location,
+      query: {
+        ...queryParams,
+        query: '',
+        viewId: tempId,
+      },
+    });
+  };
+
+  const allTabs = tempView ? [...views, tempView] : views;
+
+  const initialTabKey =
+    viewId && views.find(tab => tab.id === viewId)
+      ? views.find(tab => tab.id === viewId)!.key
+      : query
+        ? TEMPORARY_TAB_KEY
+        : views[0]!.key;
+
+  return (
+    <DraggableTabList
+      onReorder={(newOrder: Array<Node<DraggableTabListItemProps>>) =>
+        dispatch({
+          type: 'REORDER_TABS',
+          newKeyOrder: newOrder.map(node => node.key.toString()),
+        })
+      }
+      onReorderComplete={() => dispatch({type: 'SYNC_VIEWS_TO_BACKEND'})}
+      defaultSelectedKey={initialTabKey}
+      onAddView={handleCreateNewView}
+      orientation="horizontal"
+      editingTabKey={editingTabKey ?? undefined}
+      hideBorder
+    >
+      {allTabs.map(view => (
+        <DraggableTabList.Item
+          textValue={view.label}
+          key={view.key}
+          to={normalizeUrl({
+            query: {
+              ...queryParams,
+              query: view.unsavedChanges?.query ?? view.query,
+              sort: view.unsavedChanges?.querySort ?? view.querySort,
+              viewId: view.id !== TEMPORARY_TAB_KEY ? view.id : undefined,
+              cursor: undefined,
+              page: undefined,
+            },
+            pathname: `/organizations/${organization.slug}/issues/`,
+          })}
+          disabled={view.key === editingTabKey}
+        >
+          <IssueViewPFTab
+            key={view.key}
+            view={view}
+            initialTabKey={initialTabKey}
+            router={router}
+            editingTabKey={editingTabKey}
+            setEditingTabKey={setEditingTabKey}
+          />
+        </DraggableTabList.Item>
+      ))}
+    </DraggableTabList>
+  );
+}
+
+export default IssueViewsPFIssueListHeader;
+
+const StyledIssueViews = styled(IssueViewsPF)`
+  grid-column: 1 / -1;
+`;
+
+const StyledGlobalEventProcessingAlert = styled(GlobalEventProcessingAlert)`
+  grid-column: 1/-1;
+  margin-top: ${space(1)};
+  margin-bottom: ${space(1)};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    margin-top: ${space(2)};
+    margin-bottom: 0;
+  }
+`;

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -5,10 +5,8 @@ import type {Node} from '@react-types/shared';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {
-  DraggableTabList,
-  TEMPORARY_TAB_KEY,
-} from 'sentry/components/draggableTabs/draggableTabList';
+import {TEMPORARY_TAB_KEY} from 'sentry/components/draggableTabs/draggableTabList';
+import {DraggableTabListPF} from 'sentry/components/draggableTabs/draggableTabListPF';
 import type {DraggableTabListItemProps} from 'sentry/components/draggableTabs/item';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -395,7 +393,7 @@ function IssueViewsPFIssueListHeaderTabsContent({
         : views[0]!.key;
 
   return (
-    <DraggableTabList
+    <DraggableTabListPF
       onReorder={(newOrder: Array<Node<DraggableTabListItemProps>>) =>
         dispatch({
           type: 'REORDER_TABS',
@@ -410,7 +408,7 @@ function IssueViewsPFIssueListHeaderTabsContent({
       hideBorder
     >
       {allTabs.map(view => (
-        <DraggableTabList.Item
+        <DraggableTabListPF.Item
           textValue={view.label}
           key={view.key}
           to={normalizeUrl({
@@ -434,9 +432,9 @@ function IssueViewsPFIssueListHeaderTabsContent({
             editingTabKey={editingTabKey}
             setEditingTabKey={setEditingTabKey}
           />
-        </DraggableTabList.Item>
+        </DraggableTabListPF.Item>
       ))}
-    </DraggableTabList>
+    </DraggableTabListPF>
   );
 }
 

--- a/static/app/views/issueList/issueViewsPF/editableTabTitlePF.tsx
+++ b/static/app/views/issueList/issueViewsPF/editableTabTitlePF.tsx
@@ -1,0 +1,172 @@
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {GrowingInput} from 'sentry/components/growingInput';
+import {Tooltip} from 'sentry/components/tooltip';
+
+interface EditableTabTitlePFProps {
+  isEditing: boolean;
+  isSelected: boolean;
+  label: string;
+  onChange: (newLabel: string) => void;
+  setIsEditing: (isEditing: boolean) => void;
+}
+
+function EditableTabTitlePF({
+  label,
+  onChange,
+  isEditing,
+  isSelected,
+  setIsEditing,
+}: EditableTabTitlePFProps) {
+  const [inputValue, setInputValue] = useState(label);
+
+  useEffect(() => {
+    setInputValue(label);
+  }, [label]);
+
+  const theme = useTheme();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isEmpty = !inputValue.trim();
+
+  const memoizedStyles = useMemo(() => {
+    return {fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal};
+  }, [isSelected, theme.fontWeightBold, theme.fontWeightNormal]);
+
+  const handleOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const trimmedInputValue = inputValue.trim();
+    if (!isEditing) {
+      return;
+    }
+
+    if (isEmpty) {
+      setInputValue(label);
+      setIsEditing(false);
+      return;
+    }
+    if (trimmedInputValue !== label) {
+      onChange(trimmedInputValue);
+      setInputValue(trimmedInputValue);
+    }
+    setIsEditing(false);
+  };
+
+  const handleOnKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      inputRef.current?.blur();
+    }
+    if (e.key === 'Escape') {
+      setInputValue(label.trim());
+      setIsEditing(false);
+    }
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === ' ') {
+      e.stopPropagation();
+    }
+  };
+
+  useEffect(() => {
+    if (isEditing) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    } else {
+      inputRef.current?.blur();
+    }
+  }, [isEditing, inputRef]);
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  return (
+    <Tooltip title={label} disabled={isEditing} showOnlyOnOverflow skipWrapper>
+      <motion.div layout="position" transition={{duration: 0.2}}>
+        {isSelected && isEditing ? (
+          <StyledGrowingInput
+            value={inputValue}
+            onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+            onBlur={handleOnBlur}
+            ref={inputRef}
+            style={memoizedStyles}
+            isEditing={isEditing}
+            maxLength={128}
+            onPointerDown={e => {
+              e.stopPropagation();
+              if (!isEditing) {
+                e.preventDefault();
+              }
+            }}
+            onMouseDown={e => {
+              e.stopPropagation();
+              if (!isEditing) {
+                e.preventDefault();
+              }
+            }}
+          />
+        ) : (
+          <UnselectedTabTitle
+            onDoubleClick={() => setIsEditing(true)}
+            onPointerDown={e => {
+              if (isSelected) {
+                e.stopPropagation();
+                e.preventDefault();
+              }
+            }}
+            onMouseDown={e => {
+              if (isSelected) {
+                e.stopPropagation();
+                e.preventDefault();
+              }
+            }}
+            isSelected={isSelected}
+          >
+            {label}
+          </UnselectedTabTitle>
+        )}
+      </motion.div>
+    </Tooltip>
+  );
+}
+
+export default EditableTabTitlePF;
+
+const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
+  height: 20px;
+  max-width: ${p => (p.isSelected ? '325px' : '310px')};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 1px;
+  cursor: pointer;
+  line-height: 1.45;
+`;
+
+const StyledGrowingInput = styled(GrowingInput)<{
+  isEditing: boolean;
+}>`
+  position: relative;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  min-height: 0px;
+  height: 20px;
+  border-radius: 0px;
+  text-overflow: ellipsis;
+  cursor: text;
+  max-width: 325px;
+  line-height: 1.45;
+
+  &,
+  &:focus,
+  &:active,
+  &:hover {
+    box-shadow: none;
+  }
+`;

--- a/static/app/views/issueList/issueViewsPF/issueViewEllipsisMenuPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewEllipsisMenuPF.tsx
@@ -1,0 +1,114 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {IconEllipsis, IconMegaphone} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+
+interface IssueViewEllipsisMenuPFProps {
+  menuOptions: MenuItemProps[];
+  'aria-label'?: string;
+  hasUnsavedChanges?: boolean;
+}
+
+export function IssueViewEllipsisMenuPF({
+  hasUnsavedChanges = false,
+  menuOptions,
+  ...props
+}: IssueViewEllipsisMenuPFProps) {
+  return (
+    <TriggerIconWrap>
+      <StyledDropdownMenu
+        position="bottom-start"
+        triggerProps={{
+          'aria-label': props['aria-label'] ?? 'Tab Options',
+          size: 'zero',
+          showChevron: false,
+          borderless: true,
+          icon: (
+            <ButtonWrapper>
+              <IconEllipsis compact />
+              {hasUnsavedChanges && (
+                <UnsavedChangesIndicator
+                  role="presentation"
+                  data-test-id="unsaved-changes-indicator"
+                />
+              )}
+            </ButtonWrapper>
+          ),
+          style: {width: '18px', height: '16px', borderRadius: '4px'},
+        }}
+        items={menuOptions}
+        offset={[-10, 5]}
+        menuFooter={<FeedbackFooter />}
+        usePortal
+      />
+    </TriggerIconWrap>
+  );
+}
+
+function FeedbackFooter() {
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+
+  return (
+    <SectionedOverlayFooter>
+      <Button
+        size="xs"
+        icon={<IconMegaphone />}
+        onClick={() =>
+          openForm({
+            messagePlaceholder: t('How can we make custom views better for you?'),
+            tags: {
+              ['feedback.source']: 'custom_views',
+              ['feedback.owner']: 'issues',
+            },
+          })
+        }
+      >
+        {t('Give Feedback')}
+      </Button>
+    </SectionedOverlayFooter>
+  );
+}
+
+const SectionedOverlayFooter = styled('div')`
+  grid-area: footer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${space(1)};
+  border-top: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const StyledDropdownMenu = styled(DropdownMenu)`
+  font-weight: ${p => p.theme.fontWeightNormal};
+`;
+
+const UnsavedChangesIndicator = styled('div')`
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: ${p => p.theme.active};
+  border: solid 1px ${p => p.theme.background};
+  position: absolute;
+  top: -3px;
+  right: -3px;
+`;
+const ButtonWrapper = styled('div')`
+  width: 18px;
+  height: 16px;
+  border: 1px solid ${p => p.theme.gray200};
+  border-radius: 4px;
+`;
+
+const TriggerIconWrap = styled('div')`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;

--- a/static/app/views/issueList/issueViewsPF/issueViewQueryCountPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewQueryCountPF.tsx
@@ -1,0 +1,115 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {space} from 'sentry/styles/space';
+import type {PageFilters} from 'sentry/types/core';
+import {getUtcDateString} from 'sentry/utils/dates';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
+
+const TAB_MAX_COUNT = 99;
+
+const constructCountTimeFrame = (
+  pageFilters: PageFilters['datetime']
+): {
+  end?: string;
+  start?: string;
+  statsPeriod?: string;
+} => {
+  if (pageFilters.period) {
+    return {statsPeriod: pageFilters.period};
+  }
+  return {
+    ...(pageFilters.start ? {start: getUtcDateString(pageFilters.start)} : {}),
+    ...(pageFilters.end ? {end: getUtcDateString(pageFilters.end)} : {}),
+  };
+};
+
+interface IssueViewQueryCountPFProps {
+  view: IssueViewPF;
+}
+
+export function IssueViewQueryCountPF({view}: IssueViewQueryCountPFProps) {
+  const organization = useOrganization();
+  const pageFilters = usePageFilters();
+  const theme = useTheme();
+
+  // TODO(msun): Once page filters are saved to views, remember to use the view's specific
+  // page filters here instead of the global pageFilters, if they exist.
+  const {
+    data: queryCount,
+    isLoading,
+    isFetching,
+    isError,
+  } = useFetchIssueCounts({
+    orgSlug: organization.slug,
+    query: [view.unsavedChanges?.query ?? view.query],
+    project: pageFilters.selection.projects,
+    environment: pageFilters.selection.environments,
+    ...constructCountTimeFrame(pageFilters.selection.datetime),
+  });
+
+  // The endpoint's response type looks like this: { <query1>: <count>, <query2>: <count> }
+  // But this component only ever sends one query, so we can just get the count of the first key.
+  // This is a bit hacky, but it avoids having to use a state to store the previous query
+  // when the query changes and the new data is still being fetched.
+  const defaultQuery =
+    Object.keys(queryCount ?? {}).length > 0
+      ? Object.keys(queryCount ?? {})[0]
+      : undefined;
+  const count = isError
+    ? 0
+    : queryCount?.[view.unsavedChanges?.query ?? view.query] ??
+      queryCount?.[defaultQuery ?? ''] ??
+      0;
+
+  return (
+    <QueryCountBubble
+      layout="size"
+      animate={{
+        backgroundColor: isFetching
+          ? [theme.surface400, theme.surface100, theme.surface400]
+          : `#00000000`,
+      }}
+      transition={{
+        layout: {
+          duration: 0.2,
+        },
+        default: {
+          // Cuts animation short once the query has finished fetching
+          duration: isFetching ? 2 : 0,
+          repeat: isFetching ? Infinity : 0,
+          ease: 'easeInOut',
+        },
+      }}
+    >
+      <motion.span
+        // Prevents count from fading in if it's already cached on mount
+        layout="preserve-aspect"
+        initial={{opacity: isLoading ? 0 : 1}}
+        animate={{opacity: isFetching ? 0 : 1}}
+        transition={{duration: 0.1}}
+      >
+        {count > TAB_MAX_COUNT ? `${TAB_MAX_COUNT}+` : count}
+      </motion.span>
+    </QueryCountBubble>
+  );
+}
+
+const QueryCountBubble = styled(motion.span)`
+  line-height: 20px;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 0 ${space(0.5)};
+  min-width: 20px;
+  display: flex;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 1px solid ${p => p.theme.gray200};
+  color: ${p => p.theme.gray300};
+  margin-left: 0;
+`;

--- a/static/app/views/issueList/issueViewsPF/issueViewTabPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewTabPF.tsx
@@ -1,0 +1,247 @@
+import {useContext} from 'react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {TEMPORARY_TAB_KEY} from 'sentry/components/draggableTabs/draggableTabList';
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {t} from 'sentry/locale';
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import EditableTabTitlePF from 'sentry/views/issueList/issueViewsPF/editableTabTitlePF';
+import {IssueViewEllipsisMenuPF} from 'sentry/views/issueList/issueViewsPF/issueViewEllipsisMenuPF';
+import {IssueViewQueryCountPF} from 'sentry/views/issueList/issueViewsPF/issueViewQueryCountPF';
+import {
+  generateTempViewId,
+  type IssueViewPF,
+  IssueViewsPFContext,
+} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+
+interface IssueViewPFTabProps {
+  editingTabKey: string | null;
+  initialTabKey: string;
+  router: InjectedRouter;
+  setEditingTabKey: (key: string | null) => void;
+  view: IssueViewPF;
+}
+
+export function IssueViewPFTab({
+  editingTabKey,
+  initialTabKey,
+  router,
+  setEditingTabKey,
+  view,
+}: IssueViewPFTabProps) {
+  const navigate = useNavigate();
+
+  const {cursor: _cursor, page: _page, ...queryParams} = router?.location?.query ?? {};
+  const {tabListState, state, dispatch} = useContext(IssueViewsPFContext);
+  const {views} = state;
+
+  const handleDuplicateView = () => {
+    const newViewId = generateTempViewId();
+    const duplicatedTab = views.find(tab => tab.key === tabListState?.selectedKey);
+    if (!duplicatedTab) {
+      return;
+    }
+    dispatch({type: 'DUPLICATE_VIEW', newViewId, syncViews: true});
+    navigate({
+      ...location,
+      query: {
+        ...queryParams,
+        query: duplicatedTab.query,
+        sort: duplicatedTab.querySort,
+        viewId: newViewId,
+      },
+    });
+    tabListState?.setSelectedKey(newViewId);
+  };
+
+  const handleDiscardChanges = () => {
+    dispatch({type: 'DISCARD_CHANGES'});
+    const originalTab = views.find(tab => tab.key === tabListState?.selectedKey);
+    if (originalTab) {
+      navigate({
+        ...location,
+        query: {
+          ...queryParams,
+          query: originalTab.query,
+          sort: originalTab.querySort,
+          viewId: originalTab.id,
+        },
+      });
+    }
+  };
+
+  const handleDeleteView = (tab: IssueViewPF) => {
+    dispatch({type: 'DELETE_VIEW', syncViews: true});
+    // Including this logic in the dispatch call breaks the tests for some reason
+    // so we're doing it here instead
+    const nextTab = views.find(tb => tb.key !== tab.key);
+    if (nextTab) {
+      tabListState?.setSelectedKey(nextTab.key);
+    }
+  };
+
+  const makeMenuOptions = (tab: IssueViewPF): MenuItemProps[] => {
+    if (tab.key === TEMPORARY_TAB_KEY) {
+      return makeTempViewMenuOptions({
+        onSaveTempView: () => dispatch({type: 'SAVE_TEMP_VIEW', syncViews: true}),
+        onDiscardTempView: () => dispatch({type: 'DISCARD_TEMP_VIEW'}),
+      });
+    }
+    if (tab.unsavedChanges) {
+      return makeUnsavedChangesMenuOptions({
+        onRename: () => setEditingTabKey(tab.key),
+        onDuplicate: handleDuplicateView,
+        onDelete: views.length > 1 ? () => handleDeleteView(tab) : undefined,
+        onSave: () => dispatch({type: 'SAVE_CHANGES', syncViews: true}),
+        onDiscard: handleDiscardChanges,
+      });
+    }
+    return makeDefaultMenuOptions({
+      onRename: () => setEditingTabKey(tab.key),
+      onDuplicate: handleDuplicateView,
+      onDelete: views.length > 1 ? () => handleDeleteView(tab) : undefined,
+    });
+  };
+
+  return (
+    <TabContentWrap>
+      <EditableTabTitlePF
+        label={view.label}
+        isEditing={editingTabKey === view.key}
+        setIsEditing={isEditing => setEditingTabKey(isEditing ? view.key : null)}
+        onChange={newLabel =>
+          dispatch({type: 'RENAME_TAB', newLabel: newLabel.trim(), syncViews: true})
+        }
+        isSelected={
+          (tabListState && tabListState?.selectedKey === view.key) ||
+          (!tabListState && view.key === initialTabKey)
+        }
+      />
+      <IssueViewQueryCountPF view={view} />
+      {/* If tablistState isn't initialized, we want to load the elipsis menu
+          for the initial tab, that way it won't load in a second later
+          and cause the tabs to shift and animate on load. */}
+      {((tabListState && tabListState?.selectedKey === view.key) ||
+        (!tabListState && view.key === initialTabKey)) && (
+        <motion.div
+          // This stops the ellipsis menu from animating in on load (when tabListState isn't initialized yet),
+          // but enables the animation later on when switching tabs
+          initial={tabListState ? {opacity: 0} : false}
+          animate={{opacity: 1}}
+          transition={{delay: 0.1, duration: 0.1}}
+        >
+          <IssueViewEllipsisMenuPF
+            hasUnsavedChanges={!!view.unsavedChanges}
+            menuOptions={makeMenuOptions(view)}
+            aria-label={t(`%s Ellipsis Menu`, view.label)}
+          />
+        </motion.div>
+      )}
+    </TabContentWrap>
+  );
+}
+
+const makeDefaultMenuOptions = ({
+  onRename,
+  onDuplicate,
+  onDelete,
+}: {
+  onDelete?: () => void;
+  onDuplicate?: () => void;
+  onRename?: () => void;
+}): MenuItemProps[] => {
+  const menuOptions: MenuItemProps[] = [
+    {
+      key: 'rename-tab',
+      label: t('Rename'),
+      onAction: onRename,
+    },
+    {
+      key: 'duplicate-tab',
+      label: t('Duplicate'),
+      onAction: onDuplicate,
+    },
+  ];
+  if (onDelete) {
+    return [
+      ...menuOptions,
+      {
+        key: 'delete-tab',
+        label: t('Delete'),
+        priority: 'danger',
+        onAction: onDelete,
+      },
+    ];
+  }
+  return menuOptions;
+};
+
+const makeUnsavedChangesMenuOptions = ({
+  onRename,
+  onDuplicate,
+  onDelete,
+  onSave,
+  onDiscard,
+}: {
+  onDelete?: () => void;
+  onDiscard?: () => void;
+  onDuplicate?: () => void;
+  onRename?: () => void;
+  onSave?: () => void;
+}): MenuItemProps[] => {
+  return [
+    {
+      key: 'changed',
+      children: [
+        {
+          key: 'save-changes',
+          label: t('Save Changes'),
+          priority: 'primary',
+          onAction: onSave,
+        },
+        {
+          key: 'discard-changes',
+          label: t('Discard Changes'),
+          onAction: onDiscard,
+        },
+      ],
+    },
+    {
+      key: 'default',
+      children: makeDefaultMenuOptions({onRename, onDuplicate, onDelete}),
+    },
+  ];
+};
+
+const makeTempViewMenuOptions = ({
+  onSaveTempView,
+  onDiscardTempView,
+}: {
+  onDiscardTempView: () => void;
+  onSaveTempView: () => void;
+}): MenuItemProps[] => {
+  return [
+    {
+      key: 'save-changes',
+      label: t('Save View'),
+      priority: 'primary',
+      onAction: onSaveTempView,
+    },
+    {
+      key: 'discard-changes',
+      label: t('Discard'),
+      onAction: onDiscardTempView,
+    },
+  ];
+};
+
+const TabContentWrap = styled('span')`
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  padding: 0;
+  gap: 6px;
+`;

--- a/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
@@ -1,0 +1,660 @@
+import type {Dispatch, Reducer} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from 'react';
+import styled from '@emotion/styled';
+import type {TabListState} from '@react-stately/tabs';
+import type {Orientation} from '@react-types/shared';
+import debounce from 'lodash/debounce';
+
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {TabContext, TabsProps} from 'sentry/components/tabs';
+import {tabsShouldForwardProp} from 'sentry/components/tabs/utils';
+import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import type {
+  GroupSearchView,
+  UpdateGroupSearchViewPayload,
+} from 'sentry/views/issueList/types';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+import {NewTabContext, type NewView} from 'sentry/views/issueList/utils/newTabContext';
+
+const TEMPORARY_TAB_KEY = 'temporary-tab';
+
+export const generateTempViewId = () => `_${Math.random().toString().substring(2, 7)}`;
+
+export interface IssueViewPFParams {
+  query: string;
+  querySort: IssueSortOptions;
+}
+
+export interface IssueViewPF extends IssueViewPFParams {
+  id: string;
+  /**
+   * False for tabs that were added view the "Add View" button, but
+   * have not been edited in any way. Only tabs with isCommitted=true
+   * will be saved to the backend.
+   */
+  isCommitted: boolean;
+  key: string;
+  label: string;
+  content?: React.ReactNode;
+  unsavedChanges?: IssueViewPFParams;
+}
+
+type BaseIssueViewsAction = {
+  /** If true, the new views state created by the action will be synced to the backend */
+  syncViews?: boolean;
+};
+
+type ReorderTabsAction = {
+  newKeyOrder: string[];
+  type: 'REORDER_TABS';
+} & BaseIssueViewsAction;
+
+type SaveChangesAction = {
+  type: 'SAVE_CHANGES';
+} & BaseIssueViewsAction;
+
+type DiscardChangesAction = {
+  type: 'DISCARD_CHANGES';
+} & BaseIssueViewsAction;
+
+type RenameTabAction = {
+  newLabel: string;
+  type: 'RENAME_TAB';
+} & BaseIssueViewsAction;
+
+type DuplicateViewAction = {
+  newViewId: string;
+  type: 'DUPLICATE_VIEW';
+} & BaseIssueViewsAction;
+
+type DeleteViewAction = {
+  type: 'DELETE_VIEW';
+} & BaseIssueViewsAction;
+
+type CreateNewViewAction = {
+  tempId: string;
+  type: 'CREATE_NEW_VIEW';
+} & BaseIssueViewsAction;
+
+type SetTempViewAction = {
+  query: string;
+  sort: IssueSortOptions;
+  type: 'SET_TEMP_VIEW';
+} & BaseIssueViewsAction;
+
+type DiscardTempViewAction = {
+  type: 'DISCARD_TEMP_VIEW';
+} & BaseIssueViewsAction;
+
+type SaveTempViewAction = {
+  type: 'SAVE_TEMP_VIEW';
+} & BaseIssueViewsAction;
+
+type UpdateUnsavedChangesAction = {
+  type: 'UPDATE_UNSAVED_CHANGES';
+  // Explicitly typed as | undefined instead of optional to make it clear that `undefined` = no unsaved changes
+  unsavedChanges: IssueViewPFParams | undefined;
+  isCommitted?: boolean;
+} & BaseIssueViewsAction;
+
+type UpdateViewIdsAction = {
+  newViews: UpdateGroupSearchViewPayload[];
+  type: 'UPDATE_VIEW_IDS';
+} & BaseIssueViewsAction;
+
+type SetViewsAction = {
+  type: 'SET_VIEWS';
+  views: IssueViewPF[];
+} & BaseIssueViewsAction;
+
+type SyncViewsToBackendAction = {
+  /** Syncs the current views state to the backend. Does not make any changes to the views state. */
+  type: 'SYNC_VIEWS_TO_BACKEND';
+};
+
+export type IssueViewsPFActions =
+  | ReorderTabsAction
+  | SaveChangesAction
+  | DiscardChangesAction
+  | RenameTabAction
+  | DuplicateViewAction
+  | DeleteViewAction
+  | CreateNewViewAction
+  | SetTempViewAction
+  | DiscardTempViewAction
+  | SaveTempViewAction
+  | UpdateUnsavedChangesAction
+  | UpdateViewIdsAction
+  | SetViewsAction
+  | SyncViewsToBackendAction;
+
+const ACTION_ANALYTICS_MAP: Partial<Record<IssueViewsPFActions['type'], string>> = {
+  REORDER_TABS: 'issue_views.reordered_views',
+  SAVE_CHANGES: 'issue_views.saved_changes',
+  DISCARD_CHANGES: 'issue_views.discarded_changes',
+  RENAME_TAB: 'issue_views.renamed_view',
+  DUPLICATE_VIEW: 'issue_views.duplicated_view',
+  DELETE_VIEW: 'issue_views.deleted_view',
+  SAVE_TEMP_VIEW: 'issue_views.temp_view_saved',
+  DISCARD_TEMP_VIEW: 'issue_views.temp_view_discarded',
+  CREATE_NEW_VIEW: 'issue_views.add_view.clicked',
+};
+
+export interface IssueViewsPFState {
+  views: IssueViewPF[];
+  tempView?: IssueViewPF;
+}
+
+export interface IssueViewsPFContextType extends TabContext {
+  dispatch: Dispatch<IssueViewsPFActions>;
+  state: IssueViewsPFState;
+}
+
+export const IssueViewsPFContext = createContext<IssueViewsPFContextType>({
+  rootProps: {orientation: 'horizontal'},
+  setTabListState: () => {},
+  // Issue Views specific state
+  dispatch: () => {},
+  state: {views: []},
+});
+
+function reorderTabs(state: IssueViewsPFState, action: ReorderTabsAction) {
+  const newTabs: IssueViewPF[] = action.newKeyOrder
+    .map(key => {
+      const foundTab = state.views.find(tab => tab.key === key);
+      return foundTab?.key === key ? foundTab : null;
+    })
+    .filter(defined);
+  return {...state, views: newTabs};
+}
+
+function saveChanges(state: IssueViewsPFState, tabListState: TabListState<any>) {
+  const originalTab = state.views.find(tab => tab.key === tabListState?.selectedKey);
+  if (originalTab) {
+    const newViews = state.views.map(tab => {
+      return tab.key === tabListState?.selectedKey && tab.unsavedChanges
+        ? {
+            ...tab,
+            query: tab.unsavedChanges.query,
+            querySort: tab.unsavedChanges.querySort,
+            unsavedChanges: undefined,
+          }
+        : tab;
+    });
+    return {...state, views: newViews};
+  }
+  return state;
+}
+
+function discardChanges(state: IssueViewsPFState, tabListState: TabListState<any>) {
+  const originalTab = state.views.find(tab => tab.key === tabListState?.selectedKey);
+  if (originalTab) {
+    const newViews = state.views.map(tab => {
+      return tab.key === tabListState?.selectedKey
+        ? {...tab, unsavedChanges: undefined}
+        : tab;
+    });
+    return {...state, views: newViews};
+  }
+  return state;
+}
+
+function renameView(
+  state: IssueViewsPFState,
+  action: RenameTabAction,
+  tabListState: TabListState<any>
+) {
+  const renamedTab = state.views.find(tab => tab.key === tabListState?.selectedKey);
+  if (renamedTab && action.newLabel !== renamedTab.label) {
+    const newViews = state.views.map(tab =>
+      tab.key === renamedTab.key
+        ? {...tab, label: action.newLabel, isCommitted: true}
+        : tab
+    );
+    return {...state, views: newViews};
+  }
+  return state;
+}
+
+function duplicateView(
+  state: IssueViewsPFState,
+  action: DuplicateViewAction,
+  tabListState: TabListState<any>
+) {
+  const idx = state.views.findIndex(tb => tb.key === tabListState?.selectedKey);
+  if (idx !== -1) {
+    const duplicatedTab = state.views[idx]!;
+    const newTabs: IssueViewPF[] = [
+      ...state.views.slice(0, idx + 1),
+      {
+        ...duplicatedTab,
+        id: action.newViewId,
+        key: action.newViewId,
+        label: `${duplicatedTab.label} (Copy)`,
+        isCommitted: true,
+      },
+      ...state.views.slice(idx + 1),
+    ];
+    return {...state, views: newTabs};
+  }
+  return state;
+}
+
+function deleteView(state: IssueViewsPFState, tabListState: TabListState<any>) {
+  const newViews = state.views.filter(tab => tab.key !== tabListState?.selectedKey);
+  return {...state, views: newViews};
+}
+
+function createNewView(state: IssueViewsPFState, action: CreateNewViewAction) {
+  const newTabs: IssueViewPF[] = [
+    ...state.views,
+    {
+      id: action.tempId,
+      key: action.tempId,
+      label: 'New View',
+      query: '',
+      querySort: IssueSortOptions.DATE,
+      isCommitted: false,
+    },
+  ];
+  return {...state, views: newTabs};
+}
+
+function setTempView(state: IssueViewsPFState, action: SetTempViewAction) {
+  const tempView: IssueViewPF = {
+    id: TEMPORARY_TAB_KEY,
+    key: TEMPORARY_TAB_KEY,
+    label: t('Unsaved'),
+    query: action.query,
+    querySort: action.sort ?? IssueSortOptions.DATE,
+    isCommitted: true,
+  };
+  return {...state, tempView};
+}
+
+function discardTempView(state: IssueViewsPFState, tabListState: TabListState<any>) {
+  tabListState?.setSelectedKey(state.views[0]!.key);
+  return {...state, tempView: undefined};
+}
+
+function saveTempView(state: IssueViewsPFState, tabListState: TabListState<any>) {
+  if (state.tempView) {
+    const tempId = generateTempViewId();
+    const newTab: IssueViewPF = {
+      id: tempId,
+      key: tempId,
+      label: 'New View',
+      query: state.tempView?.query,
+      querySort: state.tempView?.querySort,
+      isCommitted: true,
+    };
+    tabListState?.setSelectedKey(tempId);
+    return {...state, views: [...state.views, newTab], tempView: undefined};
+  }
+  return state;
+}
+
+function updateUnsavedChanges(
+  state: IssueViewsPFState,
+  action: UpdateUnsavedChangesAction,
+  tabListState: TabListState<any>
+) {
+  return {
+    ...state,
+    views: state.views.map(tab =>
+      tab.key === tabListState?.selectedKey
+        ? {
+            ...tab,
+            unsavedChanges: action.unsavedChanges,
+            isCommitted: action.isCommitted ?? tab.isCommitted,
+          }
+        : tab
+    ),
+  };
+}
+
+function updateViewIds(state: IssueViewsPFState, action: UpdateViewIdsAction) {
+  const assignedIds = new Set();
+  const updatedViews = state.views.map(tab => {
+    if (tab.id && tab.id[0] === '_') {
+      const matchingView = action.newViews.find(
+        view =>
+          view.id &&
+          !assignedIds.has(view.id) &&
+          tab.query === view.query &&
+          tab.querySort === view.querySort &&
+          tab.label === view.name
+      );
+      if (matchingView?.id) {
+        assignedIds.add(matchingView.id);
+        return {...tab, id: matchingView.id};
+      }
+    }
+    return tab;
+  });
+  return {...state, views: updatedViews};
+}
+
+function setViews(state: IssueViewsPFState, action: SetViewsAction) {
+  return {...state, views: action.views};
+}
+
+interface IssueViewsPFStateProviderProps extends Omit<TabsProps<any>, 'children'> {
+  children: React.ReactNode;
+  initialViews: IssueViewPF[];
+  // TODO(msun): Replace router with useLocation() / useUrlParams() / useSearchParams() in the future
+  router: InjectedRouter;
+}
+
+export function IssueViewsPFStateProvider({
+  children,
+  initialViews,
+  router,
+  ...props
+}: IssueViewsPFStateProviderProps) {
+  const navigate = useNavigate();
+  const pageFilters = usePageFilters();
+  const organization = useOrganization();
+  const {setNewViewActive, setOnNewViewsSaved} = useContext(NewTabContext);
+  const [tabListState, setTabListState] = useState<TabListState<any>>();
+  const {className: _className, ...restProps} = props;
+
+  const {cursor: _cursor, page: _page, ...queryParams} = router.location.query;
+  const {query, sort, viewId, project, environment} = queryParams;
+
+  const queryParamsWithPageFilters = useMemo(() => {
+    return {
+      ...queryParams,
+      project: project ?? pageFilters.selection.projects,
+      environment: environment ?? pageFilters.selection.environments,
+      ...normalizeDateTimeParams(pageFilters.selection.datetime),
+    };
+  }, [
+    environment,
+    pageFilters.selection.datetime,
+    pageFilters.selection.environments,
+    pageFilters.selection.projects,
+    project,
+    queryParams,
+  ]);
+
+  // This function is fired upon receiving new views from the backend - it replaces any previously
+  // generated temporary view ids with the permanent view ids from the backend
+  const replaceWithPersistantViewIds = (views: GroupSearchView[]) => {
+    const newlyCreatedViews = views.filter(
+      view => !state.views.find(tab => tab.id === view.id)
+    );
+    if (newlyCreatedViews.length > 0) {
+      dispatch({type: 'UPDATE_VIEW_IDS', newViews: newlyCreatedViews});
+      const currentView = state.views.find(tab => tab.id === viewId);
+
+      if (viewId?.startsWith('_') && currentView) {
+        const matchingView = newlyCreatedViews.find(
+          view =>
+            view.id &&
+            currentView.query === view.query &&
+            currentView.querySort === view.querySort
+        );
+        if (matchingView?.id) {
+          navigate(
+            normalizeUrl({
+              ...location,
+              query: {
+                ...queryParamsWithPageFilters,
+                viewId: matchingView.id,
+              },
+            }),
+            {replace: true}
+          );
+        }
+      }
+    }
+    return;
+  };
+
+  const {mutate: updateViews} = useUpdateGroupSearchViews({
+    onSuccess: replaceWithPersistantViewIds,
+  });
+
+  const debounceUpdateViews = useMemo(
+    () =>
+      debounce((newTabs: IssueViewPF[], pageFiltersSelection: PageFilters) => {
+        const isAllProjects =
+          pageFiltersSelection.projects.length === 1 &&
+          pageFiltersSelection.projects[0] === -1;
+
+        const projects = isAllProjects ? [] : pageFiltersSelection.projects;
+
+        if (newTabs) {
+          updateViews({
+            orgSlug: organization.slug,
+            groupSearchViews: newTabs
+              .filter(tab => tab.isCommitted)
+              .map(tab => ({
+                // Do not send over an ID if it's a temporary or default tab so that
+                // the backend will save these and generate permanent Ids for them
+                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
+                  ? {id: tab.id}
+                  : {}),
+                name: tab.label,
+                query: tab.query,
+                querySort: tab.querySort,
+                projects,
+                isAllProjects,
+                environments: pageFiltersSelection.environments,
+                timeFilters: pageFiltersSelection.datetime,
+              })),
+          });
+        }
+      }, 500),
+    [organization.slug, updateViews]
+  );
+
+  const reducer: Reducer<IssueViewsPFState, IssueViewsPFActions> = useCallback(
+    (state, action): IssueViewsPFState => {
+      if (!tabListState) {
+        return state;
+      }
+      switch (action.type) {
+        case 'REORDER_TABS':
+          return reorderTabs(state, action);
+        case 'SAVE_CHANGES':
+          return saveChanges(state, tabListState);
+        case 'DISCARD_CHANGES':
+          return discardChanges(state, tabListState);
+        case 'RENAME_TAB':
+          return renameView(state, action, tabListState);
+        case 'DUPLICATE_VIEW':
+          return duplicateView(state, action, tabListState);
+        case 'DELETE_VIEW':
+          return deleteView(state, tabListState);
+        case 'CREATE_NEW_VIEW':
+          return createNewView(state, action);
+        case 'SET_TEMP_VIEW':
+          return setTempView(state, action);
+        case 'DISCARD_TEMP_VIEW':
+          return discardTempView(state, tabListState);
+        case 'SAVE_TEMP_VIEW':
+          return saveTempView(state, tabListState);
+        case 'UPDATE_UNSAVED_CHANGES':
+          return updateUnsavedChanges(state, action, tabListState);
+        case 'UPDATE_VIEW_IDS':
+          return updateViewIds(state, action);
+        case 'SET_VIEWS':
+          return setViews(state, action);
+        case 'SYNC_VIEWS_TO_BACKEND':
+          return state;
+        default:
+          return state;
+      }
+    },
+    [tabListState]
+  );
+
+  const sortOption =
+    sort && Object.values(IssueSortOptions).includes(sort.toString() as IssueSortOptions)
+      ? (sort.toString() as IssueSortOptions)
+      : IssueSortOptions.DATE;
+
+  const initialTempView: IssueViewPF | undefined =
+    query && (!viewId || !initialViews.find(tab => tab.id === viewId))
+      ? {
+          id: TEMPORARY_TAB_KEY,
+          key: TEMPORARY_TAB_KEY,
+          label: t('Unsaved'),
+          query: query.toString(),
+          querySort: sortOption,
+          isCommitted: true,
+        }
+      : undefined;
+
+  const [state, dispatch] = useReducer(reducer, {
+    views: initialViews,
+    tempView: initialTempView,
+  });
+
+  const dispatchWrapper = (action: IssueViewsPFActions) => {
+    const newState = reducer(state, action);
+    dispatch(action);
+
+    if (action.type === 'SYNC_VIEWS_TO_BACKEND' || action.syncViews) {
+      debounceUpdateViews(newState.views, pageFilters.selection);
+    }
+
+    const actionAnalyticsKey = ACTION_ANALYTICS_MAP[action.type];
+    if (actionAnalyticsKey) {
+      trackAnalytics(actionAnalyticsKey, {
+        organization,
+      });
+    }
+  };
+
+  const handleNewViewsSaved: NewTabContext['onNewViewsSaved'] = useCallback<
+    NewTabContext['onNewViewsSaved']
+  >(
+    () => (newViews: NewView[]) => {
+      if (newViews.length === 0) {
+        return;
+      }
+      setNewViewActive(false);
+      const {label, query: newQuery, saveQueryToView} = newViews[0]!;
+      const remainingNewViews: IssueViewPF[] = newViews.slice(1)?.map(view => {
+        const newId = generateTempViewId();
+        const viewToTab: IssueViewPF = {
+          id: newId,
+          key: newId,
+          label: view.label,
+          query: view.query,
+          querySort: IssueSortOptions.DATE,
+          unsavedChanges: view.saveQueryToView
+            ? undefined
+            : {query: view.query, querySort: IssueSortOptions.DATE},
+          isCommitted: true,
+        };
+        return viewToTab;
+      });
+      let updatedTabs: IssueViewPF[] = state.views.map(tab => {
+        if (tab.key === viewId) {
+          return {
+            ...tab,
+            label,
+            query: saveQueryToView ? newQuery : '',
+            querySort: IssueSortOptions.DATE,
+            unsavedChanges: saveQueryToView
+              ? undefined
+              : {query, querySort: IssueSortOptions.DATE},
+            isCommitted: true,
+          };
+        }
+        return tab;
+      });
+
+      if (remainingNewViews.length > 0) {
+        updatedTabs = [...updatedTabs, ...remainingNewViews];
+      }
+
+      dispatch({type: 'SET_VIEWS', views: updatedTabs, syncViews: true});
+      navigate(
+        {
+          ...location,
+          query: {
+            ...queryParams,
+            query: newQuery,
+            sort: IssueSortOptions.DATE,
+          },
+        },
+        {replace: true}
+      );
+    },
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [location, navigate, setNewViewActive, state.views, viewId]
+  );
+
+  useEffect(() => {
+    setOnNewViewsSaved(handleNewViewsSaved);
+  }, [setOnNewViewsSaved, handleNewViewsSaved]);
+
+  return (
+    <IssueViewsPFContext.Provider
+      value={{
+        rootProps: {...restProps, orientation: 'horizontal'},
+        tabListState,
+        setTabListState,
+        dispatch: dispatchWrapper,
+        state,
+      }}
+    >
+      {children}
+    </IssueViewsPFContext.Provider>
+  );
+}
+
+export function IssueViewsPF<T extends string | number>({
+  orientation = 'horizontal',
+  className,
+  children,
+  initialViews,
+  router,
+  ...props
+}: TabsProps<T> & Omit<IssueViewsPFStateProviderProps, 'children'>) {
+  return (
+    <IssueViewsPFStateProvider initialViews={initialViews} router={router} {...props}>
+      <TabsWrap orientation={orientation} className={className}>
+        {children}
+      </TabsWrap>
+    </IssueViewsPFStateProvider>
+  );
+}
+
+const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
+  display: flex;
+  flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
+  flex-grow: 1;
+
+  ${p =>
+    p.orientation === 'vertical' &&
+    `
+      height: 100%;
+      align-items: stretch;
+    `};
+`;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -50,6 +50,7 @@ import usePrevious from 'sentry/utils/usePrevious';
 import IssueListTable from 'sentry/views/issueList/issueListTable';
 import {IssuesDataConsentBanner} from 'sentry/views/issueList/issuesDataConsentBanner';
 import IssueViewsIssueListHeader from 'sentry/views/issueList/issueViewsHeader';
+import IssueViewsPFIssueListHeader from 'sentry/views/issueList/issueViewsHeaderPF';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
 import SavedIssueSearches from 'sentry/views/issueList/savedIssueSearches';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
@@ -1067,14 +1068,25 @@ function IssueListOverview({router}: Props) {
     <NewTabContextProvider>
       <Layout.Page>
         {organization.features.includes('issue-stream-custom-views') ? (
-          <ErrorBoundary message={'Failed to load custom tabs'} mini>
-            <IssueViewsIssueListHeader
-              router={router}
-              selectedProjectIds={selection.projects}
-              realtimeActive={realtimeActive}
-              onRealtimeChange={onRealtimeChange}
-            />
-          </ErrorBoundary>
+          organization.features.includes('issue-views-page-filter') ? (
+            <ErrorBoundary message={'Failed to load custom tabs'} mini>
+              <IssueViewsPFIssueListHeader
+                router={router}
+                selectedProjectIds={selection.projects}
+                realtimeActive={realtimeActive}
+                onRealtimeChange={onRealtimeChange}
+              />
+            </ErrorBoundary>
+          ) : (
+            <ErrorBoundary message={'Failed to load custom tabs'} mini>
+              <IssueViewsIssueListHeader
+                router={router}
+                selectedProjectIds={selection.projects}
+                realtimeActive={realtimeActive}
+                onRealtimeChange={onRealtimeChange}
+              />
+            </ErrorBoundary>
+          )
         ) : (
           <IssueListHeader
             organization={organization}


### PR DESCRIPTION
This PR duplicates all Issue Views related components to make it easier to feature flag the upcoming page filters upgrade. 

All new components have "PF" in their name, and that will be the component updated to support page filters. I cmd+f'd "/issueViews/" in all of the new PF components to ensure that there were no imports from the old issueViews folder. (All of them should import from the new issueViewsPF folder).
