### PR TITLE
fix(api) Update API docs to not use /api/0/issues

### DIFF
--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -288,7 +288,8 @@ def _check_description(json_body: Mapping[str, Any], err_str: str) -> None:
 def _fix_issue_paths(result: Any) -> Any:
     """
     The way we define `/issues/` paths causes some problems with drf-spectacular:
-    - The path may be defined twice, with `/organizations/{organization_id_slug}` prefix and without
+    - The path may be defined twice, with `/organizations/{organization_id_slug}` prefix and
+      without. We want to use the `/organizations` prefixed path as it works across regions.
     - The `/issues/` part of the path is defined as `issues|groups` for compatibility reasons,
       but we only want to use `issues` in the docs
 
@@ -305,9 +306,9 @@ def _fix_issue_paths(result: Any) -> Any:
 
     for path in modified_paths:
         updated_path = path.replace("{var}/{issue_id}", "issues/{issue_id}")
-        if path.startswith("/api/0/organizations/{organization_id_or_slug}/"):
+        if path.startswith("/api/0/issues/"):
             updated_path = updated_path.replace(
-                "/api/0/organizations/{organization_id_or_slug}/", "/api/0/"
+                "/api/0/issues/", "/api/0/organizations/{organization_id_or_slug}/issues/"
             )
         endpoint = result["paths"][path]
         for method in endpoint.keys():

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -306,7 +306,7 @@ def _fix_issue_paths(result: Any) -> Any:
 
     for path in modified_paths:
         updated_path = path.replace("{var}/{issue_id}", "issues/{issue_id}")
-        if path.startswith("/api/0/issues/"):
+        if updated_path.startswith("/api/0/issues/"):
             updated_path = updated_path.replace(
                 "/api/0/issues/", "/api/0/organizations/{organization_id_or_slug}/issues/"
             )
@@ -315,9 +315,7 @@ def _fix_issue_paths(result: Any) -> Any:
             endpoint[method]["parameters"] = [
                 param
                 for param in endpoint[method]["parameters"]
-                if not (
-                    param["in"] == "path" and param["name"] in ("var", "organization_id_or_slug")
-                )
+                if not (param["in"] == "path" and param["name"] == "var")
             ]
         result["paths"][updated_path] = endpoint
         del result["paths"][path]

--- a/tests/apidocs/endpoints/events/test_group_events.py
+++ b/tests/apidocs/endpoints/events/test_group_events.py
@@ -30,7 +30,7 @@ class ProjectGroupEventBase(APIDocsTestCase):
 class ProjectGroupEventsDocs(ProjectGroupEventBase):
     def setUp(self):
         super().setUp()
-        self.url = f"/api/0/issues/{self.group_id}/events/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group_id}/events/"
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -42,7 +42,9 @@ class ProjectGroupEventsDocs(ProjectGroupEventBase):
 class ProjectGroupEventDetailsDocs(ProjectGroupEventBase):
     def setUp(self):
         super().setUp()
-        self.url = f"/api/0/issues/{self.group_id}/events/latest/"
+        self.url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group_id}/events/latest/"
+        )
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/apidocs/test_hooks.py
+++ b/tests/apidocs/test_hooks.py
@@ -62,14 +62,6 @@ class FixIssueRoutesTest(TestCase):
         # "var" and "organization_id_or_slug" path parameters should be removed
         AFTER = {
             "paths": {
-                "/api/0/issues/{issue_id}/": {
-                    "get": {
-                        "tags": ["Events"],
-                        "description": "Get issues",
-                        "operationId": "get issue",
-                        "parameters": [],
-                    }
-                },
                 "/api/0/some/path/": {
                     "get": {
                         "tags": ["Events"],
@@ -78,8 +70,15 @@ class FixIssueRoutesTest(TestCase):
                         "parameters": [],
                     }
                 },
+                "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/": {
+                    "get": {
+                        "tags": ["Events"],
+                        "description": "Get issues",
+                        "operationId": "get issue",
+                        "parameters": [],
+                    }
+                },
             },
             "components": {"schemas": {}},
         }
-
         assert custom_postprocessing_hook(BEFORE, None) == AFTER


### PR DESCRIPTION
The /api/0/issues URLs cannot be resolved by control silo proxying and shouldn't be part of our public documentation as they result in integrations that are broken for DE customers.
