### PR TITLE
fix(react19): Pass key without spreading

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -238,7 +238,7 @@ function DropdownMenu({
             return (
               <Section key={item.key} title={item.label} items={item.children}>
                 {sectionItem => (
-                  <Item size={size} {...sectionItem}>
+                  <Item size={size} {...sectionItem} key={sectionItem.key}>
                     {sectionItem.label}
                   </Item>
                 )}


### PR DESCRIPTION
part of https://github.com/getsentry/frontend-tsc/issues/68

passes the key without spreading which is required for react 19
