### PR TITLE
ref(consumers): Rename parallel -> batched-parallel

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -109,7 +109,7 @@ def ingest_monitors_options() -> list[click.Option]:
     options = [
         click.Option(
             ["--mode", "mode"],
-            type=click.Choice(["serial", "parallel"]),
+            type=click.Choice(["serial", "parallel", "batched-parallel"]),
             default="parallel",
             help="The mode to process check-ins in. Parallel uses multithreading.",
         ),
@@ -140,7 +140,7 @@ def uptime_options() -> list[click.Option]:
     options = [
         click.Option(
             ["--mode", "mode"],
-            type=click.Choice(["serial", "parallel"]),
+            type=click.Choice(["serial", "parallel", "batched-parallel"]),
             default="serial",
             help="The mode to process results in. Parallel uses multithreading.",
         ),

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -1074,12 +1074,12 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
 
     def __init__(
         self,
-        mode: Literal["parallel", "serial"] | None = None,
+        mode: Literal["batched-parallel", "parallel", "serial"] | None = None,
         max_batch_size: int | None = None,
         max_batch_time: int | None = None,
         max_workers: int | None = None,
     ) -> None:
-        if mode == "parallel":
+        if mode == "batched-parallel" or mode == "parallel":
             self.parallel = True
             self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
 

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -79,14 +79,14 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
 
     def __init__(
         self,
-        mode: Literal["parallel", "serial"] = "serial",
+        mode: Literal["batched-parallel", "parallel", "serial"] = "serial",
         max_batch_size: int | None = None,
         max_batch_time: int | None = None,
         max_workers: int | None = None,
     ) -> None:
         self.mode = mode
         metric_tags = {"identifier": self.identifier, "mode": self.mode}
-        if mode == "parallel":
+        if mode == "batched-parallel" or mode == "parallel":
             self.parallel = True
             self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
             if max_workers is None:

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -213,7 +213,7 @@ class MonitorConsumerTest(TestCase):
         into groups by their monitor slug / environment
         """
         factory = StoreMonitorCheckInStrategyFactory(
-            mode="parallel",
+            mode="batched-parallel",
             max_batch_size=4,
             max_workers=1,
         )

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -739,7 +739,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
         into groups by their monitor slug / environment
         """
 
-        factory = UptimeResultsStrategyFactory(mode="parallel", max_batch_size=3, max_workers=1)
+        factory = UptimeResultsStrategyFactory(
+            mode="batched-parallel",
+            max_batch_size=3,
+            max_workers=1,
+        )
         consumer = factory.create_with_partitions(mock.Mock(), {self.partition: 0})
         with mock.patch.object(type(factory.result_processor), "__call__") as mock_processor_call:
             subscription_2 = self.create_uptime_subscription(
@@ -787,7 +791,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
         into groups by their monitor slug / environment
         """
 
-        factory = UptimeResultsStrategyFactory(mode="parallel", max_batch_size=3, max_workers=1)
+        factory = UptimeResultsStrategyFactory(
+            mode="batched-parallel",
+            max_batch_size=3,
+            max_workers=1,
+        )
         consumer = factory.create_with_partitions(mock.Mock(), {self.partition: 0})
         subscription_2 = self.create_uptime_subscription(
             subscription_id=uuid.uuid4().hex, interval_seconds=300, url="http://santry.io"


### PR DESCRIPTION
Both crons and uptime consumers have a parallel mode where they first
create batches and in parallel execute groups of those batches.

I'll be introducing a new parallel mode for the uptime consumer that
does not do any kind of grouping, so I am renaming this to make it more
clear.

This is aligned with the modes for the occurrence consumer