### PR TITLE
fix(autofix): Return run id from start endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -411,6 +411,9 @@ class GroupAutofixEndpoint(GroupEndpoint):
         check_autofix_status.apply_async(args=[run_id], countdown=timedelta(minutes=15).seconds)
 
         return Response(
+            {
+                "run_id": run_id,
+            },
             status=202,
         )
 


### PR DESCRIPTION
This will help us fix the start over issue on the frontend by tracking the ID of different runs.