### PR TITLE
fix(aci milestone 3): use helper to get active incidents

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -486,11 +486,7 @@ def migrate_alert_rule(
 
     workflow = create_workflow(alert_rule.name, organization_id, user)
 
-    open_incident = (
-        Incident.objects.exclude(status=IncidentStatus.CLOSED.value)
-        .filter(alert_rule=alert_rule)
-        .first()
-    )
+    open_incident = Incident.objects.get_active_incident(alert_rule, project)
     if open_incident:
         state = (
             DetectorPriorityLevel.MEDIUM


### PR DESCRIPTION
I noticed there is a method to get active incidents, so use this instead of DIYing it in the migration helpers.