### PR TITLE
feat(dashboards): Allow null values in time series visualizations

### DIFF
--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -10,6 +10,7 @@ export const X_GUTTER = space(2);
 export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a missing field. In this case we need a fallback to provide to the field rendering pipeline. `'unknown'` will results in rendering as a string
 
 export const MISSING_DATA_MESSAGE = t('No Data');
+export const NO_PLOTTABLE_VALUES = t('The data does not contain any plottable values.');
 export const NON_FINITE_NUMBER_MESSAGE = t('Value is not a finite number.');
 export const WIDGET_RENDER_ERROR_MESSAGE = t(
   'Sorry, something went wrong when rendering this widget.'

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -12,7 +12,7 @@ export type TableData = TableRow[];
 
 export type TimeSeriesItem = {
   timestamp: string;
-  value: number;
+  value: number | null;
   delayed?: boolean;
 };
 

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.spec.tsx
@@ -1,5 +1,7 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import type {TimeSeriesItem} from '../common/types';
+
 import {sampleDurationTimeSeries} from './fixtures/sampleDurationTimeSeries';
 import {LineChartWidget} from './lineChartWidget';
 
@@ -21,6 +23,53 @@ describe('LineChartWidget', () => {
       render(<LineChartWidget />);
 
       expect(screen.getByText('No Data')).toBeInTheDocument();
+    });
+
+    const UNPLOTTABLE_CASES = [
+      [[]],
+      [
+        [
+          {
+            timestamp: '2025-01-01T00:00:00',
+            value: null,
+          },
+        ],
+      ],
+      [
+        [
+          {
+            timestamp: '2025-01-01T00:00:00',
+            value: null,
+          },
+          {
+            timestamp: '2025-01-01T00:01:00',
+            value: null,
+          },
+        ],
+      ],
+    ] satisfies Array<[TimeSeriesItem[]]>;
+
+    it.each(UNPLOTTABLE_CASES)('Explains no plottable values for %s', data => {
+      render(
+        <LineChartWidget
+          timeSeries={[
+            {
+              field: 'count()',
+              data,
+              meta: {
+                fields: {
+                  'count()': 'number',
+                },
+                units: {},
+              },
+            },
+          ]}
+        />
+      );
+
+      expect(
+        screen.getByText(/does not contain any plottable values/)
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -188,7 +188,7 @@ export default storyBook('LineChartWidget', story => {
                 ...durationTimeSeries2,
                 data: durationTimeSeries2.data.map(datum => ({
                   ...datum,
-                  value: datum.value / 1000,
+                  value: datum.value === null ? null : datum.value / 1000,
                 })),
                 meta: {
                   fields: durationTimeSeries2.meta?.fields!,

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -37,6 +37,22 @@ const sampleDurationTimeSeries2 = {
   },
 };
 
+const sectionSize = sampleThroughputTimeSeries.data.length / 10;
+const sectionStart = sectionSize * 2;
+const sectionEnd = sectionSize * 3;
+const sparseThroughputTimeSeries = {
+  ...sampleThroughputTimeSeries,
+  data: sampleThroughputTimeSeries.data.map((datum, index) => {
+    if (index > sectionStart && index < sectionEnd) {
+      return {
+        ...datum,
+        value: null,
+      };
+    }
+    return datum;
+  }),
+};
+
 export default storyBook('LineChartWidget', story => {
   story('Getting Started', () => {
     return (
@@ -65,7 +81,7 @@ export default storyBook('LineChartWidget', story => {
     };
 
     const throughputTimeSeries = toTimeSeriesSelection(
-      sampleThroughputTimeSeries,
+      sparseThroughputTimeSeries,
       start,
       end
     );
@@ -87,13 +103,14 @@ export default storyBook('LineChartWidget', story => {
         <p>
           The visualization of <JSXNode name="LineChartWidget" /> a line chart. It has
           some bells and whistles including automatic axes labels, and a hover tooltip.
-          Like other widgets, it automatically fills the parent element.
+          Like other widgets, it automatically fills the parent element. <code>null</code>{' '}
+          values are supported!
         </p>
         <SmallSizingWindow>
           <LineChartWidget
             title="eps()"
             description="Number of events per second"
-            timeSeries={[throughputTimeSeries]}
+            timeSeries={[toTimeSeriesSelection(throughputTimeSeries, start, end)]}
           />
         </SmallSizingWindow>
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/scaleTimeSeriesData.tsx
@@ -81,7 +81,7 @@ export function scaleTimeSeriesData(
       const {value} = datum;
       return {
         ...datum,
-        value: scaler(value),
+        value: value === null ? null : scaler(value),
       };
     }),
     meta: {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/barChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/barChartWidgetSeries.tsx
@@ -3,6 +3,7 @@ import Color from 'color';
 import BarSeries from 'sentry/components/charts/series/barSeries';
 
 import type {TimeSeries} from '../../common/types';
+import {timeSeriesItemToEChartsDataPoint} from '../timeSeriesItemToEChartsDataPoint';
 
 export function BarChartWidgetSeries(timeSeries: TimeSeries, stack?: string) {
   return BarSeries({
@@ -18,8 +19,6 @@ export function BarChartWidgetSeries(timeSeries: TimeSeries, stack?: string) {
       },
       opacity: 1.0,
     },
-    data: timeSeries.data.map(datum => {
-      return [datum.timestamp, datum.value];
-    }),
+    data: timeSeries.data.map(timeSeriesItemToEChartsDataPoint),
   });
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/completeAreaChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/completeAreaChartWidgetSeries.tsx
@@ -1,6 +1,7 @@
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 
 import type {TimeSeries} from '../../common/types';
+import {timeSeriesItemToEChartsDataPoint} from '../timeSeriesItemToEChartsDataPoint';
 
 export function CompleteAreaChartWidgetSeries(timeSeries: TimeSeries) {
   return LineSeries({
@@ -12,8 +13,6 @@ export function CompleteAreaChartWidgetSeries(timeSeries: TimeSeries) {
       color: timeSeries.color,
       opacity: 1.0,
     },
-    data: timeSeries.data.map(datum => {
-      return [datum.timestamp, datum.value];
-    }),
+    data: timeSeries.data.map(timeSeriesItemToEChartsDataPoint),
   });
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/completeLineChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/completeLineChartWidgetSeries.tsx
@@ -1,14 +1,13 @@
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 
 import type {TimeSeries} from '../../common/types';
+import {timeSeriesItemToEChartsDataPoint} from '../timeSeriesItemToEChartsDataPoint';
 
 export function CompleteLineChartWidgetSeries(timeSeries: TimeSeries) {
   return LineSeries({
     name: timeSeries.field,
     color: timeSeries.color,
     animation: false,
-    data: timeSeries.data.map(datum => {
-      return [datum.timestamp, datum.value];
-    }),
+    data: timeSeries.data.map(timeSeriesItemToEChartsDataPoint),
   });
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/incompleteAreaChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/incompleteAreaChartWidgetSeries.tsx
@@ -1,6 +1,7 @@
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 
 import type {TimeSeries} from '../../common/types';
+import {timeSeriesItemToEChartsDataPoint} from '../timeSeriesItemToEChartsDataPoint';
 
 export function IncompleteAreaChartWidgetSeries(timeSeries: TimeSeries) {
   return LineSeries({
@@ -8,9 +9,7 @@ export function IncompleteAreaChartWidgetSeries(timeSeries: TimeSeries) {
     color: timeSeries.color,
     stack: 'incomplete',
     animation: false,
-    data: timeSeries.data.map(datum => {
-      return [datum.timestamp, datum.value];
-    }),
+    data: timeSeries.data.map(timeSeriesItemToEChartsDataPoint),
     lineStyle: {
       type: 'dotted',
     },

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/incompleteLineChartWidgetSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/seriesConstructors/incompleteLineChartWidgetSeries.tsx
@@ -1,15 +1,14 @@
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 
 import type {TimeSeries} from '../../common/types';
+import {timeSeriesItemToEChartsDataPoint} from '../timeSeriesItemToEChartsDataPoint';
 
 export function IncompleteLineChartWidgetSeries(timeSeries: TimeSeries) {
   return LineSeries({
     name: timeSeries.field,
     color: timeSeries.color,
     animation: false,
-    data: timeSeries.data.map(datum => {
-      return [datum.timestamp, datum.value];
-    }),
+    data: timeSeries.data.map(timeSeriesItemToEChartsDataPoint),
     lineStyle: {
       type: 'dotted',
     },

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesItemToEChartsDataPoint.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesItemToEChartsDataPoint.tsx
@@ -1,0 +1,14 @@
+import type {TimeSeriesItem} from '../common/types';
+
+export function timeSeriesItemToEChartsDataPoint(
+  datum: TimeSeriesItem
+): [xAxisValue: number | string, yAxisValue: number | '-'] {
+  return [
+    datum.timestamp,
+    datum.value === null ? ECHARTS_MISSING_DATA_VALUE : datum.value,
+  ];
+}
+
+// ECharts has a special value to represent missing data, it doesn't nicely
+// support `null` or `undefined`
+const ECHARTS_MISSING_DATA_VALUE = `-`;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -41,6 +41,10 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
     parsingError = MISSING_DATA_MESSAGE;
   }
 
+  // TODO: It would be polite to also scan for gaps (i.e., the items don't all
+  // have the same difference in `timestamp`s) even though this is rare, since
+  // the backend zerofills the
+
   const error = props.error ?? parsingError;
 
   return (

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -8,7 +8,7 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {MISSING_DATA_MESSAGE} from '../common/settings';
+import {MISSING_DATA_MESSAGE, NO_PLOTTABLE_VALUES} from '../common/settings';
 import type {StateProps} from '../common/types';
 import {LoadingPanel} from '../widgetLayout/loadingPanel';
 
@@ -39,6 +39,10 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
 
   if (!defined(timeseries)) {
     parsingError = MISSING_DATA_MESSAGE;
+  } else if (
+    timeseries.flatMap(timeSeries => timeSeries.data).every(item => item.value === null)
+  ) {
+    parsingError = NO_PLOTTABLE_VALUES;
   }
 
   // TODO: It would be polite to also scan for gaps (i.e., the items don't all


### PR DESCRIPTION
Makes it possible to pass null values to signify that there is missing data, as opposed to just passing a 0, which makes it seem like there's a real value of 0.

**e.g.,**
<img width="437" alt="Screenshot 2025-02-12 at 9 21 36 AM" src="https://github.com/user-attachments/assets/0cc0d8a2-1df1-45bb-bda1-5258705d3467" />
