### PR TITLE
fix(insights): extra filters on transaction summary when navigating to it from search

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -100,6 +100,7 @@ function BackendOverviewPage() {
     withStaticFilters,
     organization
   );
+  const searchBarEventView = eventView.clone();
 
   // TODO - this should come from MetricsField / EAP fields
   eventView.fields = [
@@ -236,7 +237,7 @@ function BackendOverviewPage() {
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}
-                    eventView={eventView}
+                    eventView={searchBarEventView}
                     onSearch={(query: string) => {
                       handleSearch(query);
                     }}

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -94,6 +94,7 @@ function FrontendOverviewPage() {
     withStaticFilters,
     organization
   );
+  const searchBarEventView = eventView.clone();
 
   const sharedProps = {eventView, location, organization, withStaticFilters};
 
@@ -212,7 +213,7 @@ function FrontendOverviewPage() {
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}
-                    eventView={eventView}
+                    eventView={searchBarEventView}
                     onSearch={(query: string) => {
                       handleSearch(query);
                     }}

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -98,6 +98,7 @@ function MobileOverviewPage() {
     withStaticFilters,
     organization
   );
+  const searchBarEventView = eventView.clone();
 
   let columnTitles = checkIsReactNative(eventView)
     ? REACT_NATIVE_COLUMN_TITLES
@@ -226,7 +227,7 @@ function MobileOverviewPage() {
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}
-                    eventView={eventView}
+                    eventView={searchBarEventView}
                     onSearch={(query: string) => {
                       handleSearch(query);
                     }}


### PR DESCRIPTION
fixes https://github.com/getsentry/team-visibility/issues/24

When you search for a transaction on the domain overview, and then click the little arrow to go to the transaction summary
<img width="932" alt="image" src="https://github.com/user-attachments/assets/4beb0a60-65a5-4cfd-bf7f-43ed479604ac" />

You end up with a bunch of filters in the search bar
<img width="929" alt="image" src="https://github.com/user-attachments/assets/82c88fa2-ceb8-48b8-857c-161142a9c06d" />

This PR makes it so the search bar is now blank, which is the expected behaviour