### PR TITLE
chore(issue-views): Add guide anchor key for page filter persistence to backend

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -29,4 +29,5 @@ GUIDES = {
     "new_project_filter": 32,
     "explain_archive_button_issue_stream": 33,
     "crons_backend_insights": 38,
+    "issue_views_page_filters_persistence": 39,
 }


### PR DESCRIPTION
Adds the guide key for the tool tip that will explain that page filters now save to issue views. 