### PR TITLE
feat(aci): fire actions in delayed workflow processing

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -54,8 +54,13 @@ def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action
 
 # TODO(cathy): only reinforce workflow frequency for certain issue types
 def filter_recently_fired_workflow_actions(
-    actions: BaseQuerySet[Action], group: Group
+    filtered_action_groups: set[DataConditionGroup], group: Group
 ) -> BaseQuerySet[Action]:
+    # get the actions for any of the triggered data condition groups
+    actions = Action.objects.filter(
+        dataconditiongroupaction__condition_group__in=filtered_action_groups
+    ).distinct()
+
     now = timezone.now()
     statuses = get_action_last_updated_statuses(now, actions, group)
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -386,10 +386,10 @@ def fire_actions_for_groups(
             elif dcg.id in trigger_type_to_dcg_model[DataConditionHandlerType.ACTION_FILTER]:
                 action_filters.add(dcg)
 
-        filtered_actions: list[Action] = []
-
-        # process action_filters
-        filtered_actions.extend(list(filter_recently_fired_workflow_actions(action_filters, group)))
+        # process action filters
+        filtered_actions: list[Action] = list(
+            filter_recently_fired_workflow_actions(action_filters, group)
+        )
 
         # process workflow_triggers
         workflows = set(Workflow.objects.filter(when_condition_group_id__in=workflow_triggers))

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -6,35 +6,47 @@ from typing import Any
 
 from django.utils import timezone
 
-from sentry import buffer
+from sentry import buffer, nodestore
 from sentry.db import models
+from sentry.eventstore.models import Event, GroupEvent
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.rules.conditions.event_frequency import COMPARISON_INTERVALS
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
+from sentry.tasks.post_process import should_retry_fetch
+from sentry.utils import json
+from sentry.utils.iterators import chunked
 from sentry.utils.registry import NoRegistrationExistsError
+from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.safe import safe_execute
 from sentry.workflow_engine.handlers.condition.slow_condition_query_handlers import (
     BaseEventFrequencyQueryHandler,
     slow_condition_query_handler_registry,
 )
-from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Workflow
+from sentry.workflow_engine.models import Action, DataCondition, DataConditionGroup, Workflow
 from sentry.workflow_engine.models.data_condition import (
     PERCENT_CONDITIONS,
     SLOW_CONDITIONS,
     Condition,
 )
 from sentry.workflow_engine.models.data_condition_group import get_slow_conditions
+from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.processors.data_condition_group import evaluate_data_conditions
-from sentry.workflow_engine.types import DataConditionHandlerType
+from sentry.workflow_engine.processors.detector import get_detector_by_event
+from sentry.workflow_engine.processors.workflow import evaluate_workflows_action_filters
+from sentry.workflow_engine.types import DataConditionHandlerType, WorkflowJob
 
 logger = logging.getLogger("sentry.workflow_engine.processors.delayed_workflow")
 
+EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
 
 DataConditionGroupGroups = dict[int, set[int]]
 WorkflowMapping = dict[int, Workflow]
 WorkflowEnvMapping = dict[int, int | None]
+DataConditionGroupEvent = dict[tuple[int, int], dict[str, str | None]]
 
 
 @dataclass(frozen=True)
@@ -80,24 +92,24 @@ def get_dcg_group_workflow_detector_data(
     workflow_event_dcg_data: dict[str, str]
 ) -> tuple[DataConditionGroupGroups, dict[DataConditionHandlerType, dict[int, int]]]:
     """
-    Parse the data in the buffer hash, which is in the form of {workflow/detector_id}:{event_id}:{dcg_id, ..., dcg_id}:{dcg_type}
+    Parse the data in the buffer hash, which is in the form of {workflow/detector_id}:{group_id}:{dcg_id, ..., dcg_id}:{dcg_type}
     """
 
     dcg_to_groups: DataConditionGroupGroups = defaultdict(set)
     trigger_type_to_dcg_model: dict[DataConditionHandlerType, dict[int, int]] = defaultdict(dict)
 
-    for workflow_event_dcg, _ in workflow_event_dcg_data.items():
-        data = workflow_event_dcg.split(":")
+    for workflow_group_dcg, _ in workflow_event_dcg_data.items():
+        data = workflow_group_dcg.split(":")
         try:
             dcg_type = DataConditionHandlerType(data[3])
         except ValueError:
             continue
 
-        event_id = int(data[1])
+        group_id = int(data[1])
         dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
 
         for dcg_id in dcg_ids:
-            dcg_to_groups[dcg_id].add(event_id)
+            dcg_to_groups[dcg_id].add(group_id)
 
             trigger_type_to_dcg_model[dcg_type][dcg_id] = int(data[0])
 
@@ -264,6 +276,129 @@ def get_groups_to_fire(
     return groups_to_fire
 
 
+def parse_dcg_group_event_data(
+    workflow_event_dcg_data: dict[str, str], groups_to_dcgs: dict[int, set[DataConditionGroup]]
+) -> tuple[DataConditionGroupEvent, set[str], set[str]]:
+    dcg_group_to_event_data: DataConditionGroupEvent = {}  # occurrence_id can be None
+    event_ids: set[str] = set()
+    occurrence_ids: set[str] = set()
+
+    groups_to_dcg_ids = {
+        group_id: {dcg.id for dcg in dcgs} for group_id, dcgs in groups_to_dcgs.items()
+    }
+
+    for workflow_group_dcg, instance_data in workflow_event_dcg_data.items():
+        data = workflow_group_dcg.split(":")
+        event_data = json.loads(instance_data)
+
+        event_id = event_data.get("event_id")
+        if event_id:
+            event_ids.add(event_id)
+
+        occurrence_id = event_data.get("occurrence_id")
+        if occurrence_id:
+            occurrence_ids.add(occurrence_id)
+
+        group_id = int(data[1])
+        dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
+
+        for dcg_id in dcg_ids:
+            if dcg_id in groups_to_dcg_ids[group_id]:
+                dcg_group_to_event_data[(int(dcg_id), int(group_id))] = event_data
+
+    return dcg_group_to_event_data, event_ids, occurrence_ids
+
+
+def bulk_fetch_events(event_ids: list[str], project_id: int) -> dict[str, Event]:
+    node_id_to_event_id = {
+        Event.generate_node_id(project_id, event_id=event_id): event_id for event_id in event_ids
+    }
+    node_ids = list(node_id_to_event_id.keys())
+    fetch_retry_policy = ConditionalRetryPolicy(should_retry_fetch, exponential_delay(1.00))
+
+    bulk_data = {}
+    for node_id_chunk in chunked(node_ids, EVENT_LIMIT):
+        bulk_results = fetch_retry_policy(lambda: nodestore.backend.get_multi(node_id_chunk))
+        bulk_data.update(bulk_results)
+
+    return {
+        node_id_to_event_id[node_id]: Event(
+            event_id=node_id_to_event_id[node_id], project_id=project_id, data=data
+        )
+        for node_id, data in bulk_data.items()
+        if data is not None
+    }
+
+
+def get_group_to_groupevent(
+    dcg_group_to_event_data: DataConditionGroupEvent,
+    group_ids: list[int],
+    event_ids: set[str],
+    occurrence_ids: set[str],
+    project_id: int,
+) -> dict[Group, GroupEvent]:
+    groups = Group.objects.filter(id__in=group_ids)
+    group_id_to_group = {group.id: group for group in groups}
+
+    bulk_event_id_to_events = bulk_fetch_events(list(event_ids), project_id)
+    bulk_occurrences = IssueOccurrence.fetch_multi(list(occurrence_ids), project_id=project_id)
+
+    bulk_occurrence_id_to_occurrence = {
+        occurrence.id: occurrence for occurrence in bulk_occurrences if occurrence
+    }
+
+    group_to_groupevent: dict[Group, GroupEvent] = {}
+    for dcg_group, instance_data in dcg_group_to_event_data.items():
+        event_id = instance_data.get("event_id")
+        occurrence_id = instance_data.get("occurrence_id")
+
+        if event_id is None:
+            continue
+
+        event = bulk_event_id_to_events.get(event_id)
+        group = group_id_to_group.get(int(dcg_group[1]))
+
+        if not group or not event:
+            continue
+
+        group_event = event.for_group(group)
+        if occurrence_id:
+            group_event.occurrence = bulk_occurrence_id_to_occurrence.get(occurrence_id)
+        group_to_groupevent[group] = group_event
+
+    return group_to_groupevent
+
+
+def fire_actions_for_groups(
+    groups_to_fire: dict[int, set[DataConditionGroup]],
+    trigger_type_to_dcg_model: dict[DataConditionHandlerType, dict[int, int]],
+    group_to_groupevent: dict[Group, GroupEvent],
+) -> None:
+    for group, group_event in group_to_groupevent.items():
+        job = WorkflowJob({"event": group_event})
+        detector = get_detector_by_event(job)
+
+        workflow_triggers: set[DataConditionGroup] = set()
+        action_filters: set[DataConditionGroup] = set()
+        for dcg in groups_to_fire[group.id]:
+            if dcg.id in trigger_type_to_dcg_model[DataConditionHandlerType.WORKFLOW_TRIGGER]:
+                workflow_triggers.add(dcg)
+            elif dcg.id in trigger_type_to_dcg_model[DataConditionHandlerType.ACTION_FILTER]:
+                action_filters.add(dcg)
+
+        filtered_actions: list[Action] = []
+
+        # process action_filters
+        filtered_actions.extend(list(filter_recently_fired_workflow_actions(action_filters, group)))
+
+        # process workflow_triggers
+        workflows = set(Workflow.objects.filter(when_condition_group_id__in=workflow_triggers))
+        filtered_actions.extend(list(evaluate_workflows_action_filters(workflows, job)))
+
+        for action in filtered_actions:
+            action.trigger(job, detector)
+
+
 @instrumented_task(
     name="sentry.workflow_engine.processors.delayed_workflow",
     queue="delayed_rules",
@@ -302,7 +437,7 @@ def process_delayed_workflows(
     condition_group_results = get_condition_group_results(condition_groups)
 
     # Evaluate DCGs
-    _ = get_groups_to_fire(
+    groups_to_dcgs = get_groups_to_fire(
         data_condition_groups,
         workflows_to_envs,
         dcg_to_workflow,
@@ -310,7 +445,15 @@ def process_delayed_workflows(
         condition_group_results,
     )
 
-    # TODO(cathy): fire actions on passing groups
+    dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(
+        workflow_event_dcg_data, groups_to_dcgs
+    )
+    group_to_groupevent = get_group_to_groupevent(
+        dcg_group_to_event_data, list(groups_to_dcgs.keys()), event_ids, occurrence_ids, project_id
+    )
+
+    fire_actions_for_groups(groups_to_dcgs, trigger_type_to_dcg_model, group_to_groupevent)
+
     # TODO(cathy): clean up redis buffer
 
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -106,12 +106,7 @@ def evaluate_workflows_action_filters(
             if evaluation:
                 filtered_action_groups.add(action_condition)
 
-    # get the actions for any of the triggered data condition groups
-    actions = Action.objects.filter(
-        dataconditiongroupaction__condition_group__in=filtered_action_groups
-    ).distinct()
-
-    return filter_recently_fired_workflow_actions(actions, job["event"].group)
+    return filter_recently_fired_workflow_actions(filtered_action_groups, job["event"].group)
 
 
 def process_workflows(job: WorkflowJob) -> set[Workflow]:

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.types import WorkflowJob
@@ -35,7 +35,9 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         _, action = self.create_workflow_action(workflow=self.workflow)
         status_2 = ActionGroupStatus.objects.create(action=action, group=self.group)
 
-        triggered_actions = filter_recently_fired_workflow_actions(Action.objects.all(), self.group)
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.group
+        )
         assert set(triggered_actions) == {self.action}
 
         for status in [status_1, status_2]:
@@ -55,7 +57,9 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_3 = ActionGroupStatus.objects.create(action=action_3, group=self.group)
         status_3.update(date_updated=timezone.now() - timedelta(days=2))
 
-        triggered_actions = filter_recently_fired_workflow_actions(Action.objects.all(), self.group)
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.group
+        )
         assert set(triggered_actions) == {self.action, action_3}
 
         for status in [status_1, status_2, status_3]:

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -670,18 +670,12 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             condition_group=self.workflow1_dcgs[1], action=action1
         )
 
-        # action2 = self.create_action(
-        #     type=Action.Type.SLACK,
-        #     integration_id="1234567890",
-        #     target_identifier="channel789",
-        #     target_display="#general",
-        #     data={"tags": "environment,user", "notes": "Important alert"},
-        # )
         action2 = self.create_action(
-            type=Action.Type.DISCORD,
+            type=Action.Type.SLACK,
             integration_id="1234567890",
-            target_identifier="channel456",
-            data={"tags": "environment,user,my_tag"},
+            target_identifier="channel789",
+            target_display="#general",
+            data={"tags": "environment,user", "notes": "Important alert"},
         )
         self.create_data_condition_group_action(
             condition_group=self.workflow2_dcgs[1], action=action2
@@ -740,7 +734,6 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
     @patch("sentry.workflow_engine.models.action.Action.trigger")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger):
-        # only fires each action once, even though both the triggers and filters pass
         fire_actions_for_groups(
             self.groups_to_dcgs, self.trigger_type_to_dcg_model, self.group_to_groupevent
         )
@@ -759,10 +752,6 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     def test_fire_actions_for_groups__enqueue(self, mock_enqueue):
         # enqueue the IF DCGs with slow conditions!
 
-        self.groups_to_dcgs = {
-            self.group1.id: {self.workflow1_dcgs[0]},
-            self.group2.id: {self.workflow2_dcgs[0]},
-        }
         fire_actions_for_groups(
             self.groups_to_dcgs, self.trigger_type_to_dcg_model, self.group_to_groupevent
         )

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import asdict
 from datetime import timedelta
+from unittest.mock import patch
 
 from sentry import buffer
 from sentry.eventstore.models import Event
@@ -17,24 +18,38 @@ from sentry.workflow_engine.handlers.condition.slow_condition_query_handlers imp
     EventFrequencyQueryHandler,
     EventUniqueUserFrequencyQueryHandler,
 )
-from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector, Workflow
+from sentry.workflow_engine.models import (
+    Action,
+    DataCondition,
+    DataConditionGroup,
+    Detector,
+    Workflow,
+)
 from sentry.workflow_engine.models.data_condition import (
     PERCENT_CONDITIONS,
     SLOW_CONDITIONS,
     Condition,
 )
 from sentry.workflow_engine.processors.delayed_workflow import (
+    DataConditionGroupEvent,
     DataConditionGroupGroups,
     UniqueConditionQuery,
+    bulk_fetch_events,
     fetch_group_to_event_data,
     fetch_workflows_envs,
+    fire_actions_for_groups,
     generate_unique_queries,
     get_condition_group_results,
     get_condition_query_groups,
     get_dcg_group_workflow_detector_data,
+    get_group_to_groupevent,
     get_groups_to_fire,
+    parse_dcg_group_event_data,
 )
-from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
+from sentry.workflow_engine.processors.workflow import (
+    WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+    WorkflowDataConditionGroupType,
+)
 from sentry.workflow_engine.types import DataConditionHandlerType
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
@@ -94,8 +109,8 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
             defaultdict(dict)
         )
 
-        workflow_dcgs = self.workflow1_dcgs + self.workflow2_dcgs
-        for i, dcg in enumerate(workflow_dcgs):
+        self.workflow_dcgs = self.workflow1_dcgs + self.workflow2_dcgs
+        for i, dcg in enumerate(self.workflow_dcgs):
             handler_type = (
                 DataConditionHandlerType.WORKFLOW_TRIGGER
                 if i % 2 == 0
@@ -639,3 +654,129 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
                 self.workflow1_dcgs + [self.workflow2_dcgs[0]],
             ),
         }
+
+
+class TestFireActionsForGroups(TestDelayedWorkflowBase):
+    def setUp(self):
+        super().setUp()
+
+        action1 = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            target_identifier="channel456",
+            data={"tags": "environment,user,my_tag"},
+        )
+        self.create_data_condition_group_action(
+            condition_group=self.workflow1_dcgs[1], action=action1
+        )
+
+        # action2 = self.create_action(
+        #     type=Action.Type.SLACK,
+        #     integration_id="1234567890",
+        #     target_identifier="channel789",
+        #     target_display="#general",
+        #     data={"tags": "environment,user", "notes": "Important alert"},
+        # )
+        action2 = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            target_identifier="channel456",
+            data={"tags": "environment,user,my_tag"},
+        )
+        self.create_data_condition_group_action(
+            condition_group=self.workflow2_dcgs[1], action=action2
+        )
+
+        self.groups_to_dcgs = {
+            self.group1.id: set(self.workflow1_dcgs),
+            self.group2.id: set(self.workflow2_dcgs),
+        }
+        self.dcg_group_to_event_data: DataConditionGroupEvent = {}
+        for i, dcg in enumerate(self.workflow_dcgs):
+            if i < 2:
+                group = self.group1
+                event = self.event1
+            else:
+                group = self.group2
+                event = self.event2
+
+            self.dcg_group_to_event_data[(dcg.id, group.id)] = {
+                "event_id": event.event_id,
+                "occurrence_id": None,
+            }
+
+        self.group_to_groupevent = {
+            self.group1: self.event1.for_group(self.group1),
+            self.group2: self.event2.for_group(self.group2),
+        }
+
+    def test_parse_dcg_group_event_data(self):
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(
+            buffer_data, self.groups_to_dcgs
+        )
+
+        assert dcg_group_to_event_data == self.dcg_group_to_event_data
+        assert event_ids == {self.event1.event_id, self.event2.event_id}
+        assert occurrence_ids == set()
+
+    def test_bulk_fetch_events(self):
+        event_ids = [self.event1.event_id, self.event2.event_id]
+        events = bulk_fetch_events(event_ids, self.project.id)
+
+        for event in list(events.values()):
+            assert event.event_id in event_ids
+
+    def test_get_group_to_groupevent(self):
+        group_to_groupevent = get_group_to_groupevent(
+            self.dcg_group_to_event_data,
+            [self.group1.id, self.group2.id],
+            {self.event1.event_id, self.event2.event_id},
+            set(),
+            self.project.id,
+        )
+        assert group_to_groupevent == self.group_to_groupevent
+
+    @patch("sentry.workflow_engine.models.action.Action.trigger")
+    def test_fire_actions_for_groups__fire_actions(self, mock_trigger):
+        # only fires each action once, even though both the triggers and filters pass
+        fire_actions_for_groups(
+            self.groups_to_dcgs, self.trigger_type_to_dcg_model, self.group_to_groupevent
+        )
+
+        assert mock_trigger.call_count == 2
+        assert mock_trigger.call_args_list[0][0] == (
+            {"event": self.event1.for_group(self.group1)},
+            self.detector,
+        )
+        assert mock_trigger.call_args_list[1][0] == (
+            {"event": self.event2.for_group(self.group2)},
+            self.detector,
+        )
+
+    @patch("sentry.workflow_engine.processors.workflow.enqueue_workflow")
+    def test_fire_actions_for_groups__enqueue(self, mock_enqueue):
+        # enqueue the IF DCGs with slow conditions!
+
+        self.groups_to_dcgs = {
+            self.group1.id: {self.workflow1_dcgs[0]},
+            self.group2.id: {self.workflow2_dcgs[0]},
+        }
+        fire_actions_for_groups(
+            self.groups_to_dcgs, self.trigger_type_to_dcg_model, self.group_to_groupevent
+        )
+
+        assert mock_enqueue.call_count == 2
+        assert mock_enqueue.call_args_list[0][0] == (
+            self.workflow1,
+            [self.workflow1_dcgs[1].conditions.all()[0]],
+            self.event1.for_group(self.group1),
+            WorkflowDataConditionGroupType.ACTION_FILTER,
+        )
+        assert mock_enqueue.call_args_list[1][0] == (
+            self.workflow2,
+            [self.workflow2_dcgs[1].conditions.all()[0]],
+            self.event2.for_group(self.group2),
+            WorkflowDataConditionGroupType.ACTION_FILTER,
+        )


### PR DESCRIPTION
Fire `Actions` for passing `DataConditionGroups` in delayed workflow processing.

This involves bulk fetching events and occurrences from Snuba to construct `GroupEvents`, which we will then pass along to `Action.trigger()`.

If a workflow WHEN `DataConditionGroup` has downstream IF `DataConditionGroups`, evaluate those, possibly enqueue more slow conditions from the IF DCGs, and get actions to fire.