### PR TITLE
feat(crons): Add the timeline to the graph section of cron issues

### DIFF
--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -26,6 +26,7 @@ interface CheckInTimelineConfig<Status extends string> {
   statusStyle: Record<Status, TickStyle>;
   timeWindowConfig: TimeWindowConfig;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export interface CheckInTimelineProps<Status extends string>
@@ -52,6 +53,7 @@ export function CheckInTimeline<Status extends string>({
   statusStyle,
   statusPrecedent,
   className,
+  style,
 }: CheckInTimelineProps<Status>) {
   const jobTicks = mergeBuckets(
     statusPrecedent,
@@ -60,7 +62,7 @@ export function CheckInTimeline<Status extends string>({
   );
 
   return (
-    <TimelineContainer role="figure" className={className}>
+    <TimelineContainer role="figure" className={className} style={style}>
       {jobTicks.map(jobTick => {
         const {left, startTs, width, stats, isStarting, isEnding} = jobTick;
 

--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -25,6 +25,7 @@ interface CheckInTimelineConfig<Status extends string> {
    */
   statusStyle: Record<Status, TickStyle>;
   timeWindowConfig: TimeWindowConfig;
+  className?: string;
 }
 
 export interface CheckInTimelineProps<Status extends string>
@@ -50,6 +51,7 @@ export function CheckInTimeline<Status extends string>({
   statusLabel,
   statusStyle,
   statusPrecedent,
+  className,
 }: CheckInTimelineProps<Status>) {
   const jobTicks = mergeBuckets(
     statusPrecedent,
@@ -58,7 +60,7 @@ export function CheckInTimeline<Status extends string>({
   );
 
   return (
-    <TimelineContainer role="figure">
+    <TimelineContainer role="figure" className={className}>
       {jobTicks.map(jobTick => {
         const {left, startTs, width, stats, isStarting, isEnding} = jobTick;
 

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -279,7 +279,7 @@ const LabelsContainer = styled('div')<{labelPosition: LabelPosition}>`
     `}
 `;
 
-const Gridline = styled('div')<{labelPosition: LabelPosition; left: number}>`
+export const Gridline = styled('div')<{labelPosition: LabelPosition; left: number}>`
   position: absolute;
   left: ${p => p.left}px;
   ${p =>

--- a/static/app/utils/issueTypeConfig/cronConfig.tsx
+++ b/static/app/utils/issueTypeConfig/cronConfig.tsx
@@ -24,8 +24,8 @@ const cronConfig: IssueCategoryConfigMapping = {
       share: {enabled: true},
     },
     header: {
-      filterBar: {enabled: false, fixedEnvironment: true},
-      graph: {enabled: false},
+      filterBar: {enabled: true},
+      graph: {enabled: true, type: 'cron-checks'},
       tagDistribution: {enabled: false},
       occurrenceSummary: {enabled: false},
     },

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -69,7 +69,7 @@ export type IssueTypeConfig = {
       fixedEnvironment?: boolean;
     };
     graph: DisabledWithReasonConfig & {
-      type?: 'discover-events' | 'uptime-checks' | 'detector-history';
+      type?: 'detector-history' | 'discover-events' | 'cron-checks' | 'uptime-checks';
     };
     occurrenceSummary: DisabledWithReasonConfig & {
       downtime?: boolean;

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -98,7 +98,6 @@ interface UseHoverOverlayProps {
    * Offset along the main axis.
    */
   offset?: number;
-
   /**
    * Callback whenever the hovercard is blurred
    * See also `onHover`
@@ -115,6 +114,7 @@ interface UseHoverOverlayProps {
    * Position for the overlay.
    */
   position?: PopperProps<any>['placement'];
+
   /**
    * Only display the overlay only if the content overflows
    */
@@ -128,6 +128,10 @@ interface UseHoverOverlayProps {
    * If child node supports ref forwarding, you can skip apply a wrapper
    */
   skipWrapper?: boolean;
+  /**
+   * style for when a wrapper is used. Does nothing using skipWrapper.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Color of the dotted underline, if available. See also: showUnderline.
@@ -162,6 +166,7 @@ function useHoverOverlay(
   overlayType: string,
   {
     className,
+    style,
     delay,
     displayTimeout,
     isHoverable,
@@ -304,6 +309,7 @@ function useHoverOverlay(
           ...(showUnderline ? theme.tooltipUnderline(underlineColor) : {}),
           ...(containerDisplayMode ? {display: containerDisplayMode} : {}),
           maxWidth: '100%',
+          ...style,
         },
         className,
       });
@@ -320,6 +326,7 @@ function useHoverOverlay(
       showUnderline,
       skipWrapper,
       describeById,
+      style,
       theme,
       underlineColor,
     ]

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -219,7 +219,7 @@ export function EventDetailsContent({
       {!hasStreamlinedUI && group.issueCategory === IssueCategory.UPTIME && (
         <UptimeDataSection event={event} project={project} group={group} />
       )}
-      {group.issueCategory === IssueCategory.CRON && (
+      {!hasStreamlinedUI && group.issueCategory === IssueCategory.CRON && (
         <CronTimelineSection
           event={event}
           organization={organization}

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -22,6 +22,7 @@ import {
   EventSearch,
   useEventQuery,
 } from 'sentry/views/issueDetails/streamline/eventSearch';
+import {IssueCronCheckTimeline} from 'sentry/views/issueDetails/streamline/issueCronCheckTimeline';
 import IssueTagsPreview from 'sentry/views/issueDetails/streamline/issueTagsPreview';
 import {IssueUptimeCheckTimeline} from 'sentry/views/issueDetails/streamline/issueUptimeCheckTimeline';
 import {MetricIssueChart} from 'sentry/views/issueDetails/streamline/metricIssueChart';
@@ -65,6 +66,15 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
     'Filter %s\u2026',
     issueTypeConfig.customCopy.eventUnits.toLocaleLowerCase()
   );
+
+  const hasHeader =
+    issueTypeConfig.header.filterBar.enabled ||
+    issueTypeConfig.header.graph.enabled ||
+    issueTypeConfig.header.occurrenceSummary.enabled;
+
+  if (!hasHeader) {
+    return null;
+  }
 
   return (
     <PageErrorBoundary mini message={t('There was an error loading the event filters')}>
@@ -115,6 +125,9 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
             )}
             {issueTypeConfig.header.graph.type === 'uptime-checks' && (
               <IssueUptimeCheckTimeline group={group} />
+            )}
+            {issueTypeConfig.header.graph.type === 'cron-checks' && (
+              <IssueCronCheckTimeline group={group} />
             )}
             {issueTypeConfig.header.tagDistribution.enabled && (
               <IssueTagsPreview

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.spec.tsx
@@ -1,0 +1,202 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
+import type {StatsBucket} from 'sentry/components/checkInTimeline/types';
+import {getConfigFromTimeRange} from 'sentry/components/checkInTimeline/utils/getConfigFromTimeRange';
+import GroupStore from 'sentry/stores/groupStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {IssueCategory, IssueType} from 'sentry/types/group';
+import {IssueCronCheckTimeline} from 'sentry/views/issueDetails/streamline/issueCronCheckTimeline';
+import {CheckInStatus} from 'sentry/views/monitors/types';
+import {statusToText} from 'sentry/views/monitors/utils';
+
+const startTime = new Date('2025-01-01T11:00:00Z');
+
+jest.mock('sentry/components/checkInTimeline/hooks/useTimeWindowConfig');
+
+jest
+  .mocked(useTimeWindowConfig)
+  .mockReturnValue(
+    getConfigFromTimeRange(
+      startTime,
+      new Date(startTime.getTime() + 1000 * 60 * 60),
+      1000
+    )
+  );
+
+const mockBucket: StatsBucket<CheckInStatus> = {
+  [CheckInStatus.OK]: 1,
+  [CheckInStatus.ERROR]: 1,
+  [CheckInStatus.IN_PROGRESS]: 1,
+  [CheckInStatus.MISSED]: 1,
+  [CheckInStatus.TIMEOUT]: 1,
+  [CheckInStatus.UNKNOWN]: 1,
+};
+
+describe('IssueCronCheckTimeline', () => {
+  const cronAlertId = '123';
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({
+    environments: ['dev', 'prod'],
+  });
+  const group = GroupFixture({
+    issueCategory: IssueCategory.CRON,
+    issueType: IssueType.MONITOR_CHECK_IN_FAILURE,
+  });
+  const event = EventFixture({
+    tags: [
+      {
+        key: 'monitor.id',
+        value: cronAlertId,
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    GroupStore.init();
+    GroupStore.add([group]);
+    ProjectsStore.init();
+    ProjectsStore.loadInitialData([project]);
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/recommended/`,
+      body: event,
+    });
+  });
+
+  it('renders the cron check timeline with a legend and data', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitors-stats/`,
+      query: {
+        monitor: [cronAlertId],
+        project: project.slug,
+        environment: 'dev',
+      },
+      body: {
+        [cronAlertId]: [[startTime.getTime() / 1000, {dev: mockBucket}]],
+      },
+    });
+    render(<IssueCronCheckTimeline group={group} />, {organization});
+
+    expect(await screen.findByTestId('check-in-placeholder')).not.toBeInTheDocument();
+
+    const legend = screen.getByRole('caption');
+    expect(within(legend).getByText(statusToText[CheckInStatus.OK])).toBeInTheDocument();
+    expect(screen.getByRole('figure')).toBeInTheDocument();
+
+    const gridlineLabels = [
+      'Jan 1, 2025 11:00 AM UTC',
+      '11:10 AM',
+      '11:20 AM',
+      '11:30 AM',
+      '11:40 AM',
+      '11:50 AM',
+    ];
+
+    gridlineLabels.forEach(label => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+
+    // Do not show environment labels if there is only one environment
+    expect(screen.queryByText('dev')).not.toBeInTheDocument();
+  });
+
+  it('hides statuses from legend if not present in data', async function () {
+    const newBucket = {
+      ...mockBucket,
+      // OK is always shown, even with no data
+      [CheckInStatus.OK]: 0,
+      [CheckInStatus.ERROR]: 0,
+      [CheckInStatus.IN_PROGRESS]: 0,
+      [CheckInStatus.TIMEOUT]: 0,
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitors-stats/`,
+      query: {
+        monitor: [cronAlertId],
+        project: project.slug,
+        environment: 'dev',
+      },
+      body: {
+        [cronAlertId]: [[startTime.getTime() / 1000, {dev: newBucket}]],
+      },
+    });
+    render(<IssueCronCheckTimeline group={group} />, {organization});
+    expect(await screen.findByTestId('check-in-placeholder')).not.toBeInTheDocument();
+    const legend = screen.getByRole('caption');
+    [
+      statusToText[CheckInStatus.OK],
+      statusToText[CheckInStatus.MISSED],
+      statusToText[CheckInStatus.UNKNOWN],
+    ].forEach(status => {
+      expect(within(legend).getByText(status)).toBeInTheDocument();
+    });
+
+    [
+      statusToText[CheckInStatus.ERROR],
+      statusToText[CheckInStatus.IN_PROGRESS],
+      statusToText[CheckInStatus.TIMEOUT],
+    ].forEach(status => {
+      expect(within(legend).queryByText(status)).not.toBeInTheDocument();
+    });
+  });
+
+  it('displays multiple environment legends and labels', async function () {
+    const envBucketMapping = {
+      dev: {
+        [CheckInStatus.OK]: 1,
+        [CheckInStatus.ERROR]: 1,
+        [CheckInStatus.IN_PROGRESS]: 0,
+        [CheckInStatus.MISSED]: 0,
+        [CheckInStatus.TIMEOUT]: 1,
+        [CheckInStatus.UNKNOWN]: 0,
+      },
+      prod: {
+        [CheckInStatus.OK]: 0,
+        [CheckInStatus.ERROR]: 0,
+        [CheckInStatus.IN_PROGRESS]: 1,
+        [CheckInStatus.MISSED]: 1,
+        [CheckInStatus.TIMEOUT]: 0,
+        [CheckInStatus.UNKNOWN]: 1,
+      },
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitors-stats/`,
+      query: {
+        monitor: [cronAlertId],
+        project: project.slug,
+        environment: [],
+      },
+      body: {
+        [cronAlertId]: [[startTime.getTime() / 1000, envBucketMapping]],
+      },
+    });
+    render(<IssueCronCheckTimeline group={group} />, {organization});
+    expect(await screen.findByTestId('check-in-placeholder')).not.toBeInTheDocument();
+    const legend = screen.getByRole('caption');
+    // All statuses from both environment timelines should be present
+    [
+      statusToText[CheckInStatus.OK],
+      statusToText[CheckInStatus.ERROR],
+      statusToText[CheckInStatus.IN_PROGRESS],
+      statusToText[CheckInStatus.MISSED],
+      statusToText[CheckInStatus.TIMEOUT],
+      statusToText[CheckInStatus.UNKNOWN],
+    ].forEach(status => {
+      expect(within(legend).getByText(status)).toBeInTheDocument();
+    });
+
+    // Environment labels should now be present
+    expect(screen.getByText('dev')).toBeInTheDocument();
+    expect(screen.getByText('prod')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -66,7 +66,11 @@ export function useCronIssueAlertId({groupId}: {groupId: string}): string | unde
     : event?.tags?.find(({key}) => key === 'monitor.id')?.value;
 }
 
-function useCronLegendStatuses({bucketStats}: {bucketStats: MonitorBucket[]}) {
+function useCronLegendStatuses({
+  bucketStats,
+}: {
+  bucketStats: MonitorBucket[];
+}): CheckInStatus[] {
   /**
    * Extract a list of statuses that have occurred at least once in the bucket stats.
    */
@@ -80,9 +84,8 @@ function useCronLegendStatuses({bucketStats}: {bucketStats: MonitorBucket[]}) {
       [CheckInStatus.UNKNOWN]: false,
     };
     bucketStats?.forEach(([_timestamp, bucketEnvMapping]) => {
-      const bucketEnvMappingEntries = Object.values(bucketEnvMapping) as Array<
-        StatsBucket<CheckInStatus>
-      >;
+      const bucketEnvMappingEntries: Array<StatsBucket<CheckInStatus>> =
+        Object.values(bucketEnvMapping);
       for (const statBucket of bucketEnvMappingEntries) {
         const statBucketEntries = Object.entries(statBucket) as Array<
           [CheckInStatus, number]
@@ -137,10 +140,8 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
         {!isPending &&
           legendStatuses.map(status => (
             <Flex align="center" gap={space(0.5)} key={status}>
-              <MonitorIndicator status={status as CheckInStatus} size={8} />
-              <TimelineLegendText>
-                {statusToText[status as CheckInStatus]}
-              </TimelineLegendText>
+              <MonitorIndicator status={status} size={8} />
+              <TimelineLegendText>{statusToText[status]}</TimelineLegendText>
             </Flex>
           ))}
       </TimelineLegend>
@@ -162,18 +163,22 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
           <CheckInPlaceholder />
         ) : (
           <Fragment>
-            {statEnvironments.map((env, index) => (
+            {statEnvironments.map((env, envIndex) => (
               <Fragment key={env}>
                 {statEnvironments.length > 1 && (
                   <EnvironmentLabel
                     title={tct('Environment: [env]', {env})}
-                    envIndex={index}
+                    style={{
+                      top: envIndex * totalHeight + timelineHeight,
+                    }}
                   >
                     {env}
                   </EnvironmentLabel>
                 )}
-                <PositionedTimelineContainer
-                  envIndex={index}
+                <CheckInTimeline
+                  style={{
+                    top: envIndex * (environmentHeight + paddingHeight),
+                  }}
                   bucketedData={stats && env ? selectCheckInData(cronStats, env) : []}
                   statusLabel={statusToText}
                   statusStyle={tickStyle}
@@ -219,16 +224,11 @@ const TimelineContainer = styled('div')`
   top: 36px;
 `;
 
-const PositionedTimelineContainer = styled(CheckInTimeline)<{envIndex: number}>`
-  top: calc(${p => p.envIndex * (environmentHeight + paddingHeight)}px);
-`;
-
-const EnvironmentLabel = styled(Tooltip)<{envIndex: number}>`
+const EnvironmentLabel = styled(Tooltip)`
   position: absolute;
   user-select: none;
-  font-weight: ${p => p.theme.fontWeightBold};
-  top: ${p => p.envIndex * totalHeight + timelineHeight}px;
   left: 0;
+  font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   color: ${p => p.theme.subText};
 `;

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -121,7 +121,8 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
 
   const statEnvironments = useMemo(() => {
     const envSet = cronStats.reduce((acc, [_, envs]) => {
-      return new Set([...acc, ...Object.keys(envs)]);
+      Object.keys(envs).forEach(env => acc.add(env));
+      return acc;
     }, new Set<string>());
     return [...envSet];
   }, [cronStats]);

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -123,7 +123,7 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
     const envSet = cronStats.reduce((acc, [_, envs]) => {
       return new Set([...acc, ...Object.keys(envs)]);
     }, new Set<string>());
-    return [...(envSet ?? [])];
+    return [...envSet];
   }, [cronStats]);
 
   const legendStatuses = useCronLegendStatuses({

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -1,0 +1,193 @@
+import {useMemo, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
+import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
+import {
+  GridLineLabels,
+  GridLineOverlay,
+} from 'sentry/components/checkInTimeline/gridLines';
+import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
+import type {StatsBucket} from 'sentry/components/checkInTimeline/types';
+import {Flex} from 'sentry/components/container/flex';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
+import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
+import {getGroupEventQueryKey} from 'sentry/views/issueDetails/utils';
+import {MonitorIndicator} from 'sentry/views/monitors/components/monitorIndicator';
+import {CheckInStatus, type MonitorBucket} from 'sentry/views/monitors/types';
+import {
+  checkInStatusPrecedent,
+  statusToText,
+  tickStyle,
+} from 'sentry/views/monitors/utils';
+import {selectCheckInData} from 'sentry/views/monitors/utils/selectCheckInData';
+import {useMonitorStats} from 'sentry/views/monitors/utils/useMonitorStats';
+
+export function useCronIssueAlertId({groupId}: {groupId: string}): string | undefined {
+  /**
+   * This should be removed once the cron rule value is set on the issue.
+   * This will fetch an event from the max range if the detector details
+   * are not available (e.g. time range has changed and page refreshed)
+   */
+  const user = useUser();
+  const organization = useOrganization();
+  const {detectorDetails} = useIssueDetails();
+  const {detectorId, detectorType} = detectorDetails;
+
+  const hasCronDetector = detectorId && detectorType === 'cron_monitor';
+
+  const {data: event} = useApiQuery<Event>(
+    getGroupEventQueryKey({
+      orgSlug: organization.slug,
+      groupId,
+      eventId: user.options.defaultIssueEvent,
+      environments: [],
+    }),
+    {
+      staleTime: Infinity,
+      enabled: !hasCronDetector,
+      retry: false,
+    }
+  );
+
+  // Fall back to the fetched event since the legacy UI isn't nested within the provider the provider
+  return hasCronDetector
+    ? detectorId
+    : event?.tags?.find(({key}) => key === 'monitor.id')?.value;
+}
+
+function useCronLegendStatuses({
+  bucketStats,
+  environments = [],
+}: {
+  bucketStats: MonitorBucket[];
+  environments?: string[];
+}) {
+  /**
+   * Extract a list of statuses that have occurred at least once in the bucket stats.
+   */
+  return useMemo(() => {
+    const environmentSet = new Set(environments);
+    const statusMap: Record<CheckInStatus, boolean> = {
+      [CheckInStatus.OK]: true,
+      [CheckInStatus.ERROR]: false,
+      [CheckInStatus.IN_PROGRESS]: false,
+      [CheckInStatus.MISSED]: false,
+      [CheckInStatus.TIMEOUT]: false,
+      [CheckInStatus.UNKNOWN]: false,
+    };
+    bucketStats?.forEach(([_timestamp, bucketEnvMapping]) => {
+      const bucketEnvMappingEntries = Object.entries(bucketEnvMapping) as Array<
+        [string, StatsBucket<CheckInStatus>]
+      >;
+      for (const [environment, statBucket] of bucketEnvMappingEntries) {
+        // Ignore stats from other environments if specified, otherwise show all
+        if (environmentSet.size > 0 && !environmentSet.has(environment)) {
+          continue;
+        }
+
+        const statBucketEntries = Object.entries(statBucket) as Array<
+          [CheckInStatus, number]
+        >;
+        for (const [status, count] of statBucketEntries) {
+          if (count > 0 && !statusMap[status]) {
+            statusMap[status] = true;
+          }
+        }
+      }
+    });
+    return Object.keys(statusMap).filter(status => statusMap[status as CheckInStatus]);
+  }, [bucketStats, environments]);
+}
+
+export function IssueCronCheckTimeline({group}: {group: Group}) {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
+  const timelineWidth = useDebouncedValue(containerWidth, 500);
+  const timeWindowConfig = useTimeWindowConfig({timelineWidth});
+  const cronAlertId = useCronIssueAlertId({groupId: group.id});
+  const eventView = useIssueDetailsEventView({group});
+
+  const {data: cronStats, isPending} = useMonitorStats({
+    monitors: cronAlertId ? [cronAlertId] : [],
+    timeWindowConfig,
+  });
+
+  const legendStatuses = useCronLegendStatuses({
+    bucketStats: cronStats?.[cronAlertId ?? ''] ?? [],
+    environments: (eventView.environment as string[]) ?? [],
+  });
+
+  const stats = cronAlertId ? cronStats?.[cronAlertId] : [];
+
+  return (
+    <ChartContainer>
+      <TimelineLegend ref={elementRef}>
+        {!isPending &&
+          legendStatuses.map(status => (
+            <Flex align="center" gap={space(0.5)} key={status}>
+              <MonitorIndicator status={status as CheckInStatus} size={8} />
+              <TimelineLegendText>
+                {statusToText[status as CheckInStatus]}
+              </TimelineLegendText>
+            </Flex>
+          ))}
+      </TimelineLegend>
+      <GridLineOverlay
+        stickyCursor
+        allowZoom
+        showCursor
+        timeWindowConfig={timeWindowConfig}
+        labelPosition="center-bottom"
+      />
+      <GridLineLabels timeWindowConfig={timeWindowConfig} labelPosition="center-bottom" />
+      <TimelineContainer>
+        {isPending ? (
+          <CheckInPlaceholder />
+        ) : (
+          <CheckInTimeline
+            // TODO(leander): Use the environment from the event view
+            bucketedData={stats ? selectCheckInData(stats, 'prod') : []}
+            statusLabel={statusToText}
+            statusStyle={tickStyle}
+            statusPrecedent={checkInStatusPrecedent}
+            timeWindowConfig={timeWindowConfig}
+          />
+        )}
+      </TimelineContainer>
+    </ChartContainer>
+  );
+}
+
+const ChartContainer = styled('div')`
+  position: relative;
+  min-height: 104px;
+  width: 100%;
+`;
+
+const TimelineLegend = styled('div')`
+  position: absolute;
+  width: 100%;
+  user-select: none;
+  display: flex;
+  gap: ${space(1)};
+  margin-top: ${space(1.5)};
+`;
+
+const TimelineLegendText = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const TimelineContainer = styled('div')`
+  position: absolute;
+  top: 36px;
+`;

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -100,7 +100,7 @@ function useCronLegendStatuses({bucketStats}: {bucketStats: MonitorBucket[]}) {
   }, [bucketStats]);
 }
 
-export function IssueCronCheckTimeline({group}: {group: Group; event?: Event}) {
+export function IssueCronCheckTimeline({group}: {group: Group}) {
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
@@ -132,7 +132,7 @@ export function IssueCronCheckTimeline({group}: {group: Group; event?: Event}) {
 
   return (
     <ChartContainer envCount={statEnvironments.length}>
-      <TimelineLegend ref={elementRef}>
+      <TimelineLegend ref={elementRef} role="caption">
         {!isPending &&
           legendStatuses.map(status => (
             <Flex align="center" gap={space(0.5)} key={status}>

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -15,6 +15,7 @@ export interface DetectorDetails {
   description?: string;
   detectorId?: string;
   detectorPath?: string;
+  detectorSlug?: string;
   detectorType?: 'metric_alert' | 'cron_monitor' | 'uptime_monitor';
 }
 
@@ -46,10 +47,12 @@ export function getDetectorDetails({
   }
 
   const cronSlug = event?.tags?.find(({key}) => key === 'monitor.slug')?.value;
+  const cronId = event?.tags?.find(({key}) => key === 'monitor.id')?.value;
   if (cronSlug) {
     return {
       detectorType: 'cron_monitor',
-      detectorId: cronSlug,
+      detectorId: cronId,
+      detectorSlug: cronSlug,
       detectorPath: `/organizations/${organization.slug}/alerts/rules/crons/${project.slug}/${cronSlug}/details/`,
       description: t(
         'This issue was created by a cron monitor. View the monitor details to learn more.'


### PR DESCRIPTION
This PR adds a timeline graph to the top of the cron issues. The data models are different for this and crons so I used a new component, and that was a good call since these need to account for multiple environments (since the selector doesn't disable environments yet)

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/1ab4ffab-ae32-41b1-8aa5-06a0cd13afdc" />


When only one environment selected, the label is dropped:

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/1c7783f9-8102-4c50-b6a5-b40b0b814ee6" />

**todo**
- [x] Add tests 
