### PR TITLE
feat(derive_code_mapping): Support dry run mode 

### DIFF
--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -13,7 +13,22 @@ logger = logging.getLogger(__name__)
 
 
 # We only care about extensions of files which would show up in stacktraces after symbolication
-SUPPORTED_EXTENSIONS = ["js", "jsx", "tsx", "ts", "mjs", "py", "rb", "rake", "php", "go", "cs"]
+SUPPORTED_EXTENSIONS = [
+    "clj",
+    "cs",
+    "go",
+    "groovy",
+    "js",
+    "jsx",
+    "mjs",
+    "php",
+    "py",
+    "rake",
+    "rb",
+    "scala",
+    "ts",
+    "tsx",
+]
 EXCLUDED_EXTENSIONS = ["spec.jsx"]
 EXCLUDED_PATHS = ["tests/"]
 

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from typing import NamedTuple
 
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
@@ -188,17 +189,12 @@ class CodeMappingTreesHelper:
 
     def _stacktrace_buckets(self, stacktraces: list[str]) -> dict[str, list[FrameFilename]]:
         """Groups stacktraces into buckets based on the root of the stacktrace path"""
-        buckets: dict[str, list[FrameFilename]] = {}
+        buckets: defaultdict[str, list[FrameFilename]] = defaultdict(list)
         for stacktrace_frame_file_path in stacktraces:
             try:
                 frame_filename = FrameFilename(stacktrace_frame_file_path)
                 # Any files without a top directory will be grouped together
-                bucket_key = frame_filename.root
-
-                if not buckets.get(bucket_key):
-                    buckets[bucket_key] = []
-                buckets[bucket_key].append(frame_filename)
-
+                buckets[frame_filename.root].append(frame_filename)
             except UnsupportedFrameFilename:
                 logger.info("Frame's filepath not supported: %s", stacktrace_frame_file_path)
             except Exception:

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -1,3 +1,13 @@
 SUPPORTED_INTEGRATIONS = ["github"]
 # Any new languages should also require updating the stacktraceLink.tsx and repo_trees.py SUPPORTED_EXTENSIONS
-SUPPORTED_LANGUAGES = ["javascript", "python", "node", "ruby", "php", "go", "csharp"]
+SUPPORTED_LANGUAGES = [
+    "csharp",
+    "go",
+    "javascript",
+    "node",
+    "php",
+    "python",
+    "ruby",
+]
+# These languages will run as dry-run mode by default
+DRY_RUN_PLATFORMS: list[str] = []

--- a/src/sentry/issues/auto_source_code_config/stacktraces.py
+++ b/src/sentry/issues/auto_source_code_config/stacktraces.py
@@ -19,16 +19,13 @@ def identify_stacktrace_paths(data: NodeData | Stacktrace) -> list[str]:
     stacktraces = get_stacktrace(data)
     stacktrace_paths = set()
     for stacktrace in stacktraces:
-        try:
-            frames = stacktrace["frames"]
-            for frame in frames:
-                if frame is None:
-                    continue
+        frames = stacktrace["frames"]
+        for frame in frames:
+            if frame is None:
+                continue
 
-                if frame.get("in_app"):
-                    stacktrace_paths.add(frame["filename"])
-        except Exception:
-            logger.exception("Error getting filenames for project.")
+            if frame.get("in_app") and frame.get("filename"):
+                stacktrace_paths.add(frame["filename"])
     return list(stacktrace_paths)
 
 

--- a/src/sentry/issues/auto_source_code_config/stacktraces.py
+++ b/src/sentry/issues/auto_source_code_config/stacktraces.py
@@ -21,12 +21,12 @@ def identify_stacktrace_paths(data: NodeData | Stacktrace) -> list[str]:
     for stacktrace in stacktraces:
         try:
             frames = stacktrace["frames"]
