### PR TITLE
chore(derived_code_mappings): Do not record as error UnableToAcquireLock

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -178,6 +178,10 @@ class EventLifecycle:
         """Record that the event halted in failure. Additional data may be passed
         to be logged.
 
+        Calling it means that the feature is broken and requires immediate attention.
+
+        An error will be reported to Sentry.
+
         There is no need to call this method directly if an exception is raised from
         inside the context. It will be called automatically when exiting the context
         on an exception.
@@ -196,6 +200,8 @@ class EventLifecycle:
         self, halt_reason: BaseException | str | None = None, extra: dict[str, Any] | None = None
     ) -> None:
         """Record that the event halted in an ambiguous state.
+
+        It will be logged to GCP but no Sentry error will be reported.
 
         This method can be called in response to a sufficiently ambiguous exception
         or other error condition, where it may have been caused by a user error or

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -148,7 +148,7 @@ def get_trees_for_org(
             lifecycle.record_halt(error, extra)
         except UnableToAcquireLock as error:
             extra["error"] = str(error)
-            lifecycle.record_failure(error, extra)
+            lifecycle.record_halt(error, extra)
         except Exception:
             lifecycle.record_failure(DeriveCodeMappingsErrorReason.UNEXPECTED_ERROR, extra=extra)
 

--- a/tests/sentry/issues/auto_source_code_config/test_task.py
+++ b/tests/sentry/issues/auto_source_code_config/test_task.py
@@ -81,7 +81,7 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
         with patch(GET_TREES_FOR_ORG, side_effect=error):
             process_event(self.project.id, self.event.group_id, self.event.event_id)
             assert not RepositoryProjectPathConfig.objects.exists()
-            assert_failure_metric(mock_record, error)
+            assert_halt_metric(mock_record, error)
 
     def test_raises_generic_errors(self, mock_record: Any) -> None:
         with patch(GET_TREES_FOR_ORG, side_effect=Exception("foo")):


### PR DESCRIPTION
I also clarify some of the docstring.