### PR TITLE
chore(replays): Support deprecated platform names for mobile

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -469,6 +469,10 @@ export const replayMobilePlatforms: PlatformKey[] = [
   'apple-ios',
   'react-native',
   'flutter',
+  // Old platforms
+  'java-android',
+  'cocoa-objc',
+  'cocoa-swift',
 ];
 
 // These are all the platforms that can set up replay.


### PR DESCRIPTION
If a project was created with an old platform name we should still support it in the UI for mobile replays (the ingest side should work just fine)