### PR TITLE
theme: deprecate direct import usage

### DIFF
--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -5,7 +5,8 @@ import CommonTheme from './theme';
  * Consuming it directly means that you won't get the correct colors in dark mode.
  * @deprecated use useTheme hook instead.
  */
-export default CommonTheme;
+const DO_NOT_USE_DIRECT_IMPORT_OF_THEME_VALUES = CommonTheme;
+export default DO_NOT_USE_DIRECT_IMPORT_OF_THEME_VALUES;
 // Previous import was from app/utils/theme.tsx
 // biome-ignore lint/performance/noBarrelFile: Remove this once imports are fixed
 export * from './theme';

--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -1,5 +1,10 @@
 import CommonTheme from './theme';
 
+/**
+ * Do not import theme values directly as they only define light color theme.
+ * Consuming it directly means that you won't get the correct colors in dark mode.
+ * @deprecated use useTheme hook instead.
+ */
 export default CommonTheme;
 // Previous import was from app/utils/theme.tsx
 // biome-ignore lint/performance/noBarrelFile: Remove this once imports are fixed

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1,3 +1,4 @@
+import type {Theme} from '@emotion/react';
 import color from 'color';
 
 import commonTheme, {
@@ -11,7 +12,6 @@ import commonTheme, {
   generateThemePrismVariables,
   generateThemeUtils,
   lightTheme,
-  type SentryTheme,
 } from 'sentry/utils/theme';
 
 // @TODO(jonasbadalic): eventually, we should port component usage to these values
@@ -721,7 +721,7 @@ const chonkDarkColorMapping: ColorMapping = {
 const lightAliases = generateAliases(generateChonkTokens(lightColors), lightColors);
 const darkAliases = generateAliases(generateChonkTokens(darkColors), darkColors);
 
-export const lightChonkTheme: SentryTheme = {
+export const lightChonkTheme: Theme = {
   isChonk: true,
 
   // @TODO: color theme contains some colors (like chart color palette, diff, tag and level)
@@ -761,7 +761,7 @@ export const lightChonkTheme: SentryTheme = {
   },
 };
 
-export const darkChonkTheme: SentryTheme = {
+export const darkChonkTheme: Theme = {
   isChonk: true,
 
   // @TODO: color theme contains some colors (like chart color palette, diff, tag and level)

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1181,7 +1181,13 @@ export type IconSize = Size;
 export type Aliases = typeof lightAliases;
 export type ColorOrAlias = keyof Aliases | Color;
 
-export default commonTheme;
+/**
+ * Do not import theme values directly as they only define light color theme.
+ * Consuming it directly means that you won't get the correct colors in dark mode.
+ * @deprecated use useTheme hook instead.
+ */
+const commonThemeExport = {...commonTheme};
+export default commonThemeExport;
 
 /**
  * Configure Emotion to use our theme

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1138,7 +1138,7 @@ export const lightTheme = {
   },
 };
 
-export const darkTheme = {
+export const darkTheme: typeof lightTheme = {
   isChonk: false,
   ...commonTheme,
   ...darkColors,
@@ -1170,12 +1170,7 @@ export const darkTheme = {
     border: darkAliases.border,
     superuser: '#620808',
   },
-} satisfies SentryTheme;
-
-/**
- * @deprecated use import type {Theme} from '@emotion/react'
- */
-export type SentryTheme = typeof lightTheme;
+};
 
 export type ColorMapping = typeof lightColors;
 export type Color = keyof typeof lightColors;
@@ -1196,5 +1191,6 @@ export default commonThemeExport;
  */
 declare module '@emotion/react' {
   // @TODO(jonasbadalic): interface extending a type might be prone to some issues.
+  type SentryTheme = typeof lightTheme;
   export interface Theme extends SentryTheme {}
 }

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1172,7 +1172,9 @@ export const darkTheme = {
   },
 } satisfies SentryTheme;
 
-// Theme type exports
+/**
+ * @deprecated use import type {Theme} from '@emotion/react'
+ */
 export type SentryTheme = typeof lightTheme;
 
 export type ColorMapping = typeof lightColors;


### PR DESCRIPTION
Direct import usage means colors will not be styled by the current active theme(dark or light) and will instead always default to light color scheme. We need to discourage such usage and ultimately remove it