### PR TITLE
feat(ourlogs): Update logs table and field renderers

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -434,6 +434,8 @@ export const CONFIG_DOCS_URL = 'https://develop.sentry.dev/config/';
 export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/product/discover-queries/';
 export const SPAN_PROPS_DOCS_URL =
   'https://docs.sentry.io/concepts/search/searchable-properties/spans/';
+export const LOGS_PROPS_DOCS_URL =
+  'https://docs.sentry.io/concepts/search/searchable-properties/logs/';
 
 export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
 export const NODE_ENV = process.env.NODE_ENV;

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -4,6 +4,7 @@ export const ALLOWED_WILDCARD_FIELDS = [
   'span.description',
   'span.domain',
   'span.status_code',
+  'log.body',
 ];
 export const EMPTY_OPTION_VALUE = '(empty)';
 

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -1,0 +1,99 @@
+import {useCallback} from 'react';
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+const LOGS_QUERY_KEY = 'logsQuery'; // Logs may exist on other pages.
+
+interface LogsPageParams {
+  readonly search: MutableSearch;
+}
+
+type LogPageParamsUpdate = Partial<LogsPageParams>;
+
+const [_LogsPageParamsProvider, useLogsPageParams, LogsPageParamsContext] =
+  createDefinedContext<LogsPageParams>({
+    name: 'LogsPageParamsContext',
+  });
+
+export function LogsPageParamsProvider({children}: {children: React.ReactNode}) {
+  const location = useLocation();
+  const logsQuery = decodeLogsQuery(location);
+  const search = new MutableSearch(logsQuery);
+
+  return (
+    <LogsPageParamsContext.Provider value={{search}}>
+      {children}
+    </LogsPageParamsContext.Provider>
+  );
+}
+
+const decodeLogsQuery = (location: Location): string => {
+  if (!location.query || !location.query[LOGS_QUERY_KEY]) {
+    return '';
+  }
+
+  const queryParameter = location.query[LOGS_QUERY_KEY];
+
+  return decodeScalar(queryParameter, '').trim();
+};
+
+function setLogsPageParams(location: Location, pageParams: LogPageParamsUpdate) {
+  const target: Location = {...location, query: {...location.query}};
+  updateNullableLocation(target, LOGS_QUERY_KEY, pageParams.search?.formatString());
+  return target;
+}
+
+/**
+ * Allows updating a location field, removing it if the value is null.
+ *
+ * Return true if the location field was updated, in case of side effects.
+ */
+function updateNullableLocation(
+  location: Location,
+  key: string,
+  value: string | string[] | null | undefined
+): boolean {
+  if (defined(value) && location.query[key] !== value) {
+    location.query[key] = value;
+    return true;
+  }
+  if (value === null && location.query[key]) {
+    delete location.query[key];
+    return true;
+  }
+  return false;
+}
+
+function useSetLogsPageParams() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (pageParams: LogPageParamsUpdate) => {
+      const target = setLogsPageParams(location, pageParams);
+      navigate(target);
+    },
+    [location, navigate]
+  );
+}
+
+export function useLogsSearch(): MutableSearch {
+  const {search} = useLogsPageParams();
+  return search;
+}
+
+export function useSetLogsQuery() {
+  const setPageParams = useSetLogsPageParams();
+  return useCallback(
+    (query: string) => {
+      setPageParams({search: new MutableSearch(query)});
+    },
+    [setPageParams]
+  );
+}

--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -14,17 +14,14 @@ export function defaultFields(): string[] {
   ];
 }
 
