### PR TITLE
feat(aci): special case migration logic for EventUniqueUserFrequencyConditionWithConditions

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -337,22 +337,23 @@ def create_event_unique_user_frequency_condition_with_conditions(
 
     comparison_filters = []
 
-    for condition in conditions:
-        if condition["id"] in (EventAttributeFilter.id, TaggedEventFilter.id):
-            comparison_filter = {
-                "match": condition["match"],
-                "key": (
-                    condition["attribute"]
-                    if condition["id"] == EventAttributeFilter.id
-                    else condition["key"]
-                ),
-            }
-            if comparison_filter["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
-                comparison_filter["value"] = condition["value"]
-        else:
-            raise ValueError(f"Unsupported nested condition: {condition["id"]}")
+    if conditions:
+        for condition in conditions:
+            if condition["id"] in (EventAttributeFilter.id, TaggedEventFilter.id):
+                comparison_filter = {
+                    "match": condition["match"],
+                    "key": (
+                        condition["attribute"]
+                        if condition["id"] == EventAttributeFilter.id
+                        else condition["key"]
+                    ),
+                }
+                if comparison_filter["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
+                    comparison_filter["value"] = condition["value"]
+            else:
+                raise ValueError(f"Unsupported nested condition: {condition["id"]}")
 
-        comparison_filters.append(comparison_filter)
+            comparison_filters.append(comparison_filter)
 
     comparison["filters"] = comparison_filters
 

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -317,3 +317,48 @@ def create_percent_sessions_data_condition(
         count_type=Condition.PERCENT_SESSIONS_COUNT,
         percent_type=Condition.PERCENT_SESSIONS_PERCENT,
     )
+
+
+def create_event_unique_user_frequency_condition_with_conditions(
+    data: dict[str, Any], dcg: DataConditionGroup, conditions: list[dict[str, Any]] | None = None
+) -> DataCondition:
+    comparison_type = data.get("comparisonType", ComparisonType.COUNT)
+
+    comparison = {
+        "interval": data["interval"],
+        "value": data["value"],
+    }
+
+    if comparison_type == ComparisonType.COUNT:
+        type = Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
+    else:
+        type = Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT
+        comparison["comparison_interval"] = data["comparisonInterval"]
+
+    comparison_filters = []
+
+    for condition in conditions:
+        if condition["id"] in (EventAttributeFilter.id, TaggedEventFilter.id):
+            comparison_filter = {
+                "match": condition["match"],
+                "key": (
+                    condition["attribute"]
+                    if condition["id"] == EventAttributeFilter.id
+                    else condition["key"]
+                ),
+            }
+            if comparison_filter["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
+                comparison_filter["value"] = condition["value"]
+        else:
+            raise ValueError(f"Unsupported nested condition: {condition["id"]}")
+
+        comparison_filters.append(comparison_filter)
+
+    comparison["filters"] = comparison_filters
+
+    return DataCondition(
+        type=type,
+        comparison=comparison,
+        condition_result=True,
+        condition_group=dcg,
+    )

--- a/src/sentry/workflow_engine/migration_helpers/rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule.py
@@ -249,10 +249,10 @@ def update_dcg(
     if type == WorkflowDataConditionGroupType.ACTION_FILTER:
         conditions_ids = [condition["id"] for condition in conditions]
         # skip migrating filters for special case
-        if EventUniqueUserFrequencyConditionWithConditions.id in conditions_ids:
-            return dcg
-
-    bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=dcg)
+        if EventUniqueUserFrequencyConditionWithConditions.id not in conditions_ids:
+            bulk_create_data_conditions(conditions=filters, dcg=dcg)
+    else:
+        bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=dcg)
 
     return dcg
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -50,12 +50,6 @@ class Condition(StrEnum):
     EVENT_UNIQUE_USER_FREQUENCY_PERCENT = "event_unique_user_frequency_percent"
     PERCENT_SESSIONS_COUNT = "percent_sessions_count"
     PERCENT_SESSIONS_PERCENT = "percent_sessions_percent"
-    EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT = (
-        "event_unique_user_frequency_with_conditions_count"
-    )
-    EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT = (
-        "event_unique_user_frequency_with_conditions_percent"
-    )
 
 
 CONDITION_OPS = {
@@ -71,14 +65,12 @@ PERCENT_CONDITIONS = [
     Condition.EVENT_FREQUENCY_PERCENT,
     Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
     Condition.PERCENT_SESSIONS_PERCENT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT,
 ]
 
 SLOW_CONDITIONS = [
     Condition.EVENT_FREQUENCY_COUNT,
     Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
     Condition.PERCENT_SESSIONS_COUNT,
-    Condition.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
 ] + PERCENT_CONDITIONS
 
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -6,6 +6,14 @@ from sentry.rules.conditions.event_frequency import (
     EventFrequencyCondition,
     EventFrequencyPercentCondition,
     EventUniqueUserFrequencyCondition,
+    EventUniqueUserFrequencyConditionWithConditions,
+)
+from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
+from sentry.rules.filters.event_attribute import EventAttributeFilter
+from sentry.rules.filters.tagged_event import TaggedEventFilter
+from sentry.rules.match import MatchType
+from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
+    create_event_unique_user_frequency_condition_with_conditions,
 )
 from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
@@ -252,3 +260,127 @@ class TestPercentSessionsPercentCondition(TestEventFrequencyPercentCondition):
         "comparisonType": ComparisonType.PERCENT,
         "comparisonInterval": "1d",
     }
+
+
+class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
+    condition = Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
+    payload = {
+        "interval": "1h",
+        "id": EventUniqueUserFrequencyConditionWithConditions.id,
+        "value": 50,
+        "comparisonType": ComparisonType.COUNT,
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.conditions = [
+            {
+                "id": TaggedEventFilter.id,
+                "match": MatchType.EQUAL,
+                "key": "LOGGER",
+                "value": "sentry.example",
+            },
+            {
+                "id": TaggedEventFilter.id,
+                "match": MatchType.IS_SET,
+                "key": "environment",
+            },
+            {
+                "id": EventAttributeFilter.id,
+                "match": MatchType.EQUAL,
+                "value": "hi",
+                "attribute": "message",
+            },
+        ]
+        self.expected_filters = [
+            {
+                "match": MatchType.EQUAL,
+                "key": self.conditions[0]["key"],
+                "value": self.conditions[0]["value"],
+            },
+            {"match": MatchType.IS_SET, "key": self.conditions[1]["key"]},
+            {
+                "match": MatchType.EQUAL,
+                "key": self.conditions[2]["attribute"],
+                "value": self.conditions[2]["value"],
+            },
+        ]
+        self.dcg = self.create_data_condition_group()
+
+    def test_dual_write_count(self):
+        dc = create_event_unique_user_frequency_condition_with_conditions(
+            self.payload, self.dcg, self.conditions
+        )
+
+        assert dc.type == self.condition
+        assert dc.comparison == {
+            "interval": self.payload["interval"],
+            "value": self.payload["value"],
+            "filters": self.expected_filters,
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == self.dcg
+
+    def test_dual_write_percent(self):
+        self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})
+        dc = create_event_unique_user_frequency_condition_with_conditions(
+            self.payload, self.dcg, self.conditions
+        )
+
+        assert dc.type == Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT
+        assert dc.comparison == {
+            "interval": self.payload["interval"],
+            "value": self.payload["value"],
+            "comparison_interval": self.payload["comparisonInterval"],
+            "filters": self.expected_filters,
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == self.dcg
+
+    def test_dual_write__invalid(self):
+        with pytest.raises(KeyError):
+            create_event_unique_user_frequency_condition_with_conditions(
+                self.payload,
+                self.dcg,
+                [
+                    {
+                        "id": EventAttributeFilter.id,
+                        "match": MatchType.EQUAL,
+                        "value": "hi",
+                    },
+                ],
+            )
+
+        with pytest.raises(ValueError):  # unsupported filter condition
+            create_event_unique_user_frequency_condition_with_conditions(
+                self.payload,
+                self.dcg,
+                [
+                    {
+                        "id": FirstSeenEventCondition.id,
+                    },
+                ],
+            )
+
+    def test_json_schema(self):
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "asdf",
+                    "value": 100,
+                    "filters": "asdf",
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
+                    "interval": "1d",
+                    "value": 100,
+                    "filters": [{"interval": "1d", "value": 100}],
+                },
+                condition_result=True,
+            )

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -15,7 +15,6 @@ from sentry.rules.match import MatchType
 from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     create_event_unique_user_frequency_condition_with_conditions,
 )
-from sentry.rules.match import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
 


### PR DESCRIPTION
Migrating the `EventUniqueUserFrequencyConditionWithConditions` issue alert conditions requires the conditions AND filters, because we currently depend on the filters to add Snuba conditions onto the original query, but we want to store all of this as a single `DataCondition`.