### PR TITLE
chore(autofix): Swap insight icons to refresh

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -9,7 +9,7 @@ import {replaceHeadersWithBold} from 'sentry/components/events/autofix/autofixRo
 import type {AutofixInsight} from 'sentry/components/events/autofix/types';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Input from 'sentry/components/input';
-import {IconAdd, IconChevron, IconClose, IconEdit, IconRefresh} from 'sentry/icons';
+import {IconChevron, IconClose, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import marked, {singleLineRenderer} from 'sentry/utils/marked';
@@ -242,7 +242,7 @@ function AutofixInsightCard({
                     size="zero"
                     borderless
                     onClick={handleEdit}
-                    icon={<IconEdit size="sm" />}
+                    icon={<IconRefresh size="sm" />}
                     aria-label={t('Edit insight')}
                     title={t('Replace insight and rethink')}
                   />
@@ -536,7 +536,7 @@ function ChainLink({
               size="zero"
               borderless
               onClick={() => setIsAdding(true)}
-              icon={<IconAdd size="sm" />}
+              icon={<IconRefresh size="sm" />}
               title={t('Add insight and rethink')}
               aria-label={t('Add insight and rethink')}
             />


### PR DESCRIPTION
<img width="86" alt="Screenshot 2025-02-14 at 9 42 30 AM" src="https://github.com/user-attachments/assets/07794ed4-41b6-489b-ac62-ec7d655d9619" />
