### PR TITLE
ref(workflow_engine): Refactor the model.TextChoices to be StrEnums

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from django.db import models
@@ -28,7 +29,7 @@ class Action(DefaultFieldsModel):
     __relocation_scope__ = RelocationScope.Excluded
     __repr__ = sane_repr("id", "type")
 
-    class Type(models.TextChoices):
+    class Type(StrEnum):
         SLACK = "slack"
         MSTEAMS = "msteams"
         DISCORD = "discord"
@@ -49,7 +50,7 @@ class Action(DefaultFieldsModel):
         WEBHOOK = "webhook"
 
     # The type field is used to denote the type of action we want to trigger
-    type = models.TextField(choices=Type.choices)
+    type = models.TextField(choices=[(t.value, t.value) for t in Type])
     data = models.JSONField(default=dict)
 
     # LEGACY: The integration_id is used to map the integration_id found in the AlertRuleTriggerAction

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -1,5 +1,6 @@
 import logging
 import operator
+from enum import StrEnum
 from typing import Any, TypeVar, cast
 
 from django.db import models
@@ -16,7 +17,7 @@ from sentry.workflow_engine.types import DataConditionResult, DetectorPriorityLe
 logger = logging.getLogger(__name__)
 
 
-class Condition(models.TextChoices):
+class Condition(StrEnum):
     EQUAL = "eq"
     GREATER_OR_EQUAL = "gte"
     GREATER = "gt"
@@ -99,7 +100,9 @@ class DataCondition(DefaultFieldsModel):
     condition_result = models.JSONField()
 
     # The type of condition, this is used to initialize the condition classes
-    type = models.CharField(max_length=200, choices=Condition.choices, default=Condition.EQUAL)
+    type = models.CharField(
+        max_length=200, choices=[(t.value, t.value) for t in Condition], default=Condition.EQUAL
+    )
 
     condition_group = models.ForeignKey(
         "workflow_engine.DataConditionGroup",

--- a/src/sentry/workflow_engine/models/data_condition_group.py
+++ b/src/sentry/workflow_engine/models/data_condition_group.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import ClassVar, Self
 
 from django.db import models
@@ -20,7 +21,7 @@ class DataConditionGroup(DefaultFieldsModel):
     __relocation_scope__ = RelocationScope.Organization
     __repr__ = sane_repr("logic_type")
 
-    class Type(models.TextChoices):
+    class Type(StrEnum):
         # ANY will evaluate all conditions, and return true if any of those are met
         ANY = "any"
 
@@ -33,7 +34,9 @@ class DataConditionGroup(DefaultFieldsModel):
         # NONE will return true if none of the conditions are met, will return false immediately if any are met
         NONE = "none"
 
-    logic_type = models.CharField(max_length=200, choices=Type.choices, default=Type.ANY)
+    logic_type = models.CharField(
+        max_length=200, choices=[(t.value, t.value) for t in Type], default=Type.ANY
+    )
     organization = models.ForeignKey("sentry.Organization", on_delete=models.CASCADE)
 
 


### PR DESCRIPTION
# Description
The TextChoices seem difficult to turn into mypy types for methods; changing them to str enums makes them work the same as the text choices (Except for the `choices` on the model, which is updated to work).

_Upcoming PR_ - Update places we're using `str` instead of these enums.