### PR TITLE
ref(insights): Add realistic mocks for `/events-stats/` call

### DIFF
--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -17,7 +17,10 @@ jest.mock('sentry/utils/usePageFilters');
 describe('HTTPSummaryPage', function () {
   const organization = OrganizationFixture({features: ['insights-initial-modules']});
 
-  let domainChartsRequestMock: jest.Mock;
+  let throughputRequestMock!: jest.Mock;
+  let durationRequestMock!: jest.Mock;
+  let statusRequestMock!: jest.Mock;
+
   let domainTransactionsListRequestMock: jest.Mock;
   let domainMetricsRibbonRequestMock: jest.Mock;
   let regionFilterRequestMock: jest.Mock;
@@ -97,15 +100,55 @@ describe('HTTPSummaryPage', function () {
       ],
     });
 
-    domainChartsRequestMock = MockApiClient.addMockResponse({
+    throughputRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.performance.http.domain-summary-throughput-chart',
+        }),
+      ],
       body: {
-        'spm()': {
-          data: [
-            [1699907700, [{count: 7810.2}]],
-            [1699908000, [{count: 1216.8}]],
-          ],
+        data: [
+          [1699907700, [{count: 7810.2}]],
+          [1699908000, [{count: 1216.8}]],
+        ],
+      },
+    });
+
+    durationRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.performance.http.domain-summary-duration-chart',
+        }),
+      ],
+      body: {
+        data: [
+          [1699907700, [{count: 710.2}]],
+          [1699908000, [{count: 116.8}]],
+        ],
+      },
+    });
+
+    statusRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.performance.http.domain-summary-response-code-chart',
+        }),
+      ],
+      body: {
+        'http_response_rate(3)': {
+          data: [[1699908000, [{count: 0.2}]]],
+        },
+        'http_response_rate(4)': {
+          data: [[1699908000, [{count: 0.1}]]],
+        },
+        'http_response_rate(5)': {
+          data: [[1699908000, [{count: 0.3}]]],
         },
       },
     });
@@ -119,7 +162,7 @@ describe('HTTPSummaryPage', function () {
     render(<HTTPDomainSummaryPage />, {organization});
 
     await waitFor(() => {
-      expect(domainChartsRequestMock).toHaveBeenNthCalledWith(
+      expect(throughputRequestMock).toHaveBeenNthCalledWith(
         1,
         `/organizations/${organization.slug}/events-stats/`,
         expect.objectContaining({
@@ -146,8 +189,8 @@ describe('HTTPSummaryPage', function () {
       );
     });
 
-    expect(domainChartsRequestMock).toHaveBeenNthCalledWith(
-      2,
+    expect(durationRequestMock).toHaveBeenNthCalledWith(
+      1,
       `/organizations/${organization.slug}/events-stats/`,
       expect.objectContaining({
         method: 'GET',
@@ -172,8 +215,8 @@ describe('HTTPSummaryPage', function () {
       })
     );
 
-    expect(domainChartsRequestMock).toHaveBeenNthCalledWith(
-      3,
+    expect(statusRequestMock).toHaveBeenNthCalledWith(
+      1,
       `/organizations/${organization.slug}/events-stats/`,
       expect.objectContaining({
         method: 'GET',

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -19,8 +19,11 @@ describe('HTTPLandingPage', function () {
     features: ['insights-initial-modules', 'insights-entry-points'],
   });
 
+  let throughputRequestMock!: jest.Mock;
+  let durationRequestMock!: jest.Mock;
+  let statusRequestMock!: jest.Mock;
+
   let spanListRequestMock!: jest.Mock;
-  let spanChartsRequestMock!: jest.Mock;
   let regionFilterRequestMock!: jest.Mock;
 
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
@@ -166,15 +169,55 @@ describe('HTTPLandingPage', function () {
       },
     });
 
-    spanChartsRequestMock = MockApiClient.addMockResponse({
+    throughputRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.performance.http.landing-throughput-chart',
+        }),
+      ],
       body: {
-        'spm()': {
-          data: [
-            [1699907700, [{count: 7810.2}]],
-            [1699908000, [{count: 1216.8}]],
-          ],
+        data: [
+          [1699907700, [{count: 7810.2}]],
+          [1699908000, [{count: 1216.8}]],
+        ],
+      },
+    });
+
+    durationRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.performance.http.landing-duration-chart',
+        }),
+      ],
+      body: {
+        data: [
+          [1699907700, [{count: 710.2}]],
+          [1699908000, [{count: 116.8}]],
+        ],
+      },
+    });
+
+    statusRequestMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.performance.http.landing-response-code-chart',
+        }),
+      ],
+      body: {
+        'http_response_rate(3)': {
+          data: [[1699908000, [{count: 0.2}]]],
+        },
+        'http_response_rate(4)': {
+          data: [[1699908000, [{count: 0.1}]]],
+        },
+        'http_response_rate(5)': {
+          data: [[1699908000, [{count: 0.3}]]],
         },
       },
     });
@@ -187,7 +230,7 @@ describe('HTTPLandingPage', function () {
   it('fetches module data', async function () {
     render(<HTTPLandingPage />, {organization});
 
-    expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
+    expect(throughputRequestMock).toHaveBeenNthCalledWith(
       1,
       `/organizations/${organization.slug}/events-stats/`,
       expect.objectContaining({
@@ -231,8 +274,8 @@ describe('HTTPLandingPage', function () {
       })
     );
 
-    expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
-      2,
+    expect(durationRequestMock).toHaveBeenNthCalledWith(
+      1,
       `/organizations/${organization.slug}/events-stats/`,
       expect.objectContaining({
         method: 'GET',
@@ -257,8 +300,8 @@ describe('HTTPLandingPage', function () {
       })
     );
 
-    expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
-      3,
+    expect(statusRequestMock).toHaveBeenNthCalledWith(
+      1,
       `/organizations/${organization.slug}/events-stats/`,
       expect.objectContaining({
         method: 'GET',

--- a/static/app/views/insights/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.spec.tsx
@@ -15,7 +15,7 @@ describe('latencyChart', () => {
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',
       body: {
-        data: [],
+        data: [[1739378162, [{count: 1}]]],
       },
     });
   });

--- a/static/app/views/insights/queues/charts/throughputChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.spec.tsx
@@ -15,7 +15,7 @@ describe('throughputChart', () => {
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',
       body: {
-        data: [],
+        data: [[1739378162, [{count: 1}]]],
       },
     });
   });

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -67,7 +67,9 @@ describe('destinationSummaryPage', () => {
     eventsStatsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',
-      body: {data: []},
+      body: {
+        data: [[1699907700, [{count: 0.2}]]],
+      },
     });
   });
 


### PR DESCRIPTION
Ran into this on another branch! The tests are better with real data, and it'll prevent some confusing test changes down the line.
