### PR TITLE
fix(flamegraph): Landing flamegraph tooltip was clipped

### DIFF
--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -864,7 +864,6 @@ const AggregateFlamegraphContainer = styled('div')`
   flex: 1 1 100%;
   height: 100%;
   width: 100%;
-  overflow: hidden;
   position: absolute;
   left: 0px;
   top: 0px;


### PR DESCRIPTION
If the viewport was narrow, sometimes the tooltip gets clipped when it extends past the canvas container.