### PR TITLE
fix(issues): Adjust comment user avatar size

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {
   IconAdd,
@@ -25,6 +27,7 @@ import {
   IconUser,
 } from 'sentry/icons';
 import {IconCellSignal} from 'sentry/icons/iconCellSignal';
+import {space} from 'sentry/styles/space';
 import {
   type Group,
   type GroupActivityCreateIssue,
@@ -51,7 +54,7 @@ export const groupActivityTypeIconMapping: Record<
     Component: IconChat,
     defaultProps: {},
     componentFunction: (_data, user) => {
-      return user ? () => <UserAvatar user={user} /> : IconChat;
+      return user ? () => <StyledUserAvatar user={user} /> : IconChat;
     },
   },
   [GroupActivityType.SET_RESOLVED]: {Component: IconCheckmark, defaultProps: {}},
@@ -126,3 +129,9 @@ export const groupActivityTypeIconMapping: Record<
   },
   [GroupActivityType.DELETED_ATTACHMENT]: {Component: IconDelete, defaultProps: {}},
 };
+
+const StyledUserAvatar = styled(UserAvatar)`
+  svg {
+    margin: ${space(0.25)};
+  }
+`;


### PR DESCRIPTION
adjusts size of users without avatars

before
![image](https://github.com/user-attachments/assets/edd205ff-213f-4026-ba49-3a3960867c5d)

after
![image](https://github.com/user-attachments/assets/330eefd7-482c-4317-ae09-938fbbb02d22)
