### PR TITLE
fix(alerts): fixes 7d 5min interval queries exceeding bucket limit in Span Alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -557,13 +557,13 @@ class MetricChart extends PureComponent<Props, State> {
     );
 
     // Events Analytics Platform Span queries only support up to 2016 buckets.
-    // 14 day 10m interval queries actually exceed this limit because we always extend the end date by an extra bucket.
+    // 14 day 10m and 7 day 5m interval queries actually exceed this limit because we always extend the end date by an extra bucket.
     // We push forward the start date by a bucket to counteract this and return to 2016 buckets.
     if (
       dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
       timePeriod.usingPeriod &&
-      timePeriod.period === TimePeriod.FOURTEEN_DAYS &&
-      interval === '10m'
+      ((timePeriod.period === TimePeriod.FOURTEEN_DAYS && interval === '10m') ||
+        (timePeriod.period === TimePeriod.SEVEN_DAYS && interval === '5m'))
     ) {
       viableStartDate = getUtcDateString(
         moment.utc(viableStartDate).add(timeWindow, 'minutes')


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/84948, fixes an issue where 7day 5min interval queries would exceed the 2016 bucket limit.

This should cover all scenarios because there are no other time range and interval combinations that approach 2016 buckets