### PR TITLE
 feat(new-trace): Updating copied text in drawer header

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.tsx
@@ -44,7 +44,8 @@ export function AutogroupNodeDetails(
               {t('Autogroup')}
             </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
-              text={`ID: ${node.value.span_id}`}
+              subTitle={`ID: ${node.value.span_id}`}
+              copyText={node.value.span_id}
             />
           </TraceDrawerComponents.LegacyTitleText>
         </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.tsx
@@ -45,7 +45,7 @@ export function AutogroupNodeDetails(
             </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
               subTitle={`ID: ${node.value.span_id}`}
-              copyText={node.value.span_id}
+              clipboardText={node.value.span_id}
             />
           </TraceDrawerComponents.LegacyTitleText>
         </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -47,7 +47,8 @@ export function ErrorNodeDetails(
               {t('Error')}
             </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
-              text={`ID: ${props.node.value.event_id}`}
+              subTitle={`ID: ${props.node.value.event_id}`}
+              copyText={props.node.value.event_id}
             />
           </TraceDrawerComponents.LegacyTitleText>
         </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -48,7 +48,7 @@ export function ErrorNodeDetails(
             </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
               subTitle={`ID: ${props.node.value.event_id}`}
-              copyText={props.node.value.event_id}
+              clipboardText={props.node.value.event_id}
             />
           </TraceDrawerComponents.LegacyTitleText>
         </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
@@ -49,8 +49,8 @@ export function MissingInstrumentationNodeDetails(
               {t('No Instrumentation')}
             </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
-              hideCopyButton
-              text={t('How Awkward')}
+              copyText=""
+              subTitle={t('How Awkward')}
             />
           </TraceDrawerComponents.LegacyTitleText>
         </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
@@ -49,7 +49,7 @@ export function MissingInstrumentationNodeDetails(
               {t('No Instrumentation')}
             </TraceDrawerComponents.TitleText>
             <TraceDrawerComponents.SubtitleWithCopyButton
-              copyText=""
+              clipboardText=""
               subTitle={t('How Awkward')}
             />
           </TraceDrawerComponents.LegacyTitleText>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -68,7 +68,8 @@ function SpanNodeDetailHeader({
         <TraceDrawerComponents.LegacyTitleText>
           <TraceDrawerComponents.TitleText>{t('Span')}</TraceDrawerComponents.TitleText>
           <TraceDrawerComponents.SubtitleWithCopyButton
-            text={`ID: ${node.value.span_id}`}
+            subTitle={`ID: ${node.value.span_id}`}
+            copyText={node.value.span_id}
           />
         </TraceDrawerComponents.LegacyTitleText>
       </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -69,7 +69,7 @@ function SpanNodeDetailHeader({
           <TraceDrawerComponents.TitleText>{t('Span')}</TraceDrawerComponents.TitleText>
           <TraceDrawerComponents.SubtitleWithCopyButton
             subTitle={`ID: ${node.value.span_id}`}
-            copyText={node.value.span_id}
+            clipboardText={node.value.span_id}
           />
         </TraceDrawerComponents.LegacyTitleText>
       </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -140,21 +140,21 @@ function TitleWithTestId(props: PropsWithChildren<{}>) {
 }
 
 function SubtitleWithCopyButton({
-  text,
-  hideCopyButton = false,
+  subTitle,
+  copyText,
 }: {
-  text: string;
-  hideCopyButton?: boolean;
+  copyText: string;
+  subTitle: string;
 }) {
   return (
     <SubTitleWrapper>
-      <StyledSubTitleText>{text}</StyledSubTitleText>
-      {!hideCopyButton ? (
+      <StyledSubTitleText>{subTitle}</StyledSubTitleText>
+      {copyText ? (
         <CopyToClipboardButton
           borderless
           size="zero"
           iconSize="xs"
-          text={text}
+          text={copyText}
           tooltipProps={{disabled: true}}
         />
       ) : null}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -141,20 +141,20 @@ function TitleWithTestId(props: PropsWithChildren<{}>) {
 
 function SubtitleWithCopyButton({
   subTitle,
-  copyText,
+  clipboardText,
 }: {
-  copyText: string;
+  clipboardText: string;
   subTitle: string;
 }) {
   return (
     <SubTitleWrapper>
       <StyledSubTitleText>{subTitle}</StyledSubTitleText>
-      {copyText ? (
+      {clipboardText ? (
         <CopyToClipboardButton
           borderless
           size="zero"
           iconSize="xs"
-          text={copyText}
+          text={clipboardText}
           tooltipProps={{disabled: true}}
         />
       ) : null}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -92,7 +92,8 @@ function TransactionNodeDetailHeader({
             {t('Transaction')}
           </TraceDrawerComponents.TitleText>
           <TraceDrawerComponents.SubtitleWithCopyButton
-            text={`ID: ${node.value.event_id}`}
+            subTitle={`ID: ${node.value.event_id}`}
+            copyText={node.value.event_id}
           />
         </TraceDrawerComponents.LegacyTitleText>
       </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -93,7 +93,7 @@ function TransactionNodeDetailHeader({
           </TraceDrawerComponents.TitleText>
           <TraceDrawerComponents.SubtitleWithCopyButton
             subTitle={`ID: ${node.value.event_id}`}
-            copyText={node.value.event_id}
+            clipboardText={node.value.event_id}
           />
         </TraceDrawerComponents.LegacyTitleText>
       </TraceDrawerComponents.Title>


### PR DESCRIPTION
We were copying `ID: abdf2` when we should just be copying `abdf2`