### PR TITLE
fix(flags): move flags[] stripping to fix flag values autocomplete

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -240,7 +240,9 @@ export function fetchFeatureFlagValues({
     return Promise.resolve([]);
   }
 
-  const url = `/organizations/${organization.slug}/tags/${tagKey}/values/`;
+  // Search syntax may wrap with flags[] or flags[""], but this endpoint doesn't support that syntax.
+  const strippedKey = tagKey.replace(/^flags\[(?:"?)(.*?)(?:"?)\]$/, '$1');
+  const url = `/organizations/${organization.slug}/tags/${strippedKey}/values/`;
 
   const query: Query = {
     dataset: Dataset.ERRORS,

--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -240,8 +240,9 @@ export function fetchFeatureFlagValues({
     return Promise.resolve([]);
   }
 
-  // Search syntax may wrap with flags[] or flags[""], but this endpoint doesn't support that syntax.
+  // Search syntax may wrap with flags[] or flags[""], but this endpoint doesn't support it.
   const strippedKey = tagKey.replace(/^flags\[(?:"?)(.*?)(?:"?)\]$/, '$1');
+
   const url = `/organizations/${organization.slug}/tags/${strippedKey}/values/`;
 
   const query: Query = {

--- a/static/app/views/issueList/utils/getIssueTagValues.tsx
+++ b/static/app/views/issueList/utils/getIssueTagValues.tsx
@@ -1,5 +1,5 @@
 import type {Tag, TagValue} from 'sentry/types/group';
-import {DEVICE_CLASS_TAG_VALUES, FieldKind, isDeviceClass} from 'sentry/utils/fields';
+import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
 
 /**
  * Returns a function that fetches tag values for a given tag key. Useful as
@@ -11,18 +11,12 @@ export function makeGetIssueTagValues(
   tagValueLoader: (key: string, search: string) => Promise<TagValue[]>
 ) {
   return async (tag: Tag, query: string): Promise<string[]> => {
-    // Strip flags[] or flags[""] from the tag key
-    const key =
-      tag.kind === FieldKind.FEATURE_FLAG
-        ? tag.key.replace(/^flags\[(?:"?)(.*?)(?:"?)\]$/, '$1')
-        : tag.key;
-
     // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
     // and low search filter values because discover maps device.class to these values.
-    if (isDeviceClass(key)) {
+    if (isDeviceClass(tag.key)) {
       return DEVICE_CLASS_TAG_VALUES;
     }
-    const values = await tagValueLoader(key, query);
+    const values = await tagValueLoader(tag.key, query);
     return values.map(({value}) => {
       // Truncate results to 5000 characters to avoid exceeding the max url query length
       // The message attribute for example can be 8192 characters.


### PR DESCRIPTION
We shouldn't strip flags[] for anything except the tagKeyValues API request. The flags[] wrapper is still needed to lookup from the searchbar's `filterKeys` map: https://github.com/getsentry/sentry/blob/63460542db4825e49a64face2ffefc05c90462bb/static/app/views/issueList/searchBar.tsx#L100

Checked w/dev-ui value queries are now being made and returning data. Right now prod isn't making the request at all due to this bug