### PR TITLE
fix(uptime): Further prevent unloading table/graph for uptime

### DIFF
--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -27,10 +27,9 @@ import {useUser} from 'sentry/utils/useUser';
 import {CheckStatus, type UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
 import {statusToText, tickStyle} from 'sentry/views/insights/uptime/timelineConfig';
 import {useUptimeChecks} from 'sentry/views/insights/uptime/utils/useUptimeChecks';
-import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTable';
+import {useUptimeIssueAlertId} from 'sentry/views/issueDetails/streamline/issueCheckInTimeline';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
-import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 
 /**
  * This value is used when a trace was not recorded since the field is required.
@@ -43,8 +42,8 @@ export default function GroupUptimeChecks() {
   const {groupId} = useParams<{groupId: string}>();
   const location = useLocation();
   const user = useUser();
-  const {detectorDetails} = useIssueDetails();
   const {since, until} = usePageFilterDates();
+  const uptimeAlertId = useUptimeIssueAlertId({groupId});
 
   const {
     data: group,
@@ -52,20 +51,6 @@ export default function GroupUptimeChecks() {
     isError: isGroupError,
     refetch: refetchGroup,
   } = useGroup({groupId});
-
-  const {
-    data: event,
-    isError: isEventError,
-    refetch: refetchEvent,
-  } = useGroupEvent({
-    groupId,
-    eventId: user.options.defaultIssueEvent,
-  });
-
-  // Fall back to the fetched event since the legacy UI isn't nested within the provider the provider
-  const uptimeAlertId =
-    detectorDetails.detectorId ??
-    event?.tags?.find(tag => tag.key === 'uptime_rule')?.value;
 
   const canFetchUptimeChecks =
     Boolean(organization.slug) && Boolean(group?.project.slug) && Boolean(uptimeAlertId);
@@ -85,11 +70,6 @@ export default function GroupUptimeChecks() {
 
   if (isGroupError) {
     return <LoadingError onRetry={refetchGroup} />;
-  }
-
-  // If the event query failed, only show an error if we don't already have the detector details
-  if (!canFetchUptimeChecks && isEventError) {
-    return <LoadingError onRetry={refetchEvent} />;
   }
 
   if (isGroupPending || !uptimeData) {
@@ -216,7 +196,7 @@ function CheckInBodyCell({
       let checkResult = <Cell>{cellData}</Cell>;
       const status = cellData as CheckStatus;
       if (Object.values(CheckStatus).includes(status)) {
-        const colorKey = tickStyle[status].labelColor ?? 'gray200';
+        const colorKey = tickStyle[status].labelColor ?? 'textColor';
         checkResult = (
           <Cell style={{color: theme[colorKey] as string}}>{statusToText[status]}</Cell>
         );

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -216,10 +216,9 @@ function CheckInBodyCell({
       let checkResult = <Cell>{cellData}</Cell>;
       const status = cellData as CheckStatus;
       if (Object.values(CheckStatus).includes(status)) {
+        const colorKey = tickStyle[status].labelColor ?? 'gray200';
         checkResult = (
-          <Cell style={{color: tickStyle[status].labelColor}}>
-            {statusToText[status]}
-          </Cell>
+          <Cell style={{color: theme[colorKey] as string}}>{statusToText[status]}</Cell>
         );
       }
       return dataRow.checkStatusReason ? (

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -129,6 +129,10 @@ describe('EventDetailsHeader', () => {
   });
 
   it('renders occurrence summary if enabled', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/recommended/`,
+      body: {data: event},
+    });
     render(
       <EventDetailsHeader
         {...defaultProps}

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -114,7 +114,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
               <MetricIssueChart group={group} project={project} event={event} />
             )}
             {issueTypeConfig.header.graph.type === 'checkin-timeline' && (
-              <IssueCheckInTimeline />
+              <IssueCheckInTimeline group={group} />
             )}
             {issueTypeConfig.header.tagDistribution.enabled && (
               <IssueTagsPreview

--- a/static/app/views/issueDetails/streamline/issueCheckInTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCheckInTimeline.tsx
@@ -9,8 +9,10 @@ import {
 } from 'sentry/components/checkInTimeline/gridLines';
 import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
 import {space} from 'sentry/styles/space';
+import type {Group} from 'sentry/types/group';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useUser} from 'sentry/utils/useUser';
 import {
   checkStatusPrecedent,
   statusToText,
@@ -18,17 +20,44 @@ import {
 } from 'sentry/views/insights/uptime/timelineConfig';
 import {useUptimeMonitorStats} from 'sentry/views/insights/uptime/utils/useUptimeMonitorStats';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
+import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 
-export function IssueCheckInTimeline() {
+export function useUptimeIssueAlertId({groupId}: {groupId: string}): string | undefined {
+  /**
+   * This should be removed once the uptime rule value is set on the issue.
+   * This will fetch an event from the max range if the detector details
+   * are not available (e.g. time range has changed and page refreshed)
+   */
+  const user = useUser();
   const {detectorDetails} = useIssueDetails();
   const {detectorId, detectorType} = detectorDetails;
+
+  const hasUptimeDetector = detectorId && detectorType === 'uptime_monitor';
+
+  const {data: event} = useGroupEvent({
+    groupId,
+    eventId: user.options.defaultIssueEvent,
+    options: {
+      enabled: !hasUptimeDetector,
+      period: {statsPeriod: '90d'},
+    },
+  });
+
+  // Fall back to the fetched event since the legacy UI isn't nested within the provider the provider
+  return hasUptimeDetector
+    ? detectorId
+    : event?.tags?.find(tag => tag.key === 'uptime_rule')?.value;
+}
+
+export function IssueCheckInTimeline({group}: {group: Group}) {
+  const uptimeAlertId = useUptimeIssueAlertId({groupId: group.id});
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
 
   const {data: uptimeStats, isPending} = useUptimeMonitorStats({
-    ruleIds: detectorType === 'uptime_monitor' && detectorId ? [detectorId] : [],
+    ruleIds: uptimeAlertId ? [uptimeAlertId] : [],
     timeWindowConfig,
   });
 
@@ -46,7 +75,7 @@ export function IssueCheckInTimeline() {
         <CheckInPlaceholder />
       ) : (
         <CheckInTimeline
-          bucketedData={detectorId ? uptimeStats?.[detectorId] ?? [] : []}
+          bucketedData={uptimeAlertId ? uptimeStats?.[uptimeAlertId] ?? [] : []}
           statusLabel={statusToText}
           statusStyle={tickStyle}
           statusPrecedent={checkStatusPrecedent}

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -69,10 +69,7 @@ export function getDetectorDetails({
       ),
     };
   }
-  return {
-    detectorPath: undefined,
-    description: undefined,
-  };
+  return {};
 }
 
 export function DetectorSection({group, project}: {group: Group; project: Project}) {

--- a/static/app/views/issueDetails/useGroupEvent.tsx
+++ b/static/app/views/issueDetails/useGroupEvent.tsx
@@ -16,7 +16,7 @@ export const RESERVED_EVENT_IDS = new Set(['recommended', 'latest', 'oldest']);
 interface UseGroupEventOptions {
   eventId: string | undefined;
   groupId: string;
-  options?: {enabled?: boolean};
+  options?: {enabled?: boolean; period?: ReturnType<typeof getPeriod>};
 }
 
 export function useGroupEvent({
@@ -41,7 +41,8 @@ export function useGroupEvent({
       : undefined;
 
   const {selection: pageFilters} = usePageFilters();
-  const periodQuery = hasStreamlinedUI ? getPeriod(pageFilters.datetime) : {};
+  const periodQuery =
+    options?.period ?? (hasStreamlinedUI ? getPeriod(pageFilters.datetime) : {});
 
   const queryKey = getGroupEventQueryKey({
     orgSlug: organization.slug,

--- a/static/app/views/issueDetails/useGroupEvent.tsx
+++ b/static/app/views/issueDetails/useGroupEvent.tsx
@@ -16,7 +16,7 @@ export const RESERVED_EVENT_IDS = new Set(['recommended', 'latest', 'oldest']);
 interface UseGroupEventOptions {
   eventId: string | undefined;
   groupId: string;
-  options?: {enabled?: boolean; period?: ReturnType<typeof getPeriod>};
+  options?: {enabled?: boolean};
 }
 
 export function useGroupEvent({
@@ -41,8 +41,7 @@ export function useGroupEvent({
       : undefined;
 
   const {selection: pageFilters} = usePageFilters();
-  const periodQuery =
-    options?.period ?? (hasStreamlinedUI ? getPeriod(pageFilters.datetime) : {});
+  const periodQuery = hasStreamlinedUI ? getPeriod(pageFilters.datetime) : {};
 
   const queryKey = getGroupEventQueryKey({
     orgSlug: organization.slug,


### PR DESCRIPTION
Adds a new hook that will allow for a fallback event to be loaded in a 90d window which hopefully has the tag for an `uptime_rule`. That ID will allow us to query properly for checks and stats for the graph.

This is a workaround which should be removed once we structure the uptime rule onto the group itself, since we could avoid making these complicated queries and searches.