### PR TITLE
feat(nav): Add what's new

### DIFF
--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -1,6 +1,4 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
 
@@ -34,6 +32,11 @@ const ALL_AVAILABLE_FEATURES = [
 describe('Nav', function () {
   beforeEach(() => {
     localStorage.clear();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      body: [],
+    });
   });
 
   function renderNav({
@@ -178,6 +181,20 @@ describe('Nav', function () {
     });
   });
 
+  describe('analytics', function () {
+    it('tracks primary sidebar item', async function () {
+      renderNav();
+      const issues = screen.getByRole('link', {name: 'Issues'});
+      await userEvent.click(issues);
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'growth.clicked_sidebar',
+        expect.objectContaining({
+          item: 'issues',
+        })
+      );
+    });
+  });
+
   describe('mobile navigation', function () {
     beforeEach(() => {
       // Need useMedia() to return true for isMobile query
@@ -225,28 +242,5 @@ describe('Nav', function () {
       await userEvent.click(screen.getByRole('link', {name: 'Explore'}));
       expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
     });
-  });
-});
-
-describe('analytics', function () {
-  function renderNav() {
-    render(<Nav />, {
-      router: RouterFixture({
-        location: LocationFixture({pathname: '/organizations/org-slug/traces/'}),
-      }),
-      organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
-    });
-  }
-
-  it('tracks primary sidebar item', async function () {
-    renderNav();
-    const issues = screen.getByRole('link', {name: 'Issues'});
-    await userEvent.click(issues);
-    expect(trackAnalytics).toHaveBeenCalledWith(
-      'growth.clicked_sidebar',
-      expect.objectContaining({
-        item: 'issues',
-      })
-    );
   });
 });

--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
 import {useNavContext} from 'sentry/components/nav/context';
-import {PrimaryNavigationItems} from 'sentry/components/nav/primary';
+import {PrimaryNavigationItems} from 'sentry/components/nav/primary/index';
 import {SecondaryMobile} from 'sentry/components/nav/secondaryMobile';
 import {IconClose, IconMenu, IconSentry} from 'sentry/icons';
 import {t} from 'sentry/locale';

--- a/static/app/components/nav/primary/collapse.tsx
+++ b/static/app/components/nav/primary/collapse.tsx
@@ -1,0 +1,26 @@
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {useNavContext} from 'sentry/components/nav/context';
+import {NavButton, SidebarItem} from 'sentry/components/nav/primary/components';
+import {NavLayout} from 'sentry/components/nav/types';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export function CollapseButton() {
+  const {isCollapsed, setIsCollapsed, layout} = useNavContext();
+
+  if (layout !== NavLayout.SIDEBAR) {
+    return null;
+  }
+
+  return (
+    <SidebarItem>
+      <NavButton
+        onClick={() => setIsCollapsed(!isCollapsed)}
+        aria-label={isCollapsed ? t('Expand') : t('Collapse')}
+      >
+        <InteractionStateLayer />
+        <IconChevron direction={isCollapsed ? 'right' : 'left'} isDouble />
+      </NavButton>
+    </SidebarItem>
+  );
+}

