### PR TITLE
fix(solutions hub): Add support for JSX resource descriptions

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {Fragment, isValidElement, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -198,7 +198,10 @@ export function GroupSummary({
           {
             id: 'resources',
             title: t('Resources'),
-            insight: `${config.resources?.description ?? ''}\n\n${config.resources?.links?.map(link => `[${link.text}](${link.link})`).join(' • ') ?? ''}`,
+            insight: `${isValidElement(config.resources?.description) ? '' : config.resources?.description ?? ''}\n\n${config.resources?.links?.map(link => `[${link.text}](${link.link})`).join(' • ') ?? ''}`,
+            insightElement: isValidElement(config.resources?.description)
+              ? config.resources?.description
+              : null,
             icon: <IconDocs size="sm" />,
             showWhenLoading: true,
           },
@@ -248,17 +251,34 @@ export function GroupSummary({
                       <Placeholder height="1.5rem" />
                     </CardContent>
                   ) : (
-                    card.insight && (
-                      <CardContent
-                        dangerouslySetInnerHTML={{
-                          __html: marked(
-                            preview
-                              ? card.insight.replace(/\*\*/g, '') ?? ''
-                              : card.insight ?? ''
-                          ),
-                        }}
-                      />
-                    )
+                    <CardContent>
+                      {card.insightElement ? (
+                        <Fragment>
+                          {card.insightElement}
+                          {card.insight && (
+                            <div
+                              dangerouslySetInnerHTML={{
+                                __html: marked(
+                                  preview
+                                    ? card.insight.replace(/\*\*/g, '')
+                                    : card.insight
+                                ),
+                              }}
+                            />
+                          )}
+                        </Fragment>
+                      ) : (
+                        card.insight && (
+                          <div
+                            dangerouslySetInnerHTML={{
+                              __html: marked(
+                                preview ? card.insight.replace(/\*\*/g, '') : card.insight
+                              ),
+                            }}
+                          />
+                        )
+                      )}
+                    </CardContent>
                   )}
                 </CardContentContainer>
               </InsightCard>

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -1,4 +1,4 @@
-import {Fragment, isValidElement, useEffect, useState} from 'react';
+import {isValidElement, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -252,31 +252,15 @@ export function GroupSummary({
                     </CardContent>
                   ) : (
                     <CardContent>
-                      {card.insightElement ? (
-                        <Fragment>
-                          {card.insightElement}
-                          {card.insight && (
-                            <div
-                              dangerouslySetInnerHTML={{
-                                __html: marked(
-                                  preview
-                                    ? card.insight.replace(/\*\*/g, '')
-                                    : card.insight
-                                ),
-                              }}
-                            />
-                          )}
-                        </Fragment>
-                      ) : (
-                        card.insight && (
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html: marked(
-                                preview ? card.insight.replace(/\*\*/g, '') : card.insight
-                              ),
-                            }}
-                          />
-                        )
+                      {card.insightElement}
+                      {card.insight && (
+                        <div
+                          dangerouslySetInnerHTML={{
+                            __html: marked(
+                              preview ? card.insight.replace(/\*\*/g, '') : card.insight
+                            ),
+                          }}
+                        />
                       )}
                     </CardContent>
                   )}


### PR DESCRIPTION
Turns out some resources are configured with a description that's a JSX element instead of a string. This was causing them to display as `[object Object]`. This change will render them correctly, just like string types.
<img width="628" alt="Screenshot 2025-02-07 at 8 05 37 AM" src="https://github.com/user-attachments/assets/a209157c-b205-454e-87d2-eb5557260023" />
