### PR TITLE
feat: adds user timezone and formatting to stats

### DIFF
--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -6,6 +6,7 @@ import type {TooltipSubLabel} from 'sentry/components/charts/components/tooltip'
 import type {DataCategoryInfo, IntervalPeriod} from 'sentry/types/core';
 import {Outcome} from 'sentry/types/core';
 
+import type {UserTimezone} from './usageChart/utils';
 import {getDateFromMoment} from './usageChart/utils';
 import {getReasonGroupName} from './getReasonGroupName';
 import type {UsageSeries, UsageStat} from './types';
@@ -15,6 +16,7 @@ import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 
 export function mapSeriesToChart({
   orgStats,
+  userTimezone,
   dataCategory,
   chartDateUtc,
   endpointQuery,
@@ -24,6 +26,7 @@ export function mapSeriesToChart({
   chartDateUtc: boolean;
   dataCategory: DataCategoryInfo['plural'];
   endpointQuery: Record<string, unknown>;
+  userTimezone: UserTimezone;
   orgStats?: UsageSeries;
 }): {
   cardStats: {
@@ -66,7 +69,7 @@ export function mapSeriesToChart({
       const dateTime = moment(interval);
 
       return {
-        date: getDateFromMoment(dateTime, chartDateInterval, chartDateUtc),
+        date: getDateFromMoment(dateTime, userTimezone, chartDateInterval, chartDateUtc),
         total: 0,
         accepted: 0,
         accepted_stored: 0,

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -18,6 +18,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {DataCategoryInfo, IntervalPeriod, SelectValue} from 'sentry/types/core';
 import {Outcome} from 'sentry/types/core';
@@ -258,6 +259,7 @@ function chartMetadata({
   xAxisLabelVisibility: Record<number, boolean>;
   yAxisMinInterval: number;
 } {
+  const user = ConfigStore.get('user');
   const selectDataCategory = categoryOptions.find(o => o.value === dataCategory);
   if (!selectDataCategory) {
     throw new Error('Selected item is not supported');
@@ -300,6 +302,7 @@ function chartMetadata({
   const xAxisDates = getXAxisDates(
     usageDateStart,
     usageDateEnd,
+    user.options.timezone,
     usageDateShowUtc,
     usageDateInterval
   );


### PR DESCRIPTION
fixes timezone bug for stats usage chart by using user timezone instead of local time

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
