### PR TITLE
ref(aci): skip translating EveryEventCondition

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -26,7 +26,7 @@ from sentry.rules.filters.latest_release import LatestReleaseFilter
 from sentry.rules.filters.level import LevelFilter
 from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.rules.match import MatchType
-from sentry.utils.registry import NoRegistrationExistsError, Registry
+from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
 
@@ -35,24 +35,28 @@ data_condition_translator_registry = Registry[
 ](enable_reverse_lookup=False)
 
 
-def translate_to_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
-) -> DataCondition | None:
-    try:
-        translator = data_condition_translator_registry.get(data["id"])
-    except NoRegistrationExistsError:
-        if data["id"] == EveryEventCondition.id:
-            return None
-        raise
-
+def translate_to_data_condition(data: dict[str, Any], dcg: DataConditionGroup) -> DataCondition:
+    translator = data_condition_translator_registry.get(data["id"])
     return translator(data, dcg)
+
+
+@data_condition_translator_registry.register(EveryEventCondition.id)
+def create_every_event_data_condition(
+    data: dict[str, Any], dcg: DataConditionGroup
+) -> DataCondition:
+    return DataCondition(
+        type=Condition.EVERY_EVENT,
+        comparison=True,
+        condition_result=True,
+        condition_group=dcg,
+    )
 
 
 @data_condition_translator_registry.register(ReappearedEventCondition.id)
 def create_reappeared_event_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.REAPPEARED_EVENT,
         comparison=True,
         condition_result=True,
