### PR TITLE
feat(uptime): Allow the check-ins table to use the current date query 

### DIFF
--- a/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
@@ -10,7 +10,9 @@ interface UptimeChecksParameters {
   projectSlug: string;
   uptimeAlertId: string;
   cursor?: string;
+  end?: string;
   limit?: number;
+  start?: string;
 }
 
 export function makeUptimeChecksQueryKey({
@@ -19,10 +21,12 @@ export function makeUptimeChecksQueryKey({
   uptimeAlertId,
   cursor,
   limit,
+  start,
+  end,
 }: UptimeChecksParameters): ApiQueryKey {
   return [
     `/projects/${orgSlug}/${projectSlug}/uptime/${uptimeAlertId}/checks/`,
-    {query: {per_page: limit, cursor}},
+    {query: {per_page: limit, cursor, start, end}},
   ];
 }
 
@@ -33,7 +37,7 @@ export function useUptimeChecks(
   // TODO(Leander): Add querying and sorting, when the endpoint supports it
   return useApiQuery<UptimeCheck[]>(makeUptimeChecksQueryKey(params), {
     staleTime: 10000,
-    retry: false,
+    retry: true,
     ...options,
   });
 }


### PR DESCRIPTION
- Allows the all check-ins view to use the date query, meaning the data should match what's on the graph (still doesn't sort though)
- Simplifies the render for the status to use the existing enum values
- Avoids rendering the placeholder trace ID for missed checks