### PR TITLE
tests(uptime): Add tests for uptime checks page

### DIFF
--- a/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
@@ -1,0 +1,99 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+import {UptimeCheckFixture} from 'sentry-fixture/uptimeCheck';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import GroupStore from 'sentry/stores/groupStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {IssueCategory, IssueType} from 'sentry/types/group';
+import {getShortEventId} from 'sentry/utils/events';
+import {statusToText} from 'sentry/views/insights/uptime/timelineConfig';
+import GroupUptimeChecks from 'sentry/views/issueDetails/groupUptimeChecks';
+
+describe('GroupUptimeChecks', () => {
+  const uptimeRuleId = '123';
+  const event = EventFixture({
+    tags: [
+      {
+        key: 'uptime_rule',
+        value: uptimeRuleId,
+      },
+    ],
+  });
+  const group = GroupFixture({
+    issueCategory: IssueCategory.UPTIME,
+    issueType: IssueType.UPTIME_DOMAIN_FAILURE,
+  });
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+  const router = RouterFixture({
+    params: {groupId: group.id},
+  });
+
+  beforeEach(() => {
+    GroupStore.init();
+    GroupStore.add([group]);
+    ProjectsStore.init();
+    ProjectsStore.loadInitialData([project]);
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/recommended/`,
+      body: event,
+    });
+  });
+
+  it('renders the empty uptime check table', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeRuleId}/checks/`,
+      body: [],
+    });
+
+    render(<GroupUptimeChecks />, {organization, router});
+    expect(await screen.findByText('All Uptime Checks')).toBeInTheDocument();
+    for (const column of [
+      'Timestamp',
+      'Status',
+      'Duration',
+      'Environment',
+      'Trace',
+      'Region',
+      'ID',
+    ]) {
+      expect(screen.getByText(column)).toBeInTheDocument();
+    }
+    expect(screen.getByText('No matching uptime checks found')).toBeInTheDocument();
+  });
+
+  it('renders the uptime check table with data', async () => {
+    const uptimeCheck = UptimeCheckFixture();
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeRuleId}/checks/`,
+      body: [uptimeCheck],
+    });
+
+    render(<GroupUptimeChecks />, {organization, router});
+    expect(await screen.findByText('All Uptime Checks')).toBeInTheDocument();
+    expect(screen.queryByText('No matching uptime checks found')).not.toBeInTheDocument();
+    expect(screen.getByText('Showing 1-1 matching uptime checks')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Previous Page'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Next Page'})).toBeInTheDocument();
+
+    expect(screen.getByRole('time')).toHaveTextContent(/Jan 1, 2025/);
+    expect(screen.getByText(statusToText[uptimeCheck.checkStatus])).toBeInTheDocument();
+    expect(screen.getByText(`${uptimeCheck.durationMs}ms`)).toBeInTheDocument();
+    expect(screen.getByText(uptimeCheck.environment)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: getShortEventId(uptimeCheck.traceId)})
+    ).toHaveAttribute('href', `/performance/trace/${uptimeCheck.traceId}/`);
+    expect(screen.getByText(uptimeCheck.region)).toBeInTheDocument();
+    expect(screen.getByText(uptimeCheck.uptimeCheckId)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -94,6 +94,7 @@ export default function GroupUptimeChecks() {
     >
       <GridEditable
         isLoading={isGroupPending}
+        emptyMessage={t('No matching uptime checks found')}
         data={uptimeData}
         columnOrder={[
           {key: 'timestamp', width: COL_WIDTH_UNDEFINED, name: t('Timestamp')},
@@ -221,7 +222,7 @@ function CheckInBodyCell({
         return <Cell />;
       }
       return (
-        <LinkCell to={`/performance/trace/${cellData}`}>
+        <LinkCell to={`/performance/trace/${cellData}/`}>
           {getShortEventId(String(cellData))}
         </LinkCell>
       );

--- a/tests/js/fixtures/uptimeCheck.ts
+++ b/tests/js/fixtures/uptimeCheck.ts
@@ -1,0 +1,21 @@
+import {CheckStatus, type UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
+
+
+export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeCheck {
+  return {
+    checkStatus: CheckStatus.SUCCESS,
+    checkStatusReason: 'success',
+    durationMs: 767,
+    environment: 'production',
+    projectUptimeSubscriptionId: 40123,
+    region: 'us-west',
+    scheduledCheckTime: '2025-01-01T00:00:00Z',
+    // TODO(epurkhiser): This hasn't been implemented on the backend yet
+    statusCode: '200',
+    timestamp: '2025-01-01T00:00:00Z',
+    traceId: '97f0e440317c5bb5b5e0024ca202a61d',
+    uptimeCheckId: '97f0e440-317c-5bb5-b5e0-024ca202a61d',
+    uptimeSubscriptionId: 40123,
+    ...params,
+  };
+}

--- a/tests/js/fixtures/uptimeCheck.ts
+++ b/tests/js/fixtures/uptimeCheck.ts
@@ -10,7 +10,6 @@ export function UptimeCheckFixture(params: Partial<UptimeCheck> = {}): UptimeChe
     projectUptimeSubscriptionId: 40123,
     region: 'us-west',
     scheduledCheckTime: '2025-01-01T00:00:00Z',
-    // TODO(epurkhiser): This hasn't been implemented on the backend yet
     statusCode: '200',
     timestamp: '2025-01-01T00:00:00Z',
     traceId: '97f0e440317c5bb5b5e0024ca202a61d',


### PR DESCRIPTION
Adds a test retroactively for the all uptime checks page. Tests with data and without data, while adding a new fixture for uptime checks themselves.