### PR TITLE
ref(insights): remove requirement to add module name to domain selector

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -2,6 +2,7 @@ import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
@@ -42,6 +43,7 @@ function ResourcesLandingPage() {
                     extraFilters={
                       <Fragment>
                         <DomainSelector
+                          domainAlias={t('Domain')}
                           moduleName={ModuleName.RESOURCE}
                           emptyOptionLocation="top"
                           value={filters[SPAN_DOMAIN] || ''}

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.spec.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.spec.tsx
@@ -62,7 +62,7 @@ describe('DomainSelector', function () {
   });
 
   it('allows selecting a domain', async function () {
-    render(<DomainSelector moduleName={ModuleName.DB} />);
+    render(<DomainSelector domainAlias="Domain" moduleName={ModuleName.DB} />);
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -90,7 +90,7 @@ describe('DomainSelector', function () {
       ],
     });
 
-    render(<DomainSelector moduleName={ModuleName.DB} />);
+    render(<DomainSelector domainAlias="Domain" moduleName={ModuleName.DB} />);
     expect(fetchMoreResponse).not.toHaveBeenCalled();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useEffect, useState} from 'react';
 import type {Location} from 'history';
 import debounce from 'lodash/debounce';
@@ -24,10 +23,9 @@ import {EmptyContainer} from 'sentry/views/insights/common/views/spans/selectors
 import {type ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 type Props = {
+  domainAlias: string;
   moduleName: ModuleName;
   additionalQuery?: string[];
-  // Optional prop to override the default name of the selector label
-  domainAlias?: string;
   emptyOptionLocation?: 'top' | 'bottom';
   spanCategory?: string;
   value?: string;
@@ -118,12 +116,8 @@ export function DomainSelector({
 
   const emptyOption: SelectOption<string> = {
     value: EMPTY_OPTION_VALUE,
-    label: (
-      <EmptyContainer>
-        {t('(No %s)', domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName])}
-      </EmptyContainer>
-    ),
-    textValue: t('(No %s)', domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName]),
+    label: <EmptyContainer>{t('(No %s)', domainAlias)}</EmptyContainer>,
+    textValue: t('(No %s)', domainAlias),
   };
 
   const options: Array<SelectOption<string>> = [
@@ -141,7 +135,7 @@ export function DomainSelector({
       emptyMessage={t('No results')}
       loading={isPending}
       searchable
-      menuTitle={domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName]}
+      menuTitle={domainAlias}
       maxMenuWidth={'500px'}
       data-test-id="domain-selector"
       onSearch={newValue => {
@@ -150,7 +144,7 @@ export function DomainSelector({
         }
       }}
       triggerProps={{
-        prefix: domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName],
+        prefix: domainAlias,
       }}
       onChange={newValue => {
         trackAnalytics('insight.general.select_domain_value', {
@@ -171,25 +165,6 @@ export function DomainSelector({
 }
 
 const LIMIT = 100;
-
-const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
-  http: t('Host'),
-  db: t('Table'),
-  cache: t('Domain'),
-  vital: t('Domain'),
-  queue: t('Domain'),
-  screen_load: t('Domain'),
-  app_start: t('Domain'),
-  resource: t('Resource'),
-  other: t('Domain'),
-  ai: t('Domain'),
-  crons: t('Domain'),
-  uptime: t('Domain'),
-  'screen-rendering': t('Domain'),
-  'mobile-ui': t('Domain'),
-  'mobile-vitals': t('Domain'),
-  sessions: t('Domain'),
-};
 
 function getEventView(
   location: Location,


### PR DESCRIPTION
This PR removes the `LABEL_FOR_MODULE_NAME: Record<ModuleName, React.ReactNode` constant from the insight domain selector and requires the `domainAlias` to be passed in. This record is kinda annoying, because of type safety, any new module coming in requires an entry into this record, however, for the vast majority of modules this record is meaningless as most modules don't use the domain selector.

 There is only two modules that use the `domainSelector`, db and assets. DB already only the `domainAlias` prop, so it doesn't make sense to have the `LABEL_FOR_MODULE_NAME` record just for the resource module. 