### PR TITLE
fix(autofix): Check for empty steps

### DIFF
--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -134,7 +134,8 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
 
   const stepsRef = useRef<Array<HTMLDivElement | null>>([]);
   const containerRef = useRef<HTMLDivElement>(null);
-  if (!steps) {
+
+  if (!steps?.length) {
     return null;
   }
 


### PR DESCRIPTION
Fixes drawer crash that happens infrequently: https://sentry.sentry.io/issues/6207015174/