### PR TITLE
feat(issue-views): Add guide to highlight page filter persistence 

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -208,5 +208,19 @@ export default function getGuidesContent(
         },
       ],
     },
+    {
+      guide: 'issue_views_page_filters_persistence',
+      requiredTargets: ['issue_views_page_filters_persistence'],
+      steps: [
+        {
+          title: t('Save Filters to Issue Views'),
+          target: 'issue_views_page_filters_persistence',
+          description: t(
+            'We heard your feedback — you can now save specific projects, environments, and time filters to individual Issue Views.'
+          ),
+        },
+      ],
+      dateThreshold: new Date('2025-02-11'),
+    },
   ];
 }

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,6 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -21,14 +22,20 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+  const hasIssueViews = organization.features.includes('issue-stream-custom-views');
 
   return (
     <FiltersContainer hasNewLayout={hasNewLayout}>
-      <StyledPageFilterBar>
-        <ProjectPageFilter />
-        <EnvironmentPageFilter />
-        <DatePageFilter />
-      </StyledPageFilterBar>
+      <GuideAnchor
+        target="issue_views_page_filters_persistence"
+        disabled={!hasIssueViews}
+      >
+        <StyledPageFilterBar>
+          <ProjectPageFilter />
+          <EnvironmentPageFilter />
+          <DatePageFilter />
+        </StyledPageFilterBar>
+      </GuideAnchor>
 
       <Search {...{query, onSearch}} />
 

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -22,13 +22,15 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
-  const hasIssueViews = organization.features.includes('issue-stream-custom-views');
+  const hasPageFiltersPersistence = organization.features.includes(
+    'issue-views-page-filter'
+  );
 
   return (
     <FiltersContainer hasNewLayout={hasNewLayout}>
       <GuideAnchor
         target="issue_views_page_filters_persistence"
-        disabled={!hasIssueViews}
+        disabled={!hasPageFiltersPersistence}
       >
         <StyledPageFilterBar>
           <ProjectPageFilter />


### PR DESCRIPTION
Adds a tooltip/guide that highlights the fact that page filters now save to issue views. Only shows for existing users that have the issue views feature enabled (currently all EA users) 

![image](https://github.com/user-attachments/assets/7d9eeac8-72d2-4633-bf32-0f6c1312d0f0)
