### PR TITLE
feat(releases): add error free session rate chart to frontend insights

### DIFF
--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -1,0 +1,33 @@
+import {t} from 'sentry/locale';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import useErrorFreeSessions from 'sentry/views/insights/sessions/queries/useErrorFreeSessions';
+
+export default function ErrorFreeSessionsChart() {
+  const {seriesData, isPending, error} = useErrorFreeSessions();
+
+  return (
+    <InsightsLineChartWidget
+      title={t('Error Free Session Rate')}
+      aliases={{
+        successful_session_rate: t('Error free session rate'),
+      }}
+      series={[
+        {
+          data: seriesData,
+          seriesName: 'successful_session_rate',
+          meta: {
+            fields: {
+              successful_session_rate: 'percentage',
+              time: 'date',
+            },
+            units: {
+              successful_session_rate: '%',
+            },
+          },
+        },
+      ]}
+      isLoading={isPending}
+      error={error}
+    />
+  );
+}

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -1,0 +1,65 @@
+import type {SessionApiResponse} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useErrorFreeSessions() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {
+    data: sessionsData,
+    isPending,
+    error,
+  } = useApiQuery<SessionApiResponse>(
+    [
+      `/organizations/${organization.slug}/sessions/`,
+      {query: {...location.query, field: ['sum(session)'], groupBy: ['session.status']}},
+    ],
+    {staleTime: 0}
+  );
+
+  if (isPending) {
+    return {
+      seriesData: [],
+      isPending: true,
+      error,
+    };
+  }
+
+  if (!sessionsData && !isPending) {
+    return {
+      seriesData: [],
+      isPending: false,
+      error,
+    };
+  }
+
+  // Get the healthy sessions series data
+  const healthySessionsSeries =
+    sessionsData.groups.find(group => group.by['session.status'] === 'healthy')?.series[
+      'sum(session)'
+    ] ?? [];
+
+  // Calculate total sessions for each interval
+  const totalSessionsByInterval = sessionsData.groups[0]?.series['sum(session)']?.map(
+    (_, intervalIndex) =>
+      sessionsData.groups.reduce(
+        (acc, group) => acc + (group.series['sum(session)']?.[intervalIndex] ?? 0),
+        0
+      )
+  );
+
+  // Calculate percentage for each interval
+  const healthySessionsPercentageData = healthySessionsSeries.map((healthyCount, idx) => {
+    const total = totalSessionsByInterval?.[idx] ?? 1;
+    return total > 0 ? healthyCount / total : 0;
+  });
+
+  return {
+    seriesData: healthySessionsPercentageData.map((val, idx) => {
+      return {name: sessionsData.intervals[idx] ?? '', value: val};
+    }),
+    isPending,
+    error,
+  };
+}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import type {SessionApiResponse} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
-import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
@@ -18,10 +23,48 @@ export function SessionsOverview() {
   };
 
   const {view} = useDomainViewFilters();
