### PR TITLE
fix(issue-details): Fix environment query from tag drawer

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -158,7 +158,12 @@ function TagDetailsRow({
   const organization = useOrganization();
 
   const key = tagValue.key ?? tag.key;
-  const query = {query: tagValue.query || `${key}:"${tagValue.value}"`};
+  const query =
+    key === 'environment'
+      ? {
+          environment: tagValue.value,
+        }
+      : {query: tagValue.query || `${key}:"${tagValue.value}"`};
   const allEventsLocation = {
     pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
     query,


### PR DESCRIPTION
similar to https://github.com/getsentry/sentry/pull/83550 , this pr fixes the query for environments to the tag drawer. because we have the environment selector, just passing the query doesn't work 