-            paths = {
-                frame["filename"]
-                for frame in frames
-                if frame and frame.get("in_app") and frame.get("filename")
-            }
-            stacktrace_paths.update(paths)
+            for frame in frames:
+                if frame is None:
+                    continue
+
+                if frame.get("in_app"):
+                    stacktrace_paths.add(frame["filename"])
         except Exception:
             logger.exception("Error getting filenames for project.")
     return list(stacktrace_paths)

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -71,6 +71,7 @@ def process_event(project_id: int, group_id: int, event_id: str) -> list[CodeMap
     if not stacktrace_paths:
         return []
 
+    code_mappings = []
     try:
         installation = get_installation(org)
         trees = get_trees_for_org(installation, org, extra)

--- a/src/sentry/issues/auto_source_code_config/utils.py
+++ b/src/sentry/issues/auto_source_code_config/utils.py
@@ -1,0 +1,5 @@
+from .constants import DRY_RUN_PLATFORMS, SUPPORTED_LANGUAGES
+
+
+def supported_platform(platform: str | None) -> bool:
+    return (platform or "") in SUPPORTED_LANGUAGES + DRY_RUN_PLATFORMS

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -995,7 +995,7 @@ def process_code_mappings(job: PostProcessJob) -> None:
         return
 
     from sentry.issues.auto_source_code_config.stacktraces import identify_stacktrace_paths
-    from sentry.issues.auto_source_code_config.task import supported_platform
+    from sentry.issues.auto_source_code_config.utils import supported_platform
     from sentry.tasks.auto_source_code_config import auto_source_code_config
 
     try:
@@ -1003,7 +1003,7 @@ def process_code_mappings(job: PostProcessJob) -> None:
         project = event.project
         group_id = event.group_id
 
-        if not supported_platform(event.platform):
+        if not supported_platform(event.data.get("platform")):
             return
 
         stacktrace_paths = identify_stacktrace_paths(event.data)

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -6,6 +6,7 @@ from sentry.eventstore.models import Event
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.source_code_management.repo_trees import RepoAndBranch, RepoTree
+from sentry.issues.auto_source_code_config.code_mapping import CodeMapping
 from sentry.issues.auto_source_code_config.task import DeriveCodeMappingsErrorReason, process_event
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
@@ -20,6 +21,7 @@ pytestmark = [requires_snuba]
 GET_TREES_FOR_ORG = (
     "sentry.integrations.source_code_management.repo_trees.RepoTreesIntegration.get_trees_for_org"
 )
+CODE_ROOT = "sentry.issues.auto_source_code_config"
 
 
 class BaseDeriveCodeMappings(TestCase):
@@ -36,9 +38,7 @@ class BaseDeriveCodeMappings(TestCase):
             metadata={"domain_name": f"{self.domain_name}/test-org"},
         )
 
-    def create_event(
-        self, frames: Sequence[Mapping[str, str | bool]], platform: str | None = None
-    ) -> Event:
+    def create_event(self, frames: Sequence[Mapping[str, str | bool]], platform: str) -> Event:
         """Helper function to prevent creating an event without a platform."""
         test_data = {"platform": platform, "stacktrace": {"frames": frames}}
         return self.store_event(data=test_data, project_id=self.project.id)
@@ -55,10 +55,11 @@ class BaseDeriveCodeMappings(TestCase):
             assert code_mapping.stack_root == stack_root
             assert code_mapping.source_root == source_root
 
-    def _process_and_assert_no_code_mapping(self, files: Sequence[str]) -> None:
+    def _process_and_assert_no_code_mapping(self, files: Sequence[str]) -> list[CodeMapping]:
         with patch(GET_TREES_FOR_ORG, return_value=self._get_trees_for_org(files)):
-            process_event(self.project.id, self.event.group_id, self.event.event_id)
+            code_mappings = process_event(self.project.id, self.event.group_id, self.event.event_id)
             assert not RepositoryProjectPathConfig.objects.exists()
+            return code_mappings
 
 
 @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -126,6 +127,18 @@ class TestGenericBehaviour(BaseDeriveCodeMappings):
         all_cm = RepositoryProjectPathConfig.objects.all()
         assert len(all_cm) == 1
         assert all_cm[0].automatically_generated is False
+
+    def test_dry_run_platform(self) -> None:
+        with (
+            patch(f"{CODE_ROOT}.task.supported_platform", return_value=True),
+            patch(f"{CODE_ROOT}.task.DRY_RUN_PLATFORMS", ["other"]),
+        ):
+            self.event = self.create_event([{"filename": "foo/bar.py", "in_app": True}], "other")
+            # No code mapping will be stored, however, we get what would have been created
+            code_mappings = self._process_and_assert_no_code_mapping(["src/foo/bar.py"])
+            assert len(code_mappings) == 1
+            assert code_mappings[0].stacktrace_root == "foo/"
+            assert code_mappings[0].source_path == "src/foo/"
 
 
 class LanguageSpecificDeriveCodeMappings(BaseDeriveCodeMappings):


### PR DESCRIPTION
The dry run mode allows testing the load of adding a new platform without creating the code mappings. It also helps collect metrics and discover errors.

This handles the issues found in #85065. 