### PR TITLE
fix(anomaly detection) Check for NULL_VALUE

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -34,7 +34,7 @@ def get_anomaly_data_from_seer(
     aggregation_value: float | None,
 ) -> list[TimeSeriesPoint] | None:
     snuba_query = alert_rule.snuba_query
-    if not snuba_query or aggregation_value is None:
+    if not snuba_query or aggregation_value in [None, "NULL_VALUE"]:
         return None
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -43,6 +43,7 @@ def get_anomaly_data_from_seer(
         or not alert_rule.sensitivity
         or not alert_rule.seasonality
         or not snuba_query.time_window
+        or not aggregation_value
     ):
         return None
 

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -34,7 +34,7 @@ def get_anomaly_data_from_seer(
     aggregation_value: float | None,
 ) -> list[TimeSeriesPoint] | None:
     snuba_query = alert_rule.snuba_query
-    if not snuba_query or aggregation_value in [None, "NULL_VALUE"]:
+    if not snuba_query or aggregation_value in (None, "NULL_VALUE"):
         return None
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -701,7 +701,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             alert_rule=processor.alert_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
-            aggregation_value="NULL_VALUE",
+            aggregation_value="NULL_VALUE",  # type: ignore[arg-type]
         )
         logger_extra = {
             "subscription_id": self.sub.id,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -694,6 +694,21 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @mock.patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
+    def test_seer_call_null_aggregation_value(self, mock_seer_request):
+        processor = SubscriptionProcessor(self.sub)
+        result = get_anomaly_data_from_seer(
+            alert_rule=processor.alert_rule,
+            subscription=processor.subscription,
+            last_update=processor.last_update.timestamp(),
+            aggregation_value="NULL_VALUE",
+        )
+        assert result is None
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:anomaly-detection-rollout")
+    @mock.patch(
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
+    )
     @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_timeout_error(self, mock_logger, mock_seer_request):
         rule = self.dynamic_rule


### PR DESCRIPTION
We're seeing the string `NULL_VALUE` come through as the aggregation result for some generic metrics dataset query subscriptions which is causing an error in Seer as they are expecting an actual value. Filter this out so we don't have that problem.