### PR TITLE
ref(charts): allow line chart to show discontinuous line

### DIFF
--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -11,7 +11,8 @@ import type {Confidence} from 'sentry/types/organization';
 export type SeriesDataUnit = {
   // number because we sometimes use timestamps
   name: string | number;
-  value: number;
+  // '-' will be ignored by echarts and can be used to render discontinuous lines
+  value: number | '-';
   itemStyle?: {
     color?: string;
   };

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -104,7 +104,7 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
 
         return {
           name: sessionData.intervals[idx] ?? '',
-          value: intervalTotal > 0 ? healthyCount / intervalTotal : 1,
+          value: intervalTotal > 0 ? healthyCount / intervalTotal : ('-' as const),
         };
       });
 


### PR DESCRIPTION
followup to https://github.com/getsentry/sentry/pull/84928

echarts will ignore datapoint values of `"-"`, so this PR updates the `SeriesDataUnit` type to allow for this. 

context: previously, we were forcing health rate to be 100% if there was no session data, but this PR experiments with what a discontinuous line would look like instead.

it looks awful on sentry:

<img width="626" alt="SCR-20250211-nshr" src="https://github.com/user-attachments/assets/9a45c21f-a91c-4b94-a480-f45aa05479f3" />


but real world data looks fine since there's no need for discontinuous lines here:

<img width="1242" alt="SCR-20250211-nqjk" src="https://github.com/user-attachments/assets/7ab5b214-f2d2-42d0-acfa-3e2c382a0300" />
<img width="1241" alt="SCR-20250211-nqbb" src="https://github.com/user-attachments/assets/edf94c3a-804d-4a6f-a230-b38027c45ea2" />
