### PR TITLE
fix(autofix): Actually fix start over flashing this time

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -148,15 +148,19 @@ export const useAiAutofix = (group: GroupWithAutofix, event: Event) => {
   }, []);
 
   let autofixData = apiData?.autofix ?? null;
-  let usingInitialData = false;
-  if (waitingForNextRun && apiData?.autofix?.run_id !== currentRunId) {
+  if (waitingForNextRun) {
     autofixData = makeInitialAutofixData().autofix;
-    usingInitialData = true;
   }
   if (isReset) {
     autofixData = null;
   }
-  if (autofixData?.steps?.length && !usingInitialData && waitingForNextRun) {
+
+  if (
+    apiData?.autofix?.steps?.length &&
+    apiData?.autofix?.steps[0]?.progress.length &&
+    waitingForNextRun &&
+    apiData?.autofix?.run_id === currentRunId
+  ) {
     setWaitingForNextRun(false);
   }
 


### PR DESCRIPTION
Turns out there was still a flash that occurred very rarely. It sometimes hung on the loading step too. This _should_ fix it. I hit the button like 10-15 times and it worked.