### PR TITLE
:recycle: ref(noa): remove data blobs for ticketing actions

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -359,8 +359,12 @@ class TicketActionTranslator(BaseActionTranslator, ABC):
     @property
     def required_fields(self) -> list[str]:
         return [
-            ACTION_FIELD_MAPPINGS[Action.Type.JIRA][ActionFieldMappingKeys.INTEGRATION_ID_KEY.value]
+            ACTION_FIELD_MAPPINGS[self.action_type][ActionFieldMappingKeys.INTEGRATION_ID_KEY.value]
         ]
+
+    @staticmethod
+    def standard_fields() -> list[str]:
+        return [f.name for f in dataclasses.fields(TicketDataBlob) if f.name != "additional_fields"]
 
     @property
     def integration_id(self) -> Any | None:
@@ -370,16 +374,32 @@ class TicketActionTranslator(BaseActionTranslator, ABC):
     def target_type(self) -> ActionTarget:
         return ActionTarget.SPECIFIC
 
-
-class GitHubActionTranslatorBase(TicketActionTranslator):
-
     @property
     def blob_type(self) -> type[DataBlob]:
-        return GitHubDataBlob
+        return TicketDataBlob
+
+    def get_sanitized_data(self) -> dict[str, Any]:
+        """
+        Override to handle custom fields and additional fields that aren't part of the standard fields.
+        """
+        data = super().get_sanitized_data()
+        if self.blob_type:
+            # Get all fields that aren't part of the standard TicketDataBlob fields
+            additional_fields = {
+                k: v
+                for k, v in self.action.items()
+                if k not in self.standard_fields()
+                and k not in EXCLUDED_ACTION_DATA_KEYS
+                and k not in self.required_fields
+                and k != "dynamic_form_fields"
+                and v  # Only include non-empty values
+            }
+            data["additional_fields"] = additional_fields
+        return data
 
 
 @issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.GITHUB]["id"])
-class GitHubActionTranslator(GitHubActionTranslatorBase):
+class GithubActionTranslator(TicketActionTranslator):
     @property
     def action_type(self) -> Action.Type:
         return Action.Type.GITHUB
@@ -388,7 +408,7 @@ class GitHubActionTranslator(GitHubActionTranslatorBase):
 @issue_alert_action_translator_registry.register(
     ACTION_FIELD_MAPPINGS[Action.Type.GITHUB_ENTERPRISE]["id"]
 )
-class GitHubEnterpriseActionTranslator(GitHubActionTranslatorBase):
+class GithubEnterpriseActionTranslator(TicketActionTranslator):
     @property
     def action_type(self) -> Action.Type:
         return Action.Type.GITHUB_ENTERPRISE
@@ -397,14 +417,26 @@ class GitHubEnterpriseActionTranslator(GitHubActionTranslatorBase):
 @issue_alert_action_translator_registry.register(
     ACTION_FIELD_MAPPINGS[Action.Type.AZURE_DEVOPS]["id"]
 )
-class AzureDevOpsActionTranslator(TicketActionTranslator):
+class AzureDevopsActionTranslator(TicketActionTranslator):
     @property
     def action_type(self) -> Action.Type:
         return Action.Type.AZURE_DEVOPS
 
+
+@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.JIRA]["id"])
+class JiraActionTranslatorBase(TicketActionTranslator):
     @property
-    def blob_type(self) -> type[DataBlob]:
-        return AzureDevOpsDataBlob
+    def action_type(self) -> Action.Type:
+        return Action.Type.JIRA
+
+
+@issue_alert_action_translator_registry.register(
+    ACTION_FIELD_MAPPINGS[Action.Type.JIRA_SERVER]["id"]
+)
+class JiraServerActionTranslatorBase(TicketActionTranslator):
+    @property
+    def action_type(self) -> Action.Type:
+        return Action.Type.JIRA_SERVER
 
 
 @issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.EMAIL]["id"])
@@ -532,50 +564,6 @@ class WebhookActionTranslator(BaseActionTranslator):
         )
 
 
