### PR TITLE
feat(new-trace): Updating numeric value check for key-value drawer ac…

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -795,17 +795,21 @@ function KeyValueAction({
     },
   ];
 
-  const valueType = getFieldDefinition(rowKey)?.valueType;
-  const isMeasurement =
-    valueType &&
-    [
-      FieldValueType.DURATION,
-      FieldValueType.NUMBER,
-      FieldValueType.INTEGER,
-      FieldValueType.PERCENTAGE,
-    ].includes(valueType);
+  const valueType = getFieldDefinition(rowKey, 'span')?.valueType;
+  const isNumeric =
+    typeof rowValue === 'number' ||
+    (valueType &&
+      [
+        FieldValueType.DURATION,
+        FieldValueType.NUMBER,
+        FieldValueType.INTEGER,
+        FieldValueType.PERCENTAGE,
+        FieldValueType.DATE,
+        FieldValueType.RATE,
+        FieldValueType.PERCENT_CHANGE,
+      ].includes(valueType));
 
-  if (isMeasurement) {
+  if (isNumeric) {
     dropdownOptions.push(
       {
         key: 'includeGreaterThan',


### PR DESCRIPTION
- We weren't checking against some span field definitions for known keys like `http.decoded_response_content_length`, resulting in them not being treated as numeric field types:
<img width="587" alt="Screenshot 2025-02-07 at 12 58 42 PM" src="https://github.com/user-attachments/assets/3fcea8fb-6e8a-410b-a78f-be89defcb44d" />
