### PR TITLE
ref(quick-start): Add 'quickStartDisplay' user's option

### DIFF
--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -43,7 +43,7 @@ def validate_quick_start_display(value: dict[str, int] | None) -> None:
     if value is not None:
         for display_value in value.values():
             if not isinstance(display_value, int):
-                raise ValidationError("The value shall be an integer.")
+                raise ValidationError("The value should be an integer.")
             if display_value <= 0:
                 raise ValidationError("The value cannot be less than or equal to 0.")
             if display_value > 2:

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -68,6 +68,12 @@ class UserOptionsSerializer(serializers.Serializer[UserOption]):
     )
     prefersIssueDetailsStreamlinedUI = serializers.BooleanField(required=False)
 
+    quickStartDisplay = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text="Tracks whether the quick start guide was already automatically shown to the user during their second visit.",
+    )
+
 
 class BaseUserSerializer(CamelSnakeModelSerializer[User]):
     def validate_username(self, value: str) -> str:
@@ -230,6 +236,7 @@ class UserDetailsEndpoint(UserEndpoint):
             "defaultIssueEvent": "default_issue_event",
             "clock24Hours": "clock_24_hours",
             "prefersIssueDetailsStreamlinedUI": "prefers_issue_details_streamlined_ui",
+            "quickStartDisplay": "quick_start_display",
         }
 
         options_result = serializer_options.validated_data

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -39,7 +39,7 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 TIMEZONE_CHOICES = get_timezone_choices()
 
 
-def validate_quick_start_display(value: dict[str, int]):
+def validate_quick_start_display(value: dict[str, int] | None) -> None:
     if value is not None:
         for display_value in value.values():
             if not isinstance(display_value, int):
@@ -48,7 +48,6 @@ def validate_quick_start_display(value: dict[str, int]):
                 raise ValidationError("The value cannot be less than or equal to 0.")
             if display_value > 2:
                 raise ValidationError("The value cannot exceed 2.")
-    return value
 
 
 class UserOptionsSerializer(serializers.Serializer[UserOption]):

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -6,6 +6,7 @@ from django.contrib.auth import logout
 from django.db import router, transaction
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -36,6 +37,18 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 TIMEZONE_CHOICES = get_timezone_choices()
+
+
+def validate_quick_start_display(value: dict[str, int]):
+    if value is not None:
+        for display_value in value.values():
+            if not isinstance(display_value, int):
+                raise ValidationError("The value shall be an integer.")
+            if display_value <= 0:
+                raise ValidationError("The value cannot be less than or equal to 0.")
+            if display_value > 2:
+                raise ValidationError("The value cannot exceed 2.")
+    return value
 
 
 class UserOptionsSerializer(serializers.Serializer[UserOption]):
@@ -71,6 +84,7 @@ class UserOptionsSerializer(serializers.Serializer[UserOption]):
     quickStartDisplay = serializers.JSONField(
         required=False,
         allow_null=True,
+        validators=[validate_quick_start_display],
         help_text="Tracks whether the quick start guide was already automatically shown to the user during their second visit.",
     )
 

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -266,8 +266,7 @@ class UserDetailsEndpoint(UserEndpoint):
 
                     new_value = options_result.get(key)
 
-                    for org_id, display_value in new_value.items():
-                        current_value[org_id] = display_value
+                    current_value.update(new_value)
 
                     UserOption.objects.set_value(
                         user=user, key=key_map.get(key, key), value=current_value

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -66,6 +66,7 @@ class _UserOptions(TypedDict):
     timezone: str
     clock24Hours: bool
     prefersIssueDetailsStreamlinedUI: bool
+    quickStartDisplay: dict[str, int]
 
 
 class UserSerializerResponseOptional(TypedDict, total=False):
@@ -198,6 +199,7 @@ class UserSerializer(Serializer):
                 "prefersIssueDetailsStreamlinedUI": options.get(
                     "prefers_issue_details_streamlined_ui", False
                 ),
+                "quickStartDisplay": options.get("quick_start_display") or {},
             }
 
             d["flags"] = {"newsletter_consent_prompt": bool(obj.flags.newsletter_consent_prompt)}

--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -163,8 +163,10 @@ class UserOption(Model):
         - unused
      - issues:defaults:jira_server
         - unused
-    - prefers_issue_details_streamlined_ui
+     - prefers_issue_details_streamlined_ui
         - Whether the user prefers the new issue details experience (boolean)
+     - quick_start_display
+        - Tracks whether the quick start guide was already automatically shown to the user during their second visit
      - language
         - which language to display the app in
      - mail:email

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -209,54 +209,60 @@ class UserDetailsUpdateTest(UserDetailsTest):
         assert user.username == "c@example.com"
 
     def test_saving_quick_start_display_option(self):
