### PR TITLE
fix(performance): Remove SpanRow key spreading

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -658,6 +658,7 @@ class SpanTree extends Component<PropType> {
     return (
       <SpanRow
         {...props}
+        key={props.key}
         spanTree={spanTree}
         spanContextProps={this.props.spanContextProps}
         cache={this.cache}


### PR DESCRIPTION
part of https://github.com/getsentry/frontend-tsc/issues/68

Keys must not be `...` spread onto the element for react 19
