### PR TITLE
feat(nav): Adjust labels in primary nav sidebar

### DIFF
--- a/static/app/components/nav/constants.tsx
+++ b/static/app/components/nav/constants.tsx
@@ -6,9 +6,10 @@ export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-co
 export const NAV_GROUP_LABELS: Record<PrimaryNavGroup, string> = {
   [PrimaryNavGroup.ISSUES]: t('Issues'),
   [PrimaryNavGroup.EXPLORE]: t('Explore'),
-  [PrimaryNavGroup.DASHBOARDS]: t('Boards'),
+  [PrimaryNavGroup.DASHBOARDS]: t('Dashboards'),
   [PrimaryNavGroup.INSIGHTS]: t('Insights'),
   [PrimaryNavGroup.SETTINGS]: t('Settings'),
 };
 
+export const PRIMARY_SIDEBAR_WIDTH = 66;
 export const SECONDARY_SIDEBAR_WIDTH = 190;

--- a/static/app/components/nav/constants.tsx
+++ b/static/app/components/nav/constants.tsx
@@ -11,5 +11,5 @@ export const NAV_GROUP_LABELS: Record<PrimaryNavGroup, string> = {
   [PrimaryNavGroup.SETTINGS]: t('Settings'),
 };
 
-export const PRIMARY_SIDEBAR_WIDTH = 66;
+export const PRIMARY_SIDEBAR_WIDTH = 76;
 export const SECONDARY_SIDEBAR_WIDTH = 190;

