### PR TITLE
chore(devservices): Remove mentions of sentry devservices in testing util files

### DIFF
--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -18,10 +18,13 @@ def _service_available(host: str, port: int) -> bool:
 
 
 def _requires_service_message(name: str) -> str:
-    return f"requires '{name}' server running\n\t💡 Hint: run `sentry devservices up {name}`"
+    if name == "symbolicator":
+        return (
+            f"requires '{name}' server running\n\t💡 Hint: run `devservices up --mode=symbolicator`"
+        )
+    return f"requires '{name}' server running\n\t💡 Hint: run `devservices up`"
 
 
-@pytest.fixture(scope="session")
 def _requires_snuba() -> None:
     parsed = urlparse(settings.SENTRY_SNUBA)
     assert parsed.hostname is not None

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -25,6 +25,7 @@ def _requires_service_message(name: str) -> str:
     return f"requires '{name}' server running\n\t💡 Hint: run `devservices up`"
 
 
+@pytest.fixture(scope="session")
 def _requires_snuba() -> None:
     parsed = urlparse(settings.SENTRY_SNUBA)
     assert parsed.hostname is not None

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -18,10 +18,6 @@ def _service_available(host: str, port: int) -> bool:
 
 
 def _requires_service_message(name: str) -> str:
-    if name == "symbolicator":
-        return (
-            f"requires '{name}' server running\n\t💡 Hint: run `devservices up --mode=symbolicator`"
-        )
     return f"requires '{name}' server running\n\t💡 Hint: run `devservices up`"
 
 
@@ -49,7 +45,8 @@ def _requires_symbolicator() -> None:
     (port,) = symbolicator_conf["ports"].values()
 
     if not _service_available("127.0.0.1", port):
-        pytest.fail(_requires_service_message("symbolicator"))
+        service_message = "requires 'symbolicator' server running\n\t💡 Hint: run `devservices up --mode=symbolicator`"
+        pytest.fail(service_message)
 
 
 requires_snuba = pytest.mark.usefixtures("_requires_snuba")

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -13,7 +13,7 @@ from sentry.testutils.skips import requires_kafka, requires_symbolicator
 # IMPORTANT:
 #
 # This test suite requires Symbolicator in order to run correctly.
-# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `devservices up --mode=symbolicator`
 #
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -32,7 +32,7 @@ from sentry.utils.safe import get_path
 # IMPORTANT:
 #
 # This test suite requires Symbolicator in order to run correctly.
-# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `devservices up --mode=symbolicator`
 #
 # If you are using a local instance of Symbolicator, you need to either change `system.url-prefix`
 # to `system.internal-url-prefix` inside `initialize` method below, or add `127.0.0.1 host.docker.internal`

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -16,7 +16,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
 
     To run this locally you may need to set the ENABLE_SPANS_CONSUMER flag to True in Snuba.
     A way to do this is
-    1. run: `sentry devservices down snuba`
+    1. run: `docker container rm snuba-snuba-1`
     2. clone snuba locally
     3. run: `export ENABLE_SPANS_CONSUMER=True`
     4. run snuba

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -20,7 +20,7 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # IMPORTANT:
 #
 # This test suite requires Symbolicator in order to run correctly.
-# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `devservices up --mode=symbolicator`
 #
 # If you are using a local instance of Symbolicator, you need to
 # either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -28,7 +28,7 @@ from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_loc
 # IMPORTANT:
 #
 # This test suite requires Symbolicator in order to run correctly.
-# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `devservices up --mode=symbolicator`
 #
 # If you are using a local instance of Symbolicator, you need to
 # either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -18,7 +18,7 @@ from tests.symbolicator import normalize_native_exception
 # IMPORTANT:
 #
 # This test suite requires Symbolicator in order to run correctly.
-# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `devservices up --mode=symbolicator`
 #
 # If you are using a local instance of Symbolicator, you need to
 # either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,


### PR DESCRIPTION
As we move from `sentry devservices` to the `devservices` cli tool, we should update the documentation/testutils there. 