### PR TITLE
feat(dashboards): Optional stacking for `BarChartWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.stories.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
+import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import type {DateString} from 'sentry/types/core';
@@ -21,9 +22,8 @@ export default storyBook('BarChartWidget', story => {
       <Fragment>
         <p>
           <JSXNode name="BarChartWidget" /> is a Dashboard Widget Component. It displays a
-          timeseries chart with multiple timeseries, and the timeseries are stacked and
-          discontinuous. In all other ways, it behaves like{' '}
-          <JSXNode name="AreaChartWidget" />
+          timeseries chart with multiple timeseries, and the timeseries and discontinuous.
+          In all other ways, it behaves like <JSXNode name="AreaChartWidget" />
         </p>
         <p>
           <em>NOTE:</em> Prefer <JSXNode name="LineChartWidget" /> and{' '}
@@ -50,21 +50,38 @@ export default storyBook('BarChartWidget', story => {
     return (
       <Fragment>
         <p>
-          The visualization of <JSXNode name="BarChartWidget" /> is a stacked bar chart.
-          It has some bells and whistles including automatic axes labels, and a hover
-          tooltip. Like other widgets, it automatically fills the parent element.
+          The visualization of <JSXNode name="BarChartWidget" /> is a bar chart. It has
+          some bells and whistles including automatic axes labels, and a hover tooltip.
+          Like other widgets, it automatically fills the parent element.
         </p>
-        <SmallSizingWindow>
-          <BarChartWidget
-            title="Duration Breakdown"
-            description="Explains what proportion of total duration is taken up by latency vs. span duration"
-            timeseries={[
-              shiftTimeserieToNow(latencyTimeSeries),
-              shiftTimeserieToNow(spanDurationTimeSeries),
-            ]}
-            dataCompletenessDelay={600}
-          />
-        </SmallSizingWindow>
+        <p>
+          The <code>stacked</code> boolean prop controls stacking. Bar charts are not
+          stacked by default.
+        </p>
+        <SideBySide>
+          <SmallSizingWindow>
+            <BarChartWidget
+              title="Duration Breakdown"
+              description="Explains what proportion of total duration is taken up by latency vs. span duration"
+              timeseries={[
+                shiftTimeserieToNow(latencyTimeSeries),
+                shiftTimeserieToNow(spanDurationTimeSeries),
+              ]}
+              dataCompletenessDelay={600}
+            />
+          </SmallSizingWindow>
+          <SmallSizingWindow>
+            <BarChartWidget
+              title="Duration Breakdown"
+              description="Explains what proportion of total duration is taken up by latency vs. span duration"
+              timeseries={[
+                shiftTimeserieToNow(latencyTimeSeries),
+                shiftTimeserieToNow(spanDurationTimeSeries),
+              ]}
+              stacked
+            />
+          </SmallSizingWindow>
+        </SideBySide>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/barChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/barChartWidgetSeries.tsx
@@ -4,11 +4,11 @@ import BarSeries from 'sentry/components/charts/series/barSeries';
 
 import type {TimeseriesData} from '../../common/types';
 
-export function BarChartWidgetSeries(timeserie: TimeseriesData) {
+export function BarChartWidgetSeries(timeserie: TimeseriesData, stack?: string) {
   return BarSeries({
     name: timeserie.field,
     color: timeserie.color,
-    stack: 'complete',
+    stack,
     animation: false,
     itemStyle: {
       color: params => {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -57,6 +57,7 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
           timeseries={timeseries}
           releases={props.releases}
           aliases={props.aliases}
+          stacked={props.stacked}
           dataCompletenessDelay={props.dataCompletenessDelay}
           timeseriesSelection={props.timeseriesSelection}
           onTimeseriesSelectionChange={props.onTimeseriesSelectionChange}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -56,6 +56,7 @@ export interface TimeSeriesWidgetVisualizationProps {
   dataCompletenessDelay?: number;
   onTimeseriesSelectionChange?: (selection: TimeseriesSelection) => void;
   releases?: Release[];
+  stacked?: boolean;
   timeseriesSelection?: TimeseriesSelection;
 }
 
@@ -150,7 +151,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     // For bar charts, convert straight from time series to series, which will
     // automatically mark "delayed" bars
     markedSeries.forEach(timeSeries => {
-      plottableSeries.push(BarChartWidgetSeries(timeSeries));
+      plottableSeries.push(
+        BarChartWidgetSeries(timeSeries, props.stacked ? GLOBAL_STACK_NAME : undefined)
+      );
     });
   } else {
     // For line and area charts, split each time series into two series, each
@@ -329,3 +332,5 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     />
   );
 }
+
+const GLOBAL_STACK_NAME = 'time-series-visualization-widget-stack';


### PR DESCRIPTION
New prop for `BarChartWidget`, it accepts `stacked`. If passed, stacks the bars. Otherwise does not!

**e.g.,**
<img width="982" alt="Screenshot 2025-02-07 at 5 00 00 PM" src="https://github.com/user-attachments/assets/007fb69b-801e-433b-9de6-8c6ee79515ac" />
