### PR TITLE
fix(widget-builder): Add release fields into merged aggregate list

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1013,6 +1013,61 @@ describe('Visualize', () => {
     );
   });
 
+  it('shows the correct aggregate options for release dataset', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {dataset: WidgetType.RELEASE, field: ['crash_free_rate(session)']},
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    expect(screen.getByRole('option', {name: 'release'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'environment'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'project'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'session.status'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'user'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'session'})).not.toBeInTheDocument();
+  });
+
+  it('adds a separate field when only one function field is present on release tables', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {dataset: WidgetType.RELEASE, field: ['crash_free_rate(session)']},
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'release'}));
+
+    expect(screen.getAllByRole('button', {name: 'Column Selection'})).toHaveLength(2);
+    expect(
+      screen.getAllByRole('button', {name: 'Column Selection'})[0]
+    ).toHaveTextContent('release');
+    expect(
+      screen.getAllByRole('button', {name: 'Column Selection'})[1]
+    ).toHaveTextContent('session');
+
+    expect(
+      screen.getAllByRole('button', {name: 'Aggregate Selection'})[1]
+    ).toHaveTextContent('crash_free_rate');
+  });
+
   describe('spans', () => {
     beforeEach(() => {
       jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -148,13 +148,13 @@ function getColumnOptions(
           dataset === WidgetType.RELEASE
             ? value.kind === FieldValueKind.METRICS &&
               validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value)
-            : value.kind === FieldValueKind.FIELD ||
-              value.kind === FieldValueKind.TAG ||
-              value.kind === FieldValueKind.MEASUREMENT ||
-              value.kind === FieldValueKind.CUSTOM_MEASUREMENT ||
-              value.kind === FieldValueKind.METRICS ||
-              (value.kind === FieldValueKind.BREAKDOWN &&
-                validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value))
+            : (value.kind === FieldValueKind.FIELD ||
+                value.kind === FieldValueKind.TAG ||
+                value.kind === FieldValueKind.MEASUREMENT ||
+                value.kind === FieldValueKind.CUSTOM_MEASUREMENT ||
+                value.kind === FieldValueKind.METRICS ||
+                value.kind === FieldValueKind.BREAKDOWN) &&
+              validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value)
         ),
         columnFilterMethod
       );

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -583,10 +583,15 @@ function Visualize({error, setError}: VisualizeProps) {
                                     );
                                     // Update the current field's aggregate with the new aggregate
                                     if (!selectedAggregate && !isNone) {
+                                      const functionFields = newFields.filter(
+                                        newField =>
+                                          newField.kind === FieldValueKind.FUNCTION
+                                      );
                                       // Handles selection of release tags from aggregate dropdown
                                       if (
                                         state.dataset === WidgetType.RELEASE &&
-                                        state.displayType === DisplayType.TABLE
+                                        state.displayType === DisplayType.TABLE &&
+                                        functionFields.length === 1
                                       ) {
                                         newFields = [
                                           {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -413,13 +413,7 @@ function Visualize({error, setError}: VisualizeProps) {
                     renderTag(option.value.kind, option.value.meta.name) ?? null,
                 }));
 
-                // TODO: These options should be exposing other Release health options such as
-                // environment, project, release, session.status
-                if (
-                  !isChartWidget &&
-                  !isBigNumberWidget &&
-                  !(state.dataset === WidgetType.RELEASE && !canDelete)
-                ) {
+                if (!isChartWidget && !isBigNumberWidget) {
                   const baseOptions = [NONE_AGGREGATE, ...aggregateOptions];
 
                   if (state.dataset === WidgetType.ISSUE) {
@@ -428,6 +422,22 @@ function Visualize({error, setError}: VisualizeProps) {
                   } else if (state.dataset === WidgetType.SPANS) {
                     // Add span column options for Spans dataset
                     aggregateOptions = [...baseOptions, ...spanColumnOptions];
+                  } else if (state.dataset === WidgetType.RELEASE) {
+                    aggregateOptions = [
+                      ...(canDelete ? baseOptions : aggregateOptions),
+                      ...Object.values(fieldOptions)
+                        // release dataset tables only use specific fields "SESSION_TAGS"
+                        .filter(option => SESSIONS_TAGS.includes(option.value.meta.name))
+                        .map(option => ({
+                          label: option.value.meta.name,
+                          value: option.value.meta.name,
+                          textValue: option.value.meta.name,
+                          trailingItems: renderTag(
+                            option.value.kind,
+                            option.value.meta.name
+                          ),
+                        })),
+                    ];
                   } else {
                     // Add column options to the aggregate dropdown for non-Issue and non-Spans datasets
                     aggregateOptions = [
@@ -448,27 +458,6 @@ function Visualize({error, setError}: VisualizeProps) {
                         })),
                     ];
                   }
-                }
-
-                if (
-                  state.dataset === WidgetType.RELEASE &&
-                  state.displayType === DisplayType.TABLE
-                ) {
-                  // add the additional session tags to the aggregate options
-                  aggregateOptions = [
-                    ...aggregateOptions,
-                    ...Object.values(fieldOptions)
-                      .filter(option => SESSIONS_TAGS.includes(option.value.meta.name))
-                      .map(option => ({
-                        label: option.value.meta.name,
-                        value: option.value.meta.name,
-                        textValue: option.value.meta.name,
-                        trailingItems: renderTag(
-                          option.value.kind,
-                          option.value.meta.name
-                        ),
-                      })),
-                  ];
                 }
 
                 let matchingAggregate: any;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -144,15 +144,17 @@ function getColumnOptions(
     if (parameter && parameter.kind === 'column' && parameter.columnTypes) {
       return formatColumnOptions(
         dataset,
-        fieldValues.filter(
-          ({value}) =>
-            (value.kind === FieldValueKind.FIELD ||
+        fieldValues.filter(({value}) =>
+          dataset === WidgetType.RELEASE
+            ? value.kind === FieldValueKind.METRICS &&
+              validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value)
+            : value.kind === FieldValueKind.FIELD ||
               value.kind === FieldValueKind.TAG ||
               value.kind === FieldValueKind.MEASUREMENT ||
               value.kind === FieldValueKind.CUSTOM_MEASUREMENT ||
               value.kind === FieldValueKind.METRICS ||
-              value.kind === FieldValueKind.BREAKDOWN) &&
-            validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value)
+              (value.kind === FieldValueKind.BREAKDOWN &&
+                validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, value))
         ),
         columnFilterMethod
       );

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -608,6 +608,87 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.thresholds).toBeUndefined();
     });
