### PR TITLE
ref(aci): optional tag filters on event frequency conditions

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -5,6 +5,9 @@ from sentry.rules.conditions.event_frequency import (
     STANDARD_INTERVALS,
     percent_increase,
 )
+from sentry.workflow_engine.handlers.condition.tagged_event_handler import (
+    TaggedEventConditionHandler,
+)
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, DataConditionResult
@@ -18,6 +21,10 @@ class EventFrequencyCountHandler(DataConditionHandler[list[int]]):
         "properties": {
             "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
             "value": {"type": "integer", "minimum": 0},
+            "filters": {
+                "type": "array",
+                "items": TaggedEventConditionHandler.comparison_json_schema,
+            },
         },
         "required": ["interval", "value"],
         "additionalProperties": False,
@@ -39,6 +46,10 @@ class EventFrequencyPercentHandler(DataConditionHandler[list[int]]):
             "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
             "value": {"type": "integer", "minimum": 0},
             "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
+            "filters": {
+                "type": "array",
+                "items": TaggedEventConditionHandler.comparison_json_schema,
+            },
         },
         "required": ["interval", "value", "comparison_interval"],
         "additionalProperties": False,
@@ -59,6 +70,10 @@ class PercentSessionsCountHandler(EventFrequencyCountHandler):
         "properties": {
             "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
             "value": {"type": "number", "minimum": 0, "maximum": 100},
+            "filters": {
+                "type": "array",
+                "items": TaggedEventConditionHandler.comparison_json_schema,
+            },
         },
         "required": ["interval", "value"],
         "additionalProperties": False,
@@ -73,6 +88,10 @@ class PercentSessionsPercentHandler(EventFrequencyPercentHandler):
             "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
             "value": {"type": "number", "minimum": 0, "maximum": 100},
             "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
+            "filters": {
+                "type": "array",
+                "items": TaggedEventConditionHandler.comparison_json_schema,
+            },
         },
         "required": ["interval", "value", "comparison_interval"],
         "additionalProperties": False,

--- a/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
@@ -230,9 +230,9 @@ class BaseEventFrequencyQueryHandler(ABC):
         if comparison_interval:
             current_time -= comparison_interval
         start, end = self.get_query_window(end=current_time, duration=duration)
+        conditions = []
 
         if filters:
-            conditions = []
             for filter in filters:
                 snuba_condition = self.convert_filter_to_snuba_condition(filter)
                 if snuba_condition:
@@ -244,7 +244,7 @@ class BaseEventFrequencyQueryHandler(ABC):
                 start=start,
                 end=end,
                 environment_id=environment_id,
-                conditions=conditions,
+                conditions=conditions or None,
             )
         return result
 

--- a/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/slow_condition_query_handlers.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Literal, TypedDict
 
 from django.core.cache import cache
 from django.db.models import QuerySet
+from snuba_sdk import Op
 
 from sentry import release_health, tsdb
 from sentry.issues.constants import get_issue_tsdb_group_model, get_issue_tsdb_user_group_model
@@ -18,6 +19,7 @@ from sentry.rules.conditions.event_frequency import (
     SNUBA_LIMIT,
     STANDARD_INTERVALS,
 )
+from sentry.rules.match import MatchType
 from sentry.tsdb.base import TSDBModel
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
@@ -65,6 +67,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         end: datetime,
         environment_id: int | None,
         referrer_suffix: str,
+        conditions: list[tuple[str, str, str | None]] | None = None,
     ) -> Mapping[int, int]:
         result: Mapping[int, int] = tsdb_function(
             model=model,
@@ -76,6 +79,7 @@ class BaseEventFrequencyQueryHandler(ABC):
             jitter_value=group_id,
             tenant_ids={"organization_id": organization_id},
             referrer_suffix=referrer_suffix,
+            conditions=conditions,
         )
         return result
 
@@ -89,6 +93,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         end: datetime,
         environment_id: int | None,
         referrer_suffix: str,
