### PR TITLE
fix(broadcasts): Increase stale time of /broadcasts/ endpoint

### DIFF
--- a/static/app/components/sidebar/broadcasts.tsx
+++ b/static/app/components/sidebar/broadcasts.tsx
@@ -47,7 +47,8 @@ export function Broadcasts({
   const {isPending, data: broadcasts = []} = useApiQuery<Broadcast[]>(
     [`/organizations/${organization.slug}/broadcasts/`],
     {
-      staleTime: 0,
+      // Five minute stale time prevents window focus frequent refetches
+      staleTime: 1000 * 60 * 5,
       refetchInterval: POLLER_DELAY,
       refetchOnWindowFocus: true,
     }


### PR DESCRIPTION
Right now any window focus change triggers the request because stale time is `0`. This will refetch on window focus when > 5 minutes or if it hits the refetch interval.
