### PR TITLE
ref(theme): Lighten dark gray300

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -649,7 +649,7 @@ const darkColors: Colors = {
 
   gray500: '#EBE6EF',
   gray400: '#D6D0DC',
-  gray300: '#998DA5',
+  gray300: '#A398AE',
   gray200: '#393041',
   gray100: '#302735',
 


### PR DESCRIPTION
Lighten `gray300` in dark mode to provide better contrast.
Before ——
![image](https://github.com/user-attachments/assets/129d4c48-7819-4df6-b390-3f61aa8909b6)

After ——
![image](https://github.com/user-attachments/assets/19f8b5fa-f6f6-4e9b-8ef3-03a9b3a040d6)
