### PR TITLE
 feat(releases): add error free rate chart to mobile insights

### DIFF
--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -39,7 +39,7 @@ export function MobileHeader({
   const hasMobileUi = isModuleEnabled(ModuleName.MOBILE_UI, organization);
 
   const modules = hasMobileScreens
-    ? [ModuleName.MOBILE_VITALS, ModuleName.HTTP]
+    ? [ModuleName.MOBILE_VITALS, ModuleName.HTTP, ModuleName.SESSIONS]
     : [
         ModuleName.APP_START,
         ModuleName.SCREEN_LOAD,

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -2,8 +2,45 @@ import {t} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useErrorFreeSessions from 'sentry/views/insights/sessions/queries/useErrorFreeSessions';
 
-export default function ErrorFreeSessionsChart() {
-  const {seriesData, isPending, error} = useErrorFreeSessions();
+interface Props {
+  groupByRelease?: boolean;
+}
+
+export default function ErrorFreeSessionsChart({groupByRelease}: Props) {
+  const {seriesData, mobileSeriesData, releases, isPending, error} = useErrorFreeSessions(
+    {
+      groupByRelease,
+    }
+  );
+
+  const mobileSeries =
+    mobileSeriesData?.map((series, index) => ({
+      data: series,
+      seriesName: `successful_session_rate_${releases[index]}`,
+      meta: {
+        fields: {
+          [`successful_session_rate_${releases[index]}`]: 'percentage' as const,
+          time: 'date' as const,
+        },
+        units: {
+          [`successful_session_rate_${releases[index]}`]: '%',
+        },
+      },
+    })) ?? [];
+
+  if (groupByRelease) {
+    return (
+      <InsightsLineChartWidget
+        title={t('Error Free Session Rate')}
+        aliases={Object.fromEntries(
+          releases?.map(release => [`successful_session_rate_${release}`, release]) ?? []
+        )}
+        series={mobileSeries}
+        isLoading={isPending}
+        error={error}
+      />
+    );
+  }
 
   return (
     <InsightsLineChartWidget

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -7,62 +7,23 @@ interface Props {
 }
 
 export default function ErrorFreeSessionsChart({groupByRelease}: Props) {
-  const {seriesData, mobileSeriesData, releases, isPending, error} = useErrorFreeSessions(
-    {
-      groupByRelease,
-    }
-  );
+  const {series, releases, isPending, error} = useErrorFreeSessions({
+    groupByRelease,
+  });
 
-  const mobileSeries =
-    mobileSeriesData?.map((series, index) => ({
-      data: series,
-      seriesName: `successful_session_rate_${releases[index]}`,
-      meta: {
-        fields: {
-          [`successful_session_rate_${releases[index]}`]: 'percentage' as const,
-          time: 'date' as const,
-        },
-        units: {
-          [`successful_session_rate_${releases[index]}`]: '%',
-        },
-      },
-    })) ?? [];
-
-  if (groupByRelease) {
-    return (
-      <InsightsLineChartWidget
-        title={t('Error Free Session Rate')}
-        aliases={Object.fromEntries(
-          releases?.map(release => [`successful_session_rate_${release}`, release]) ?? []
-        )}
-        series={mobileSeries}
-        isLoading={isPending}
-        error={error}
-      />
-    );
-  }
+  const aliases = groupByRelease
+    ? Object.fromEntries(
+        releases?.map(release => [`successful_session_rate_${release}`, release]) ?? []
+      )
+    : {
+        successful_session_rate: t('Error free session rate'),
+      };
 
   return (
     <InsightsLineChartWidget
       title={t('Error Free Session Rate')}
-      aliases={{
-        successful_session_rate: t('Error free session rate'),
-      }}
-      series={[
-        {
-          data: seriesData,
-          seriesName: 'successful_session_rate',
-          meta: {
-            fields: {
-              successful_session_rate: 'percentage',
-              time: 'date',
-            },
-            units: {
-              successful_session_rate: '%',
-            },
-          },
-        },
-      ]}
+      aliases={aliases}
+      series={series}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -124,7 +124,7 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
     return {series, releases, isPending, error};
   }
 
-  // For series data not grouped by release
+  // Returns series data not grouped by release
   const getStatusSeries = (status: string) =>
     sessionsData.groups.find(group => group.by['session.status'] === status)?.series[
       'sum(session)'

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -50,7 +50,10 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
 
   // Returns series data for each release
   if (groupByRelease) {
+    // Maps release to its API response groups
     const releaseGroups = new Map<string, typeof sessionsData.groups>();
+
+    // Maps release to its adoption rate calculation
     const releaseAdoption = new Map<string, number>();
 
     sessionsData.groups.forEach(group => {
@@ -60,16 +63,18 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
         const groups = sessionsData.groups.filter(
           g => g.by.release?.toString() === release
         );
+
+        // Calculate total sessions for entire time period
         const totalSessions = groups.reduce(
           (acc, g) => acc + (g.totals['sum(session)'] ?? 0),
           0
         );
-        // Only add releases with sessions > 0
+
+        // Only consider releases with total sessions > 0
         if (totalSessions > 0) {
           releaseAdoption.set(release, percent(totalSessions, projTotal));
         }
       }
-      // Only collect groups for releases with sessions
       if (releaseAdoption.has(release)) {
         releaseGroups.get(release)!.push(group);
       }
@@ -86,7 +91,7 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
       const getStatusSeries = (status: string) =>
         groups.find(g => g.by['session.status'] === status)?.series['sum(session)'] ?? [];
 
-      // Get all status series at once
+      // Get all status series at once and calculate healthy session percentage for each interval
       const seriesData = getStatusSeries('healthy').map((healthy, idx) => {
         const total = [
           healthy,

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -138,7 +138,7 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
   // Calculate percentage for each interval
   const healthySessionsPercentageData = healthySessionsSeries.map((healthyCount, idx) => {
     const total = totalSessionsByInterval?.[idx] ?? 1;
-    return total > 0 ? healthyCount / total : 0;
+    return total > 0 ? healthyCount / total : 1;
   });
 
   const seriesData = healthySessionsPercentageData.map((val, idx) => {

--- a/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
@@ -1,0 +1,32 @@
+import type {SessionApiResponse} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useSessionProjectTotal() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {
+    data: projSessionData,
+    isPending,
+    isError,
+  } = useApiQuery<SessionApiResponse>(
+    [
+      `/organizations/${organization.slug}/sessions/`,
+      {
+        query: {
+          ...location.query,
+          field: ['sum(session)'],
+          groupBy: ['project'],
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+
+  if (isPending || isError || !projSessionData) {
+    return 0;
+  }
+
+  return projSessionData.groups[0]!.totals['sum(session)'] ?? 0;
+}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -10,6 +10,8 @@ import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHead
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -20,11 +22,13 @@ export function SessionsOverview() {
   };
 
   const {view} = useDomainViewFilters();
+  const isMobile = view === MOBILE_LANDING_SUB_PATH;
 
   return (
     <React.Fragment>
       {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
       {view === BACKEND_LANDING_SUB_PATH && <BackendHeader {...headerProps} />}
+      {view === MOBILE_LANDING_SUB_PATH && <MobileHeader {...headerProps} />}
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
@@ -36,9 +40,15 @@ export function SessionsOverview() {
                 />
               </ToolRibbon>
             </ModuleLayout.Full>
-            <ModuleLayout.Third>
-              <ErrorFreeSessionsChart />
-            </ModuleLayout.Third>
+            {isMobile ? (
+              <ModuleLayout.Half>
+                <ErrorFreeSessionsChart groupByRelease />
+              </ModuleLayout.Half>
+            ) : (
+              <ModuleLayout.Third>
+                <ErrorFreeSessionsChart />
+              </ModuleLayout.Third>
+            )}
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -22,7 +22,6 @@ export function SessionsOverview() {
   };
 
   const {view} = useDomainViewFilters();
-  const isMobile = view === MOBILE_LANDING_SUB_PATH;
 
   return (
     <React.Fragment>
@@ -40,7 +39,7 @@ export function SessionsOverview() {
                 />
               </ToolRibbon>
             </ModuleLayout.Full>
-            {isMobile ? (
+            {view === MOBILE_LANDING_SUB_PATH ? (
               <ModuleLayout.Half>
                 <ErrorFreeSessionsChart groupByRelease />
               </ModuleLayout.Half>


### PR DESCRIPTION
closes https://github.com/getsentry/team-replay/issues/540?reload=1?reload=1

creates a mobile version of the error-free rate chart:

<img width="538" alt="SCR-20250211-lsjc" src="https://github.com/user-attachments/assets/ea6063d8-18a8-47c3-b93a-dcdd5e1678cb" />

https://github.com/user-attachments/assets/37178836-3796-4419-9c46-cac5c50d1444




todo
- [x] reduce noise on the chart (only show "top 5" releases?)
- [x] what to do about sessions with no data?
- [x] does `['release']` grouping automatically give me the active releases?? or do i need query another endpoint? need to research