### PR TITLE
ref(uptime): Remove environment from checks table

### DIFF
--- a/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
@@ -58,15 +58,7 @@ describe('GroupUptimeChecks', () => {
 
     render(<GroupUptimeChecks />, {organization, router});
     expect(await screen.findByText('All Uptime Checks')).toBeInTheDocument();
-    for (const column of [
-      'Timestamp',
-      'Status',
-      'Duration',
-      'Environment',
-      'Trace',
-      'Region',
-      'ID',
-    ]) {
+    for (const column of ['Timestamp', 'Status', 'Duration', 'Trace', 'Region', 'ID']) {
       expect(screen.getByText(column)).toBeInTheDocument();
     }
     expect(screen.getByText('No matching uptime checks found')).toBeInTheDocument();
@@ -89,7 +81,6 @@ describe('GroupUptimeChecks', () => {
     expect(screen.getByRole('time')).toHaveTextContent(/Jan 1, 2025/);
     expect(screen.getByText(statusToText[uptimeCheck.checkStatus])).toBeInTheDocument();
     expect(screen.getByText(`${uptimeCheck.durationMs}ms`)).toBeInTheDocument();
-    expect(screen.getByText(uptimeCheck.environment)).toBeInTheDocument();
     expect(
       screen.getByRole('link', {name: getShortEventId(uptimeCheck.traceId)})
     ).toHaveAttribute('href', `/performance/trace/${uptimeCheck.traceId}/`);

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -100,7 +100,6 @@ export default function GroupUptimeChecks() {
           {key: 'timestamp', width: COL_WIDTH_UNDEFINED, name: t('Timestamp')},
           {key: 'checkStatus', width: 115, name: t('Status')},
           {key: 'durationMs', width: 110, name: t('Duration')},
-          {key: 'environment', width: 115, name: t('Environment')},
           {key: 'traceId', width: 100, name: t('Trace')},
           {key: 'region', width: 100, name: t('Region')},
           {key: 'uptimeCheckId', width: 100, name: t('ID')},


### PR DESCRIPTION
The environment will always be the same for a single uptime monitor
and monitor issue.