### PR TITLE
ref(quick-start): Make quick start panel have the same name as in the sidebar

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -66,7 +66,7 @@ export default function getGuidesContent(
           ),
         },
         {
-          title: t('Quick Setup'),
+          title: t('Onboarding'),
           target: 'onboarding_sidebar',
           description: t(
             'Walk through this guide to get the most out of Sentry right away.'

--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -16,7 +16,9 @@ import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import type {useOnboardingTasks} from 'sentry/components/onboardingWizard/useOnboardingTasks';
 import {findCompleteTasks, taskIsDone} from 'sentry/components/onboardingWizard/utils';
 import ProgressRing from 'sentry/components/progressRing';
-import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
+import SidebarPanel, {
+  type SidebarPanelProps,
+} from 'sentry/components/sidebar/sidebarPanel';
 import type {CommonSidebarProps} from 'sentry/components/sidebar/types';
 import {Tooltip} from 'sentry/components/tooltip';
 import {
@@ -577,7 +579,8 @@ function TaskGroup({
 }
 
 interface SidebarProps
-  extends Pick<CommonSidebarProps, 'orientation' | 'collapsed'>,
+  extends Pick<SidebarPanelProps, 'title'>,
+    Pick<CommonSidebarProps, 'orientation' | 'collapsed'>,
     Pick<
       ReturnType<typeof useOnboardingTasks>,
       'gettingStartedTasks' | 'beyondBasicsTasks'
@@ -591,9 +594,8 @@ export function OnboardingSidebar({
   collapsed,
   gettingStartedTasks,
   beyondBasicsTasks,
+  title,
 }: SidebarProps) {
-  const walkthrough = isDemoModeEnabled();
-
   const sortedGettingStartedTasks = gettingStartedTasks.sort(
     (a, b) =>
       orderedGettingStartedTasks.indexOf(a.task) -
@@ -616,7 +618,7 @@ export function OnboardingSidebar({
       collapsed={collapsed}
       hidePanel={onClose}
       orientation={orientation}
-      title={walkthrough ? t('Guided Tour') : t('Quick Setup')}
+      title={title}
     >
       <Content>
         <TaskGroup

--- a/static/app/components/sidebar/onboardingStatus.spec.tsx
+++ b/static/app/components/sidebar/onboardingStatus.spec.tsx
@@ -102,7 +102,7 @@ describe('Onboarding Status', function () {
     expect(screen.queryByTestId('pending-seen-indicator')).not.toBeInTheDocument();
 
     // Shows the panel
-    expect(screen.getByText('Quick Setup')).toBeInTheDocument();
+    expect(screen.getAllByText('Onboarding')).toHaveLength(2);
 
     // Triggers a fetch request
     expect(getOnboardingTasksMock).toHaveBeenCalled();

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -165,6 +165,7 @@ export function OnboardingStatus({
           onClose={hidePanel}
           gettingStartedTasks={gettingStartedTasks}
           beyondBasicsTasks={beyondBasicsTasks}
+          title={label}
         />
       )}
     </GuideAnchor>

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -45,7 +45,7 @@ const PanelContainer = styled('div')<PositionProps>`
         `};
 `;
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+export interface SidebarPanelProps extends React.HTMLAttributes<HTMLDivElement> {
   collapsed: CommonSidebarProps['collapsed'];
   hidePanel: CommonSidebarProps['hidePanel'];
   orientation: CommonSidebarProps['orientation'];
@@ -71,7 +71,7 @@ export default function SidebarPanel({
   title,
   children,
   ...props
-}: Props): React.ReactElement {
+}: SidebarPanelProps): React.ReactElement {
   const portalEl = useRef<HTMLDivElement>(getSidebarPortal());
 
   const panelCloseHandler = useCallback(


### PR DESCRIPTION


Preview 

![Screenshot 2025-02-12 at 08 06 02](https://github.com/user-attachments/assets/0dc1d6b8-da8c-41a3-9cca-4c1b4b7b523b)
