### PR TITLE
chore(ACI): Rename group_type to detector_type

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -22,7 +22,7 @@ from sentry.utils import metrics
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.models.project import Project
-    from sentry.workflow_engine.endpoints.validators.base import BaseGroupTypeDetectorValidator
+    from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
     from sentry.workflow_engine.handlers.detector import DetectorHandler
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,7 @@ class GroupType:
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
     notification_config: NotificationConfig = NotificationConfig()
     detector_handler: type[DetectorHandler] | None = None
-    detector_validator: type[BaseGroupTypeDetectorValidator] | None = None
+    detector_validator: type[BaseDetectorTypeValidator] | None = None
     # Controls whether status change (i.e. resolved, regressed) workflow notifications are enabled.
     # Defaults to true to maintain the default workflow notification behavior as it exists for error group types.
     enable_status_change_workflow_notifications: bool = True

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -33,13 +33,13 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
     # too?
     permission_classes = (ProjectAlertRulePermission,)
 
-    def _get_validator(self, request, project, group_type_slug):
-        detector_type = grouptype.registry.get_by_slug(group_type_slug)
+    def _get_validator(self, request, project, detector_type_slug):
+        detector_type = grouptype.registry.get_by_slug(detector_type_slug)
         if detector_type is None:
-            raise ValidationError({"groupType": ["Unknown group type"]})
+            raise ValidationError({"detectorType": ["Unknown detector type"]})
 
         if detector_type.detector_validator is None:
-            raise ValidationError({"groupType": ["Group type not compatible with detectors"]})
+            raise ValidationError({"detectorType": ["Detector type not compatible with detectors"]})
 
         return detector_type.detector_validator(
             context={
@@ -110,15 +110,15 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         Create a new detector for a project.
 
         :param string name: The name of the detector
-        :param string group_type: The type of detector to create
+        :param string detector_type: The type of detector to create
         :param object data_source: Configuration for the data source
         :param array data_conditions: List of conditions to trigger the detector
         """
-        group_type = request.data.get("groupType")
-        if not group_type:
-            raise ValidationError({"groupType": ["This field is required."]})
+        detector_type = request.data.get("detectorType")
+        if not detector_type:
+            raise ValidationError({"detectorType": ["This field is required."]})
 
-        validator = self._get_validator(request, project, group_type)
+        validator = self._get_validator(request, project, detector_type)
         if not validator.is_valid():
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/__init__.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/__init__.py
@@ -1,11 +1,11 @@
 __all__ = [
     "BaseDataConditionValidator",
     "BaseDataSourceValidator",
-    "BaseGroupTypeDetectorValidator",
+    "BaseDetectorTypeValidator",
     "DataSourceCreator",
     "NumericComparisonConditionValidator",
 ]
 
 from .data_condition import BaseDataConditionValidator, NumericComparisonConditionValidator
 from .data_source import BaseDataSourceValidator, DataSourceCreator
-from .detector import BaseGroupTypeDetectorValidator
+from .detector import BaseDetectorTypeValidator

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -19,7 +19,7 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import DataCondition
 
 
-class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
+class BaseDetectorTypeValidator(CamelSnakeSerializer):
     name = serializers.CharField(
         required=True,
         max_length=200,
@@ -27,7 +27,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
     )
     detector_type = serializers.CharField()
 
-    def validate_group_type(self, value: str) -> type[GroupType]:
+    def validate_detector_type(self, value: str) -> type[GroupType]:
         detector_type = grouptype.registry.get_by_slug(value)
         if detector_type is None:
             raise serializers.ValidationError("Unknown detector type")
@@ -72,7 +72,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
                 project_id=self.context["project"].id,
                 name=validated_data["name"],
                 workflow_condition_group=condition_group,
-                type=validated_data["detector_type"],
+                type=validated_data["detector_type"].slug,
                 config=validated_data.get("config", {}),
             )
             DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -25,14 +25,14 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
         max_length=200,
         help_text="Name of the uptime monitor",
     )
-    group_type = serializers.CharField()
+    detector_type = serializers.CharField()
 
     def validate_group_type(self, value: str) -> type[GroupType]:
         detector_type = grouptype.registry.get_by_slug(value)
         if detector_type is None:
-            raise serializers.ValidationError("Unknown group type")
+            raise serializers.ValidationError("Unknown detector type")
         if detector_type.detector_validator is None:
-            raise serializers.ValidationError("Group type not compatible with detectors")
+            raise serializers.ValidationError("Detector type not compatible with detectors")
         # TODO: Probably need to check a feature flag to decide if a given
         # org/user is allowed to add a detector
         return detector_type
@@ -43,6 +43,9 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
 
     @property
     def data_conditions(self) -> BaseDataConditionValidator:
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
         raise NotImplementedError
 
     def create(self, validated_data):
@@ -69,7 +72,7 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
                 project_id=self.context["project"].id,
                 name=validated_data["name"],
                 workflow_condition_group=condition_group,
-                type=validated_data["group_type"].slug,
+                type=validated_data["detector_type"],
                 config=validated_data.get("config", {}),
             )
             DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)
@@ -78,7 +81,9 @@ class BaseGroupTypeDetectorValidator(CamelSnakeSerializer):
                 request=self.context["request"],
                 organization=self.context["organization"],
                 target_object=detector.id,
-                event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
+                event=audit_log.get_event_id(
+                    "UPTIME_MONITOR_ADD"
+                ),  # TODO this is the wrong event type
                 data=detector.get_audit_log_data(),
             )
         return detector

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -19,7 +19,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
     )
 
     def validate_detector_type(self, value: str):
-        detector_type = super().validate_group_type(value)
+        detector_type = super().validate_detector_type(value)
         if detector_type.slug != "error":
             raise serializers.ValidationError("Detector type must be error")
 

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -6,11 +6,11 @@ from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
 from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
-from sentry.workflow_engine.endpoints.validators.base import BaseGroupTypeDetectorValidator
+from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
 from sentry.workflow_engine.models.detector import Detector
 
 
-class ErrorDetectorValidator(BaseGroupTypeDetectorValidator):
+class ErrorDetectorValidator(BaseDetectorTypeValidator):
     fingerprinting_rules = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     resolve_age = EmptyIntegerField(
         required=False,
@@ -18,10 +18,10 @@ class ErrorDetectorValidator(BaseGroupTypeDetectorValidator):
         help_text="Automatically resolve an issue if it hasn't been seen for this many hours. Set to `0` to disable auto-resolve.",
     )
 
-    def validate_group_type(self, value: str):
+    def validate_detector_type(self, value: str):
         detector_type = super().validate_group_type(value)
         if detector_type.slug != "error":
-            raise serializers.ValidationError("Group type must be error")
+            raise serializers.ValidationError("Detector type must be error")
 
         return detector_type
 

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -48,7 +48,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
                 project_id=self.context["project"].id,
                 name=validated_data["name"],
                 # no workflow_condition_group
-                type=validated_data["group_type"].slug,
+                type=validated_data["detector_type"].slug,
                 config={},
             )
 

--- a/src/sentry/workflow_engine/endpoints/validators/metric_alert_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/metric_alert_detector.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.workflow_engine.endpoints.validators.base import (
-    BaseGroupTypeDetectorValidator,
+    BaseDetectorTypeValidator,
     NumericComparisonConditionValidator,
 )
 from sentry.workflow_engine.models.data_condition import Condition
@@ -14,7 +14,7 @@ class MetricAlertComparisonConditionValidator(NumericComparisonConditionValidato
     supported_results = frozenset((DetectorPriorityLevel.HIGH, DetectorPriorityLevel.MEDIUM))
 
 
-class MetricAlertsDetectorValidator(BaseGroupTypeDetectorValidator):
+class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
     data_source = SnubaQueryValidator(required=True)
     data_conditions = MetricAlertComparisonConditionValidator(many=True)
 

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -23,7 +23,7 @@ class TestErrorDetectorValidator(TestCase):
         }
         self.valid_data = {
             "name": "Test Detector",
-            "group_type": "error",
+            "detectorType": "error",
             "fingerprinting_rules": """message:"hello world 1" -> hw1 title="HW1""",
             "resolve_age": 30,
         }
@@ -55,12 +55,12 @@ class TestErrorDetectorValidator(TestCase):
             data=detector.get_audit_log_data(),
         )
 
