### PR TITLE
fix(react19): Remove key spreading `genericField`

### DIFF
--- a/static/app/components/deprecatedforms/genericField.tsx
+++ b/static/app/components/deprecatedforms/genericField.tsx
@@ -78,7 +78,6 @@ function GenericField({
     error: formErrors?.[config.name],
     defaultValue: config.default,
     disabled: config.readonly,
-    key: config.name,
     formState,
     help:
       defined(config.help) && config.help !== '' ? (
@@ -88,22 +87,22 @@ function GenericField({
 
   switch (config.type) {
     case 'secret':
-      return <PasswordField {...fieldProps} />;
+      return <PasswordField key={config.name} {...fieldProps} />;
     case 'bool':
-      return <BooleanField {...fieldProps} />;
+      return <BooleanField key={config.name} {...fieldProps} />;
     case 'email':
-      return <EmailField {...fieldProps} />;
+      return <EmailField key={config.name} {...fieldProps} />;
     case 'string':
     case 'text':
     case 'url':
       if (fieldProps.choices) {
-        return <SelectCreatableField {...fieldProps} />;
+        return <SelectCreatableField key={config.name} {...fieldProps} />;
       }
-      return <TextField {...fieldProps} />;
+      return <TextField key={config.name} {...fieldProps} />;
     case 'number':
-      return <NumberField {...fieldProps} />;
+      return <NumberField key={config.name} {...fieldProps} />;
     case 'textarea':
-      return <TextareaField {...fieldProps} />;
+      return <TextareaField key={config.name} {...fieldProps} />;
     case 'choice':
     case 'select': {
       // the chrome required tip winds up in weird places
@@ -116,9 +115,9 @@ function GenericField({
           ...config,
           ...selectProps,
         };
-        return <SelectAsyncField {...selectFieldProps} />;
+        return <SelectAsyncField key={config.name} {...selectFieldProps} />;
       }
-      return <SelectField {...selectProps} />;
+      return <SelectField key={config.name} {...selectProps} />;
     }
     default:
       return null;


### PR DESCRIPTION
Moves key from fieldProps to being directly declared on each component.

`Warning: A props object containing a "key" prop is being spread into JSX:`

part of https://github.com/getsentry/frontend-tsc/issues/68
