### PR TITLE
chore(api): Generalize `NOT_SET` constant so that we can use it elsewhere

### DIFF
--- a/src/sentry/api/helpers/constants.py
+++ b/src/sentry/api/helpers/constants.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 MAX_QUERY_SUBSCRIPTIONS_HEADER = "X-Sentry-Alert-Rule-Limit"
 ALERT_RULES_COUNT_HEADER = "X-Sentry-Alert-Rule-Hits"

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -6,7 +6,6 @@ from collections.abc import Collection, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
-from enum import Enum, auto
 from typing import Any, TypedDict
 from uuid import UUID, uuid4
 
@@ -98,19 +97,13 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
+from sentry.utils.not_set import NOT_SET, NotSet
 from sentry.utils.snuba import is_measurement
 
 # We can return an incident as "windowed" which returns a range of points around the start of the incident
 # It attempts to center the start of the incident, only showing earlier data if there isn't enough time
 # after the incident started to display the correct start date.
 WINDOWED_STATS_DATA_POINTS = 200
-
-
-class NotSet(Enum):
-    TOKEN = auto()
-
-
-NOT_SET = NotSet.TOKEN
 
 CRITICAL_TRIGGER_LABEL = "critical"
 WARNING_TRIGGER_LABEL = "warning"

--- a/src/sentry/utils/not_set.py
+++ b/src/sentry/utils/not_set.py
@@ -19,7 +19,7 @@ def default_if_not_set(current_value: T, new_value: T | NotSet) -> T:
     This is useful for updating fields on a model, since we can't set those defaults on the function level.
     Example usage:
     def my_updater(my_model: SomeModel, val_a: str | NotSet = NOT_SET):
-        my_model.some_field = get_current_value_if_not_set(my_model.some_field, val_a)
+        my_model.some_field = default_if_not_set(my_model.some_field, val_a)
         my_model.save()
     """
     if new_value is NOT_SET:

--- a/src/sentry/utils/not_set.py
+++ b/src/sentry/utils/not_set.py
@@ -13,7 +13,7 @@ NOT_SET = NotSet.TOKEN
 T = TypeVar("T")
 
 
-def get_current_value_if_not_set(current_value: T, new_value: T | NotSet) -> T:
+def default_if_not_set(current_value: T, new_value: T | NotSet) -> T:
     """
     Used for optionally passing parameters to a function, and defaulting to some value if not passed.
     This is useful for updating fields on a model, since we can't set those defaults on the function level.

--- a/src/sentry/utils/not_set.py
+++ b/src/sentry/utils/not_set.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class NotSet(Enum):
+    TOKEN = auto()
+
+
+NOT_SET = NotSet.TOKEN

--- a/src/sentry/utils/not_set.py
+++ b/src/sentry/utils/not_set.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum, auto
+from typing import TypeVar
 
 
 class NotSet(Enum):
@@ -8,3 +9,19 @@ class NotSet(Enum):
 
 
 NOT_SET = NotSet.TOKEN
+
+T = TypeVar("T")
+
+
+def get_current_value_if_not_set(current_value: T, new_value: T | NotSet) -> T:
+    """
+    Used for optionally passing parameters to a function, and defaulting to some value if not passed.
+    This is useful for updating fields on a model, since we can't set those defaults on the function level.
+    Example usage:
+    def my_updater(my_model: SomeModel, val_a: str | NotSet = NOT_SET):
+        my_model.some_field = get_current_value_if_not_set(my_model.some_field, val_a)
+        my_model.save()
+    """
+    if new_value is NOT_SET:
+        return current_value
+    return new_value

--- a/tests/sentry/utils/test_not_set.py
+++ b/tests/sentry/utils/test_not_set.py
@@ -1,8 +1,8 @@
 from sentry.testutils.cases import TestCase
-from sentry.utils.not_set import NOT_SET, get_current_value_if_not_set
+from sentry.utils.not_set import NOT_SET, default_if_not_set
 
 
 class ClearFlagTest(TestCase):
     def test(self):
-        assert get_current_value_if_not_set(1, NOT_SET) == 1
-        assert get_current_value_if_not_set(1, 2) == 2
+        assert default_if_not_set(1, NOT_SET) == 1
+        assert default_if_not_set(1, 2) == 2

--- a/tests/sentry/utils/test_not_set.py
+++ b/tests/sentry/utils/test_not_set.py
@@ -1,0 +1,8 @@
+from sentry.testutils.cases import TestCase
+from sentry.utils.not_set import NOT_SET, get_current_value_if_not_set
+
+
+class ClearFlagTest(TestCase):
+    def test(self):
+        assert get_current_value_if_not_set(1, NOT_SET) == 1
+        assert get_current_value_if_not_set(1, 2) == 2


### PR DESCRIPTION
This is useful when providing partial updates to a function

<!-- Describe your PR here. -->