### PR TITLE
fix(insights): ignore http.server on frontend

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -33,7 +33,10 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
-import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
+import {
+  BACKEND_LANDING_TITLE,
+  OVERVIEW_PAGE_ALLOWED_OPS,
+} from 'sentry/views/insights/pages/backend/settings';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {
   FRONTEND_PLATFORMS,
@@ -139,6 +142,7 @@ function BackendOverviewPage() {
   );
 
   const existingQuery = new MutableSearch(eventView.query);
+  existingQuery.addOp('(');
   existingQuery.addFilterValues('!transaction.op', disallowedOps);
 
   if (selectedFrontendProjects.length > 0 || selectedMobileProjects.length > 0) {
@@ -150,6 +154,9 @@ function BackendOverviewPage() {
       ]}]`
     );
   }
+  existingQuery.addOp(')');
+  existingQuery.addOp('OR');
+  existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
 
   eventView.query = existingQuery.formatString();
 

--- a/static/app/views/insights/pages/backend/settings.ts
+++ b/static/app/views/insights/pages/backend/settings.ts
@@ -14,3 +14,5 @@ export const MODULES = [
   ModuleName.UPTIME,
   ModuleName.SESSIONS,
 ];
+
+export const OVERVIEW_PAGE_ALLOWED_OPS = ['http.server'];

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -41,7 +41,7 @@ describe('FrontendOverviewPage', () => {
   });
 
   describe('data fetching', () => {
-    it('fetches correct data with unkown + frontend platform', async () => {
+    it('fetches correct data with unknown + frontend platform', async () => {
       render(<FrontendOverviewPage />);
 
       expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(
@@ -52,7 +52,7 @@ describe('FrontendOverviewPage', () => {
         expect.objectContaining({
           query: expect.objectContaining({
             query:
-              '( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) OR project.id:[1] event.type:transaction',
+              '( ( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) OR project.id:[1] ) !transaction.op:http.server event.type:transaction',
           }),
         })
       );
@@ -80,7 +80,7 @@ describe('FrontendOverviewPage', () => {
         expect.objectContaining({
           query: expect.objectContaining({
             query:
-              '( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) event.type:transaction',
+              '( ( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) ) !transaction.op:http.server event.type:transaction',
           }),
         })
       );

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -32,6 +32,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTrendsButton';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {
@@ -123,6 +124,8 @@ function FrontendOverviewPage() {
   );
 
   const existingQuery = new MutableSearch(eventView.query);
+  // TODO - this query is getting complicated, once were on EAP, we should consider moving this to the backend
+  existingQuery.addOp('(');
   existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
   // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
   if (selectedFrontendProjects.length > 0) {
@@ -132,6 +135,8 @@ function FrontendOverviewPage() {
       `[${selectedFrontendProjects.map(({id}) => id).join(',')}]`
     );
   }
+  existingQuery.addOp(')');
+  existingQuery.addFilterValues('!transaction.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -14,6 +14,8 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'interaction',
 ];
 
+export const OVERVIEW_PAGE_DISALLOWED_OPS = ['http.server'];
+
 export const MODULES = [
   ModuleName.VITAL,
   ModuleName.HTTP,


### PR DESCRIPTION
A couple projects have multiple SDKs associated with them, although this is debatably not how sentry is setup to work, we can make domain views more robust in this case case. In this PR we explicitly look for `http.server` on the backend view, and ignore it on frontend.