### PR TITLE
feat(insights): remove navigation and pageload ops from mobile view

### DIFF
--- a/static/app/views/insights/pages/mobile/settings.ts
+++ b/static/app/views/insights/pages/mobile/settings.ts
@@ -14,9 +14,6 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'ui.action',
   'ui.load',
   'app.lifecycle',
-  // navigation and pageload are seen in react-native
-  'navigation',
-  'pageload',
 ];
 
 export const MODULES = [


### PR DESCRIPTION
work for #84021 

Removes the `pageload` and `navigation` filter from the mobile views. This filter is duplicated between the frontend and mobile, which means you will see mobile transactions on the frontend page. Now that we filter domain view pages by SDK (see https://github.com/getsentry/sentry/pull/84646) we don't need this because all mobile SDKs that generate these transaction ops, are accounted for.

