### PR TITLE
feat(issues): Forward ref from debugMeta

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
@@ -1,3 +1,4 @@
+import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -19,7 +20,10 @@ type Props = {
   style?: React.CSSProperties;
 };
 
-function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
+const DebugImage = forwardRef<HTMLDivElement, Props>(function DebugImage(
+  {image, onOpenImageDetailsModal, style},
+  ref
+) {
   const {unwind_status, debug_status, debug_file, code_file, status} = image;
 
   const codeFilename = getFileName(code_file);
@@ -27,7 +31,7 @@ function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
   const imageAddress = getImageAddress(image);
 
   return (
-    <Wrapper style={style}>
+    <Wrapper ref={ref} style={style}>
       <StatusColumn>
         <Status status={status} />
       </StatusColumn>
@@ -58,7 +62,7 @@ function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
       </DebugFilesColumn>
     </Wrapper>
   );
-}
+});
 
 export default DebugImage;
 


### PR DESCRIPTION
We use a virtual list here for some reason. in the next version of react-virtualized `CellMeasurer` passes a ref down to the first child. We should hand that ref down to the nearest dom element

part of https://github.com/getsentry/frontend-tsc/issues/68
