### PR TITLE
fix(outbox) Fire signal handlers outside of db transactions

### DIFF
--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -250,8 +250,7 @@ class OutboxBase(Model):
         filters: dict[str, Any] = {}
         if latest_shard_row is not None:
             # If we have a latest row, only operate on messages that were created earlier
-            # and haven't been scheduled to run the future.
-            filters = {"id__lte": latest_shard_row.id, "scheduled_for__lte": now}
+            filters = {"id__lte": latest_shard_row.id}
 
         try:
             with transaction.atomic(using=using, savepoint=False):

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -161,3 +161,10 @@ register(
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "hybrid_cloud.outbox.reservation_shards",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -178,6 +178,7 @@ def process_outbox_batch(
     for shard_attributes in outbox_model.find_scheduled_shards(
         outbox_identifier_low, outbox_identifier_hi
     ):
+        # The shard outboxes have schedule_for updated here
         shard_outbox: OutboxBase | None = outbox_model.prepare_next_from_shard(shard_attributes)
         if not shard_outbox:
             continue

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -374,6 +374,7 @@ class Factories:
                 shard_identifier=org.id,
                 shard_scope=OutboxScope.ORGANIZATION_SCOPE,
                 category=OutboxCategory.ORGANIZATION_UPDATE,
+                object_identifier=org.id,
             ).drain_shard()
 
         if owner:


### PR DESCRIPTION
We have a few outbox handlers that consistently hit statement/transaction timeouts in production. These timeouts occur when network is slow, or we're moving large payloads between regions. In some circumstances outbox delivery can become permanently stuck due to these timeouts.

Similar to #84631, these changes adopt a 'reservation' style flow that advances outbox `scheduled_for` to help mitigate concurrent updates. However, instead of modifying the existing implementation, I've built a parallel branch of logic that we can enable incrementally per shard scope. I feel that this gives us a safer/easier to control rollout approach. My plan is to start by enabling this for the most problematic scopes (relocation, audit log, userip) as these scopes encounter timeouts most frequently.

I've not included the cleanup logic for schedule advancements, because if a delivery fails, we can simply retry later. Outboxes are always *eventually consistent* and having the revert logic felt like additional complexity that we could forego.
