### PR TITLE
feat(explore): Render the equation input under visualize

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -79,9 +79,14 @@ export function SpansTabContentImpl({
   const query = useExploreQuery();
   const setQuery = useSetExploreQuery();
 
-  const toolbarExtras = organization?.features?.includes('visibility-explore-dataset')
-    ? ['dataset toggle' as const]
-    : [];
+  const toolbarExtras = [
+    ...(organization?.features?.includes('visibility-explore-dataset')
+      ? ['dataset toggle' as const]
+      : []),
+    ...(organization?.features?.includes('visibility-explore-equations')
+      ? ['equations' as const]
+      : []),
+  ];
 
   const queryType: 'aggregate' | 'samples' | 'traces' =
     mode === Mode.AGGREGATE

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -21,7 +21,7 @@ import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
 import {ToolbarSuggestedQueries} from 'sentry/views/explore/toolbar/toolbarSuggestedQueries';
 import {ToolbarVisualize} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
-type Extras = 'dataset toggle';
+type Extras = 'dataset toggle' | 'equations';
 
 interface ExploreToolbarProps {
   extras?: Extras[];
@@ -45,7 +45,7 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
         <ToolbarDataset dataset={dataset} setDataset={setDataset} />
       )}
       <ToolbarMode mode={mode} setMode={setMode} />
-      <ToolbarVisualize />
+      <ToolbarVisualize equationSupport={extras?.includes('equations')} />
       {mode === Mode.AGGREGATE && <ToolbarGroupBy />}
       <ToolbarSortBy
         fields={fields}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
 import {Button} from 'sentry/components/button';
 import type {SelectKey, SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -40,7 +41,11 @@ type ParsedVisualize = {
   label: string;
 };
 
-export function ToolbarVisualize() {
+interface ToolbarVisualizeProps {
+  equationSupport?: boolean;
+}
+
+export function ToolbarVisualize({equationSupport}: ToolbarVisualizeProps) {
   const visualizes = useExploreVisualizes();
   const setVisualizes = useSetExploreVisualizes();
 
@@ -188,6 +193,20 @@ export function ToolbarVisualize() {
                   />
                 </ToolbarRow>
               ))}
+              {equationSupport &&
+                parsedVisualizeGroup.map((_, index) => (
+                  <ToolbarRow key={index}>
+                    <ArithmeticBuilder expression="" />
+                    <Button
+                      borderless
+                      icon={<IconDelete />}
+                      size="zero"
+                      disabled={lastVisualization}
+                      onClick={() => deleteOverlay(group, index)}
+                      aria-label={t('Remove Overlay')}
+                    />
+                  </ToolbarRow>
+                ))}
               <ToolbarFooter>
                 <ToolbarFooterButton
                   borderless


### PR DESCRIPTION
This renders the input without hooking it up to the visualize component for now.