--- a/static/app/components/nav/primary/components.tsx
+++ b/static/app/components/nav/primary/components.tsx
@@ -1,0 +1,197 @@
+import {type MouseEventHandler, useCallback} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Link from 'sentry/components/links/link';
+import {linkStyles} from 'sentry/components/links/styles';
+import {PRIMARY_SIDEBAR_WIDTH} from 'sentry/components/nav/constants';
+import {useNavContext} from 'sentry/components/nav/context';
+import {NavLayout} from 'sentry/components/nav/types';
+import {isLinkActive, makeLinkPropsFromTo} from 'sentry/components/nav/utils';
+import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface SidebarItemLinkProps {
+  analyticsKey: string;
+  label: string;
+  to: string;
+  activeTo?: string;
+  children?: React.ReactNode;
+  forceLabel?: boolean;
+  onClick?: MouseEventHandler<HTMLElement>;
+}
+
+interface SidebarItemDropdownProps {
+  analyticsKey: string;
+  items: MenuItemProps[];
+  label: string;
+  children?: React.ReactNode;
+  forceLabel?: boolean;
+}
+
+export function SidebarItem({children}: {children: React.ReactNode}) {
+  const {layout} = useNavContext();
+  return (
+    <SidebarItemWrapper isMobile={layout === NavLayout.MOBILE}>
+      {children}
+    </SidebarItemWrapper>
+  );
+}
+
+export function SidebarMenu({
+  items,
+  children,
+  analyticsKey,
+  label,
+  forceLabel,
+}: SidebarItemDropdownProps) {
+  const organization = useOrganization();
+  const recordAnalytics = useCallback(
+    () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
+    [organization, analyticsKey]
+  );
+  const {layout} = useNavContext();
+
+  const showLabel = forceLabel || layout === NavLayout.MOBILE;
+
+  return (
+    <SidebarItem>
+      <DropdownMenu
+        position="right-end"
+        trigger={(props, isOpen) => {
+          return (
+            <NavButton
+              {...props}
+              aria-label={!showLabel ? label : undefined}
+              onClick={event => {
+                recordAnalytics();
+                props.onClick?.(event);
+              }}
+            >
+              <InteractionStateLayer hasSelectedBackground={isOpen} />
+              {children}
+              {showLabel ? label : null}
+            </NavButton>
+          );
+        }}
+        items={items}
+      />
+    </SidebarItem>
+  );
+}
+
+export function SidebarLink({
+  children,
+  to,
+  activeTo = to,
+  analyticsKey,
+  label,
+  forceLabel = false,
+}: SidebarItemLinkProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const isActive = isLinkActive(normalizeUrl(activeTo, location), location.pathname);
+  const linkProps = makeLinkPropsFromTo(to);
+
+  const {layout} = useNavContext();
+  const showLabel = forceLabel || layout === NavLayout.MOBILE;
+
+  const recordAnalytics = useCallback(
+    () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
+    [organization, analyticsKey]
+  );
+
+  return (
+    <SidebarItem>
+      <NavLink
+        {...linkProps}
+        onClick={recordAnalytics}
+        aria-selected={isActive}
+        aria-current={isActive ? 'page' : undefined}
+        aria-label={!showLabel ? label : undefined}
+      >
+        <InteractionStateLayer hasSelectedBackground={isActive} />
+        {children}
+        {showLabel ? label : null}
+      </NavLink>
+    </SidebarItem>
+  );
+}
+
+const SidebarItemWrapper = styled('li')<{isMobile: boolean}>`
+  svg {
+    --size: 14px;
+    width: var(--size);
+    height: var(--size);
+
+    ${p =>
+      !p.isMobile &&
+      css`
+        --size: 16px;
+      `}
+  }
+  > a,
+  button {
+    display: flex;
+    flex-direction: row;
+    gap: ${space(1.5)};
+    align-items: center;
+    padding: ${space(1.5)} ${space(3)};
+    color: var(--color, currentColor);
+    font-size: ${p => p.theme.fontSizeMedium};
+    font-weight: ${p => p.theme.fontWeightNormal};
+    line-height: 1;
+    width: 100%;
+
+    & > * {
+      pointer-events: none;
+    }
+
+    ${p =>
+      !p.isMobile &&
+      css`
+        flex-direction: column;
+        justify-content: center;
+        border-radius: ${p.theme.borderRadius};
+        margin-inline: 0 auto;
+        gap: ${space(0.75)};
+        padding: ${space(1.5)} 0;
+        min-height: 44px;
+        width: ${PRIMARY_SIDEBAR_WIDTH - 10}px;
+        letter-spacing: -0.02em;
+        font-size: 10px;
+      `}
+  }
+`;
+
+export const NavLink = styled(Link)`
+  position: relative;
+`;
+
+export const NavButton = styled('button')`
+  border: none;
+  position: relative;
+  background: transparent;
+
+  ${linkStyles}
+`;
+
+export const SidebarItemBadge = styled('span')`
+  position: absolute;
+  top: ${space(0.5)};
+  right: ${space(1)};
+  display: block;
+  text-align: center;
+  color: ${p => p.theme.white};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  background: ${p => p.theme.red300};
+  width: 16px;
+  height: 16px;
+  border-radius: 16px;
+  line-height: 16px;
+`;

