### PR TITLE
feat(uptime): Add scaffolding to support including `host_provider` in the result consumer metrics

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -150,6 +150,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         subscription.update(status=UptimeSubscription.Status.UPDATING.value)
         update_remote_uptime_subscription.delay(subscription.id)
 
+    def get_host_provider_if_valid(self, subscription: UptimeSubscription) -> str:
+        return "other"
+
     def handle_result(self, subscription: UptimeSubscription | None, result: CheckResult):
         if random.random() < 0.01:
             logger.info("process_result", extra=result)
@@ -168,6 +171,12 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             )
             return
 
+        metric_tags = {
+            "host_provider": self.get_host_provider_if_valid(subscription),
+            "status": result["status"],
+            "uptime_region": result.get("region", "default"),
+        }
+
         self.check_and_update_regions(subscription, result)
 
         project_subscriptions = list(
@@ -183,13 +192,19 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
 
         for last_update_raw, project_subscription in zip(last_updates, project_subscriptions):
             last_update_ms = 0 if last_update_raw is None else int(last_update_raw)
-            self.handle_result_for_project(project_subscription, result, last_update_ms)
+            self.handle_result_for_project(
+                project_subscription,
+                result,
+                last_update_ms,
+                metric_tags.copy(),
+            )
 
     def handle_result_for_project(
         self,
         project_subscription: ProjectUptimeSubscription,
         result: CheckResult,
         last_update_ms: int,
+        metric_tags: dict[str, str],
     ):
         if features.has(
             "organizations:uptime-detailed-logging", project_subscription.project.organization
@@ -206,11 +221,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             metrics.incr("uptime.result_processor.dropped_no_feature")
             return
 
-        metric_tags = {
-            "status": result["status"],
-            "mode": ProjectUptimeSubscriptionMode(project_subscription.mode).name.lower(),
-            "uptime_region": result.get("region", "default"),
-        }
+        mode_name = ProjectUptimeSubscriptionMode(project_subscription.mode).name.lower()
 
         status_reason = "none"
         if result["status_reason"]:
@@ -218,7 +229,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
 
         metrics.incr(
             "uptime.result_processor.handle_result_for_project",
-            tags={"status_reason": status_reason, **metric_tags},
+            tags={"mode": mode_name, "status_reason": status_reason, **metric_tags},
             sample_rate=1.0,
         )
         try:
@@ -229,7 +240,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 # We only ever want to process the first value related to each check, so we just skip and log here
                 metrics.incr(
                     "uptime.result_processor.skipping_already_processed_update",
-                    tags=metric_tags,
+                    tags={"mode": mode_name, **metric_tags},
                     sample_rate=1.0,
                 )
                 return
@@ -259,23 +270,27 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                         result["duration_ms"],
                         sample_rate=1.0,
                         unit="millisecond",
-                        tags=metric_tags,
+                        tags={"mode": mode_name, **metric_tags},
                     )
                 metrics.distribution(
                     "uptime.result_processor.check_result.delay",
                     result["actual_check_time_ms"] - result["scheduled_check_time_ms"],
                     sample_rate=1.0,
                     unit="millisecond",
-                    tags=metric_tags,
+                    tags={"mode": mode_name, **metric_tags},
                 )
 
             if project_subscription.mode == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING:
-                self.handle_result_for_project_auto_onboarding_mode(project_subscription, result)
+                self.handle_result_for_project_auto_onboarding_mode(
+                    project_subscription, result, metric_tags.copy()
+                )
             elif project_subscription.mode in (
                 ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
                 ProjectUptimeSubscriptionMode.MANUAL,
             ):
-                self.handle_result_for_project_active_mode(project_subscription, result)
+                self.handle_result_for_project_active_mode(
+                    project_subscription, result, metric_tags.copy()
+                )
         except Exception:
             logger.exception("Failed to process result for uptime project subscription")
 
@@ -289,7 +304,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
 
         # After processing the result and updating Redis, produce message to Kafka
         if options.get("uptime.snuba_uptime_results.enabled"):
-            self._produce_snuba_uptime_result(project_subscription, result)
+            self._produce_snuba_uptime_result(project_subscription, result, metric_tags.copy())
 
         # The amount of time it took for a check result to get from the checker to this consumer and be processed
         metrics.distribution(
@@ -306,7 +321,10 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         )
 
     def handle_result_for_project_auto_onboarding_mode(
-        self, project_subscription: ProjectUptimeSubscription, result: CheckResult
+        self,
+        project_subscription: ProjectUptimeSubscription,
+        result: CheckResult,
+        metric_tags: dict[str, str],
     ):
         if result["status"] == CHECKSTATUS_FAILURE:
             redis = _get_cluster()
@@ -330,10 +348,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                     status_reason = result["status_reason"]["type"]
                 metrics.incr(
                     "uptime.result_processor.autodetection.failed_onboarding",
-                    tags={
-                        "failure_reason": status_reason,
-                        "uptime_region": result.get("region", "default"),
-                    },
+                    tags={"failure_reason": status_reason, **metric_tags},
                     sample_rate=1.0,
                 )
                 logger.info(
@@ -366,7 +381,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 metrics.incr(
                     "uptime.result_processor.autodetection.graduated_onboarding",
                     sample_rate=1.0,
-                    tags={"uptime_region": result.get("region", "default")},
+                    tags=metric_tags,
                 )
                 logger.info(
                     "uptime_onboarding_graduated",
@@ -378,7 +393,10 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 )
 
     def handle_result_for_project_active_mode(
-        self, project_subscription: ProjectUptimeSubscription, result: CheckResult
+        self,
+        project_subscription: ProjectUptimeSubscription,
+        result: CheckResult,
+        metric_tags: dict[str, str],
     ):
         redis = _get_cluster()
         delete_status = (
@@ -391,7 +409,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             project_subscription.uptime_status == UptimeStatus.OK
             and result["status"] == CHECKSTATUS_FAILURE
         ):
-            if not self.has_reached_status_threshold(project_subscription, result["status"]):
+            if not self.has_reached_status_threshold(
+                project_subscription, result["status"], metric_tags
+            ):
                 return
 
             issue_creation_flag_enabled = features.has(
@@ -412,7 +432,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                     sample_rate=1.0,
                     tags={
                         "host_provider_id": host_provider_id,
-                        "uptime_region": result.get("region", "default"),
+                        **metric_tags,
                     },
                 )
 
@@ -420,7 +440,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 create_issue_platform_occurrence(result, project_subscription)
                 metrics.incr(
                     "uptime.result_processor.active.sent_occurrence",
-                    tags={"uptime_region": result.get("region", "default")},
+                    tags=metric_tags,
                     sample_rate=1.0,
                 )
                 logger.info(
@@ -436,7 +456,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             project_subscription.uptime_status == UptimeStatus.FAILED
             and result["status"] == CHECKSTATUS_SUCCESS
         ):
-            if not self.has_reached_status_threshold(project_subscription, result["status"]):
+            if not self.has_reached_status_threshold(
+                project_subscription, result["status"], metric_tags
+            ):
                 return
 
             if features.has(
@@ -446,7 +468,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 metrics.incr(
                     "uptime.result_processor.active.resolved",
                     sample_rate=1.0,
-                    tags={"uptime_region": result.get("region", "default")},
+                    tags=metric_tags,
                 )
                 logger.info(
                     "uptime_active_resolved",
@@ -459,7 +481,10 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             project_subscription.update(uptime_status=UptimeStatus.OK)
 
     def has_reached_status_threshold(
-        self, project_subscription: ProjectUptimeSubscription, status: str
+        self,
+        project_subscription: ProjectUptimeSubscription,
+        status: str,
+        metric_tags: dict[str, str],
     ) -> bool:
         pipeline = _get_cluster().pipeline()
         key = build_active_consecutive_status_key(project_subscription, status)
@@ -473,12 +498,15 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             metrics.incr(
                 "uptime.result_processor.active.under_threshold",
                 sample_rate=1.0,
-                tags={"status": status},
+                tags=metric_tags,
             )
         return result
 
     def _produce_snuba_uptime_result(
-        self, project_subscription: ProjectUptimeSubscription, result: CheckResult
+        self,
+        project_subscription: ProjectUptimeSubscription,
+        result: CheckResult,
+        metric_tags: dict[str, str],
     ) -> None:
         """
         Produces a message to Snuba's Kafka topic for uptime check results.
@@ -520,6 +548,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             metrics.incr(
                 "uptime.result_processor.snuba_message_produced",
                 sample_rate=1.0,
+                tags=metric_tags,
             )
 
         except Exception:
@@ -527,6 +556,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             metrics.incr(
                 "uptime.result_processor.snuba_message_failed",
                 sample_rate=1.0,
+                tags=metric_tags,
             )
 
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -95,17 +95,22 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.active.under_threshold",
                         sample_rate=1.0,
-                        tags={"status": "failure"},
+                        tags={
+                            "status": CHECKSTATUS_FAILURE,
+                            "host_provider": "other",
+                            "uptime_region": "us-west",
+                        },
                     ),
                 ]
             )
@@ -121,10 +126,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -159,17 +165,22 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "default",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.active.under_threshold",
                         sample_rate=1.0,
-                        tags={"status": "failure"},
+                        tags={
+                            "host_provider": "other",
+                            "status": CHECKSTATUS_FAILURE,
+                            "uptime_region": "default",
+                        },
                     ),
                 ]
             )
@@ -199,7 +210,12 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.restricted_by_provider",
                         sample_rate=1.0,
-                        tags={"host_provider_id": "TEST", "uptime_region": "us-west"},
+                        tags={
+                            "host_provider_id": "TEST",
+                            "uptime_region": "us-west",
+                            "status": CHECKSTATUS_FAILURE,
+                            "host_provider": "other",
+                        },
                     ),
                 ],
                 any_order=True,
@@ -230,17 +246,22 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.active.under_threshold",
                         sample_rate=1.0,
-                        tags={"status": "failure"},
+                        tags={
+                            "uptime_region": "us-west",
+                            "status": CHECKSTATUS_FAILURE,
+                            "host_provider": "other",
+                        },
                     ),
                 ]
             )
@@ -257,10 +278,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "success",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_SUCCESS,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -278,17 +300,22 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.active.under_threshold",
                         sample_rate=1.0,
-                        tags={"status": "failure"},
+                        tags={
+                            "status": CHECKSTATUS_FAILURE,
+                            "host_provider": "other",
+                            "uptime_region": "us-west",
+                        },
                     ),
                 ]
             )
@@ -314,10 +341,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     )
@@ -350,10 +378,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -371,10 +400,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -403,10 +433,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "success",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_SUCCESS,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     )
@@ -504,10 +535,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "failure",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -517,6 +549,7 @@ class ProcessResultTest(ConfigPusherTestMixin):
                             "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_active",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -542,8 +575,9 @@ class ProcessResultTest(ConfigPusherTestMixin):
                 tags={
                     "status": CHECKSTATUS_MISSED_WINDOW,
                     "mode": "auto_detected_active",
-                    "status_reason": "timeout",
+                    "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
                     "uptime_region": "us-west",
+                    "host_provider": "other",
                 },
                 sample_rate=1.0,
             )
@@ -579,8 +613,9 @@ class ProcessResultTest(ConfigPusherTestMixin):
                         tags={
                             "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_onboarding",
-                            "status_reason": "timeout",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -613,8 +648,9 @@ class ProcessResultTest(ConfigPusherTestMixin):
                         tags={
                             "status": CHECKSTATUS_FAILURE,
                             "mode": "auto_detected_onboarding",
-                            "status_reason": "timeout",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -623,6 +659,8 @@ class ProcessResultTest(ConfigPusherTestMixin):
                         tags={
                             "failure_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
                             "uptime_region": "us-west",
+                            "host_provider": "other",
+                            "status": CHECKSTATUS_FAILURE,
                         },
                         sample_rate=1.0,
                     ),
@@ -662,10 +700,11 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "success",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_SUCCESS,
                             "mode": "auto_detected_onboarding",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
@@ -703,16 +742,21 @@ class ProcessResultTest(ConfigPusherTestMixin):
                     call(
                         "uptime.result_processor.handle_result_for_project",
                         tags={
-                            "status_reason": "timeout",
-                            "status": "success",
+                            "status_reason": CHECKSTATUSREASONTYPE_TIMEOUT,
+                            "status": CHECKSTATUS_SUCCESS,
                             "mode": "auto_detected_onboarding",
                             "uptime_region": "us-west",
+                            "host_provider": "other",
                         },
                         sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.autodetection.graduated_onboarding",
-                        tags={"uptime_region": "us-west"},
+                        tags={
+                            "status": CHECKSTATUS_SUCCESS,
+                            "uptime_region": "us-west",
+                            "host_provider": "other",
+                        },
                         sample_rate=1.0,
                     ),
                 ]


### PR DESCRIPTION
This adds all the scaffolding we need to include host provider in the result consumer metrics. Also standardises how we pass around metrics, so that it doesn't need to be updated in many places.
