### PR TITLE
fix(dashboard): Ensure _creator is not sent in teams selector request

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -73,7 +73,9 @@ function EditAccessSelector({
         : [],
   });
   const {teams: allSelectedTeams} = useTeamsById({
-    ids: selectedOptions.filter(option => option !== '_allUsers'),
+    ids: selectedOptions.filter(
+      option => option !== '_allUsers' && option !== '_creator'
+    ),
   });
 
   // Gets selected options for the dropdown from dashboard object


### PR DESCRIPTION
Causes a 400 error in a request for the edit access selector. `_allUsers` and `_creator` are placeholder values and shouldn't be sent in requests.