### PR TITLE
fix(ui): Fix time range selector styles when searching

### DIFF
--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -188,36 +188,38 @@ export function TimeRangeSelector({
 
   const getOptions = useCallback(
     (items: Item[]): Array<SelectOption<string>> => {
-      // Return the default options if there's nothing in search
-      if (!search) {
-        return items.map(item => {
-          if (item.value === 'absolute') {
-            return {
-              value: item.value,
-              // Wrap inside OptionLabel to offset custom margins from SelectorItemLabel
-              // TODO: Remove SelectorItemLabel & OptionLabel
-              label: <OptionLabel>{item.label}</OptionLabel>,
-              details:
-                start && end ? (
-                  <AbsoluteSummary>{getAbsoluteSummary(start, end, utc)}</AbsoluteSummary>
-                ) : null,
-              trailingItems: ({isFocused, isSelected}) => (
-                <IconArrow
-                  direction="right"
-                  size="xs"
-                  color={isFocused || isSelected ? undefined : 'subText'}
-                />
-              ),
-              textValue: item.searchKey,
-            };
-          }
-
+      const makeOption = (item: Item): SelectOption<string> => {
+        if (item.value === 'absolute') {
           return {
             value: item.value,
+            // Wrap inside OptionLabel to offset custom margins from SelectorItemLabel
+            // TODO: Remove SelectorItemLabel & OptionLabel
             label: <OptionLabel>{item.label}</OptionLabel>,
+            details:
+              start && end ? (
+                <AbsoluteSummary>{getAbsoluteSummary(start, end, utc)}</AbsoluteSummary>
+              ) : null,
+            trailingItems: ({isFocused, isSelected}) => (
+              <IconArrow
+                direction="right"
+                size="xs"
+                color={isFocused || isSelected ? undefined : 'subText'}
+              />
+            ),
             textValue: item.searchKey,
           };
-        });
+        }
+
+        return {
+          value: item.value,
+          label: <OptionLabel>{item.label}</OptionLabel>,
+          textValue: item.searchKey,
+        };
+      };
+
+      // Return the default options if there's nothing in search
+      if (!search) {
+        return items.map(makeOption);
       }
 
       const filteredItems = disallowArbitraryRelativeRanges
@@ -229,11 +231,7 @@ export function TimeRangeSelector({
             maxDateRange,
           });
 
-      return filteredItems.map<SelectOption<string>>(item => ({
-        value: item.value,
-        label: item.label,
-        textValue: item.searchKey,
-      }));
+      return filteredItems.map(makeOption);
     },
     [
       start,


### PR DESCRIPTION
Styles were changing when inputting search text. This ensure that the items are given the same styling regardless of whether or not there is a filter value.

![CleanShot 2025-02-13 at 11 09 06](https://github.com/user-attachments/assets/fc8a8a40-9244-4cd0-b583-d54a1ad72f64)
![CleanShot 2025-02-13 at 11 09 11](https://github.com/user-attachments/assets/268c4a7a-4f31-421b-8e9f-f870a7d3bb73)
