### PR TITLE
chore(aci): avoid double migrating, use nested transaction in dual create issue alerts

### DIFF
--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -32,8 +32,14 @@ class ProjectRuleCreator:
             if features.has(
                 "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
             ):
-                # TODO(cathy): handle errors from broken actions
-                migrate_issue_alert(self.rule, self.request.user.id if self.request else None)
+                try:
+                    with transaction.atomic(router.db_for_write(Rule)):
+                        # TODO(cathy): handle errors from broken actions
+                        migrate_issue_alert(
+                            self.rule, self.request.user.id if self.request else None
+                        )
+                except Exception:
+                    pass
 
             return self.rule
 

--- a/src/sentry/workflow_engine/migration_helpers/rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule.py
@@ -38,7 +38,10 @@ def migrate_issue_alert(rule: Rule, user_id: int | None = None):
     error_detector, _ = Detector.objects.get_or_create(
         type=ErrorGroupType.slug, project=project, defaults={"config": {}, "name": "Error Detector"}
     )
-    AlertRuleDetector.objects.create(detector=error_detector, rule=rule)
+    _, created = AlertRuleDetector.objects.get_or_create(detector=error_detector, rule=rule)
+    if not created:
+        logger.info("Issue alert already migrated", extra={"rule_id": rule.id})
+        return
 
     conditions, filters = split_conditions_and_filters(data["conditions"])
     when_dcg = create_when_dcg(

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -159,6 +159,16 @@ class RuleMigrationHelpersTest(APITestCase):
         dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
         assert dc.condition_group.logic_type == DataConditionGroup.Type.ALL
 
+    def test_create_issue_no_double_migrate(self):
+        migrate_issue_alert(self.issue_alert, self.user.id)
+        migrate_issue_alert(self.issue_alert, self.user.id)
+
+        # there should be only 1
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+        issue_alert_detector = AlertRuleDetector.objects.get(rule=self.issue_alert)
+        Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+        Detector.objects.get(id=issue_alert_detector.detector.id)
+
     def test_update_issue_alert(self):
         migrate_issue_alert(self.issue_alert, self.user.id)
         conditions_payload = [


### PR DESCRIPTION
1. Prevent migrating an issue alert more than once
2. Add a nested transaction inside `ProjectRuleCreator` for dual create. If the `migrate_issue_alert` helper fails, it shouldn't prevent the `Rule` from being created. (Failures will likely be exceptions that raise a Sentry error, so we can track them).