### PR TITLE
fix(search-query): Start with empty input autocompleting arguments

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2841,7 +2841,17 @@ describe('SearchQueryBuilder', function () {
           name: 'Edit function parameters',
         });
         expect(input).toHaveFocus();
-        expect(input).toHaveValue('transaction.duration,');
+        expect(input).toHaveAttribute('placeholder', 'transaction.duration,');
+        expect(input).toHaveValue('');
+
+        await userEvent.click(
+          await screen.findByRole('option', {name: 'transaction.duration'})
+        );
+        await waitFor(() => {
+          expect(input).toHaveValue('transaction.duration');
+        });
+
+        await userEvent.keyboard(',');
 
         await userEvent.click(await screen.findByRole('option', {name: 'less'}));
         await waitFor(() => {
@@ -2894,11 +2904,6 @@ describe('SearchQueryBuilder', function () {
         await userEvent.click(
           screen.getByRole('button', {name: 'Edit parameters for filter: count_if'})
         );
-        const input = await screen.findByRole('combobox', {
-          name: 'Edit function parameters',
-        });
-
-        await userEvent.clear(input);
         await userEvent.keyboard('a,b,c{enter}');
 
         expect(

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -177,10 +177,18 @@ export function SearchQueryBuilderParametersCombobox({
 }: ParametersComboboxProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const {dispatch} = useSearchQueryBuilder();
-  const [inputValue, setInputValue] = useState(() => getInitialInputValue(token));
+  const initialValue = getInitialInputValue(token);
+  const [inputValue, setInputValue] = useState('');
+  const [inputChanged, setInputChanged] = useState(false);
+
+  function updateInputValue(value: string) {
+    setInputValue(value);
+    setInputChanged(true);
+  }
+
   const {selectionIndex, updateSelectionIndex} = useSelectionIndex({
     inputRef,
-    inputValue,
+    inputValue: initialValue,
   });
 
   const {parameterIndex, textValue: filterValue} = getParameterAtCursorPosition(
@@ -202,11 +210,17 @@ export function SearchQueryBuilderParametersCombobox({
 
   const handleInputValueConfirmed = useCallback(
     (value: string) => {
-      dispatch({type: 'UPDATE_AGGREGATE_ARGS', token, value});
+      if (inputChanged) {
+        dispatch({
+          type: 'UPDATE_AGGREGATE_ARGS',
+          token,
+          value,
+        });
 
-      onCommit();
+        onCommit();
+      }
     },
-    [dispatch, onCommit, token]
+    [inputChanged, dispatch, onCommit, token]
   );
 
   const handleOptionSelected = useCallback(
@@ -222,7 +236,7 @@ export function SearchQueryBuilderParametersCombobox({
         token,
         value: newValue,
       });
-      setInputValue(newValue);
+      updateInputValue(newValue);
       const newCursorPosition = getCursorPositionAtEndOfParameter(
         newValue,
         parameterIndex
@@ -239,6 +253,7 @@ export function SearchQueryBuilderParametersCombobox({
     <SearchQueryBuilderCombobox
       ref={inputRef}
       items={items}
+      placeholder={initialValue}
       onOptionSelected={handleOptionSelected}
       onCustomValueBlurred={handleInputValueConfirmed}
       onCustomValueCommitted={handleInputValueConfirmed}
@@ -247,7 +262,7 @@ export function SearchQueryBuilderParametersCombobox({
       filterValue={filterValue}
       token={token}
       inputLabel={t('Edit function parameters')}
-      onInputChange={e => setInputValue(e.target.value)}
+      onInputChange={e => updateInputValue(e.target.value)}
       onKeyDown={onKeyDown}
       onKeyUp={updateSelectionIndex}
       onClick={updateSelectionIndex}


### PR DESCRIPTION
In the search query builder, to change the argument of an aggregate, you have to first click on the argument which turns it into an input. When this happens, the input is already prepopulated with the previous selection. This results in the suggestions only showing the selected argument.

This change starts the input in an empty state which allows them to see all possible suggestions immediately. If no changes were made, the argument will remain what it was.

# Preview

## Before

https://github.com/user-attachments/assets/0d93f525-9acd-425a-84d0-8147e23f01d2

## After

https://github.com/user-attachments/assets/beb0e158-bbff-44c3-83dc-5423ba052c7e