+        conditions: list[tuple[str, str, str | None]] | None = None,
     ) -> dict[int, int]:
         batch_totals: dict[int, int] = defaultdict(int)
         group_id = group_ids[0]
@@ -103,6 +108,7 @@ class BaseEventFrequencyQueryHandler(ABC):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix=referrer_suffix,
+                conditions=conditions,
             )
             batch_totals.update(result)
         return batch_totals
@@ -134,9 +140,68 @@ class BaseEventFrequencyQueryHandler(ABC):
             result = group.get(value)
         return result
 
+    @staticmethod
+    def convert_filter_to_snuba_condition(
+        condition: dict[str, Any]
+    ) -> tuple[str, str, str | None] | None:
+        lhs = f"tags[{condition['key']}]"
+        rhs = (
+            condition["value"]
+            if condition["match"] not in (MatchType.IS_SET, MatchType.NOT_SET)
+            else None
+        )
+        match condition["match"]:
+            case MatchType.EQUAL:
+                operator = Op.EQ
+            case MatchType.NOT_EQUAL:
+                operator = Op.NEQ
+            case MatchType.STARTS_WITH:
+                operator = Op.LIKE
+                rhs = f"{rhs}%"
+            case MatchType.NOT_STARTS_WITH:
+                operator = Op.NOT_LIKE
+                rhs = f"{rhs}%"
+            case MatchType.ENDS_WITH:
+                operator = Op.LIKE
+                rhs = f"%{rhs}"
+            case MatchType.NOT_ENDS_WITH:
+                operator = Op.NOT_LIKE
+                rhs = f"%{rhs}"
+            case MatchType.CONTAINS:
+                operator = Op.LIKE
+                rhs = f"%{rhs}%"
+            case MatchType.NOT_CONTAINS:
+                operator = Op.NOT_LIKE
+                rhs = f"%{rhs}%"
+            case MatchType.IS_SET:
+                operator = Op.IS_NOT_NULL
+                rhs = None
+            case MatchType.NOT_SET:
+                operator = Op.IS_NULL
+                rhs = None
+            case MatchType.IS_IN:
+                operator = Op.IN
+                if not isinstance(rhs, str):
+                    raise ValueError(f"Unsupported value type for {condition['match']}")
+                rhs = rhs.split(",")
+            case MatchType.NOT_IN:
+                operator = Op.NOT_IN
+                if not isinstance(rhs, str):
+                    raise ValueError(f"Unsupported value type for {condition['match']}")
+                rhs = rhs.split(",")
+            case _:
+                raise ValueError(f"Unsupported match type: {condition['match']}")
+
+        return (lhs, operator.value, rhs)
+
     @abstractmethod
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
+        self,
+        group_ids: set[int],
+        start: datetime,
+        end: datetime,
+        environment_id: int | None,
+        conditions: list[tuple[str, str, str | None]] | None = None,
     ) -> dict[int, int]:
         """
         Abstract method that specifies how to query Snuba for multiple groups
@@ -151,6 +216,7 @@ class BaseEventFrequencyQueryHandler(ABC):
         environment_id: int | None,
         current_time: datetime,
         comparison_interval: timedelta | None,
+        filters: list[dict[str, Any]] | None,
     ) -> dict[int, int]:
         """
         Make a batch query for multiple groups. The return value is a dictionary
@@ -165,12 +231,20 @@ class BaseEventFrequencyQueryHandler(ABC):
             current_time -= comparison_interval
         start, end = self.get_query_window(end=current_time, duration=duration)
 
+        if filters:
+            conditions = []
+            for filter in filters:
+                snuba_condition = self.convert_filter_to_snuba_condition(filter)
+                if snuba_condition:
+                    conditions.append(snuba_condition)
+
         with self.disable_consistent_snuba_mode(duration):
             result = self.batch_query(
                 group_ids=group_ids,
                 start=start,
                 end=end,
                 environment_id=environment_id,
+                conditions=conditions,
             )
         return result
 
