### PR TITLE
theme: remove theme imports in favor of useTheme

### DIFF
--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -10,7 +10,6 @@ import {SecondaryMobile} from 'sentry/components/nav/secondaryMobile';
 import {IconClose, IconMenu, IconSentry} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import theme from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -108,7 +107,7 @@ const Topbar = styled('header')`
   justify-content: space-between;
   position: sticky;
   top: 0;
-  z-index: ${theme.zIndex.sidebar};
+  z-index: ${p => p.theme.zIndex.sidebar};
 `;
 
 const HomeLink = styled(Link)`

--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useRef} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
@@ -7,7 +8,6 @@ import type {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import type {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {Rect} from 'sentry/utils/profiling/speedscope';
-import theme from 'sentry/utils/theme';
 
 // The cursor icon is drawn with an origin in the top left, which means that if we render
 // a tooltip directly at the cursor's position, it will overlap with the cursor icon.
@@ -79,6 +79,7 @@ function BoundTooltip({
   canvasView,
   children,
 }: BoundTooltipProps): React.ReactElement | null {
+  const theme = useTheme();
   const flamegraphTheme = useFlamegraphTheme();
 
   const physicalSpaceCursor = vec2.transformMat3(

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import CircleIndicator from 'sentry/components/circleIndicator';
@@ -8,7 +9,6 @@ import type {SelectFieldProps} from 'sentry/components/forms/fields/selectField'
 import SelectField from 'sentry/components/forms/fields/selectField';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import theme from 'sentry/utils/theme';
 import {getThresholdUnitSelectOptions} from 'sentry/views/dashboards/utils';
 
 import {BuildStep} from '../buildStep';
@@ -95,6 +95,7 @@ export function Thresholds({
   dataType = '',
   dataUnit = '',
 }: ThresholdsStepProps) {
+  const theme = useTheme();
   const maxOneValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_1] ?? '';
   const maxTwoValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_2] ?? '';
   const unit = thresholdsConfig?.unit ?? dataUnit;

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -6,7 +7,6 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import theme from 'sentry/utils/theme';
 import useMedia from 'sentry/utils/useMedia';
 import {
   IssueDetailsContext,
@@ -32,6 +32,7 @@ export function GroupDetailsLayout({
   project,
   children,
 }: GroupDetailsLayoutProps) {
+  const theme = useTheme();
   const {issueDetails, dispatch} = useIssueDetailsReducer();
   const isScreenSmall = useMedia(`(max-width: ${theme.breakpoints.large})`);
   const shouldDisplaySidebar = issueDetails.isSidebarOpen || isScreenSmall;

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -1,3 +1,5 @@
+import {useTheme} from '@emotion/react';
+
 import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import LoadingError from 'sentry/components/loadingError';
@@ -6,7 +8,6 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import StreamGroup from 'sentry/components/stream/group';
 import GroupStore from 'sentry/stores/groupStore';
 import type {Group} from 'sentry/types/group';
-import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -94,6 +95,7 @@ function GroupList({
   onActionTaken,
 }: GroupListProps) {
   const organization = useOrganization();
+  const theme = useTheme();
   const [isSavedSearchesOpen] = useSyncedLocalStorageState(
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
     false

--- a/static/app/views/monitors/components/monitorStats.tsx
+++ b/static/app/views/monitors/components/monitorStats.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useRef} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {AreaChartSeries} from 'sentry/components/charts/areaChart';
@@ -18,7 +19,6 @@ import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import theme from 'sentry/utils/theme';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -30,6 +30,7 @@ type Props = {
 };
 
 export function MonitorStats({monitor, monitorEnvs}: Props) {
+  const theme = useTheme();
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const {start, end, period} = selection.datetime;

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {Location} from 'history';
@@ -33,7 +34,6 @@ import type {
 } from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import VitalsCardsDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {decodeList} from 'sentry/utils/queryString';
-import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 
 import ColorBar from '../vitalDetail/colorBar';
@@ -305,6 +305,7 @@ type SparklineChartProps = {
 };
 
 function SparklineChart(props: SparklineChartProps) {
+  const theme = useTheme();
   const {data} = props;
   const width = 150;
   const height = 24;

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {useTheme} from '@emotion/react';
 import type {Location} from 'history';
 
 import {BarChart} from 'sentry/components/charts/barChart';
@@ -18,7 +19,6 @@ import {
   computeBuckets,
   formatHistogramData,
 } from 'sentry/utils/performance/histogram/utils';
-import theme from 'sentry/utils/theme';
 
 import type {ViewProps} from '../../../types';
 import {filterToColor, filterToField, SpanOperationBreakdownFilter} from '../../filter';
@@ -56,6 +56,7 @@ function Content({
   queryExtras,
   totalCount,
 }: Props) {
+  const theme = useTheme();
   const [zoomError, setZoomError] = useState(false);
 
   function handleMouseOver() {

--- a/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.spec.tsx
@@ -1,6 +1,5 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import theme from 'sentry/utils/theme';
 import EventIdField from 'sentry/views/settings/components/dataScrubbing/modals/form/eventIdField';
 import {EventIdStatus} from 'sentry/views/settings/components/dataScrubbing/types';
 
@@ -62,7 +61,7 @@ describe('EventIdField', function () {
 
     expect(screen.queryByLabelText('Clear event ID')).not.toBeInTheDocument();
 
-    expect(screen.getByTestId('icon-check-mark')).toHaveAttribute('fill', theme.green400);
+    expect(screen.getByTestId('icon-check-mark')).toBeInTheDocument();
   });
 
   it('ERROR status', async function () {


### PR DESCRIPTION
Last batch of easy imports. The rest now are either class components or static instances that cant easily be changed