### PR TITLE
fix(crons): Account for 'Never' check-in dates

### DIFF
--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -231,6 +231,7 @@ const EnvironmentLabel = styled(Tooltip)`
   font-weight: ${p => p.theme.fontWeightBold};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   color: ${p => p.theme.subText};
+  white-space: nowrap;
 `;
 
 const IssueGridLineLabels = styled(GridLineLabels)<{envCount: number}>`

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.spec.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.spec.tsx
@@ -54,14 +54,12 @@ describe('OccurrenceSummary', () => {
       ],
     });
     const event = EventFixture();
-    render(<OccurrenceSummary group={group} event={event} />, {
-      organization,
-    });
+    render(<OccurrenceSummary group={group} event={event} />, {organization});
     expect(screen.getByText('Downtime')).toBeInTheDocument();
     expect(screen.getByText('1 day')).toBeInTheDocument();
   });
 
-  it('renders detector details if found', function () {
+  it('renders detector details correctly', function () {
     const group = GroupFixture({
       issueCategory: IssueCategory.UPTIME,
       issueType: IssueType.UPTIME_DOMAIN_FAILURE,
@@ -74,14 +72,12 @@ describe('OccurrenceSummary', () => {
         },
       ],
     });
-    render(<OccurrenceSummary group={group} event={event} />, {
-      organization,
-    });
+    render(<OccurrenceSummary group={group} event={event} />, {organization});
     expect(screen.getByText('Monitor ID')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
   });
 
-  it('renders evidence detailsif found', function () {
+  it('renders evidence details correctly', function () {
     const now = '2025-01-01T12:00:00Z';
     setMockDate(new Date(now));
 
@@ -111,9 +107,7 @@ describe('OccurrenceSummary', () => {
         ],
       },
     });
-    render(<OccurrenceSummary group={group} event={event} />, {
-      organization,
-    });
+    render(<OccurrenceSummary group={group} event={event} />, {organization});
     expect(screen.getByText('Environment')).toBeInTheDocument();
     expect(screen.getByText('production')).toBeInTheDocument();
 
@@ -125,5 +119,26 @@ describe('OccurrenceSummary', () => {
 
     expect(screen.getByText('Last Successful Check-In')).toBeInTheDocument();
     expect(screen.getByText('an hour ago')).toBeInTheDocument();
+  });
+
+  it('allows for invalid check-in dates', function () {
+    const group = GroupFixture({
+      issueCategory: IssueCategory.CRON,
+      issueType: IssueType.MONITOR_CHECK_IN_FAILURE,
+    });
+    const event = EventFixture({
+      occurrence: {
+        evidenceDisplay: [
+          {
+            name: 'Last successful check-in',
+            // This is sometimes returned from the API
+            value: 'Never',
+          },
+        ],
+      },
+    });
+    render(<OccurrenceSummary group={group} event={event} />, {organization});
+    expect(screen.getByText('Last Successful Check-In')).toBeInTheDocument();
+    expect(screen.getByText('Never')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -60,7 +60,11 @@ function getEvidenceItem({
       return (
         <Flex column>
           <ItemTitle>{t('Last Successful Check-In')}</ItemTitle>
-          <ItemTimeSince date={evidence.value} />
+          {evidence.value === 'Never' ? (
+            <ItemValue>{evidence.value}</ItemValue>
+          ) : (
+            <ItemTimeSince date={evidence.value} />
+          )}
         </Flex>
       );
     default:

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import moment from 'moment-timezone';
 
 import {Flex} from 'sentry/components/container/flex';
 import {DowntimeDuration} from 'sentry/components/events/interfaces/uptime/uptimeDataSection';
@@ -60,10 +61,10 @@ function getEvidenceItem({
       return (
         <Flex column>
           <ItemTitle>{t('Last Successful Check-In')}</ItemTitle>
-          {evidence.value === 'Never' ? (
-            <ItemValue>{evidence.value}</ItemValue>
-          ) : (
+          {moment(evidence.value).isValid() ? (
             <ItemTimeSince date={evidence.value} />
+          ) : (
+            <ItemValue>{evidence.value}</ItemValue>
           )}
         </Flex>
       );


### PR DESCRIPTION
Resolves https://sentry.sentry.io/issues/6297384163/ and some formatting on the chart I noticed when debugging this issue.
Adds a test to prevent regressions as well