@@ -184,7 +258,12 @@ slow_condition_query_handler_registry = Registry[type[BaseEventFrequencyQueryHan
 @slow_condition_query_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
 class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
+        self,
+        group_ids: set[int],
+        start: datetime,
+        end: datetime,
+        environment_id: int | None,
+        conditions: list[tuple[str, str, str | None]] | None = None,
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
@@ -206,6 +285,7 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix="batch_alert_event_frequency",
+                conditions=conditions,
             )
 
         for category, issue_ids in category_group_ids.items():
@@ -219,7 +299,12 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
 class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
+        self,
+        group_ids: set[int],
+        start: datetime,
+        end: datetime,
+        environment_id: int | None,
+        conditions: list[tuple[str, str, str | None]] | None = None,
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids).values(
@@ -241,6 +326,7 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix="batch_alert_event_uniq_user_frequency",
+                conditions=conditions,
             )
 
         for category, issue_ids in category_group_ids.items():
@@ -280,7 +366,12 @@ class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
         return None
 
     def batch_query(
-        self, group_ids: set[int], start: datetime, end: datetime, environment_id: int | None
+        self,
+        group_ids: set[int],
+        start: datetime,
+        end: datetime,
+        environment_id: int | None,
+        conditions: list[tuple[str, str, str | None]] | None = None,
     ) -> dict[int, int]:
 
         batch_percents: dict[int, int] = defaultdict(int)
@@ -316,6 +407,7 @@ class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
                 end=end,
                 environment_id=environment_id,
                 referrer_suffix="batch_alert_event_frequency",
+                conditions=conditions,
             )
 
         for category, issue_ids in category_group_ids.items():

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -61,6 +61,7 @@ class UniqueConditionQuery:
     interval: str
     environment_id: int | None
     comparison_interval: str | None = None
+    filters: list[dict[str, Any]] | None = None
 
 
 def fetch_project(project_id: int) -> Project | None:
@@ -177,6 +178,7 @@ def generate_unique_queries(
             handler=handler,
             interval=condition.comparison["interval"],
             environment_id=environment_id,
+            filters=condition.comparison.get("filters"),
         )
     ]
     if condition_type in PERCENT_CONDITIONS:
@@ -186,6 +188,7 @@ def generate_unique_queries(
                 interval=condition.comparison["interval"],
                 environment_id=environment_id,
                 comparison_interval=condition.comparison.get("comparison_interval"),
+                filters=condition.comparison.get("filters"),
             )
         )
     return unique_queries
@@ -235,6 +238,7 @@ def get_condition_group_results(
             environment_id=unique_condition.environment_id,
             current_time=current_time,
             comparison_interval=comparison_interval,
+            filters=unique_condition.filters,
         )
         condition_group_results[unique_condition] = result or {}
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -64,6 +64,7 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
                 "timestamp": before_now(seconds=30).isoformat(),
                 "fingerprint": ["group-1"],
                 "user": {"id": uuid4().hex},
+                "tags": {"foo": "bar", "baz": "quux", "region": "US"},
             },
             project_id=self.project.id,
         )
@@ -74,6 +75,7 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
                 "timestamp": before_now(seconds=12).isoformat(),
                 "fingerprint": ["group-2"],
                 "user": {"id": uuid4().hex},
+                "tags": {"foo": "bar", "baz": "biz", "region": "EU"},
             },
             project_id=self.project.id,
         )
@@ -85,6 +87,7 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
                 "timestamp": before_now(seconds=12).isoformat(),
                 "fingerprint": ["group-3"],
                 "user": {"id": uuid4().hex},
+                "tags": {"foo": None, "biz": "baz", "region": "US"},
             },
             project_id=self.project.id,
         )

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -7,6 +7,7 @@ from sentry.rules.conditions.event_frequency import (
     EventFrequencyPercentCondition,
     EventUniqueUserFrequencyCondition,
 )
