### PR TITLE
feat(uptime): Stop sharing `UptimeSubscription` rows, and also stop changing subscription id when we update.

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -24,9 +24,9 @@ from sentry.uptime.detectors.ranking import (
 )
 from sentry.uptime.models import ProjectUptimeSubscription, ProjectUptimeSubscriptionMode
 from sentry.uptime.subscriptions.subscriptions import (
+    create_project_uptime_subscription,
     delete_uptime_subscriptions_for_project,
     get_auto_monitored_subscriptions_for_project,
-    get_or_create_project_uptime_subscription,
     is_url_auto_monitored_for_project,
 )
 from sentry.utils import metrics
@@ -256,7 +256,7 @@ def monitor_url_for_project(project: Project, url: str) -> ProjectUptimeSubscrip
             ],
         )
     metrics.incr("uptime.detectors.candidate_url.monitor_created", sample_rate=1.0)
-    return get_or_create_project_uptime_subscription(
+    return create_project_uptime_subscription(
         project,
         # TODO(epurkhiser): This is where we would put the environment object
         # from autodetection if we decide to do that.
@@ -265,7 +265,7 @@ def monitor_url_for_project(project: Project, url: str) -> ProjectUptimeSubscrip
         interval_seconds=ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS,
         timeout_ms=ONBOARDING_SUBSCRIPTION_TIMEOUT_MS,
         mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
-    )[0]
+    )
 
 
 def is_failed_url(url: str) -> bool:

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -21,7 +21,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     MAX_MANUAL_SUBSCRIPTIONS_PER_ORG,
     MaxManualUptimeSubscriptionsReached,
     UptimeMonitorNoSeatAvailable,
-    get_or_create_project_uptime_subscription,
+    create_project_uptime_subscription,
     update_project_uptime_subscription,
 )
 from sentry.utils.audit import create_audit_entry
@@ -201,7 +201,7 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
             k: v for k, v in validated_data.items() if k in {"method", "headers", "body"}
         }
         try:
