### PR TITLE
chore(aci milestone 3): wrap helper + original calls in transactions

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db import router, transaction
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
@@ -30,6 +31,7 @@ from sentry.incidents.logic import (
     delete_alert_rule,
     get_slack_actions_with_async_lookups,
 )
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
@@ -118,18 +120,21 @@ def remove_alert_rule(request: Request, organization, alert_rule):
         # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:
         # the user could be removed from the dual write flag for whatever reason, and we need to make sure
         # that the extra table data is deleted. If the rows don't exist, we'll exit early.
-        # TODO (mifu67): wrap these calls in a transaction
-        try:
-            dual_delete_migrated_alert_rule(alert_rule=alert_rule, user=request.user)
-        except Exception as e:
-            logger.exception(
-                "Error when dual deleting alert rule",
-                extra={"details": str(e)},
+        with transaction.atomic(router.db_for_write(AlertRule)):
+            try:
+                dual_delete_migrated_alert_rule(alert_rule=alert_rule, user=request.user)
+            except Exception as e:
+                logger.exception(
+                    "Error when dual deleting alert rule",
+                    extra={"details": str(e)},
+                )
+                return Response(
+                    "Error when dual deleting alert rule",
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
+            delete_alert_rule(
+                alert_rule, user=request.user, ip_address=request.META.get("REMOTE_ADDR")
             )
-            return Response(
-                "Error when dual deleting alert rule", status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
-        delete_alert_rule(alert_rule, user=request.user, ip_address=request.META.get("REMOTE_ADDR"))
         return Response(status=status.HTTP_204_NO_CONTENT)
     except AlreadyDeletedError:
         return Response("This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -319,9 +319,9 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 id__in=trigger_ids
             )
             for trigger in triggers_to_delete:
-                # TODO: wrap these in a transaction
-                dual_delete_migrated_alert_rule_trigger(trigger)
-                delete_alert_rule_trigger(trigger)
+                with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
+                    dual_delete_migrated_alert_rule_trigger(trigger)
+                    delete_alert_rule_trigger(trigger)
 
             for trigger_data in triggers:
                 if "id" in trigger_data:

--- a/src/sentry/incidents/serializers/alert_rule_trigger.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db import router, transaction
 from rest_framework import serializers
 
 from sentry import features
@@ -43,24 +44,26 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
         extra_kwargs = {"label": {"min_length": 1, "max_length": 64}}
 
     def create(self, validated_data):
-        # TODO (mifu67): wrap the two calls in a transaction
-        try:
-            actions = validated_data.pop("actions", None)
-            alert_rule_trigger = create_alert_rule_trigger(
-                alert_rule=self.context["alert_rule"], **validated_data
-            )
+        with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
+            try:
+                actions = validated_data.pop("actions", None)
+                alert_rule_trigger = create_alert_rule_trigger(
+                    alert_rule=self.context["alert_rule"], **validated_data
+                )
 
-        except forms.ValidationError as e:
-            # if we fail in create_alert_rule_trigger, then only one message is ever returned
-            raise serializers.ValidationError(e.error_list[0].message)
-        except AlertRuleTriggerLabelAlreadyUsedError:
-            raise serializers.ValidationError("This label is already in use for this alert rule")
+            except forms.ValidationError as e:
+                # if we fail in create_alert_rule_trigger, then only one message is ever returned
+                raise serializers.ValidationError(e.error_list[0].message)
+            except AlertRuleTriggerLabelAlreadyUsedError:
+                raise serializers.ValidationError(
+                    "This label is already in use for this alert rule"
+                )
 
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-write",
-            alert_rule_trigger.alert_rule.organization,
-        ):
-            migrate_metric_data_conditions(alert_rule_trigger)
+            if features.has(
+                "organizations:workflow-engine-metric-alert-dual-write",
+                alert_rule_trigger.alert_rule.organization,
+            ):
+                migrate_metric_data_conditions(alert_rule_trigger)
         self._handle_actions(alert_rule_trigger, actions)
         return alert_rule_trigger
 
@@ -87,9 +90,9 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
                 alert_rule_trigger=alert_rule_trigger
             ).exclude(id__in=action_ids)
             for action in actions_to_delete:
-                # TODO (mifu67): wrap these two calls in a transaction
-                dual_delete_migrated_alert_rule_trigger_action(action)
-                delete_alert_rule_trigger_action(action)
+                with transaction.atomic(router.db_for_write(AlertRuleTriggerAction)):
+                    dual_delete_migrated_alert_rule_trigger_action(action)
+                    delete_alert_rule_trigger_action(action)
 
             for action_data in actions:
                 action_data = rewrite_trigger_action_fields(action_data)

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -1,9 +1,8 @@
-from django.db import router, transaction
 from django.forms import ValidationError
 from django.utils.encoding import force_str
 from rest_framework import serializers
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.auth.access import Access
 from sentry.incidents.logic import (
@@ -20,7 +19,6 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.notifications.models.notificationaction import ActionService
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
-from sentry.workflow_engine.migration_helpers.alert_rule import migrate_metric_action
 
 
 class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
@@ -196,22 +194,15 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
     def create(self, validated_data):
         for key in ("id", "sentry_app_installation_uuid"):
             validated_data.pop(key, None)
-        with transaction.atomic(router.db_for_write(AlertRuleTriggerAction)):
-            try:
-                action = create_alert_rule_trigger_action(
-                    trigger=self.context["trigger"], **validated_data
-                )
-            except (ApiRateLimitedError, InvalidTriggerActionError) as e:
-                raise serializers.ValidationError(force_str(e))
-            if features.has(
-                "organizations:workflow-engine-metric-alert-dual-write",
-                action.alert_rule_trigger.alert_rule.organization,
-            ):
-                try:
-                    migrate_metric_action(action)
-                except ValidationError as e:
-                    # invalid action type
-                    raise serializers.ValidationError(str(e))
+        try:
+            action = create_alert_rule_trigger_action(
+                trigger=self.context["trigger"], **validated_data
+            )
+        except (ApiRateLimitedError, InvalidTriggerActionError) as e:
+            raise serializers.ValidationError(force_str(e))
+        except ValidationError as e:
+            # invalid action type
+            raise serializers.ValidationError(str(e))
 
         analytics.record(
             "metric_alert_with_ui_component.created",


### PR DESCRIPTION
If something goes wrong in the dual write (wlog, could also be update or delete) helper, we want to roll back the change in the original alert rule creation as well. Add transactions to accomplish this.

Requires that https://github.com/getsentry/sentry/pull/85079 be merged first.