### PR TITLE
fix(uptime): correct environment field for uptime eap api

### DIFF
--- a/src/sentry/search/eap/uptime_check_columns.py
+++ b/src/sentry/search/eap/uptime_check_columns.py
@@ -17,7 +17,7 @@ UPTIME_CHECK_ATTRIBUTE_DEFINITIONS = {
     + [
         ResolvedColumn(
             public_alias="environment",
-            internal_name="sentry.environment",
+            internal_name="environment",
             search_type="string",
         ),
         ResolvedColumn(


### PR DESCRIPTION
uptime does not use the prefixes `sentry.` for it's fields, so this should be removed.