### PR TITLE
fix(explore): Autocomplete free text into function better

### DIFF
--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -154,12 +154,13 @@ function InternalInput({
         if (isTokenFreeText(tok)) {
           const input = text.trim();
           if (input.endsWith('(')) {
-            const maybeFunc = input.substring(0, input.length - 1);
+            const pos = input.lastIndexOf(' ');
+            const maybeFunc = input.substring(pos + 1, input.length - 1);
             if (allowedFunctions.includes(maybeFunc)) {
               dispatch({
                 type: 'REPLACE_TOKEN',
                 token,
-                text: getInitialText(maybeFunc),
+                text: `${input.substring(0, pos + 1)}${getInitialText(maybeFunc)}`,
                 focusOverride: {
                   itemKey: nextTokenKeyOfKind(state, token, TokenKind.FUNCTION),
                 },

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -136,6 +136,26 @@ describe('token', function () {
       ).toBeInTheDocument();
     });
 
+    it('autocompletes function token when they reach the open parenthesis even if there is more text', async function () {
+      render(<Tokens expression="" />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Add a term',
+      });
+      expect(input).toBeInTheDocument();
+
+      await userEvent.click(input);
+      await userEvent.type(input, 'foo bar  avg(');
+
+      expect(
+        await screen.findByRole('row', {
+          name: 'avg(span.duration)',
+        })
+      ).toBeInTheDocument();
+
+      expect(input).toHaveValue('foo bar');
+    });
+
     it('autocompletes addition', async function () {
       render(<Tokens expression="" />);
 


### PR DESCRIPTION
The existing implementation required that the user did not type any characters before the actual function. This relaxes it to as long as the last word in the input looks like a function.