### PR TITLE
ref(grouping): Add sample rate for grouphash metadata backfill

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2855,6 +2855,12 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "grouping.grouphash_metadata.backfill_sample_rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "ecosystem:enable_integration_form_error_raise", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -63,6 +63,7 @@ class GroupHashMetadataTest(TestCase):
         self.assert_metadata_value(grouphash, "latest_grouping_config", DEFAULT_GROUPING_CONFIG)
 
     @with_feature("organizations:grouphash-metadata-creation")
+    @override_options({"grouping.grouphash_metadata.backfill_sample_rate": 1.0})
     def test_updates_grouping_config(self):
         self.project.update_option("sentry:grouping_config", LEGACY_GROUPING_CONFIG)
 


### PR DESCRIPTION
This adds a new option, `grouping.grouphash_metadata.backfill_sample_rate`, to control the rate at which we add or update grouphash metadata for existing grouphashes. It also adds and switches to using a helper function, `should_handle_grouphash_metadata`, which checks both the existing killswitch and feature flag and the new option in cases where the grouphash already exists.

There's not yet any code to do the adding/updating (and the option defaults to `0`), so this doesn't change any behavior*, but it does set us up for when said code is added.

*This is only 99.9% true. Technically there is a theoretical behavior change, in that the one bit of updating we already do (to the grouping config) is now subject to the sample rate, which is currently `0`. That said, we've been on the same grouping config since we started collecting grouphash metadata, so there aren't any records to update. So a thing that never happens now actually _can't_ happen (at least until we up the sample rate), but in the real world that doesn't actually make things any different.