### PR TITLE
chore(relocations) Add killswitches for stuck relocations

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2491,6 +2491,13 @@ register(
     flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "relocation.outbox-orgslug.killswitch",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # max number of profiles to use for computing
 # the aggregated flamegraph.
 register(

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -8,10 +8,12 @@ and perform RPC calls to propagate changes to Control Silo.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from django.dispatch import receiver
 
+from sentry import options
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.auth.services.auth import auth_service
 from sentry.auth.services.orgauthtoken import orgauthtoken_rpc_service
@@ -29,6 +31,8 @@ from sentry.models.project import Project
 from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.relocation.services.relocation_export.service import control_relocation_export_service
 from sentry.types.region import get_local_region
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(process_region_outbox, sender=OutboxCategory.AUDIT_LOG_EVENT)
@@ -83,6 +87,18 @@ def process_disable_auth_provider(object_identifier: int, shard_identifier: int,
 def process_relocation_reply_with_export(payload: Any, **kwds):
     uuid = payload["relocation_uuid"]
     slug = payload["org_slug"]
+
+    killswitch_orgs = options.get("relocation.outbox-orgslug.killswitch")
+    if slug in killswitch_orgs:
+        logger.info(
+            "relocation.killswitch.org",
+            extra={
+                "org_slug": slug,
+                "relocation_uuid": uuid,
+            },
+        )
+        return
+
     relocation_storage = get_relocation_storage()
     path = f"runs/{uuid}/saas_to_saas_export/{slug}.tar"
     try:


### PR DESCRIPTION
We have a few more stuck relocations that hit outbox timeouts and are now wedged. The relocations have been advanced to 'failed', but the outboxes will not resolve natrually as the cross-region transfers take more time than we have in our statement timeouts.

Having a way to killswitch stuck outboxes will allow for simpler responses to these situations in the future.

Refs #84362