+  const location = useLocation();
+  const organization = useOrganization();
+  const {
+    data: sessionsData,
+    isPending,
+    error,
+  } = useApiQuery<SessionApiResponse>(
+    [
+      `/organizations/${organization.slug}/sessions/`,
+      {query: {...location.query, field: ['sum(session)'], groupBy: ['session.status']}},
+    ],
+    {staleTime: 0}
+  );
+
+  if (!sessionsData) {
+    return null;
+  }
+
+  // Get the healthy sessions series data
+  const healthySessionsSeries =
+    sessionsData.groups.find(group => group.by['session.status'] === 'healthy')?.series[
+      'sum(session)'
+    ] ?? [];
+
+  // Calculate total sessions for each interval
+  const totalSessionsByInterval = sessionsData.groups[0]?.series['sum(session)']?.map(
+    (_, intervalIndex) =>
+      sessionsData.groups.reduce(
+        (acc, group) => acc + (group.series['sum(session)']?.[intervalIndex] ?? 0),
+        0
+      )
+  );
+
+  // Calculate percentage for each interval
+  const healthySessionsPercentageData = healthySessionsSeries.map((healthyCount, idx) => {
+    const total = totalSessionsByInterval?.[idx] ?? 1;
+    return total > 0 ? healthyCount / total : 0;
+  });
+
   return (
     <React.Fragment>
       {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
-
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
@@ -33,13 +76,30 @@ export function SessionsOverview() {
                 />
               </ToolRibbon>
             </ModuleLayout.Full>
-
-            <ModulesOnboarding moduleName={ModuleName.SESSIONS}>
-              {
-                // TODO: charts go here
-                null
-              }
-            </ModulesOnboarding>
+            <ModuleLayout.Third>
+              <InsightsLineChartWidget
+                title={t('Error Free Session Rate')}
+                series={[
+                  {
+                    data: healthySessionsPercentageData.map((val, idx) => {
+                      return {name: sessionsData.intervals[idx] ?? '', value: val};
+                    }),
+                    seriesName: 'Error free session rate',
+                    meta: {
+                      fields: {
+                        'Error free session rate': 'percentage',
+                        time: 'date',
+                      },
+                      units: {
+                        'Error free session rate': '%',
+                      },
+                    },
+                  },
+                ]}
+                isLoading={isPending}
+                error={error}
+              />
+            </ModuleLayout.Third>
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
 import * as Layout from 'sentry/components/layouts/thirds';
-import {t} from 'sentry/locale';
-import type {SessionApiResponse} from 'sentry/types/organization';
-import {useApiQuery} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -15,6 +9,7 @@ import SubregionSelector from 'sentry/views/insights/common/views/spans/selector
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export function SessionsOverview() {
@@ -23,44 +18,6 @@ export function SessionsOverview() {
   };
 
   const {view} = useDomainViewFilters();
-  const location = useLocation();
-  const organization = useOrganization();
-  const {
-    data: sessionsData,
-    isPending,
-    error,
-  } = useApiQuery<SessionApiResponse>(
-    [
-      `/organizations/${organization.slug}/sessions/`,
-      {query: {...location.query, field: ['sum(session)'], groupBy: ['session.status']}},
-    ],
-    {staleTime: 0}
-  );
-
-  if (!sessionsData) {
-    return null;
-  }
-
-  // Get the healthy sessions series data
-  const healthySessionsSeries =
-    sessionsData.groups.find(group => group.by['session.status'] === 'healthy')?.series[
-      'sum(session)'
-    ] ?? [];
-
-  // Calculate total sessions for each interval
-  const totalSessionsByInterval = sessionsData.groups[0]?.series['sum(session)']?.map(
-    (_, intervalIndex) =>
-      sessionsData.groups.reduce(
-        (acc, group) => acc + (group.series['sum(session)']?.[intervalIndex] ?? 0),
-        0
-      )
-  );
-
-  // Calculate percentage for each interval
-  const healthySessionsPercentageData = healthySessionsSeries.map((healthyCount, idx) => {
-    const total = totalSessionsByInterval?.[idx] ?? 1;
-    return total > 0 ? healthyCount / total : 0;
-  });
 
   return (
     <React.Fragment>
@@ -77,28 +34,7 @@ export function SessionsOverview() {
               </ToolRibbon>
             </ModuleLayout.Full>
             <ModuleLayout.Third>
-              <InsightsLineChartWidget
-                title={t('Error Free Session Rate')}
-                series={[
-                  {
-                    data: healthySessionsPercentageData.map((val, idx) => {
-                      return {name: sessionsData.intervals[idx] ?? '', value: val};
-                    }),
-                    seriesName: 'Error free session rate',
-                    meta: {
-                      fields: {
-                        'Error free session rate': 'percentage',
-                        time: 'date',
-                      },
-                      units: {
-                        'Error free session rate': '%',
-                      },
-                    },
-                  },
-                ]}
-                isLoading={isPending}
-                error={error}
-              />
+              <ErrorFreeSessionsChart />
             </ModuleLayout.Third>
           </ModuleLayout.Layout>
         </Layout.Main>


### PR DESCRIPTION

https://github.com/user-attachments/assets/dec0dc18-54d3-4126-b6e6-16ff490faf21

the full screen behavior after clicking on the legend is a bit janky but is consistent w/ other widgets in insights

relates to https://github.com/getsentry/team-replay/issues/540

