### PR TITLE
feat(nav): Add pathname builder for alerts

### DIFF
--- a/static/app/views/alerts/pathnames.tsx
+++ b/static/app/views/alerts/pathnames.tsx
@@ -1,0 +1,19 @@
+import type {Organization} from 'sentry/types/organization';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+const LEGACY_ALERTS_BASE_PATHNAME = 'alerts';
+const ALERTS_BASE_PATHNAME = 'issues/alerts';
+
+export function makeAlertsPathname({
+  path,
+  organization,
+}: {
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}) {
+  return normalizeUrl(
+    organization.features.includes('navigation-sidebar-v2')
+      ? `/organizations/${organization.slug}/${ALERTS_BASE_PATHNAME}${path}`
+      : `/organizations/${organization.slug}/${LEGACY_ALERTS_BASE_PATHNAME}${path}`
+  );
+}


### PR DESCRIPTION
Updated a bunch of alert links in https://github.com/getsentry/sentry/pull/85005, but one was broken so trying again with smaller PRs. This adds the pathname builder that will fix the links for the new nav structure.