### PR TITLE
fix(onboarding): Modify useCurrentProjectState to not require an additional rerender

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
@@ -202,4 +202,25 @@ describe('useCurrentProjectState', () => {
     act(() => result.current.setCurrentProject(angular));
     expect(result.current.currentProject).toBe(angular);
   });
+
+  it('should update when the page filters store changes', () => {
+    ProjectsStore.loadInitialData([javascript, angular]);
+    mockPageFilterStore([angular]);
+    const {result} = renderHook(useCurrentProjectState, {
+      initialProps: {
+        currentPanel: SidebarPanelKey.FEEDBACK_ONBOARDING,
+        targetPanel: SidebarPanelKey.FEEDBACK_ONBOARDING,
+        onboardingPlatforms: feedbackOnboardingPlatforms,
+        allPlatforms: feedbackOnboardingPlatforms,
+      },
+      wrapper: createWrapper(),
+    });
+
+    // Starts with angular
+    expect(result.current.currentProject).toBe(angular);
+
+    // Changes to javascript when page filters change
+    act(() => mockPageFilterStore([javascript]));
+    expect(result.current.currentProject).toBe(javascript);
+  });
 });


### PR DESCRIPTION
Am updating some onboarding components and noticed that this hook will always require one rerender to return the correct project. Small refactor to find the default project on initial render if the projects are already available.