--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -73,9 +73,11 @@ describe('Nav', function () {
       ).getAllByRole('link');
       expect(links).toHaveLength(5);
 
-      ['Issues', 'Explore', 'Boards', 'Insights', 'Settings'].forEach((title, index) => {
-        expect(links[index]).toHaveAccessibleName(title);
-      });
+      ['Issues', 'Explore', 'Dashboards', 'Insights', 'Settings'].forEach(
+        (title, index) => {
+          expect(links[index]).toHaveAccessibleName(title);
+        }
+      );
     });
 
     it('displays the current primary route as active', function () {
@@ -215,7 +217,7 @@ describe('Nav', function () {
       ).toBeInTheDocument();
       expect(screen.getByRole('link', {name: 'Issues'})).toBeInTheDocument();
       expect(screen.getByRole('link', {name: 'Explore'})).toBeInTheDocument();
-      expect(screen.getByRole('link', {name: 'Boards'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: 'Dashboards'})).toBeInTheDocument();
       expect(screen.getByRole('link', {name: 'Insights'})).toBeInTheDocument();
       expect(screen.getByRole('link', {name: 'Settings'})).toBeInTheDocument();
 

--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -35,6 +35,7 @@ interface SidebarItemLinkProps {
   to: string;
   activeTo?: string;
   children?: React.ReactNode;
+  forceLabel?: boolean;
   onClick?: MouseEventHandler<HTMLElement>;
 }
 
@@ -43,6 +44,7 @@ interface SidebarItemDropdownProps {
   items: MenuItemProps[];
   label: string;
   children?: React.ReactNode;
+  forceLabel?: boolean;
 }
 
 function SidebarBody({children}: {children: React.ReactNode}) {
@@ -56,7 +58,12 @@ function SidebarFooter({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
   return (
     <SidebarFooterWrapper>
-      <SidebarItemList isMobile={layout === NavLayout.MOBILE}>{children}</SidebarItemList>
+      <SidebarItemList
+        isMobile={layout === NavLayout.MOBILE}
+        compact={layout === NavLayout.SIDEBAR}
+      >
+        {children}
+      </SidebarItemList>
     </SidebarFooterWrapper>
   );
 }
@@ -70,7 +77,13 @@ function SidebarItem({children}: {children: React.ReactNode}) {
   );
 }
 
-function SidebarMenu({items, children, analyticsKey, label}: SidebarItemDropdownProps) {
+function SidebarMenu({
+  items,
+  children,
+  analyticsKey,
+  label,
+  forceLabel,
+}: SidebarItemDropdownProps) {
   const organization = useOrganization();
   const recordAnalytics = useCallback(
     () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
@@ -78,7 +91,7 @@ function SidebarMenu({items, children, analyticsKey, label}: SidebarItemDropdown
   );
   const {layout} = useNavContext();
 
-  const showLabel = layout === NavLayout.MOBILE;
+  const showLabel = forceLabel || layout === NavLayout.MOBILE;
 
   return (
     <SidebarItem>
@@ -112,6 +125,7 @@ function SidebarLink({
   activeTo = to,
   analyticsKey,
   label,
+  forceLabel = false,
 }: SidebarItemLinkProps) {
   const organization = useOrganization();
   const location = useLocation();
@@ -119,7 +133,7 @@ function SidebarLink({
   const linkProps = makeLinkPropsFromTo(to);
 
   const {layout} = useNavContext();
-  const showLabel = layout === NavLayout.MOBILE;
+  const showLabel = forceLabel || layout === NavLayout.MOBILE;
 
   const recordAnalytics = useCallback(
     () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
@@ -174,6 +188,7 @@ export function PrimaryNavigationItems() {
           to={`/${prefix}/issues/`}
           analyticsKey="issues"
           label={NAV_GROUP_LABELS[PrimaryNavGroup.ISSUES]}
+          forceLabel
         >
           <IconIssues />
         </SidebarLink>
@@ -182,6 +197,7 @@ export function PrimaryNavigationItems() {
           to={`/${prefix}/explore/traces/`}
           analyticsKey="explore"
           label={NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}
+          forceLabel
         >
           <IconSearch />
         </SidebarLink>
@@ -195,6 +211,7 @@ export function PrimaryNavigationItems() {
             to={`/${prefix}/dashboards/`}
             analyticsKey="customizable-dashboards"
             label={NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}
+            forceLabel
           >
             <IconDashboard />
           </SidebarLink>
@@ -205,6 +222,7 @@ export function PrimaryNavigationItems() {
             to={`/${prefix}/insights/frontend/`}
             analyticsKey="insights-domains"
             label={NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
+            forceLabel
           >
             <IconGraph />
           </SidebarLink>
@@ -258,7 +276,7 @@ export function PrimaryNavigationItems() {
   );
 }
 
-const SidebarItemList = styled('ul')<{isMobile: boolean}>`
+const SidebarItemList = styled('ul')<{isMobile: boolean; compact?: boolean}>`
   position: relative;
   list-style: none;
   margin: 0;
@@ -277,6 +295,12 @@ const SidebarItemList = styled('ul')<{isMobile: boolean}>`
       align-items: center;
       gap: ${space(1)};
     `}
+
+  ${p =>
+    p.compact &&
+    css`
+      gap: ${space(0.5)};
+    `}
 `;
 
 const SidebarItemWrapper = styled('li')<{isMobile: boolean}>`
@@ -288,7 +312,7 @@ const SidebarItemWrapper = styled('li')<{isMobile: boolean}>`
     ${p =>
       !p.isMobile &&
       css`
-        --size: 18px;
+        --size: 16px;
       `}
   }
   > a,
@@ -318,7 +342,9 @@ const SidebarItemWrapper = styled('li')<{isMobile: boolean}>`
         gap: ${space(0.75)};
         padding: ${space(1.5)} 0;
         min-height: 44px;
-        width: ${PRIMARY_SIDEBAR_WIDTH - 16}px;
+        width: ${PRIMARY_SIDEBAR_WIDTH - 10}px;
+        letter-spacing: -0.02em;
+        font-size: 10px;
       `}
   }
 `;
@@ -329,7 +355,6 @@ const SidebarFooterWrapper = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  padding-bottom: ${space(0.5)};
   margin-top: auto;
 `;
 

--- a/static/app/components/nav/primary.tsx
+++ b/static/app/components/nav/primary.tsx
@@ -1,15 +1,14 @@
 import {Fragment, type MouseEventHandler, useCallback} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {mergeProps} from '@react-aria/utils';
 
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
-import type {ButtonProps} from 'sentry/components/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import Link, {type LinkProps} from 'sentry/components/links/link';
+import Link from 'sentry/components/links/link';
 import {linkStyles} from 'sentry/components/links/styles';
-import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
+import {NAV_GROUP_LABELS, PRIMARY_SIDEBAR_WIDTH} from 'sentry/components/nav/constants';
 import {useNavContext} from 'sentry/components/nav/context';
 import {NavLayout, PrimaryNavGroup} from 'sentry/components/nav/types';
 import {isLinkActive, makeLinkPropsFromTo} from 'sentry/components/nav/utils';
@@ -32,52 +31,64 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 interface SidebarItemLinkProps {
   analyticsKey: string;
+  label: string;
   to: string;
   activeTo?: string;
   children?: React.ReactNode;
-  linkProps?: Partial<Omit<LinkProps, 'ref'>>;
   onClick?: MouseEventHandler<HTMLElement>;
 }
 
 interface SidebarItemDropdownProps {
   analyticsKey: string;
   items: MenuItemProps[];
-  buttonProps?: Partial<ButtonProps>;
+  label: string;
   children?: React.ReactNode;
 }
 
 function SidebarBody({children}: {children: React.ReactNode}) {
-  return <SidebarItemList>{children}</SidebarItemList>;
+  const {layout} = useNavContext();
+  return (
+    <SidebarItemList isMobile={layout === NavLayout.MOBILE}>{children}</SidebarItemList>
+  );
 }
 
 function SidebarFooter({children}: {children: React.ReactNode}) {
+  const {layout} = useNavContext();
   return (
     <SidebarFooterWrapper>
-      <SidebarItemList>{children}</SidebarItemList>
+      <SidebarItemList isMobile={layout === NavLayout.MOBILE}>{children}</SidebarItemList>
     </SidebarFooterWrapper>
   );
 }
 
-function SidebarMenu({
-  items,
-  children,
-  analyticsKey,
-  buttonProps = {},
-}: SidebarItemDropdownProps) {
+function SidebarItem({children}: {children: React.ReactNode}) {
+  const {layout} = useNavContext();
+  return (
+    <SidebarItemWrapper isMobile={layout === NavLayout.MOBILE}>
+      {children}
+    </SidebarItemWrapper>
+  );
+}
+
+function SidebarMenu({items, children, analyticsKey, label}: SidebarItemDropdownProps) {
   const organization = useOrganization();
   const recordAnalytics = useCallback(
     () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
     [organization, analyticsKey]
   );
+  const {layout} = useNavContext();
+
+  const showLabel = layout === NavLayout.MOBILE;
 
   return (
-    <SidebarItemWrapper>
+    <SidebarItem>
       <DropdownMenu
         position="right-end"
         trigger={(props, isOpen) => {
           return (
             <NavButton
-              {...mergeProps(buttonProps, props)}
+              {...props}
+              aria-label={!showLabel ? label : undefined}
               onClick={event => {
                 recordAnalytics();
                 props.onClick?.(event);
@@ -85,12 +96,13 @@ function SidebarMenu({
             >
               <InteractionStateLayer hasSelectedBackground={isOpen} />
               {children}
+              {showLabel ? label : null}
             </NavButton>
           );
         }}
         items={items}
       />
-    </SidebarItemWrapper>
+    </SidebarItem>
   );
 }
 
@@ -99,12 +111,15 @@ function SidebarLink({
   to,
   activeTo = to,
   analyticsKey,
-  linkProps: incomingLinkProps = {},
+  label,
 }: SidebarItemLinkProps) {
   const organization = useOrganization();
   const location = useLocation();
   const isActive = isLinkActive(normalizeUrl(activeTo, location), location.pathname);
   const linkProps = makeLinkPropsFromTo(to);
+
+  const {layout} = useNavContext();
+  const showLabel = layout === NavLayout.MOBILE;
 
   const recordAnalytics = useCallback(
     () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
@@ -112,17 +127,19 @@ function SidebarLink({
   );
 
   return (
-    <SidebarItemWrapper>
+    <SidebarItem>
       <NavLink
-        {...mergeProps(linkProps, incomingLinkProps)}
+        {...linkProps}
         onClick={recordAnalytics}
         aria-selected={isActive}
         aria-current={isActive ? 'page' : undefined}
+        aria-label={!showLabel ? label : undefined}
       >
         <InteractionStateLayer hasSelectedBackground={isActive} />
         {children}
+        {showLabel ? label : null}
       </NavLink>
-    </SidebarItemWrapper>
+    </SidebarItem>
   );
 }
 
@@ -134,7 +151,7 @@ function CollapseButton() {
   }
 
   return (
-    <SidebarItemWrapper>
+    <SidebarItem>
       <NavButton
         onClick={() => setIsCollapsed(!isCollapsed)}
         aria-label={isCollapsed ? t('Expand') : t('Collapse')}
@@ -142,28 +159,31 @@ function CollapseButton() {
         <InteractionStateLayer />
         <IconChevron direction={isCollapsed ? 'right' : 'left'} isDouble />
       </NavButton>
-    </SidebarItemWrapper>
+    </SidebarItem>
   );
 }
 
 export function PrimaryNavigationItems() {
   const organization = useOrganization();
   const prefix = `organizations/${organization.slug}`;
-  const {layout} = useNavContext();
-
-  const includeFooterLabels = layout !== NavLayout.SIDEBAR;
 
   return (
     <Fragment>
       <SidebarBody>
-        <SidebarLink to={`/${prefix}/issues/`} analyticsKey="issues">
+        <SidebarLink
+          to={`/${prefix}/issues/`}
+          analyticsKey="issues"
+          label={NAV_GROUP_LABELS[PrimaryNavGroup.ISSUES]}
+        >
           <IconIssues />
-          <span>{NAV_GROUP_LABELS[PrimaryNavGroup.ISSUES]}</span>
         </SidebarLink>
 
-        <SidebarLink to={`/${prefix}/explore/traces/`} analyticsKey="explore">
+        <SidebarLink
+          to={`/${prefix}/explore/traces/`}
+          analyticsKey="explore"
+          label={NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}
+        >
           <IconSearch />
-          <span>{NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}</span>
         </SidebarLink>
 
         <Feature
@@ -174,9 +194,9 @@ export function PrimaryNavigationItems() {
           <SidebarLink
             to={`/${prefix}/dashboards/`}
             analyticsKey="customizable-dashboards"
+            label={NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}
           >
             <IconDashboard />
-            <span>{NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}</span>
           </SidebarLink>
         </Feature>
 
@@ -184,9 +204,9 @@ export function PrimaryNavigationItems() {
           <SidebarLink
             to={`/${prefix}/insights/frontend/`}
             analyticsKey="insights-domains"
+            label={NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
           >
             <IconGraph />
-            <span>{NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}</span>
           </SidebarLink>
         </Feature>
       </SidebarBody>
@@ -218,20 +238,18 @@ export function PrimaryNavigationItems() {
             },
           ]}
           analyticsKey="help"
-          buttonProps={!includeFooterLabels ? {'aria-label': t('Help')} : undefined}
+          label={t('Help')}
         >
           <IconQuestion />
-          {includeFooterLabels && <span>{t('Help')}</span>}
         </SidebarMenu>
 
         <SidebarLink
           to={`/${prefix}/settings/${organization.slug}/`}
           activeTo={`/${prefix}/settings/`}
           analyticsKey="settings"
-          linkProps={!includeFooterLabels ? {'aria-label': t('Settings')} : undefined}
+          label={NAV_GROUP_LABELS[PrimaryNavGroup.SETTINGS]}
         >
           <IconSettings />
-          {includeFooterLabels && <span>{t('Settings')}</span>}
         </SidebarLink>
 
         <CollapseButton />
@@ -240,7 +258,7 @@ export function PrimaryNavigationItems() {
   );
 }
 
-const SidebarItemList = styled('ul')`
+const SidebarItemList = styled('ul')<{isMobile: boolean}>`
   position: relative;
   list-style: none;
   margin: 0;
@@ -248,23 +266,30 @@ const SidebarItemList = styled('ul')`
   padding-top: ${space(1)};
   display: flex;
   flex-direction: column;
+  align-items: stretch;
+  gap: ${space(0.5)};
   width: 100%;
   color: rgba(255, 255, 255, 0.85);
 
-  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
-    gap: ${space(1)};
-  }
+  ${p =>
+    !p.isMobile &&
+    css`
+      align-items: center;
+      gap: ${space(1)};
+    `}
 `;
 
-const SidebarItemWrapper = styled('li')`
+const SidebarItemWrapper = styled('li')<{isMobile: boolean}>`
   svg {
     --size: 14px;
     width: var(--size);
     height: var(--size);
 
-    @media (min-width: ${p => p.theme.breakpoints.medium}) {
-      --size: 16px;
-    }
+    ${p =>
+      !p.isMobile &&
+      css`
+        --size: 18px;
+      `}
   }
   > a,
   button {
@@ -277,21 +302,24 @@ const SidebarItemWrapper = styled('li')`
     font-size: ${p => p.theme.fontSizeMedium};
     font-weight: ${p => p.theme.fontWeightNormal};
     line-height: 1;
+    width: 100%;
 
     & > * {
       pointer-events: none;
     }
 
-    @media (min-width: ${p => p.theme.breakpoints.medium}) {
-      flex-direction: column;
-      justify-content: center;
-      border-radius: ${p => p.theme.borderRadius};
-      font-size: ${p => p.theme.fontSizeExtraSmall};
-      margin-inline: ${space(1)};
-      gap: ${space(0.75)};
-      padding: 10px 0;
-      min-height: 40px;
-    }
+    ${p =>
+      !p.isMobile &&
+      css`
+        flex-direction: column;
+        justify-content: center;
+        border-radius: ${p.theme.borderRadius};
+        margin-inline: 0 auto;
+        gap: ${space(0.75)};
+        padding: ${space(1.5)} 0;
+        min-height: 44px;
+        width: ${PRIMARY_SIDEBAR_WIDTH - 16}px;
+      `}
   }
 `;
 
@@ -313,7 +341,6 @@ const NavButton = styled('button')`
   border: none;
   position: relative;
   background: transparent;
-  min-width: 58px;
 
   ${linkStyles}
 `;

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -46,6 +46,16 @@ export function SecondaryNav({children, group}: SecondaryNavProps) {
   return createPortal(children, secondaryNavEl);
 }
 
+SecondaryNav.Header = function SecondaryNavHeader({children}: {children: ReactNode}) {
+  const {layout} = useNavContext();
+
+  if (layout === NavLayout.MOBILE) {
+    return null;
+  }
+
+  return <Header>{children}</Header>;
+};
+
 SecondaryNav.Body = function SecondaryNavBody({children}: {children: ReactNode}) {
   const {layout} = useNavContext();
 
@@ -101,6 +111,12 @@ SecondaryNav.Footer = function SecondaryNavFooter({children}: {children: ReactNo
 
   return <Footer layout={layout}>{children}</Footer>;
 };
+
+const Header = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: ${p => p.theme.fontWeightBold};
+  padding: ${space(2)} ${space(2)} ${space(1)} ${space(2)};
+`;
 
 const Body = styled('div')<{layout: NavLayout}>`
   padding: ${space(1)};

--- a/static/app/components/nav/secondarySidebar.tsx
+++ b/static/app/components/nav/secondarySidebar.tsx
@@ -19,10 +19,8 @@ const SecondarySidebarWrapper = styled('div')`
   position: relative;
   border-right: 1px solid ${p => p.theme.translucentGray200};
   background: ${p => p.theme.surface300};
-  display: flex;
-  align-items: stretch;
-  justify-content: space-between;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
   width: ${SECONDARY_SIDEBAR_WIDTH}px;
   z-index: ${p => p.theme.zIndex.sidebarPanel};
   height: 100%;

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -50,7 +50,7 @@ export function Sidebar({isHovered}: SidebarProps) {
 
 const SidebarWrapper = styled('div')`
   width: ${PRIMARY_SIDEBAR_WIDTH}px;
-  padding: ${space(2)} 0;
+  padding: ${space(2)} 0 ${space(1)} 0;
   border-right: 1px solid ${p => p.theme.translucentGray100};
   background: #3e2648;
   background: linear-gradient(180deg, #3e2648 0%, #442c4e 100%);

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -2,7 +2,10 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
-import {SECONDARY_SIDEBAR_WIDTH} from 'sentry/components/nav/constants';
+import {
+  PRIMARY_SIDEBAR_WIDTH,
+  SECONDARY_SIDEBAR_WIDTH,
+} from 'sentry/components/nav/constants';
 import {useNavContext} from 'sentry/components/nav/context';
 import {PrimaryNavigationItems} from 'sentry/components/nav/primary';
 import {SecondarySidebar} from 'sentry/components/nav/secondarySidebar';
@@ -46,7 +49,7 @@ export function Sidebar({isHovered}: SidebarProps) {
 }
 
 const SidebarWrapper = styled('div')`
-  width: 74px;
+  width: ${PRIMARY_SIDEBAR_WIDTH}px;
   padding: ${space(2)} 0;
   border-right: 1px solid ${p => p.theme.translucentGray100};
   background: #3e2648;
@@ -59,7 +62,7 @@ const SidebarWrapper = styled('div')`
 const CollapsedSecondaryWrapper = styled(motion.div)`
   position: absolute;
   top: 0;
-  left: 74px;
+  left: ${PRIMARY_SIDEBAR_WIDTH}px;
   height: 100%;
 `;
 

--- a/static/app/views/dashboards/navigation.tsx
+++ b/static/app/views/dashboards/navigation.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
@@ -22,6 +23,9 @@ export default function DashboardsNavigation({children}: DashboardsNavigationPro
   return (
     <Fragment>
       <SecondaryNav group={PrimaryNavGroup.DASHBOARDS}>
+        <SecondaryNav.Header>
+          {NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}
+        </SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/`} end>

--- a/static/app/views/explore/navigation.tsx
+++ b/static/app/views/explore/navigation.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
@@ -24,6 +25,9 @@ export default function ExploreNavigation({children}: Props) {
   return (
     <Fragment>
       <SecondaryNav group={PrimaryNavGroup.EXPLORE}>
+        <SecondaryNav.Header>
+          {NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}
+        </SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <Feature features="performance-trace-explorer">

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
@@ -39,6 +40,9 @@ export default function InsightsNavigation({children}: InsightsNavigationProps) 
   return (
     <Fragment>
       <SecondaryNav group={PrimaryNavGroup.INSIGHTS}>
+        <SecondaryNav.Header>
+          {NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
+        </SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/projects/`}>

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -23,6 +23,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
   return (
     <Fragment>
       <SecondaryNav group={PrimaryNavGroup.ISSUES}>
+        <SecondaryNav.Header>{t('Issues')}</SecondaryNav.Header>
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/`} end>

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -2,6 +2,7 @@ import {cloneElement, Component} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {space} from 'sentry/styles/space';
@@ -42,6 +43,9 @@ function SettingsSecondaryNavigation({
 
   return (
     <SecondaryNav group={PrimaryNavGroup.SETTINGS}>
+      <SecondaryNav.Header>
+        {NAV_GROUP_LABELS[PrimaryNavGroup.SETTINGS]}
+      </SecondaryNav.Header>
       <SecondaryNav.Body>
         {navWithHooks.map(config => (
           <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />


### PR DESCRIPTION
Adjusts labels in primary sidebar and adds them additionally to the top of secondary sidebar.

![CleanShot 2025-02-10 at 16 12 13](https://github.com/user-attachments/assets/7ea28d76-d8ea-4dff-be57-9c797ab3e17c)
