### PR TITLE
feat(widget-builder): Skip wrapper on sort tooltip

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -94,6 +94,7 @@ function WidgetBuilderSortBySelector() {
       <Tooltip
         title={disableSortReason}
         disabled={!(disableSortDirection && disableSort)}
+        skipWrapper
       >
         <FieldGroup
           inline={false}


### PR DESCRIPTION
The tooltip children get wrapped in a span which truncates the contents. This was only noticed on the release health widgets when adding session.status as a grouping so far.

Before:

![Screenshot 2025-02-10 at 3 54 14 PM](https://github.com/user-attachments/assets/abb199e3-3f0e-4993-bdea-1601033584e4)

After:

![Screenshot 2025-02-10 at 3 54 20 PM](https://github.com/user-attachments/assets/822aa209-8e4c-477e-b699-8fa0dcdb1992)