-class JiraActionTranslatorBase(TicketActionTranslator):
-    @property
-    def blob_type(self) -> type[DataBlob]:
-        return JiraDataBlob
-
-    def get_sanitized_data(self) -> dict[str, Any]:
-        """
-        Override to handle custom fields and additional fields that aren't part of the standard fields.
-        """
-        data = super().get_sanitized_data()
-        if self.blob_type:
-            # Get all fields that aren't part of the standard JiraDataBlob fields
-            standard_fields = {
-                f.name for f in dataclasses.fields(JiraDataBlob) if f.name != "additional_fields"
-            }
-            additional_fields = {
-                k: v
-                for k, v in self.action.items()
-                if k not in standard_fields
-                and k not in EXCLUDED_ACTION_DATA_KEYS
-                and k not in self.required_fields
-                and k != "dynamic_form_fields"
-                and v  # Only include non-empty values
-            }
-            data["additional_fields"] = additional_fields
-        return data
-
-    @staticmethod
-    def standard_fields() -> list[str]:
-        return [f.name for f in dataclasses.fields(JiraDataBlob) if f.name != "additional_fields"]
-
-
-@issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.JIRA]["id"])
-class JiraActionTranslator(JiraActionTranslatorBase):
-    action_type = Action.Type.JIRA
-
-
-@issue_alert_action_translator_registry.register(
-    ACTION_FIELD_MAPPINGS[Action.Type.JIRA_SERVER]["id"]
-)
-class JiraServerActionTranslator(JiraActionTranslatorBase):
-    action_type = Action.Type.JIRA_SERVER
-
-
 @issue_alert_action_translator_registry.register(
     ACTION_FIELD_MAPPINGS[Action.Type.SENTRY_APP]["id"]
 )
@@ -670,29 +658,10 @@ class TicketDataBlob(DataBlob):
     TicketDataBlob is a specific type that represents the data blob for a ticket creation action.
     """
 
-    # This is dynamic and can whatever customer config the customer setup on GitHub
+    # Dynamic form fields from customer configuration
     dynamic_form_fields: list[dict] = field(default_factory=list)
-
-
-@dataclass
-class GitHubDataBlob(TicketDataBlob):
-    """
-    GitHubDataBlob represents the data blob for a GitHub ticket creation action.
-    """
-
-    repo: str = ""
-    assignee: str = ""  # Optional field, defaults to empty string
-    labels: list[str] = field(default_factory=list)  # Optional field, defaults to empty list
-
-
-@dataclass
-class AzureDevOpsDataBlob(TicketDataBlob):
-    """
-    AzureDevOpsDataBlob represents the data blob for an Azure DevOps ticket creation action.
-    """
-
-    project: str = ""
-    work_item_type: str = ""
+    # Store any additional fields that aren't part of standard fields
+    additional_fields: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -734,19 +703,3 @@ class EmailDataBlob(DataBlob):
     """
 
     fallthroughType: str = ""
-
-
-@dataclass
-class JiraDataBlob(TicketDataBlob):
-    """
-    JiraDataBlob represents the data blob for a Jira ticket creation action.
-    Includes required fields and supports dynamic custom fields.
-    """
-
-    project: str = ""
-    issuetype: str = ""
-    priority: str = ""
-    labels: str = ""
-    reporter: str = ""
-    # Store any custom fields (customfield_*) or additional fields
-    additional_fields: dict[str, Any] = field(default_factory=dict)

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -20,18 +20,29 @@ EXCLUDED_ACTION_DATA_KEYS = ["uuid", "id"]
 
 @dataclass
 class FieldMapping:
-    """FieldMapping is a class that represents the mapping of a target field to a source field."""
+    """
+    FieldMapping is a class that represents the mapping of a target field to a source field.
+    """
 
     source_field: str
     default_value: Any = None
 
 
 class ActionFieldMappingKeys(StrEnum):
-    """ActionFieldMappingKeys is an enum that represents the keys of an action field mapping."""
+    """
+    ActionFieldMappingKeys is an enum that represents the keys of an action field mapping.
+    """
 
     INTEGRATION_ID_KEY = "integration_id_key"
     TARGET_IDENTIFIER_KEY = "target_identifier_key"
     TARGET_DISPLAY_KEY = "target_display_key"
+
+
+class TicketFieldMappingKeys(StrEnum):
+    """
+    TicketFieldMappingKeys is an enum that represents the keys of a ticket field mapping.
+    """
+
     DYNAMIC_FORM_FIELDS_KEY = "dynamic_form_fields"
     ADDITIONAL_FIELDS_KEY = "additional_fields"
 
