### PR TITLE
analytics(new-trace): Adding analytics for empty and error states

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -1,5 +1,6 @@
 import type {Confidence} from 'sentry/types/organization';
 import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import type {TraceWaterFallSource} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import type {TraceDrawerActionKind} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 export type TracingEventParameters = {
@@ -22,6 +23,12 @@ export type TracingEventParameters = {
     visualizes: Visualize[];
     visualizes_count: number;
   };
+  'trace.load.empty_state': {
+    source: TraceWaterFallSource;
+  };
+  'trace.load.error_state': {
+    source: TraceWaterFallSource;
+  };
   'trace.metadata': {
     has_exceeded_performance_usage_limit: boolean | null;
     num_nodes: number;
@@ -29,6 +36,7 @@ export type TracingEventParameters = {
     project_platforms: string[];
     referrer: string | null;
     shape: string;
+    source: TraceWaterFallSource;
     trace_duration_seconds: number;
   };
   'trace.preferences.autogrouping_change': {
@@ -132,6 +140,8 @@ export type TracingEventKey = keyof TracingEventParameters;
 
 export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace.metadata': 'Trace Load Metadata',
+  'trace.load.empty_state': 'Trace Load Empty State',
+  'trace.load.error_state': 'Trace Load Error State',
   'trace.explorer.metadata': 'Improved Trace Explorer Pageload Metadata',
   'trace.trace_layout.change': 'Changed Trace Layout',
   'trace.trace_layout.drawer_minimize': 'Minimized Trace Drawer',

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -148,7 +148,8 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
         props.tree,
         projectsRef.current,
         props.organization,
-        hasExceededPerformanceUsageLimit
+        hasExceededPerformanceUsageLimit,
+        'issue_details'
       );
     }
 

--- a/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
@@ -8,11 +8,14 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import type {TraceDrawerActionKind} from './traceDrawer/details/utils';
 import {TraceShape, type TraceTree} from './traceModels/traceTree';
 
+export type TraceWaterFallSource = 'trace_view' | 'replay_details' | 'issue_details';
+
 const trackTraceMetadata = (
   tree: TraceTree,
   projects: Project[],
   organization: Organization,
-  hasExceededPerformanceUsageLimit: boolean | null
+  hasExceededPerformanceUsageLimit: boolean | null,
+  source: TraceWaterFallSource
 ) => {
   // space[1] represents the node duration (in milliseconds)
   const trace_duration_seconds = (tree.root.space?.[1] ?? 0) / 1000;
@@ -38,6 +41,7 @@ const trackTraceMetadata = (
     num_nodes: tree.list.length,
     project_platforms: projectPlatforms,
     organization,
+    source,
   });
 };
 
@@ -128,6 +132,18 @@ const trackMissingSpansDocLinkClicked = (organization: Organization) =>
     organization,
   });
 