+from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 
@@ -24,6 +25,26 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         dc = self.create_data_condition(
             type=self.condition,
             comparison={"interval": self.payload["interval"], "value": self.payload["value"]},
+            condition_result=True,
+        )
+
+        results = [self.payload["value"] + 1]
+        self.assert_slow_condition_passes(dc, results)
+
+        results = [self.payload["value"] - 1]
+        self.assert_slow_condition_does_not_pass(dc, results)
+
+    def test_count_with_filters(self):
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison={
+                "interval": self.payload["interval"],
+                "value": self.payload["value"],
+                "filters": [
+                    {"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},
+                    {"match": MatchType.IS_SET, "key": "environment"},
+                ],
+            },
             condition_result=True,
         )
 
@@ -85,6 +106,27 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
                 "interval": self.payload["interval"],
                 "value": self.payload["value"],
                 "comparison_interval": self.payload["comparisonInterval"],
+            },
+            condition_result=True,
+        )
+
+        results = [16, 10]
+        self.assert_slow_condition_passes(dc, results)
+
+        results = [10, 10]
+        self.assert_slow_condition_does_not_pass(dc, results)
+
+    def test_percent_with_filters(self):
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison={
+                "interval": self.payload["interval"],
+                "value": self.payload["value"],
+                "comparison_interval": self.payload["comparisonInterval"],
+                "filters": [
+                    {"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"},
+                    {"match": MatchType.IS_SET, "key": "environment"},
+                ],
             },
             condition_result=True,
         )

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -88,6 +88,20 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
                 condition_result=True,
             )
 
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": 100,
+                    "comparison_interval": "asdf",
+                    "filters": [
+                        {"match": MatchType.IS_SET, "key": "LOGGER", "value": "sentry.example"}
+                    ],
+                },
+                condition_result=True,
+            )
+
 
 class TestEventFrequencyPercentCondition(ConditionTestCase):
     condition = Condition.EVENT_FREQUENCY_PERCENT
@@ -181,6 +195,18 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
                     "interval": "1d",
                     "value": 100,
                     "comparison_interval": "asdf",
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": 100,
+                    "comparison_interval": "asdf",
+                    "filters": [{"match": "asdf", "key": "LOGGER", "value": "sentry.example"}],
                 },
                 condition_result=True,
             )

--- a/tests/sentry/workflow_engine/handlers/condition/test_slow_condition_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_slow_condition_query_handlers.py
@@ -40,6 +40,29 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         )
         assert batch_query == {self.event3.group_id: 1}
 
+    def test_batch_query_with_conditions(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            conditions=[("tags[region]", "=", "US")],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 0,
+        }
+
+        batch_query = self.handler().batch_query(
+            group_ids={self.event3.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment2.id,
+            conditions=[("tags[biz]", "LIKE", "%%b%")],
+        )
+        assert batch_query == {self.event3.group_id: 1}
+
     def test_get_error_and_generic_group_ids(self):
         groups = Group.objects.filter(
             id__in=[self.event.group_id, self.event2.group_id, self.perf_event.group_id]
@@ -72,6 +95,29 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
+        )
+        assert batch_query == {self.event3.group_id: 1}
+
+    def test_batch_query_user_with_conditions(self):
+        batch_query = self.handler().batch_query(
+            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            conditions=[("tags[region]", "=", "US")],
+        )
+        assert batch_query == {
+            self.event.group_id: 1,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 0,
+        }
+
+        batch_query = self.handler().batch_query(
+            group_ids={self.event3.group_id},
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment2.id,
+            conditions=[("tags[biz]", "LIKE", "%%b%")],
         )
         assert batch_query == {self.event3.group_id: 1}
 


### PR DESCRIPTION
We will be allowing event frequency conditions with additional tag filters in workflow engine. This PR modifies the existing slow condition handlers to:

1. Accept an optional list of `filters` in the handlers' `comparison_json_schema`, which have the same shape as `TaggedEventConditionHandler.comparison_json_schema`
2. Collect the filters in delayed workflow processing -- this can determine whether a condition is unique
3. Convert the filters to Snuba conditions in the query handlers and pass them along with the base query