### PR TITLE
ref(releases): mobile chart shows crash-free rate

### DIFF
--- a/static/app/views/insights/sessions/charts/crashFreeSessionChart.tsx
+++ b/static/app/views/insights/sessions/charts/crashFreeSessionChart.tsx
@@ -1,0 +1,21 @@
+import {t} from 'sentry/locale';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import useCrashFreeSessions from 'sentry/views/insights/sessions/queries/useCrashFreeSessions';
+
+export default function CrashFreeSessionsChart() {
+  const {series, releases, isPending, error} = useCrashFreeSessions();
+
+  const aliases = Object.fromEntries(
+    releases?.map(release => [`crash_free_session_rate_${release}`, release]) ?? []
+  );
+
+  return (
+    <InsightsLineChartWidget
+      title={t('Crash Free Session Rate')}
+      aliases={aliases}
+      series={series}
+      isLoading={isPending}
+      error={error}
+    />
+  );
+}

--- a/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
+++ b/static/app/views/insights/sessions/charts/errorFreeSessionsChart.tsx
@@ -2,22 +2,12 @@ import {t} from 'sentry/locale';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import useErrorFreeSessions from 'sentry/views/insights/sessions/queries/useErrorFreeSessions';
 
-interface Props {
-  groupByRelease?: boolean;
-}
+export default function ErrorFreeSessionsChart() {
+  const {series, isPending, error} = useErrorFreeSessions();
 
-export default function ErrorFreeSessionsChart({groupByRelease}: Props) {
-  const {series, releases, isPending, error} = useErrorFreeSessions({
-    groupByRelease,
-  });
-
-  const aliases = groupByRelease
-    ? Object.fromEntries(
-        releases?.map(release => [`successful_session_rate_${release}`, release]) ?? []
-      )
-    : {
-        successful_session_rate: t('Error free session rate'),
-      };
+  const aliases = {
+    successful_session_rate: t('Error free session rate'),
+  };
 
   return (
     <InsightsLineChartWidget

--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -1,0 +1,121 @@
+import type {SessionApiResponse} from 'sentry/types/organization';
+import {percent} from 'sentry/utils';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useSessionAdoptionRate from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
+
+export default function useCrashFreeSessions() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {
+    data: sessionData,
+    isPending,
+    error,
+  } = useApiQuery<SessionApiResponse>(
+    [
+      `/organizations/${organization.slug}/sessions/`,
+      {
+        query: {
+          ...location.query,
+          field: ['sum(session)'],
+          groupBy: ['session.status', 'release'],
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+
+  const projectTotal = useSessionAdoptionRate();
+
+  if (isPending) {
+    return {
+      series: [],
+      isPending: true,
+      error,
+    };
+  }
+
+  if (!sessionData && !isPending) {
+    return {
+      series: [],
+      isPending: false,
+      error,
+    };
+  }
+
+  const getStatusSeries = (status: string, groups: typeof sessionData.groups) =>
+    groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
+    [];
+
+  // Maps release to its API response groups
+  const releaseGroupMap = new Map<string, typeof sessionData.groups>();
+
+  // Maps release to its adoption rate calculation
+  const releaseAdoptionMap = new Map<string, number>();
+
+  sessionData.groups.forEach(group => {
+    const release = group.by.release?.toString() ?? '';
+    if (!releaseGroupMap.has(release)) {
+      releaseGroupMap.set(release, []);
+      const releaseGroups = sessionData.groups.filter(
+        g => g.by.release?.toString() === release
+      );
+
+      // Calculate total sessions for entire time period
+      const totalSessionCount = releaseGroups.reduce(
+        (acc, g) => acc + (g.totals['sum(session)'] ?? 0),
+        0
+      );
+
+      // Only consider releases with total sessions > 0
+      if (totalSessionCount > 0) {
+        releaseAdoptionMap.set(release, percent(totalSessionCount, projectTotal));
+      }
+    }
+    if (releaseAdoptionMap.has(release)) {
+      releaseGroupMap.get(release)!.push(group);
+    }
+  });
+
+  // Get top 5 releases
+  const topReleases = Array.from(releaseAdoptionMap.entries())
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5)
+    .map(([release]) => release);
+
+  const series = topReleases.map(release => {
+    const groups = releaseGroupMap.get(release)!;
+
+    // Get all status series at once and calculate crash-free session percentage for each interval
+    const seriesData = getStatusSeries('crashed', groups).map((crashedCount, idx) => {
+      const intervalTotal = [
+        crashedCount,
+        getStatusSeries('abnormal', groups)[idx] || 0,
+        getStatusSeries('crashed', groups)[idx] || 0,
+        getStatusSeries('healthy', groups)[idx] || 0,
+      ].reduce((sum, val) => sum + val, 0);
+
+      return {
+        name: sessionData.intervals[idx] ?? '',
+        value: intervalTotal > 0 ? 1 - crashedCount / intervalTotal : 1,
+      };
+    });
+
+    return {
+      data: seriesData,
+      seriesName: `crash_free_session_rate_${release}`,
+      meta: {
+        fields: {
+          [`crash_free_session_rate_${release}`]: 'percentage' as const,
+          time: 'date' as const,
+        },
+        units: {
+          [`crash_free_session_rate_${release}`]: '%',
+        },
+      },
+    };
+  });
+
+  return {series, releases: topReleases, isPending, error};
+}

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -1,15 +1,9 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
-import {percent} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import useSessionAdoptionRate from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
 
-interface Props {
-  groupByRelease?: boolean;
-}
-
-export default function useErrorFreeSessions({groupByRelease}: Props) {
+export default function useErrorFreeSessions() {
   const location = useLocation();
   const organization = useOrganization();
   const {
@@ -23,14 +17,12 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
         query: {
           ...location.query,
           field: ['sum(session)'],
-          groupBy: groupByRelease ? ['session.status', 'release'] : ['session.status'],
+          groupBy: ['session.status'],
         },
       },
     ],
     {staleTime: 0}
   );
-
-  const projectTotal = useSessionAdoptionRate();
 
   if (isPending) {
     return {
@@ -51,80 +43,6 @@ export default function useErrorFreeSessions({groupByRelease}: Props) {
   const getStatusSeries = (status: string, groups: typeof sessionData.groups) =>
     groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
     [];
-
-  // Returns series data for each release
-  if (groupByRelease) {
-    // Maps release to its API response groups
-    const releaseGroupMap = new Map<string, typeof sessionData.groups>();
-
-    // Maps release to its adoption rate calculation
-    const releaseAdoptionMap = new Map<string, number>();
-
-    sessionData.groups.forEach(group => {
-      const release = group.by.release?.toString() ?? '';
-      if (!releaseGroupMap.has(release)) {
-        releaseGroupMap.set(release, []);
-        const releaseGroups = sessionData.groups.filter(
-          g => g.by.release?.toString() === release
-        );
-
-        // Calculate total sessions for entire time period
-        const totalSessionCount = releaseGroups.reduce(
-          (acc, g) => acc + (g.totals['sum(session)'] ?? 0),
-          0
-        );
-
-        // Only consider releases with total sessions > 0
-        if (totalSessionCount > 0) {
-          releaseAdoptionMap.set(release, percent(totalSessionCount, projectTotal));
-        }
-      }
-      if (releaseAdoptionMap.has(release)) {
-        releaseGroupMap.get(release)!.push(group);
-      }
-    });
-
-    // Get top 5 releases
-    const topReleases = Array.from(releaseAdoptionMap.entries())
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 5)
-      .map(([release]) => release);
-
-    const series = topReleases.map(release => {
-      const groups = releaseGroupMap.get(release)!;
-
-      // Get all status series at once and calculate healthy session percentage for each interval
-      const seriesData = getStatusSeries('healthy', groups).map((healthyCount, idx) => {
-        const intervalTotal = [
-          healthyCount,
-          getStatusSeries('abnormal', groups)[idx] || 0,
-          getStatusSeries('crashed', groups)[idx] || 0,
-          getStatusSeries('errored', groups)[idx] || 0,
-        ].reduce((sum, val) => sum + val, 0);
-
-        return {
-          name: sessionData.intervals[idx] ?? '',
-          value: intervalTotal > 0 ? healthyCount / intervalTotal : 1,
-        };
-      });
-
-      return {
-        data: seriesData,
-        seriesName: `successful_session_rate_${release}`,
-        meta: {
-          fields: {
-            [`successful_session_rate_${release}`]: 'percentage' as const,
-            time: 'date' as const,
-          },
-          units: {
-            [`successful_session_rate_${release}`]: '%',
-          },
-        },
-      };
-    });
-
-    return {series, releases: topReleases, isPending, error};
-  }
 
   // Returns series data not grouped by release
   const seriesData = getStatusSeries('healthy', sessionData.groups).map(

--- a/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
@@ -28,5 +28,7 @@ export default function useSessionProjectTotal() {
     return 0;
   }
 
-  return projSessionData.groups[0]!.totals['sum(session)'] ?? 0;
+  return projSessionData.groups.length
+    ? projSessionData.groups[0]!.totals['sum(session)'] ?? 0
+    : 0;
 }

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -13,6 +13,7 @@ import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/se
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import CrashFreeSessionChart from 'sentry/views/insights/sessions/charts/crashFreeSessionChart';
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
 import {ModuleName} from 'sentry/views/insights/types';
 
@@ -41,7 +42,7 @@ export function SessionsOverview() {
             </ModuleLayout.Full>
             {view === MOBILE_LANDING_SUB_PATH ? (
               <ModuleLayout.Half>
-                <ErrorFreeSessionsChart groupByRelease />
+                <CrashFreeSessionChart />
               </ModuleLayout.Half>
             ) : (
               <ModuleLayout.Third>


### PR DESCRIPTION
## new crash-free session rate charts for mobile:

<img width="630" alt="SCR-20250212-jtpr" src="https://github.com/user-attachments/assets/6dd27e58-f689-4a06-b94a-c3a1f9051528" />

<img width="607" alt="SCR-20250212-jtmk" src="https://github.com/user-attachments/assets/7e90a6e8-747c-4660-98b0-8017ba06639f" />

the calculation is
```
1 - (crashed sessions / total sessions)
```

## frontend/backend charts still look the same:

<img width="474" alt="SCR-20250212-jwip" src="https://github.com/user-attachments/assets/77088191-fe04-45a4-906a-c77ade37245a" />

the calculation is
```
(healthy sessions / total sessions)
```

## mobile chart with no data (e.g. no releases) will show up like this:

<img width="586" alt="SCR-20250212-jwgd" src="https://github.com/user-attachments/assets/928beb9b-1c85-4fa4-9c9c-170459c42709" />