-            uptime_monitor, created = get_or_create_project_uptime_subscription(
+            uptime_monitor = create_project_uptime_subscription(
                 project=self.context["project"],
                 environment=environment,
                 url=validated_data["url"],
@@ -217,10 +217,6 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
         except MaxManualUptimeSubscriptionsReached:
             raise serializers.ValidationError(
                 f"You may have at most {MAX_MANUAL_SUBSCRIPTIONS_PER_ORG} uptime monitors per organization"
-            )
-        if not created:
-            raise serializers.ValidationError(
-                "A monitor with these parameters already exists in this project"
             )
         create_audit_entry(
             request=self.context["request"],

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -278,10 +278,10 @@ def create_uptime_subscription(
     )
 
     # Associate active regions with this subscription
-    for region_config in get_active_region_configs():
-        UptimeSubscriptionRegion.objects.get_or_create(
+    for region_config in get_active_regions():
+        UptimeSubscriptionRegion.objects.create(
             uptime_subscription=subscription, region_slug=region_config.slug
-        )[1]
+        )
 
     create_remote_uptime_subscription.delay(subscription.id)
     fetch_subscription_rdap_info.delay(subscription.id)
@@ -324,7 +324,8 @@ def update_uptime_subscription(
     )
 
     # Associate active regions with this subscription
-    for region_config in get_active_region_configs():
+    # TODO: This should use core code from `check_and_update_regions`
+    for region_config in get_active_regions():
         UptimeSubscriptionRegion.objects.get_or_create(
             uptime_subscription=subscription, region_slug=region_config.slug
         )

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -26,7 +26,9 @@ from sentry.uptime.subscriptions.regions import get_active_regions
 from sentry.uptime.subscriptions.tasks import (
     create_remote_uptime_subscription,
     delete_remote_uptime_subscription,
+    update_remote_uptime_subscription,
 )
+from sentry.utils.not_set import NOT_SET, NotSet, default_if_not_set
 from sentry.utils.outcomes import Outcome
 
 logger = logging.getLogger(__name__)
@@ -100,10 +102,7 @@ def get_or_create_uptime_subscription(
     body: str | None = None,
     trace_sampling: bool = False,
 ) -> UptimeSubscription:
-    """
-    Creates a new uptime subscription. This creates the row in postgres, and fires a task that will send the config
-    to the uptime check system.
-    """
+    # XXX: Remove this, keeping it around for getsentry backwards compat
     if headers is None:
         headers = []
     # We extract the domain and suffix of the url here. This is used to prevent there being too many checks to a single
@@ -173,15 +172,6 @@ def get_or_create_uptime_subscription(
     return subscription
 
 
-def delete_uptime_subscription(uptime_subscription: UptimeSubscription):
-    """
-    Deletes an existing uptime subscription. This updates the row in postgres, and fires a task that will send the
-    deletion to the external system and remove the row once successful.
-    """
-    uptime_subscription.update(status=UptimeSubscription.Status.DELETING.value)
-    delete_remote_uptime_subscription.delay(uptime_subscription.id)
-
-
 def get_or_create_project_uptime_subscription(
     project: Project,
     environment: Environment | None,
@@ -198,9 +188,7 @@ def get_or_create_project_uptime_subscription(
     trace_sampling: bool = False,
     override_manual_org_limit: bool = False,
 ) -> tuple[ProjectUptimeSubscription, bool]:
-    """
-    Links a project to an uptime subscription so that it can process results.
-    """
+    # XXX: Remove this function after getsentry is compat
     if mode == ProjectUptimeSubscriptionMode.MANUAL:
         manual_subscription_count = ProjectUptimeSubscription.objects.filter(
             project__organization=project.organization, mode=ProjectUptimeSubscriptionMode.MANUAL
@@ -255,25 +243,135 @@ def get_or_create_project_uptime_subscription(
     return uptime_monitor, created
 
 
-def update_project_uptime_subscription(
-    uptime_monitor: ProjectUptimeSubscription,
+def create_uptime_subscription(
+    url: str,
+    interval_seconds: int,
+    timeout_ms: int,
+    method: str = "GET",
+    headers: Sequence[tuple[str, str]] | None = None,
+    body: str | None = None,
+    trace_sampling: bool = False,
+) -> UptimeSubscription:
+    """
+    Creates a new uptime subscription. This creates the row in postgres, and fires a task that will send the config
+    to the uptime check system.
+    """
+    if headers is None:
+        headers = []
+    # We extract the domain and suffix of the url here. This is used to prevent there being too many checks to a single
+    # domain.
+    result = extract_domain_parts(url)
+
+    subscription = UptimeSubscription.objects.create(
+        url=url,
+        url_domain=result.domain,
+        url_domain_suffix=result.suffix,
+        interval_seconds=interval_seconds,
+        timeout_ms=timeout_ms,
+        status=UptimeSubscription.Status.CREATING.value,
+        type=UPTIME_SUBSCRIPTION_TYPE,
+        method=method,
+        headers=headers,  # type: ignore[misc]
+        body=body,
+        trace_sampling=trace_sampling,
+        migrated=True,
+    )
+
+    # Associate active regions with this subscription
+    for region_config in get_active_region_configs():
+        UptimeSubscriptionRegion.objects.get_or_create(
+            uptime_subscription=subscription, region_slug=region_config.slug
+        )[1]
+
+    create_remote_uptime_subscription.delay(subscription.id)
+    fetch_subscription_rdap_info.delay(subscription.id)
+    return subscription
+
+
+def update_uptime_subscription(
+    subscription: UptimeSubscription,
+    url: str | NotSet = NOT_SET,
+    interval_seconds: int | NotSet = NOT_SET,
+    timeout_ms: int | NotSet = NOT_SET,
+    method: str | NotSet = NOT_SET,
+    headers: Sequence[tuple[str, str]] | None | NotSet = NOT_SET,
+    body: str | None | NotSet = NOT_SET,
+    trace_sampling: bool | NotSet = NOT_SET,
+):
+    """
+    Updates an existing uptime subscription. This updates the row in postgres, and fires a task that will send the
+    config to the uptime check system.
+    """
+    url = default_if_not_set(subscription.url, url)
+    # We extract the domain and suffix of the url here. This is used to prevent there being too many checks to a single
+    # domain.
+    result = extract_domain_parts(url)
+    headers = default_if_not_set(subscription.headers, headers)
+    if headers is None:
+        headers = []
+
+    subscription.update(
+        status=UptimeSubscription.Status.UPDATING.value,
+        url=url,
+        url_domain=result.domain,
+        url_domain_suffix=result.suffix,
+        interval_seconds=default_if_not_set(subscription.interval_seconds, interval_seconds),
+        timeout_ms=default_if_not_set(subscription.timeout_ms, timeout_ms),
+        method=default_if_not_set(subscription.method, method),
+        headers=headers,
+        body=default_if_not_set(subscription.body, body),
+        trace_sampling=default_if_not_set(subscription.trace_sampling, trace_sampling),
+    )
+
+    # Associate active regions with this subscription
+    for region_config in get_active_region_configs():
+        UptimeSubscriptionRegion.objects.get_or_create(
+            uptime_subscription=subscription, region_slug=region_config.slug
+        )
+
+    update_remote_uptime_subscription.delay(subscription.id)
+    fetch_subscription_rdap_info.delay(subscription.id)
+
+
+def delete_uptime_subscription(uptime_subscription: UptimeSubscription):
+    """
+    Deletes an existing uptime subscription. This updates the row in postgres, and fires a task that will send the
+    deletion to the external system and remove the row once successful.
+    """
+    uptime_subscription.update(status=UptimeSubscription.Status.DELETING.value)
+    delete_remote_uptime_subscription.delay(uptime_subscription.id)
+
+
+def create_project_uptime_subscription(
+    project: Project,
     environment: Environment | None,
     url: str,
     interval_seconds: int,
     timeout_ms: int,
-    method: str,
-    headers: Sequence[tuple[str, str]],
-    body: str | None,
-    name: str,
-    owner: Actor | None,
-    trace_sampling: bool,
+    method: str = "GET",
+    headers: Sequence[tuple[str, str]] | None = None,
+    body: str | None = None,
+    mode: ProjectUptimeSubscriptionMode = ProjectUptimeSubscriptionMode.MANUAL,
     status: int = ObjectStatus.ACTIVE,
-):
+    name: str = "",
+    owner: Actor | None = None,
+    trace_sampling: bool = False,
+    override_manual_org_limit: bool = False,
+) -> ProjectUptimeSubscription:
     """
     Links a project to an uptime subscription so that it can process results.
     """
-    cur_uptime_subscription = uptime_monitor.uptime_subscription
-    new_uptime_subscription = get_or_create_uptime_subscription(
+    if mode == ProjectUptimeSubscriptionMode.MANUAL:
+        manual_subscription_count = ProjectUptimeSubscription.objects.filter(
+            project__organization=project.organization, mode=ProjectUptimeSubscriptionMode.MANUAL
+        ).count()
+        if (
+            not override_manual_org_limit
+            and manual_subscription_count >= MAX_MANUAL_SUBSCRIPTIONS_PER_ORG
+        ):
+            raise MaxManualUptimeSubscriptionsReached
+
+    uptime_subscription = create_uptime_subscription(
         url=url,
         interval_seconds=interval_seconds,
         timeout_ms=timeout_ms,
@@ -282,10 +380,90 @@ def update_project_uptime_subscription(
         body=body,
         trace_sampling=trace_sampling,
     )
+    owner_user_id = None
+    owner_team_id = None
+    if owner:
+        if owner.is_user:
+            owner_user_id = owner.id
+        if owner.is_team:
+            owner_team_id = owner.id
+    uptime_monitor = ProjectUptimeSubscription.objects.create(
+        project=project,
+        environment=environment,
+        uptime_subscription=uptime_subscription,
+        mode=mode.value,
+        name=name,
+        owner_user_id=owner_user_id,
+        owner_team_id=owner_team_id,
+    )
+
+    # Update status. This may have the side effect of removing or creating a
+    # remote subscription. When a new monitor is created we will ensure seat
+    # assignment, which may cause the monitor to be disabled if there are no
+    # available seat assignments.
+    match status:
+        case ObjectStatus.ACTIVE:
+            try:
+                enable_project_uptime_subscription(uptime_monitor, ensure_assignment=True)
+            except UptimeMonitorNoSeatAvailable:
+                # No need to do anything if we failed to handle seat
+                # assignment. The monitor will be created, but not enabled
+                pass
+        case ObjectStatus.DISABLED:
+            disable_project_uptime_subscription(uptime_monitor)
+
+    return uptime_monitor
+
+
+def update_project_uptime_subscription(
+    uptime_monitor: ProjectUptimeSubscription,
+    environment: Environment | None | NotSet = NOT_SET,
+    url: str | NotSet = NOT_SET,
+    interval_seconds: int | NotSet = NOT_SET,
+    timeout_ms: int | NotSet = NOT_SET,
+    method: str | NotSet = NOT_SET,
+    headers: Sequence[tuple[str, str]] | NotSet = NOT_SET,
+    body: str | None | NotSet = NOT_SET,
+    name: str | NotSet = NOT_SET,
+    owner: Actor | None | NotSet = NOT_SET,
+    trace_sampling: bool | NotSet = NOT_SET,
+    status: int = ObjectStatus.ACTIVE,
+    mode: ProjectUptimeSubscriptionMode = ProjectUptimeSubscriptionMode.MANUAL,
+):
+    """
+    Links a project to an uptime subscription so that it can process results.
+    """
+    cur_uptime_subscription = uptime_monitor.uptime_subscription
+    if cur_uptime_subscription.migrated:
+        update_uptime_subscription(
+            cur_uptime_subscription,
+            url=url,
+            interval_seconds=interval_seconds,
+            timeout_ms=timeout_ms,
+            method=method,
+            headers=headers,
+            body=body,
+            trace_sampling=trace_sampling,
+        )
+        new_uptime_subscription = cur_uptime_subscription
+    else:
+        new_uptime_subscription = create_uptime_subscription(
+            url=default_if_not_set(cur_uptime_subscription.url, url),
+            interval_seconds=default_if_not_set(
+                cur_uptime_subscription.interval_seconds, interval_seconds
+            ),
+            timeout_ms=default_if_not_set(cur_uptime_subscription.timeout_ms, timeout_ms),
+            method=default_if_not_set(cur_uptime_subscription.method, method),
+            headers=default_if_not_set(cur_uptime_subscription.headers, headers),
+            body=default_if_not_set(cur_uptime_subscription.body, body),
+            trace_sampling=default_if_not_set(
+                cur_uptime_subscription.trace_sampling, trace_sampling
+            ),
+        )
 
     owner_user_id = uptime_monitor.owner_user_id
     owner_team_id = uptime_monitor.owner_team_id
-    if owner:
+    if owner and owner is not NOT_SET:
         if owner.is_user:
             owner_user_id = owner.id
             owner_team_id = None
@@ -294,16 +472,17 @@ def update_project_uptime_subscription(
             owner_user_id = None
 
     uptime_monitor.update(
-        environment=environment,
+        environment=default_if_not_set(uptime_monitor.environment, environment),
+        # Temporarily keep assigning the subscription here, although we can remove this once we've moved away from the
+        # delete/recreate method
         uptime_subscription=new_uptime_subscription,
-        name=name,
-        # After an update, we always convert a subscription to manual mode
-        mode=ProjectUptimeSubscriptionMode.MANUAL,
+        name=default_if_not_set(uptime_monitor.name, name),
+        mode=mode,
         owner_user_id=owner_user_id,
         owner_team_id=owner_team_id,
     )
-    # If we changed any fields on the actual subscription we created a new subscription and associated it with this
-    # uptime monitor. Check if the old subscription was orphaned due to this.
+    # TODO: Remove. If we haven't migrated the subscription yet then we recreated it, and might have orphaned it. Remove
+    # any orphaned subs now
     remove_uptime_subscription_if_unused(cur_uptime_subscription)
 
     # Update status. This may have the side effect of removing or creating a

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -193,7 +193,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             headers=[["header", "value"]],
         )
         new_uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
-        assert uptime_monitor.uptime_subscription_id == new_uptime_monitor.uptime_subscription_id
+        assert uptime_monitor.uptime_subscription_id != new_uptime_monitor.uptime_subscription_id
         assert new_uptime_monitor.project_id != uptime_monitor.project_id
         resp = self.get_success_response(
             self.organization.slug,

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -22,17 +22,18 @@ from sentry.uptime.subscriptions.subscriptions import (
     UPTIME_SUBSCRIPTION_TYPE,
     MaxManualUptimeSubscriptionsReached,
     UptimeMonitorNoSeatAvailable,
+    create_project_uptime_subscription,
+    create_uptime_subscription,
     delete_project_uptime_subscription,
     delete_uptime_subscription,
     delete_uptime_subscriptions_for_project,
     disable_project_uptime_subscription,
     enable_project_uptime_subscription,
     get_auto_monitored_subscriptions_for_project,
-    get_or_create_project_uptime_subscription,
-    get_or_create_uptime_subscription,
     is_url_auto_monitored_for_project,
     remove_uptime_subscription_if_unused,
     update_project_uptime_subscription,
+    update_uptime_subscription,
 )
 from sentry.utils.outcomes import Outcome
 
@@ -45,7 +46,7 @@ class CreateUptimeSubscriptionTest(UptimeTestCase):
         interval_seconds = 300
         timeout_ms = 500
         with self.tasks():
-            uptime_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
+            uptime_sub = create_uptime_subscription(url, interval_seconds, timeout_ms)
         # Subscription.subscription_id ends up set in the task, so refresh
         uptime_sub.refresh_from_db()
         assert uptime_sub.subscription_id is not None
@@ -61,7 +62,7 @@ class CreateUptimeSubscriptionTest(UptimeTestCase):
         url = "https://test.vercel.app"
         interval_seconds = 300
         timeout_ms = 500
-        uptime_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
+        uptime_sub = create_uptime_subscription(url, interval_seconds, timeout_ms)
         # Subscription.subscription_id ends up set in the task, so refresh
         uptime_sub.refresh_from_db()
         assert uptime_sub.subscription_id is None
@@ -78,39 +79,22 @@ class CreateUptimeSubscriptionTest(UptimeTestCase):
         interval_seconds = 300
         timeout_ms = 500
         with self.tasks():
-            uptime_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
+            uptime_sub = create_uptime_subscription(url, interval_seconds, timeout_ms)
         # Subscription.subscription_id ends up set in the task, so refresh
         uptime_sub.refresh_from_db()
         assert uptime_sub.subscription_id is not None
         with self.tasks():
-            second_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
+            second_sub = create_uptime_subscription(url, interval_seconds, timeout_ms)
         second_sub.refresh_from_db()
 
-        assert uptime_sub.id == second_sub.id
-        assert uptime_sub.subscription_id == second_sub.subscription_id
-
-    def test_deleting_status(self):
-        url = "https://sentry.io"
-        interval_seconds = 300
-        timeout_ms = 500
-        with self.tasks():
-            uptime_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
-        # Subscription.subscription_id ends up set in the task, so refresh
-        uptime_sub.refresh_from_db()
-        uptime_sub.update(status=UptimeSubscription.Status.DELETING.value)
-        with self.tasks():
-            new_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
-        # Should be the same sub
-        new_sub.refresh_from_db()
-        assert uptime_sub.id == new_sub.id
-        assert new_sub.status == UptimeSubscription.Status.ACTIVE.value
-        assert new_sub.subscription_id is not None
+        assert uptime_sub.id != second_sub.id
+        assert uptime_sub.subscription_id != second_sub.subscription_id
 
     def test_without_task(self):
         url = "https://sentry.io"
         interval_seconds = 300
         timeout_ms = 500
-        uptime_sub = get_or_create_uptime_subscription(url, interval_seconds, timeout_ms)
+        uptime_sub = create_uptime_subscription(url, interval_seconds, timeout_ms)
         assert uptime_sub.subscription_id is None
         assert uptime_sub.status == UptimeSubscription.Status.CREATING.value
         assert uptime_sub.type == UPTIME_SUBSCRIPTION_TYPE
@@ -121,10 +105,49 @@ class CreateUptimeSubscriptionTest(UptimeTestCase):
         assert uptime_sub.timeout_ms == timeout_ms
 
 
+class UpdateUptimeSubscriptionTest(UptimeTestCase):
+    def test(self):
+        with self.tasks():
+            uptime_sub = create_uptime_subscription("https://sentry.io", 300, 500)
+        uptime_sub.refresh_from_db()
+        prev_subscription_id = uptime_sub.subscription_id
+
+        url = "https://santry.io"
+        interval_seconds = 600
+        timeout_ms = 1000
+        method = "POST"
+        body = "some body"
+        trace_sampling = True
+        with self.tasks():
+            update_uptime_subscription(
+                uptime_sub,
+                url,
+                interval_seconds,
+                timeout_ms,
+                method,
+                [("something", "some_val")],
+                body=body,
+                trace_sampling=trace_sampling,
+            )
+        uptime_sub.refresh_from_db()
+        assert uptime_sub.subscription_id == prev_subscription_id
+        assert uptime_sub.status == UptimeSubscription.Status.ACTIVE.value
+        assert uptime_sub.type == UPTIME_SUBSCRIPTION_TYPE
+        assert uptime_sub.url == url
+        assert uptime_sub.url_domain == "santry"
+        assert uptime_sub.url_domain_suffix == "io"
+        assert uptime_sub.interval_seconds == interval_seconds
+        assert uptime_sub.timeout_ms == timeout_ms
+        assert uptime_sub.method == method
+        assert uptime_sub.headers == [["something", "some_val"]]
+        assert uptime_sub.body == body
+        assert uptime_sub.trace_sampling == trace_sampling
+
+
 class DeleteUptimeSubscriptionTest(UptimeTestCase):
     def test_with_task(self):
         with self.tasks():
-            uptime_sub = get_or_create_uptime_subscription("https://sentry.io", 3600, 1000)
+            uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
         with self.tasks():
             delete_uptime_subscription(uptime_sub)
         with pytest.raises(UptimeSubscription.DoesNotExist):
@@ -132,7 +155,7 @@ class DeleteUptimeSubscriptionTest(UptimeTestCase):
 
     def test_without_task(self):
         with self.tasks():
-            uptime_sub = get_or_create_uptime_subscription("https://sentry.io", 3600, 1000)
+            uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
 
         delete_uptime_subscription(uptime_sub)
 
@@ -142,15 +165,14 @@ class DeleteUptimeSubscriptionTest(UptimeTestCase):
 
 class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     def test(self):
-        created = get_or_create_project_uptime_subscription(
+        create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[1]
-        assert created
+        )
         assert ProjectUptimeSubscription.objects.filter(
             project=self.project,
             uptime_subscription__url="https://sentry.io",
@@ -160,22 +182,22 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         ).exists()
 
     def test_already_exists(self):
-        assert get_or_create_project_uptime_subscription(
+        create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[1]
-        assert not get_or_create_project_uptime_subscription(
+        )
+        assert create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[1]
+        )
 
         assert (
             ProjectUptimeSubscription.objects.filter(
@@ -185,34 +207,6 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 uptime_subscription__timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
             ).count()
-            == 1
-        )
-
-    def test_different_modes(self):
-        assert get_or_create_project_uptime_subscription(
-            self.project,
-            self.environment,
-            url="https://sentry.io",
-            interval_seconds=3600,
-            timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[1]
-        assert get_or_create_project_uptime_subscription(
-            self.project,
-            self.environment,
-            url="https://sentry.io",
-            interval_seconds=3600,
-            timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )[1]
-
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project,
-                uptime_subscription__url="https://sentry.io",
-                uptime_subscription__interval_seconds=3600,
-                uptime_subscription__timeout_ms=1000,
-            ).count()
             == 2
         )
 
@@ -220,38 +214,38 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         with mock.patch(
             "sentry.uptime.subscriptions.subscriptions.MAX_MANUAL_SUBSCRIPTIONS_PER_ORG", new=1
         ):
-            assert get_or_create_project_uptime_subscription(
+            assert create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
-            )[1]
+            )
             with pytest.raises(MaxManualUptimeSubscriptionsReached):
-                assert get_or_create_project_uptime_subscription(
+                assert create_project_uptime_subscription(
                     self.project,
                     self.environment,
                     url="https://santry.io",
                     interval_seconds=3600,
                     timeout_ms=1000,
                     mode=ProjectUptimeSubscriptionMode.MANUAL,
-                )[1]
+                )
 
     def test_override_max_proj_subs(self):
         with mock.patch(
             "sentry.uptime.subscriptions.subscriptions.MAX_MANUAL_SUBSCRIPTIONS_PER_ORG", new=1
         ):
-            assert get_or_create_project_uptime_subscription(
+            assert create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
-            )[1]
+            )
             with pytest.raises(MaxManualUptimeSubscriptionsReached):
-                get_or_create_project_uptime_subscription(
+                create_project_uptime_subscription(
                     self.project,
                     self.environment,
                     url="https://santry.io",
@@ -259,8 +253,8 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                     timeout_ms=1000,
                     mode=ProjectUptimeSubscriptionMode.MANUAL,
                     override_manual_org_limit=False,
-                )[1]
-            assert get_or_create_project_uptime_subscription(
+                )
+            assert create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://santry.io",
@@ -268,7 +262,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
                 override_manual_org_limit=True,
-            )[1]
+            )
 
     def test_auto_associates_active_regions(self):
         regions = [
@@ -301,7 +295,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 }
             ),
         ):
-            subscription = get_or_create_uptime_subscription(
+            subscription = create_uptime_subscription(
                 url="https://example.com",
                 interval_seconds=60,
                 timeout_ms=1000,
@@ -311,19 +305,9 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             subscription_regions = {r.region_slug for r in subscription.regions.all()}
             assert subscription_regions == {"region1", "region2"}
 
-            # Creating again should return same subscription with same regions
-            subscription2 = get_or_create_uptime_subscription(
-                url="https://example.com",
-                interval_seconds=60,
-                timeout_ms=1000,
-            )
-            assert subscription2.id == subscription.id
-            subscription_regions = {r.region_slug for r in subscription2.regions.all()}
-            assert subscription_regions == {"region1", "region2"}
-
     @mock.patch("sentry.uptime.subscriptions.subscriptions.disable_project_uptime_subscription")
     def test_status_disable(self, mock_disable_project_uptime_subscription):
-        get_or_create_project_uptime_subscription(
+        create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
@@ -337,7 +321,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     @mock.patch("sentry.uptime.subscriptions.subscriptions.enable_project_uptime_subscription")
     def test_status_enable(self, mock_enable_project_uptime_subscription):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
@@ -345,7 +329,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.ACTIVE,
-            )[0]
+            )
             mock_enable_project_uptime_subscription.assert_called_with(
                 proj_sub, ensure_assignment=True
             )
@@ -356,7 +340,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     )
     def test_no_seat_asssignment(self, _mock_check_assign_seat):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
@@ -364,7 +348,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.ACTIVE,
-            )[0]
+            )
 
         # Monitor created but is not enabled due to no seat assignment
         assert proj_sub.status == ObjectStatus.DISABLED
@@ -374,15 +358,17 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
 class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
     def test(self):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-            )[0]
+            )
             prev_uptime_subscription = proj_sub.uptime_subscription
