### PR TITLE
rip getsentry: add stripe types

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/react-virtualized": "^9.21.22",
     "@types/reflux": "0.4.1",
     "@types/scroll-to-element": "^2.0.2",
+    "@types/stripe-v3": "^3.1.20",
     "@types/webpack-env": "^1.18.5",
     "ansi-to-react": "^6.1.6",
     "babel-loader": "^9.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4181,6 +4181,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/stripe-v3@^3.1.20":
+  version "3.1.33"
+  resolved "https://registry.yarnpkg.com/@types/stripe-v3/-/stripe-v3-3.1.33.tgz#5cd34d9c37c5a0f7aee9adc42acd0c21bf813b5d"
+  integrity sha512-fIE7F7alypCrnIMsk4naprHf8kXEvPM2Q9FGdL/3TDeGM0xlHohdVWkwuaEZ2tKzXB9QQKoS8k+ocLkPjZajwQ==
+
 "@types/tapable@2.2.7":
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-2.2.7.tgz#4b55aa23daca730d83f192dd0933409d5a0338e4"


### PR DESCRIPTION
this preemptively adds stripe types since gsApp can't be moved (https://github.com/getsentry/sentry/pull/84580) without some type fails 