### PR TITLE
feat(nav): Update other links to replay pages

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -28,6 +28,7 @@ import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import BrowserOSIcons from 'sentry/views/replays/detail/browserOSIcons';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -88,7 +89,10 @@ function ReplayPreviewPlayer({
         <LinkButton
           size="sm"
           to={{
-            pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
+            pathname: makeReplaysPathname({
+              path: `/${replayId}/`,
+              organization,
+            }),
             query: {
               referrer: getRouteStringFromRoutes(routes),
               t_main: fromFeedback ? TabKey.BREADCRUMBS : TabKey.ERRORS,

--- a/static/app/components/events/eventReplay/staticReplayPreview.tsx
+++ b/static/app/components/events/eventReplay/staticReplayPreview.tsx
@@ -15,6 +15,7 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 type StaticReplayPreviewProps = {
   analyticsContext: string;
@@ -38,7 +39,10 @@ export function StaticReplayPreview({
   const organization = useOrganization();
   const routes = useRoutes();
   const fullReplayUrl = {
-    pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
+    pathname: makeReplaysPathname({
+      path: `/${replayId}/`,
+      organization,
+    }),
     query: {
       referrer: getRouteStringFromRoutes(routes),
       t_main: focusTab ?? TabKey.ERRORS,

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -31,6 +31,7 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {useHasTraceNewUi} from 'sentry/views/performance/newTraceDetails/useHasTraceNewUi';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 interface EventTagTreeRowConfig {
   // Omits the dropdown of actions applicable to this tag
@@ -257,7 +258,10 @@ function EventTagsTreeRowDropdown({
       to:
         originalTag.key === 'replay_id' || originalTag.key === 'replayId'
           ? {
-              pathname: `/organizations/${organization.slug}/replays/${encodeURIComponent(content.value)}/`,
+              pathname: makeReplaysPathname({
+                path: `/${encodeURIComponent(content.value)}/`,
+                organization,
+              }),
               query: {referrer},
             }
           : undefined,
@@ -343,11 +347,20 @@ function EventTagsTreeValue({
     }
     case 'replayId':
     case 'replay_id': {
-      const replayQuery = qs.stringify({referrer});
-      const replayDestination = `/organizations/${organization.slug}/replays/${encodeURIComponent(content.value)}/?${replayQuery}`;
+      const replayPath = makeReplaysPathname({
+        path: `/${encodeURIComponent(content.value)}/`,
+        organization,
+      });
       tagValue = (
         <TagLinkText>
-          <Link to={replayDestination}>{content.value}</Link>
+          <Link
+            to={{
+              pathname: replayPath,
+              query: {referrer},
+            }}
+          >
+            {content.value}
+          </Link>
         </TagLinkText>
       );
       break;

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -22,8 +22,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {isDemoModeEnabled} from 'sentry/utils/demoMode';
 import {getDemoWalkthroughTasks} from 'sentry/utils/demoMode/guides';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 function hasPlatformWithSourceMaps(projects: Project[] | undefined) {
   return projects !== undefined
@@ -302,12 +302,13 @@ export function getOnboardingTasks({
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
       actionType: 'action',
       action: router => {
-        router.push(
-          normalizeUrl({
-            pathname: `/organizations/${organization.slug}/replays/`,
-            query: {referrer: 'onboarding_task'},
-          })
-        );
+        router.push({
+          pathname: makeReplaysPathname({
+            path: '/',
+            organization,
+          }),
+          query: {referrer: 'onboarding_task'},
+        });
         // Since the quick start panel is already open and closes on route change
         // Wait for the next tick to open the replay onboarding panel
         setTimeout(() => {

--- a/static/app/components/replays/breadcrumbs/selectorList.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.tsx
@@ -4,9 +4,9 @@ import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {ClickFrame} from 'sentry/utils/replays/types';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 export default function SelectorList({frame}: {frame: ClickFrame}) {
   const location = useLocation();
@@ -26,7 +26,10 @@ export default function SelectorList({frame}: {frame: ClickFrame}) {
       >
         <Link
           to={{
-            pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+            pathname: makeReplaysPathname({
+              path: '/',
+              organization,
+            }),
             query: {
               ...location.query,
               query: `click.component_name:${componentName}`,

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -6,17 +6,18 @@ import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
-  orgSlug: string;
   replayRecord: ReplayRecord | undefined;
 };
 
-function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
+function DetailsPageBreadcrumbs({replayRecord}: Props) {
+  const organization = useOrganization();
   const location = useLocation();
   const eventView = EventView.fromLocation(location);
 
@@ -34,14 +35,20 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
       crumbs={[
         {
           to: {
-            pathname: normalizeUrl(`/organizations/${orgSlug}/replays/`),
+            pathname: makeReplaysPathname({
+              path: '/',
+              organization,
+            }),
             query: eventView.generateQueryStringObject(),
           },
           label: t('Session Replay'),
         },
         {
           to: {
-            pathname: normalizeUrl(`/organizations/${orgSlug}/replays/`),
+            pathname: makeReplaysPathname({
+              path: '/',
+              organization,
+            }),
             query: {
               ...eventView.generateQueryStringObject(),
               project: replayRecord?.project_id,

--- a/static/app/utils/replays/hooks/useDeleteReplay.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplay.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 interface DeleteButtonProps {
   projectSlug: string | null;
@@ -30,7 +31,13 @@ export default function useDeleteReplay({projectSlug, replayId}: DeleteButtonPro
           method: 'DELETE',
         }
       );
-      navigate(`/organizations/${organization.slug}/replays/`, {replace: true});
+      navigate(
+        makeReplaysPathname({
+          path: '/',
+          organization,
+        }),
+        {replace: true}
+      );
     } catch (err) {
       addErrorMessage(t('Failed to delete replay'));
       Sentry.captureException(err);

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -35,13 +35,13 @@ import type {
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import Tags from 'sentry/views/discover/tags';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {TraceShape} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {MetaData} from 'sentry/views/performance/transactionDetails/styles';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 import {BrowserDisplay} from '../transactionDetails/eventMetas';
 
@@ -135,9 +135,10 @@ function NewTraceDetailsContent(props: Props) {
                 tooltipText=""
                 bodyText={
                   <Link
-                    to={normalizeUrl(
-                      `/organizations/${organization.slug}/replays/${replay_id}/`
-                    )}
+                    to={makeReplaysPathname({
+                      path: `/${replay_id}/`,
+                      organization,
+                    })}
                   >
                     <ReplayLinkBody>
                       {getShortEventId(replay_id)}

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -18,6 +18,7 @@ import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 import {TraceViewSources} from '../newTraceDetails/traceHeader/breadcrumbs';
 
@@ -242,9 +243,10 @@ export function generateReplayLink(routes: Array<PlainRoute<any>>) {
 
     if (!tableRow.timestamp) {
       return {
-        pathname: normalizeUrl(
-          `/organizations/${organization.slug}/replays/${replayId}/`
-        ),
+        pathname: makeReplaysPathname({
+          path: `/${replayId}/`,
+          organization,
+        }),
         query: {
           referrer,
         },

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -259,7 +259,10 @@ export function generateReplayLink(routes: Array<PlainRoute<any>>) {
       : undefined;
 
     return {
-      pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replayId}/`),
+      pathname: makeReplaysPathname({
+        path: `/${replayId}/`,
+        organization,
+      }),
       query: {
         event_t: transactionStartTimestamp,
         referrer,

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -76,11 +76,11 @@ export default function Page({
 
   const header = replayRecord?.is_archived ? (
     <Header>
-      <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
+      <DetailsPageBreadcrumbs replayRecord={replayRecord} />
     </Header>
   ) : (
     <Header>
-      <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
+      <DetailsPageBreadcrumbs replayRecord={replayRecord} />
 
       <ButtonActionsWrapper>
         {isLoading ? (

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -9,13 +9,13 @@ import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayTagsTableRow from 'sentry/components/replays/replayTagsTableRow';
 import {t} from 'sentry/locale';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
 import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
 import TagFilters from 'sentry/views/replays/detail/tagPanel/tagFilters';
 import useTagFilters from 'sentry/views/replays/detail/tagPanel/useTagFilters';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 function TagPanel() {
   const organization = useOrganization();
@@ -54,13 +54,16 @@ function TagPanel() {
 
   const generateUrl = useCallback(
     (name: string, value: ReactNode): LocationDescriptor => ({
-      pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+      pathname: makeReplaysPathname({
+        path: '/',
+        organization,
+      }),
       query: {
         // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax, whether `name` is a tag or not.
         query: `${name}:"${value}"`,
       },
     }),
-    [organization.slug]
+    [organization]
   );
 
   if (!replayRecord) {


### PR DESCRIPTION
Modified internal replay links in https://github.com/getsentry/sentry/pull/84909, and this should convert the links from other product surfaces.