### PR TITLE
fix(insights): link from cache module widget broken

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -692,7 +692,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           const cacheMissRate = listItem[fieldString] as any;
 
           const target = normalizeUrl(
-            `/${moduleRoute}/?${qs.stringify({transaction, project: listItem['project.id']})}`
+            `${moduleRoute}/?${qs.stringify({transaction, project: listItem['project.id']})}`
           );
 
           return (


### PR DESCRIPTION
Fixes a bug where clicking a transaction from the cache module widget resulted in an invalid url. (double slash `//insights/backend/caches` instead of `/insights/backend/caches`)

This was a regression from https://github.com/getsentry/sentry/pull/84538 
In that PR we removed bare=true, which means that the url returned from `moduleUrlBuilder` is now prepended with a `/`, in this PR we remove the extra slash.