### PR TITLE
fix(issues): Remove stack trace key spreading

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -147,12 +147,8 @@ function Content({
   };
 
   function renderOmittedFrames(firstFrameOmitted: any, lastFrameOmitted: any) {
-    const props = {
-      className: 'frame frames-omitted',
-      key: 'omitted',
-    };
     return (
-      <li {...props}>
+      <li key="omitted" className="frame frames-omitted">
         {t(
           'Frames %d until %d were omitted and not available.',
           firstFrameOmitted,


### PR DESCRIPTION
part of https://github.com/getsentry/frontend-tsc/issues/68

Keys must not be `...` spread onto the element for react 19
