### PR TITLE
ref(seer grouping): Include Seer non-matches in hybrid fingerprint metric

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -324,7 +324,7 @@ def get_seer_similar_issues(
                 result = "fingerprint_match"
 
             metrics.incr(
-                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                "grouping.similarity.hybrid_fingerprint_seer_result",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": event.platform, "result": result},
             )

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -328,6 +328,15 @@ def get_seer_similar_issues(
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": event.platform, "result": result},
             )
+    # For convenience and ease of graph creation in DD, we collect the no-match case as part of this
+    # metric in addition to collecting it as part of the overall seer request metric
+    else:
+        if event_has_hybrid_fingerprint:
+            metrics.incr(
+                "grouping.similarity.hybrid_fingerprint_seer_result",
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+                tags={"platform": event.platform, "result": "no_seer_match"},
+            )
 
     similar_issues_metadata = {
         "results": seer_results_json,

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -416,7 +416,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 existing_grouphash,
             )
             mock_metrics_incr.assert_called_with(
-                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                "grouping.similarity.hybrid_fingerprint_seer_result",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": "python", "result": "fingerprint_match"},
             )
@@ -456,7 +456,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 None,
             )
             mock_metrics_incr.assert_called_with(
-                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                "grouping.similarity.hybrid_fingerprint_seer_result",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": "python", "result": "no_fingerprint_match"},
             )
@@ -496,7 +496,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 None,
             )
             mock_metrics_incr.assert_called_with(
-                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                "grouping.similarity.hybrid_fingerprint_seer_result",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": "python", "result": "only_event_hybrid"},
             )
@@ -534,7 +534,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 None,
             )
             mock_metrics_incr.assert_called_with(
-                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                "grouping.similarity.hybrid_fingerprint_seer_result",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": "python", "result": "only_parent_hybrid"},
             )
@@ -587,7 +587,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 None,
             )
             mock_metrics_incr.assert_called_with(
-                "grouping.similarity.hybrid_fingerprint_seer_result_check",
+                "grouping.similarity.hybrid_fingerprint_seer_result",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"platform": "python", "result": "no_parent_metadata"},
             )

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -592,7 +592,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 tags={"platform": "python", "result": "no_parent_metadata"},
             )
 
-    def test_no_parent_group_found(self) -> None:
+    def test_no_parent_group_found_simple(self) -> None:
         new_event, new_variants, new_grouphash, _ = self.create_new_event()
 
         with patch(
@@ -607,6 +607,31 @@ class GetSeerSimilarIssuesTest(TestCase):
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 expected_metadata,
                 None,
+            )
+
+    @patch("sentry.grouping.ingest.seer.metrics.incr")
+    def test_no_parent_group_found_hybrid_fingerprint(self, mock_metrics_incr: MagicMock) -> None:
+        new_event, new_variants, new_grouphash, _ = self.create_new_event(
+            fingerprint=["{{ default }}", "maisey"]
+        )
+
+        with patch(
+            "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
+            return_value=[],
+        ):
+            expected_metadata = {
+                "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
+                "results": [],
+            }
+
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                expected_metadata,
+                None,
+            )
+            mock_metrics_incr.assert_called_with(
+                "grouping.similarity.hybrid_fingerprint_seer_result",
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+                tags={"platform": "python", "result": "no_seer_match"},
             )
 
 


### PR DESCRIPTION
We currently collect a metric, `grouping.similarity.hybrid_fingerprint_seer_result_check`, which tracks what happens when an event with a hybrid fingerprint finds a match in Seer - does the match have the same fingerprint? does it not? do we even have enough info to tell? etc., etc.. However, the slightly more intuitive metric to track would be what happens to _any_ event with a hybrid fingerprint, Seer match or not (and we can derive the current metric's numbers from that).

This PR therefore makes that switch. Since it is no longer tracking just the fingerprint check which occurs after a Seer match but in fact all Seer request outcomes for events with hybrid fingerprints, its name has also been changed to `grouping.similarity.hybrid_fingerprint_seer_result`.