### PR TITLE
fix(relocation) Improve error logging and resilience of pre-process stage

### DIFF
--- a/src/sentry/backup/services/import_export/impl.py
+++ b/src/sentry/backup/services/import_export/impl.py
@@ -208,7 +208,9 @@ class UniversalImportExportService(ImportExportService):
                 min_inserted_pk: int | None = None
                 max_inserted_pk: int | None = None
                 last_seen_ordinal = min_ordinal - 1
-                for deserialized_object in deserialize("json", json_data, use_natural_keys=False):
+                for deserialized_object in deserialize(
+                    "json", json_data, use_natural_keys=False, ignorenonexistent=True
+                ):
                     model_instance = deserialized_object.object
                     inst_model_name = get_model_name(model_instance)
 
@@ -365,12 +367,16 @@ class UniversalImportExportService(ImportExportService):
                     max_inserted_pk=max_inserted_pk,
                 )
 
-        except DeserializationError:
+        except DeserializationError as err:
             sentry_sdk.capture_exception()
+            reason = "No additional information"
+            if err.__cause__:
+                reason = str(err.__cause__)
+
             return RpcImportError(
                 kind=RpcImportErrorKind.DeserializationFailed,
                 on=InstanceID(import_model_name),
-                reason="The submitted JSON could not be deserialized into Django model instances",
+                reason=f"The submitted JSON could not be deserialized into Django model instances. {reason}",
             )
 
         except DatabaseError as e:

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -781,37 +781,6 @@ class BadImportExportDomainErrorTests(TransactionTestCase):
 
 
 class BadImportExportCommandTests(TestCase):
-    def test_import_invalid_json(self):
-        with TemporaryDirectory() as tmp_dir:
-            tmp_invalid_json = Path(tmp_dir).joinpath(f"{self._testMethodName}.invalid.json")
-            with open(get_fixture_path("backup", "single-option.json")) as backup_file:
-                models = json.load(backup_file)
-                models[0]["fields"]["invalid_field"] = "invalid_data"
-                with open(tmp_invalid_json, "w") as invalid_input_file:
-                    json.dump(models, invalid_input_file)
-
-            for scope in {"users", "organizations", "config", "global"}:
-                tmp_findings = Path(tmp_dir).joinpath(
-                    f"{self._testMethodName}.{scope}.findings.json"
-                )
-                rv = CliRunner().invoke(
-                    import_,
-                    [
-                        scope,
-                        str(tmp_invalid_json),
-                        "--no-prompt",
-                        "--findings-file",
-                        str(tmp_findings),
-                    ],
-                )
-                assert rv.exit_code == 1, rv.output
-
-                with open(tmp_findings) as findings_file:
-                    findings = json.load(findings_file)
-                    assert len(findings) == 1
-                    assert findings[0]["finding"] == "RpcImportError"
-                    assert findings[0]["kind"] == "DeserializationFailed"
-
     def test_import_file_read_error_exit_code(self):
         rv = CliRunner().invoke(import_, ["global", NONEXISTENT_FILE_PATH, "--no-prompt"])
         assert not isinstance(rv.exception, ImportingError)


### PR DESCRIPTION
We had another relocation fail due to schema deltas. The error message that was accessible in cloudbuilder was not helpful as it didn't include the error message. By using `err.__cause__` we can get more context on the source of the issue.

The `nonexistentent` parameter should supress these missing field error going forward as well. Going forward only fields that exist in the import file, and the current schema will be processed, and removed fields will not cause failures.
