### PR TITLE
feat(crons): Allow the occurrence summary on cron issues

### DIFF
--- a/static/app/utils/issueTypeConfig/cronConfig.tsx
+++ b/static/app/utils/issueTypeConfig/cronConfig.tsx
@@ -27,7 +27,7 @@ const cronConfig: IssueCategoryConfigMapping = {
       filterBar: {enabled: true},
       graph: {enabled: true, type: 'cron-checks'},
       tagDistribution: {enabled: false},
-      occurrenceSummary: {enabled: false},
+      occurrenceSummary: {enabled: true},
     },
     detector: {
       enabled: true,

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -231,7 +231,8 @@ const GraphSection = styled('div')`
 
 const OccurrenceSummarySection = styled(OccurrenceSummary)`
   grid-area: timeline;
-  padding: ${space(2)} 0 0 ${space(2)};
+  padding: ${space(1)};
+  padding-left: 0;
   &:not(:first-child) {
     border-top: 1px solid ${p => p.theme.translucentBorder};
   }

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -231,8 +231,7 @@ const GraphSection = styled('div')`
 
 const OccurrenceSummarySection = styled(OccurrenceSummary)`
   grid-area: timeline;
-  padding: ${space(2)};
-  padding-right: 0;
+  padding: ${space(2)} 0 0 ${space(2)};
   &:not(:first-child) {
     border-top: 1px solid ${p => p.theme.translucentBorder};
   }

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.spec.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.spec.tsx
@@ -1,0 +1,129 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
+
+import {
+  GroupActivityType,
+  GroupStatus,
+  IssueCategory,
+  IssueType,
+} from 'sentry/types/group';
+import {OccurrenceSummary} from 'sentry/views/issueDetails/streamline/occurrenceSummary';
+
+describe('OccurrenceSummary', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  afterEach(() => {
+    resetMockDate();
+  });
+
+  it('renders empty if not enabled in the issue config', function () {
+    const group = GroupFixture();
+    const event = EventFixture();
+    const {container} = render(<OccurrenceSummary group={group} event={event} />, {
+      organization,
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders downtime if enabled', function () {
+    const group = GroupFixture({
+      issueCategory: IssueCategory.UPTIME,
+      issueType: IssueType.UPTIME_DOMAIN_FAILURE,
+      status: GroupStatus.RESOLVED,
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED,
+          dateCreated: '2025-01-02T11:00:00Z',
+          data: {},
+          project,
+          id: '2',
+        },
+        {
+          type: GroupActivityType.FIRST_SEEN,
+          dateCreated: '2025-01-01T11:00:00Z',
+          data: {},
+          project,
+          id: '1',
+        },
+      ],
+    });
+    const event = EventFixture();
+    render(<OccurrenceSummary group={group} event={event} />, {
+      organization,
+    });
+    expect(screen.getByText('Downtime')).toBeInTheDocument();
+    expect(screen.getByText('1 day')).toBeInTheDocument();
+  });
+
+  it('renders detector details if found', function () {
+    const group = GroupFixture({
+      issueCategory: IssueCategory.UPTIME,
+      issueType: IssueType.UPTIME_DOMAIN_FAILURE,
+    });
+    const event = EventFixture({
+      tags: [
+        {
+          key: 'uptime_rule',
+          value: '123',
+        },
+      ],
+    });
+    render(<OccurrenceSummary group={group} event={event} />, {
+      organization,
+    });
+    expect(screen.getByText('Monitor ID')).toBeInTheDocument();
+    expect(screen.getByText('123')).toBeInTheDocument();
+  });
+
+  it('renders evidence detailsif found', function () {
+    const now = '2025-01-01T12:00:00Z';
+    setMockDate(new Date(now));
+
+    const group = GroupFixture({
+      issueCategory: IssueCategory.CRON,
+      issueType: IssueType.MONITOR_CHECK_IN_FAILURE,
+    });
+    const event = EventFixture({
+      occurrence: {
+        evidenceDisplay: [
+          {
+            name: 'Environment',
+            value: 'production',
+          },
+          {
+            name: 'Status Code',
+            value: '500',
+          },
+          {
+            name: 'Failure reason',
+            value: 'bad things',
+          },
+          {
+            name: 'Last successful check-in',
+            value: '2025-01-01T11:00:00Z',
+          },
+        ],
+      },
+    });
+    render(<OccurrenceSummary group={group} event={event} />, {
+      organization,
+    });
+    expect(screen.getByText('Environment')).toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+
+    expect(screen.getByText('Status Code')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument();
+
+    expect(screen.getByText('Reason')).toBeInTheDocument();
+    expect(screen.getByText('bad things')).toBeInTheDocument();
+
+    expect(screen.getByText('Last Successful Check-In')).toBeInTheDocument();
+    expect(screen.getByText('an hour ago')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import {Flex} from 'sentry/components/container/flex';
 import {DowntimeDuration} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
 import Link from 'sentry/components/links/link';
+import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Event, EventEvidenceDisplay} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -115,17 +115,14 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
 
   return items.length > 0 ? (
     <div className={className}>
-      {items.map((item, i) => (
-        <Item key={i}>{item}</Item>
-      ))}
+      <ScrollCarousel gap={3} aria-label={t('Occurrence summary')} className={className}>
+        {items.map((item, i) => (
+          <div key={i}>{item}</div>
+        ))}
+      </ScrollCarousel>
     </div>
   ) : null;
 }
-
-const Item = styled('div')`
-  display: inline-block;
-  margin: 0 ${space(4)} ${space(2)} 0;
-`;
 
 const ItemTitle = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -12,10 +12,60 @@ import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDetectorDetails} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
 
+enum KnownEvidence {
+  ENVIRONMENT = 'Environment',
+  STATUS_CODE = 'Status Code',
+  FAILURE_REASON = 'Failure reason',
+  LAST_SUCCESSFUL_CHECK_IN = 'Last successful check-in',
+}
+
+const KnownEvidenceKeys = new Set<string>(Object.values(KnownEvidence));
+
 interface OccurrenceSummaryProps {
   group: Group;
   className?: string;
   event?: Event;
+}
+
+function getEvidenceItem({
+  evidence,
+  evidenceKey,
+}: {
+  evidence: EventEvidenceDisplay;
+  evidenceKey: KnownEvidence;
+}) {
+  switch (evidenceKey) {
+    case KnownEvidence.ENVIRONMENT:
+      return (
+        <Flex column>
+          <ItemTitle>{t('Environment')}</ItemTitle>
+          <ItemValue>{evidence.value}</ItemValue>
+        </Flex>
+      );
+    case KnownEvidence.STATUS_CODE:
+      return (
+        <Flex column>
+          <ItemTitle>{t('Status Code')}</ItemTitle>
+          <ItemValue>{evidence.value}</ItemValue>
+        </Flex>
+      );
+    case KnownEvidence.FAILURE_REASON:
+      return (
+        <Flex column>
+          <ItemTitle>{t('Reason')}</ItemTitle>
+          <ItemValue>{evidence.value}</ItemValue>
+        </Flex>
+      );
+    case KnownEvidence.LAST_SUCCESSFUL_CHECK_IN:
+      return (
+        <Flex column>
+          <ItemTitle>{t('Last Successful Check-In')}</ItemTitle>
+          <ItemTimeSince date={evidence.value} />
+        </Flex>
+      );
+    default:
+      return null;
+  }
 }
 
 /**
@@ -70,48 +120,22 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
     }
   }
 
-  const evidenceMap = event?.occurrence?.evidenceDisplay?.reduce<
-    Record<string, EventEvidenceDisplay>
-  >((map, eed) => {
-    map[eed.name] = eed;
-    return map;
-  }, {});
+  const knownEvidence =
+    event?.occurrence?.evidenceDisplay?.reduce(
+      (map, eed) => {
+        if (KnownEvidenceKeys.has(eed.name)) {
+          map[eed.name as KnownEvidence] = eed;
+        }
+        return map;
+      },
+      {} as Record<KnownEvidence, EventEvidenceDisplay>
+    ) ?? ({} as Record<KnownEvidence, EventEvidenceDisplay>);
 
-  if (evidenceMap?.Environment) {
-    items.push(
-      <Flex column>
-        <ItemTitle>{t('Environment')}</ItemTitle>
-        <ItemValue>{evidenceMap.Environment.value}</ItemValue>
-      </Flex>
-    );
-  }
-
-  if (evidenceMap?.['Status Code']) {
-    items.push(
-      <Flex column>
-        <ItemTitle>{t('Status Code')}</ItemTitle>
-        <ItemValue>{evidenceMap['Status Code'].value}</ItemValue>
-      </Flex>
-    );
-  }
-
-  if (evidenceMap?.['Failure reason']) {
-    items.push(
-      <Flex column>
-        <ItemTitle>{t('Reason')}</ItemTitle>
-        <ItemValue>{evidenceMap['Failure reason'].value}</ItemValue>
-      </Flex>
-    );
-  }
-
-  if (evidenceMap?.['Last successful check-in']) {
-    items.push(
-      <Flex column>
-        <ItemTitle>{t('Last Successful Check-In')}</ItemTitle>
-        <ItemTimeSince date={evidenceMap['Last successful check-in'].value} />
-      </Flex>
-    );
-  }
+  (Object.entries(knownEvidence) as Array<[KnownEvidence, EventEvidenceDisplay]>).forEach(
+    ([evidenceKey, evidence]) => {
+      items.push(getEvidenceItem({evidence, evidenceKey}));
+    }
+  );
 
   return items.length > 0 ? (
     <div className={className}>

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -1,9 +1,9 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
 import {DowntimeDuration} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
 import Link from 'sentry/components/links/link';
+import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, EventEvidenceDisplay} from 'sentry/types/event';
@@ -77,6 +77,15 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
     return map;
   }, {});
 
+  if (evidenceMap?.Environment) {
+    items.push(
+      <Flex column>
+        <ItemTitle>{t('Environment')}</ItemTitle>
+        <ItemValue>{evidenceMap.Environment.value}</ItemValue>
+      </Flex>
+    );
+  }
+
   if (evidenceMap?.['Status Code']) {
     items.push(
       <Flex column>
@@ -95,17 +104,28 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
     );
   }
 
-  // TODO(Leander): Add last successful check-in when the data is available
-  // TODO(Leander): Add Incident ID when the data is available
+  if (evidenceMap?.['Last successful check-in']) {
+    items.push(
+      <Flex column>
+        <ItemTitle>{t('Last Successful Check-In')}</ItemTitle>
+        <ItemTimeSince date={evidenceMap['Last successful check-in'].value} />
+      </Flex>
+    );
+  }
 
   return items.length > 0 ? (
-    <Flex align="start" gap={space(4)} className={className}>
+    <div className={className}>
       {items.map((item, i) => (
-        <Fragment key={i}>{item}</Fragment>
+        <Item key={i}>{item}</Item>
       ))}
-    </Flex>
+    </div>
   ) : null;
 }
+
+const Item = styled('div')`
+  display: inline-block;
+  margin: 0 ${space(4)} ${space(2)} 0;
+`;
 
 const ItemTitle = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
@@ -117,6 +137,10 @@ const ItemValue = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: ${p => p.theme.fontWeightNormal};
   max-width: 400px;
+`;
+
+const ItemTimeSince = styled(TimeSince)`
+  font-size: ${p => p.theme.fontSizeLarge};
 `;
 
 const ItemLink = styled(Link)`


### PR DESCRIPTION
Allows the occurrence summary section to appear on cron issues. 

They can be a bit longer than the window, so I used the scroll container to avoid pushing content on the page further down if users don't really need this summary.

<img width="829" alt="image" src="https://github.com/user-attachments/assets/97284dcb-eea3-46bf-9460-4cd0a2330d13" />


Also added tests for this component aside from the ones in `eventDetailsHeader.spec.tsx`