+            prev_uptime_subscription.refresh_from_db()
+            prev_subscription_id = prev_uptime_subscription.subscription_id
             update_project_uptime_subscription(
                 proj_sub,
                 environment=self.environment,
@@ -397,35 +383,32 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 trace_sampling=False,
             )
 
-        with pytest.raises(UptimeSubscription.DoesNotExist):
-            prev_uptime_subscription.refresh_from_db()
-
-        assert ProjectUptimeSubscription.objects.filter(
-            project=self.project,
-            uptime_subscription__url="https://santry.io",
-            uptime_subscription__interval_seconds=60,
-            uptime_subscription__timeout_ms=1000,
-            uptime_subscription__method="POST",
-            uptime_subscription__headers=[["some", "header"]],
-            uptime_subscription__body="a body",
-            name="New name",
-            owner_user_id=self.user.id,
-            owner_team_id=None,
-            # Since we updated, should be marked as manual
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
-        ).exists()
+        proj_sub.refresh_from_db()
+        assert proj_sub.name == "New name"
+        assert proj_sub.owner_user_id == self.user.id
+        assert proj_sub.owner_team_id is None
+        assert proj_sub.mode == ProjectUptimeSubscriptionMode.MANUAL
+        prev_uptime_subscription.refresh_from_db()
+        assert prev_uptime_subscription.url == "https://santry.io"
+        assert prev_uptime_subscription.interval_seconds == 60
+        assert prev_uptime_subscription.timeout_ms == 1000
+        assert prev_uptime_subscription.method == "POST"
+        assert prev_uptime_subscription.headers == [["some", "header"]]
+        assert prev_uptime_subscription.body == "a body"
+        assert prev_uptime_subscription.subscription_id == prev_subscription_id
 
     def test_removes_old(self):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-            )[0]
