### PR TITLE
fix(taskworker) Handle an empty schedule set

### DIFF
--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -157,6 +157,9 @@ class ScheduleRunner:
         """
         self._update_heap()
 
+        if not self._heap:
+            return 60
+
         while True:
             # Peek at the top, and if it is due, pop, spawn and update last run time
             _, entry = self._heap[0]

--- a/tests/sentry/taskworker/scheduler/test_runner.py
+++ b/tests/sentry/taskworker/scheduler/test_runner.py
@@ -66,6 +66,14 @@ def test_schedulerunner_add_invalid(taskregistry) -> None:
     assert "microseconds" in str(err)
 
 
+def test_schedulerunner_tick_no_tasks(taskregistry: TaskRegistry, run_storage: RunStorage) -> None:
+    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+
+    with freeze_time("2025-01-24 14:25:00"):
+        sleep_time = schedule_set.tick()
+        assert sleep_time == 60
+
+
 def test_schedulerunner_tick_one_task_time_remaining(
     taskregistry: TaskRegistry, run_storage: RunStorage
 ) -> None:


### PR DESCRIPTION
Don't error if there are no scheduled tasks. This will happen in the sandbox and when we first start deploying taskworkers.
