### PR TITLE
ref: remove dep management from useHotkeys

### DIFF
--- a/static/app/components/deprecatedSmartSearchBar/searchHotkeysListener.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/searchHotkeysListener.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import {useHotkeys} from 'sentry/utils/useHotkeys';
 
 import type {Shortcut} from './types';
@@ -9,17 +11,17 @@ function SearchHotkeysListener({
   runShortcut: (shortcut: Shortcut) => void;
   visibleShortcuts: Shortcut[];
 }) {
-  useHotkeys(
-    visibleShortcuts
+  const hotkeys = useMemo(() => {
+    return visibleShortcuts
       .filter(shortcut => typeof shortcut.hotkeys !== 'undefined')
       .map(shortcut => ({
         match: shortcut.hotkeys?.actual ?? [],
         includeInputs: true,
         callback: () => runShortcut(shortcut),
-      })),
-    [visibleShortcuts]
-  );
+      }));
+  }, [visibleShortcuts, runShortcut]);
 
+  useHotkeys(hotkeys);
   return null;
 }
 

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -1,5 +1,5 @@
 import type {ComponentProps} from 'react';
-import {Fragment, useCallback, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -72,13 +72,13 @@ export default function ScreenshotModal({
     [attachments, currentAttachmentIndex]
   );
 
-  useHotkeys(
-    [
+  const paginateHotkeys = useMemo(() => {
+    return [
       {match: 'right', callback: () => paginateItems(1)},
       {match: 'left', callback: () => paginateItems(-1)},
-    ],
-    [paginateItems]
-  );
+    ];
+  }, [paginateItems]);
+  useHotkeys(paginateHotkeys);
 
   const {dateCreated, size, mimetype} = currentEventAttachment;
 

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -148,12 +149,20 @@ export function GlobalDrawer({children}: any) {
   });
 
   // Close the drawer when escape is pressed and options allow it.
-  const handleEscapePress = useCallback(() => {
-    if (currentDrawerConfig?.options?.closeOnEscapeKeypress ?? true) {
-      handleClose();
-    }
-  }, [currentDrawerConfig, handleClose]);
-  useHotkeys([{match: 'Escape', callback: handleEscapePress}], [handleEscapePress]);
+  const globalDrawerHotkeys = useMemo(() => {
+    return [
+      {
+        match: 'Escape',
+        callback: () => {
+          if (currentDrawerConfig?.options?.closeOnEscapeKeypress ?? true) {
+            handleClose();
+          }
+        },
+      },
+    ];
+  }, [currentDrawerConfig?.options?.closeOnEscapeKeypress, handleClose]);
+
+  useHotkeys(globalDrawerHotkeys);
 
   const renderedChild = currentDrawerConfig?.renderer
     ? currentDrawerConfig.renderer({

--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import createCache from '@emotion/cache';
 import {CacheProvider, ThemeProvider} from '@emotion/react';
@@ -37,8 +37,8 @@ export function ThemeAndStyleProvider({children}: Props) {
   const [chonkTheme] = useChonkTheme();
 
   // Theme toggle global shortcut
-  useHotkeys(
-    [
+  const themeToggleHotkeys = useMemo(() => {
+    return [
       {
         match: ['command+shift+1', 'ctrl+shift+1'],
         includeInputs: true,
@@ -46,9 +46,10 @@ export function ThemeAndStyleProvider({children}: Props) {
           ConfigStore.set('theme', config.theme === 'light' ? 'dark' : 'light');
         },
       },
-    ],
-    [config.theme]
-  );
+    ];
+  }, [config.theme]);
+
+  useHotkeys(themeToggleHotkeys);
 
   // Use default theme or chonk theme if set.
   let theme = config.theme === 'dark' ? darkTheme : lightTheme;

--- a/static/app/utils/theme/useChonkTheme.tsx
+++ b/static/app/utils/theme/useChonkTheme.tsx
@@ -53,7 +53,7 @@ export function useChonkTheme(): [
     }
   }, [config.theme, organization, previousTheme, setChonkTheme]);
 
-  const chonkHotkey = useMemo(() => {
+  const chonkToggleHotkeys = useMemo(() => {
     return organization?.features?.includes('chonk-ui')
       ? [
           {
@@ -67,7 +67,7 @@ export function useChonkTheme(): [
       : [];
   }, [organization, chonkTheme.theme, setChonkWithSideEffect]);
 
-  useHotkeys(chonkHotkey, [chonkHotkey]);
+  useHotkeys(chonkToggleHotkeys);
 
   return [theme, setChonkWithSideEffect];
 }

--- a/static/app/utils/useHotkeys.spec.tsx
+++ b/static/app/utils/useHotkeys.spec.tsx
@@ -31,7 +31,7 @@ describe('useHotkeys', function () {
   it('handles a simple match', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: 'ctrl+s', callback}],
     });
 
@@ -48,7 +48,7 @@ describe('useHotkeys', function () {
   it('handles multiple matches', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: ['ctrl+s', 'command+m'], callback}],
     });
 
@@ -68,7 +68,7 @@ describe('useHotkeys', function () {
   it('handles a complex match', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: ['command+ctrl+alt+shift+x'], callback}],
     });
 
@@ -90,7 +90,7 @@ describe('useHotkeys', function () {
   it('does not match when extra modifiers are pressed', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: ['command+shift+x'], callback}],
     });
 
@@ -112,7 +112,7 @@ describe('useHotkeys', function () {
   it('updates with rerender', function () {
     const callback = jest.fn();
 
-    const {rerender} = renderHook(p => useHotkeys([{match: p.match, callback}], [p]), {
+    const {rerender} = renderHook(p => useHotkeys([{match: p.match, callback}]), {
       initialProps: {match: 'ctrl+s'},
     });
 
@@ -136,7 +136,7 @@ describe('useHotkeys', function () {
   it('skips input and textarea', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: ['/'], callback}],
     });
 
@@ -148,7 +148,7 @@ describe('useHotkeys', function () {
   it('does not skips input and textarea with includesInputs', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: ['/'], callback, includeInputs: true}],
     });
 
@@ -160,7 +160,7 @@ describe('useHotkeys', function () {
   it('skips preventDefault', function () {
     const callback = jest.fn();
 
-    renderHook(p => useHotkeys(p, []), {
+    renderHook(p => useHotkeys(p), {
       initialProps: [{match: 'ctrl+s', callback, skipPreventDefault: true}],
     });
 

--- a/static/app/utils/useHotkeys.tsx
+++ b/static/app/utils/useHotkeys.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useEffect} from 'react';
 
 import toArray from 'sentry/utils/array/toArray';
 
@@ -55,13 +55,10 @@ type Hotkey = {
  *
  * Note: you can only use one non-modifier (keys other than shift, ctrl, alt, command) key at a time.
  */
-export function useHotkeys(hotkeys: Hotkey[], deps: React.DependencyList): void {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedHotkeys = useMemo(() => hotkeys, deps);
-
+export function useHotkeys(hotkeys: Hotkey[]): void {
   const onKeyDown = useCallback(
     (evt: KeyboardEvent) => {
-      for (const hotkey of memoizedHotkeys) {
+      for (const hotkey of hotkeys) {
         const preventDefault = !hotkey.skipPreventDefault;
         const keysets = toArray(hotkey.match).map(keys => keys.toLowerCase());
 
@@ -88,7 +85,7 @@ export function useHotkeys(hotkeys: Hotkey[], deps: React.DependencyList): void 
         }
       }
     },
-    [memoizedHotkeys]
+    [hotkeys]
   );
 
   useEffect(() => {

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -1,4 +1,4 @@
-import {lazy, Suspense, useCallback, useEffect, useRef} from 'react';
+import {lazy, Suspense, useCallback, useEffect, useMemo, useRef} from 'react';
 import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -63,16 +63,15 @@ function App({children, params}: Props) {
   const config = useLegacyStore(ConfigStore);
 
   // Command palette global-shortcut
-  useHotkeys(
-    [
-      {
-        match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
-        includeInputs: true,
-        callback: () => openCommandPalette(),
-      },
-    ],
-    []
-  );
+  const commandPaletteHotkeys = useMemo(() => {
+    return {
+      match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
+      includeInputs: true,
+      callback: () => openCommandPalette(),
+    };
+  }, []);
+
+  useHotkeys([commandPaletteHotkeys]);
 
   /**
    * Loads the users organization list into the OrganizationsStore

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -355,8 +355,8 @@ function IssueViewsIssueListHeaderTabsContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewId, query]);
 
-  useHotkeys(
-    [
+  const issuesViewSaveHotkeys = useMemo(() => {
+    return [
       {
         match: ['command+s', 'ctrl+s'],
         includeInputs: true,
@@ -367,9 +367,10 @@ function IssueViewsIssueListHeaderTabsContent({
           }
         },
       },
-    ],
-    [dispatch, tabListState?.selectedKey, views]
-  );
+    ];
+  }, [dispatch, tabListState?.selectedKey, views]);
+
+  useHotkeys(issuesViewSaveHotkeys);
 
   const handleCreateNewView = () => {
     const tempId = generateTempViewId();

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
+import {useContext, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Node} from '@react-types/shared';
 import isEqual from 'lodash/isEqual';
@@ -392,8 +392,8 @@ function IssueViewsIssueListHeaderTabsContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewId, query]);
 
-  useHotkeys(
-    [
+  const issuesViewSaveHotkeys = useMemo(() => {
+    return [
       {
         match: ['command+s', 'ctrl+s'],
         includeInputs: true,
@@ -404,9 +404,10 @@ function IssueViewsIssueListHeaderTabsContent({
           }
         },
       },
-    ],
-    [dispatch, tabListState?.selectedKey, views]
-  );
+    ];
+  }, [dispatch, tabListState?.selectedKey, views]);
+
+  useHotkeys(issuesViewSaveHotkeys);
 
   const handleCreateNewView = () => {
     const tempId = generateTempViewId();

--- a/static/app/views/settings/components/settingsSearch/index.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Search} from 'sentry/components/search';
@@ -12,7 +12,11 @@ const MAX_RESULTS = 10;
 function SettingsSearch() {
   const searchInput = useRef<HTMLInputElement>(null);
 
-  useHotkeys([{match: '/', callback: () => searchInput.current?.focus()}], []);
+  const settingsSearchHotkeys = useMemo(() => {
+    return [{match: '/', callback: () => searchInput.current?.focus()}];
+  }, []);
+
+  useHotkeys(settingsSearchHotkeys);
 
   return (
     <Search

--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -47,7 +47,10 @@ export default function Stories() {
     [location.query, navigate]
   );
 
-  useHotkeys([{match: '/', callback: () => searchInput.current?.focus()}], []);
+  const storiesSearchHotkeys = useMemo(() => {
+    return [{match: '/', callback: () => searchInput.current?.focus()}];
+  }, []);
+  useHotkeys(storiesSearchHotkeys);
 
   return (
     <RouteAnalyticsContextProvider>


### PR DESCRIPTION
Removing the dep management from useHotkeys as it does not enforce or warn about hook dependencies, making it prone to errors.

I have tried to add this hook to react hook exhaustive deps first as opposed to removing dep (something we do for useMemoWithPrevious for example) , to see if we can get it to properly warn on wrong dependencies, but the linter trips on the inline function callback definition inside the hotkey definition, and wrongly recommends passing a function to this hook (which the signature does not allow for).
