### PR TITLE
feat(releases): add error-free session rate and sessions tab to backend insights

### DIFF
--- a/static/app/views/insights/pages/backend/settings.ts
+++ b/static/app/views/insights/pages/backend/settings.ts
@@ -12,4 +12,5 @@ export const MODULES = [
   ModuleName.QUEUE,
   ModuleName.CRONS,
   ModuleName.UPTIME,
+  ModuleName.SESSIONS,
 ];

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -6,6 +6,8 @@ import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modul
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
+import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
+import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
@@ -22,6 +24,7 @@ export function SessionsOverview() {
   return (
     <React.Fragment>
       {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
+      {view === BACKEND_LANDING_SUB_PATH && <BackendHeader {...headerProps} />}
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>


### PR DESCRIPTION
- same chart & sessions tab as the frontend insights tab
- gated by the same feature flag `insights-session-health-tab-ui` so visible only to sentry
- it's a quick change since we're re-using the sessions module from the frontend page PRs, and we're using the same chart

<img width="1138" alt="SCR-20250210-jhhh" src="https://github.com/user-attachments/assets/aa0127ea-0b36-4aa3-b804-dcaadf02d96b" />




relates to https://github.com/getsentry/team-replay/issues/540