### PR TITLE
ref(js): Clamp crons/uptime stats query to no latter than now

### DIFF
--- a/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
@@ -1,3 +1,5 @@
+import {useState} from 'react';
+
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -21,6 +23,7 @@ interface Options {
  */
 export function useUptimeMonitorStats({ruleIds, timeWindowConfig}: Options) {
   const {start, end, rollupConfig} = timeWindowConfig;
+  const [now] = useState(() => new Date().getTime() / 1000);
 
   const until =
     Math.floor(end.getTime() / 1000) +
@@ -32,7 +35,7 @@ export function useUptimeMonitorStats({ruleIds, timeWindowConfig}: Options) {
 
   const selectionQuery = {
     since: Math.floor(start.getTime() / 1000),
-    until,
+    until: Math.min(until, now),
     resolution: `${rollupConfig.interval}s`,
   };
 

--- a/static/app/views/monitors/utils/useMonitorStats.tsx
+++ b/static/app/views/monitors/utils/useMonitorStats.tsx
@@ -1,3 +1,5 @@
+import {useState} from 'react';
+
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -21,6 +23,7 @@ interface Options {
  */
 export function useMonitorStats({monitors, timeWindowConfig}: Options) {
   const {start, end, rollupConfig} = timeWindowConfig;
+  const [now] = useState(() => new Date().getTime() / 1000);
 
   const until =
     Math.floor(end.getTime() / 1000) +
@@ -32,7 +35,7 @@ export function useMonitorStats({monitors, timeWindowConfig}: Options) {
 
   const selectionQuery = {
     since: Math.floor(start.getTime() / 1000),
-    until,
+    until: Math.min(until, now),
     resolution: `${rollupConfig.interval}s`,
   };
 


### PR DESCRIPTION
Ensures we don't end up hitting weird EAP problems.