### PR TITLE
ref(post_process): Move code mapping logic to main location

### DIFF
--- a/src/sentry/issues/auto_source_code_config/post_process.py
+++ b/src/sentry/issues/auto_source_code_config/post_process.py
@@ -1,0 +1,31 @@
+from sentry.eventstore.models import GroupEvent
+from sentry.tasks.auto_source_code_config import auto_source_code_config
+from sentry.utils.cache import cache
+
+from .stacktraces import identify_stacktrace_paths
+from .utils import supported_platform
+
+
+def schedule_event_processing(event: GroupEvent) -> None:
+    project = event.project
+    group_id = event.group_id
+
+    if not supported_platform(event.data.get("platform")):
+        return
+
+    stacktrace_paths = identify_stacktrace_paths(event.data)
+    if not stacktrace_paths:
+        return
+
+    # To limit the overall number of tasks, only process one issue per project per hour. In
+    # order to give the most issues a chance to to be processed, don't reprocess any given
+    # issue for at least 24 hours.
+    project_cache_key = f"code-mappings:project:{project.id}"
+    issue_cache_key = f"code-mappings:group:{group_id}"
+    if cache.get(project_cache_key) is None and cache.get(issue_cache_key) is None:
+        cache.set(project_cache_key, True, 3600)  # 1 hour
+        cache.set(issue_cache_key, True, 86400)  # 24 hours
+    else:
+        return
+
+    auto_source_code_config.delay(project.id, event_id=event.event_id, group_id=group_id)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -994,34 +994,10 @@ def process_code_mappings(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
-    from sentry.issues.auto_source_code_config.stacktraces import identify_stacktrace_paths
-    from sentry.issues.auto_source_code_config.utils import supported_platform
-    from sentry.tasks.auto_source_code_config import auto_source_code_config
+    from sentry.issues.auto_source_code_config.post_process import schedule_event_processing
 
     try:
-        event = job["event"]
-        project = event.project
-        group_id = event.group_id
-
-        if not supported_platform(event.data.get("platform")):
-            return
-
-        stacktrace_paths = identify_stacktrace_paths(event.data)
-        if not stacktrace_paths:
-            return
-
-        # To limit the overall number of tasks, only process one issue per project per hour. In
-        # order to give the most issues a chance to to be processed, don't reprocess any given
-        # issue for at least 24 hours.
-        project_cache_key = f"code-mappings:project:{project.id}"
-        issue_cache_key = f"code-mappings:group:{group_id}"
-        if cache.get(project_cache_key) is None and cache.get(issue_cache_key) is None:
-            cache.set(project_cache_key, True, 3600)  # 1 hour
-            cache.set(issue_cache_key, True, 86400)  # 24 hours
-        else:
-            return
-
-        auto_source_code_config.delay(project.id, event_id=event.event_id, group_id=group_id)
+        schedule_event_processing(job["event"])
 
     except Exception:
         logger.exception("Failed to process automatic source code config")


### PR DESCRIPTION
This makes it faster to check any typing issues without forgetting to include post_process.py in the list of files.