### PR TITLE
fix(autofix): Allow issues with threads but no exception

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -357,7 +357,12 @@ class GroupAutofixEndpoint(GroupEndpoint):
         if serialized_event is None:
             return self._respond_with_error("Cannot fix issues without an event.", 400)
 
-        if not any([entry.get("type") == "exception" for entry in serialized_event["entries"]]):
+        if not any(
+            [
+                entry.get("type") == "exception" or entry.get("type") == "threads"
+                for entry in serialized_event["entries"]
+            ]
+        ):
             return self._respond_with_error("Cannot fix issues without a stacktrace.", 400)
 
         repos = get_autofix_repos_from_project_code_mappings(group.project)


### PR DESCRIPTION
Certain issues without an exception, but with a stacktrace, were being rejected by the backend, causing runs to fail. The check was too harsh.

[Here](https://sentry.sentry.io/issues/6290382999/?project=6178942&query=is:unresolved%20assigned_or_suggested:%5Bme,my_teams%5D&statsPeriod=7d&stream_index=0) is an example of an error with a full stacktrace but no exception that Autofix should be able to handle.