### PR TITLE
feat(crons): Record clock_time for check-ins

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -123,6 +123,7 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime):
         monitor_environment=monitor_environment,
         status=CheckInStatus.MISSED,
         date_added=expected_time,
+        date_clock=ts,
         expected_time=expected_time,
         monitor_config=monitor.get_validated_config(),
     )

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -1,7 +1,7 @@
 import contextlib
 import uuid
 from collections.abc import Generator, Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest import mock
 
@@ -74,6 +74,7 @@ class MonitorConsumerTest(TestCase):
         monitor_slug: str,
         guid: str | None = None,
         ts: datetime | None = None,
+        item_ts: datetime | None = None,
         consumer: ProcessingStrategy | None = None,
         expected_error: ProcessingErrorsException | ExpectNoProcessingError | None = None,
         expected_monitor_slug: str | None = None,
@@ -81,6 +82,8 @@ class MonitorConsumerTest(TestCase):
     ) -> None:
         if ts is None:
             ts = datetime.now()
+        if item_ts is None:
+            item_ts = ts
         if consumer is None:
             consumer = self.create_consumer()
 
@@ -112,7 +115,7 @@ class MonitorConsumerTest(TestCase):
                         KafkaPayload(b"fake-key", msgpack.packb(wrapper), []),
                         self.partition,
                         1,
-                        ts,
+                        item_ts,
                     )
                 )
             )
@@ -308,6 +311,17 @@ class MonitorConsumerTest(TestCase):
         assert monitor_environment.next_checkin_latest == monitor.get_next_expected_checkin_latest(
             checkin.date_added
         )
+
+    def test_check_in_date_clock(self):
+        monitor = self._create_monitor(slug="my-monitor")
+        now = datetime.now()
+        item_ts = now
+        ts = now + timedelta(seconds=5)
+
+        self.send_checkin(monitor.slug, ts=ts, item_ts=item_ts)
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.date_added == ts.replace(tzinfo=UTC)
+        assert checkin.date_clock == item_ts.replace(tzinfo=UTC)
 
     def test_check_in_timeout_at(self):
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
This will be the timestamp the check-in from the kafka message itself,
the time that we base our entire clock system off of.

In the future this will help us to understand some scenarios where weird
things happen with check-in ordering that we are unable to debug just
using the time the check-in was received.