### PR TITLE
:sparkles: feat(threads): use NOA thread repo for activity thread notifs

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -297,7 +297,16 @@ class SlackService:
                             "parent notification does not have a message identifier, skipping"
                         )
                         continue
-                    channel_id = self._get_channel_id_from_parent_notification(parent_notification)
+                    if isinstance(parent_notification, NotificationActionNotificationMessage):
+                        channel_id = (
+                            self._get_channel_id_from_parent_notification_notification_action(
+                                parent_notification
+                            )
+                        )
+                    else:
+                        channel_id = self._get_channel_id_from_parent_notification(
+                            parent_notification
+                        )
                     self._send_notification_to_slack_channel(
                         channel_id=channel_id,
                         message_identifier=parent_notification.message_identifier,
@@ -341,12 +350,8 @@ class SlackService:
 
     def _get_channel_id_from_parent_notification(
         self,
-        parent_notification: NotificationActionNotificationMessage | IssueAlertNotificationMessage,
+        parent_notification: IssueAlertNotificationMessage,
     ) -> str:
-        if isinstance(parent_notification, NotificationActionNotificationMessage):
-            return self._get_channel_id_from_parent_notification_notification_action(
-                parent_notification
-            )
         """Get the channel ID from a parent notification by looking up the rule action details."""
         if not parent_notification.rule_fire_history:
             raise RuleDataError(

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from copy import copy
 from logging import Logger, getLogger
 from typing import Any
@@ -227,6 +227,9 @@ class SlackService:
             )
 
             use_open_period_start = False
+            parent_notifications: Generator[
+                NotificationActionNotificationMessage | IssueAlertNotificationMessage
+            ]
             if (
                 features.has(
                     "organizations:slack-threads-refactor-uptime",

--- a/src/sentry/integrations/utils/common.py
+++ b/src/sentry/integrations/utils/common.py
@@ -26,3 +26,26 @@ def get_active_integration_for_organization(
             },
         )
         return None
+
+
+def get_integration_id_integration_mapping_for_organization(
+    organization_id: int,
+    provider: ExternalProviderEnum,
+) -> dict[int, RpcIntegration]:
+    """
+    Returns a mapping of integration id to integration for the given organization.
+    """
+    try:
+        integrations = integration_service.get_integrations(
+            organization_id=organization_id,
+            status=ObjectStatus.ACTIVE,
+            providers=[provider.value],
+        )
+        return {integration.id: integration for integration in integrations}
+    except Exception as err:
+        _default_logger.info(
+            "error getting active integrations for organization from service",
+            exc_info=err,
+            extra={"organization_id": organization_id},
+        )
+        return {}


### PR DESCRIPTION
uses the NOA Threads repo + Action definition to send activity notification messages in a thread for slack.

its gated behind the NOA FF.