### PR TITLE
feat(trace-view): update insight breadcrumbs

### DIFF
--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -17,8 +17,6 @@ const BreadcrumbList = styled('nav')`
   padding: ${space(1)} 0;
 `;
 
-BreadcrumbList.displayName = 'BreadcrumbList';
-
 export interface Crumb {
   /**
    * Label of the crumb

--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -17,6 +17,8 @@ const BreadcrumbList = styled('nav')`
   padding: ${space(1)} 0;
 `;
 
+BreadcrumbList.displayName = 'BreadcrumbList';
+
 export interface Crumb {
   /**
    * Label of the crumb
@@ -93,7 +95,7 @@ export function Breadcrumbs({crumbs, linkLastItem = false, ...props}: Props) {
   }
 
   return (
-    <BreadcrumbList {...props}>
+    <BreadcrumbList {...props} data-test-id="breadcrumb-list">
       {crumbs.map((crumb, index) => {
         if (isCrumbDropdown(crumb)) {
           const {label, ...crumbProps} = crumb;
@@ -123,7 +125,7 @@ export function Breadcrumbs({crumbs, linkLastItem = false, ...props}: Props) {
                 {label}
               </BreadcrumbLink>
             ) : (
-              <BreadcrumbItem>{label}</BreadcrumbItem>
+              <BreadcrumbItem data-test-id="breadcrumb-item">{label}</BreadcrumbItem>
             )}
 
             {index < crumbs.length - 1 && <BreadcrumbDividerIcon direction="right" />}

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -225,7 +225,7 @@ function getDashboardsBreadCrumbs(organization: Organization, location: Location
   return crumbs;
 }
 
-export function getInsightsModuleBreadcrumbs(
+function getInsightsModuleBreadcrumbs(
   location: Location,
   organization: Organization,
   moduleURLBuilder: URLBuilder,

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -9,7 +9,7 @@ import type {
   RoutableModuleNames,
   URLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
-import {DOMAIN_VIEW_BASE_TITLE} from 'sentry/views/insights/pages/settings';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {DOMAIN_VIEW_TITLES} from 'sentry/views/insights/pages/types';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -225,7 +225,7 @@ function getDashboardsBreadCrumbs(organization: Organization, location: Location
   return crumbs;
 }
 
-function getInsightsModuleBreadcrumbs(
+export function getInsightsModuleBreadcrumbs(
   location: Location,
   organization: Organization,
   moduleURLBuilder: URLBuilder,
@@ -235,8 +235,12 @@ function getInsightsModuleBreadcrumbs(
 
   if (view && DOMAIN_VIEW_TITLES[view]) {
     crumbs.push({
-      label: DOMAIN_VIEW_BASE_TITLE,
-      to: undefined,
+      label: DOMAIN_VIEW_TITLES[view],
+      to: getBreadCrumbTarget(
+        `${DOMAIN_VIEW_BASE_URL}/${view}/`,
+        location.query,
+        organization
+      ),
     });
   } else {
     crumbs.push({

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -9,13 +9,9 @@ import type {
   RoutableModuleNames,
   URLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
-import {
-  DOMAIN_VIEW_BASE_TITLE,
-  DOMAIN_VIEW_BASE_URL,
-} from 'sentry/views/insights/pages/settings';
+import {DOMAIN_VIEW_BASE_TITLE} from 'sentry/views/insights/pages/settings';
 import {DOMAIN_VIEW_TITLES} from 'sentry/views/insights/pages/types';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
-import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
@@ -242,14 +238,6 @@ function getInsightsModuleBreadcrumbs(
       label: DOMAIN_VIEW_BASE_TITLE,
       to: undefined,
     });
-    crumbs.push({
-      label: DOMAIN_VIEW_TITLES[view],
-      to: getBreadCrumbTarget(
-        `${DOMAIN_VIEW_BASE_URL}/${view}/`,
-        location.query,
-        organization
-      ),
-    });
   } else {
     crumbs.push({
       label: t('Insights'),
@@ -267,14 +255,6 @@ function getInsightsModuleBreadcrumbs(
     moduleName = TRACE_SOURCE_TO_INSIGHTS_MODULE[
       location.query.source as keyof typeof TRACE_SOURCE_TO_INSIGHTS_MODULE
     ] as RoutableModuleNames;
-    crumbs.push({
-      label: MODULE_TITLES[moduleName],
-      to: getBreadCrumbTarget(
-        `${moduleURLBuilder(moduleName, view)}/`,
-        location.query,
-        organization
-      ),
-    });
   }
 
   switch (moduleName) {

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -1,0 +1,105 @@
+import {TransactionEventFixture} from 'sentry-fixture/event';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {useLocation} from 'sentry/utils/useLocation';
+import {
+  TraceMetaDataHeader,
+  type TraceMetadataHeaderProps,
+} from 'sentry/views/performance/newTraceDetails/traceHeader';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+jest.mock('sentry/views/performance/newTraceDetails/traceState/traceStateProvider');
+jest.mock('sentry/utils/useLocation');
+
+const baseProps: Partial<TraceMetadataHeaderProps> = {
+  metaResults: {
+    data: {
+      errors: 1,
+      performance_issues: 1,
+      projects: 1,
+      transactions: 1,
+      transactiontoSpanChildrenCount: {span1: 1},
+    },
+    errors: [],
+    status: 'success',
+  },
+  rootEventResults: {
+    data: TransactionEventFixture(),
+  } as any,
+  tree: new TraceTree().build(),
+  traceEventView: EventView.fromSavedQuery({
+    id: '1',
+    name: 'test',
+    fields: ['title', 'event.type', 'project', 'timestamp'],
+    projects: [],
+    version: 2,
+  }),
+};
+let organization: Organization;
+
+const useLocationMock = jest.mocked(useLocation);
+
+describe('TraceMetaDataHeader', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    organization = OrganizationFixture();
+  });
+
+  describe('breadcrumbs', () => {
+    it('should render module breadcrumbs', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/insights/backend/trace/123',
+          query: {
+            source: TraceViewSources.REQUESTS_MODULE,
+          },
+        })
+      );
+      const props = {...baseProps} as TraceMetadataHeaderProps;
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      const breadcrumbs = screen.getByTestId('breadcrumb-list');
+      const breadcrumbsLinks = screen.getAllByTestId('breadcrumb-link');
+      const breadcrumbsItems = screen.getAllByTestId('breadcrumb-item');
+
+      expect(breadcrumbs.childElementCount).toBe(5);
+
+      expect(breadcrumbsLinks).toHaveLength(2);
+      expect(breadcrumbsLinks[0]).toHaveTextContent('Backend');
+      expect(breadcrumbsLinks[1]).toHaveTextContent('Domain Summary');
+      expect(breadcrumbsItems).toHaveLength(1);
+      expect(breadcrumbsItems[0]).toHaveTextContent('Trace View');
+    });
+
+    it('should render domain overview breadcrumbs', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/insights/frontend/trace/123',
+          query: {
+            source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY,
+          },
+        })
+      );
+      const props = {...baseProps} as TraceMetadataHeaderProps;
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      const breadcrumbs = screen.getByTestId('breadcrumb-list');
+      const breadcrumbsLinks = screen.getAllByTestId('breadcrumb-link');
+      const breadcrumbsItems = screen.getAllByTestId('breadcrumb-item');
+
+      expect(breadcrumbs.childElementCount).toBe(5);
+
+      expect(breadcrumbsLinks).toHaveLength(2);
+      expect(breadcrumbsLinks[0]).toHaveTextContent('Frontend');
+      expect(breadcrumbsLinks[1]).toHaveTextContent('Transaction Summary');
+      expect(breadcrumbsItems).toHaveLength(1);
+      expect(breadcrumbsItems[0]).toHaveTextContent('Trace View');
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -38,7 +38,7 @@ import {getTraceViewBreadcrumbs} from './breadcrumbs';
 import {Meta} from './meta';
 import {Title} from './title';
 
-interface TraceMetadataHeaderProps {
+export interface TraceMetadataHeaderProps {
   metaResults: TraceMetaQueryResults;
   organization: Organization;
   rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;


### PR DESCRIPTION
Updates the trace view breadcrumbs to match the insights breadcrumbs, adds tests to prevent regressions

Before
<img width="648" alt="image" src="https://github.com/user-attachments/assets/cb35cf51-db7a-47c1-8021-6886aaf0ff3c" />


After
<img width="447" alt="image" src="https://github.com/user-attachments/assets/02f89388-e871-4f7f-a9bc-9ff1bf8a0045" />