@@ -367,7 +378,7 @@ class TicketingActionDataBlobHelper(ABC):
         Returns tuple of (dynamic_form_fields, additional_fields)
         """
         excluded_keys = excluded_keys or []
-        dynamic_form_fields = data.get(ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {})
+        dynamic_form_fields = data.get(TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {})
 
         additional_fields = {
             k: v
@@ -375,7 +386,7 @@ class TicketingActionDataBlobHelper(ABC):
             if k not in dynamic_form_fields
             and k not in EXCLUDED_ACTION_DATA_KEYS
             and k not in excluded_keys
-            and k != ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value
+            and k != TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value
         }
         return dynamic_form_fields, additional_fields
 
@@ -409,7 +420,7 @@ class TicketActionTranslator(BaseActionTranslator, TicketingActionDataBlobHelper
             _, additional_fields = self.separate_fields(
                 self.action, excluded_keys=self.required_fields
             )
-            data[ActionFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value] = additional_fields
+            data[TicketFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value] = additional_fields
         return data
 
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -12,7 +12,7 @@ from sentry.workflow_engine.migration_helpers.rule_action import (
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
-    TicketActionTranslator,
+    ActionFieldMappingKeys,
     TicketDataBlob,
     issue_alert_action_translator_registry,
 )
@@ -26,19 +26,18 @@ class TestNotificationActionMigrationUtils(TestCase):
     def assert_ticketing_action_data_blob(
         self, action: Action, compare_dict: dict, exclude_keys: list[str]
     ):
-        # Get standard fields from JiraDataBlob, excluding additional_fields
-        standard_fields = TicketActionTranslator.standard_fields()
 
-        # Check standard fields
-        for field in standard_fields:
-            assert action.data.get(field, "") == compare_dict.get(field, "")
+        # Check dynamic_form_fields
+        assert action.data.get(
+            ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {}
+        ) == compare_dict.get(ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {})
 
         # Check that additional_fields contains all other non-excluded fields
-        additional_fields = action.data.get("additional_fields", {})
+        additional_fields = action.data.get(ActionFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value, {})
         for key, value in compare_dict.items():
             if (
                 key not in exclude_keys
-                and key not in standard_fields
+                and key not in ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value
                 and key != "id"
                 and value  # Only check non-empty values
             ):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -12,8 +12,8 @@ from sentry.workflow_engine.migration_helpers.rule_action import (
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
-    ActionFieldMappingKeys,
     TicketDataBlob,
+    TicketFieldMappingKeys,
     issue_alert_action_translator_registry,
 )
 
@@ -29,17 +29,16 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         # Check dynamic_form_fields
         assert action.data.get(
-            ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {}
-        ) == compare_dict.get(ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {})
+            TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {}
+        ) == compare_dict.get(TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value, {})
 
         # Check that additional_fields contains all other non-excluded fields
-        additional_fields = action.data.get(ActionFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value, {})
+        additional_fields = action.data.get(TicketFieldMappingKeys.ADDITIONAL_FIELDS_KEY.value, {})
         for key, value in compare_dict.items():
             if (
                 key not in exclude_keys
-                and key not in ActionFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value
+                and key not in TicketFieldMappingKeys.DYNAMIC_FORM_FIELDS_KEY.value
                 and key != "id"
-                and value  # Only check non-empty values
             ):
                 assert additional_fields.get(key) == value
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -12,8 +12,8 @@ from sentry.workflow_engine.migration_helpers.rule_action import (
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
-    JiraActionTranslator,
-    JiraDataBlob,
+    TicketActionTranslator,
+    TicketDataBlob,
     issue_alert_action_translator_registry,
 )
 
@@ -23,11 +23,11 @@ class TestNotificationActionMigrationUtils(TestCase):
         self.group = self.create_group(project=self.project)
         self.group_event = GroupEvent.from_event(self.event, self.group)
 
-    def assert_jira_action_data_blob(
+    def assert_ticketing_action_data_blob(
         self, action: Action, compare_dict: dict, exclude_keys: list[str]
     ):
         # Get standard fields from JiraDataBlob, excluding additional_fields
-        standard_fields = JiraActionTranslator.standard_fields()
+        standard_fields = TicketActionTranslator.standard_fields()
 
         # Check standard fields
         for field in standard_fields:
@@ -73,9 +73,9 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         # If we have a blob type, verify the data matches the blob structure
         if translator.blob_type:
-            # Special handling for JiraDataBlob which has additional_fields
-            if translator.blob_type == JiraDataBlob:
-                self.assert_jira_action_data_blob(action, compare_dict, exclude_keys)
+            # Special handling for TicketDataBlob which has additional_fields
+            if translator.blob_type == TicketDataBlob:
+                self.assert_ticketing_action_data_blob(action, compare_dict, exclude_keys)
             else:
                 # Original logic for other blob types
                 for field in translator.blob_type.__dataclass_fields__:


### PR DESCRIPTION
this is a meta pr that remove the custom data blobs for ticketing actions.

couple reasons for this:
1. they were pretty much slop. most fields are suppose to be NonRequired, meaning they don't have to exist. 
2. because we are using dataclasses, it was a bit tedious to check to make sure we didn't add extra keys when generating a dictionary from the dataclass


overall, i think this solution of keeping `additional_fields` dictionary is more scalable and better encapsulates this translation process.