+            )
             prev_uptime_subscription = proj_sub.uptime_subscription
+            prev_uptime_subscription.update(migrated=False)
             update_project_uptime_subscription(
                 proj_sub,
                 environment=self.environment,
@@ -454,22 +437,22 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
 
     def test_already_exists(self):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
-            )[0]
-            other_proj_sub = get_or_create_project_uptime_subscription(
+            )
+            other_proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://santry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
-            )[0]
+            )
 
             update_project_uptime_subscription(
                 proj_sub,
@@ -495,18 +478,28 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             ).count()
             == 1
         )
+        assert (
+            ProjectUptimeSubscription.objects.filter(
+                project=self.project,
+                uptime_subscription__url="https://santry.io",
+                uptime_subscription__interval_seconds=3600,
+                uptime_subscription__timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.MANUAL,
+            ).count()
+            == 1
+        )
 
     @mock.patch("sentry.uptime.subscriptions.subscriptions.disable_project_uptime_subscription")
     def test_status_disable(self, mock_disable_project_uptime_subscription):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-            )[0]
+            )
             update_project_uptime_subscription(
                 proj_sub,
                 environment=self.environment,
@@ -526,7 +519,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
     @mock.patch("sentry.uptime.subscriptions.subscriptions.enable_project_uptime_subscription")
     def test_status_enable(self, mock_enable_project_uptime_subscription):
         with self.tasks():
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
@@ -534,7 +527,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.DISABLED,
-            )[0]
+            )
             update_project_uptime_subscription(
                 proj_sub,
                 environment=self.environment,
@@ -551,26 +544,100 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             )
         mock_enable_project_uptime_subscription.assert_called()
 
