### PR TITLE
fix(alerts): Append selected metric to list

### DIFF
--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -54,7 +54,7 @@ function EAPField({aggregate, onChange}: Props) {
 
   useEffect(() => {
     const selectedMeta = field ? numberTags[field] : undefined;
-    if (!field && !selectedMeta) {
+    if (!field || !selectedMeta) {
       const newSelection = fieldsArray[0];
       if (newSelection) {
         onChange(`count(${newSelection.name})`, {});


### PR DESCRIPTION
If the user picks a different numeric tag, the value defaults to span.duration if the tag collection is not already loaded