### PR TITLE
ref(grouping): Normalize `{{ default }}` value in fingerprints

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -11,7 +11,11 @@ from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor, RegexNode
 
-from sentry.grouping.utils import bool_from_string
+from sentry.grouping.utils import (
+    DEFAULT_FINGERPRINT_VARIABLE,
+    bool_from_string,
+    is_default_fingerprint_var,
+)
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.utils.event_frames import find_stack_frames
@@ -647,6 +651,9 @@ class FingerprintingVisitor(NodeVisitorBase):
 
     def visit_fp_value(self, _: object, children: tuple[object, str, object, object]) -> str:
         _, argument, _, _ = children
+        # Normalize variations of `{{ default }}`
+        if isinstance(argument, str) and is_default_fingerprint_var(argument):
+            return DEFAULT_FINGERPRINT_VARIABLE
         return argument
 
     def visit_fp_attribute(self, _: object, children: tuple[str, object, str]) -> tuple[str, str]:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -138,6 +138,8 @@ def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str |
 def resolve_fingerprint_values(values: list[str], event_data: NodeData) -> list[str]:
     def _get_fingerprint_value(value: str) -> str:
         var = parse_fingerprint_var(value)
+        if var == "default":
+            return DEFAULT_FINGERPRINT_VARIABLE
         if var is None:
             return value
         rv = get_fingerprint_value(var, event_data)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 
 _fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
+DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
 def parse_fingerprint_var(value: str) -> str | None:


### PR DESCRIPTION
When attempting to use hybrid fingerprints, users sometimes muck up the formatting of the `{{ default }}` signal value, writing it as `{{default}}` or `{{ default}}` or the like. When detecting this value, we _should_ always use the `is_default_fingerprint_var` helper (which accounts for such differences), but it's easy to forget to do that and just compare to the string `{{ default }}` itself. To save ourselves in such cases, this adds normalization of the value to fingerprint rule parsing and fingerprint variable resolution. By adding it in both spots, we'll catch problems in client fingerprints as well as server-side ones.