### PR TITLE
fix(scim): allow removing idp-member from non-idp team

### DIFF
--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -52,6 +52,7 @@ function TeamMembersRow({
           isSelf={isSelf}
           onClick={() => removeMember({memberId: member.id})}
           team={team}
+          member={member}
         />
       </div>
     </TeamRolesPanelItem>
@@ -61,10 +62,11 @@ function TeamMembersRow({
 function RemoveButton(props: {
   hasWriteAccess: boolean;
   isSelf: boolean;
+  member: TeamMember;
   onClick: () => void;
   team: Team;
 }) {
-  const {hasWriteAccess, isSelf, onClick, team} = props;
+  const {member, hasWriteAccess, isSelf, onClick, team} = props;
 
   const canRemoveMember = hasWriteAccess || isSelf;
   if (!canRemoveMember) {

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -51,7 +51,7 @@ function TeamMembersRow({
           hasWriteAccess={hasWriteAccess}
           isSelf={isSelf}
           onClick={() => removeMember({memberId: member.id})}
-          member={member}
+          team={team}
         />
       </div>
     </TeamRolesPanelItem>
@@ -61,10 +61,10 @@ function TeamMembersRow({
 function RemoveButton(props: {
   hasWriteAccess: boolean;
   isSelf: boolean;
-  member: TeamMember;
   onClick: () => void;
+  team: Team;
 }) {
-  const {member, hasWriteAccess, isSelf, onClick} = props;
+  const {hasWriteAccess, isSelf, onClick, team} = props;
 
   const canRemoveMember = hasWriteAccess || isSelf;
   if (!canRemoveMember) {
@@ -81,7 +81,7 @@ function RemoveButton(props: {
     );
   }
 
-  const isIdpProvisioned = member.flags['idp:provisioned'];
+  const isIdpProvisioned = team.flags['idp:provisioned'];
   const buttonHelpText = getButtonHelpText(isIdpProvisioned);
 
   const buttonRemoveText = isSelf ? t('Leave') : t('Remove');


### PR DESCRIPTION
The ability to add/remove a member from a team should depend on the team's `idp:provisioned` flag and the current user's permissions.

Currently we are using the member's `idp:provisioned` flag to determine whether the member can be removed, this should be the team's.

Resolves https://github.com/getsentry/sentry/issues/84457