### PR TITLE
chore(explore): Add arrow to explore traces table

### DIFF
--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -11,6 +11,7 @@ import Pagination from 'sentry/components/pagination';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Tooltip} from 'sentry/components/tooltip';
 import {SPAN_PROPS_DOCS_URL} from 'sentry/constants';
+import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tct} from 'sentry/locale';
@@ -78,7 +79,10 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
             {t('Root Duration')}
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
-            {t('Timestamp')}
+            <Header>
+              {t('Timestamp')}
+              <IconArrow size="xs" direction="down" />
+            </Header>
           </StyledPanelHeader>
           {isPending && (
             <StyledPanelItem span={6} overflow>
@@ -279,6 +283,11 @@ function Breakdown({trace}: {trace: TraceResult}) {
     </BreakdownPanelItem>
   );
 }
+
+const Header = styled('span')`
+  display: flex;
+  gap: ${space(0.5)};
+`;
 
 const StyledButton = styled(Button)`
   margin-right: ${space(0.5)};


### PR DESCRIPTION
The traces table is always sorted by timestamp descending.