### PR TITLE
ref: remote MetricUnit literal

### DIFF
--- a/src/sentry/sentry_metrics/querying/metadata/metrics.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics.py
@@ -7,7 +7,7 @@ from sentry.models.project import Project
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics import parse_mri
 from sentry.snuba.metrics.naming_layer.mri import ParsedMRI, get_available_operations
-from sentry.snuba.metrics.utils import MetricMeta, MetricType, MetricUnit
+from sentry.snuba.metrics.utils import MetricMeta, MetricType
 from sentry.snuba.metrics_layer.query import fetch_metric_mris
 
 
@@ -75,7 +75,7 @@ def _build_metric_meta(
     return MetricMeta(
         type=cast(MetricType, parsed_mri.entity),
         name=parsed_mri.name,
-        unit=cast(MetricUnit, parsed_mri.unit),
+        unit=parsed_mri.unit,
         mri=parsed_mri.mri_string,
         operations=available_operations,
         projectIds=project_ids,

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -48,7 +48,6 @@ from sentry.snuba.metrics.utils import (
     OP_REGEX,
     MetricEntity,
     MetricOperationType,
-    MetricUnit,
 )
 
 MRI_SCHEMA_REGEX_STRING = r"(?P<entity>[^:]+):(?P<namespace>[^/]+)/(?P<name>[^@]+)@(?P<unit>.+)"
@@ -274,8 +273,9 @@ def format_mri_field_value(field: str, value: str) -> str:
         if parsed_mri_field is None:
             return value
 
-        unit = cast(MetricUnit, parsed_mri_field.mri.unit)
-        return format_value_using_unit_and_op(float(value), unit, parsed_mri_field.op)
+        return format_value_using_unit_and_op(
+            float(value), parsed_mri_field.mri.unit, parsed_mri_field.op
+        )
 
     except InvalidParams:
         return value

--- a/src/sentry/snuba/metrics/units.py
+++ b/src/sentry/snuba/metrics/units.py
@@ -1,4 +1,4 @@
-from sentry.snuba.metrics.utils import MetricOperationType, MetricUnit
+from sentry.snuba.metrics.utils import MetricOperationType
 from sentry.utils.numbers import format_bytes
 
 __all__ = (
@@ -8,7 +8,7 @@ __all__ = (
 
 
 def format_value_using_unit_and_op(
-    value: int | float, unit: MetricUnit, op: MetricOperationType | None
+    value: int | float, unit: str, op: MetricOperationType | None
 ) -> str:
     if op == "count" or op == "count_unique":
         return round_with_fixed(value, 2)
@@ -16,7 +16,7 @@ def format_value_using_unit_and_op(
     return format_value_using_unit(value, unit)
 
 
-def format_value_using_unit(value: int | float, unit: MetricUnit) -> str:
+def format_value_using_unit(value: int | float, unit: str) -> str:
     if unit == "nanosecond":
         return get_duration(value / 1000000000)
     elif unit == "microsecond":

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -15,7 +15,6 @@ __all__ = (
     "TS_COL_GROUP",
     "TAG_REGEX",
     "MetricOperationType",
-    "MetricUnit",
     "MetricType",
     "OP_TO_SNUBA_FUNCTION",
     "AVAILABLE_OPERATIONS",
@@ -92,31 +91,6 @@ MetricOperationType = Literal[
     "on_demand_count_unique",
     "on_demand_count_web_vitals",
     "on_demand_user_misery",
-]
-MetricUnit = Literal[
-    "nanosecond",
-    "microsecond",
-    "millisecond",
-    "second",
-    "minute",
-    "hour",
-    "day",
-    "week",
-    "bit",
-    "byte",
-    "kibibyte",
-    "mebibyte",
-    "gibibyte",
-    "tebibyte",
-    "pebibyte",
-    "exbibyte",
-    "kilobyte",
-    "megabyte",
-    "gigabyte",
-    "terabyte",
-    "petabyte",
-    "exabyte",
-    "none",
 ]
 #: The type of metric, which determines the snuba entity to query
 MetricType = Literal[
@@ -338,7 +312,7 @@ class MetricMeta(TypedDict):
     name: str
     type: MetricType
     operations: Collection[MetricOperationType]
-    unit: MetricUnit | None
+    unit: str | None
     metric_id: NotRequired[int]
     mri: str
     projectIds: Sequence[int]


### PR DESCRIPTION
it was only ever cast to and never validated for contents.  when adding validation many tests fail due to units being a variety of things not found in the Literal

<!-- Describe your PR here. -->