### PR TITLE
fix(crons): Serialize the config type correctly

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
 
 from django.db.models import prefetch_related_objects
 
@@ -331,9 +331,7 @@ class MonitorCheckInSerializer(Serializer):
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs) -> MonitorCheckInSerializerResponse:
-        config: MonitorConfigSerializerResponse = (
-            obj.monitor_config.copy() if obj.monitor_config else {}
-        )
+        config = obj.monitor_config.copy() if obj.monitor_config else {}
         if "schedule_type" in config:
             # XXX: We don't use monitor.get_schedule_type_display() in case it differs from the
             # config saved on the check-in
@@ -345,7 +343,7 @@ class MonitorCheckInSerializer(Serializer):
             "duration": obj.duration,
             "dateCreated": obj.date_added,
             "expectedTime": obj.expected_time,
-            "monitorConfig": config,
+            "monitorConfig": cast(MonitorConfigSerializerResponse, config),
         }
 
         if self._expand("groups"):

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -17,6 +17,7 @@ from sentry.monitors.models import (
     MonitorEnvironment,
     MonitorIncident,
     MonitorStatus,
+    ScheduleType,
 )
 from sentry.monitors.processing_errors.errors import (
     CheckinProcessingError,
@@ -334,7 +335,9 @@ class MonitorCheckInSerializer(Serializer):
             obj.monitor_config.copy() if obj.monitor_config else {}
         )
         if "schedule_type" in config:
-            config["schedule_type"] = obj.get_schedule_type_display()
+            # XXX: We don't use monitor.get_schedule_type_display() in case it differs from the
+            # config saved on the check-in
+            config["schedule_type"] = ScheduleType.get_name(config["schedule_type"])
         result: MonitorCheckInSerializerResponse = {
             "id": str(obj.guid),
             "environment": attrs["environment_name"],

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -276,7 +276,7 @@ class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional)
     duration: int
     dateCreated: datetime
     expectedTime: datetime
-    monitorConfig: Any
+    monitorConfig: MonitorConfigSerializerResponse
 
 
 @register(MonitorCheckIn)
@@ -330,6 +330,11 @@ class MonitorCheckInSerializer(Serializer):
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs) -> MonitorCheckInSerializerResponse:
+        config: MonitorConfigSerializerResponse = (
+            obj.monitor_config.copy() if obj.monitor_config else {}
+        )
+        if "schedule_type" in config:
+            config["schedule_type"] = obj.get_schedule_type_display()
         result: MonitorCheckInSerializerResponse = {
             "id": str(obj.guid),
             "environment": attrs["environment_name"],
@@ -337,7 +342,7 @@ class MonitorCheckInSerializer(Serializer):
             "duration": obj.duration,
             "dateCreated": obj.date_added,
             "expectedTime": obj.expected_time,
-            "monitorConfig": obj.monitor_config or {},
+            "monitorConfig": config,
         }
 
         if self._expand("groups"):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -26,6 +26,7 @@ from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.monitors.models import (
     Monitor,
+    MonitorCheckIn,
     MonitorEnvironment,
     MonitorIncident,
     MonitorType,
@@ -464,6 +465,9 @@ class Fixtures:
 
     def create_monitor_incident(self, **kwargs):
         return MonitorIncident.objects.create(**kwargs)
+
+    def create_monitor_checkin(self, **kwargs):
+        return MonitorCheckIn.objects.create(**kwargs)
 
     def create_external_user(self, user=None, organization=None, integration=None, **kwargs):
         if not user:

--- a/tests/sentry/monitors/endpoints/test_base_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_checkin_index.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from sentry.models.environment import Environment
 from sentry.models.group import Group
-from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorStatus
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorStatus, ScheduleType
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.skips import requires_snuba
@@ -225,3 +225,42 @@ class BaseListMonitorCheckInsTest(MonitorTestCase):
         assert resp.data[0]["groups"] == []
         assert resp.data[1]["id"] == str(checkin1.guid)
         assert resp.data[1]["groups"] == [{"id": group.id, "shortId": group.qualified_short_id}]
+
+    def test_serializes_monitor_config_correctly(self):
+        monitor = self.create_monitor(project=self.project)
+        config = {
+            "schedule": "0 0 * * *",
+            "schedule_type": ScheduleType.CRONTAB,
+            "timezone": "US/Arizona",
+            "max_runtime": None,
+            "checkin_margin": None,
+        }
+        monitor_environment = self._create_monitor_environment(monitor)
+        self.create_monitor_checkin(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=2),
+            status=CheckInStatus.OK,
+            monitor_config=config,
+        )
+        # Mutating the monitor config to test that the check-in config is used
+        monitor.config = {
+            "schedule": "0 * * * *",
+            "schedule_type": ScheduleType.INTERVAL,
+            "timezone": "CA/Toronto",
+            "max_runtime": 1000,
+            "checkin_margin": 100,
+        }
+        monitor.save()
+        response = self.get_success_response(
+            self.project.organization.slug,
+            monitor.slug,
+        )
+        assert response.data[0]["monitorConfig"]["schedule_type"] == ScheduleType.get_name(
+            config["schedule_type"]
+        )
+        assert response.data[0]["monitorConfig"]["schedule"] == config["schedule"]
+        assert response.data[0]["monitorConfig"]["timezone"] == config["timezone"]
+        assert response.data[0]["monitorConfig"]["max_runtime"] == config["max_runtime"]
+        assert response.data[0]["monitorConfig"]["checkin_margin"] == config["checkin_margin"]


### PR DESCRIPTION
Applies the serialization to the config that the frontend has been typed to expect. Specifically the schedule type being served as an integer, but expected as a string.