### PR TITLE
fix(issue-views): Update copy on tooltip

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -216,7 +216,7 @@ export default function getGuidesContent(
           title: t('Save Filters to Issue Views'),
           target: 'issue_views_page_filters_persistence',
           description: t(
-            'We heard your feedback — you can now save specific projects, environments, and time filters to individual Issue Views.'
+            'We heard your feedback — Issue Views now save project, environment, and time range filters.'
           ),
         },
       ],


### PR DESCRIPTION
Tweaks the copy in the guide tooltip introducing page filter persistence.