-export function getFieldsFromLocation(
-  location: Location,
-  locationDefaultFields: () => string[] = defaultFields
-): string[] {
+export function getFieldsFromLocation(location: Location): string[] {
   const fields = decodeList(location.query.field);
 
   if (fields.length) {
     return fields;
   }
 
-  return locationDefaultFields();
+  return defaultFields();
 }
 
 export function updateLocationWithFields(

--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -14,14 +14,17 @@ export function defaultFields(): string[] {
   ];
 }
 
-export function getFieldsFromLocation(location: Location): string[] {
+export function getFieldsFromLocation(
+  location: Location,
+  locationDefaultFields: () => string[] = defaultFields
+): string[] {
   const fields = decodeList(location.query.field);
 
   if (fields.length) {
     return fields;
   }
 
-  return defaultFields();
+  return locationDefaultFields();
 }
 
 export function updateLocationWithFields(

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -1,12 +1,9 @@
-import isNumber from 'lodash/isNumber';
-import moment from 'moment-timezone';
-
+import {DateTime} from 'sentry/components/dateTime';
 import {Tooltip} from 'sentry/components/tooltip';
-import getDynamicText from 'sentry/utils/getDynamicText';
-import {useUser} from 'sentry/utils/useUser';
 import {
   ColoredLogCircle,
   ColoredLogText,
+  type getLogColors,
   LogDate,
   LogsHighlight,
   WrappingText,
@@ -14,17 +11,19 @@ import {
 import {
   getLogSeverityLevel,
   SeverityLevel,
-  severityLevelToColorLevel,
   severityLevelToText,
 } from 'sentry/views/explore/logs/utils';
 
-export function severityCircleRenderer(severityNumber: number, severityText: string) {
+export function severityCircleRenderer(
+  severityNumber: number,
+  severityText: string,
+  logColors: ReturnType<typeof getLogColors>
+) {
   const level = getLogSeverityLevel(severityNumber, severityText);
   const levelLabel = severityLevelToText(level);
-  const levelColor = severityLevelToColorLevel(level);
   return (
     <Tooltip skipWrapper disabled={level === SeverityLevel.UNKNOWN} title={levelLabel}>
-      <ColoredLogCircle level={levelColor}>{severityText}</ColoredLogCircle>
+      <ColoredLogCircle logColors={logColors}>{severityText}</ColoredLogCircle>
     </Tooltip>
   );
 }
@@ -32,35 +31,20 @@ export function severityCircleRenderer(severityNumber: number, severityText: str
 export function severityTextRenderer(
   severityNumber: number,
   severityText: string,
+  logColors: ReturnType<typeof getLogColors>,
   useFullSeverityText: boolean = false
 ) {
   const level = getLogSeverityLevel(severityNumber, severityText);
   const levelLabel = useFullSeverityText ? level : severityLevelToText(level);
-  const levelColor = severityLevelToColorLevel(level);
-  return <ColoredLogText level={levelColor}>[{levelLabel}]</ColoredLogText>;
-}
-
-type RelaxedDateType = string | number | Date;
-function getDateObj(date: RelaxedDateType): Date {
-  return typeof date === 'string' || isNumber(date) ? new Date(date) : date;
+  return <ColoredLogText logColors={logColors}>[{levelLabel}]</ColoredLogText>;
 }
 
 export function TimestampRenderer({timestamp}: {timestamp: string}) {
-  const user = useUser();
-  const options = user ? user.options : null;
-
-  const baseFormat = 'MMM D, YYYY h:mm:ss A z';
-  const format = options?.clock24Hours ? 'MMMM D, YYYY HH:mm z' : baseFormat;
-
-  const dateObj = getDateObj(timestamp);
-
-  const date = getDynamicText({
-    fixed: options?.clock24Hours
-      ? 'November 3, 2020 08:57 UTC'
-      : 'November 3, 2020 8:58 AM UTC',
-    value: moment.tz(dateObj, options?.timezone ?? '').format(format),
-  });
-  return <LogDate>{date}</LogDate>;
+  return (
+    <LogDate>
+      <DateTime seconds date={timestamp} />
+    </LogDate>
+  );
 }
 
 export function bodyRenderer(

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -1,0 +1,78 @@
+import isNumber from 'lodash/isNumber';
+import moment from 'moment-timezone';
+
+import {Tooltip} from 'sentry/components/tooltip';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {useUser} from 'sentry/utils/useUser';
+import {
+  ColoredLogCircle,
+  ColoredLogText,
+  LogDate,
+  LogsHighlight,
+  WrappingText,
+} from 'sentry/views/explore/logs/styles';
+import {
+  getLogSeverityLevel,
+  SeverityLevel,
+  severityLevelToColorLevel,
+  severityLevelToText,
+} from 'sentry/views/explore/logs/utils';
+
+export function severityCircleRenderer(severityNumber: number, severityText: string) {
+  const level = getLogSeverityLevel(severityNumber, severityText);
+  const levelLabel = severityLevelToText(level);
+  const levelColor = severityLevelToColorLevel(level);
+  return (
+    <Tooltip skipWrapper disabled={level === SeverityLevel.UNKNOWN} title={levelLabel}>
+      <ColoredLogCircle level={levelColor}>{severityText}</ColoredLogCircle>
+    </Tooltip>
+  );
+}
+
+export function severityTextRenderer(
+  severityNumber: number,
+  severityText: string,
+  useFullSeverityText: boolean = false
+) {
+  const level = getLogSeverityLevel(severityNumber, severityText);
+  const levelLabel = useFullSeverityText ? level : severityLevelToText(level);
+  const levelColor = severityLevelToColorLevel(level);
+  return <ColoredLogText level={levelColor}>[{levelLabel}]</ColoredLogText>;
+}
+
+type RelaxedDateType = string | number | Date;
+function getDateObj(date: RelaxedDateType): Date {
+  return typeof date === 'string' || isNumber(date) ? new Date(date) : date;
+}
+
+export function TimestampRenderer({timestamp}: {timestamp: string}) {
+  const user = useUser();
+  const options = user ? user.options : null;
+
+  const baseFormat = 'MMM D, YYYY h:mm:ss A z';
+  const format = options?.clock24Hours ? 'MMMM D, YYYY HH:mm z' : baseFormat;
+
+  const dateObj = getDateObj(timestamp);
+
+  const date = getDynamicText({
+    fixed: options?.clock24Hours
+      ? 'November 3, 2020 08:57 UTC'
+      : 'November 3, 2020 8:58 AM UTC',
+    value: moment.tz(dateObj, options?.timezone ?? '').format(format),
+  });
+  return <LogDate>{date}</LogDate>;
+}
+
+export function bodyRenderer(
+  body: string,
+  highlightTerms: string[],
+  wrap: boolean = false
+) {
+  const highlightTerm = highlightTerms[0] ?? '';
+  // TODO: Allow more than one highlight term to be highlighted at once.
+  return (
+    <WrappingText wrap={wrap}>
+      <LogsHighlight text={highlightTerm}>{body}</LogsHighlight>
+    </WrappingText>
+  );
+}

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -4,6 +4,7 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 
@@ -24,11 +25,13 @@ export default function LogsPage() {
               </Layout.Title>
             </Layout.HeaderContent>
           </Layout.Header>
-          <LogsTabContent
-            defaultPeriod={defaultPeriod}
-            maxPickableDays={maxPickableDays}
-            relativeOptions={relativeOptions}
-          />
+          <LogsPageParamsProvider>
+            <LogsTabContent
+              defaultPeriod={defaultPeriod}
+              maxPickableDays={maxPickableDays}
+              relativeOptions={relativeOptions}
+            />
+          </LogsPageParamsProvider>
         </Layout.Page>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -9,7 +8,10 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {
+  useLogsSearch,
+  useSetLogsQuery,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsTable} from 'sentry/views/explore/logs/logsTable';
 import type {DefaultPeriod, MaxPickableDays} from 'sentry/views/explore/utils';
 
@@ -24,7 +26,8 @@ export function LogsTabContent({
   maxPickableDays,
   relativeOptions,
 }: LogsTabProps) {
-  const [search, setSearch] = useState(new MutableSearch(''));
+  const setLogsQuery = useSetLogsQuery();
+  const logsSearch = useLogsSearch();
   return (
     <Layout.Body>
       <Layout.Main fullWidth>
@@ -45,14 +48,14 @@ export function LogsTabContent({
             placeholder={t('Search for logs')}
             filterKeys={{}}
             getTagValues={() => new Promise<string[]>(() => [])}
-            initialQuery=""
+            initialQuery={logsSearch.formatString()}
             searchSource="ourlogs"
-            onSearch={query => setSearch(new MutableSearch(query))}
+            onSearch={setLogsQuery}
           />
         </FilterBarContainer>
       </Layout.Main>
       <LogsTableContainer fullWidth>
-        <LogsTable search={search} />
+        <LogsTable search={logsSearch} />
       </LogsTableContainer>
     </Layout.Body>
   );

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -45,10 +45,10 @@ type LogsRowProps = {
 };
 
 const LOG_FIELDS: Array<keyof OurlogsFields> = [
-  'sentry.severity_text',
+  'log.severity_text',
   'log.severity_number',
-  'sentry.body',
-  'sentry.timestamp',
+  'log.body',
+  'timestamp',
 ];
 
 export function LogsTable(props: LogsTableProps) {
@@ -121,7 +121,7 @@ function LogsRow({dataRow, highlightTerms}: LogsRowProps) {
   const theme = useTheme();
   const level = getLogSeverityLevel(
     dataRow['log.severity_number'],
-    dataRow['sentry.severity_text']
+    dataRow['log.severity_text']
   );
   const logColors = getLogColors(level, theme);
 
@@ -137,20 +137,20 @@ function LogsRow({dataRow, highlightTerms}: LogsRowProps) {
         />
         {severityCircleRenderer(
           dataRow['log.severity_number'],
-          dataRow['sentry.severity_text'],
+          dataRow['log.severity_text'],
           logColors
         )}
         {severityTextRenderer(
           dataRow['log.severity_number'],
-          dataRow['sentry.severity_text'],
+          dataRow['log.severity_text'],
           logColors
         )}
       </StyledPanelItem>
       <StyledPanelItem overflow>
-        {bodyRenderer(dataRow['sentry.body'], highlightTerms)}
+        {bodyRenderer(dataRow['log.body'], highlightTerms)}
       </StyledPanelItem>
       <StyledPanelItem align="right">
-        <TimestampRenderer timestamp={dataRow['sentry.timestamp']} />
+        <TimestampRenderer timestamp={dataRow.timestamp} />
       </StyledPanelItem>
       {expanded && <LogDetails dataRow={dataRow} highlightTerms={highlightTerms} />}
     </Fragment>
@@ -166,7 +166,7 @@ function LogDetails({
 }) {
   const level = getLogSeverityLevel(
     dataRow['log.severity_number'],
-    dataRow['sentry.severity_text']
+    dataRow['log.severity_text']
   );
   const theme = useTheme();
   const logColors = getLogColors(level, theme);
@@ -176,7 +176,7 @@ function LogDetails({
         <DetailsSubGrid>
           <DetailsLabel>Timestamp</DetailsLabel>
           <DetailsValue>
-            <TimestampRenderer timestamp={dataRow['sentry.timestamp']} />
+            <TimestampRenderer timestamp={dataRow.timestamp} />
           </DetailsValue>
         </DetailsSubGrid>
         <DetailsSubGrid>
@@ -184,7 +184,7 @@ function LogDetails({
           <DetailsValue>
             {severityTextRenderer(
               dataRow['log.severity_number'],
-              dataRow['sentry.severity_text'],
+              dataRow['log.severity_text'],
               logColors,
               true
             )}
@@ -192,7 +192,7 @@ function LogDetails({
         </DetailsSubGrid>
       </DetailsGrid>
       <DetailsFooter logColors={logColors}>
-        {bodyRenderer(dataRow['sentry.body'], highlightTerms, true)}
+        {bodyRenderer(dataRow['log.body'], highlightTerms, true)}
       </DetailsFooter>
     </DetailsWrapper>
   );

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -118,6 +118,12 @@ export function LogsTable(props: LogsTableProps) {
 function LogsRow({dataRow, highlightTerms}: LogsRowProps) {
   const [expanded, setExpanded] = useState<boolean>(false);
   const onClickExpand = useCallback(() => setExpanded(e => !e), [setExpanded]);
+  const theme = useTheme();
+  const level = getLogSeverityLevel(
+    dataRow['log.severity_number'],
+    dataRow['sentry.severity_text']
+  );
+  const logColors = getLogColors(level, theme);
 
   return (
     <Fragment>
@@ -131,11 +137,13 @@ function LogsRow({dataRow, highlightTerms}: LogsRowProps) {
         />
         {severityCircleRenderer(
           dataRow['log.severity_number'],
-          dataRow['sentry.severity_text']
+          dataRow['sentry.severity_text'],
+          logColors
         )}
         {severityTextRenderer(
           dataRow['log.severity_number'],
-          dataRow['sentry.severity_text']
+          dataRow['sentry.severity_text'],
+          logColors
         )}
       </StyledPanelItem>
       <StyledPanelItem overflow>
@@ -177,6 +185,7 @@ function LogDetails({
             {severityTextRenderer(
               dataRow['log.severity_number'],
               dataRow['sentry.severity_text'],
+              logColors,
               true
             )}
           </DetailsValue>

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -1,58 +1,190 @@
-import GridEditable from 'sentry/components/gridEditable';
-import TimeSince from 'sentry/components/timeSince';
+import {Fragment, useCallback, useState} from 'react';
+import {useTheme} from '@emotion/react';
+
+import EmptyStateWarning, {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
+import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {LOGS_PROPS_DOCS_URL} from 'sentry/constants';
+import {IconWarning} from 'sentry/icons';
+import {IconChevron} from 'sentry/icons/iconChevron';
+import {t, tct} from 'sentry/locale';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {
+  bodyRenderer,
+  severityCircleRenderer,
+  severityTextRenderer,
+  TimestampRenderer,
+} from 'sentry/views/explore/logs/fieldRenderers';
 import {useOurlogs} from 'sentry/views/insights/common/queries/useDiscover';
 import type {OurlogsFields} from 'sentry/views/insights/types';
+import {EmptyStateText} from 'sentry/views/traces/styles';
+
+import {
+  DetailsFooter,
+  DetailsGrid,
+  DetailsLabel,
+  DetailsSubGrid,
+  DetailsValue,
+  DetailsWrapper,
+  getLogColors,
+  LogPanelContent,
+  StyledChevronButton,
+  StyledPanel,
+  StyledPanelHeader,
+  StyledPanelItem,
+} from './styles';
+import {getLogBodySearchTerms, getLogSeverityLevel} from './utils';
 
 export type LogsTableProps = {
   search: MutableSearch;
 };
 
+type LogsRowProps = {
+  dataRow: OurlogsFields;
+  highlightTerms: string[];
+};
+
+const LOG_FIELDS: Array<keyof OurlogsFields> = [
+  'sentry.severity_text',
+  'log.severity_number',
+  'sentry.body',
+  'sentry.timestamp',
+];
+
 export function LogsTable(props: LogsTableProps) {
-  const {data, error, isPending} = useOurlogs(
+  const {data, isError, isPending} = useOurlogs(
     {
       limit: 100,
       sorts: [],
-      fields: ['sentry.severity_text', 'sentry.body', 'sentry.timestamp'],
+      fields: LOG_FIELDS,
       search: props.search,
     },
     'api.logs-tab.view'
   );
+
+  const isEmpty = !isPending && !isError && (data?.length ?? 0) === 0;
+  const highlightTerms = getLogBodySearchTerms(props.search);
+
   return (
-    <GridEditable<OurlogsFields, keyof OurlogsFields>
-      isLoading={isPending}
-      columnOrder={[
-        {key: 'sentry.severity_text', name: 'Severity', width: 60},
-        {key: 'sentry.body', name: 'Body', width: 500},
-        {key: 'sentry.timestamp', name: 'Timestamp', width: 90},
-      ]}
-      columnSortBy={[]}
-      data={data}
-      error={error}
-      grid={{
-        renderHeadCell: col => {
-          return <div>{col.name}</div>;
-        },
-        renderBodyCell: (col, dataRow) => {
-          if (col.key === 'sentry.timestamp') {
-            return timestampRenderer(dataRow['sentry.timestamp']);
-          }
-          if (col.key === 'sentry.severity_text') {
-            return severityTextRenderer(dataRow['sentry.severity_text']);
-          }
-          return <div>{dataRow[col.key]}</div>;
-        },
-      }}
-    />
+    <StyledPanel>
+      <LogPanelContent>
+        <StyledPanelHeader align="left" lightText>
+          {t('Severity')}
+        </StyledPanelHeader>
+        <StyledPanelHeader align="left" lightText>
+          {t('Message')}
+        </StyledPanelHeader>
+        <StyledPanelHeader align="right" lightText>
+          {t('Timestamp')}
+        </StyledPanelHeader>
+        {isPending && (
+          <StyledPanelItem span={3} overflow>
+            <LoadingIndicator />
+          </StyledPanelItem>
+        )}
+        {isError && (
+          <StyledPanelItem span={3} overflow>
+            <EmptyStreamWrapper>
+              <IconWarning color="gray300" size="lg" />
+            </EmptyStreamWrapper>
+          </StyledPanelItem>
+        )}
+        {isEmpty && (
+          <StyledPanelItem span={3} overflow>
+            <EmptyStateWarning withIcon>
+              <EmptyStateText size="fontSizeExtraLarge">
+                {t('No logs found')}
+              </EmptyStateText>
+              <EmptyStateText size="fontSizeMedium">
+                {tct('Try adjusting your filters or refer to [docSearchProps].', {
+                  docSearchProps: (
+                    <ExternalLink href={LOGS_PROPS_DOCS_URL}>
+                      {t('docs for search properties')}
+                    </ExternalLink>
+                  ),
+                })}
+              </EmptyStateText>
+            </EmptyStateWarning>
+          </StyledPanelItem>
+        )}
+        {data?.map((row, index) => (
+          <LogsRow key={index} dataRow={row} highlightTerms={highlightTerms} />
+        ))}
+      </LogPanelContent>
+    </StyledPanel>
   );
 }
 
-function severityTextRenderer(text: string) {
-  return <div>{text.toUpperCase().slice(0, 4)}</div>;
+function LogsRow({dataRow, highlightTerms}: LogsRowProps) {
+  const [expanded, setExpanded] = useState<boolean>(false);
+  const onClickExpand = useCallback(() => setExpanded(e => !e), [setExpanded]);
+
+  return (
+    <Fragment>
+      <StyledPanelItem align="left" center onClick={onClickExpand}>
+        <StyledChevronButton
+          icon={<IconChevron size="xs" direction={expanded ? 'down' : 'right'} />}
+          aria-label={t('Toggle trace details')}
+          aria-expanded={expanded}
+          size="zero"
+          borderless
+        />
+        {severityCircleRenderer(
+          dataRow['log.severity_number'],
+          dataRow['sentry.severity_text']
+        )}
+        {severityTextRenderer(
+          dataRow['log.severity_number'],
+          dataRow['sentry.severity_text']
+        )}
+      </StyledPanelItem>
+      <StyledPanelItem overflow>
+        {bodyRenderer(dataRow['sentry.body'], highlightTerms)}
+      </StyledPanelItem>
+      <StyledPanelItem align="right">
+        <TimestampRenderer timestamp={dataRow['sentry.timestamp']} />
+      </StyledPanelItem>
+      {expanded && <LogDetails dataRow={dataRow} highlightTerms={highlightTerms} />}
+    </Fragment>
+  );
 }
 
-function timestampRenderer(timestamp: string) {
+function LogDetails({
+  dataRow,
+  highlightTerms,
+}: {
+  dataRow: OurlogsFields;
+  highlightTerms: string[];
+}) {
+  const level = getLogSeverityLevel(
+    dataRow['log.severity_number'],
+    dataRow['sentry.severity_text']
+  );
+  const theme = useTheme();
+  const logColors = getLogColors(level, theme);
   return (
-    <TimeSince unitStyle="extraShort" date={new Date(timestamp)} tooltipShowSeconds />
+    <DetailsWrapper span={3}>
+      <DetailsGrid>
+        <DetailsSubGrid>
+          <DetailsLabel>Timestamp</DetailsLabel>
+          <DetailsValue>
+            <TimestampRenderer timestamp={dataRow['sentry.timestamp']} />
+          </DetailsValue>
+        </DetailsSubGrid>
+        <DetailsSubGrid>
+          <DetailsLabel>Severity</DetailsLabel>
+          <DetailsValue>
+            {severityTextRenderer(
+              dataRow['log.severity_number'],
+              dataRow['sentry.severity_text'],
+              true
+            )}
+          </DetailsValue>
+        </DetailsSubGrid>
+      </DetailsGrid>
+      <DetailsFooter logColors={logColors}>
+        {bodyRenderer(dataRow['sentry.body'], highlightTerms, true)}
+      </DetailsFooter>
+    </DetailsWrapper>
   );
 }

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -42,7 +42,7 @@ export const StyledPanelItem = styled(PanelItem)<{
 export const LogPanelContent = styled('div')`
   width: 100%;
   display: grid;
-  grid-template-columns: 95px auto min-content;
+  grid-template-columns: min-content auto min-content;
 `;
 
 export const LogRowContent = styled('div')`
@@ -116,7 +116,7 @@ export const StyledChevronButton = styled(Button)`
 const DEFAULT_SIZE = '8px';
 
 export const ColoredLogCircle = styled('span')<{
-  level: 'sample' | 'info' | 'warning' | 'error' | 'fatal' | 'default' | 'unknown';
+  logColors: ReturnType<typeof getLogColors>;
   size?: string;
 }>`
   padding: 0;
@@ -128,13 +128,13 @@ export const ColoredLogCircle = styled('span')<{
   display: inline-block;
   border-radius: 50%;
   flex-shrink: 0;
-  background-color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
+  background-color: ${p => p.logColors.background};
 `;
 
 export const ColoredLogText = styled('span')<{
-  level: 'sample' | 'info' | 'warning' | 'error' | 'fatal' | 'default' | 'unknown';
+  logColors: ReturnType<typeof getLogColors>;
 }>`
-  color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
+  color: ${p => p.logColors.color};
   font-weight: ${p => p.theme.fontWeightBold};
   font-family: ${p => p.theme.text.familyMono};
 `;
@@ -164,7 +164,7 @@ export function getLogColors(level: SeverityLevel, theme: Theme) {
         backgroundLight: theme.backgroundSecondary,
         border: theme.border,
         borderHover: theme.border,
-        color: 'inherit',
+        color: theme.gray200,
       };
     case SeverityLevel.TRACE:
       return {
@@ -183,12 +183,13 @@ export function getLogColors(level: SeverityLevel, theme: Theme) {
         color: theme.yellow400,
       };
     case SeverityLevel.ERROR:
+      // All these colours are likely changing, so we'll hold off moving them into theme for now.
       return {
-        background: theme.red300,
-        backgroundLight: theme.red100,
-        border: theme.red200,
-        borderHover: theme.red300,
-        color: theme.red400,
+        background: '#FF7738', // Matches the legacy error level color
+        backgroundLight: 'rgba(245, 113, 54, 0.11)',
+        border: 'rgba(245, 113, 54, 0.55)',
+        borderHover: '#FF7738',
+        color: '#b34814',
       };
     case SeverityLevel.FATAL:
       return {
@@ -204,7 +205,7 @@ export function getLogColors(level: SeverityLevel, theme: Theme) {
         backgroundLight: theme.gray100,
         border: theme.gray200,
         borderHover: theme.gray300,
-        color: theme.gray400,
+        color: theme.gray300,
       };
     case SeverityLevel.INFO:
       return {
@@ -220,7 +221,7 @@ export function getLogColors(level: SeverityLevel, theme: Theme) {
         backgroundLight: theme.gray100,
         border: theme.gray200,
         borderHover: theme.gray300,
-        color: theme.gray400,
+        color: theme.gray200,
       };
     default:
       unreachable(level);

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -1,0 +1,234 @@
+import type {Theme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {HighlightComponent} from 'sentry/components/highlight';
+import Panel from 'sentry/components/panels/panel';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import PanelItem from 'sentry/components/panels/panelItem';
+import {space} from 'sentry/styles/space';
+import {SeverityLevel} from 'sentry/views/explore/logs/utils';
+
+export const StyledPanel = styled(Panel)`
+  margin-bottom: 0px;
+`;
+
+export const StyledPanelHeader = styled(PanelHeader)<{align: 'left' | 'right'}>`
+  white-space: nowrap;
+  justify-content: ${p => (p.align === 'left' ? 'flex-start' : 'flex-end')};
+`;
+
+export const StyledPanelItem = styled(PanelItem)<{
+  align?: 'left' | 'center' | 'right';
+  overflow?: boolean;
+  span?: number;
+}>`
+  align-items: center;
+  padding: ${space(1)} ${space(2)};
+  ${p => (p.align === 'left' ? 'justify-content: flex-start;' : null)}
+  ${p => (p.align === 'right' ? 'justify-content: flex-end;' : null)}
+  ${p => (p.overflow ? p.theme.overflowEllipsis : null)};
+  ${p =>
+    p.align === 'center'
+      ? `
+  justify-content: space-around;`
+      : p.align === 'left' || p.align === 'right'
+        ? `text-align: ${p.align};`
+        : undefined}
+  ${p => p.span && `grid-column: auto / span ${p.span};`}
+  white-space: nowrap;
+`;
+
+export const LogPanelContent = styled('div')`
+  width: 100%;
+  display: grid;
+  grid-template-columns: 95px auto min-content;
+`;
+
+export const LogRowContent = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const DetailsWrapper = styled(StyledPanelItem)`
+  background-color: ${p => p.theme.gray100};
+  flex-direction: column;
+`;
+
+export const DetailsGrid = styled(StyledPanel)`
+  display: grid;
+  grid-template-columns: 1fr;
+  width: 100%;
+  gap: ${space(1)} ${space(2)};
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding: ${space(1)} ${space(2)};
+`;
+
+export const DetailsSubGrid = styled('div')`
+  display: grid;
+  grid-template-columns: min-content min-content;
+`;
+
+export const DetailsFooter = styled(StyledPanelItem)<{
+  logColors: ReturnType<typeof getLogColors>;
+  opaque?: boolean;
+}>`
+  width: 100%;
+  padding: ${space(1)} ${space(2)};
+  color: ${p => p.logColors.color};
+
+  &:last-child {
+    border: 1px solid ${p => p.logColors.border};
+  }
+
+  border-bottom-left-radius: ${p => p.theme.borderRadius};
+  border-bottom-right-radius: ${p => p.theme.borderRadius};
+
+  background: ${p =>
+    p.opaque
+      ? `linear-gradient(
+          ${p.logColors.backgroundLight},
+          ${p.logColors.backgroundLight}),
+          linear-gradient(${p.theme.background}, ${p.theme.background}
+        )`
+      : `
+          ${p.logColors.backgroundLight}
+        `};
+`;
+
+export const DetailsLabel = styled('div')`
+  font-weight: 600;
+  min-width: 100px;
+  color: ${p => p.theme.gray300};
+`;
+
+export const DetailsValue = styled('div')`
+  word-break: break-word;
+`;
+
+export const StyledChevronButton = styled(Button)`
+  margin-right: ${space(0.5)};
+`;
+
+const DEFAULT_SIZE = '8px';
+
+export const ColoredLogCircle = styled('span')<{
+  level: 'sample' | 'info' | 'warning' | 'error' | 'fatal' | 'default' | 'unknown';
+  size?: string;
+}>`
+  padding: 0;
+  position: relative;
+  width: ${p => p.size || DEFAULT_SIZE};
+  height: ${p => p.size || DEFAULT_SIZE};
+  margin-right: ${space(0.5)};
+  text-indent: -9999em;
+  display: inline-block;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background-color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
+`;
+
+export const ColoredLogText = styled('span')<{
+  level: 'sample' | 'info' | 'warning' | 'error' | 'fatal' | 'default' | 'unknown';
+}>`
+  color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
+  font-weight: ${p => p.theme.fontWeightBold};
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+export const LogDate = styled('span')`
+  color: ${p => p.theme.gray300};
+`;
+
+export const LogsHighlight = styled(HighlightComponent)`
+  font-weight: ${p => p.theme.fontWeightBold};
+  background-color: ${p => p.theme.gray200};
+  margin-right: 2px;
+  margin-left: 2px;
+`;
+
+export const WrappingText = styled('div')<{wrap?: boolean}>`
+  width: 100%;
+  ${p => p.theme.overflowEllipsis};
+  ${p => p.wrap && 'text-wrap: auto;'}
+`;
+
+export function getLogColors(level: SeverityLevel, theme: Theme) {
+  switch (level) {
+    case SeverityLevel.DEFAULT:
+      return {
+        background: theme.gray200,
+        backgroundLight: theme.backgroundSecondary,
+        border: theme.border,
+        borderHover: theme.border,
+        color: 'inherit',
+      };
+    case SeverityLevel.TRACE:
+      return {
+        background: theme.blue300,
+        backgroundLight: theme.blue100,
+        border: theme.blue200,
+        borderHover: theme.blue300,
+        color: theme.blue400,
+      };
+    case SeverityLevel.WARN:
+      return {
+        background: theme.yellow300,
+        backgroundLight: theme.yellow100,
+        border: theme.yellow200,
+        borderHover: theme.yellow300,
+        color: theme.yellow400,
+      };
+    case SeverityLevel.ERROR:
+      return {
+        background: theme.red300,
+        backgroundLight: theme.red100,
+        border: theme.red200,
+        borderHover: theme.red300,
+        color: theme.red400,
+      };
+    case SeverityLevel.FATAL:
+      return {
+        background: theme.red300,
+        backgroundLight: theme.red100,
+        border: theme.red200,
+        borderHover: theme.red300,
+        color: theme.red400,
+      };
+    case SeverityLevel.DEBUG:
+      return {
+        background: theme.gray300,
+        backgroundLight: theme.gray100,
+        border: theme.gray200,
+        borderHover: theme.gray300,
+        color: theme.gray400,
+      };
+    case SeverityLevel.INFO:
+      return {
+        background: theme.blue300,
+        backgroundLight: theme.blue100,
+        border: theme.blue200,
+        borderHover: theme.blue300,
+        color: theme.blue400,
+      };
+    case SeverityLevel.UNKNOWN:
+      return {
+        background: theme.gray300,
+        backgroundLight: theme.gray100,
+        border: theme.gray200,
+        borderHover: theme.gray300,
+        color: theme.gray400,
+      };
+    default:
+      unreachable(level);
+      throw new Error(`Invalid log type, got ${level}`);
+  }
+}
+
+// One day we'll have `match`.
+function unreachable(x: never) {
+  return x;
+}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -24,7 +24,7 @@ export const StyledPanelItem = styled(PanelItem)<{
   span?: number;
 }>`
   align-items: center;
-  padding: ${space(1)} ${space(2)};
+  padding: ${space(1)} ${space(1)};
   ${p => (p.align === 'left' ? 'justify-content: flex-start;' : null)}
   ${p => (p.align === 'right' ? 'justify-content: flex-end;' : null)}
   ${p => (p.overflow ? p.theme.overflowEllipsis : null)};

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -6,6 +6,7 @@ export function getLogSeverityLevel(
   severityText: string | null
 ): SeverityLevel {
   // Defer to the severity number if it is provided
+  // Currently follows https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
   if (severityNumber) {
     if (severityNumber >= 1 && severityNumber <= 4) {
       return SeverityLevel.TRACE;
@@ -45,8 +46,8 @@ export function getLogSeverityLevel(
     }
   }
 
-  //
-  return SeverityLevel.DEFAULT;
+  // If the severity number isn't in range or the severity text can't map to a level, the severity level is unknown.
+  return SeverityLevel.UNKNOWN;
 }
 
 /**
@@ -77,40 +78,15 @@ export enum SeverityLevel {
  */
 export function severityLevelToText(level: SeverityLevel) {
   return {
-    [SeverityLevel.TRACE]: t('TRAC'),
-    [SeverityLevel.DEBUG]: t('DEBU'),
+    [SeverityLevel.TRACE]: t('TRACE'),
+    [SeverityLevel.DEBUG]: t('DEBUG'),
     [SeverityLevel.INFO]: t('INFO'),
     [SeverityLevel.WARN]: t('WARN'),
-    [SeverityLevel.ERROR]: t('ERRO'),
-    [SeverityLevel.FATAL]: t('CRIT'),
-    [SeverityLevel.DEFAULT]: t('DEFA'),
-    [SeverityLevel.UNKNOWN]: t('INFO'), // Maps to info for now.
+    [SeverityLevel.ERROR]: t('ERROR'),
+    [SeverityLevel.FATAL]: t('FATAL'),
+    [SeverityLevel.DEFAULT]: t('DEFAULT'),
+    [SeverityLevel.UNKNOWN]: t('UNKNOWN'), // Maps to info for now.
   }[level];
-}
-
-type SeverityColorLevel =
-  | 'sample'
-  | 'info'
-  | 'warning'
-  | 'error'
-  | 'fatal'
-  | 'default'
-  | 'unknown';
-
-/**
- * Maps all internal severity levels to the appropriate color level, making use of the existing issues colors to maintain consistency.
- */
-export function severityLevelToColorLevel(level: SeverityLevel): SeverityColorLevel {
-  return {
-    [SeverityLevel.DEFAULT]: 'default',
-    [SeverityLevel.TRACE]: 'info',
-    [SeverityLevel.DEBUG]: 'info',
-    [SeverityLevel.INFO]: 'info',
-    [SeverityLevel.WARN]: 'warning',
-    [SeverityLevel.ERROR]: 'error',
-    [SeverityLevel.FATAL]: 'fatal',
-    [SeverityLevel.UNKNOWN]: 'info',
-  }[level] as SeverityColorLevel;
 }
 
 export function getLogBodySearchTerms(search: MutableSearch): string[] {

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -1,0 +1,125 @@
+import {t} from 'sentry/locale';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+
+export function getLogSeverityLevel(
+  severityNumber: number | null,
+  severityText: string | null
+): SeverityLevel {
+  // Defer to the severity number if it is provided
+  if (severityNumber) {
+    if (severityNumber >= 1 && severityNumber <= 4) {
+      return SeverityLevel.TRACE;
+    }
+    if (severityNumber >= 5 && severityNumber <= 8) {
+      return SeverityLevel.DEBUG;
+    }
+    if (severityNumber >= 9 && severityNumber <= 12) {
+      return SeverityLevel.INFO;
+    }
+    if (severityNumber >= 13 && severityNumber <= 16) {
+      return SeverityLevel.WARN;
+    }
+    if (severityNumber >= 17 && severityNumber <= 20) {
+      return SeverityLevel.ERROR;
+    }
+    if (severityNumber >= 21 && severityNumber <= 24) {
+      return SeverityLevel.FATAL;
+    }
+  }
+
+  // Otherwise use severity text if it's a case insensitive match for one of the severity levels
+  if (severityText) {
+    const upperText = severityText.toUpperCase();
+    const validLevels = [
+      SeverityLevel.TRACE,
+      SeverityLevel.DEBUG,
+      SeverityLevel.INFO,
+      SeverityLevel.WARN,
+      SeverityLevel.ERROR,
+      SeverityLevel.FATAL,
+      SeverityLevel.DEFAULT,
+      SeverityLevel.UNKNOWN,
+    ];
+    if (validLevels.includes(upperText as SeverityLevel)) {
+      return upperText as SeverityLevel;
+    }
+  }
+
+  //
+  return SeverityLevel.DEFAULT;
+}
+
+/**
+ * This level is the source of truth for the severity level.
+ * Currently overlaps with the OpenTelemetry log severity level, with the addition of DEFAULT and UNKNOWN.
+ */
+export enum SeverityLevel {
+  // A fine-grained debugging event. Typically disabled in default configurations.
+  TRACE = 'TRACE',
+  // A debugging event.
+  DEBUG = 'DEBUG',
+  // An informational event. Indicates that an event happened.
+  INFO = 'INFO',
+  // A warning event. Not an error but is likely more important than an informational event.
+  WARN = 'WARN',
+  // An error event. Something went wrong.
+  ERROR = 'ERROR',
+  // A fatal error such as application or system crash.
+  FATAL = 'FATAL',
+  // The log entry has no assigned severity level.
+  DEFAULT = 'DEFAULT',
+  // Unknown severity level, no severity text or number provided.
+  UNKNOWN = 'UNKNOWN',
+}
+
+/**
+ * Maps all internal severity levels to the appropriate text level. Should all be 4 characters for display purposes.
+ */
+export function severityLevelToText(level: SeverityLevel) {
+  return {
+    [SeverityLevel.TRACE]: t('TRAC'),
+    [SeverityLevel.DEBUG]: t('DEBU'),
+    [SeverityLevel.INFO]: t('INFO'),
+    [SeverityLevel.WARN]: t('WARN'),
+    [SeverityLevel.ERROR]: t('ERRO'),
+    [SeverityLevel.FATAL]: t('CRIT'),
+    [SeverityLevel.DEFAULT]: t('DEFA'),
+    [SeverityLevel.UNKNOWN]: t('INFO'), // Maps to info for now.
+  }[level];
+}
+
+type SeverityColorLevel =
+  | 'sample'
+  | 'info'
+  | 'warning'
+  | 'error'
+  | 'fatal'
+  | 'default'
+  | 'unknown';
+
+/**
+ * Maps all internal severity levels to the appropriate color level, making use of the existing issues colors to maintain consistency.
+ */
+export function severityLevelToColorLevel(level: SeverityLevel): SeverityColorLevel {
+  return {
+    [SeverityLevel.DEFAULT]: 'default',
+    [SeverityLevel.TRACE]: 'info',
+    [SeverityLevel.DEBUG]: 'info',
+    [SeverityLevel.INFO]: 'info',
+    [SeverityLevel.WARN]: 'warning',
+    [SeverityLevel.ERROR]: 'error',
+    [SeverityLevel.FATAL]: 'fatal',
+    [SeverityLevel.UNKNOWN]: 'info',
+  }[level] as SeverityColorLevel;
+}
+
+export function getLogBodySearchTerms(search: MutableSearch): string[] {
+  const searchTerms: string[] = search.freeText.map(text => text.replaceAll('*', ''));
+  const bodyFilters = search.getFilterValues('log.body');
+  for (const filter of bodyFilters) {
+    if (!filter.startsWith('!') && !filter.startsWith('[')) {
+      searchTerms.push(filter);
+    }
+  }
+  return searchTerms;
+}

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -433,11 +433,11 @@ export const subregionCodeToName = {
 export type SubregionCode = keyof typeof subregionCodeToName;
 
 export type OurlogsFields = {
+  'log.body': string;
   'log.severity_number': number;
-  'sentry.body': string;
+  'log.severity_text': string;
   'sentry.organization_id': number;
   'sentry.project_id': number;
-  'sentry.severity_text': string;
   'sentry.span_id': string;
-  'sentry.timestamp': string;
+  timestamp: string;
 };

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -433,7 +433,11 @@ export const subregionCodeToName = {
 export type SubregionCode = keyof typeof subregionCodeToName;
 
 export type OurlogsFields = {
+  'log.severity_number': number;
   'sentry.body': string;
+  'sentry.organization_id': number;
+  'sentry.project_id': number;
   'sentry.severity_text': string;
+  'sentry.span_id': string;
   'sentry.timestamp': string;
 };


### PR DESCRIPTION
### Summary
This adds field renders closer to the initial mocks, as well as the accordion structure to open each log line. Custom attributes will come in a subsequent PR as they might need a structure similar to EventTagsTree.


#### Other
- We're only showing one highlight term for the time being, since the highlight component only allows for one, we may change that in the future. 
- There is [trouble](https://github.com/getsentry/sentry/pull/84962) with the aliases (eg. `log.severity_number`) hence why it's switching between `sentry.___` and `log.___`, which we'll fix up after the backend api is fixed.
- Timestamps seem to be off a few hours (by the timezone offset), which has to be fixed upstream. 
- The new context has too many differences to re-use explore page params, perhaps we can in the future.
- Colors, log level etc. are not finalized, but these mostly match the mocks. We'll do another pass before LA, the severity text color is identical to `theme.level` minus some missing levels, and the detailed log body component colors are similar to alerts, again, minus some missing levels.

#### Screenshot
![Screenshot 2025-02-12 at 3 31 27 PM](https://github.com/user-attachments/assets/19f45400-cb34-4f0e-91cf-b8c682c7b7da)
