### PR TITLE
feat(insights): Remove "New" badge from accordion widgets

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -12,23 +12,11 @@ import type {
   WidgetDataConstraint,
   WidgetDataProps,
 } from '../types';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 export function WidgetHeader<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> & WidgetDataProps<T>
 ) {
-  const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle, chartSetting} =
-    props;
-  const isWebVitalsWidget = [
-    PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES,
-    PerformanceWidgetSetting.OVERALL_PERFORMANCE_SCORE,
-  ].includes(chartSetting);
-
-  const isCacheWidget =
-    chartSetting === PerformanceWidgetSetting.HIGHEST_CACHE_MISS_RATE_TRANSACTIONS;
-
-  const featureBadge =
-    isWebVitalsWidget || isCacheWidget ? <FeatureBadge type="new" /> : null;
+  const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle} = props;
 
   return (
     <WidgetHeaderContainer>
@@ -39,7 +27,6 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
           ) : (
             <TextOverflow>{title}</TextOverflow>
           )}
-          {featureBadge}
           <MEPTag />
           {titleTooltip && (
             <QuestionTooltip position="top" size="sm" title={titleTooltip} />


### PR DESCRIPTION
Neither "Caches" nor "Web Vitals" are new anymore, we can remove the badge.