@@ -64,7 +68,7 @@ def create_reappeared_event_data_condition(
 def create_regression_event_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.REGRESSION_EVENT,
         comparison=True,
         condition_result=True,
@@ -76,7 +80,7 @@ def create_regression_event_data_condition(
 def create_existing_high_priority_issue_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.EXISTING_HIGH_PRIORITY_ISSUE,
         comparison=True,
         condition_result=True,
@@ -95,7 +99,7 @@ def create_event_attribute_data_condition(
         "attribute": data["attribute"],
     }
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.EVENT_ATTRIBUTE,
         comparison=comparison,
         condition_result=True,
@@ -107,7 +111,7 @@ def create_event_attribute_data_condition(
 def create_first_seen_event_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.FIRST_SEEN_EVENT,
         comparison=True,
         condition_result=True,
@@ -119,7 +123,7 @@ def create_first_seen_event_data_condition(
 def create_new_high_priority_issue_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.NEW_HIGH_PRIORITY_ISSUE,
         comparison=True,
         condition_result=True,
@@ -132,7 +136,7 @@ def create_new_high_priority_issue_data_condition(
 def create_level_data_condition(data: dict[str, Any], dcg: DataConditionGroup) -> DataCondition:
     comparison = {"match": data["match"], "level": data["level"]}
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.LEVEL,
         comparison=comparison,
         condition_result=True,
@@ -152,7 +156,7 @@ def create_tagged_event_data_condition(
     if comparison["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
         comparison["value"] = data["value"]
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.TAGGED_EVENT,
         comparison=comparison,
         condition_result=True,
@@ -170,7 +174,7 @@ def create_age_comparison_data_condition(
         "time": data["time"],
     }
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.AGE_COMPARISON,
         comparison=comparison,
         condition_result=True,
@@ -187,7 +191,7 @@ def create_assigned_to_data_condition(
         "target_identifier": data["targetIdentifier"],
     }
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.ASSIGNED_TO,
         comparison=comparison,
         condition_result=True,
@@ -203,7 +207,7 @@ def create_issue_category_data_condition(
         "value": data["value"],
     }
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.ISSUE_CATEGORY,
         comparison=comparison,
         condition_result=True,
@@ -219,7 +223,7 @@ def create_issue_occurrences_data_condition(
         "value": data["value"],
     }
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.ISSUE_OCCURRENCES,
         comparison=comparison,
         condition_result=True,
@@ -231,7 +235,7 @@ def create_issue_occurrences_data_condition(
 def create_latest_release_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.LATEST_RELEASE,
         comparison=True,
         condition_result=True,
@@ -248,7 +252,7 @@ def create_latest_adopted_release_data_condition(
         "age_comparison": data["older_or_newer"],
         "environment": data["environment"],
     }
-    return DataCondition.objects.create(
+    return DataCondition(
         type=Condition.LATEST_ADOPTED_RELEASE,
         comparison=comparison,
         condition_result=True,
@@ -271,7 +275,7 @@ def create_base_event_frequency_data_condition(
         type = percent_type
         comparison["comparison_interval"] = data["comparisonInterval"]
 
-    return DataCondition.objects.create(
+    return DataCondition(
         type=type,
         comparison=comparison,
         condition_result=True,

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -40,6 +40,7 @@ class Condition(models.TextChoices):
     REAPPEARED_EVENT = "reappeared_event"
     TAGGED_EVENT = "tagged_event"
     ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
+    EVERY_EVENT = "every_event"  # skipped
 
     # Event frequency conditions
     EVENT_FREQUENCY_COUNT = "event_frequency_count"

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -14,7 +14,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 @freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0))
 class TestAgeComparisonCondition(ConditionTestCase):
     condition = Condition.AGE_COMPARISON
-    rule_cls = AgeComparisonFilter
     payload = {
         "id": AgeComparisonFilter.id,
         "comparison_type": AgeComparisonType.OLDER,

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -45,6 +45,7 @@ class TestAgeComparisonCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -45,7 +45,6 @@ class TestAgeComparisonCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -10,7 +10,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestAssignedToCondition(ConditionTestCase):
     condition = Condition.ASSIGNED_TO
-    rule_cls = AssignedToFilter
     payload = {
         "id": AssignedToFilter.id,
         "targetType": "Member",

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -35,7 +35,6 @@ class TestAssignedToCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -35,6 +35,7 @@ class TestAssignedToCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -30,7 +30,7 @@ class ConditionTestCase(BaseWorkflowTest):
 
     def translate_to_data_condition(
         self, data: dict[str, Any], dcg: DataConditionGroup
-    ) -> DataCondition | None:
+    ) -> DataCondition:
         return dual_write_condition(data, dcg)
 
     def assert_passes(self, data_condition: DataCondition, job: WorkflowJob) -> None:

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -30,7 +30,7 @@ class ConditionTestCase(BaseWorkflowTest):
 
     def translate_to_data_condition(
         self, data: dict[str, Any], dcg: DataConditionGroup
-    ) -> DataCondition:
+    ) -> DataCondition | None:
         return dual_write_condition(data, dcg)
 
     def assert_passes(self, data_condition: DataCondition, job: WorkflowJob) -> None:

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -129,6 +129,7 @@ class TestEventAttributeCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -143,6 +144,7 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.payload["id"] = EventAttributeFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -129,7 +129,6 @@ class TestEventAttributeCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -144,7 +143,6 @@ class TestEventAttributeCondition(ConditionTestCase):
         self.payload["id"] = EventAttributeFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -41,6 +41,7 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
     def test_dual_write_count(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -106,6 +107,7 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
     def test_dual_write_percent(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
@@ -2,13 +2,12 @@ from sentry.rules.conditions.every_event import EveryEventCondition
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
-class TestFirstSeenEventCondition(ConditionTestCase):
+class TestEveryEventCondition(ConditionTestCase):
     payload = {"id": EveryEventCondition.id}
 
     def test_dual_write(self):
         # skip translating every event condition
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc is None

--- a/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
@@ -9,5 +9,6 @@ class TestFirstSeenEventCondition(ConditionTestCase):
         # skip translating every event condition
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc is None

--- a/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
@@ -1,4 +1,5 @@
 from sentry.rules.conditions.every_event import EveryEventCondition
+from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
 
@@ -6,8 +7,10 @@ class TestEveryEventCondition(ConditionTestCase):
     payload = {"id": EveryEventCondition.id}
 
     def test_dual_write(self):
-        # skip translating every event condition
+        # we will create the object but not write to the db
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
 
-        assert dc is None
+        assert dc.type == Condition.EVERY_EVENT
+        assert dc.comparison is True
+        assert dc.condition_result is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_every_event.py
@@ -1,0 +1,13 @@
+from sentry.rules.conditions.every_event import EveryEventCondition
+from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
+
+
+class TestFirstSeenEventCondition(ConditionTestCase):
+    payload = {"id": EveryEventCondition.id}
+
+    def test_dual_write(self):
+        # skip translating every event condition
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc is None

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -11,7 +11,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestExistingHighPriorityIssueCondition(ConditionTestCase):
     condition = Condition.EXISTING_HIGH_PRIORITY_ISSUE
-    rule_cls = ExistingHighPriorityIssueCondition
     payload = {"id": ExistingHighPriorityIssueCondition.id}
 
     def setUp(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -40,6 +40,7 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -40,7 +40,6 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -11,7 +11,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestFirstSeenEventCondition(ConditionTestCase):
     condition = Condition.FIRST_SEEN_EVENT
-    rule_cls = FirstSeenEventCondition
     payload = {"id": FirstSeenEventCondition.id}
 
     def setUp(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -38,7 +38,6 @@ class TestFirstSeenEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -38,6 +38,7 @@ class TestFirstSeenEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -12,7 +12,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestIssueCategoryCondition(ConditionTestCase):
     condition = Condition.ISSUE_CATEGORY
-    rule_cls = IssueCategoryFilter
     payload = {
         "id": IssueCategoryFilter.id,
         "value": 1,

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -35,7 +35,6 @@ class TestIssueCategoryCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -35,6 +35,7 @@ class TestIssueCategoryCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -9,7 +9,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestIssueOccurrencesCondition(ConditionTestCase):
     condition = Condition.ISSUE_OCCURRENCES
-    rule_cls = IssueOccurrencesFilter
     payload = {
         "id": IssueOccurrencesFilter.id,
         "value": 10,

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -33,7 +33,6 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -33,6 +33,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -20,7 +20,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestLatestAdoptedReleaseCondition(ConditionTestCase):
     condition = Condition.LATEST_ADOPTED_RELEASE
-    rule_cls = LatestAdoptedReleaseFilter
     payload = {
         "id": LatestAdoptedReleaseFilter.id,
         "oldest_or_newest": "oldest",

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -80,7 +80,6 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -80,6 +80,7 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -18,7 +18,6 @@ pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
 
 class TestLatestReleaseCondition(ConditionTestCase):
     condition = Condition.LATEST_RELEASE
-    rule_cls = LatestReleaseFilter
     payload = {
         "id": LatestReleaseFilter.id,
     }

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -38,6 +38,7 @@ class TestLatestReleaseCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -38,7 +38,6 @@ class TestLatestReleaseCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -2,6 +2,7 @@ import pytest
 from jsonschema import ValidationError
 
 from sentry.rules.conditions.level import LevelCondition
+from sentry.rules.filters.level import LevelFilter
 from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowJob
@@ -10,7 +11,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestLevelCondition(ConditionTestCase):
     condition = Condition.LEVEL
-    rule_cls = LevelCondition
     payload = {
         "id": LevelCondition.id,
         "match": MatchType.EQUAL,
@@ -38,6 +38,19 @@ class TestLevelCondition(ConditionTestCase):
         )
 
     def test_dual_write(self):
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison == {
+            "match": MatchType.EQUAL,
+            "level": 20,
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
+    def test_dual_write_filter(self):
+        self.payload["id"] = LevelFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -40,6 +40,7 @@ class TestLevelCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -53,6 +54,7 @@ class TestLevelCondition(ConditionTestCase):
         self.payload["id"] = LevelFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -40,7 +40,6 @@ class TestLevelCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -54,7 +53,6 @@ class TestLevelCondition(ConditionTestCase):
         self.payload["id"] = LevelFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -12,7 +12,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestNewHighPriorityIssueCondition(ConditionTestCase):
     condition = Condition.NEW_HIGH_PRIORITY_ISSUE
-    rule_cls = NewHighPriorityIssueCondition
     payload = {"id": NewHighPriorityIssueCondition.id}
 
     def setUp(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -39,6 +39,7 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -39,7 +39,6 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -9,7 +9,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestReappearedEventCondition(ConditionTestCase):
     condition = Condition.REAPPEARED_EVENT
-    rule_cls = ReappearedEventCondition
     payload = {"id": ReappearedEventCondition.id}
 
     def test_dual_write(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -14,7 +14,6 @@ class TestReappearedEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -14,6 +14,7 @@ class TestReappearedEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -10,7 +10,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestRegressionEventCondition(ConditionTestCase):
     condition = Condition.REGRESSION_EVENT
-    rule_cls = RegressionEventCondition
     payload = {"id": RegressionEventCondition.id}
 
     def test_dual_write(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -15,6 +15,7 @@ class TestRegressionEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -15,7 +15,6 @@ class TestRegressionEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison is True

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -47,7 +47,6 @@ class TestTaggedEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -65,7 +64,6 @@ class TestTaggedEventCondition(ConditionTestCase):
         }
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -79,7 +77,6 @@ class TestTaggedEventCondition(ConditionTestCase):
         self.payload["id"] = TaggedEventFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -97,7 +94,6 @@ class TestTaggedEventCondition(ConditionTestCase):
         }
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
-        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -47,6 +47,7 @@ class TestTaggedEventCondition(ConditionTestCase):
     def test_dual_write(self):
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -64,6 +65,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         }
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -77,6 +79,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         self.payload["id"] = TaggedEventFilter.id
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -94,6 +97,7 @@ class TestTaggedEventCondition(ConditionTestCase):
         }
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)
+        assert dc
 
         assert dc.type == self.condition
         assert dc.comparison == {


### PR DESCRIPTION
`EveryEventCondition` won't be translated.

if you have an ALL `DataConditionGroup` with `EveryEventCondition`, `EveryEventCondition` will always be true, so the result of the DCG will depend on the other conditions in the DCG -- removing it does not impact the evaluation.

If you have an ANY `DataConditionGroup` with `EveryEventCondition`, it will always fire, but any other conditions in the ANY will be ignored. We're still removing `EveryEventCondition` in this case.