### PR TITLE
ref(assemble): Remove old sequential assemble

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -15,7 +15,7 @@ from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
 
-from sentry import features, ratelimits
+from sentry import ratelimits
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -505,90 +505,11 @@ def batch_assemble(project, files):
         if file_info is None:
             continue
 
-        name, debug_id, chunks = file_info
-        assemble_dif.apply_async(
-            kwargs={
-                "project_id": project.id,
-                "name": name,
-                "debug_id": debug_id,
-                "checksum": checksum,
-                "chunks": chunks,
-            }
-        )
-
-        file_response[checksum] = {"state": ChunkFileState.CREATED, "missingChunks": []}
-
-    return file_response
-
-
-def sequential_assemble(project, files):
-    """
-    Performs assembling in a sequential fashion, issuing queries for each file, identified by its `checksum`.
-    """
-    file_response = {}
-
-    for checksum, file_to_assemble in files.items():
-        name = file_to_assemble.get("name", None)
-        debug_id = file_to_assemble.get("debug_id", None)
-        chunks = file_to_assemble.get("chunks", [])
-
-        # First, check the cached assemble status. During assembling, a
-        # ProjectDebugFile will be created and we need to prevent a race
-        # condition.
-        state, detail = get_assemble_status(AssembleTask.DIF, project.id, checksum)
-        if state == ChunkFileState.OK:
-            file_response[checksum] = {
-                "state": state,
-                "detail": None,
-                "missingChunks": [],
-                "dif": detail,
-            }
-            continue
-        elif state is not None:
-            file_response[checksum] = {"state": state, "detail": detail, "missingChunks": []}
-            continue
-
-        # Next, check if this project already owns the ProjectDebugFile.
-        # This can under rare circumstances yield more than one file
-        # which is why we use first() here instead of get().
-        dif = (
-            ProjectDebugFile.objects.filter(project_id=project.id, checksum=checksum)
-            .select_related("file")
-            .order_by("-id")
-            .first()
-        )
-
-        if dif is not None:
-            file_response[checksum] = {
-                "state": ChunkFileState.OK,
-                "detail": None,
-                "missingChunks": [],
-                "dif": serialize(dif),
-            }
-            continue
-
-        # There is neither a known file nor a cached state, so we will
-        # have to create a new file.  Assure that there are checksums.
-        # If not, we assume this is a poll and report NOT_FOUND
-        if not chunks:
-            file_response[checksum] = {"state": ChunkFileState.NOT_FOUND, "missingChunks": []}
-            continue
-
-        # Check if all requested chunks have been uploaded.
-        missing_chunks = find_missing_chunks(project.organization.id, chunks)
-        if missing_chunks:
-            file_response[checksum] = {
-                "state": ChunkFileState.NOT_FOUND,
-                "missingChunks": missing_chunks,
-            }
-            continue
-
         # We don't have a state yet, this means we can now start
         # an assemble job in the background.
         set_assemble_status(AssembleTask.DIF, project.id, checksum, ChunkFileState.CREATED)
 
-        from sentry.tasks.assemble import assemble_dif
-
+        name, debug_id, chunks = file_info
         assemble_dif.apply_async(
             kwargs={
                 "project_id": project.id,
@@ -647,16 +568,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
         except Exception:
             return Response({"error": "Invalid json body"}, status=400)
 
-        use_batch_assemble = features.has(
-            "organizations:batch-assemble-debug-files",
-            organization=project.organization,
-            actor=request.user,
-        )
-
-        if use_batch_assemble:
-            file_response = batch_assemble(project=project, files=files)
-        else:
-            file_response = sequential_assemble(project=project, files=files)
+        file_response = batch_assemble(project=project, files=files)
 
         return Response(file_response, status=200)
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -505,8 +505,8 @@ def batch_assemble(project, files):
         if file_info is None:
             continue
 
-        # We don't have a state yet, this means we can now start
-        # an assemble job in the background.
+        # We don't have a state yet, this means we can now start an assemble job in the background and mark
+        # this in the state.
         set_assemble_status(AssembleTask.DIF, project.id, checksum, ChunkFileState.CREATED)
 
         name, debug_id, chunks = file_info

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -483,13 +483,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:streamlined-publishing-flow", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Relay extracting logs from breadcrumbs for a project.
     manager.add("projects:ourlogs-breadcrumb-extraction", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable the new option to batch assemble debug files
-    manager.add(
-        "organizations:batch-assemble-debug-files",
-        OrganizationFeature,
-        FeatureHandlerStrategy.FLAGPOLE,
-        api_expose=False
-    )
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -20,7 +20,6 @@ from sentry.tasks.assemble import (
     set_assemble_status,
 )
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -37,7 +36,6 @@ class DifAssembleEndpoint(APITestCase):
             "sentry-api-0-assemble-dif-files", args=[self.organization.slug, self.project.slug]
         )
 
-    @with_feature("organizations:batch-assemble-debug-files")
     def test_assemble_json_schema(self):
         response = self.client.post(
             self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
@@ -65,7 +63,6 @@ class DifAssembleEndpoint(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data[checksum]["state"] == ChunkFileState.NOT_FOUND
 
-    @with_feature("organizations:batch-assemble-debug-files")
     def test_assemble_check(self):
         content = b"foo bar"
         fileobj = ContentFile(content)
@@ -141,7 +138,6 @@ class DifAssembleEndpoint(APITestCase):
         assert response.data[not_found_checksum]["state"] == ChunkFileState.NOT_FOUND
         assert set(response.data[not_found_checksum]["missingChunks"]) == {not_found_checksum}
 
-    @with_feature("organizations:batch-assemble-debug-files")
     @patch("sentry.tasks.assemble.assemble_dif")
     def test_assemble(self, mock_assemble_dif):
         content1 = b"foo"
@@ -213,7 +209,6 @@ class DifAssembleEndpoint(APITestCase):
         file_blob_index = FileBlobIndex.objects.all()
         assert len(file_blob_index) == 3
 
-    @with_feature("organizations:batch-assemble-debug-files")
     def test_dif_response(self):
         sym_file = self.load_fixture("crash.sym")
         blob1 = FileBlob.from_file(ContentFile(sym_file))
@@ -237,7 +232,6 @@ class DifAssembleEndpoint(APITestCase):
             response.data[total_checksum]["dif"]["uuid"] == "67e9247c-814e-392b-a027-dbde6748fcbf"
         )
 
-    @with_feature("organizations:batch-assemble-debug-files")
     def test_dif_error_response(self):
         sym_file = b"fail"
         blob1 = FileBlob.from_file(ContentFile(sym_file))


### PR DESCRIPTION
This PR removes the old `sequential_assemble` and the feature flag `organizations:batch-assemble-debug-files`. In addition, it also adds the `set_assemble_status` for each checksum which was missed in the previous refactor.

Given the code, the missing state creation of `set_assemble_status` would have led to unnecessary assemble async jobs to be triggered, but only in the case of failure to start the async task, since the task would immediately flip that status to `ASSEMBLING` if it started successfully.