### PR TITLE
feat(projects): add RPC method interface to get project by external_id

### DIFF
--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -66,6 +66,11 @@ class ProjectService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def get_by_external_id(self, *, organization_id: int, external_id: str) -> RpcProject | None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def serialize_many(
         self,
         *,


### PR DESCRIPTION
Add `get_by_external_id` to `ProjectService`

Depends on https://github.com/getsentry/sentry/pull/84937