--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -1,19 +1,16 @@
-import {Fragment, type MouseEventHandler, useCallback} from 'react';
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
-import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import Link from 'sentry/components/links/link';
-import {linkStyles} from 'sentry/components/links/styles';
-import {NAV_GROUP_LABELS, PRIMARY_SIDEBAR_WIDTH} from 'sentry/components/nav/constants';
+import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {useNavContext} from 'sentry/components/nav/context';
+import {CollapseButton} from 'sentry/components/nav/primary/collapse';
+import {SidebarLink, SidebarMenu} from 'sentry/components/nav/primary/components';
+import {WhatsNew} from 'sentry/components/nav/primary/whatsNew';
 import {NavLayout, PrimaryNavGroup} from 'sentry/components/nav/types';
-import {isLinkActive, makeLinkPropsFromTo} from 'sentry/components/nav/utils';
 import {
-  IconChevron,
   IconDashboard,
   IconGraph,
   IconIssues,
@@ -24,28 +21,7 @@ import {
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-
-interface SidebarItemLinkProps {
-  analyticsKey: string;
-  label: string;
-  to: string;
-  activeTo?: string;
-  children?: React.ReactNode;
-  forceLabel?: boolean;
-  onClick?: MouseEventHandler<HTMLElement>;
-}
-
-interface SidebarItemDropdownProps {
-  analyticsKey: string;
-  items: MenuItemProps[];
-  label: string;
-  children?: React.ReactNode;
-  forceLabel?: boolean;
-}
 
 function SidebarBody({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
@@ -65,115 +41,6 @@ function SidebarFooter({children}: {children: React.ReactNode}) {
         {children}
       </SidebarItemList>
     </SidebarFooterWrapper>
-  );
-}
-
-function SidebarItem({children}: {children: React.ReactNode}) {
-  const {layout} = useNavContext();
-  return (
-    <SidebarItemWrapper isMobile={layout === NavLayout.MOBILE}>
-      {children}
-    </SidebarItemWrapper>
-  );
-}
-
-function SidebarMenu({
-  items,
-  children,
-  analyticsKey,
-  label,
-  forceLabel,
-}: SidebarItemDropdownProps) {
-  const organization = useOrganization();
-  const recordAnalytics = useCallback(
-    () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
-    [organization, analyticsKey]
-  );
-  const {layout} = useNavContext();
-
-  const showLabel = forceLabel || layout === NavLayout.MOBILE;
-
-  return (
-    <SidebarItem>
-      <DropdownMenu
-        position="right-end"
-        trigger={(props, isOpen) => {
-          return (
-            <NavButton
-              {...props}
-              aria-label={!showLabel ? label : undefined}
-              onClick={event => {
-                recordAnalytics();
-                props.onClick?.(event);
-              }}
-            >
-              <InteractionStateLayer hasSelectedBackground={isOpen} />
-              {children}
-              {showLabel ? label : null}
-            </NavButton>
-          );
-        }}
-        items={items}
-      />
-    </SidebarItem>
-  );
-}
-
-function SidebarLink({
-  children,
-  to,
-  activeTo = to,
-  analyticsKey,
-  label,
-  forceLabel = false,
-}: SidebarItemLinkProps) {
-  const organization = useOrganization();
-  const location = useLocation();
-  const isActive = isLinkActive(normalizeUrl(activeTo, location), location.pathname);
-  const linkProps = makeLinkPropsFromTo(to);
-
-  const {layout} = useNavContext();
-  const showLabel = forceLabel || layout === NavLayout.MOBILE;
-
-  const recordAnalytics = useCallback(
-    () => trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization}),
-    [organization, analyticsKey]
-  );
-
-  return (
-    <SidebarItem>
-      <NavLink
-        {...linkProps}
-        onClick={recordAnalytics}
-        aria-selected={isActive}
-        aria-current={isActive ? 'page' : undefined}
-        aria-label={!showLabel ? label : undefined}
-      >
-        <InteractionStateLayer hasSelectedBackground={isActive} />
-        {children}
-        {showLabel ? label : null}
-      </NavLink>
-    </SidebarItem>
-  );
-}
-
-function CollapseButton() {
-  const {isCollapsed, setIsCollapsed, layout} = useNavContext();
-
-  if (layout !== NavLayout.SIDEBAR) {
-    return null;
-  }
-
-  return (
-    <SidebarItem>
-      <NavButton
-        onClick={() => setIsCollapsed(!isCollapsed)}
-        aria-label={isCollapsed ? t('Expand') : t('Collapse')}
-      >
-        <InteractionStateLayer />
-        <IconChevron direction={isCollapsed ? 'right' : 'left'} isDouble />
-      </NavButton>
-    </SidebarItem>
   );
 }
 
@@ -230,6 +97,7 @@ export function PrimaryNavigationItems() {
       </SidebarBody>
 
       <SidebarFooter>
+        <WhatsNew />
         <SidebarMenu
           items={[
             {
@@ -325,52 +193,6 @@ const SidebarItemList = styled('ul')<{isMobile: boolean; compact?: boolean}>`
     `}
 `;
 
-const SidebarItemWrapper = styled('li')<{isMobile: boolean}>`
-  svg {
-    --size: 14px;
-    width: var(--size);
-    height: var(--size);
-
-    ${p =>
-      !p.isMobile &&
-      css`
-        --size: 16px;
-      `}
-  }
-  > a,
-  button {
-    display: flex;
-    flex-direction: row;
-    gap: ${space(1.5)};
-    align-items: center;
-    padding: ${space(1.5)} ${space(3)};
-    color: var(--color, currentColor);
-    font-size: ${p => p.theme.fontSizeMedium};
-    font-weight: ${p => p.theme.fontWeightNormal};
-    line-height: 1;
-    width: 100%;
-
-    & > * {
-      pointer-events: none;
-    }
-
-    ${p =>
-      !p.isMobile &&
-      css`
-        flex-direction: column;
-        justify-content: center;
-        border-radius: ${p.theme.borderRadius};
-        margin-inline: 0 auto;
-        gap: ${space(0.75)};
-        padding: ${space(1.5)} 0;
-        min-height: 44px;
-        width: ${PRIMARY_SIDEBAR_WIDTH - 10}px;
-        letter-spacing: -0.02em;
-        font-size: 10px;
-      `}
-  }
-`;
-
 const SidebarFooterWrapper = styled('div')`
   position: relative;
   border-top: 1px solid ${p => p.theme.translucentGray200};
@@ -378,16 +200,4 @@ const SidebarFooterWrapper = styled('div')`
   flex-direction: row;
   align-items: stretch;
   margin-top: auto;
-`;
-
-const NavLink = styled(Link)`
-  position: relative;
-`;
-
-const NavButton = styled('button')`
-  border: none;
-  position: relative;
-  background: transparent;
-
-  ${linkStyles}
 `;

--- a/static/app/components/nav/primary/whatsNew.spec.tsx
+++ b/static/app/components/nav/primary/whatsNew.spec.tsx
@@ -1,0 +1,102 @@
+import {BroadcastFixture} from 'sentry-fixture/broadcast';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {WhatsNew} from 'sentry/components/nav/primary/whatsNew';
+import {BROADCAST_CATEGORIES} from 'sentry/components/sidebar/broadcastPanelItem';
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+jest.mock('sentry/utils/analytics');
+
+describe('WhatsNew', function () {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/broadcasts/',
+      method: 'PUT',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      body: [],
+    });
+  });
+
+  it('renders empty state', async function () {
+    render(<WhatsNew />);
+
+    await userEvent.click(screen.getByRole('button', {name: "What's New"}));
+
+    expect(await screen.findByText(/No recent updates/)).toBeInTheDocument();
+  });
+
+  it('displays the correct number of unseen broadcasts as a badge', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      body: [
+        BroadcastFixture({
+          id: '1',
+          category: 'blog',
+          hasSeen: false,
+        }),
+        BroadcastFixture({
+          id: '2',
+          category: 'blog',
+          hasSeen: false,
+        }),
+        BroadcastFixture({
+          id: '3',
+          category: 'blog',
+          hasSeen: true,
+        }),
+      ],
+    });
+
+    render(<WhatsNew />);
+
+    expect(await screen.findByTestId('whats-new-badge')).toHaveTextContent('2');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      body: [],
+    });
+
+    //
+    await userEvent.click(screen.getByRole('button', {name: "What's New"}));
+    await waitFor(() => {
+      expect(screen.queryByTestId('whats-new-badge')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders a broadcast item with media content correctly', async function () {
+    const broadcast = BroadcastFixture({
+      mediaUrl:
+        'https://images.ctfassets.net/em6l9zw4tzag/2vWdw7ZaApWxygugalbyOC/285525e5b7c9fbfa8fb814a69ab214cd/PerformancePageSketches_hero.jpg?w=2520&h=945&q=50&fm=webp',
+      category: 'blog',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      body: [broadcast],
+    });
+
+    render(<WhatsNew />);
+
+    await userEvent.click(screen.getByRole('button', {name: "What's New"}));
+
+    // Verify that the broadcast content is rendered correctly
+    expect(await screen.findByText(BROADCAST_CATEGORIES.blog)).toBeInTheDocument();
+    const titleLink = screen.getByRole('link', {name: broadcast.title});
+    expect(titleLink).toHaveAttribute('href', broadcast.link);
+    expect(screen.getByText(/Source maps are JSON/)).toBeInTheDocument();
+
+    // Simulate click and check if analytics tracking is called
+    await userEvent.click(titleLink);
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'whats_new.link_clicked',
+      expect.objectContaining({
+        title: broadcast.title,
+        category: 'blog',
+      })
+    );
+  });
+});

