### PR TITLE
fix(insights): double clicking module tab removes global filters

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.spec.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.spec.tsx
@@ -1,4 +1,4 @@
-import type {Location} from 'history';
+import type {Location, Query} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -11,6 +11,8 @@ import {ModuleName} from 'sentry/views/insights/types';
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useOrganization');
 
+const useLocationMock = jest.mocked(useLocation);
+
 describe('DomainViewHeader', function () {
   const organization = OrganizationFixture({
     features: ['insights-entry-points'],
@@ -18,7 +20,7 @@ describe('DomainViewHeader', function () {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    jest.mocked(useLocation).mockReturnValue({
+    useLocationMock.mockReturnValue({
       pathname: '/organizations/org-slug/insights/frontend/',
     } as Location);
     jest.mocked(useOrganization).mockReturnValue(organization);
@@ -37,6 +39,39 @@ describe('DomainViewHeader', function () {
     expect(screen.getByText('domainTitle')).toBeInTheDocument();
     expect(screen.getByRole('tab', {name: 'Overview'})).toBeInTheDocument();
     expect(screen.getByRole('tab', {name: 'Network Requests'})).toBeInTheDocument();
+  });
+
+  it('renders link with page filters', () => {
+    useLocationMock.mockClear();
+    useLocationMock.mockReturnValue({
+      pathname: '/organizations/org-slug/insights/frontend/',
+      query: {
+        project: ['1'],
+        environment: ['prod'],
+        statsPeriod: '14d',
+        transaction: '123',
+      } as Query,
+    } as Location);
+
+    render(
+      <DomainViewHeader
+        domainBaseUrl="domainBaseUrl"
+        domainTitle="domainTitle"
+        modules={[ModuleName.HTTP]}
+        selectedModule={undefined}
+      />
+    );
+
+    const overviewTab = screen.getByRole('tab', {name: 'Overview'});
+    const networkRequestsTab = screen.getByRole('tab', {name: 'Network Requests'});
+    expect(overviewTab.firstChild).toHaveAttribute(
+      'href',
+      '/domainBaseUrl?environment=prod&project=1&statsPeriod=14d'
+    );
+    expect(networkRequestsTab.firstChild).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/insights/frontend/http/?environment=prod&project=1&statsPeriod=14d'
+    );
   });
 
   it('does not show network requests without features', () => {

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -5,10 +5,12 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
 import {TabList} from 'sentry/components/tabs';
 import type {TabListItemProps} from 'sentry/components/tabs/item';
 import {IconBusiness} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {
@@ -46,6 +48,7 @@ export function DomainViewHeader({
   tabs,
 }: Props) {
   const organization = useOrganization();
+  const location = useLocation();
   const moduleURLBuilder = useModuleURLBuilder();
 
   const crumbs: Crumb[] = [
@@ -60,13 +63,15 @@ export function DomainViewHeader({
   const tabValue =
     hideDefaultTabs && tabs?.value ? tabs.value : selectedModule ?? OVERVIEW_PAGE_TITLE;
 
+  const globalQuery = extractSelectionParameters(location?.query);
+
   const tabList: TabListItemProps[] = [
     ...(hasOverviewPage
       ? [
           {
             key: OVERVIEW_PAGE_TITLE,
             children: OVERVIEW_PAGE_TITLE,
-            to: domainBaseUrl,
+            to: {pathname: domainBaseUrl, query: globalQuery},
           },
         ]
       : []),
@@ -75,7 +80,10 @@ export function DomainViewHeader({
       .map(moduleName => ({
         key: moduleName,
         children: <TabLabel moduleName={moduleName} />,
-        to: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
+        to: {
+          pathname: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
+          query: globalQuery,
+        },
       })),
   ];
 


### PR DESCRIPTION
When you are already on a module tab, for example the network requests tab,`/insights/frontend/http/?project=123&statsPeriod=7d`
and then you click the network requests tab again, the page filters were not filtering leaving all projects selected, and other global filters reset. I.e the link changes to `/insights/frontend/http/`

This PR ensures that the global filters do not get reset when clicking the tab twice.