### PR TITLE
feat(seer grouping): Add metrics to hybrid fingerprint Seer requests

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -269,8 +269,10 @@ def get_seer_similar_issues(
     }
     event.data.pop("stacktrace_string", None)
 
+    seer_request_metric_tags = {"hybrid_fingerprint": event_has_hybrid_fingerprint}
+
     # Similar issues are returned with the closest match first
-    seer_results = get_similarity_data_from_seer(request_data)
+    seer_results = get_similarity_data_from_seer(request_data, seer_request_metric_tags)
     seer_results_json = [asdict(result) for result in seer_results]
     parent_grouphash = (
         GroupHash.objects.filter(

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -298,6 +298,9 @@ def get_seer_similar_issues(
         # new event be, and again the values must match.
         parent_fingerprint = parent_grouphash.get_associated_fingerprint()
         parent_has_hybrid_fingerprint = get_fingerprint_type(parent_fingerprint) == "hybrid"
+        parent_has_metadata = bool(
+            parent_grouphash.metadata and parent_grouphash.metadata.hashing_metadata
+        )
 
         if event_has_hybrid_fingerprint or parent_has_hybrid_fingerprint:
             # This check will catch both fingerprint type match and fingerprint value match
@@ -308,6 +311,23 @@ def get_seer_similar_issues(
             if not fingerprints_match:
                 parent_grouphash = None
                 seer_results_json = []
+
+            if not parent_has_metadata:
+                result = "no_parent_metadata"
+            elif event_has_hybrid_fingerprint and not parent_has_hybrid_fingerprint:
+                result = "only_event_hybrid"
+            elif parent_has_hybrid_fingerprint and not event_has_hybrid_fingerprint:
+                result = "only_parent_hybrid"
+            elif not fingerprints_match:
+                result = "no_fingerprint_match"
+            else:
+                result = "fingerprint_match"
+
+            metrics.incr(
+                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+                tags={"platform": event.platform, "result": result},
+            )
 
     similar_issues_metadata = {
         "results": seer_results_json,

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Mapping
 
 from django.conf import settings
 from urllib3.exceptions import MaxRetryError, TimeoutError
@@ -34,6 +35,7 @@ seer_grouping_connection_pool = connection_from_url(
 
 def get_similarity_data_from_seer(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
+    metric_tags: Mapping[str, str | int | bool] | None = None,
 ) -> list[SeerSimilarIssueData]:
     """
     Request similar issues data from seer and normalize the results. Returns similar groups
@@ -43,7 +45,7 @@ def get_similarity_data_from_seer(
     project_id = similar_issues_request["project_id"]
     request_hash = similar_issues_request["hash"]
     referrer = similar_issues_request.get("referrer")
-    metric_tags: dict[str, str | int] = {"referrer": referrer} if referrer else {}
+    metric_tags = {**(metric_tags or {}), **({"referrer": referrer} if referrer else {})}
 
     logger_extra = apply_key_filter(
         similar_issues_request,


### PR DESCRIPTION
This makes two changes to metrics in order to track the effects of allowing events with hybrid fingerprints to be sent to Seer.

- It adds a `grouping.similarity.hybrid_fingerprint_seer_result_check` metric, to track the result of the fingerprint comparison in cases where either the incoming event or the parent hash has a hybrid fingerprint.

- It adds a `hybrid_fingerprint` tag (a boolean) to the existing `seer.similar_issues_request` metric which we use to determine what percentage of events come back from Seer with a match. We assume that before the check for fingerprint match, hybrid fingerprint events are equally likely to have a Seer match as non-hybrid fingerprint events, but it's not guaranteed. (Maybe there's something about certain kinds of events which both affects their Seer matchiness and makes people more likely to apply hybrid fingerprints to whem, who knows?) Having this tag will let us check, and once we know, we'll be able to accurately weight the results of the aforementioned `hybrid_fingerprint_seer_result_check` metric.