### PR TITLE
fix(crons): Move GuideAnchor to header

### DIFF
--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -4,6 +4,7 @@ import * as qs from 'query-string';
 
 import {openBulkEditMonitorsModal} from 'sentry/actionCreators/modal';
 import {deleteProjectProcessingErrorByType} from 'sentry/actionCreators/monitors';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -110,7 +111,7 @@ function CronsOverview() {
       <BackendHeader
         headerTitle={
           <Fragment>
-            {MODULE_TITLE}
+            <GuideAnchor target="crons_backend_insights">{MODULE_TITLE}</GuideAnchor>
             <PageHeadingQuestionTooltip
               docsUrl={MODULE_DOC_LINK}
               title={MODULE_DESCRIPTION}

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
@@ -18,7 +17,7 @@ import {
 } from 'sentry/views/insights/common/utils/useModuleURL';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {isModuleEnabled, isModuleVisible} from 'sentry/views/insights/pages/utils';
-import {ModuleName} from 'sentry/views/insights/types';
+import type {ModuleName} from 'sentry/views/insights/types';
 
 export type Props = {
   domainBaseUrl: string;
@@ -75,7 +74,7 @@ export function DomainViewHeader({
       .filter(moduleName => isModuleVisible(moduleName, organization))
       .map(moduleName => ({
         key: moduleName,
-        children: <TabLabel moduleName={moduleName} isActive={tabValue === moduleName} />,
+        children: <TabLabel moduleName={moduleName} />,
         to: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
       })),
   ];
@@ -109,11 +108,10 @@ export function DomainViewHeader({
 }
 
 interface TabLabelProps {
-  isActive: boolean;
   moduleName: ModuleName;
 }
 
-function TabLabel({moduleName, isActive}: TabLabelProps) {
+function TabLabel({moduleName}: TabLabelProps) {
   const moduleTitles = useModuleTitles();
   const organization = useOrganization();
   const showBusinessIcon = !isModuleEnabled(moduleName, organization);
@@ -123,15 +121,6 @@ function TabLabel({moduleName, isActive}: TabLabelProps) {
         {moduleTitles[moduleName]}
         <IconBusiness />
       </TabWithIconContainer>
-    );
-  }
-
-  // XXX(epurkhiser): Crons explicitly get's a guide anchor
-  if (moduleName === ModuleName.CRONS) {
-    return (
-      <GuideAnchor target="crons_backend_insights" disabled={!isActive}>
-        {moduleTitles[moduleName]}
-      </GuideAnchor>
     );
   }
 


### PR DESCRIPTION
This fixes a problem where having the GuideAnchor wrap a tab was causing
clicks within the guide to trigger the tabs click handler. Unfortunately
this is somewhat non-trivial to fix, so moving it is just simpler.