### PR TITLE
feat(uptime): Add route for "existing or create"

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1297,6 +1297,12 @@ function buildRoutes() {
               path=":projectId/:uptimeRuleId/details/"
               component={make(() => import('sentry/views/alerts/rules/uptime/details'))}
             />
+            <Route
+              path="existing-or-create/"
+              component={make(
+                () => import('sentry/views/alerts/rules/uptime/existingOrCreate')
+              )}
+            />
           </Route>
           <Route
             path="crons/"

--- a/static/app/views/alerts/rules/uptime/existingOrCreate.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/existingOrCreate.spec.tsx
@@ -1,0 +1,46 @@
+import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
+
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import ExistingOrCreate from './existingOrCreate';
+
+describe('ExistingOrCreate', () => {
+  it('redirects to create a new alert when none exist', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      body: [],
+    });
+
+    const {router} = render(<ExistingOrCreate />, {disableRouterMocks: true});
+    await waitFor(() =>
+      expect(router.location.pathname).toBe('/organizations/org-slug/alerts/new/uptime/')
+    );
+  });
+
+  it('redirects to specific alert when one exists', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      body: [UptimeRuleFixture()],
+    });
+
+    const {router} = render(<ExistingOrCreate />, {disableRouterMocks: true});
+    await waitFor(() =>
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/alerts/uptime-rules/project-slug/1/'
+      )
+    );
+  });
+
+  it('redirects to the list when multiple eixst', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      body: [UptimeRuleFixture({id: '1'}), UptimeRuleFixture({id: '2'})],
+    });
+
+    const {router} = render(<ExistingOrCreate />, {disableRouterMocks: true});
+    await waitFor(() =>
+      expect(router.location.pathname).toBe('/organizations/org-slug/alerts/rules/')
+    );
+    expect(router.location.query).toEqual({alertType: 'uptime'});
+  });
+});

--- a/static/app/views/alerts/rules/uptime/existingOrCreate.tsx
+++ b/static/app/views/alerts/rules/uptime/existingOrCreate.tsx
@@ -1,0 +1,59 @@
+import {useEffect} from 'react';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import {CombinedAlertType, type UptimeAlert} from '../../types';
+
+/**
+ * When no uptime alert rules exist, takes the user to create a new alert. If
+ * multiple rules exists redirects them to the listing page. If only a single
+ * rule exists, tak them to edit that alert rule.
+ *
+ * This route is used for docs and marketing purposes.
+ */
+export default function ExistingOrCreate() {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+
+  const {data: existingRules, isPending} = useApiQuery<UptimeAlert[]>(
+    [
+      `/organizations/${organization.slug}/combined-rules/`,
+      {query: {alertType: CombinedAlertType.UPTIME}},
+    ],
+    {staleTime: 300}
+  );
+
+  useEffect(() => {
+    if (isPending || !existingRules) {
+      return;
+    }
+
+    // Has one single alert rule
+    if (existingRules.length === 1) {
+      const url = normalizeUrl(
+        `/organizations/${organization.slug}/alerts/uptime-rules/${existingRules[0]?.projectSlug}/${existingRules[0]?.id}/`
+      );
+      navigate(url, {replace: true});
+      return;
+    }
+
+    // Has multiple existing alert rules
+    if (existingRules.length > 1) {
+      const url = normalizeUrl(
+        `/organizations/${organization.slug}/alerts/rules/?alertType=uptime`
+      );
+      navigate(url, {replace: true});
+      return;
+    }
+
+    // No alert rules, create a new one
+    const url = normalizeUrl(`/organizations/${organization.slug}/alerts/new/uptime/`);
+    navigate(url, {replace: true});
+  }, [existingRules, isPending, navigate, organization.slug]);
+
+  return <LoadingIndicator />;
+}


### PR DESCRIPTION
This will be primarily used for marketing and documentation. When you
hit this route you're conditionally redirected:

 - If you have no uptime alerts you're take to create one
 - If you have exactly one alert you're taken to edit it
 - If you have multiple you're taken to the alert listing page

The route will be 

https://sentry.io/alerts/rules/uptime/existing-or-create/