### PR TITLE
feat(tempest): Add UI for tempest dumps project option

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -89,6 +89,7 @@ export type Project = {
   stats?: TimeseriesValue[];
   subjectPrefix?: string;
   symbolSources?: string;
+  tempestFetchDumps?: boolean;
   tempestFetchScreenshots?: boolean;
   transactionStats?: TimeseriesValue[];
 } & AvatarProject;

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -99,6 +99,7 @@ export default function TempestSettings({organization, project}: Props) {
         apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
         initialData={{
           tempestFetchScreenshots: project?.tempestFetchScreenshots,
+          tempestFetchDumps: project?.tempestFetchDumps,
         }}
         saveOnBlur
         hideFooter
@@ -114,25 +115,6 @@ export default function TempestSettings({organization, project}: Props) {
                   label: t('Attach Screenshots'),
                   help: t('Attach screenshots to issues.'),
                 },
-              ],
-            },
-          ]}
-        />
-      </Form>
-      <Form
-        apiMethod="PUT"
-        apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
-        initialData={{
-          tempestFetchDumps: project?.tempestFetchDumps,
-        }}
-        saveOnBlur
-        hideFooter
-      >
-        <JsonForm
-          forms={[
-            {
-              title: t('General Settings'),
-              fields: [
                 {
                   name: 'tempestFetchDumps',
                   type: 'boolean',

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -119,6 +119,31 @@ export default function TempestSettings({organization, project}: Props) {
           ]}
         />
       </Form>
+      <Form
+        apiMethod="PUT"
+        apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
+        initialData={{
+          tempestFetchDumps: project?.tempestFetchDumps,
+        }}
+        saveOnBlur
+        hideFooter
+      >
+        <JsonForm
+          forms={[
+            {
+              title: t('General Settings'),
+              fields: [
+                {
+                  name: 'tempestFetchDumps',
+                  type: 'boolean',
+                  label: t('Attach Dumps'),
+                  help: t('Attach dumps to issues.'),
+                },
+              ],
+            },
+          ]}
+        />
+      </Form>
 
       <PanelTable
         headers={[


### PR DESCRIPTION
UI form for managing setting if Tempest should attach dumps

![Screenshot 2025-02-12 at 1 01 23 PM](https://github.com/user-attachments/assets/9c3aa0ba-d958-4bca-b2b1-72934c1a9810)

Note this code mirrors the previously added project option for fetching screenshots added here (https://github.com/getsentry/sentry/pull/82520)

API part:#85048
Part of https://github.com/getsentry/tempest/issues/81