+    def test_migration_creates_new_migrated_row(self):
+        with self.tasks():
+            proj_sub = create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            )
+            prev_uptime_subscription = proj_sub.uptime_subscription
+            prev_uptime_subscription.update(migrated=False)
+            update_project_uptime_subscription(
+                proj_sub,
+                environment=self.environment,
+                url="https://santry.io",
+                interval_seconds=60,
+                timeout_ms=1000,
+                method="POST",
+                headers=[("some", "header")],
+                body="a body",
+                name="New name",
+                owner=Actor.from_orm_user(self.user),
+                trace_sampling=False,
+            )
+
+        proj_sub.refresh_from_db()
+        assert proj_sub.name == "New name"
+        assert proj_sub.owner_user_id == self.user.id
+        assert proj_sub.owner_team_id is None
+        assert proj_sub.mode == ProjectUptimeSubscriptionMode.MANUAL
+        new_uptime_subscription = proj_sub.uptime_subscription
+        assert new_uptime_subscription.id != prev_uptime_subscription.id
+        assert new_uptime_subscription.subscription_id != prev_uptime_subscription.subscription_id
+        assert new_uptime_subscription.url == "https://santry.io"
+        assert new_uptime_subscription.interval_seconds == 60
+        assert new_uptime_subscription.timeout_ms == 1000
+        assert new_uptime_subscription.method == "POST"
+        assert new_uptime_subscription.headers == [["some", "header"]]
+        assert new_uptime_subscription.body == "a body"
+        assert new_uptime_subscription.migrated
+        with pytest.raises(UptimeSubscription.DoesNotExist):
+            prev_uptime_subscription.refresh_from_db()
+
+    def test_migrated_does_not_violate_constraint(self):
+        with self.tasks():
+            proj_sub = create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            )
+            uptime_sub_1 = proj_sub.uptime_subscription
+            uptime_sub_1.update(migrated=False)
+
+            proj_sub_2 = create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            )
+            uptime_sub_2 = proj_sub_2.uptime_subscription
+
+        uptime_sub_1.refresh_from_db()
+        uptime_sub_2.refresh_from_db()
+        assert uptime_sub_1.url == uptime_sub_2.url
+        assert uptime_sub_1.interval_seconds == uptime_sub_2.interval_seconds
+        assert uptime_sub_1.id != uptime_sub_2.id
+        assert uptime_sub_1.subscription_id != uptime_sub_2.subscription_id
+
 
 class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
     def test_other_subscriptions(self):
         other_project = self.create_project()
