### PR TITLE
feat(dashboards): Improve widget hover and state props

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -315,7 +315,7 @@ function WidgetCard(props: Props) {
                   error={widgetQueryError || errorMessage || undefined}
                   preferredPolarity="-"
                   borderless={props.borderless}
-                  forceDescriptionTooltip={props.forceDescriptionTooltip}
+                  revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
                 />
               );
             }}
@@ -332,7 +332,7 @@ function WidgetCard(props: Props) {
             actions={actions}
             onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
             borderless={props.borderless}
-            forceDescriptionTooltip={props.forceDescriptionTooltip}
+            revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
             noVisualizationPadding
           >
             <WidgetCardChartContainer

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -33,7 +33,8 @@ export function BigNumberWidget(props: BigNumberWidgetProps) {
         title={props.title}
         description={props.description}
         borderless={props.borderless}
-        forceDescriptionTooltip={props.forceDescriptionTooltip}
+        revealActions={props.revealActions}
+        revealTooltip={props.revealTooltip}
       >
         <LoadingPlaceholder>{LOADING_PLACEHOLDER}</LoadingPlaceholder>
       </WidgetFrame>
@@ -66,7 +67,8 @@ export function BigNumberWidget(props: BigNumberWidgetProps) {
       error={error}
       onRetry={props.onRetry}
       borderless={props.borderless}
-      forceDescriptionTooltip={props.forceDescriptionTooltip}
+      revealActions={props.revealActions}
+      revealTooltip={props.revealTooltip}
     >
       {defined(value) && (
         <BigNumberResizeWrapper>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -29,7 +29,11 @@ export default storyBook('WidgetFrame', story => {
           content. This includes a title, a description, and the <code>children</code>.
           The title is automatically wrapped in a tooltip if it does not fit. The
           description and the actions are usually hidden and shown on hover. You can
-          control this behaviour with the <code>hideActions</code> prop.
+          control this behaviour with the <code>revealActions</code> prop.
+          <code>revealActions</code> is set to <code>"hover"</code> by default, but you
+          can set it to <code>"always"</code> to forcibly show the actions.
+          <code>revealActions</code> is automatically set to <code>"always"</code> if the{' '}
+          <code>revealTooltip</code> prop is set to <code>"always"</code>.
         </p>
 
         <p>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -27,7 +27,9 @@ export default storyBook('WidgetFrame', story => {
         <p>
           <JSXNode name="WidgetFrame" /> supports a few basic props that control its
           content. This includes a title, a description, and the <code>children</code>.
-          The title is automatically wrapped in a tooltip if it does not fit.
+          The title is automatically wrapped in a tooltip if it does not fit. The
+          description and the actions are usually hidden and shown on hover. You can
+          control this behaviour with the <code>hideActions</code> prop.
         </p>
 
         <p>
@@ -46,12 +48,6 @@ export default storyBook('WidgetFrame', story => {
           </NormalWidget>
           <NormalWidget>
             <WidgetFrame
-              title="p95(measurements.lcp) / p95(measurements.inp)"
-              description="This is a tough formula to reason about"
-            />
-          </NormalWidget>
-          <NormalWidget>
-            <WidgetFrame
               title="p95(span.duration)"
               description={tct('Learn more about this on our [documentation] website.', {
                 documentation: (
@@ -60,6 +56,24 @@ export default storyBook('WidgetFrame', story => {
                   </ExternalLink>
                 ),
               })}
+            />
+          </NormalWidget>
+        </SideBySide>
+
+        <br />
+
+        <SideBySide>
+          <NormalWidget>
+            <WidgetFrame
+              title="p95(measurements.lcp) / p95(measurements.inp)"
+              description="This is a tough formula to reason about"
+              hideActions
+            />
+          </NormalWidget>
+          <NormalWidget>
+            <WidgetFrame
+              title="p95(measurements.lcp) / p95(measurements.inp)"
+              description="This is a tough formula to reason about"
             />
           </NormalWidget>
         </SideBySide>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -67,7 +67,6 @@ export default storyBook('WidgetFrame', story => {
             <WidgetFrame
               title="p95(measurements.lcp) / p95(measurements.inp)"
               description="This is a tough formula to reason about"
-              hideActions
             />
           </NormalWidget>
           <NormalWidget>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -91,7 +91,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
             <WidgetDescription
               title={props.title}
               description={props.description}
-              revealTooltip={props.revealTooltip}
+              revealTooltip={props.revealTooltip ?? 'hover'}
             />
           )}
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -32,6 +32,8 @@ export interface WidgetFrameProps extends StateProps, WidgetDescriptionProps {
   children?: React.ReactNode;
   noVisualizationPadding?: boolean;
   onFullScreenViewClick?: () => void | Promise<void>;
+  revealActions?: 'always' | 'hover';
+  revealTooltip?: 'always' | 'hover';
   title?: string;
   warnings?: string[];
 }
@@ -61,7 +63,6 @@ export function WidgetFrame(props: WidgetFrameProps) {
   return (
     <WidgetLayout
       ariaLabel="Widget panel"
-      forceShowActions={props.forceDescriptionTooltip}
       Title={
         <Fragment>
           {props.warnings && props.warnings.length > 0 && (
@@ -80,6 +81,9 @@ export function WidgetFrame(props: WidgetFrameProps) {
             )}
         </Fragment>
       }
+      revealActions={
+        props.revealTooltip === 'always' ? 'always' : props.revealActions ?? 'hover'
+      }
       Actions={
         <Fragment>
           {props.description && (
@@ -87,7 +91,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
             <WidgetDescription
               title={props.title}
               description={props.description}
-              forceDescriptionTooltip={props.forceDescriptionTooltip}
+              revealTooltip={props.revealTooltip}
             />
           )}
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -24,7 +24,12 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
 
   if (props.isLoading) {
     return (
-      <WidgetFrame title={props.title} description={props.description}>
+      <WidgetFrame
+        title={props.title}
+        description={props.description}
+        revealActions={props.revealActions}
+        revealTooltip={props.revealTooltip}
+      >
         <LoadingPanel />
       </WidgetFrame>
     );
@@ -50,6 +55,8 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
       warnings={props.warnings}
       error={error}
       onRetry={props.onRetry}
+      revealActions={props.revealActions}
+      revealTooltip={props.revealTooltip}
     >
       {defined(timeseries) && (
         <TimeSeriesWidgetVisualization

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetDescription.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetDescription.tsx
@@ -8,7 +8,7 @@ import {space} from 'sentry/styles/space';
 
 export interface WidgetDescriptionProps {
   description?: React.ReactElement | string;
-  forceDescriptionTooltip?: boolean;
+  revealTooltip?: 'hover' | 'always';
   title?: string;
 }
 
@@ -25,7 +25,7 @@ export function WidgetDescription(props: WidgetDescriptionProps) {
       }
       containerDisplayMode="grid"
       isHoverable
-      forceVisible={props.forceDescriptionTooltip}
+      forceVisible={props.revealTooltip === 'always'}
     >
       <WidgetTooltipButton
         aria-label={t('Widget description')}

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetDescription.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetDescription.tsx
@@ -25,7 +25,7 @@ export function WidgetDescription(props: WidgetDescriptionProps) {
       }
       containerDisplayMode="grid"
       isHoverable
-      forceVisible={props.revealTooltip === 'always'}
+      forceVisible={props.revealTooltip === 'always' ? true : undefined}
     >
       <WidgetTooltipButton
         aria-label={t('Widget description')}

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
@@ -38,9 +38,11 @@ export default storyBook('WidgetLayout', story => {
           bordered widget frame. The contents of the <code>Title</code> prop are shown in
           the top left, and are always visible. The title is truncated to fit. The
           contents of the <code>Actions</code> prop are shown in the top right, and only
-          shown on hover. Actions are not truncated. The contents of{' '}
-          <code>Visualization</code> are always visible, shown below the title and
-          actions. The layout expands both horizontally and vertically to fit the parent.
+          shown on hover. You can set the <code>revealActions</code> prop to{' '}
+          <code>&lt;always&gt;</code> to always show the actions. Actions are not
+          truncated. The contents of <code>Visualization</code> are always visible, shown
+          below the title and actions. The layout expands both horizontally and vertically
+          to fit the parent.
         </p>
 
         <p>

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.stories.tsx
@@ -39,10 +39,10 @@ export default storyBook('WidgetLayout', story => {
           the top left, and are always visible. The title is truncated to fit. The
           contents of the <code>Actions</code> prop are shown in the top right, and only
           shown on hover. You can set the <code>revealActions</code> prop to{' '}
-          <code>&lt;always&gt;</code> to always show the actions. Actions are not
-          truncated. The contents of <code>Visualization</code> are always visible, shown
-          below the title and actions. The layout expands both horizontally and vertically
-          to fit the parent.
+          <code>"always"</code> to always show the actions. Actions are not truncated. The
+          contents of <code>Visualization</code> are always visible, shown below the title
+          and actions. The layout expands both horizontally and vertically to fit the
+          parent.
         </p>
 
         <p>

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -11,11 +11,11 @@ export interface WidgetLayoutProps {
   Title?: React.ReactNode;
   Visualization?: React.ReactNode;
   ariaLabel?: string;
-  forceShowActions?: boolean;
   height?: number;
   noFooterPadding?: boolean;
   noHeaderPadding?: boolean;
   noVisualizationPadding?: boolean;
+  revealActions?: 'hover' | 'always';
 }
 
 export function WidgetLayout(props: WidgetLayoutProps) {
@@ -23,7 +23,7 @@ export function WidgetLayout(props: WidgetLayoutProps) {
     <Frame
       aria-label={props.ariaLabel}
       height={props.height}
-      forceShowActions={props.forceShowActions}
+      revealActions={props.revealActions}
     >
       <Header noPadding={props.noHeaderPadding}>
         {props.Title && <Fragment>{props.Title}</Fragment>}
@@ -55,7 +55,7 @@ const TitleHoverItems = styled('div')`
   transition: opacity 0.1s;
 `;
 
-const Frame = styled('div')<{forceShowActions?: boolean; height?: number}>`
+const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'}>`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -79,7 +79,7 @@ const Frame = styled('div')<{forceShowActions?: boolean; height?: number}>`
   }
 
   ${p =>
-    !p.forceShowActions &&
+    p.revealActions === 'hover' &&
     `&:not(:hover):not(:focus-within) {
     ${TitleHoverItems} {
       opacity: 0;

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -74,7 +74,8 @@ const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'
 
   ${p =>
     p.revealActions === 'hover' &&
-    css` :hover {
+    css`
+      :hover {
         background-color: ${p.theme.surface200};
         transition:
           background-color 100ms linear,
@@ -83,10 +84,10 @@ const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'
       }
 
       &:not(:hover):not(:focus-within) {
-          ${TitleHoverItems} {
-            opacity: 0;
-            ${p.theme.visuallyHidden}
-          }
+        ${TitleHoverItems} {
+          opacity: 0;
+          ${p.theme.visuallyHidden}
+        }
       }
     `}
 `;

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -19,11 +19,13 @@ export interface WidgetLayoutProps {
 }
 
 export function WidgetLayout(props: WidgetLayoutProps) {
+  const {revealActions = 'hover'} = props;
+
   return (
     <Frame
       aria-label={props.ariaLabel}
       height={props.height}
-      revealActions={props.revealActions}
+      revealActions={revealActions}
     >
       <Header noPadding={props.noHeaderPadding}>
         {props.Title && <Fragment>{props.Title}</Fragment>}

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -74,7 +74,7 @@ const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'
 
   ${p =>
     p.revealActions === 'hover' &&
-    ` :hover {
+    css` :hover {
         background-color: ${p.theme.surface200};
         transition:
           background-color 100ms linear,

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -70,22 +70,23 @@ const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'
 
   background: ${p => p.theme.background};
 
-  :hover {
-    background-color: ${p => p.theme.surface200};
-    transition:
-      background-color 100ms linear,
-      box-shadow 100ms linear;
-    box-shadow: ${p => p.theme.dropShadowLight};
-  }
-
   ${p =>
     p.revealActions === 'hover' &&
-    `&:not(:hover):not(:focus-within) {
-    ${TitleHoverItems} {
-      opacity: 0;
-      ${p.theme.visuallyHidden}
-    }
-  }`}
+    ` :hover {
+        background-color: ${p.theme.surface200};
+        transition:
+          background-color 100ms linear,
+          box-shadow 100ms linear;
+        box-shadow: ${p.theme.dropShadowLight};
+      }
+
+      &:not(:hover):not(:focus-within) {
+          ${TitleHoverItems} {
+            opacity: 0;
+            ${p.theme.visuallyHidden}
+          }
+      }
+    `}
 `;
 
 const Header = styled('div')<{noPadding?: boolean}>`


### PR DESCRIPTION
A small refactor and UI improvement. Follow-up to https://github.com/getsentry/sentry/pull/84092

**Before:**

- `forceShowActions` boolean prop on `WidgetLayout`, available on `WidgetFrame` but not passed through from `BigNumberWidget` and `LineChartWidget`
- `shouldForceDescriptionTooltip` boolean prop on `WidgetTitle`, passed in through `WidgetFrame` but also not passed through from the widget components
- the grey hover effect exists even if the actions are always visible

**After:**

- `revealActions` enum prop on `WidgetLayout`, value is either `"always"` or `"hover"` (default)
- `revealTooltip` enum prop on `WidgetFrame`, value is either `"always"` or `"hover"` (default). If `"always"` is also reveals the action
- stories for the new props

Enum props are a little nicer, since the states are mutually exclusive in a more obvious way, and the default is a little clearer. Also in this version, their names match, which makes it easier to guess what's going on.
