### PR TITLE
chore(apis): Publish GroupExternalIssue endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -284,6 +284,7 @@ from sentry.rules.history.endpoints.project_rule_stats import ProjectRuleStatsIn
 from sentry.scim.endpoints.members import OrganizationSCIMMemberDetails, OrganizationSCIMMemberIndex
 from sentry.scim.endpoints.schemas import OrganizationSCIMSchemaIndex
 from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails, OrganizationSCIMTeamIndex
+from sentry.sentry_apps.api.endpoints.group_external_issues import GroupExternalIssuesEndpoint
 from sentry.sentry_apps.api.endpoints.installation_details import (
     SentryAppInstallationDetailsEndpoint,
 )
@@ -412,7 +413,6 @@ from .endpoints.group_attachments import GroupAttachmentsEndpoint
 from .endpoints.group_autofix_update import GroupAutofixUpdateEndpoint
 from .endpoints.group_current_release import GroupCurrentReleaseEndpoint
 from .endpoints.group_external_issue_details import GroupExternalIssueDetailsEndpoint
-from .endpoints.group_external_issues import GroupExternalIssuesEndpoint
 from .endpoints.group_first_last_release import GroupFirstLastReleaseEndpoint
 from .endpoints.group_reprocessing import GroupReprocessingEndpoint
 from .endpoints.group_stats import GroupStatsEndpoint

--- a/src/sentry/apidocs/examples/sentry_app_examples.py
+++ b/src/sentry/apidocs/examples/sentry_app_examples.py
@@ -86,5 +86,7 @@ class SentryAppExamples:
                     "webUrl": "https://example.com/my-test-project/issue/example-issue-2/this-is-an-example-python-exception",
                 }
             ],
+            status_codes=["200"],
+            response_only=True,
         )
     ]

--- a/src/sentry/apidocs/examples/sentry_app_examples.py
+++ b/src/sentry/apidocs/examples/sentry_app_examples.py
@@ -73,3 +73,18 @@ class SentryAppExamples:
             response_only=True,
         )
     ]
+
+    GET_PLATFORM_EXTERNAL_ISSUE = [
+        OpenApiExample(
+            "Retrieve the custom integrations associated with an issue id",
+            value=[
+                {
+                    "id": "123456",
+                    "issueId": "1234567890",
+                    "serviceType": "example-app",
+                    "displayName": "example-issue#2",
+                    "webUrl": "https://example.com/my-test-project/issue/example-issue-2/this-is-an-example-python-exception",
+                }
+            ],
+        )
+    ]

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -13,7 +13,7 @@ from sentry.apidocs.examples.sentry_app_examples import SentryAppExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.sentry_apps.api.serializers.platform_external_issue import (
-    PlatformExternalIssueSerializer,
+    PlatformExternalIssueSerializerResponse,
 )
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 
@@ -31,7 +31,7 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
         parameters=[IssueParams.ISSUE_ID, GlobalParams.ORG_ID_OR_SLUG],
         responses={
             200: inline_sentry_response_serializer(
-                "GroupExternalIssueResponse", Sequence[PlatformExternalIssueSerializer]
+                "GroupExternalIssueResponse", Sequence[PlatformExternalIssueSerializerResponse]
             ),
         },
         examples=SentryAppExamples.RETRIEVE_SENTRY_APP,

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -19,13 +19,13 @@ from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssu
 @extend_schema(tags=["Integration"])
 @region_silo_endpoint
 class GroupExternalIssuesEndpoint(GroupEndpoint):
