### PR TITLE
feat(devenv): Add env var to skip frontend dep updates

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -160,7 +160,7 @@ Then, use it to run sync this one time.
         (
             # TODO: devenv should provide a job runner (jobs run in parallel, tasks run sequentially)
             (
-                "python dependencies (1/4)",
+                "python dependencies (1/3)",
                 (
                     # upgrading pip first
                     "pip",
@@ -176,44 +176,25 @@ Then, use it to run sync this one time.
     ):
         return 1
 
-    procs = []
-    if not SKIP_FRONTEND:
-        procs.append(
-            (
-                # Spreading out the network load by installing js,
-                # then py in the next batch.
-                "javascript dependencies (1/1)",
-                (
-                    "yarn",
-                    "install",
-                    "--frozen-lockfile",
-                    "--no-progress",
-                    "--non-interactive",
-                ),
-                {
-                    "NODE_ENV": "development",
-                },
-            )
-        )
-    procs.append(
-        (
-            "python dependencies (2/4)",
-            (
-                "pip",
-                "uninstall",
-                "-qqy",
-                "djangorestframework-stubs",
-                "django-stubs",
-            ),
-            {},
-        )
-    )
-
-    if not run_procs(
+    if not SKIP_FRONTEND and not run_procs(
         repo,
         reporoot,
         venv_dir,
-        procs,
+        (
+            # Spreading out the network load by installing js,
+            # then py in the next batch.
+            "javascript dependencies (1/1)",
+            (
+                "yarn",
+                "install",
+                "--frozen-lockfile",
+                "--no-progress",
+                "--non-interactive",
+            ),
+            {
+                "NODE_ENV": "development",
+            },
+        ),
         verbose,
     ):
         return 1
@@ -226,7 +207,7 @@ Then, use it to run sync this one time.
             # could opt out of syncing python if FRONTEND_ONLY but only if repo-local devenv
             # and pre-commit were moved to inside devenv and not the sentry venv
             (
-                "python dependencies (3/4)",
+                "python dependencies (2/3)",
                 (
                     "pip",
                     "install",
@@ -248,7 +229,7 @@ Then, use it to run sync this one time.
         venv_dir,
         (
             (
-                "python dependencies (4/4)",
+                "python dependencies (3/3)",
                 ("python3", "-m", "tools.fast_editable", "--path", "."),
                 {},
             ),

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -107,6 +107,7 @@ Then, use it to run sync this one time.
     verbose = os.environ.get("SENTRY_DEVENV_VERBOSE") is not None
 
     FRONTEND_ONLY = os.environ.get("SENTRY_DEVENV_FRONTEND_ONLY") is not None
+    SKIP_FRONTEND = os.environ.get("SENTRY_DEVENV_SKIP_FRONTEND") is not None
 
     USE_OLD_DEVSERVICES = os.environ.get("USE_OLD_DEVSERVICES") == "1"
 
@@ -175,11 +176,9 @@ Then, use it to run sync this one time.
     ):
         return 1
 
-    if not run_procs(
-        repo,
-        reporoot,
-        venv_dir,
-        (
+    procs = []
+    if not SKIP_FRONTEND:
+        procs.append(
             (
                 # Spreading out the network load by installing js,
                 # then py in the next batch.
@@ -194,19 +193,27 @@ Then, use it to run sync this one time.
                 {
                     "NODE_ENV": "development",
                 },
-            ),
+            )
+        )
+    procs.append(
+        (
+            "python dependencies (2/4)",
             (
-                "python dependencies (2/4)",
-                (
-                    "pip",
-                    "uninstall",
-                    "-qqy",
-                    "djangorestframework-stubs",
-                    "django-stubs",
-                ),
-                {},
+                "pip",
+                "uninstall",
+                "-qqy",
+                "djangorestframework-stubs",
+                "django-stubs",
             ),
-        ),
+            {},
+        )
+    )
+
+    if not run_procs(
+        repo,
+        reporoot,
+        venv_dir,
+        procs,
         verbose,
     ):
         return 1

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -181,19 +181,21 @@ Then, use it to run sync this one time.
         reporoot,
         venv_dir,
         (
-            # Spreading out the network load by installing js,
-            # then py in the next batch.
-            "javascript dependencies (1/1)",
             (
-                "yarn",
-                "install",
-                "--frozen-lockfile",
-                "--no-progress",
-                "--non-interactive",
+                # Spreading out the network load by installing js,
+                # then py in the next batch.
+                "javascript dependencies (1/1)",
+                (
+                    "yarn",
+                    "install",
+                    "--frozen-lockfile",
+                    "--no-progress",
+                    "--non-interactive",
+                ),
+                {
+                    "NODE_ENV": "development",
+                },
             ),
-            {
-                "NODE_ENV": "development",
-            },
         ),
         verbose,
     ):


### PR DESCRIPTION
I mostly don't care about js updates, so I'd like to skip any js dependency updates during `devenv sync`.

<!-- Describe your PR here. -->