### PR TITLE
Fix variable subtitutions to avoid code execution via manual workflow trigger with malicious payload

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -30,11 +30,13 @@ jobs:
           committer_email: bot@sentry.io
           token: ${{ secrets.BUMP_SENTRY_TOKEN }}
       - name: comment on failure
+        env:
+          PR: ${{ github.event.number || github.event.inputs.pr }}
         run: |
           curl \
               --silent \
               -X POST \
               -H 'Authorization: token ${{ secrets.BUMP_SENTRY_TOKEN }}' \
               -d'{"body": "revert failed (conflict? already reverted?) -- [check the logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
-              https://api.github.com/repositories/${{ github.event.repository.id }}/issues/${{ github.event.number || github.event.inputs.pr }}/comments
+              https://api.github.com/repositories/${{ github.event.repository.id }}/issues/${PR}/comments
         if: failure()


### PR DESCRIPTION
<!-- Describe your PR here. -->
Malicious actors with workflow dispatch permission can execute this workflow with manually crafted `pr` which will contain a payload leading to RCE. Like this one: `;printenv|base64;`
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
