### PR TITLE
fix(dashboards): Add `borderless` prop for `WidgetLayout`

### DIFF
--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -63,6 +63,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
   return (
     <WidgetLayout
       ariaLabel="Widget panel"
+      borderless={props.borderless}
       Title={
         <Fragment>
           {props.warnings && props.warnings.length > 0 && (

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -12,6 +12,7 @@ export interface WidgetLayoutProps {
   Title?: React.ReactNode;
   Visualization?: React.ReactNode;
   ariaLabel?: string;
+  borderless?: boolean;
   height?: number;
   noFooterPadding?: boolean;
   noHeaderPadding?: boolean;
@@ -26,6 +27,7 @@ export function WidgetLayout(props: WidgetLayoutProps) {
     <Frame
       aria-label={props.ariaLabel}
       height={props.height}
+      borderless={props.borderless}
       revealActions={revealActions}
     >
       <Header noPadding={props.noHeaderPadding}>
@@ -58,7 +60,11 @@ const TitleHoverItems = styled('div')`
   transition: opacity 0.1s;
 `;
 
-const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'}>`
+const Frame = styled('div')<{
+  borderless?: boolean;
+  height?: number;
+  revealActions?: 'always' | 'hover';
+}>`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -69,7 +75,7 @@ const Frame = styled('div')<{height?: number; revealActions?: 'always' | 'hover'
   min-width: ${MIN_WIDTH}px;
 
   border-radius: ${p => p.theme.borderRadius};
-  border: 1px solid ${p => p.theme.border};
+  border: ${p => (p.borderless ? 'none' : `1px solid ${p.theme.border}`)};
 
   background: ${p => p.theme.background};
 


### PR DESCRIPTION
This was lost during a refactor! This prop is 100% in use. Bring it back.

**Before:**
![Screenshot 2025-02-11 at 12 00 24 PM](https://github.com/user-attachments/assets/351b0971-4009-4062-b5da-3188938cb44f)

**After:**
![Screenshot 2025-02-11 at 12 00 35 PM](https://github.com/user-attachments/assets/788c126a-a15d-40d6-bc09-5a4375842ad3)