-        org_id = str(self.organization.id)
+        org1_id = str(self.organization.id)
+        org2_id = str(self.create_organization().id)
 
         # 1 = Shown once (on the second visit)
         self.get_success_response(
             "me",
-            options={"quickStartDisplay": {self.organization.id: 1}},
+            options={"quickStartDisplay": {org1_id: 1, org2_id: 2}},
         )
         assert (
-            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org_id) == 1
+            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org1_id)
+            == 1
         )
 
         # 2 = Hidden automatically after the second visit
-        self.get_success_response(
-            "me",
-            options={"quickStartDisplay": {self.organization.id: 2}},
-        )
+        self.get_success_response("me", options={"quickStartDisplay": {org1_id: 2}})
         assert (
-            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org_id) == 2
+            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org1_id)
+            == 2
+        )
+
+        # Validate that existing other orgs entries are not affected
+        assert (
+            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org2_id)
+            == 2
         )
 
         # Invalid values
         self.get_error_response(
             "me",
-            options={"quickStartDisplay": {self.organization.id: None}},
+            options={"quickStartDisplay": {org1_id: None}},
             status_code=400,
         )
 
         self.get_error_response(
             "me",
-            options={"quickStartDisplay": {self.organization.id: -1}},
+            options={"quickStartDisplay": {org1_id: -1}},
             status_code=400,
         )
 
         self.get_error_response(
             "me",
-            options={"quickStartDisplay": {self.organization.id: 0}},
+            options={"quickStartDisplay": {org1_id: 0}},
             status_code=400,
         )
 
         self.get_error_response(
             "me",
-            options={"quickStartDisplay": {self.organization.id: 3}},
+            options={"quickStartDisplay": {org1_id: 3}},
             status_code=400,
         )
 
         self.get_error_response(
             "me",
-            options={"quickStartDisplay": {self.organization.id: "invalid"}},
+            options={"quickStartDisplay": {org1_id: "invalid"}},
             status_code=400,
         )
 

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -208,6 +208,58 @@ class UserDetailsUpdateTest(UserDetailsTest):
         assert user.email == "c@example.com"
         assert user.username == "c@example.com"
 
+    def test_saving_quick_start_display_option(self):
+        org_id = str(self.organization.id)
+
+        # 1 = Shown once (on the second visit)
+        self.get_success_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: 1}},
+        )
+        assert (
+            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org_id) == 1
+        )
+
+        # 2 = Hidden automatically after the second visit
+        self.get_success_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: 2}},
+        )
+        assert (
+            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org_id) == 2
+        )
+
+        # Invalid values
+        self.get_error_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: None}},
+            status_code=400,
+        )
+
+        self.get_error_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: -1}},
+            status_code=400,
+        )
+
+        self.get_error_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: 0}},
+            status_code=400,
+        )
+
+        self.get_error_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: 3}},
+            status_code=400,
+        )
+
+        self.get_error_response(
+            "me",
+            options={"quickStartDisplay": {self.organization.id: "invalid"}},
+            status_code=400,
+        )
+
 
 @control_silo_test
 class UserDetailsSuperuserUpdateTest(UserDetailsTest):

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -46,6 +46,7 @@ class UserDetailsGetTest(UserDetailsTest):
         assert resp.data["options"]["stacktraceOrder"] == -1
         assert not resp.data["options"]["clock24Hours"]
         assert not resp.data["options"]["prefersIssueDetailsStreamlinedUI"]
+        assert not resp.data["options"]["quickStartDisplay"]
 
     def test_superuser_simple(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -116,6 +117,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
                 "clock24Hours": True,
                 "extra": True,
                 "prefersIssueDetailsStreamlinedUI": True,
+                "quickStartDisplay": {self.organization.id: 1},
             },
         )
 
@@ -134,6 +136,12 @@ class UserDetailsUpdateTest(UserDetailsTest):
         assert UserOption.objects.get_value(user=self.user, key="clock_24_hours")
         assert UserOption.objects.get_value(
             user=self.user, key="prefers_issue_details_streamlined_ui"
+        )
+        assert (
+            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(
+                str(self.organization.id)
+            )
+            == 1
         )
 
         assert not UserOption.objects.get_value(user=self.user, key="extra")


### PR DESCRIPTION
- Introduces a new user option called "quickStartDisplay". This option is stored as a dictionary {organization id: quick start display status} where:

  _null or 0_: Indicates the user has seen the quick start once.
  _1_: Indicates the user has seen the quick start twice. When this happens we automatically display the quick start.
   _2_: Means the user has seen the quick start enough and we no longer want to automatically show it to them.


- Contributes to the last point of https://github.com/getsentry/sentry/issues/84062

- Follow-up of https://github.com/getsentry/sentry/pull/84679#issuecomment-2648332843