### PR TITLE
fix(insights): update performance moving banner to not include ai

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -36,7 +36,6 @@ import {
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useTeams} from 'sentry/utils/useTeams';
-import {AI_SIDEBAR_LABEL} from 'sentry/views/insights/pages/ai/settings';
 import {BACKEND_SIDEBAR_LABEL} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_SIDEBAR_LABEL} from 'sentry/views/insights/pages/frontend/settings';
 import {MOBILE_SIDEBAR_LABEL} from 'sentry/views/insights/pages/mobile/settings';
@@ -112,12 +111,10 @@ export function PerformanceLanding(props: Props) {
         <Link to={`${getPerformanceBaseUrl(slug, 'backend')}/`}>
           {BACKEND_SIDEBAR_LABEL}
         </Link>
-        {`, `}
+        {t(', and ')}
         <Link to={`${getPerformanceBaseUrl(slug, 'mobile')}/`}>
           {MOBILE_SIDEBAR_LABEL}
         </Link>
-        {t(', and ')}
-        <Link to={`${getPerformanceBaseUrl(slug, 'ai')}/`}>{AI_SIDEBAR_LABEL}</Link>
         {t(' performance pages. They can all be found in the Insights tab.')}
       </Fragment>
     );


### PR DESCRIPTION
Remove `AI` from the performance moving banner, as the ai overview page no longer exists.

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/d1a11e18-688e-4899-b377-0832a983e530" />
