### PR TITLE
fix(grouping): Use json for client fingerprint in grouphash metadata

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -335,7 +335,7 @@ def _get_fingerprint_hashing_metadata(
     if matched_rule:
         metadata["matched_fingerprinting_rule"] = matched_rule["text"]
     if client_fingerprint:
-        metadata["client_fingerprint"] = str(client_fingerprint)
+        metadata["client_fingerprint"] = json.dumps(client_fingerprint)
 
     return metadata
 

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -158,10 +158,14 @@ def _assert_and_snapshot_results(
         assert metric_names == expected_metric_names
 
     # Convert any fingerprint value from json to a string before jsonifying the entire metadata dict
-    # to avoid a bunch of escaping which would be caused by double jsonification
+    # below to avoid a bunch of escaping which would be caused by double jsonification
+    _hashing_metadata: Any = hashing_metadata  # Alias for typing purposes
     if "fingerprint" in hashing_metadata:
-        _hashing_metadata: Any = hashing_metadata  # Alias for typing purposes
         _hashing_metadata["fingerprint"] = str(json.loads(_hashing_metadata["fingerprint"]))
+    if "client_fingerprint" in hashing_metadata:
+        _hashing_metadata["client_fingerprint"] = str(
+            json.loads(_hashing_metadata["client_fingerprint"])
+        )
 
     lines.append("hash_basis: %s" % hash_basis)
     lines.append("hashing_metadata: %s" % to_json(hashing_metadata, pretty_print=True))


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/83975, which switched the storage of the resolved fingerprint in grouphash metadata from stringifying to jsonifying. That PR should have included the client fingerprint in addition to the resolved fingerprint, but it was mistakenly left out. This fixes that and makes the switch for client fingerprint as well.