-    def test_invalid_group_type(self):
-        data = {**self.valid_data, "group_type": "metric_alert_fire"}
+    def test_invalid_detector_type(self):
+        data = {**self.valid_data, "detectorType": "metric_alert_fire"}
         validator = ErrorDetectorValidator(data=data, context=self.context)
         assert not validator.is_valid()
-        assert validator.errors.get("groupType") == [
-            ErrorDetail(string="Group type must be error", code="invalid")
+        assert validator.errors.get("detectorType") == [
+            ErrorDetail(string="Detector type must be error", code="invalid")
         ]
 
     def test_invalid_fingerprinting_rules(self):

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -54,7 +54,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
         super().setUp()
         self.valid_data = {
             "name": "Test Detector",
-            "groupType": MetricAlertFire.slug,
+            "detectorType": MetricAlertFire.slug,
             "dataSource": {
                 "queryType": SnubaQuery.Type.ERROR.value,
                 "dataset": Dataset.Events.name.lower(),
@@ -75,36 +75,38 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
 
     def test_missing_group_type(self):
         data = {**self.valid_data}
-        del data["groupType"]
+        del data["detectorType"]
         response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
             **data,
             status_code=400,
         )
-        assert response.data == {"groupType": ["This field is required."]}
+        assert response.data == {"detectorType": ["This field is required."]}
 
     def test_invalid_group_type(self):
-        data = {**self.valid_data, "groupType": "invalid_type"}
+        data = {**self.valid_data, "detectorType": "invalid_type"}
         response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
             **data,
             status_code=400,
         )
-        assert response.data == {"groupType": ["Unknown group type"]}
+        assert response.data == {"detectorType": ["Unknown detector type"]}
 
     def test_incompatible_group_type(self):
         with mock.patch("sentry.issues.grouptype.registry.get_by_slug") as mock_get:
             mock_get.return_value = mock.Mock(detector_validator=None)
-            data = {**self.valid_data, "groupType": "incompatible_type"}
+            data = {**self.valid_data, "detectorType": "incompatible_type"}
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 **data,
                 status_code=400,
             )
-            assert response.data == {"groupType": ["Group type not compatible with detectors"]}
+            assert response.data == {
+                "detectorType": ["Detector type not compatible with detectors"]
+            }
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_valid_creation(self, mock_audit):
@@ -168,7 +170,7 @@ class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
             self.project.slug,
             status_code=400,
         )
-        assert response.data == {"groupType": ["This field is required."]}
+        assert response.data == {"detectorType": ["This field is required."]}
 
     def test_missing_name(self):
         data = {**self.valid_data}


### PR DESCRIPTION
Rename the detector type variable to `detector_type` instead of `group_type` and the `BaseGroupTypeDetectorValidator` to `BaseDetectorTypeValidator`.