### PR TITLE
ref(insights): Clean up SpanIndexedField.ID and SpanIndexedField.SPAN_ID enums

### DIFF
--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -120,7 +120,7 @@ export const SORTABLE_INDEXED_INTERACTION_FIELDS = [
   SpanIndexedField.INP_SCORE,
   SpanIndexedField.INP_SCORE_WEIGHT,
   SpanIndexedField.TOTAL_SCORE,
-  SpanIndexedField.ID,
+  SpanIndexedField.SPAN_ID,
   SpanIndexedField.TIMESTAMP,
   SpanIndexedField.PROFILE_ID,
   SpanIndexedField.REPLAY_ID,

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -155,7 +155,7 @@ export function CacheSamplePanel() {
           SpanIndexedField.PROJECT,
           SpanIndexedField.TRACE,
           SpanIndexedField.TRANSACTION_ID,
-          SpanIndexedField.ID,
+          SpanIndexedField.SPAN_ID,
           SpanIndexedField.TIMESTAMP,
           SpanIndexedField.SPAN_DESCRIPTION,
           SpanIndexedField.CACHE_HIT,

--- a/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
@@ -24,13 +24,13 @@ type DataRowKeys =
   | SpanIndexedField.TRANSACTION_ID
   | SpanIndexedField.TRACE
   | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.CACHE_HIT
   | SpanIndexedField.CACHE_ITEM_SIZE;
 
 type ColumnKeys =
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.CACHE_HIT
   | SpanIndexedField.CACHE_ITEM_SIZE
@@ -44,7 +44,7 @@ type Column = GridColumnHeader<ColumnKeys>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.ID,
+    key: SpanIndexedField.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
@@ -123,7 +123,7 @@ function renderBodyCell(
   location: Location,
   organization: Organization
 ) {
-  if (column.key === SpanIndexedField.ID) {
+  if (column.key === SpanIndexedField.SPAN_ID) {
     return (
       <SpanIdCell
         moduleName={ModuleName.CACHE}
@@ -131,7 +131,7 @@ function renderBodyCell(
         traceId={row.trace}
         timestamp={row.timestamp}
         transactionId={row[SpanIndexedField.TRANSACTION_ID]}
-        spanId={row[SpanIndexedField.ID]}
+        spanId={row[SpanIndexedField.SPAN_ID]}
         source={TraceViewSources.CACHES_MODULE}
         location={location}
       />

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -11,6 +11,7 @@ import type {
   MetricsProperty,
   MetricsResponse,
   OurlogsFields,
+  SpanIndexedField,
   SpanIndexedProperty,
   SpanIndexedResponse,
   SpanMetricsProperty,
@@ -33,7 +34,7 @@ export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
   referrer: string
 ) => {
   // Indexed spans dataset always returns an `id`
-  return useDiscover<Fields | ['id'], SpanIndexedResponse>(
+  return useDiscover<Fields | [SpanIndexedField.ID], SpanIndexedResponse>(
     options,
     DiscoverDatasets.SPANS_INDEXED,
     referrer

--- a/static/app/views/insights/common/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/insights/common/queries/useFullSpanFromTrace.tsx
@@ -33,7 +33,7 @@ export function useFullSpanFromTrace(
         SpanIndexedField.TIMESTAMP,
         SpanIndexedField.TRANSACTION_ID,
         SpanIndexedField.PROJECT,
-        SpanIndexedField.ID,
+        SpanIndexedField.SPAN_ID,
         ...(sorts?.map(sort => sort.field as SpanIndexedProperty) || []),
       ],
     },
@@ -54,7 +54,7 @@ export function useFullSpanFromTrace(
   );
 
   const fullSpan = spanEntry?.data?.find(
-    span => span.span_id === firstIndexedSpan?.[SpanIndexedField.ID]
+    span => span.span_id === firstIndexedSpan?.[SpanIndexedField.SPAN_ID]
   );
 
   // N.B. There isn't a great pattern for us to merge the responses together,

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -36,7 +36,7 @@ export type SpanSample = Pick<
   | SpanIndexedField.TRANSACTION_ID
   | SpanIndexedField.PROJECT
   | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.PROFILE_ID
   | SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH
   | SpanIndexedField.TRACE

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -256,7 +256,7 @@ export function HTTPSamplesPanel() {
         SpanIndexedField.PROJECT,
         SpanIndexedField.TRACE,
         SpanIndexedField.TRANSACTION_ID,
-        SpanIndexedField.ID,
+        SpanIndexedField.SPAN_ID,
         SpanIndexedField.TIMESTAMP,
         SpanIndexedField.SPAN_DESCRIPTION,
         SpanIndexedField.RESPONSE_CODE,

--- a/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
@@ -23,12 +23,12 @@ type DataRowKeys =
   | SpanIndexedField.TRANSACTION_ID
   | SpanIndexedField.TRACE
   | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.RESPONSE_CODE;
 
 type ColumnKeys =
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.RESPONSE_CODE;
 
@@ -38,7 +38,7 @@ type Column = GridColumnHeader<ColumnKeys>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.ID,
+    key: SpanIndexedField.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
@@ -108,7 +108,7 @@ function renderBodyCell(
   location: Location,
   organization: Organization
 ) {
-  if (column.key === SpanIndexedField.ID) {
+  if (column.key === SpanIndexedField.SPAN_ID) {
     return (
       <SpanIdCell
         moduleName={ModuleName.HTTP}
@@ -116,7 +116,7 @@ function renderBodyCell(
         traceId={row.trace}
         timestamp={row.timestamp}
         transactionId={row[SpanIndexedField.TRANSACTION_ID]}
-        spanId={row[SpanIndexedField.ID]}
+        spanId={row[SpanIndexedField.SPAN_ID]}
         source={TraceViewSources.REQUESTS_MODULE}
         location={location}
       />

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -61,7 +61,7 @@ describe('useSpanSamples', () => {
         initialProps: {
           fields: [
             SpanIndexedField.TRANSACTION_ID,
-            SpanIndexedField.ID,
+            SpanIndexedField.SPAN_ID,
           ] as SpanIndexedProperty[],
           enabled: false,
         },
@@ -105,7 +105,7 @@ describe('useSpanSamples', () => {
           },
           fields: [
             SpanIndexedField.TRANSACTION_ID,
-            SpanIndexedField.ID,
+            SpanIndexedField.SPAN_ID,
           ] as SpanIndexedProperty[],
           referrer: 'api-spec',
         },

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -57,7 +57,7 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
             | SpanIndexedField.PROJECT
             | SpanIndexedField.TRANSACTION_ID
             | SpanIndexedField.TIMESTAMP
-            | SpanIndexedField.ID
+            | SpanIndexedField.SPAN_ID
             | SpanIndexedField.PROFILE_ID
             | SpanIndexedField.SPAN_SELF_TIME
           >

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelineSpansTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelineSpansTable.tsx
@@ -30,7 +30,7 @@ import {SpanIndexedField} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 type Column = GridColumnHeader<
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.SPAN_DURATION
   | SpanIndexedField.TIMESTAMP
   | SpanIndexedField.USER
@@ -38,7 +38,7 @@ type Column = GridColumnHeader<
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.ID,
+    key: SpanIndexedField.SPAN_ID,
     name: t('Span ID'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -60,14 +60,14 @@ const COLUMN_ORDER: Column[] = [
 ];
 
 const SORTABLE_FIELDS = [
-  SpanIndexedField.ID,
+  SpanIndexedField.SPAN_ID,
   SpanIndexedField.SPAN_DURATION,
   SpanIndexedField.TIMESTAMP,
 ];
 
 type ValidSort = Sort & {
   field:
-    | SpanIndexedField.ID
+    | SpanIndexedField.SPAN_ID
     | SpanIndexedField.SPAN_DURATION
     | SpanIndexedField.TIMESTAMP;
 };
@@ -103,7 +103,7 @@ export function PipelineSpansTable({groupId, useEAP}: Props) {
       limit: 30,
       sorts: [sort],
       fields: [
-        SpanIndexedField.ID,
+        SpanIndexedField.SPAN_ID,
         SpanIndexedField.TRACE,
         SpanIndexedField.SPAN_DURATION,
         SpanIndexedField.TRANSACTION_ID,
@@ -127,7 +127,7 @@ export function PipelineSpansTable({groupId, useEAP}: Props) {
       limit: 30,
       sorts: [sort],
       fields: [
-        SpanIndexedField.ID,
+        SpanIndexedField.SPAN_ID,
         SpanIndexedField.TRACE,
         SpanIndexedField.SPAN_DURATION,
         SpanIndexedField.TRANSACTION_ID,
@@ -185,12 +185,12 @@ function renderBodyCell(
   groupId: string,
   view: DomainView | undefined
 ) {
-  if (column.key === SpanIndexedField.ID) {
-    if (!row[SpanIndexedField.ID]) {
+  if (column.key === SpanIndexedField.SPAN_ID) {
+    if (!row[SpanIndexedField.SPAN_ID]) {
       return <span>(unknown)</span>;
     }
     if (!row[SpanIndexedField.TRACE]) {
-      return <span>{row[SpanIndexedField.ID]}</span>;
+      return <span>{row[SpanIndexedField.SPAN_ID]}</span>;
     }
     return (
       <Link
@@ -208,12 +208,12 @@ function renderBodyCell(
             },
           },
           eventView: EventView.fromLocation(location),
-          spanId: row[SpanIndexedField.ID],
+          spanId: row[SpanIndexedField.SPAN_ID],
           source: TraceViewSources.LLM_MODULE,
           view,
         })}
       >
-        {row[SpanIndexedField.ID]}
+        {row[SpanIndexedField.SPAN_ID]}
       </Link>
     );
   }

--- a/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
@@ -24,7 +24,7 @@ type DataRowKeys =
   | SpanIndexedField.TRANSACTION_ID
   | SpanIndexedField.TRACE
   | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE
   | SpanIndexedField.MESSAGING_MESSAGE_RECEIVE_LATENCY
@@ -34,7 +34,7 @@ type DataRowKeys =
   | SpanIndexedField.SPAN_DURATION;
 
 type ColumnKeys =
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.MESSAGING_MESSAGE_ID
   | SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE
   | SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT
@@ -47,7 +47,7 @@ type Column = GridColumnHeader<ColumnKeys>;
 
 const CONSUMER_COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.ID,
+    key: SpanIndexedField.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
@@ -75,7 +75,7 @@ const CONSUMER_COLUMN_ORDER: Column[] = [
 
 const PRODUCER_COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.ID,
+    key: SpanIndexedField.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
@@ -162,7 +162,7 @@ function renderBodyCell(
     );
   }
 
-  if (key === SpanIndexedField.ID) {
+  if (key === SpanIndexedField.SPAN_ID) {
     return (
       <SpanIdCell
         moduleName={ModuleName.QUEUE}
@@ -170,7 +170,7 @@ function renderBodyCell(
         traceId={row.trace}
         timestamp={row.timestamp}
         transactionId={row[SpanIndexedField.TRANSACTION_ID]}
-        spanId={row[SpanIndexedField.ID]}
+        spanId={row[SpanIndexedField.SPAN_ID]}
         source={TraceViewSources.QUEUES_MODULE}
         location={location}
       />

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -227,7 +227,8 @@ export enum SpanIndexedField {
   SPAN_DESCRIPTION = 'span.description',
   SPAN_STATUS = 'span.status',
   SPAN_OP = 'span.op',
-  ID = 'span_id',
+  ID = 'id',
+  SPAN_ID = 'span_id',
   SPAN_ACTION = 'span.action',
   SPAN_AI_PIPELINE_GROUP = 'span.ai.pipeline.group',
   SPAN_AI_PIPELINE_GROUP_TAG = 'ai_pipeline_group',
@@ -282,8 +283,8 @@ export enum SpanIndexedField {
 }
 
 export type SpanIndexedResponse = {
-  id: string;
   [SpanIndexedField.ID]: string;
+  [SpanIndexedField.SPAN_ID]: string;
   [SpanIndexedField.ENVIRONMENT]: string;
   [SpanIndexedField.RELEASE]: string;
   [SpanIndexedField.SDK_NAME]: string;
@@ -314,7 +315,7 @@ export type SpanIndexedResponse = {
     | 'unavailable'
     | 'data_loss'
     | 'unauthenticated';
-  [SpanIndexedField.ID]: string;
+  [SpanIndexedField.SPAN_ID]: string;
   [SpanIndexedField.SPAN_ACTION]: string;
   [SpanIndexedField.TRACE]: string;
   [SpanIndexedField.TRANSACTION]: string;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -46,7 +46,7 @@ import {useSpanSummarySort} from 'sentry/views/performance/transactionSummary/tr
 import Tab from '../../tabs';
 
 type DataRowKeys =
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.TIMESTAMP
   | SpanIndexedField.SPAN_DURATION
   | SpanIndexedField.TRANSACTION_ID
@@ -54,7 +54,7 @@ type DataRowKeys =
   | SpanIndexedField.PROJECT;
 
 type ColumnKeys =
-  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_ID
   | SpanIndexedField.TIMESTAMP
   | SpanIndexedField.SPAN_DURATION;
 
@@ -64,7 +64,7 @@ type Column = GridColumnHeader<ColumnKeys>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.ID,
+    key: SpanIndexedField.SPAN_ID,
     name: t('Span ID'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -125,7 +125,7 @@ export default function SpanSummaryTable(props: Props) {
   } = useSpansIndexed(
     {
       fields: [
-        SpanIndexedField.ID,
+        SpanIndexedField.SPAN_ID,
         SpanIndexedField.TRANSACTION_ID,
         SpanIndexedField.TIMESTAMP,
         SpanIndexedField.SPAN_DURATION,
@@ -307,7 +307,7 @@ function renderBodyCell(
       );
     }
 
-    if (column.key === SpanIndexedField.ID) {
+    if (column.key === SpanIndexedField.SPAN_ID) {
       if (!defined(span_id)) {
         return null;
       }


### PR DESCRIPTION
Moves the existing `SpanIndexedField.ID` to `SpanIndexedField.SPAN_ID` to better match it's value of `span_id`.
Adds `SpanIndexedField.ID` as `id`.