### PR TITLE
feat(autofix): Add markdown rendering to timeline titles

### DIFF
--- a/static/app/components/events/autofix/autofixTimeline.tsx
+++ b/static/app/components/events/autofix/autofixTimeline.tsx
@@ -78,7 +78,11 @@ export function AutofixTimeline({events, activeColor, getCustomIcon}: Props) {
                 isTruncated={isTruncated}
                 data-test-id={`autofix-root-cause-timeline-item-${index}`}
               >
-                {event.title}
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: singleLineRenderer(event.title),
+                  }}
+                />
                 {!isTruncated && (
                   <StyledIconChevron
                     direction={expandedItems.includes(index) ? 'down' : 'right'}


### PR DESCRIPTION
Render markdown in timeline titles.
<img width="597" alt="Screenshot 2025-02-09 at 12 04 57 PM" src="https://github.com/user-attachments/assets/596baf31-ee69-43f3-9bde-bb77acd31103" />
