### PR TITLE
fix(code_mappings): For Java projects handle $$ differently

### DIFF
--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -35,6 +35,14 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
         db_table = "sentry_repositoryprojectpathconfig"
         unique_together = (("project", "stack_root"),)
 
+    def __repr__(self) -> str:  # type: ignore[override]
+        return (
+            f"RepositoryProjectPathConfig(repo={self.repository.name}, "
+            + f"branch={self.default_branch}, "
+            + f"stack_root={self.stack_root}, "
+            + f"source_root={self.source_root})"
+        )
+
 
 def process_resource_change(instance, **kwargs):
     from sentry.models.group import Group

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -43,7 +43,7 @@ def java_frame_munger(frame: EventFrame) -> str | None:
         return None
 
     if "$$" in frame.module:
-        return frame.module.split("$$")[0].replace(".", "/")
+        return frame.module.split("$$")[0].replace(".", "/") + ".java"
 
     if "/" not in str(frame.filename) and frame.module:
         # Replace the last module segment with the filename, as the

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -41,6 +41,10 @@ class SdkFrameMunger:
 def java_frame_munger(frame: EventFrame) -> str | None:
     if not frame.filename or not frame.module:
         return None
+
+    if "$$" in frame.module:
+        return frame.module.split("$$")[0].replace(".", "/")
+
     if "/" not in str(frame.filename) and frame.module:
         # Replace the last module segment with the filename, as the
         # terminal element in a module path is the class

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -412,12 +412,51 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
     def test_convert_stacktrace_frame_path_to_source_path_java(self) -> None:
         assert (
             convert_stacktrace_frame_path_to_source_path(
-                frame=EventFrame(filename="File.java", module="sentry.module.File"),
+                frame=EventFrame(
+                    filename="File.java",
+                    module="sentry.module.File",
+                ),
                 code_mapping=self.code_mapping_file,
                 platform="java",
                 sdk_name="sentry.java",
             )
             == "src/sentry/module/File.java"
+        )
+
+    def test_convert_stacktrace_frame_path_to_source_path_java_no_source_context(self) -> None:
+        code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            # XXX: Discuss support for dot notation
+            # XXX: Discuss support for forgetting a last back slash
+            stack_root="com/example/",
+            source_root="src/com/example/",
+            automatically_generated=False,
+        )
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                frame=EventFrame(
+                    filename="MainActivity.java",
+                    module="com.example.vu.android.MainActivity",
+                ),
+                code_mapping=code_mapping,
+                platform="java",
+                sdk_name="sentry.java.android",
+            )
+            == "src/com/example/vu/android/MainActivity.java"
+        )
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                frame=EventFrame(
+                    filename="D8$$SyntheticClass",
+                    module="com.example.vu.android.MainActivity$$ExternalSyntheticLambda4",
+                ),
+                code_mapping=code_mapping,
+                platform="java",
+                sdk_name="sentry.java.android",
+            )
+            == "src/com/example/vu/android/MainActivity.java"
         )
 
     def test_convert_stacktrace_frame_path_to_source_path_backslashes(self) -> None:


### PR DESCRIPTION
Java events without Source Context can end up having frames with these values:

```
filename="D8$$SyntheticClass"
module="com.example.vu.android.MainActivity$$ExternalSyntheticLambda4"
```

This change handles this case correctly.