### PR TITLE
fix(invite): add note informing users not to share member invite emails

### DIFF
--- a/fixtures/emails/invitation.txt
+++ b/fixtures/emails/invitation.txt
@@ -6,4 +6,6 @@ Join your team by visiting the following url:
 
     http://testserver/accept/1/None/
 
+Do not share this invite email or link. This invite is unique to you. Sharing may result in unauthorized access.
+
 Check out the Sentry website (https://sentry.io) if you'd like to learn more before diving in.

--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -11,10 +11,7 @@
 
     <p>Check out the <a href="https://sentry.io/">Sentry website</a> if you'd like to learn more before diving in.</p>
 
-    <div class="notice">
-        Do <strong>not</strong> share this invite email or link. This invite is unique to you.
-        Sharing may result in unauthorized access.
-    </div>
+    <div class="notice">Do <strong>not</strong> share this invite email or link. This invite is unique to you. Sharing may result in unauthorized access.</div>
 {% endblock %}
 
 {% block footer %}

--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -10,6 +10,11 @@
     <p><a href="{{ url }}" class="btn">Join your team</a></p>
 
     <p>Check out the <a href="https://sentry.io/">Sentry website</a> if you'd like to learn more before diving in.</p>
+
+    <div class="notice">
+        Do <strong>not</strong> share this invite email or link. This invite is unique to you.
+        Sharing may result in unauthorized access.
+    </div>
 {% endblock %}
 
 {% block footer %}

--- a/src/sentry/templates/sentry/emails/member-invite.txt
+++ b/src/sentry/templates/sentry/emails/member-invite.txt
@@ -6,7 +6,7 @@ Join your team by visiting the following url:
 
     {{ url }}
 
-Do <strong>not</strong> share this invite email or link. This invite is unique to you.
+Do not share this invite email or link. This invite is unique to you.
 Sharing may result in unauthorized access.
 
 Check out the Sentry website (https://sentry.io) if you'd like to learn more before diving in.

--- a/src/sentry/templates/sentry/emails/member-invite.txt
+++ b/src/sentry/templates/sentry/emails/member-invite.txt
@@ -6,7 +6,6 @@ Join your team by visiting the following url:
 
     {{ url }}
 
-Do not share this invite email or link. This invite is unique to you.
-Sharing may result in unauthorized access.
+Do not share this invite email or link. This invite is unique to you. Sharing may result in unauthorized access.
 
 Check out the Sentry website (https://sentry.io) if you'd like to learn more before diving in.

--- a/src/sentry/templates/sentry/emails/member-invite.txt
+++ b/src/sentry/templates/sentry/emails/member-invite.txt
@@ -6,4 +6,7 @@ Join your team by visiting the following url:
 
     {{ url }}
 
+Do <strong>not</strong> share this invite email or link. This invite is unique to you.
+Sharing may result in unauthorized access.
+
 Check out the Sentry website (https://sentry.io) if you'd like to learn more before diving in.


### PR DESCRIPTION
Users should avoid sharing their invite links/emails as they are unique to them and allow signing up in the organization. Our email should inform them of this.