### PR TITLE
fix(search-query-builder): Always show search indicator in search bar

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -126,11 +126,7 @@ function SearchIndicator({
   initialQuery?: string;
   showUnsubmittedIndicator?: boolean;
 }) {
-  const {size, query} = useSearchQueryBuilder();
-
-  if (size === 'small') {
-    return null;
-  }
+  const {query} = useSearchQueryBuilder();
 
   const unSubmittedChanges = query !== initialQuery;
   const showIndicator = showUnsubmittedIndicator && unSubmittedChanges;

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -81,7 +81,6 @@ function Grid(props: GridProps) {
     <SearchQueryGridWrapper
       {...gridProps}
       ref={ref}
-      size={size}
       style={size === 'small' ? undefined : {paddingRight: props.actionBarWidth + 12}}
     >
       <SelectionKeyHandler ref={selectionKeyHandlerRef} state={state} undo={undo} />
@@ -161,10 +160,10 @@ export function TokenizedQueryGrid({label, actionBarWidth}: TokenizedQueryGridPr
   );
 }
 
-const SearchQueryGridWrapper = styled('div')<{size: 'small' | 'normal'}>`
+const SearchQueryGridWrapper = styled('div')`
   padding-top: ${space(0.75)};
   padding-bottom: ${space(0.75)};
-  padding-left: ${p => (p.size === 'small' ? space(0.75) : '32px')};
+  padding-left: 32px;
   padding-right: ${space(0.75)};
   display: flex;
   align-items: stretch;


### PR DESCRIPTION
The indicator has a dot showing if the query has been submitted yet and we always want to be able to see it.