### PR TITLE
feat(nav): Update user feedback links for /issues/feedback

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
@@ -12,9 +12,9 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 interface Props {
   feedbackItem: FeedbackIssue;
@@ -45,7 +45,10 @@ export default function FeedbackShortId({className, feedbackItem, style}: Props)
   // or other options are passed, which breaks the copy-paste.
   const feedbackUrl =
     window.location.origin +
-    normalizeUrl(`/organizations/${organization.slug}/feedback/`) +
+    makeFeedbackPathname({
+      path: '/',
+      organization,
+    }) +
     queryString.stringifyUrl({
       url: '?',
       query: {

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -19,10 +19,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import type {FeedbackIssueListItem} from 'sentry/utils/feedback/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCountForFeedbacks from 'sentry/utils/replayCount/useReplayCountForFeedbacks';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 interface Props {
   feedbackItem: FeedbackIssueListItem;
@@ -61,7 +61,10 @@ export default function FeedbackListItem({
       <LinkedFeedbackCard
         data-selected={isOpen}
         to={{
-          pathname: normalizeUrl(`/organizations/${organization.slug}/feedback/`),
+          pathname: makeFeedbackPathname({
+            path: '/',
+            organization,
+          }),
           query: {
             ...location.query,
             referrer: 'feedback_list_page',

--- a/static/app/components/feedback/useDeleteFeedback.tsx
+++ b/static/app/components/feedback/useDeleteFeedback.tsx
@@ -9,6 +9,7 @@ import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
   const organization = useOrganization();
@@ -33,7 +34,10 @@ export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
             complete: () => {
               navigate(
                 normalizeUrl({
-                  pathname: `/organizations/${organization.slug}/feedback/`,
+                  pathname: makeFeedbackPathname({
+                    path: '/',
+                    organization,
+                  }),
                   query: {
                     mailbox: locationQuery.mailbox,
                     project: locationQuery.project,
@@ -49,5 +53,15 @@ export const useDeleteFeedback = (feedbackIds: any, projectId: any) => {
       message: t('Deleting feedbacks is permanent. Are you sure you wish to continue?'),
       confirmText: t('Delete'),
     });
-  }, [api, feedbackIds, locationQuery, navigate, organization.slug, projectId]);
+  }, [
+    api,
+    feedbackIds,
+    locationQuery.mailbox,
+    locationQuery.project,
+    locationQuery.query,
+    locationQuery.statsPeriod,
+    navigate,
+    organization,
+    projectId,
+  ]);
 };

--- a/static/app/components/feedback/useRedirectToFeedbackFromEvent.tsx
+++ b/static/app/components/feedback/useRedirectToFeedbackFromEvent.tsx
@@ -6,6 +6,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 export default function useRedirectToFeedbackFromEvent() {
   const organization = useOrganization();
@@ -29,9 +30,17 @@ export default function useRedirectToFeedbackFromEvent() {
   useEffect(() => {
     if (projectSlug && event?.groupID) {
       navigate(
-        `/organizations/${organization.slug}/feedback/?feedbackSlug=${projectSlug}:${event.groupID}`,
+        {
+          pathname: makeFeedbackPathname({
+            path: '/',
+            organization,
+          }),
+          query: {
+            feedbackSlug: `${projectSlug}:${event.groupID}`,
+          },
+        },
         {replace: true}
       );
     }
-  }, [navigate, organization.slug, projectSlug, event]);
+  }, [navigate, projectSlug, event, organization]);
 }

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -40,6 +40,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 type MouseCallback = (frame: ReplayFrame, nodeId?: number) => void;
 
@@ -315,7 +316,10 @@ function CrumbErrorIssue({frame}: {frame: FeedbackFrame | ErrorFrame}) {
         to={
           isFeedbackFrame(frame)
             ? {
-                pathname: `/organizations/${organization.slug}/feedback/`,
+                pathname: makeFeedbackPathname({
+                  path: '/',
+                  organization,
+                }),
                 query: {feedbackSlug: `${frame.data.projectSlug}:${frame.data.groupId}`},
               }
             : `/organizations/${organization.slug}/issues/${frame.data.groupId}/`

--- a/static/app/views/alerts/rules/issue/details/issuesList.tsx
+++ b/static/app/views/alerts/rules/issue/details/issuesList.tsx
@@ -19,6 +19,7 @@ import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 type GroupHistory = {
   count: number;
@@ -85,7 +86,10 @@ function AlertRuleIssuesList({project, rule, period, start, end, utc, cursor}: P
           const path =
             (issue as unknown as FeedbackIssue).issueType === 'feedback'
               ? {
-                  pathname: `/organizations/${organization.slug}/feedback/`,
+                  pathname: makeFeedbackPathname({
+                    path: '/',
+                    organization,
+                  }),
                   query: {feedbackSlug: `${issue.project.slug}:${issue.id}`},
                 }
               : {

--- a/static/app/views/userFeedback/index.tsx
+++ b/static/app/views/userFeedback/index.tsx
@@ -25,8 +25,8 @@ import {space} from 'sentry/styles/space';
 import type {UserReport} from 'sentry/types/group';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 import {UserFeedbackEmpty} from './userFeedbackEmpty';
 import {getQuery} from './utils';
@@ -127,9 +127,10 @@ function OrganizationUserFeedback({location: {search, pathname, query}, router}:
                     size="sm"
                     priority="default"
                     to={{
-                      pathname: normalizeUrl(
-                        `/organizations/${organization.slug}/feedback/`
-                      ),
+                      pathname: makeFeedbackPathname({
+                        path: '/',
+                        organization,
+                      }),
                       query: {
                         ...query,
                         query: undefined,

--- a/static/app/views/userFeedback/pathnames.tsx
+++ b/static/app/views/userFeedback/pathnames.tsx
@@ -1,0 +1,19 @@
+import type {Organization} from 'sentry/types/organization';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+const LEGACY_FEEDBACK_BASE_PATHNAME = 'feedback';
+const FEEDBACK_BASE_PATHNAME = 'issues/feedback';
+
+export function makeFeedbackPathname({
+  path,
+  organization,
+}: {
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}) {
+  return normalizeUrl(
+    organization.features.includes('navigation-sidebar-v2')
+      ? `/organizations/${organization.slug}/${FEEDBACK_BASE_PATHNAME}${path}`
+      : `/organizations/${organization.slug}/${LEGACY_FEEDBACK_BASE_PATHNAME}${path}`
+  );
+}


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

Updates links to the user feedback pages so that they use `makeFeedbackPathname()` so that we can change the link to `/issues/feedback/` when the new nav flag is enabled.