### PR TITLE
fix(widget-builder): Update positioning of tooltip when children change

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -51,8 +51,18 @@ function Tooltip({
 }: TooltipProps) {
   const {container} = useContext(TooltipContext);
   const theme = useTheme();
-  const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps, reset} =
-    useHoverOverlay('tooltip', hoverOverlayProps);
+  const {
+    wrapTrigger,
+    isOpen,
+    overlayProps,
+    placement,
+    arrowData,
+    arrowProps,
+    reset,
+    update,
+  } = useHoverOverlay('tooltip', hoverOverlayProps);
+
+  const {forceVisible} = hoverOverlayProps;
 
   // Reset the visibility when the tooltip becomes disabled
   useEffect(() => {
@@ -60,6 +70,13 @@ function Tooltip({
       reset();
     }
   }, [reset, disabled]);
+
+  // Update the tooltip when the tooltip is forced to be visible and the children change
+  useEffect(() => {
+    if (update && forceVisible) {
+      update();
+    }
+  }, [update, children, forceVisible]);
 
   if (disabled || !title) {
     return <Fragment>{children}</Fragment>;


### PR DESCRIPTION
Noticed that when the height of the preview changes the tooltip doesn't change position with it. This is because the tooltips position is fixed and when this happens (when the tooltip is forced visible) it is not updating the position automatically. I put in a `useEffect` to update the tooltip if the tooltip trigger children have changed.

Here's a before and after:

**Before**

https://github.com/user-attachments/assets/a5ab02d6-5b9d-480c-81fb-1d2e2ea7c9a3

**After**

https://github.com/user-attachments/assets/d84be46c-7141-4c6c-b15f-e283a6f689e9
