### PR TITLE
feat(nav): Modify link paths in replays to match new structure

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -14,7 +14,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
 import type {ColorOrAlias} from 'sentry/utils/theme';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -30,6 +29,7 @@ import {
   SelectorLink,
   transformSelectorQuery,
 } from 'sentry/views/replays/deadRageClick/selectorTable';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 function DeadRageSelectorCards() {
   return (
@@ -165,7 +165,7 @@ function AccordionWidget({
       )}
       <SearchButton
         label={t('See all selectors')}
-        path="selectors"
+        path="/selectors/"
         sort={`-${clickType}`}
       />
     </StyledWidgetContainer>
@@ -213,18 +213,23 @@ function SearchButton({
   ...props
 }: {
   label: ReactNode;
-  path: string;
+  path: '/' | `/${string}/`;
   sort: string;
 } & Omit<LinkButtonProps, 'size' | 'to' | 'external'>) {
   const location = useLocation();
   const organization = useOrganization();
+
+  const pathname = makeReplaysPathname({
+    path,
+    organization,
+  });
 
   return (
     <StyledButton
       {...props}
       size="xs"
       to={{
-        pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${path}/`),
+        pathname,
         query: {
           ...location.query,
           sort,

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -16,11 +16,11 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconCursorArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {WiderHovercard} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
 
 export interface UrlState {
@@ -182,12 +182,17 @@ export function SelectorLink({
     </TooltipContainer>
   );
 
+  const pathname = makeReplaysPathname({
+    path: '/',
+    organization,
+  });
+
   return (
     <StyledTextOverflow>
       <WiderHovercard position="right" body={hovercardContent}>
         <Link
           to={{
-            pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+            pathname,
             query: {
               ...location.query,
               query: selectorQuery,

--- a/static/app/views/replays/pathnames.tsx
+++ b/static/app/views/replays/pathnames.tsx
@@ -1,0 +1,19 @@
+import type {Organization} from 'sentry/types/organization';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+const LEGACY_REPLAYS_BASE_PATHNAME = 'replays';
+const REPLAYS_BASE_PATHNAME = 'explore/replays';
+
+export function makeReplaysPathname({
+  path,
+  organization,
+}: {
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}) {
+  return normalizeUrl(
+    organization.features.includes('navigation-sidebar-v2')
+      ? `/organizations/${organization.slug}/${REPLAYS_BASE_PATHNAME}${path}`
+      : `/organizations/${organization.slug}/${LEGACY_REPLAYS_BASE_PATHNAME}${path}`
+  );
+}

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -33,11 +33,11 @@ import {spanOperationRelativeBreakdownRenderer} from 'sentry/utils/discover/fiel
 import {getShortEventId} from 'sentry/utils/events';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useProjects from 'sentry/utils/useProjects';
 import type {ReplayListRecordWithTx} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {ReplayListLocationQuery, ReplayListRecord} from 'sentry/views/replays/types';
 
 type Props = {
@@ -305,8 +305,13 @@ export function ReplayCell({
   const {projects} = useProjects();
   const project = projects.find(p => p.id === replay.project_id);
 
+  const replayDetailsPathname = makeReplaysPathname({
+    path: `/${replay.id}/`,
+    organization,
+  });
+
   const replayDetails = {
-    pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replay.id}/`),
+    pathname: replayDetailsPathname,
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),
@@ -314,7 +319,7 @@ export function ReplayCell({
   };
 
   const replayDetailsDeadRage = {
-    pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replay.id}/`),
+    pathname: replayDetailsPathname,
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),

--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -3,10 +3,10 @@ import {useMemo} from 'react';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useAllMobileProj from 'sentry/views/replays/detail/useAllMobileProj';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 interface Props {
   selected: 'replays' | 'selectors';
@@ -17,22 +17,32 @@ export default function ReplayTabs({selected}: Props) {
   const location = useLocation();
   const {allMobileProj} = useAllMobileProj({});
 
+  const replaysPathname = makeReplaysPathname({
+    path: '/',
+    organization,
+  });
+
+  const selectorsPathname = makeReplaysPathname({
+    path: '/selectors/',
+    organization,
+  });
+
   const tabs = useMemo(
     () => [
       {
         key: 'replays',
         label: t('Replays'),
-        pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+        pathname: replaysPathname,
         query: {...location.query, sort: undefined},
       },
       {
         key: 'selectors',
         label: t('Selectors'),
-        pathname: normalizeUrl(`/organizations/${organization.slug}/replays/selectors/`),
+        pathname: selectorsPathname,
         query: {...location.query, sort: '-count_dead_clicks'},
       },
     ],
-    [organization.slug, location.query]
+    [location.query, replaysPathname, selectorsPathname]
   );
 
   return (


### PR DESCRIPTION
We need to modify all the existing links and `navigate`s to use the new `/explore/replays/` structure when the feature flag for the new nav is enabled. To accomplish this, I've added a `makeReplaysPathname` util to help generate those links.