### PR TITLE
feat(feedback): Forward ref from CellMeasurer

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -78,14 +78,8 @@ export default function FeedbackList() {
     }
 
     return (
-      <CellMeasurer
-        cache={cache}
-        columnIndex={0}
-        key={key}
-        parent={parent}
-        rowIndex={index}
-      >
-        <ErrorBoundary mini>
+      <ErrorBoundary mini key={key}>
+        <CellMeasurer cache={cache} columnIndex={0} parent={parent} rowIndex={index}>
           <FeedbackListItem
             feedbackItem={item}
             isSelected={checkboxState.isSelected(item.id)}
@@ -94,8 +88,8 @@ export default function FeedbackList() {
             }}
             style={style}
           />
-        </ErrorBoundary>
-      </CellMeasurer>
+        </CellMeasurer>
+      </ErrorBoundary>
     );
   };
 

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -1,4 +1,5 @@
 import type {CSSProperties} from 'react';
+import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
@@ -39,12 +40,10 @@ function useIsSelectedFeedback({feedbackItem}: {feedbackItem: FeedbackIssueListI
   return feedbackId === feedbackItem.id;
 }
 
-export default function FeedbackListItem({
-  feedbackItem,
-  isSelected,
-  onSelect,
-  style,
-}: Props) {
+const FeedbackListItem = forwardRef<HTMLDivElement, Props>(function FeedbackListItem(
+  {feedbackItem, isSelected, onSelect, style},
+  ref
+) {
   const organization = useOrganization();
   const isOpen = useIsSelectedFeedback({feedbackItem});
   const {feedbackHasReplay} = useReplayCountForFeedbacks();
@@ -57,7 +56,7 @@ export default function FeedbackListItem({
   const hasComments = feedbackItem.numComments > 0;
 
   return (
-    <CardSpacing style={style}>
+    <CardSpacing ref={ref} style={style}>
       <LinkedFeedbackCard
         data-selected={isOpen}
         to={{
@@ -169,7 +168,9 @@ export default function FeedbackListItem({
       </LinkedFeedbackCard>
     </CardSpacing>
   );
-}
+});
+
+export default FeedbackListItem;
 
 const LinkedFeedbackCard = styled(Link)`
   position: relative;


### PR DESCRIPTION
in the next version of react-virtualized `CellMeasurer` passes a ref down to the first child. We should hand that ref down to the nearest dom element

part of https://github.com/getsentry/frontend-tsc/issues/68
