### PR TITLE
ref(kafka router): increase default stale-threshold

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -507,7 +507,7 @@ def cron(**options: Any) -> None:
 @click.option(
     "--stale-threshold-sec",
     type=click.IntRange(min=120),
-    help="Routes stale messages to stale topic if provided. This feature is currently being tested, do not pass in production yet.",
+    help="Routes stale messages to stale topic if provided. See Kafka Router documentation to enable. https://www.notion.so/sentry/Kafka-Router-18f8b10e4b5d80679e98cc6d4d7a5eca",
 )
 @click.option(
     "--log-level",

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -506,7 +506,7 @@ def cron(**options: Any) -> None:
 )
 @click.option(
     "--stale-threshold-sec",
-    type=click.IntRange(min=60),
+    type=click.IntRange(min=120),
     help="Routes stale messages to stale topic if provided. This feature is currently being tested, do not pass in production yet.",
 )
 @click.option(

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -500,14 +500,14 @@ def cron(**options: Any) -> None:
 )
 @click.option(
     "--enable-dlq/--disable-dlq",
-    help="Enable dlq to route invalid messages to. See https://getsentry.github.io/arroyo/dlqs.html#arroyo.dlq.DlqPolicy for more information.",
+    help="Enable dlq to route invalid messages to the dlq topic. See https://getsentry.github.io/arroyo/dlqs.html#arroyo.dlq.DlqPolicy for more information.",
     is_flag=True,
     default=True,
 )
 @click.option(
     "--stale-threshold-sec",
     type=click.IntRange(min=120),
-    help="Routes stale messages to stale topic if provided. See Kafka Router documentation to enable. https://www.notion.so/sentry/Kafka-Router-18f8b10e4b5d80679e98cc6d4d7a5eca",
+    help="Enable backlog queue to route stale messages to the blq topic.",
 )
 @click.option(
     "--log-level",


### PR DESCRIPTION
this was identified as[ an action item from Feb 10 2025 Infra TSC](https://www.notion.so/sentry/Kafka-Router-18f8b10e4b5d80679e98cc6d4d7a5eca?pvs=4#1968b10e4b5d8094b73cc731c31bd0c6).

make sure the default stale-threshold is not smaller than the default latency monitoring threshold. That would be bad because all the stale messages would be routed away and the latency monitor would not fire.