+
+    it('sets sort to first available sortable field when switching to release table', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.LINE,
+            dataset: WidgetType.RELEASE,
+            field: ['environment', 'crash_free_rate(session)'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.TABLE,
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([
+        {field: 'crash_free_rate(session)', kind: 'desc'},
+      ]);
+    });
+
+    it('sets sort to empty array when switching to release table and no sortable fields are available', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.LINE,
+            dataset: WidgetType.RELEASE,
+            field: ['project', 'count_errored(session)'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.TABLE,
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([]);
+    });
+
+    it('sets sort to default sort when switching to chart from non sortable release fields', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.RELEASE,
+            field: ['project', 'count_errored(session)'],
+            displayType: DisplayType.TABLE,
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.sort).toEqual([]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.LINE,
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([
+        {field: 'crash_free_rate(session)', kind: 'desc'},
+      ]);
+    });
   });
 
   describe('dataset', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -310,8 +310,11 @@ function useWidgetBuilderState(): {
               return;
             }
 
-            const firstActionPayloadNotEquation = action.payload.filter(
-              field => field.kind !== FieldValueKind.EQUATION
+            const firstActionPayloadNotEquation = action.payload.filter(field =>
+              dataset === WidgetType.RELEASE && displayType === DisplayType.TABLE
+                ? field.kind !== FieldValueKind.FIELD &&
+                  field.kind !== FieldValueKind.EQUATION
+                : field.kind !== FieldValueKind.EQUATION
             )[0];
 
             if (isRemoved) {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -346,7 +346,6 @@ function useWidgetBuilderState(): {
             const firstActionPayloadNotEquation: QueryFieldValue | undefined =
               action.payload.filter(field => field.kind !== FieldValueKind.EQUATION)[0];
 
-            // add something else here , figure out what the release sortable options are
             let validSortOptions: QueryFieldValue[] = firstActionPayloadNotEquation
               ? [firstActionPayloadNotEquation]
               : [];

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -310,11 +310,8 @@ function useWidgetBuilderState(): {
               return;
             }
 
-            const firstActionPayloadNotEquation = action.payload.filter(field =>
-              dataset === WidgetType.RELEASE && displayType === DisplayType.TABLE
-                ? field.kind !== FieldValueKind.FIELD &&
-                  field.kind !== FieldValueKind.EQUATION
-                : field.kind !== FieldValueKind.EQUATION
+            const firstActionPayloadNotEquation = action.payload.filter(
+              field => field.kind !== FieldValueKind.EQUATION
             )[0];
 
             if (isRemoved) {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -41,8 +41,11 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       ? state.fields?.map(generateFieldAsString)
       : [...(columns ?? []), ...(aggregates ?? [])];
 
-  // If there's no sort, use the first field as the default sort
-  const defaultSort = fields?.[0] ?? defaultQuery.orderby;
+  // If there's no sort, use the first field as the default sort (this doesn't apply to release table widgets)
+  const defaultSort =
+    state.displayType === DisplayType.TABLE && state.dataset === WidgetType.RELEASE
+      ? ''
+      : fields?.[0] ?? defaultQuery.orderby;
   const sort =
     defined(state.sort) && state.sort.length > 0
       ? _formatSort(state.sort[0]!)


### PR DESCRIPTION
The merged list didn't include the release specific fields that can be shown with no aggregate. For context in releases there are fields that can only be shown with aggregates and fields that can only be shown without. The ones that cannot be aggregated on are now in the merged list. When clicked they have the state of other fields. There are a couple things to note:

1. With releases these fields cannot be present without another aggregate field; when selecting a field from the merged list when there is only one aggregate, the selection results in an addition of a field above the aggregate
2. These standalone fields cannot be aggregated on (only the metrics fields can) so conditions were added in the `getColumnOptions` function to accommodate that
3. Only certain aggregates and fields are sortable (*sigh*) so we have to account for times that there is no sortable field present and place an empty orderBy (otherwise we will get errors)
4. Chart and table sort bys are different naturally but they have special behaviour when it comes to releases, so i've implemented checks to handle switching data types

There's a lot of intricacies with the releases dataset 😞  let me know if I missed anything of if you think it would be useful to have comments in parts of the code that I added in!