### PR TITLE
fix(issue-views): Fix temp view bugs with renaming and unexpected redirect

### DIFF
--- a/static/app/views/issueList/issueViewsPF/editableTabTitlePF.tsx
+++ b/static/app/views/issueList/issueViewsPF/editableTabTitlePF.tsx
@@ -12,6 +12,7 @@ interface EditableTabTitlePFProps {
   label: string;
   onChange: (newLabel: string) => void;
   setIsEditing: (isEditing: boolean) => void;
+  disableEditing?: boolean;
 }
 
 function EditableTabTitlePF({
@@ -20,6 +21,7 @@ function EditableTabTitlePF({
   isEditing,
   isSelected,
   setIsEditing,
+  disableEditing,
 }: EditableTabTitlePFProps) {
   const [inputValue, setInputValue] = useState(label);
 
@@ -86,7 +88,7 @@ function EditableTabTitlePF({
   return (
     <Tooltip title={label} disabled={isEditing} showOnlyOnOverflow skipWrapper>
       <motion.div layout="position" transition={{duration: 0.2}}>
-        {isSelected && isEditing ? (
+        {isSelected && isEditing && !disableEditing ? (
           <StyledGrowingInput
             value={inputValue}
             onChange={handleOnChange}

--- a/static/app/views/issueList/issueViewsPF/issueViewTabPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewTabPF.tsx
@@ -89,10 +89,22 @@ export function IssueViewPFTab({
     }
   };
 
+  const handleSaveTempView = () => {
+    const newViewId = generateTempViewId();
+    dispatch({type: 'SAVE_TEMP_VIEW', newViewId, syncViews: true});
+    navigate({
+      ...location,
+      query: {
+        ...queryParams,
+        viewId: newViewId,
+      },
+    });
+  };
+
   const makeMenuOptions = (tab: IssueViewPF): MenuItemProps[] => {
     if (tab.key === TEMPORARY_TAB_KEY) {
       return makeTempViewMenuOptions({
-        onSaveTempView: () => dispatch({type: 'SAVE_TEMP_VIEW', syncViews: true}),
+        onSaveTempView: handleSaveTempView,
         onDiscardTempView: () => dispatch({type: 'DISCARD_TEMP_VIEW'}),
       });
     }

--- a/static/app/views/issueList/issueViewsPF/issueViewTabPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewTabPF.tsx
@@ -137,6 +137,7 @@ export function IssueViewPFTab({
           (tabListState && tabListState?.selectedKey === view.key) ||
           (!tabListState && view.key === initialTabKey)
         }
+        disableEditing={view.key === TEMPORARY_TAB_KEY}
       />
       <IssueViewQueryCountPF view={view} />
       {/* If tablistState isn't initialized, we want to load the elipsis menu

--- a/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
@@ -121,6 +121,7 @@ type DiscardTempViewAction = {
 } & BaseIssueViewsAction;
 
 type SaveTempViewAction = {
+  newViewId: string;
   type: 'SAVE_TEMP_VIEW';
 } & BaseIssueViewsAction;
 
@@ -330,12 +331,15 @@ function discardTempView(state: IssueViewsPFState, tabListState: TabListState<an
   return {...state, tempView: undefined};
 }
 
-function saveTempView(state: IssueViewsPFState, tabListState: TabListState<any>) {
+function saveTempView(
+  state: IssueViewsPFState,
+  action: SaveTempViewAction,
+  tabListState: TabListState<any>
+) {
   if (state.tempView) {
-    const tempId = generateTempViewId();
     const newTab: IssueViewPF = {
-      id: tempId,
-      key: tempId,
+      id: action.newViewId,
+      key: action.newViewId,
       label: 'New View',
       query: state.tempView?.query,
       querySort: state.tempView?.querySort,
@@ -344,7 +348,7 @@ function saveTempView(state: IssueViewsPFState, tabListState: TabListState<any>)
       projects: state.tempView?.projects,
       timeFilters: state.tempView?.timeFilters,
     };
-    tabListState?.setSelectedKey(tempId);
+    tabListState?.setSelectedKey(action.newViewId);
     return {...state, views: [...state.views, newTab], tempView: undefined};
   }
   return state;
@@ -528,7 +532,7 @@ export function IssueViewsPFStateProvider({
         case 'DISCARD_TEMP_VIEW':
           return discardTempView(state, tabListState);
         case 'SAVE_TEMP_VIEW':
-          return saveTempView(state, tabListState);
+          return saveTempView(state, action, tabListState);
         case 'UPDATE_UNSAVED_CHANGES':
           return updateUnsavedChanges(state, action, tabListState);
         case 'UPDATE_VIEW_IDS':


### PR DESCRIPTION
Fixes two minor bugs with issue views: 

1. When clicking "Save View", you are redirected to the first view, rather than to the new persistent view you just created 
2. You are able to rename a temporary tab by double clicking. This caused all sorts of behavior. 