### PR TITLE
🔧 chore(aci): Add support to invoke rule registry email handler from NOA

### DIFF
--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 """
 Contains data blobs that we store in the Rule.action json field.
 
@@ -753,7 +755,7 @@ JIRA_SERVER_ACTION_DATA_BLOBS = [
     },
 ]
 
-EMAIL_ACTION_DATA_BLOBS = [
+EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
     # IssueOwners (targetIdentifier is "None")
     {
         "targetType": "IssueOwners",

--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -752,3 +752,61 @@ JIRA_SERVER_ACTION_DATA_BLOBS = [
         "uuid": "22222222-2222-2222-2222-222222222222",
     },
 ]
+
+EMAIL_ACTION_DATA_BLOBS = [
+    # IssueOwners (targetIdentifier is "None")
+    {
+        "targetType": "IssueOwners",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "targetIdentifier": "None",
+        "fallthroughType": "ActiveMembers",
+        "uuid": "2e8847d7-8fe4-44d2-8a16-e25040329790",
+    },
+    # NoOne Fallthrough (targetIdentifier is "")
+    {
+        "targetType": "IssueOwners",
+        "targetIdentifier": "",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "fallthroughType": "NoOne",
+        "uuid": "fb039430-0848-4fc4-89b4-bc7689a9f851",
+    },
+    # AllMembers Fallthrough (targetIdentifier is None)
+    {
+        "targetType": "IssueOwners",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "targetIdentifier": None,
+        "fallthroughType": "AllMembers",
+        "uuid": "41f13756-8f90-4afe-b162-55268c6e3cdb",
+    },
+    # NoOne Fallthrough (targetIdentifier is "None")
+    {
+        "targetType": "IssueOwners",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "targetIdentifier": "None",
+        "fallthroughType": "NoOne",
+        "uuid": "99c9b517-0a0f-47f0-b3ff-2a9cd2fd9c49",
+    },
+    # ActiveMembers Fallthrough
+    {
+        "targetType": "Member",
+        "fallthroughType": "ActiveMembers",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "targetIdentifier": 3234013,
+        "uuid": "6e83337b-9561-4167-a208-27d6bdf5e613",
+    },
+    # Member Email
+    {
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "targetIdentifier": 2160509,
+        "targetType": "Member",
+        "uuid": "42c3e1d6-4004-4a51-a90b-13d3404f1e55",
+    },
+    # Team Email
+    {
+        "targetType": "Team",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "fallthroughType": "AllMembers",
+        "uuid": "71b445cf-573b-4e0c-86bc-8dfbad93c480",
+        "targetIdentifier": 188022,
+    },
+]

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -296,7 +296,10 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
-        target_type = ActionTarget(action.target_type).value
+        if action.target_type is None:
+            raise ValueError(f"No target type found for {action.type} action {action.id}")
+
+        target_type = ActionTarget(action.target_type)
 
         final_blob = {
             EmailFieldMappingKeys.TARGET_TYPE_KEY.value: EmailActionHelper.get_target_type_string(

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -475,9 +475,9 @@ class JiraServerActionTranslatorBase(TicketActionTranslator):
 
 class EmailActionHelper(ABC):
     target_type_mapping = {
-        ActionTarget.USER: "Member",
-        ActionTarget.TEAM: "Team",
-        ActionTarget.ISSUE_OWNERS: "IssueOwners",
+        ActionTarget.USER: ActionTargetType.MEMBER.value,
+        ActionTarget.TEAM: ActionTargetType.TEAM.value,
+        ActionTarget.ISSUE_OWNERS: ActionTargetType.ISSUE_OWNERS.value,
     }
 
     reverse_target_type_mapping = {v: k for k, v in target_type_mapping.items()}

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -7,6 +7,7 @@ from sentry.constants import ObjectStatus
 from sentry.models.rule import Rule, RuleSource
 from sentry.testutils.helpers.data_blobs import (
     AZURE_DEVOPS_ACTION_DATA_BLOBS,
+    EMAIL_ACTION_DATA_BLOBS,
     GITHUB_ACTION_DATA_BLOBS,
     JIRA_ACTION_DATA_BLOBS,
     JIRA_SERVER_ACTION_DATA_BLOBS,
@@ -14,6 +15,7 @@ from sentry.testutils.helpers.data_blobs import (
 from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     BaseIssueAlertHandler,
     DiscordIssueAlertHandler,
+    EmailIssueAlertHandler,
     MSTeamsIssueAlertHandler,
     OpsgenieIssueAlertHandler,
     PagerDutyIssueAlertHandler,
@@ -27,6 +29,7 @@ from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
     ActionFieldMapping,
     ActionFieldMappingKeys,
+    EmailActionHelper,
 )
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -353,17 +356,24 @@ class TestTicketingIssueAlertHandlerBase(BaseWorkflowTest):
         )
         blob = self.handler.build_rule_action_blob(action)
 
+        # pop uuid from blob
+        # (we don't store it anymore since its a legacy artifact when we didn't have the action model)
+        expected.pop("uuid")
+
         assert blob == {
             "id": expected["id"],
             "integration": expected["integration"],
-            **blob,
+            **expected,
         }
 
 
 class TestGithubIssueAlertHandler(TestTicketingIssueAlertHandlerBase):
     def test_build_rule_action_blob(self):
         for expected in GITHUB_ACTION_DATA_BLOBS:
-            self._test_build_rule_action_blob(expected, Action.Type.GITHUB)
+            if expected["id"] == ACTION_FIELD_MAPPINGS[Action.Type.GITHUB]["id"]:
+                self._test_build_rule_action_blob(expected, Action.Type.GITHUB)
+            else:
+                self._test_build_rule_action_blob(expected, Action.Type.GITHUB_ENTERPRISE)
 
 
 class TestAzureDevopsIssueAlertHandler(TestTicketingIssueAlertHandlerBase):
@@ -382,3 +392,80 @@ class TestJiraServerIssueAlertHandler(TestTicketingIssueAlertHandlerBase):
     def test_build_rule_action_blob(self):
         for expected in JIRA_SERVER_ACTION_DATA_BLOBS:
             self._test_build_rule_action_blob(expected, Action.Type.JIRA_SERVER)
+
+
+class TestEmailIssueAlertHandler(BaseWorkflowTest):
+    def setUp(self):
+        super().setUp()
+        self.handler = EmailIssueAlertHandler()
+        # These are the actions that are healed from the old email action data blobs
+        # It removes targetIdentifier for IssueOwner targets (since that shouldn't be set for those)
+        # It also removes the fallthroughType for Team and Member targets (since that shouldn't be set for those)
+        self.HEALED_EMAIL_ACTION_DATA_BLOBS = [
+            # IssueOwners (targetIdentifier is "None")
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "ActiveMembers",
+            },
+            # NoOne Fallthrough (targetIdentifier is "")
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "NoOne",
+            },
+            # AllMembers Fallthrough (targetIdentifier is None)
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "AllMembers",
+            },
+            # NoOne Fallthrough (targetIdentifier is "None")
+            {
+                "targetType": "IssueOwners",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "fallthroughType": "NoOne",
+            },
+            # ActiveMembers Fallthrough
+            {
+                "targetType": "Member",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": 3234013,
+            },
+            # Member Email
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": 2160509,
+                "targetType": "Member",
+            },
+            # Team Email
+            {
+                "targetType": "Team",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": 188022,
+            },
+        ]
+
+    def test_build_rule_action_blob(self):
+        for expected, healed in zip(EMAIL_ACTION_DATA_BLOBS, self.HEALED_EMAIL_ACTION_DATA_BLOBS):
+            action_data = pop_keys_from_data_blob(expected, Action.Type.EMAIL)
+
+            # pop the targetType from the action_data
+            target_type = EmailActionHelper.get_target_type_object(action_data.pop("targetType"))
+
+            # Handle all possible targetIdentifier formats
+            target_identifier = expected["targetIdentifier"]
+            if target_identifier in ("None", "", None):
+                target_identifier = None
+            elif str(target_identifier).isnumeric():
+                target_identifier = int(target_identifier)
+
+            action = self.create_action(
+                type=Action.Type.EMAIL,
+                data=action_data,
+                target_type=target_type,
+                target_identifier=target_identifier,
+            )
+            blob = self.handler.build_rule_action_blob(action)
+
+            assert blob == healed

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -8,6 +8,7 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.data_blobs import (
     AZURE_DEVOPS_ACTION_DATA_BLOBS,
+    EMAIL_ACTION_DATA_BLOBS,
     GITHUB_ACTION_DATA_BLOBS,
     JIRA_ACTION_DATA_BLOBS,
     JIRA_SERVER_ACTION_DATA_BLOBS,
@@ -582,56 +583,7 @@ class TestNotificationActionMigrationUtils(TestCase):
             build_notification_actions_from_rule_data_actions(action_data)
 
     def test_email_migration(self):
-        action_data: list[dict[str, Any]] = [
-            {
-                "targetType": "IssueOwners",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "None",
-                "fallthroughType": "ActiveMembers",
-                "uuid": "2e8847d7-8fe4-44d2-8a16-e25040329790",
-            },
-            {
-                "targetType": "IssueOwners",
-                "targetIdentifier": "",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "NoOne",
-                "uuid": "fb039430-0848-4fc4-89b4-bc7689a9f851",
-            },
-            {
-                "targetType": "IssueOwners",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": None,
-                "fallthroughType": "AllMembers",
-                "uuid": "41f13756-8f90-4afe-b162-55268c6e3cdb",
-            },
-            {
-                "targetType": "IssueOwners",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "None",
-                "fallthroughType": "NoOne",
-                "uuid": "99c9b517-0a0f-47f0-b3ff-2a9cd2fd9c49",
-            },
-            {
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": 2160509,
-                "targetType": "Member",
-                "uuid": "42c3e1d6-4004-4a51-a90b-13d3404f1e55",
-            },
-            {
-                "targetType": "Member",
-                "fallthroughType": "ActiveMembers",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": 3234013,
-                "uuid": "6e83337b-9561-4167-a208-27d6bdf5e613",
-            },
-            {
-                "targetType": "Team",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "AllMembers",
-                "uuid": "71b445cf-573b-4e0c-86bc-8dfbad93c480",
-                "targetIdentifier": 188022,
-            },
-        ]
+        action_data: list[dict[str, Any]] = EMAIL_ACTION_DATA_BLOBS
 
         actions = build_notification_actions_from_rule_data_actions(action_data)
         self.assert_actions_migrated_correctly(

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -583,7 +583,7 @@ class TestNotificationActionMigrationUtils(TestCase):
             build_notification_actions_from_rule_data_actions(action_data)
 
     def test_email_migration(self):
-        action_data: list[dict[str, Any]] = EMAIL_ACTION_DATA_BLOBS
+        action_data = EMAIL_ACTION_DATA_BLOBS
 
         actions = build_notification_actions_from_rule_data_actions(action_data)
         self.assert_actions_migrated_correctly(


### PR DESCRIPTION
adds support to send emails for issue alerts via NOA.

as part of this change, i also decomposed some of the translation for email so it can be reused between migration and noa.

i also fixed up some tests for Ticketing since i realized the comparison i was doing was incorrect (i was comparing the result with itself)
