### PR TITLE
feat(uptime): query for http status code

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2392,7 +2392,7 @@ class UptimeCheckSnubaTestCase(TestCase):
                 "status_reason": None,
                 "trace_id": str(uuid.uuid4()),
                 "request_info": {
-                    "status_code": http_status,
+                    "http_status_code": http_status,
                 },
             }
         )

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -145,7 +145,10 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
                     label="trace_id",
                     key=AttributeKey(name="trace_id", type=AttributeKey.Type.TYPE_STRING),
                 ),
-                # TODO: Add http_status_code once nullable problem figured out
+                Column(
+                    label="http_status_code",
+                    key=AttributeKey(name="http_status_code", type=AttributeKey.Type.TYPE_INT),
+                ),
             ],
             order_by=[
                 TraceItemTableRequest.OrderBy(

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -57,6 +57,7 @@ class ProjectUptimeAlertCheckIndexEndpoint(
             "checkStatus",
             "checkStatusReason",
             "traceId",
+            "httpStatusCode",
         ]:
             assert key in first, f"{key} not in {first}"
         assert first["uptimeSubscriptionId"] == self.project_uptime_subscription.id


### PR DESCRIPTION
was previously not included because of an issue in snuba, but this has been fixed. can include these in the table rows now.