### PR TITLE
:sparkles: feat(aci): add support to trigger webhooks for issue alerts in NOA

### DIFF
--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -812,3 +812,36 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetIdentifier": 188022,
     },
 ]
+
+WEBHOOK_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
+    {
+        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+        "service": "bufo-bot-integration-1f946b",
+        "uuid": "02babf2f-d767-483c-bb5d-0eaae85c532a",
+    },
+    {
+        "service": "opsgenie",
+        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+        "uuid": "02b91e1d-a91c-4357-8190-a08c9e8c15c4",
+    },
+    {
+        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+        "service": "slack",
+        "uuid": "45a8b34b-325d-4efa-b5a1-0c6effc4eba1",
+    },
+    {
+        "service": "webhooks",
+        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+        "uuid": "722decb0-bad9-4f5e-ad06-865439169289",
+    },
+    {
+        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+        "service": "slack",
+        "uuid": "c19cdf39-8110-43fc-ad15-12b372332ac0",
+    },
+    {
+        "service": "chat-erwiuyhrwejkh",
+        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+        "uuid": "add56da2-be45-4182-800e-6b1b7fc4d012",
+    },
+]

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -327,3 +327,14 @@ class PluginIssueAlertHandler(BaseIssueAlertHandler):
     @classmethod
     def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         return {}
+
+
+@issue_alert_handler_registry.register(Action.Type.WEBHOOK)
+class WebhookIssueAlertHandler(BaseIssueAlertHandler):
+    @classmethod
+    def get_integration_id(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
+        return {}
+
+    @classmethod
+    def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
+        return {}

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -11,6 +11,7 @@ from sentry.testutils.helpers.data_blobs import (
     GITHUB_ACTION_DATA_BLOBS,
     JIRA_ACTION_DATA_BLOBS,
     JIRA_SERVER_ACTION_DATA_BLOBS,
+    WEBHOOK_ACTION_DATA_BLOBS,
 )
 from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     BaseIssueAlertHandler,
@@ -22,6 +23,7 @@ from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     PluginIssueAlertHandler,
     SlackIssueAlertHandler,
     TicketingIssueAlertHandler,
+    WebhookIssueAlertHandler,
 )
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowJob
@@ -486,3 +488,23 @@ class TestPluginIssueAlertHandler(BaseWorkflowTest):
         assert blob == {
             "id": ACTION_FIELD_MAPPINGS[Action.Type.PLUGIN]["id"],
         }
+
+
+class TestWebhookIssueAlertHandler(BaseWorkflowTest):
+    def setUp(self):
+        super().setUp()
+        self.handler = WebhookIssueAlertHandler()
+
+    def test_build_rule_action_blob(self):
+        for expected in WEBHOOK_ACTION_DATA_BLOBS:
+            action = self.create_action(
+                type=Action.Type.WEBHOOK,
+                target_identifier=expected["service"],
+            )
+
+            # pop uuid from blob
+            expected.pop("uuid")
+
+            blob = self.handler.build_rule_action_blob(action)
+
+            assert blob == expected

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -12,6 +12,7 @@ from sentry.testutils.helpers.data_blobs import (
     GITHUB_ACTION_DATA_BLOBS,
     JIRA_ACTION_DATA_BLOBS,
     JIRA_SERVER_ACTION_DATA_BLOBS,
+    WEBHOOK_ACTION_DATA_BLOBS,
 )
 from sentry.workflow_engine.migration_helpers.rule_action import (
     build_notification_actions_from_rule_data_actions,
@@ -649,39 +650,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         self.assert_actions_migrated_correctly(actions, action_data, None, None, None)
 
     def test_webhook_action_migration(self):
-        action_data = [
-            {
-                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                "service": "bufo-bot-integration-1f946b",
-                "uuid": "02babf2f-d767-483c-bb5d-0eaae85c532a",
-            },
-            {
-                "service": "opsgenie",
-                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                "uuid": "02b91e1d-a91c-4357-8190-a08c9e8c15c4",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                "service": "slack",
-                "uuid": "45a8b34b-325d-4efa-b5a1-0c6effc4eba1",
-            },
-            {
-                "service": "webhooks",
-                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                "uuid": "722decb0-bad9-4f5e-ad06-865439169289",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                "service": "slack",
-                "uuid": "c19cdf39-8110-43fc-ad15-12b372332ac0",
-            },
-            {
-                "service": "chat-erwiuyhrwejkh",
-                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                "uuid": "add56da2-be45-4182-800e-6b1b7fc4d012",
-            },
-        ]
-
+        action_data = WEBHOOK_ACTION_DATA_BLOBS
         actions = build_notification_actions_from_rule_data_actions(action_data)
         self.assert_actions_migrated_correctly(actions, action_data, None, "service", None)
 


### PR DESCRIPTION
just chugging along, this one is also simple, webhooks just need the "service key"