### PR TITLE
ref(crons): Use nbsp in guide

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -264,7 +264,7 @@ export default function getGuidesContent(
           title: t('Crons are now Alerts'),
           target: 'crons_backend_insights',
           description: tct(
-            'Crons are now a type of Sentry Alert and can be managed there. The detailed timeline is now here under Insights → Backend. [link:Learn more].',
+            'Crons are now a type of Sentry Alert and can be managed there. The detailed timeline is now here under Insights\u00A0→\u00A0Backend. [link:Learn more].',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/product/crons/alerts-backend-insights-migration/" />


### PR DESCRIPTION
This avoids the text breaking in funny ways

<img alt="clipboard.png" width="431" src="https://i.imgur.com/tSsNoQm.png" />