### PR TITLE
feat(replays): Forward ref from CellMeasurer

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties, ReactNode} from 'react';
-import {isValidElement, memo, useCallback} from 'react';
+import {forwardRef, isValidElement, useCallback} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -57,18 +57,21 @@ interface Props {
   style?: CSSProperties;
 }
 
-function BreadcrumbItem({
-  className,
-  extraction,
-  frame,
-  expandPaths,
-  onClick,
-  onInspectorExpanded,
-  onMouseEnter,
-  onMouseLeave,
-  startTimestampMs,
-  style,
-}: Props) {
+const BreadcrumbItem = forwardRef<HTMLDivElement, Props>(function BreadcrumbItem(
+  {
+    className,
+    extraction,
+    frame,
+    expandPaths,
+    onClick,
+    onInspectorExpanded,
+    onMouseEnter,
+    onMouseLeave,
+    startTimestampMs,
+    style,
+  },
+  ref
+) {
   const {color, description, title, icon} = getFrameDetails(frame);
   const {replay} = useReplayContext();
 
@@ -142,6 +145,7 @@ function BreadcrumbItem({
 
   return (
     <StyledTimelineItem
+      ref={ref}
       icon={icon}
       title={title}
       colorConfig={{title: color, icon: color, iconBorder: color}}
@@ -172,7 +176,7 @@ function BreadcrumbItem({
       </ErrorBoundary>
     </StyledTimelineItem>
   );
-}
+});
 
 function WebVitalData({
   selectors,
@@ -416,4 +420,4 @@ const Wrapper = styled('div')`
   }
 `;
 
-export default memo(BreadcrumbItem);
+export default BreadcrumbItem;

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties} from 'react';
-import {useCallback} from 'react';
+import {forwardRef, useCallback} from 'react';
 import classNames from 'classnames';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
@@ -25,16 +25,19 @@ interface Props {
   expandPaths?: string[];
 }
 
-export default function BreadcrumbRow({
-  expandPaths,
-  extraction,
-  frame,
-  index,
-  onClick,
-  onInspectorExpanded,
-  startTimestampMs,
-  style,
-}: Props) {
+const BreadcrumbRow = forwardRef<HTMLDivElement, Props>(function BreadcrumbRow(
+  {
+    expandPaths,
+    extraction,
+    frame,
+    index,
+    onClick,
+    onInspectorExpanded,
+    startTimestampMs,
+    style,
+  },
+  ref
+) {
   const {currentTime} = useReplayContext();
   const [currentHoverTime] = useCurrentHoverTime();
 
@@ -51,6 +54,7 @@ export default function BreadcrumbRow({
 
   return (
     <BreadcrumbItem
+      ref={ref}
       className={classNames({
         beforeCurrentTime: hasOccurred,
         afterCurrentTime: !hasOccurred,
@@ -68,4 +72,6 @@ export default function BreadcrumbRow({
       onInspectorExpanded={handleObjectInspectorExpanded}
     />
   );
-}
+});
+
+export default BreadcrumbRow;

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties} from 'react';
-import {useCallback} from 'react';
+import {forwardRef, useCallback} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
@@ -28,19 +28,22 @@ interface Props extends ReturnType<typeof useCrumbHandlers> {
   expandPaths?: string[];
 }
 
-export default function ConsoleLogRow({
-  currentHoverTime,
-  currentTime,
-  expandPaths,
-  frame,
-  onMouseEnter,
-  onMouseLeave,
-  index,
-  onClickTimestamp,
-  onDimensionChange,
-  startTimestampMs,
-  style,
-}: Props) {
+const ConsoleLogRow = forwardRef<HTMLDivElement, Props>(function ConsoleLogRow(
+  {
+    currentHoverTime,
+    currentTime,
+    expandPaths,
+    frame,
+    onMouseEnter,
+    onMouseLeave,
+    index,
+    onClickTimestamp,
+    onDimensionChange,
+    startTimestampMs,
+    style,
+  },
+  ref
+) {
   const handleDimensionChange = useCallback(
     (path: any, expandedState: any) => onDimensionChange?.(index, path, expandedState),
     [onDimensionChange, index]
@@ -52,6 +55,7 @@ export default function ConsoleLogRow({
 
   return (
     <ConsoleLog
+      ref={ref}
       className={classNames({
         beforeCurrentTime: hasOccurred,
         afterCurrentTime: !hasOccurred,
@@ -84,7 +88,9 @@ export default function ConsoleLogRow({
       />
     </ConsoleLog>
   );
-}
+});
+
+export default ConsoleLogRow;
 
 const ConsoleLog = styled('div')<{
   hasOccurred: boolean;


### PR DESCRIPTION
in the next version of react-virtualized `CellMeasurer` passes a ref down to the first child. We should hand that ref down to the nearest dom element

part of https://github.com/getsentry/frontend-tsc/issues/68