+const trackTraceEmptyState = (organization: Organization, source: TraceWaterFallSource) =>
+  trackAnalytics('trace.load.empty_state', {
+    organization,
+    source,
+  });
+
+const trackTraceErrorState = (organization: Organization, source: TraceWaterFallSource) =>
+  trackAnalytics('trace.load.error_state', {
+    organization,
+    source,
+  });
+
 const trackQuotaExceededLearnMoreClicked = (
   organization: Organization,
   traceType: string
@@ -187,7 +203,8 @@ function trackTraceShape(
   tree: TraceTree,
   projects: Project[],
   organization: Organization,
-  hasExceededPerformanceUsageLimit: boolean | null
+  hasExceededPerformanceUsageLimit: boolean | null,
+  source: TraceWaterFallSource
 ) {
   switch (tree.shape) {
     case TraceShape.BROKEN_SUBTRACES:
@@ -201,7 +218,8 @@ function trackTraceShape(
         tree,
         projects,
         organization,
-        hasExceededPerformanceUsageLimit
+        hasExceededPerformanceUsageLimit,
+        source
       );
       break;
     default: {
@@ -214,6 +232,8 @@ const traceAnalytics = {
   // Trace shape
   trackTraceMetadata,
   trackTraceShape,
+  trackTraceEmptyState,
+  trackTraceErrorState,
   // Drawer actions
   trackExploreSearch,
   trackShowInView,

--- a/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
@@ -8,6 +8,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {IssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/issuesTraceTree';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
+import {traceAnalytics} from '../traceAnalytics';
 import type {TraceTree} from '../traceModels/traceTree';
 
 import type {TraceMetaQueryResults} from './useTraceMeta';
@@ -58,6 +59,7 @@ export function useIssuesTraceTree({
               event_id: traceSlug,
             })
       );
+      traceAnalytics.trackTraceErrorState(organization, 'issue_details');
       return;
     }
 
@@ -66,6 +68,7 @@ export function useIssuesTraceTree({
       trace?.data?.orphan_errors.length === 0
     ) {
       setTree(t => (t.type === 'empty' ? t : IssuesTraceTree.Empty()));
+      traceAnalytics.trackTraceEmptyState(organization, 'issue_details');
       return;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
@@ -7,6 +7,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
+import {traceAnalytics} from '../traceAnalytics';
 import {TraceTree} from '../traceModels/traceTree';
 
 import type {TraceMetaQueryResults} from './useTraceMeta';
@@ -45,6 +46,8 @@ export function useTraceTree({
 
   const [tree, setTree] = useState<TraceTree>(TraceTree.Empty());
 
+  const traceWaterfallSource = replay ? 'replay_details' : 'trace_view';
+
   useEffect(() => {
     const status = getTraceViewQueryStatus(trace.status, meta.status);
 
@@ -57,6 +60,7 @@ export function useTraceTree({
               event_id: traceSlug,
             })
       );
+      traceAnalytics.trackTraceErrorState(organization, traceWaterfallSource);
       return;
     }
 
@@ -65,6 +69,7 @@ export function useTraceTree({
       trace?.data?.orphan_errors.length === 0
     ) {
       setTree(t => (t.type === 'empty' ? t : TraceTree.Empty()));
+      traceAnalytics.trackTraceEmptyState(organization, traceWaterfallSource);
       return;
     }
 
@@ -100,6 +105,7 @@ export function useTraceTree({
     trace.data,
     meta.data,
     traceSlug,
+    traceWaterfallSource,
   ]);
 
   return tree;

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -66,7 +66,7 @@ import {
 import {usePerformanceSubscriptionDetails} from './traceTypeWarnings/usePerformanceSubscriptionDetails';
 import {Trace} from './trace';
 import TraceActionsMenu from './traceActionsMenu';
-import {traceAnalytics} from './traceAnalytics';
+import {traceAnalytics, type TraceWaterFallSource} from './traceAnalytics';
 import {
   isAutogroupedNode,
   isParentAutogroupedNode,
@@ -521,6 +521,8 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     isLoading: isLoadingSubscriptionDetails,
   } = usePerformanceSubscriptionDetails();
 
+  const source: TraceWaterFallSource = props.replay ? 'replay_details' : 'trace_view';
+
   // Callback that is invoked when the trace loads and reaches its initialied state,
   // that is when the trace tree data and any data that the trace depends on is loaded,
   // but the trace is not yet rendered in the view.
@@ -530,7 +532,8 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         props.tree,
         projectsRef.current,
         props.organization,
-        hasExceededPerformanceUsageLimit
+        hasExceededPerformanceUsageLimit,
+        source
       );
     }
     // The tree has the data fetched, but does not yet respect the user preferences.
@@ -633,6 +636,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     props.organization,
     isLoadingSubscriptionDetails,
     hasExceededPerformanceUsageLimit,
+    source,
   ]);
 
   // Setup the middleware for the trace reducer


### PR DESCRIPTION
Added a source attr to the trace load event, where source is `'trace_view' | 'replay_details' | 'issue_details'`