-        proj_sub = get_or_create_project_uptime_subscription(
+        proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
-        get_or_create_project_uptime_subscription(
+        )
+        create_project_uptime_subscription(
             other_project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
+        )
 
         with self.tasks():
             delete_uptime_subscriptions_for_project(
@@ -582,17 +649,17 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
         with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
             proj_sub.refresh_from_db()
 
-        assert UptimeSubscription.objects.filter(id=proj_sub.uptime_subscription.id).exists()
+        assert not UptimeSubscription.objects.filter(id=proj_sub.uptime_subscription.id).exists()
 
     def test_single_subscriptions(self):
-        proj_sub = get_or_create_project_uptime_subscription(
+        proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
+        )
 
         with self.tasks():
             delete_uptime_subscriptions_for_project(
@@ -608,7 +675,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
             proj_sub.uptime_subscription.refresh_from_db()
 
     def test_does_not_exist(self):
-        uptime_sub = get_or_create_uptime_subscription("https://sentry.io", 3600, 1000)
+        uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
         with self.tasks():
             delete_uptime_subscriptions_for_project(
                 self.project, uptime_sub, modes=[ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE]
@@ -619,14 +686,14 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
 
     def test_does_not_exist_other_subs(self):
         other_project = self.create_project()
-        other_proj_sub = get_or_create_project_uptime_subscription(
+        other_proj_sub = create_project_uptime_subscription(
             other_project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
+        )
 
         with self.tasks():
             delete_uptime_subscriptions_for_project(
@@ -638,32 +705,34 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
         assert UptimeSubscription.objects.filter(id=other_proj_sub.uptime_subscription_id).exists()
 
     def test_delete_other_modes(self):
-        proj_active_sub = get_or_create_project_uptime_subscription(
+        proj_active_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
-        proj_manual_sub = get_or_create_project_uptime_subscription(
+        )
+        proj_manual_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )[0]
+        )
 
         with self.tasks():
             delete_uptime_subscriptions_for_project(
                 self.project,
-                proj_manual_sub.uptime_subscription,
+                proj_active_sub.uptime_subscription,
                 modes=[ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE],
             )
 
         with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
             proj_active_sub.refresh_from_db()
+        with pytest.raises(UptimeSubscription.DoesNotExist):
+            proj_active_sub.uptime_subscription.refresh_from_db()
 
         assert ProjectUptimeSubscription.objects.filter(id=proj_manual_sub.id).exists()
         assert UptimeSubscription.objects.filter(id=proj_manual_sub.uptime_subscription.id).exists()
@@ -686,25 +755,24 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
     @mock.patch("sentry.quotas.backend.disable_seat")
     def test_other_subscriptions(self, mock_disable_seat):
         other_project = self.create_project()
-        proj_sub = get_or_create_project_uptime_subscription(
+        proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
-
-        other_sub = get_or_create_project_uptime_subscription(
+        )
+        other_sub = create_project_uptime_subscription(
             other_project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
+        )
 
-        assert proj_sub.uptime_subscription_id == other_sub.uptime_subscription_id
+        assert proj_sub.uptime_subscription_id != other_sub.uptime_subscription_id
 
         with self.tasks():
             delete_project_uptime_subscription(proj_sub)
@@ -717,14 +785,14 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
 
     @mock.patch("sentry.quotas.backend.disable_seat")
     def test_single_subscriptions(self, mock_disable_seat):
-        proj_sub = get_or_create_project_uptime_subscription(
+        proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
+        )
         with self.tasks():
             delete_project_uptime_subscription(proj_sub)
 
@@ -738,7 +806,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
 
 class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
     def test_remove(self):
-        uptime_sub = get_or_create_uptime_subscription("https://sentry.io", 3600, 1000)
+        uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
         with self.tasks():
             remove_uptime_subscription_if_unused(uptime_sub)
 
@@ -746,14 +814,14 @@ class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
             uptime_sub.refresh_from_db()
 
     def test_keep(self):
-        proj_sub = get_or_create_project_uptime_subscription(
+        proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
-        )[0]
+        )
 
         with self.tasks():
             remove_uptime_subscription_if_unused(proj_sub.uptime_subscription)
@@ -818,14 +886,14 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
 class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
     @mock.patch("sentry.quotas.backend.disable_seat")
     def test(self, mock_disable_seat):
-        proj_sub = get_or_create_project_uptime_subscription(
+        proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )[0]
+        )
 
         with self.tasks():
             disable_project_uptime_subscription(proj_sub)
@@ -839,26 +907,26 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         project1 = self.project
         project2 = self.create_project()
 
-        proj_sub1 = get_or_create_project_uptime_subscription(
+        proj_sub1 = create_project_uptime_subscription(
             project1,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )[0]
-        proj_sub2 = get_or_create_project_uptime_subscription(
+        )
+        proj_sub2 = create_project_uptime_subscription(
             project2,
             self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
             mode=ProjectUptimeSubscriptionMode.MANUAL,
-        )[0]
+        )
 
         uptime_subscription = proj_sub1.uptime_subscription
 
-        # Disabling the first project subscription does NOT disable the
+        # Disabling the first project subscription does disable the
         # subscription
         with self.tasks():
             disable_project_uptime_subscription(proj_sub1)
@@ -867,7 +935,8 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         uptime_subscription.refresh_from_db()
         assert proj_sub1.status == ObjectStatus.DISABLED
         assert proj_sub2.status == ObjectStatus.ACTIVE
-        assert uptime_subscription.status != UptimeSubscription.Status.DISABLED.value
+        assert proj_sub1.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        assert proj_sub2.uptime_subscription.status != UptimeSubscription.Status.DISABLED.value
 
         # Disabling the second project subscription DOES disable the
         # subscription
@@ -875,9 +944,8 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             disable_project_uptime_subscription(proj_sub2)
 
         proj_sub2.refresh_from_db()
-        uptime_subscription.refresh_from_db()
         assert proj_sub2.status == ObjectStatus.DISABLED
-        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        assert proj_sub2.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
 
 
 class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
@@ -895,14 +963,14 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         with mock.patch(
             "sentry.uptime.subscriptions.subscriptions.enable_project_uptime_subscription"
         ):
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
-            )[0]
+            )
 
         # Calling enable_project_uptime_subscription on an already enabled
         # monitor does nothing
@@ -941,14 +1009,14 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         with mock.patch(
             "sentry.uptime.subscriptions.subscriptions.enable_project_uptime_subscription"
         ):
-            proj_sub = get_or_create_project_uptime_subscription(
+            proj_sub = create_project_uptime_subscription(
                 self.project,
                 self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
                 mode=ProjectUptimeSubscriptionMode.MANUAL,
-            )[0]
+            )
 
         # We'll be unable to assign a seat
         with self.tasks(), raises(UptimeMonitorNoSeatAvailable) as exc_info:


### PR DESCRIPTION
This changes our code to stop sharing `UptimeSubscription` rows that are identical between different `ProjectUptimeSubscription` rows. We want to do this for a couple of reasons:
 - The unique constraint that helps us maintain this is getting increasingly onerous to maintain
 - Whenever we update a subscription, the subscription id changes and so we lose history
 - The upside of sharing a subscription is fairly low, and there aren't that many shared subscriptions in the db

This adds in code so that on create, we create an `UptimeSubscription` with `migrated=True`. Anything with this set isn't bound by the unique constraint. When we update, if `migrated=False`, we create a new `UptimeSubscription` row that is set to `migrated=True`. This allows us to start writing correct data now, until we get the backfill in place.