### PR TITLE
fix(flamegraph): Use `project.slug` only in landing flamegraph

### DIFF
--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -680,7 +680,7 @@ function AggregateFlamegraphProfileReference(props: {
     <AggregateFlamegraphProfileReferenceContainer>
       <AggregateFlamegraphProfileReferenceProject>
         <ProjectAvatar project={project} />
-        {project.name || project.slug}
+        {project.slug}
       </AggregateFlamegraphProfileReferenceProject>
       <Link to={to}>
         <TextOverflow>{reference.substring(0, 8)}</TextOverflow>


### PR DESCRIPTION
We shouldn't use `project.name` anymore, just the `project.slug`.