### PR TITLE
feat(vercel): SSO for Vercel native integration

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -35,6 +35,7 @@ from sentry.auth.idpmigration import (
 from sentry.auth.partnership_configs import ChannelName
 from sentry.auth.provider import MigratingIdentityId, Provider
 from sentry.auth.providers.fly.provider import FlyOAuth2Provider
+from sentry.auth.providers.vercel.provider import VercelOAuth2Provider
 from sentry.auth.superuser import is_active_superuser
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.locks import locks
@@ -989,4 +990,7 @@ class AuthHelper(Pipeline):
         )
 
 
-CHANNEL_PROVIDER_MAP = {ChannelName.FLY_IO.value: FlyOAuth2Provider}
+CHANNEL_PROVIDER_MAP = {
+    ChannelName.FLY_IO.value: FlyOAuth2Provider,
+    ChannelName.VERCEL.value: VercelOAuth2Provider,
+}

--- a/src/sentry/auth/partnership_configs.py
+++ b/src/sentry/auth/partnership_configs.py
@@ -4,6 +4,11 @@ from enum import Enum
 class ChannelName(Enum):
     FLY_IO = "fly"
     FLY_NON_PARTNER = "fly-non-partner"
+    VERCEL = "vercel"
 
 
-SPONSOR_OAUTH_NAME = {ChannelName.FLY_IO: "Fly.io", ChannelName.FLY_NON_PARTNER: "Fly.io"}
+SPONSOR_OAUTH_NAME = {
+    ChannelName.FLY_IO: "Fly.io",
+    ChannelName.FLY_NON_PARTNER: "Fly.io",
+    ChannelName.VERCEL: "Vercel",
+}

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -214,7 +214,3 @@ class OAuth2Provider(Provider, abc.ABC):
 
         auth_identity.data.update(self.get_oauth_data(payload))
         auth_identity.update(data=auth_identity.data)
-
-    @classmethod
-    def build_config(cls, resource: dict) -> dict:
-        raise NotImplementedError

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -214,3 +214,7 @@ class OAuth2Provider(Provider, abc.ABC):
 
         auth_identity.data.update(self.get_oauth_data(payload))
         auth_identity.update(data=auth_identity.data)
+
+    @classmethod
+    def build_config(cls, resource: dict) -> dict:
+        raise NotImplementedError

--- a/src/sentry/auth/providers/vercel/apps.py
+++ b/src/sentry/auth/providers/vercel/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry.auth.providers.vercel"
+
+    def ready(self):
+        from sentry import auth
+
+        from .provider import VercelOAuth2Provider
+
+        auth.register("vercel", VercelOAuth2Provider)

--- a/src/sentry/auth/providers/vercel/constants.py
+++ b/src/sentry/auth/providers/vercel/constants.py
@@ -1,0 +1,3 @@
+AUTHORIZE_URL = "https://api.vercel.com/oauth/authorize"
+
+ACCESS_TOKEN_URL = "https://api.vercel.com/v1/integrations/sso/token"

--- a/src/sentry/auth/providers/vercel/provider.py
+++ b/src/sentry/auth/providers/vercel/provider.py
@@ -39,7 +39,6 @@ class VercelOAuth2Provider(OAuth2Provider):
     ) -> Callable[[HttpRequest, RpcOrganization, RpcAuthProvider], DeferredResponse | str]:
         return vercel_configure_view
 
-    @classmethod
     def build_config(cls, resource):
         """
         On configuration, we determine which provider organization to configure sentry SSO for.

--- a/src/sentry/auth/providers/vercel/provider.py
+++ b/src/sentry/auth/providers/vercel/provider.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 
 import jwt
 from django.http.request import HttpRequest
@@ -9,7 +9,6 @@ from sentry import options
 from sentry.auth.partnership_configs import SPONSOR_OAUTH_NAME, ChannelName
 from sentry.auth.providers.oauth2 import OAuth2Provider
 from sentry.auth.services.auth.model import RpcAuthProvider
-from sentry.auth.view import AuthView
 from sentry.identity.oauth2 import OAuth2CallbackView
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.base.response import DeferredResponse
@@ -49,7 +48,7 @@ class VercelOAuth2Provider(OAuth2Provider):
         """
         return {"org": {"id": resource.get("id")}}
 
