### PR TITLE
style(replays): rm margin from alert for consistent spacing

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage.tsx
@@ -1,10 +1,12 @@
+import styled from '@emotion/styled';
+
 import {Alert} from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {tct} from 'sentry/locale';
 
 export default function TracePropagationMessage() {
   return (
-    <Alert type="info" showIcon>
+    <AlertNoMargin type="info" showIcon>
       {tct(
         `To see replays for backend errors, ensure that you have set up trace propagation. To learn more, [link:read the docs].`,
         {
@@ -13,6 +15,10 @@ export default function TracePropagationMessage() {
           ),
         }
       )}
-    </Alert>
+    </AlertNoMargin>
   );
 }
+
+const AlertNoMargin = styled(Alert)`
+  margin-bottom: 0;
+`;


### PR DESCRIPTION
debugging an onboarding thing and saw this

before:
<img width="530" alt="SCR-20250210-liio" src="https://github.com/user-attachments/assets/7daa0cdf-435e-42c1-948e-8faf4666e3b4" />


after:
<img width="465" alt="SCR-20250210-lijt" src="https://github.com/user-attachments/assets/d991faef-d4d8-4607-a3ce-4500c6df8b63" />
