### PR TITLE
fix(issue-views): Fix issue views for superusers

### DIFF
--- a/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
@@ -21,6 +21,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -414,6 +415,8 @@ export function IssueViewsPFStateProvider({
   const {className: _className, ...restProps} = props;
 
   const allowMultipleProjects = organization.features.includes('global-views');
+  const isSuperUser = isActiveSuperuser();
+
   const {projects: allProjects} = useProjects();
   const memberProjects = useMemo(
     () => allProjects.filter(project => project.isMember),
@@ -424,8 +427,13 @@ export function IssueViewsPFStateProvider({
     if (allowMultipleProjects) {
       return [];
     }
+
+    if (isSuperUser) {
+      return allowMultipleProjects ? [] : [parseInt(allProjects[0]!.id, 10)];
+    }
+
     return [parseInt(memberProjects[0]!.id, 10)];
-  }, [memberProjects, allowMultipleProjects]);
+  }, [memberProjects, allowMultipleProjects, isSuperUser, allProjects]);
 
   const {query, sort, viewId} = router.location.query;
 


### PR DESCRIPTION
Fixes JAVASCRIPT-2XWV
Fixes JAVASCRIPT-2XWW

Fixes an issue for internal employees using superuser that would crash the issue views component. This was caused by the assumption that all users would belong to a project, which will rarely happen for superusers. The change is to just give them the all projects view. 

Now, the default project for superusers is  "All Projects" if the org has that feature, or the first project otherwise. 