### PR TITLE
chore(profiling): Lower to 3 functions to bring more content above fold

### DIFF
--- a/static/app/views/profiling/landing/constants.tsx
+++ b/static/app/views/profiling/landing/constants.tsx
@@ -1,1 +1,1 @@
-export const MAX_FUNCTIONS = 5;
+export const MAX_FUNCTIONS = 3;


### PR DESCRIPTION
This was raised to 5 at one point but it's pushing the table and flamegraph too far past the fold.