### PR TITLE
feat(loader): Make JS loader frontend forwards-compatible with v9

### DIFF
--- a/static/app/components/devtoolbar/hooks/useSentryClientAndScope.tsx
+++ b/static/app/components/devtoolbar/hooks/useSentryClientAndScope.tsx
@@ -29,7 +29,7 @@ export function useScopeAndClient() {
     // using console log for now, will change this when moving to dev tool bar repo
     // eslint-disable-next-line no-console
     console.log(
-      "Couldn't find a Sentry SDK scope or client. Make sure you're using a Sentry SDK with version 7.x or 8.x"
+      "Couldn't find a Sentry SDK scope or client. Make sure you're using a Sentry SDK with version 7.x or above"
     );
   }
 

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -283,5 +283,10 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
 }
 
 function sdkVersionSupportsPerformanceAndReplay(sdkVersion: string): boolean {
-  return sdkVersion === 'latest' || sdkVersion === '7.x' || sdkVersion === '8.x';
+  return (
+    sdkVersion === 'latest' ||
+    sdkVersion === '7.x' ||
+    sdkVersion === '8.x' ||
+    sdkVersion === '9.x'
+  );
 }


### PR DESCRIPTION
Makes the loader frontend forwards compatible with v9. Should be deployed before https://github.com/getsentry/sentry/pull/85135 is merged.