### PR TITLE
fix(uptime): Styling fix on check timeline 

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -309,11 +309,11 @@ const TimeLabelContainer = styled('div')<{
   display: flex;
   align-items: center;
   height: 100%;
+  padding-left: ${space(1)};
   ${p =>
     p.labelPosition === 'center-bottom' &&
     // Skip the translation for the first label
     css`
-      padding-left: ${space(1)};
       transform: ${p.isFirst ? 'none' : 'translateX(-50%)'};
     `}
 `;

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -313,8 +313,9 @@ const TimeLabelContainer = styled('div')<{
   ${p =>
     p.labelPosition === 'center-bottom' &&
     // Skip the translation for the first label
+    !p.isFirst &&
     css`
-      transform: ${p.isFirst ? 'none' : 'translateX(-50%)'};
+      transform: translateX(-50%);
     `}
 `;
 


### PR DESCRIPTION
Fixes the padding on the left-top position grid line labels.

**left-top**
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/5982c24f-fba4-4ad6-aa7e-06d579f6048e" />


**center-bottom**
<img width="959" alt="image" src="https://github.com/user-attachments/assets/c8639c98-3f74-4a56-918f-7855c426b9e2" />
