### PR TITLE
fix(explore): Do not clear include conditions on exclude

### DIFF
--- a/static/app/views/discover/table/cellAction.spec.tsx
+++ b/static/app/views/discover/table/cellAction.spec.tsx
@@ -466,17 +466,17 @@ describe('updateQuery()', function () {
     updateQuery(results, Actions.ADD, columnB, '2');
     expect(results.formatString()).toBe('a:1 b:2');
     updateQuery(results, Actions.EXCLUDE, columnA, '3');
-    expect(results.formatString()).toBe('b:2 !a:3');
+    expect(results.formatString()).toBe('a:1 b:2 !a:3');
     updateQuery(results, Actions.EXCLUDE, columnB, '4');
-    expect(results.formatString()).toBe('!a:3 !b:4');
+    expect(results.formatString()).toBe('a:1 b:2 !a:3 !b:4');
     results.addFilterValues('!a', ['*dontescapeme*'], false);
-    expect(results.formatString()).toBe('!a:3 !b:4 !a:*dontescapeme*');
+    expect(results.formatString()).toBe('a:1 b:2 !a:3 !b:4 !a:*dontescapeme*');
     updateQuery(results, Actions.EXCLUDE, columnA, '*escapeme*');
     expect(results.formatString()).toBe(
-      '!b:4 !a:3 !a:*dontescapeme* !a:"\\*escapeme\\*"'
+      'a:1 b:2 !b:4 !a:3 !a:*dontescapeme* !a:"\\*escapeme\\*"'
     );
     updateQuery(results, Actions.ADD, columnA, '5');
-    expect(results.formatString()).toBe('!b:4 a:5');
+    expect(results.formatString()).toBe('b:2 !b:4 a:5');
     updateQuery(results, Actions.ADD, columnB, '6');
     expect(results.formatString()).toBe('a:5 b:6');
   });

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -115,9 +115,6 @@ export function excludeFromFilter(
   key: string,
   value: React.ReactText | string[]
 ) {
-  // Remove positive if it exists.
-  oldFilter.removeFilter(key);
-
   // Negations should stack up.
   const negation = `!${key}`;
 

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -242,7 +242,7 @@ describe('TableView > CellActions', function () {
     expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: location.pathname,
       query: expect.objectContaining({
-        query: 'tag:value !title:"some title"',
+        query: 'tag:value title:nope !title:"some title"',
       }),
     });
   });


### PR DESCRIPTION
When excluding a value via cell actions, we should not blindly clear existing include conditions for that key. The existing conditions might be a wild card that matches more than just the excluded key.