-    owner = ApiOwner.INTEGRATIONS
+    owner = ApiOwner.ECOSYSTEM
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
 
     @extend_schema(
-        operation_id="Retrieve the custom integrations associated with an issue id",
+        operation_id="Retrieve custom integration issue links for the given Sentry issue",
         parameters=[IssueParams.ISSUE_ID, GlobalParams.ORG_ID_OR_SLUG],
         responses={
             200: inline_sentry_response_serializer(
@@ -36,7 +36,7 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
     )
     def get(self, request: Request, group) -> Response:
         """
-        Retrieve the custom integrations associated with an issue
+        Retrieve custom integration issue links for the given Sentry issue
 
         """
         external_issues = PlatformExternalIssue.objects.filter(group_id=group.id)

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -1,5 +1,3 @@
-from collections.abc import Sequence
-
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -31,7 +29,7 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
         parameters=[IssueParams.ISSUE_ID, GlobalParams.ORG_ID_OR_SLUG],
         responses={
             200: inline_sentry_response_serializer(
-                "GroupExternalIssueResponse", Sequence[PlatformExternalIssueSerializerResponse]
+                "GroupExternalIssueResponse", list[PlatformExternalIssueSerializerResponse]
             ),
         },
         examples=SentryAppExamples.RETRIEVE_SENTRY_APP,

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -26,13 +26,17 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
 
     @extend_schema(
         operation_id="Retrieve custom integration issue links for the given Sentry issue",
-        parameters=[IssueParams.ISSUE_ID, GlobalParams.ORG_ID_OR_SLUG],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            IssueParams.ISSUES_OR_GROUPS,
+            IssueParams.ISSUE_ID,
+        ],
         responses={
             200: inline_sentry_response_serializer(
                 "GroupExternalIssueResponse", list[PlatformExternalIssueSerializerResponse]
             ),
         },
-        examples=SentryAppExamples.RETRIEVE_SENTRY_APP,
+        examples=SentryAppExamples.GET_PLATFORM_EXTERNAL_ISSUE,
     )
     def get(self, request: Request, group) -> Response:
         """

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -7,6 +9,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
+from sentry.apidocs.examples.sentry_app_examples import SentryAppExamples
+from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.sentry_apps.api.serializers.platform_external_issue import (
+    PlatformExternalIssueSerializer,
+)
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 
 
@@ -15,10 +23,24 @@ from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssu
 class GroupExternalIssuesEndpoint(GroupEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PUBLIC,
     }
 
+    @extend_schema(
+        operation_id="Retrieve the custom integrations associated with an issue id",
+        parameters=[IssueParams.ISSUE_ID, GlobalParams.ORG_ID_OR_SLUG],
+        responses={
+            200: inline_sentry_response_serializer(
+                "GroupExternalIssueResponse", Sequence[PlatformExternalIssueSerializer]
+            ),
+        },
+        examples=SentryAppExamples.RETRIEVE_SENTRY_APP,
+    )
     def get(self, request: Request, group) -> Response:
+        """
+        Retrieve the custom integrations associated with an issue
+
+        """
         external_issues = PlatformExternalIssue.objects.filter(group_id=group.id)
 
         return self.paginate(

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -1,6 +1,8 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
@@ -8,8 +10,10 @@ from sentry.api.serializers import serialize
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 
 
+@extend_schema(tags=["Integration"])
 @region_silo_endpoint
 class GroupExternalIssuesEndpoint(GroupEndpoint):
+    owner = ApiOwner.INTEGRATIONS
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
+++ b/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
@@ -1,10 +1,30 @@
+from collections.abc import Mapping
+from typing import Any, TypedDict
+
 from sentry.api.serializers import Serializer, register
+from sentry.models.team import AnonymousUser
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+
+
+class PlatformExternalIssueSerializer(TypedDict):
+    id: str
+    issueId: str
+    serviceType: str
+    displayName: str
+    webUrl: str
 
 
 @register(PlatformExternalIssue)
 class PlatformExternalIssueSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(
+        self,
+        obj: PlatformExternalIssue,
+        attrs: Mapping[str, Any],
+        user: User | AnonymousUser | RpcUser,
+        **kwargs: Any,
+    ) -> PlatformExternalIssueSerializer:
         return {
             "id": str(obj.id),
             "issueId": str(obj.group_id),

--- a/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
+++ b/src/sentry/sentry_apps/api/serializers/platform_external_issue.py
@@ -1,14 +1,15 @@
 from collections.abc import Mapping
 from typing import Any, TypedDict
 
+from django.contrib.auth.models import AnonymousUser
+
 from sentry.api.serializers import Serializer, register
-from sentry.models.team import AnonymousUser
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
 
-class PlatformExternalIssueSerializer(TypedDict):
+class PlatformExternalIssueSerializerResponse(TypedDict):
     id: str
     issueId: str
     serviceType: str
@@ -24,7 +25,7 @@ class PlatformExternalIssueSerializer(Serializer):
         attrs: Mapping[str, Any],
         user: User | AnonymousUser | RpcUser,
         **kwargs: Any,
-    ) -> PlatformExternalIssueSerializer:
+    ) -> PlatformExternalIssueSerializerResponse:
         return {
             "id": str(obj.id),
             "issueId": str(obj.group_id),


### PR DESCRIPTION
Moving this to under the Ecosystem team, as `PlatformExternalIssues` are just issues linked with Sentry apps. We want to publish this endpoint since we don't provide an` issue.unlinked `webhook