### PR TITLE
fix(auto_source_config): Handle when the frame is None

### DIFF
--- a/src/sentry/issues/auto_source_code_config/stacktraces.py
+++ b/src/sentry/issues/auto_source_code_config/stacktraces.py
@@ -20,6 +20,9 @@ def get_frames_to_process(
     for stacktrace in stacktraces:
         frames = stacktrace["frames"]
         for frame in frames:
+            if frame is None:
+                continue
+
             if platform in PROCESS_ALL_FRAMES:
                 frames_to_process.append(frame)
 

--- a/tests/sentry/issues/auto_source_code_config/test_stacktraces.py
+++ b/tests/sentry/issues/auto_source_code_config/test_stacktraces.py
@@ -77,6 +77,7 @@ def test_get_frames_to_process(
     "frames, expected",
     [
         ([], []),
+        ([None], []),
         ([{"in_app": True}], []),
     ],
 )


### PR DESCRIPTION
Fixes [SENTRY-3NS9](https://sentry.sentry.io/issues/6299550160/)
Fixes [SENTRY-3NSA](https://sentry.sentry.io/issues/6299583637/)