-    def get_pipeline_views(self) -> Sequence[AuthView]:
+    def get_pipeline_views(self):
         return [
             OAuth2CallbackView(
                 access_token_url=self.access_token_url,
@@ -67,7 +66,7 @@ class VercelOAuth2Provider(OAuth2Provider):
         """
 
         data = state["data"]
-        decoded_id_token = jwt.decode(data["id_token"], verify=False)
+        decoded_id_token = jwt.decode(data["id_token"], options={"verify_signature": False})
         return {
             "type": "vercel",
             "id": decoded_id_token["user_id"],

--- a/src/sentry/auth/providers/vercel/provider.py
+++ b/src/sentry/auth/providers/vercel/provider.py
@@ -40,7 +40,7 @@ class VercelOAuth2Provider(OAuth2Provider):
         return vercel_configure_view
 
     @classmethod
-    def build_config(self, resource):
+    def build_config(cls, resource):
         """
         On configuration, we determine which provider organization to configure sentry SSO for.
         This configuration is then stored and passed into the pipeline instances during SSO

--- a/src/sentry/auth/providers/vercel/provider.py
+++ b/src/sentry/auth/providers/vercel/provider.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import jwt
+from django.http.request import HttpRequest
+
+from sentry import options
+from sentry.auth.partnership_configs import SPONSOR_OAUTH_NAME, ChannelName
+from sentry.auth.providers.oauth2 import OAuth2Provider
+from sentry.auth.services.auth.model import RpcAuthProvider
+from sentry.auth.view import AuthView
+from sentry.identity.oauth2 import OAuth2CallbackView
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.plugins.base.response import DeferredResponse
+
+from .constants import ACCESS_TOKEN_URL, AUTHORIZE_URL
+from .views import vercel_configure_view
+
+
+class VercelOAuth2Provider(OAuth2Provider):
+    """
+    OAuth2 provider for Vercel Native integration, not
+    to be confused with standard, already existing Vercel OAuth2 provider.
+    """
+
+    is_partner = True
+    name = SPONSOR_OAUTH_NAME[ChannelName.VERCEL]
+    access_token_url = ACCESS_TOKEN_URL
+    authorize_url = AUTHORIZE_URL
+
+    def get_client_id(self):
+        return options.get("vercel.client-id")
+
+    def get_client_secret(self):
+        return options.get("vercel.client-secret")
+
+    def get_configure_view(
+        self,
+    ) -> Callable[[HttpRequest, RpcOrganization, RpcAuthProvider], DeferredResponse | str]:
+        return vercel_configure_view
+
+    @classmethod
+    def build_config(self, resource):
+        """
+        On configuration, we determine which provider organization to configure sentry SSO for.
+        This configuration is then stored and passed into the pipeline instances during SSO
+        to determine whether the Auth'd user has the appropriate access to the provider org
+        """
+        return {"org": {"id": resource.get("id")}}
+
+    def get_pipeline_views(self) -> Sequence[AuthView]:
+        return [
+            OAuth2CallbackView(
+                access_token_url=self.access_token_url,
+                client_id=self.get_client_id(),
+                client_secret=self.get_client_secret(),
+            ),
+        ]
+
+    def get_refresh_token_url(self):
+        return ACCESS_TOKEN_URL
+
+    def build_identity(self, state):
+        """
+        As a part of response we get an id_token from Vercel which has the needed claims.
+        """
+
+        data = state["data"]
+        decoded_id_token = jwt.decode(data["id_token"], verify=False)
+        return {
+            "type": "vercel",
+            "id": decoded_id_token["user_id"],
+            "email": decoded_id_token["user_email"],
+            "name": decoded_id_token["user_name"],
+            "data": self.get_oauth_data(data),
+            "email_verified": True,
+        }

--- a/src/sentry/auth/providers/vercel/templates/sentry_auth_vercel/configure.html
+++ b/src/sentry/auth/providers/vercel/templates/sentry_auth_vercel/configure.html
@@ -1,0 +1,3 @@
+<h3>Domain</h3>
+
+<p>Users will be allowed to authenticate if they have an account under the Vercel domain <strong>{{ domains|join:" or " }}</strong>.</p>

--- a/src/sentry/auth/providers/vercel/views.py
+++ b/src/sentry/auth/providers/vercel/views.py
@@ -1,0 +1,11 @@
+from django.http import HttpRequest
+
+from sentry.auth.services.auth.model import RpcAuthProvider
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.plugins.base.response import DeferredResponse
+
+
+def vercel_configure_view(
+    request: HttpRequest, org: RpcOrganization, auth_provider: RpcAuthProvider
+) -> DeferredResponse:
+    return DeferredResponse("sentry_auth_vercel/configure.html")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -424,6 +424,7 @@ INSTALLED_APPS: tuple[str, ...] = (
     "sentry.eventstream",
     "sentry.auth.providers.google.apps.Config",
     "sentry.auth.providers.fly.apps.Config",
+    "sentry.auth.providers.vercel.apps.Config",
     "django.contrib.staticfiles",
     "sentry.issues.apps.Config",
     "sentry.feedback",

--- a/tests/sentry/auth/providers/vercel/test_provider.py
+++ b/tests/sentry/auth/providers/vercel/test_provider.py
@@ -1,0 +1,23 @@
+from sentry.auth.partnership_configs import ChannelName
+from sentry.models.authprovider import AuthProvider
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class VercelOAuth2ProviderTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.auth_provider: AuthProvider = AuthProvider.objects.create(
+            provider=ChannelName.VERCEL.value, organization_id=self.organization.id
+        )
+
+    def test_build_config(self):
+        provider = self.auth_provider.get_provider()
+        resource = {"id": "test-org", "role": "member"}
+        result = provider.build_config(resource=resource)
+        assert result == {"org": {"id": "test-org"}}
+
+    def test_build_identity(self):
+        # TODO: implement when we get final confirmation from Vercel which claims are going to be present in the id_token
+        pass

--- a/tests/sentry/auth/providers/vercel/test_provider.py
+++ b/tests/sentry/auth/providers/vercel/test_provider.py
@@ -1,3 +1,5 @@
+import jwt
+
 from sentry.auth.partnership_configs import ChannelName
 from sentry.models.authprovider import AuthProvider
 from sentry.testutils.cases import APITestCase
@@ -19,5 +21,34 @@ class VercelOAuth2ProviderTest(APITestCase):
         assert result == {"org": {"id": "test-org"}}
 
     def test_build_identity(self):
-        # TODO: implement when we get final confirmation from Vercel which claims are going to be present in the id_token
-        pass
+        provider = self.auth_provider.get_provider()
+        user_id = "test-user-123"
+        user_email = "test@example.com"
+        user_name = "Test User"
+
+        token_payload = {
+            "user_id": user_id,
+            "user_email": user_email,
+            "user_name": user_name,
+        }
+        id_token = jwt.encode(token_payload, "dummy-secret", algorithm="HS256")
+
+        # state dict that matches what OAuth2CallbackView would create
+        state = {
+            "data": {
+                "id_token": id_token,
+                "access_token": "dummy-access-token",
+                "token_type": "Bearer",
+            }
+        }
+
+        result = provider.build_identity(state)
+
+        assert result == {
+            "type": "vercel",
+            "id": user_id,
+            "email": user_email,
+            "name": user_name,
+            "data": provider.get_oauth_data(state["data"]),
+            "email_verified": True,
+        }


### PR DESCRIPTION
Adds SSO for a new Vercel native integration. This will be used to open Sentry when user clicks "Open in Sentry" button in Vercel UI.

The whole flow is [described here](https://vercel.com/docs/integrations/marketplace-flows#open-in-provider-button-flow):
<img width="745" alt="image" src="https://github.com/user-attachments/assets/1880cf89-6504-4a73-b89d-b87aeb1b6a1a" />

This PR has a similar use case as Fly.io flow, and it was modeled after this [PR](https://github.com/getsentry/sentry/pull/51667) which added Fly provider.