### PR TITLE
fix(alerts): Fix issue with Span Metric Alerts timeseries preview sometimes exceeding 2016 bucket limit

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -547,12 +547,26 @@ class MetricChart extends PureComponent<Props, State> {
 
     // If the chart duration isn't as long as the rollup duration the events-stats
     // endpoint will return an invalid timeseriesData dataset
-    const viableStartDate = getUtcDateString(
+    let viableStartDate = getUtcDateString(
       moment.min(
         moment.utc(timePeriod.start),
         moment.utc(timePeriod.end).subtract(timeWindow, 'minutes')
       )
     );
+
+    // Events Analytics Platform Span queries only support up to 2016 buckets.
+    // 14 day 10m interval queries actually exceed this limit because we always extend the end date by an extra bucket.
+    // We push forward the start date by a bucket to counteract this and return to 2016 buckets.
+    if (
+      dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
+      timePeriod.usingPeriod &&
+      timePeriod.period === TimePeriod.FOURTEEN_DAYS &&
+      interval === '10m'
+    ) {
+      viableStartDate = getUtcDateString(
+        moment.utc(viableStartDate).add(timeWindow, 'minutes')
+      );
+    }
 
     const viableEndDate = getUtcDateString(
       moment.utc(timePeriod.end).add(timeWindow, 'minutes')


### PR DESCRIPTION
On the Span Metric Alert overview page, the timeseries query complains about too many buckets on 14 day 10 minute interval queries. EAP imposes a 2016 bucket limit, and the overview page exceeds this limit by 1 because we append an extra bucket to the end date of the query to include the current bucket in progress (2017 buckets in total). 

This PR fixes the issue by pushing the start date one bucket ahead, so we return back to 2016 buckets again.