### PR TITLE
Reapply "ref(crons): Remove parallel mode (batched-parallel replaced it)"

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -109,8 +109,8 @@ def ingest_monitors_options() -> list[click.Option]:
     options = [
         click.Option(
             ["--mode", "mode"],
-            type=click.Choice(["serial", "parallel", "batched-parallel"]),
-            default="parallel",
+            type=click.Choice(["serial", "batched-parallel"]),
+            default="batched-parallel",
             help="The mode to process check-ins in. Parallel uses multithreading.",
         ),
         click.Option(

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -1074,12 +1074,12 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
 
     def __init__(
         self,
-        mode: Literal["batched-parallel", "parallel", "serial"] | None = None,
+        mode: Literal["batched-parallel", "serial"] | None = None,
         max_batch_size: int | None = None,
         max_batch_time: int | None = None,
         max_workers: int | None = None,
     ) -> None:
-        if mode == "batched-parallel" or mode == "parallel":
+        if mode == "batched-parallel":
             self.parallel = True
             self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
 


### PR DESCRIPTION
This reverts commit 592ce76b729e7aa1e5c62754553da8f60338f2f7.

This correctly includes the change to the `default` to be `batched-parallel`