### PR TITLE
fix(nav): Better overflow behavior for secondary nav items

### DIFF
--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -30,6 +30,7 @@ interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
    */
   end?: boolean;
   isActive?: boolean;
+  trailingItems?: ReactNode;
 }
 
 export function SecondaryNav({children, group}: SecondaryNavProps) {
@@ -90,6 +91,7 @@ SecondaryNav.Item = function SecondaryNavItem({
   activeTo = to,
   isActive: incomingIsActive,
   end = false,
+  trailingItems,
   ...linkProps
 }: SecondaryNavItemProps) {
   const location = useLocation();
@@ -106,7 +108,8 @@ SecondaryNav.Item = function SecondaryNavItem({
       layout={layout}
     >
       <InteractionStateLayer hasSelectedBackground={isActive} />
-      {children}
+      <ItemText>{children}</ItemText>
+      {trailingItems}
     </Item>
   );
 };
@@ -167,7 +170,7 @@ const SectionSeparator = styled('hr')`
 const Item = styled(Link)<{layout: NavLayout}>`
   position: relative;
   display: flex;
-  padding: 5px ${space(1.5)};
+  padding: 4px ${space(1.5)};
   height: 34px;
   align-items: center;
   color: inherit;
@@ -201,6 +204,10 @@ const Item = styled(Link)<{layout: NavLayout}>`
       padding: 0 ${space(1.5)} 0 48px;
       border-radius: 0;
     `}
+`;
+
+const ItemText = styled('span')`
+  ${p => p.theme.overflowEllipsis}
 `;
 
 const Footer = styled('div')<{layout: NavLayout}>`

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -25,11 +25,8 @@ const LabelHook = HookOrDefault({
 });
 
 function SettingsNavBadge({badge}: {badge: string | number | null | ReactElement}) {
-  if (badge === 'new') {
-    return <FeatureBadge type="new" />;
-  }
-  if (badge === 'beta') {
-    return <FeatureBadge type="beta" />;
+  if (badge === 'new' || badge === 'beta' || badge === 'alpha') {
+    return <FeatureBadge type={badge} variant="short" />;
   }
   if (badge === 'warning') {
     return (
@@ -47,9 +44,13 @@ function SettingsNavBadge({badge}: {badge: string | number | null | ReactElement
 
 function SettingsNavItem({badge, label, id, to, index, ...props}: Props) {
   return (
-    <SecondaryNav.Item to={to} end={index} {...props}>
+    <SecondaryNav.Item
+      to={to}
+      end={index}
+      trailingItems={badge ? <SettingsNavBadge badge={badge} /> : null}
+      {...props}
+    >
       <LabelHook id={id}>{label}</LabelHook>
-      {badge ? <SettingsNavBadge badge={badge} /> : null}
     </SecondaryNav.Item>
   );
 }

--- a/static/app/views/settings/components/settingsNavItemDeprecated.tsx
+++ b/static/app/views/settings/components/settingsNavItemDeprecated.tsx
@@ -33,6 +33,8 @@ function SettingsNavItemDeprecated({badge, label, index, id, to, ...props}: Prop
     renderedBadge = <FeatureBadge type="new" />;
   } else if (badge === 'beta') {
     renderedBadge = <FeatureBadge type="beta" />;
+  } else if (badge === 'alpha') {
+    renderedBadge = <FeatureBadge type="alpha" />;
   } else if (badge === 'warning') {
     renderedBadge = (
       <Tooltip title={t('This setting needs review')} position="right">

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -114,7 +114,7 @@ const organizationNavigation: NavigationSection[] = [
         path: `${organizationSettingsPathPrefix}/dynamic-sampling/`,
         title: t('Dynamic Sampling'),
         description: t('Manage your sampling rate'),
-        badge: () => <FeatureBadge type="alpha" />,
+        badge: () => 'alpha',
         show: ({organization}) =>
           !!organization && hasDynamicSamplingCustomFeature(organization),
       },
@@ -122,7 +122,7 @@ const organizationNavigation: NavigationSection[] = [
         path: `${organizationSettingsPathPrefix}/feature-flags/`,
         title: t('Feature Flags'),
         description: t('Set up your provider webhooks'),
-        badge: () => <FeatureBadge type="beta" />,
+        badge: () => 'beta',
         show: ({organization}) =>
           !!organization && organization.features.includes('feature-flag-ui'),
       },


### PR DESCRIPTION
Fixes a couple styling issues with overflow. Previously the alpha/beta badges were too long, and overflowing didn't apply the ellipsis. 

![CleanShot 2025-02-11 at 15 45 07@2x](https://github.com/user-attachments/assets/6dcdb1ac-6986-44c8-a565-d5ee9d6db333)

![CleanShot 2025-02-11 at 15 45 13@2x](https://github.com/user-attachments/assets/c950e378-1609-4683-aac2-6d47a0b57417)
