### PR TITLE
ref(dashboards): Move visualization error handling into visualization components

### DIFF
--- a/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/areaChartWidget/areaChartWidget.spec.tsx
@@ -19,9 +19,11 @@ describe('AreaChartWidget', () => {
 
   describe('Visualization', () => {
     it('Explains missing data', () => {
+      jest.spyOn(console, 'error').mockImplementation();
       render(<AreaChartWidget />);
 
       expect(screen.getByText('No Data')).toBeInTheDocument();
+      jest.resetAllMocks();
     });
   });
 

--- a/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/barChartWidget/barChartWidget.spec.tsx
@@ -19,9 +19,11 @@ describe('BarChartWidget', () => {
 
   describe('Visualization', () => {
     it('Explains missing data', () => {
+      jest.spyOn(console, 'error').mockImplementation();
       render(<BarChartWidget />);
 
       expect(screen.getByText('No Data')).toBeInTheDocument();
+      jest.resetAllMocks();
     });
   });
 

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -28,6 +28,14 @@ describe('BigNumberWidget', () => {
   });
 
   describe('Visualization', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
     it('Explains missing data', () => {
       render(
         <BigNumberWidget

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -10,11 +10,7 @@ import {
   type WidgetFrameProps,
 } from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
-import {
-  DEFAULT_FIELD,
-  MISSING_DATA_MESSAGE,
-  NON_FINITE_NUMBER_MESSAGE,
-} from '../common/settings';
+import {DEFAULT_FIELD, MISSING_DATA_MESSAGE} from '../common/settings';
 import type {StateProps} from '../common/types';
 
 import {DEEMPHASIS_COLOR_NAME, LOADING_PLACEHOLDER} from './settings';
@@ -45,11 +41,6 @@ export function BigNumberWidget(props: BigNumberWidgetProps) {
 
   if (!defined(value)) {
     parsingError = MISSING_DATA_MESSAGE;
-  } else if (
-    (typeof value === 'number' && !Number.isFinite(value)) ||
-    Number.isNaN(value)
-  ) {
-    parsingError = NON_FINITE_NUMBER_MESSAGE;
   }
 
   const error = props.error ?? parsingError;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -15,6 +15,8 @@ import type {
   Thresholds,
 } from 'sentry/views/dashboards/widgets/common/types';
 
+import {NON_FINITE_NUMBER_MESSAGE} from '../common/settings';
+
 import {ThresholdsIndicator} from './thresholdsIndicator';
 
 export interface BigNumberWidgetVisualizationProps {
@@ -36,6 +38,10 @@ export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualization
     preferredPolarity,
     meta,
   } = props;
+
+  if ((typeof value === 'number' && !Number.isFinite(value)) || Number.isNaN(value)) {
+    throw new Error(NON_FINITE_NUMBER_MESSAGE);
+  }
 
   const location = useLocation();
   const organization = useOrganization();

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -4,6 +4,14 @@ import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
 describe('WidgetFrame', () => {
   describe('Layout', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
     it('Renders the title and description', async () => {
       render(<WidgetFrame title="EPS" description="Number of events per second" />);
 
@@ -14,8 +22,6 @@ describe('WidgetFrame', () => {
     });
 
     it('Catches errors in the visualization', async () => {
-      jest.spyOn(console, 'error').mockImplementation();
-
       render(
         <WidgetFrame title="Uh Oh">
           <UhOh />
@@ -25,8 +31,6 @@ describe('WidgetFrame', () => {
       expect(screen.getByText('Uh Oh')).toBeInTheDocument();
 
       expect(await screen.findByText(/cannot read properties/i)).toBeInTheDocument();
-
-      jest.resetAllMocks();
     });
   });
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -24,9 +24,7 @@ describe('WidgetFrame', () => {
 
       expect(screen.getByText('Uh Oh')).toBeInTheDocument();
 
-      expect(
-        await screen.findByText('Sorry, something went wrong when rendering this widget.')
-      ).toBeInTheDocument();
+      expect(await screen.findByText(/cannot read properties/i)).toBeInTheDocument();
 
       jest.resetAllMocks();
     });

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import type {BadgeProps} from 'sentry/components/badge/badge';
 import {LinkButton} from 'sentry/components/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis, IconExpand, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -18,7 +17,6 @@ import {
 import {WidgetLayout} from '../widgetLayout/widgetLayout';
 import {WidgetTitle} from '../widgetLayout/widgetTitle';
 
-import {WIDGET_RENDER_ERROR_MESSAGE} from './settings';
 import {TooltipIconTrigger} from './tooltipIconTrigger';
 import type {StateProps} from './types';
 import {WarningsList} from './warningsList';
@@ -150,17 +148,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
           )}
         </Fragment>
       }
-      Visualization={
-        props.error ? (
-          <ErrorPanel error={error} />
-        ) : (
-          <ErrorBoundary
-            customComponent={() => <ErrorPanel error={WIDGET_RENDER_ERROR_MESSAGE} />}
-          >
-            {props.children}
-          </ErrorBoundary>
-        )
-      }
+      Visualization={props.error ? <ErrorPanel error={error} /> : props.children}
       noVisualizationPadding={props.noVisualizationPadding}
     />
   );

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.spec.tsx
@@ -20,9 +20,11 @@ describe('LineChartWidget', () => {
 
   describe('Visualization', () => {
     it('Explains missing data', () => {
+      jest.spyOn(console, 'error').mockImplementation();
       render(<LineChartWidget />);
 
       expect(screen.getByText('No Data')).toBeInTheDocument();
+      jest.resetAllMocks();
     });
 
     const UNPLOTTABLE_CASES = [
@@ -50,6 +52,7 @@ describe('LineChartWidget', () => {
     ] satisfies Array<[TimeSeriesItem[]]>;
 
     it.each(UNPLOTTABLE_CASES)('Explains no plottable values for %s', data => {
+      jest.spyOn(console, 'error').mockImplementation();
       render(
         <LineChartWidget
           timeSeries={[
@@ -70,6 +73,7 @@ describe('LineChartWidget', () => {
       expect(
         screen.getByText(/does not contain any plottable values/)
       ).toBeInTheDocument();
+      jest.resetAllMocks();
     });
   });
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -8,7 +8,7 @@ import {
   type TimeSeriesWidgetVisualizationProps,
 } from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
-import {MISSING_DATA_MESSAGE, NO_PLOTTABLE_VALUES} from '../common/settings';
+import {MISSING_DATA_MESSAGE} from '../common/settings';
 import type {StateProps} from '../common/types';
 import {LoadingPanel} from '../widgetLayout/loadingPanel';
 
@@ -39,15 +39,7 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
 
   if (!defined(timeseries)) {
     parsingError = MISSING_DATA_MESSAGE;
-  } else if (
-    timeseries.flatMap(timeSeries => timeSeries.data).every(item => item.value === null)
-  ) {
-    parsingError = NO_PLOTTABLE_VALUES;
   }
-
-  // TODO: It would be polite to also scan for gaps (i.e., the items don't all
-  // have the same difference in `timestamp`s) even though this is rare, since
-  // the backend zerofills the
 
   const error = props.error ?? parsingError;
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -27,6 +27,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 import {useWidgetSyncContext} from '../../contexts/widgetSyncContext';
+import {NO_PLOTTABLE_VALUES} from '../common/settings';
 import type {Aliases, Release, TimeSeries, TimeseriesSelection} from '../common/types';
 
 import {BarChartWidgetSeries} from './seriesConstructors/barChartWidgetSeries';
@@ -56,6 +57,18 @@ export interface TimeSeriesWidgetVisualizationProps {
 }
 
 export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizationProps) {
+  if (
+    props.timeSeries
+      .flatMap(timeSeries => timeSeries.data)
+      .every(item => item.value === null)
+  ) {
+    throw new Error(NO_PLOTTABLE_VALUES);
+  }
+
+  // TODO: It would be polite to also scan for gaps (i.e., the items don't all
+  // have the same difference in `timestamp`s) even though this is rare, since
+  // the backend zerofills the
+
   const chartRef = useRef<EChartsReactCore | null>(null);
   const {register: registerWithWidgetSyncContext} = useWidgetSyncContext();
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -67,7 +67,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   // TODO: It would be polite to also scan for gaps (i.e., the items don't all
   // have the same difference in `timestamp`s) even though this is rare, since
-  // the backend zerofills the
+  // the backend zerofills the data
 
   const chartRef = useRef<EChartsReactCore | null>(null);
   const {register: registerWithWidgetSyncContext} = useWidgetSyncContext();

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -2,9 +2,12 @@ import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import {space} from 'sentry/styles/space';
 
 import {MIN_HEIGHT, MIN_WIDTH, X_GUTTER, Y_GUTTER} from '../common/settings';
+
+import {ErrorPanel} from './errorPanel';
 
 export interface WidgetLayoutProps {
   Actions?: React.ReactNode;
@@ -36,9 +39,13 @@ export function WidgetLayout(props: WidgetLayoutProps) {
       </Header>
 
       {props.Visualization && (
-        <VisualizationWrapper noPadding={props.noVisualizationPadding}>
-          {props.Visualization}
-        </VisualizationWrapper>
+        <ErrorBoundary
+          customComponent={({error}) => <ErrorPanel error={error ?? undefined} />}
+        >
+          <VisualizationWrapper noPadding={props.noVisualizationPadding}>
+            {props.Visualization}
+          </VisualizationWrapper>
+        </ErrorBoundary>
       )}
 
       {props.Footer && (

--- a/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
+++ b/static/app/views/dashboards/widgets/widgetLayout/widgetLayout.tsx
@@ -40,7 +40,9 @@ export function WidgetLayout(props: WidgetLayoutProps) {
 
       {props.Visualization && (
         <ErrorBoundary
-          customComponent={({error}) => <ErrorPanel error={error ?? undefined} />}
+          customComponent={({error}) => (
+            <ErrorPanel error={error?.message ?? undefined} />
+          )}
         >
           <VisualizationWrapper noPadding={props.noVisualizationPadding}>
             {props.Visualization}


### PR DESCRIPTION
Right now there's some error handling inside `BigNumberWidget` and `TimeSeriesWidget`. I'm moving that error handling into the corresponding visualizations. This will make it possible to use those visualization components without the widgets! This makes it easier to compose widget components.

From this PR, the visualizations will check data for errors (this should be very rare, only happens if the backend returns something pretty broken). If they find an error, they will immediately `throw`! I'm adding an `ErrorBoundary` into `WidgetLayout` so it can always be used to safely wrap a visualization.
