### PR TITLE
fix(sentryapps): prevent url from being unbound

### DIFF
--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -42,6 +42,7 @@ class SelectRequester:
 
     def run(self) -> SelectRequesterResult:
         response: list[dict[str, str]] = []
+        url = None
         try:
             url = self._build_url()
             body = safe_urlread(


### PR DESCRIPTION
if `build_url` raises an exception, url will be unbound and we won't log correctly.

resolves [SENTRY-3NHT](https://sentry.sentry.io/issues/6285961990/)