### PR TITLE
fix(new-trace): Setting base url to performance for deprecated transaction detail page.

### DIFF
--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -113,8 +113,7 @@ export function generateLinkToEventInTraceView({
       eventSlug,
       transactionName,
       location.query,
-      spanId,
-      view
+      spanId
     );
   }
 

--- a/static/app/utils/performance/urls.ts
+++ b/static/app/utils/performance/urls.ts
@@ -4,7 +4,6 @@ import {spanTargetHash} from 'sentry/components/events/interfaces/spans/utils';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 
 /**
@@ -19,8 +18,7 @@ export function getTransactionDetailsUrl(
   eventSlug: string,
   transaction?: string,
   query?: Query,
-  spanId?: string,
-  view?: DomainView
+  spanId?: string
 ): LocationDescriptor {
   const locationQuery = {
     ...(query || {}),
@@ -31,7 +29,7 @@ export function getTransactionDetailsUrl(
   }
 
   const target: LocationDescriptor = {
-    pathname: normalizeUrl(`${getPerformanceBaseUrl(orgSlug, view)}/${eventSlug}/`),
+    pathname: normalizeUrl(`${getPerformanceBaseUrl(orgSlug)}/${eventSlug}/`),
     query: locationQuery,
     hash: defined(spanId) ? spanTargetHash(spanId) : undefined,
   };


### PR DESCRIPTION
This prevents the trace view page from 404'ing as domain/module specific routing to the trace view is not supported for the transaction details page. With this change, whenever we land on the transaction details page we route to `/performance/trace/` and load the transaction as a part of the trace view. 