### PR TITLE
:wrench: chore(slo): make discord bot permission errors as halt

### DIFF
--- a/src/sentry/integrations/discord/utils/metrics.py
+++ b/src/sentry/integrations/discord/utils/metrics.py
@@ -3,7 +3,8 @@ from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 
 # https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
 DISCORD_HALT_ERROR_CODES = [
-    50001,  # Missing access
+    50001,  # Missing access (bot auth revoked)
+    50013,  # Bot does not have permission to perform this action (e.g. sending messages in a channel the bot doesn't have access to)
     10003,  # Unknown Channel
 ]
 


### PR DESCRIPTION
According to Discord [docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes), 50013 means the bot doesn't have permission to perform the action, which in this case would be send a message to the channel. this can happen when there are special permissions added to the channel where only certain members can send a notification.

this is different from 50001, which is when the bot's auth is revoked.

resolves [SENTRY-3KD1](https://sentry.sentry.io/issues/6128190749/)

