### PR TITLE
feat(nav): Update discover links to /explore/discover/

### DIFF
--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -122,7 +122,7 @@ function PerformanceCardTable({
         <SubTitle key={idx}>
           <Link
             to={newView.getResultsViewUrlTarget(
-              organization.slug,
+              organization,
               false,
               hasDatasetSelector(organization)
                 ? SavedQueryDatasets.TRANSACTIONS
@@ -144,7 +144,7 @@ function PerformanceCardTable({
         <SubTitle key={idx}>
           <Link
             to={newView.getResultsViewUrlTarget(
-              organization.slug,
+              organization,
               false,
               hasDatasetSelector(organization)
                 ? SavedQueryDatasets.TRANSACTIONS
@@ -332,7 +332,7 @@ function PerformanceCardTable({
         <SubTitle key={idx}>
           <Link
             to={newView.getResultsViewUrlTarget(
-              organization.slug,
+              organization,
               false,
               hasDatasetSelector(organization)
                 ? SavedQueryDatasets.TRANSACTIONS

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -336,7 +336,7 @@ class _TransactionsList extends Component<Props> {
               <DiscoverButton
                 onClick={handleOpenInDiscoverClick}
                 to={this.generateDiscoverEventView().getResultsViewUrlTarget(
-                  organization.slug,
+                  organization,
                   false,
                   hasDatasetSelector(organization)
                     ? SavedQueryDatasets.TRANSACTIONS

--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -142,7 +142,7 @@ export function EventCustomPerformanceMetric({
         });
       case EventDetailPageSource.DISCOVER:
       default:
-        return eventView.getResultsViewUrlTarget(organization.slug, isHomepage);
+        return eventView.getResultsViewUrlTarget(organization, isHomepage);
     }
   }
 
@@ -238,7 +238,7 @@ export function TraceEventCustomPerformanceMetric({
         });
       case EventDetailPageSource.DISCOVER:
       default:
-        return eventView.getResultsViewUrlTarget(organization.slug, isHomepage);
+        return eventView.getResultsViewUrlTarget(organization, isHomepage);
     }
   }
 

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -169,7 +169,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
         data-test-id="view-child-transactions"
         size="xs"
         to={childrenEventView.getResultsViewUrlTarget(
-          organization.slug,
+          organization,
           false,
           hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
         )}

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -179,7 +179,7 @@ function SpanDetail(props: Props) {
         data-test-id="view-child-transactions"
         size="xs"
         to={childrenEventView.getResultsViewUrlTarget(
-          organization.slug,
+          organization,
           false,
           hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
         )}

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -295,7 +295,7 @@ export const renderPrependColumns =
     const eventSlug = generateEventSlug(dataRow);
 
     const target = eventDetailsRouteWithEventView({
-      orgSlug: organization.slug,
+      organization,
       eventSlug,
       eventView,
     });

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -61,7 +61,7 @@ function generateDiscoverEventTarget(
     },
   };
   return eventDetailsRouteWithEventView({
-    orgSlug: organization.slug,
+    organization,
     eventSlug,
     eventView: EventView.fromLocation(newLocation),
     isHomepage: location.query.homepage === 'true' || undefined,

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -113,7 +113,7 @@ export function generateMultiTransactionsTarget(
     end,
   });
   return traceEventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
   );
@@ -177,7 +177,7 @@ export function generateTraceTarget(
     ...dateSelection,
   });
   return eventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
   );

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -325,7 +325,7 @@ function BaseGroupRow({
 
       const discoverView = EventView.fromSavedQuery(discoverQuery);
       return discoverView.getResultsViewUrlTarget(
-        organization.slug,
+        organization,
         false,
         hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
       );

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -228,7 +228,7 @@ const getDiscoverUrl = (
     version: 2,
   });
   return discoverView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
   );

--- a/static/app/utils/discover/eventView.spec.tsx
+++ b/static/app/utils/discover/eventView.spec.tsx
@@ -2993,7 +2993,7 @@ describe('EventView.getResultsViewUrlTarget()', function () {
   it('generates a URL with non-customer domain context', function () {
     ConfigStore.set('customerDomain', null);
     const view = new EventView(state);
-    const result = view.getResultsViewUrlTarget(organization.slug);
+    const result = view.getResultsViewUrlTarget(organization);
     expect(result.pathname).toBe('/organizations/org-slug/discover/results/');
     expect(result.query.query).toEqual(state.query);
     expect(result.query.project).toBe('42');
@@ -3002,7 +3002,7 @@ describe('EventView.getResultsViewUrlTarget()', function () {
 
   it('generates a URL with customer domain context', function () {
     const view = new EventView(state);
-    const result = view.getResultsViewUrlTarget(organization.slug);
+    const result = view.getResultsViewUrlTarget(organization);
     expect(result.pathname).toBe('/discover/results/');
     expect(result.query.query).toEqual(state.query);
     expect(result.query.project).toBe('42');
@@ -3050,7 +3050,7 @@ describe('EventView.getResultsViewShortUrlTarget()', function () {
     ConfigStore.set('customerDomain', null);
 
     const view = new EventView(state);
-    const result = view.getResultsViewShortUrlTarget(organization.slug);
+    const result = view.getResultsViewShortUrlTarget(organization);
     expect(result.pathname).toBe('/organizations/org-slug/discover/results/');
     expect(result.query).not.toHaveProperty('name');
     expect(result.query).not.toHaveProperty('fields');
@@ -3063,7 +3063,7 @@ describe('EventView.getResultsViewShortUrlTarget()', function () {
 
   it('generates a URL with customer domain context', function () {
     const view = new EventView(state);
-    const result = view.getResultsViewShortUrlTarget(organization.slug);
+    const result = view.getResultsViewShortUrlTarget(organization);
     expect(result.pathname).toBe('/discover/results/');
     expect(result.query).not.toHaveProperty('name');
     expect(result.query).not.toHaveProperty('fields');

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -41,6 +41,7 @@ import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {decodeList, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {WidgetType} from 'sentry/views/dashboards/types';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {getSavedQueryDatasetFromLocationOrDataset} from 'sentry/views/discover/savedQuery/utils';
 import type {TableColumn, TableColumnSort} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
@@ -1231,7 +1232,7 @@ class EventView {
   }
 
   getResultsViewUrlTarget(
-    slug: string,
+    organization: Organization,
     isHomepage: boolean = false,
     queryDataset?: SavedQueryDatasets
   ): {pathname: string; query: Query} {
@@ -1241,12 +1242,18 @@ class EventView {
       query.queryDataset = queryDataset;
     }
     return {
-      pathname: normalizeUrl(`/organizations/${slug}/discover/${target}/`),
+      pathname: makeDiscoverPathname({
+        path: `/${target}/`,
+        organization,
+      }),
       query,
     };
   }
 
-  getResultsViewShortUrlTarget(slug: string): {pathname: string; query: Query} {
+  getResultsViewShortUrlTarget(organization: Organization): {
+    pathname: string;
+    query: Query;
+  } {
     const output: any = {id: this.id};
     for (const field of [...Object.values(URL_PARAM), 'cursor']) {
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -1259,7 +1266,10 @@ class EventView {
     stringifyQueryParams(output);
 
     return {
-      pathname: normalizeUrl(`/organizations/${slug}/discover/results/`),
+      pathname: makeDiscoverPathname({
+        path: `/results/`,
+        organization,
+      }),
       query: cloneDeep(output),
     };
   }

--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
-import type {Organization, OrganizationSummary} from 'sentry/types/organization';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import type {Organization} from 'sentry/types/organization';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import type {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
@@ -29,12 +29,15 @@ export function generateEventSlug(eventData: EventData): string {
  */
 export function eventDetailsRoute({
   eventSlug,
-  orgSlug,
+  organization,
 }: {
   eventSlug: string;
-  orgSlug: string;
+  organization: Organization;
 }): string {
-  return normalizeUrl(`/organizations/${orgSlug}/discover/${eventSlug}/`);
+  return makeDiscoverPathname({
+    path: `/${eventSlug}/`,
+    organization,
+  });
 }
 
 /**
@@ -120,7 +123,7 @@ export function generateLinkToEventInTraceView({
 
   const target: LocationDescriptorObject = {
     pathname: eventDetailsRoute({
-      orgSlug: organization.slug,
+      organization,
       eventSlug,
     }),
     query: {..._eventView.generateQueryStringObject(), homepage: isHomepage},
@@ -137,18 +140,18 @@ export function generateLinkToEventInTraceView({
  * Create a URL target to event details with an event view in the query string.
  */
 export function eventDetailsRouteWithEventView({
-  orgSlug,
+  organization,
   eventSlug,
   eventView,
   isHomepage,
 }: {
   eventSlug: string;
   eventView: EventView;
-  orgSlug: string;
+  organization: Organization;
   isHomepage?: boolean;
 }) {
   const pathname = eventDetailsRoute({
-    orgSlug,
+    organization,
     eventSlug,
   });
 
@@ -162,13 +165,22 @@ export function eventDetailsRouteWithEventView({
  * Get the URL for the discover entry page which changes based on organization
  * feature flags.
  */
-export function getDiscoverLandingUrl(organization: OrganizationSummary): string {
+export function getDiscoverLandingUrl(organization: Organization): string {
   if (organization.features.includes('discover-query')) {
-    return `/organizations/${organization.slug}/discover/homepage/`;
+    return makeDiscoverPathname({
+      path: `/homepage/`,
+      organization,
+    });
   }
-  return `/organizations/${organization.slug}/discover/results/`;
+  return makeDiscoverPathname({
+    path: `/results/`,
+    organization,
+  });
 }
 
-export function getDiscoverQueriesUrl(organization: OrganizationSummary): string {
-  return `/organizations/${organization.slug}/discover/queries/`;
+export function getDiscoverQueriesUrl(organization: Organization): string {
+  return makeDiscoverPathname({
+    path: `/queries/`,
+    organization,
+  });
 }

--- a/static/app/views/alerts/utils/getIncidentDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getIncidentDiscoverUrl.tsx
@@ -1,4 +1,4 @@
-import type {NewQuery} from 'sentry/types/organization';
+import type {NewQuery, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import EventView from 'sentry/utils/discover/eventView';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
@@ -17,13 +17,13 @@ import {getStartEndFromStats} from 'sentry/views/alerts/utils';
  * - Start and end are scoped to the same period as the alert rule
  */
 export function getIncidentDiscoverUrl(opts: {
-  orgSlug: string;
+  organization: Organization;
   projects: Project[];
   extraQueryParams?: Partial<NewQuery>;
   incident?: Incident;
   stats?: IncidentStats;
 }) {
-  const {orgSlug, projects, incident, stats, extraQueryParams} = opts;
+  const {organization, projects, incident, stats, extraQueryParams} = opts;
 
   if (!projects || !projects.length || !incident || !stats) {
     return '';
@@ -52,7 +52,7 @@ export function getIncidentDiscoverUrl(opts: {
   };
 
   const discoverView = EventView.fromSavedQuery(discoverQuery);
-  const {query, ...toObject} = discoverView.getResultsViewUrlTarget(orgSlug);
+  const {query, ...toObject} = discoverView.getResultsViewUrlTarget(organization);
 
   return {
     query: {...query, interval: timeWindowString},

--- a/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
@@ -32,14 +32,13 @@ export function getMetricRuleDiscoverUrl({
   openInDiscoverDataset,
   ...rest
 }: MetricRuleDiscoverUrlOptions) {
-  const orgSlug = organization.slug;
   const discoverView = getMetricRuleDiscoverQuery(rest);
   if (!discoverView || !rest.rule) {
     return '';
   }
 
   const {query, ...toObject} = discoverView.getResultsViewUrlTarget(
-    orgSlug,
+    organization,
     false,
     hasDatasetSelector(organization) ? openInDiscoverDataset : undefined
   );

--- a/static/app/views/alerts/utils/utils.spec.tsx
+++ b/static/app/views/alerts/utils/utils.spec.tsx
@@ -46,7 +46,7 @@ describe('Alert utils', function () {
       });
 
       const to = getIncidentDiscoverUrl({
-        orgSlug: organization.slug,
+        organization,
         projects,
         incident,
         stats: mockStats,
@@ -80,7 +80,7 @@ describe('Alert utils', function () {
       });
 
       const to = getIncidentDiscoverUrl({
-        orgSlug: organization.slug,
+        organization,
         projects,
         incident,
         stats: mockStats,

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -369,7 +369,7 @@ export function renderEventIdAsLinkable(
   const eventSlug = generateEventSlug(data);
 
   const target = eventDetailsRouteWithEventView({
-    orgSlug: organization.slug,
+    organization,
     eventSlug,
     eventView,
   });

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -265,7 +265,7 @@ export function getWidgetDiscoverUrl(
 ) {
   const eventView = eventViewFromWidget(widget.title, widget.queries[index]!, selection);
   const discoverLocation = eventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) && widget.widgetType
       ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -23,7 +23,7 @@ export function getWidgetExploreUrl(
 ) {
   const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);
   const {query: locationQueryParams} = eventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     undefined
   );

--- a/static/app/views/discover/breadcrumb.tsx
+++ b/static/app/views/discover/breadcrumb.tsx
@@ -8,6 +8,7 @@ import type {Event} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type EventView from 'sentry/utils/discover/eventView';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 
 type Props = {
   eventView: EventView;
@@ -46,7 +47,10 @@ function DiscoverBreadcrumb({
 
   if (!isHomepage && eventView && eventView.isValid()) {
     crumbs.push({
-      to: `/organizations/${organization.slug}/discover/queries/`,
+      to: makeDiscoverPathname({
+        path: `/queries/`,
+        organization,
+      }),
       label: t('Saved Queries'),
     });
     crumbs.push({

--- a/static/app/views/discover/breadcrumb.tsx
+++ b/static/app/views/discover/breadcrumb.tsx
@@ -39,7 +39,7 @@ function DiscoverBreadcrumb({
   crumbs.push({
     to:
       isHomepage && eventView
-        ? eventView.getResultsViewUrlTarget(organization.slug, isHomepage)
+        ? eventView.getResultsViewUrlTarget(organization, isHomepage)
         : discoverTarget,
     label: t('Discover'),
   });
@@ -50,7 +50,7 @@ function DiscoverBreadcrumb({
       label: t('Saved Queries'),
     });
     crumbs.push({
-      to: eventView.getResultsViewUrlTarget(organization.slug, isHomepage),
+      to: eventView.getResultsViewUrlTarget(organization, isHomepage),
       label: eventView.name || '',
     });
   }

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -204,7 +204,7 @@ function EventDetailsContent(props: Props) {
                         getViewChildTransactionTarget: childTransactionProps => {
                           const childTransactionLink = eventDetailsRoute({
                             eventSlug: childTransactionProps.eventSlug,
-                            orgSlug: organization.slug,
+                            organization,
                           });
 
                           return {

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -100,7 +100,7 @@ function EventDetailsContent(props: Props) {
     }
     const tagKey = formatTagKey(tag.key);
     const nextView = getExpandedResults(eventView, {[tagKey]: tag.value}, eventReference);
-    return nextView.getResultsViewUrlTarget(organization.slug, isHomepage);
+    return nextView.getResultsViewUrlTarget(organization, isHomepage);
   };
 
   function renderContent() {

--- a/static/app/views/discover/eventInputName.tsx
+++ b/static/app/views/discover/eventInputName.tsx
@@ -49,7 +49,7 @@ function EventInputName({organization, eventView, savedQuery, isHomepage}: Props
         renamedEventView.name = nextQueryName;
 
         browserHistory.push(
-          normalizeUrl(renamedEventView.getResultsViewUrlTarget(organization.slug))
+          normalizeUrl(renamedEventView.getResultsViewUrlTarget(organization))
         );
       }
     );

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -23,6 +23,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {decodeScalar} from 'sentry/utils/queryString';
 import withOrganization from 'sentry/utils/withOrganization';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
 
 import QueryList from './queryList';
@@ -272,7 +273,10 @@ class DiscoverLanding extends DeprecatedAsyncComponent<Props, State> {
 
   render() {
     const {organization} = this.props;
-    const to = `/organizations/${organization.slug}/discover/homepage/`;
+    const to = makeDiscoverPathname({
+      path: `/homepage/`,
+      organization,
+    });
 
     return (
       <Feature

--- a/static/app/views/discover/pathnames.tsx
+++ b/static/app/views/discover/pathnames.tsx
@@ -1,0 +1,19 @@
+import type {Organization} from 'sentry/types/organization';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+const LEGACY_DISCOVER_BASE_PATHNAME = 'discover';
+const DISCOVER_BASE_PATHNAME = 'explore/discover';
+
+export function makeDiscoverPathname({
+  path,
+  organization,
+}: {
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}) {
+  return normalizeUrl(
+    organization.features.includes('navigation-sidebar-v2')
+      ? `/organizations/${organization.slug}/${DISCOVER_BASE_PATHNAME}${path}`
+      : `/organizations/${organization.slug}/${LEGACY_DISCOVER_BASE_PATHNAME}${path}`
+  );
+}

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -174,7 +174,7 @@ class QueryList extends Component<Props> {
         moment(eventView.end).format('MMM D, YYYY h:mm A');
 
       const to = eventView.getResultsViewUrlTarget(
-        organization.slug,
+        organization,
         false,
         hasDatasetSelector(organization) ? view.queryDataset : undefined
       );
@@ -270,7 +270,7 @@ class QueryList extends Component<Props> {
         ' - ' +
         moment(eventView.end).format('MMM D, YYYY h:mm A');
 
-      const to = eventView.getResultsViewShortUrlTarget(organization.slug);
+      const to = eventView.getResultsViewShortUrlTarget(organization);
       const dateStatus = <TimeSince date={savedQuery.dateUpdated} />;
       const referrer = `api.discover.${eventView.getDisplayMode()}-chart`;
 

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -387,7 +387,7 @@ export class Results extends Component<Props, State> {
     browserHistory.replace(
       normalizeUrl(
         nextEventView.getResultsViewUrlTarget(
-          organization.slug,
+          organization,
           isHomepage,
           hasDatasetSelector(organization) ? savedQueryDataset : undefined
         )
@@ -561,7 +561,7 @@ export class Results extends Component<Props, State> {
     const {eventView, savedQueryDataset} = this.state;
 
     const url = eventView.getResultsViewUrlTarget(
-      organization.slug,
+      organization,
       isHomepage,
       hasDatasetSelector(organization) ? savedQueryDataset : undefined
     );

--- a/static/app/views/discover/resultsHeader.tsx
+++ b/static/app/views/discover/resultsHeader.tsx
@@ -132,7 +132,7 @@ class ResultsHeader extends Component<Props, State> {
   renderBanner() {
     const {location, organization} = this.props;
     const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
-    const to = eventView.getResultsViewUrlTarget(organization.slug);
+    const to = eventView.getResultsViewUrlTarget(organization);
     const resultsUrl = `${to.pathname}?${stringify(to.query)}`;
 
     return (

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
@@ -138,7 +138,7 @@ export function DatasetSelectorTabs(props: Props) {
             : DiscoverDatasets.TRANSACTIONS
         );
         const nextLocation = nextEventView.getResultsViewUrlTarget(
-          organization.slug,
+          organization,
           isHomepage
         );
         navigate({

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -269,9 +269,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
         Banner.dismiss('discover');
         this.setState({queryName: ''});
-        browserHistory.push(
-          normalizeUrl(view.getResultsViewUrlTarget(organization.slug))
-        );
+        browserHistory.push(normalizeUrl(view.getResultsViewUrlTarget(organization)));
       }
     );
   };
@@ -288,7 +286,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
         const view = EventView.fromSavedQuery(savedQuery);
         setSavedQuery(savedQuery);
         this.setState({queryName: ''});
-        browserHistory.push(view.getResultsViewShortUrlTarget(organization.slug));
+        browserHistory.push(view.getResultsViewShortUrlTarget(organization));
         updateCallback();
       }
     );

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -611,7 +611,7 @@ function TableView(props: TableViewProps) {
           browserHistory.push(
             normalizeUrl(
               nextView.getResultsViewUrlTarget(
-                organization.slug,
+                organization,
                 isHomepage,
                 hasDatasetSelector(organization) ? queryDataset : undefined
               )
@@ -640,7 +640,7 @@ function TableView(props: TableViewProps) {
       nextView.query = query.formatString();
 
       const target = nextView.getResultsViewUrlTarget(
-        organization.slug,
+        organization,
         isHomepage,
         hasDatasetSelector(organization) ? queryDataset : undefined
       );
@@ -660,7 +660,7 @@ function TableView(props: TableViewProps) {
 
     const nextView = eventView.withColumns(columns);
     const resultsViewUrlTarget = nextView.getResultsViewUrlTarget(
-      organization.slug,
+      organization,
       isHomepage,
       hasDatasetSelector(organization) ? queryDataset : undefined
     );

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -129,7 +129,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
 
     const discoverView = EventView.fromSavedQuery(discoverQuery);
     return discoverView.getResultsViewUrlTarget(
-      organization.slug,
+      organization,
       false,
       hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
     );

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -316,7 +316,7 @@ function GroupEventActions({event, group, projectSlug}: GroupEventActionsProps) 
             hidden: !organization.features.includes('discover-basic'),
             to: eventDetailsRoute({
               eventSlug: generateEventSlug({project: projectSlug, id: event.id}),
-              orgSlug: organization.slug,
+              organization,
             }),
             onAction: () => {
               trackAnalytics('issue_details.event_details_clicked', {

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -261,7 +261,7 @@ export function GroupTagValues() {
                   key: 'open-in-discover',
                   label: t('Open in Discover'),
                   to: discoverView.getResultsViewUrlTarget(
-                    orgId,
+                    organization,
                     false,
                     hasDatasetSelector(organization)
                       ? SavedQueryDatasets.ERRORS

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -264,7 +264,7 @@ function TagValueActionsMenu({
           key: 'open-in-discover',
           label: t('Open in Discover'),
           to: eventView.getResultsViewUrlTarget(
-            organization.slug,
+            organization,
             false,
             hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
           ),

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -46,7 +46,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
     !issueTypeConfig.pages.replays.enabled;
 
   const discoverUrl = eventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
   );

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -349,7 +349,7 @@ const getEventViewDiscoverPath = (
   eventView: EventView
 ): string => {
   const discoverUrlTarget = eventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
   );

--- a/static/app/views/performance/newTraceDetails/traceActionsMenu.tsx
+++ b/static/app/views/performance/newTraceDetails/traceActionsMenu.tsx
@@ -50,7 +50,7 @@ function TraceActionsMenu({
               organization,
             });
             const target = traceEventView.getResultsViewUrlTarget(
-              organization.slug,
+              organization,
               false,
               hasDatasetSelector(organization)
                 ? SavedQueryDatasets.TRANSACTIONS

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -147,7 +147,7 @@ function SpanChildrenTraversalButton({
       data-test-id="view-child-transactions"
       size="xs"
       to={childrenEventView.getResultsViewUrlTarget(
-        organization.slug,
+        organization,
         false,
         hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
       )}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
@@ -28,7 +28,7 @@ const getTagTarget = (
   organization: Organization
 ) => {
   const url = eventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
   );

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -203,7 +203,7 @@ function LegacyTraceMetadataHeader(props: TraceMetadataHeaderProps) {
           <DiscoverButton
             size="sm"
             to={props.traceEventView.getResultsViewUrlTarget(
-              props.organization.slug,
+              props.organization,
               false,
               hasDatasetSelector(props.organization)
                 ? SavedQueryDatasets.TRANSACTIONS

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -405,7 +405,7 @@ class TraceDetailsContent extends Component<Props, State> {
               <DiscoverButton
                 size="sm"
                 to={traceEventView.getResultsViewUrlTarget(
-                  organization.slug,
+                  organization,
                   false,
                   hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
                 )}

--- a/static/app/views/performance/traceDetails/limitExceededMessage.tsx
+++ b/static/app/views/performance/traceDetails/limitExceededMessage.tsx
@@ -45,7 +45,7 @@ function LimitExceededMessage({
   }
 
   const target = traceEventView.getResultsViewUrlTarget(
-    organization.slug,
+    organization,
     false,
     hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
   );

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -320,10 +320,7 @@ function NewTraceDetailsContent(props: Props) {
           <div style={{flex: 1}}>
             <Tags
               generateUrl={(key: string, value: string) => {
-                const url = traceEventView.getResultsViewUrlTarget(
-                  organization.slug,
-                  false
-                );
+                const url = traceEventView.getResultsViewUrlTarget(organization, false);
                 url.query = generateQueryWithTag(url.query, {
                   key: formatTagKey(key),
                   value,
@@ -442,7 +439,7 @@ function NewTraceDetailsContent(props: Props) {
           <ButtonBar gap={1}>
             <DiscoverButton
               size="sm"
-              to={traceEventView.getResultsViewUrlTarget(organization.slug)}
+              to={traceEventView.getResultsViewUrlTarget(organization)}
               onClick={() => {
                 trackAnalytics('performance_views.trace_view.open_in_discover', {
                   organization,

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -247,7 +247,7 @@ function Search(props: Props) {
       />
       <LinkButton
         to={eventView.getResultsViewUrlTarget(
-          organization.slug,
+          organization,
           false,
           hasDatasetSelector(organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
         )}

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -78,7 +78,7 @@ export function createUnnamedTransactionsDiscoverTarget(props: {
     props.location
   ).withSorts([{field: 'epm', kind: 'desc'}]);
   const target = discoverEventView.getResultsViewUrlTarget(
-    props.organization.slug,
+    props.organization,
     false,
     hasDatasetSelector(props.organization) ? SavedQueryDatasets.TRANSACTIONS : undefined
   );

--- a/static/app/views/projectDetail/projectIssues.tsx
+++ b/static/app/views/projectDetail/projectIssues.tsx
@@ -25,6 +25,7 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {appendQueryDatasetParam} from 'sentry/views/dashboards/utils';
+import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 
 import NoGroupsHandler from '../issueList/noGroupsHandler';
 
@@ -148,7 +149,10 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
 
   function getDiscoverUrl() {
     return {
-      pathname: `/organizations/${organization.slug}/discover/results/`,
+      pathname: makeDiscoverPathname({
+        path: `/results/`,
+        organization,
+      }),
       query: {
         name: t('Frequent Unhandled Issues'),
         field: ['issue', 'title', 'count()', 'count_unique(user)', 'project'],


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

The new nav structure moves `/discover/` to `/explore/discover/`.

To facilitate the transition, I'm adding a util `makeDiscoverPathname()` that will check a feature flag to decide which link to generate. In order to use this I needed to change many function arguments from `orgSlug` to `organization`. 