--- a/static/app/components/nav/primary/whatsNew.tsx
+++ b/static/app/components/nav/primary/whatsNew.tsx
@@ -1,0 +1,155 @@
+import {Fragment, useEffect, useMemo, useRef} from 'react';
+
+import useDrawer from 'sentry/components/globalDrawer';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {useNavContext} from 'sentry/components/nav/context';
+import {
+  NavButton,
+  SidebarItem,
+  SidebarItemBadge,
+} from 'sentry/components/nav/primary/components';
+import {NavLayout} from 'sentry/components/nav/types';
+import {BroadcastPanelItem} from 'sentry/components/sidebar/broadcastPanelItem';
+import SidebarPanelEmpty from 'sentry/components/sidebar/sidebarPanelEmpty';
+import {IconBroadcast} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {Broadcast} from 'sentry/types/system';
+import {
+  type ApiQueryKey,
+  setApiQueryData,
+  useApiQuery,
+  useMutation,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+const MARK_SEEN_DELAY = 1000;
+
+function makeBroadcastsQueryKey({
+  organization,
+}: {
+  organization: Organization;
+}): ApiQueryKey {
+  return [`/organizations/${organization.slug}/broadcasts/`];
+}
+
+function useFetchBroadcasts() {
+  const organization = useOrganization();
+
+  return useApiQuery<Broadcast[]>(makeBroadcastsQueryKey({organization}), {
+    // Five minute stale time prevents window focus frequent refetches
+    staleTime: 1000 * 60 * 5,
+    // 10 minutes poll
+    refetchInterval: 1000 * 60 * 10,
+    refetchOnWindowFocus: true,
+  });
+}
+
+function WhatsNewContent({unseenPostIds}: {unseenPostIds: string[]}) {
+  const api = useApi();
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  const {mutate: markBroadcastsAsSeen} = useMutation({
+    mutationFn: (newUnseenPostIds: string[]) => {
+      return api.requestPromise('/broadcasts/', {
+        method: 'PUT',
+        query: {id: newUnseenPostIds},
+        data: {hasSeen: '1'},
+      });
+    },
+    onSuccess: () => {
+      setApiQueryData<Broadcast[]>(
+        queryClient,
+        makeBroadcastsQueryKey({organization}),
+        data => (data ? data.map(item => ({...item, hasSeen: true})) : [])
+      );
+    },
+  });
+
+  const {isPending, data: broadcasts = []} = useFetchBroadcasts();
+
+  useEffect(() => {
+    const markSeenTimeout = window.setTimeout(() => {
+      markBroadcastsAsSeen(unseenPostIds);
+    }, MARK_SEEN_DELAY);
+
+    return () => {
+      if (markSeenTimeout) {
+        window.clearTimeout(markSeenTimeout);
+      }
+    };
+  }, [unseenPostIds, markBroadcastsAsSeen]);
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (broadcasts.length === 0) {
+    return (
+      <SidebarPanelEmpty>
+        {t('No recent updates from the Sentry team.')}
+      </SidebarPanelEmpty>
+    );
+  }
+
+  return (
+    <Fragment>
+      {broadcasts.map(item => (
+        <BroadcastPanelItem
+          key={item.id}
+          hasSeen={item.hasSeen}
+          title={item.title}
+          message={item.message}
+          link={item.link}
+          mediaUrl={item.mediaUrl}
+          category={item.category}
+        />
+      ))}
+    </Fragment>
+  );
+}
+
+export function WhatsNew() {
+  const ref = useRef<HTMLButtonElement>(null);
+  const {openDrawer, isDrawerOpen, closeDrawer} = useDrawer();
+  const {data: broadcasts = []} = useFetchBroadcasts();
+  const unseenPostIds = useMemo(
+    () => broadcasts.filter(item => !item.hasSeen).map(item => item.id),
+    [broadcasts]
+  );
+
+  const {layout} = useNavContext();
+  const showLabel = layout === NavLayout.MOBILE;
+
+  return (
+    <SidebarItem>
+      <NavButton
+        ref={ref}
+        onClick={() => {
+          if (isDrawerOpen) {
+            closeDrawer();
+          } else {
+            openDrawer(() => <WhatsNewContent unseenPostIds={unseenPostIds} />, {
+              ariaLabel: t("What's New"),
+              shouldCloseOnInteractOutside: el => !ref.current?.contains(el),
+            });
+          }
+        }}
+        aria-label={showLabel ? undefined : t("What's New")}
+      >
+        <InteractionStateLayer />
+        <IconBroadcast />
+        {showLabel && <span>{t("What's New")}</span>}
+        {unseenPostIds.length > 0 && (
+          <SidebarItemBadge data-test-id="whats-new-badge">
+            {unseenPostIds.length}
+          </SidebarItemBadge>
+        )}
+      </NavButton>
+    </SidebarItem>
+  );
+}

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -7,7 +7,7 @@ import {
   SECONDARY_SIDEBAR_WIDTH,
 } from 'sentry/components/nav/constants';
 import {useNavContext} from 'sentry/components/nav/context';
-import {PrimaryNavigationItems} from 'sentry/components/nav/primary';
+import {PrimaryNavigationItems} from 'sentry/components/nav/primary/index';
 import {SecondarySidebar} from 'sentry/components/nav/secondarySidebar';
 import SidebarDropdown from 'sentry/components/sidebar/sidebarDropdown';
 import {space} from 'sentry/styles/space';


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

Adds "What's new" (broadcasts) to the new nav. 

While adding this, I reorganized the nav files a bit so it could reuse some of the existing components. Instead of everything residing in `primary.tsx`, I've created a `primary` folder and broke out the current file into `components.tsx` and `index.tsx`.

One big difference is that this now uses the drawer instead of the old panel.

![CleanShot 2025-02-13 at 10 07 01](https://github.com/user-attachments/assets/9f649aae-cd77-4822-bf66-03271bb5fef9)
