### PR TITLE
:sparkles: feat(flagpole): add support for orgmapping

### DIFF
--- a/src/sentry/features/flagpole_context.py
+++ b/src/sentry/features/flagpole_context.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import AnonymousUser
 from flagpole.evaluation_context import ContextBuilder, EvaluationContextDict
 from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
 from sentry.models.organization import Organization
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
@@ -21,7 +22,12 @@ class InvalidContextDataException(Exception):
 class SentryContextData:
     actor: User | RpcUser | AnonymousUser | None = None
     organization: (
-        Organization | RpcOrganization | RpcOrganizationSummary | RpcOrganizationMapping | None
+        Organization
+        | RpcOrganization
+        | RpcOrganizationSummary
+        | RpcOrganizationMapping
+        | OrganizationMapping
+        | None
     ) = None
     project: Project | RpcProject | None = None
 
@@ -38,6 +44,12 @@ def organization_context_transformer(data: SentryContextData) -> EvaluationConte
         context_data["organization_id"] = org.id
         early_adopter = bool(org.flags.early_adopter) if org.flags is not None else False
         context_data["organization_is-early-adopter"] = early_adopter
+
+    elif isinstance(org, OrganizationMapping):
+        context_data["organization_slug"] = org.slug
+        context_data["organization_name"] = org.name
+        context_data["organization_id"] = org.organization_id
+        context_data["organization_is-early-adopter"] = org.flags.early_adopter
 
     elif isinstance(org, RpcOrganization):
         context_data["organization_slug"] = org.slug

--- a/tests/sentry/features/test_flagpole_context.py
+++ b/tests/sentry/features/test_flagpole_context.py
@@ -10,9 +10,10 @@ from sentry.features.flagpole_context import (
     user_context_transformer,
 )
 from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.organizations.services.organization import organization_service
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import SiloMode, assume_test_silo_mode, control_silo_test
 from sentry.users.models.useremail import UserEmail
 
 
@@ -96,6 +97,20 @@ class TestSentryOrganizationContextTransformer(TestCase):
             "organization_name": "Foo Bar",
             "organization_is-early-adopter": False,
         }
+
+    def test_with_organization_mapping(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            org = self.create_organization(slug="foobar", name="Foo Bar")
+            org_mapping = OrganizationMapping.objects.get(organization_id=org.id)
+            context_data = organization_context_transformer(
+                SentryContextData(organization=org_mapping)
+            )
+            assert context_data == {
+                "organization_slug": "foobar",
+                "organization_id": org.id,
+                "organization_name": "Foo Bar",
+                "organization_is-early-adopter": False,
+            }
 
 
 class TestProjectContextTransformer(TestCase):

--- a/tests/sentry/features/test_flagpole_context.py
+++ b/tests/sentry/features/test_flagpole_context.py
@@ -12,8 +12,9 @@ from sentry.features.flagpole_context import (
 from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.organizations.services.organization import organization_service
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import SiloMode, assume_test_silo_mode, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.useremail import UserEmail
 
 


### PR DESCRIPTION
i see that we support `RpcOrganizationMapping`, so figured we should also support `OrganizationMapping` if someone is checking a flag from control.