### PR TITLE
feat(ui): Add release bubbles support to `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -750,6 +750,19 @@ const getTooltipStyles = (p: {theme: Theme}) => css`
   }
 
   .tooltip-arrow {
+    &.arrow-top {
+      bottom: 100%;
+      top: auto;
+      border-bottom: 8px solid ${p.theme.backgroundElevated};
+      border-top: none;
+      &:before {
+        border-top: none;
+        border-bottom: 8px solid ${p.theme.translucentBorder};
+        bottom: -7px;
+        top: auto;
+      }
+    }
+
     top: 100%;
     left: 50%;
     position: absolute;

--- a/static/app/components/releases/releasesDrawer.tsx
+++ b/static/app/components/releases/releasesDrawer.tsx
@@ -1,6 +1,7 @@
 import {Fragment, type ReactElement} from 'react';
 import styled from '@emotion/styled';
 
+import {DateTime} from 'sentry/components/dateTime';
 import {
   EventDrawerBody,
   EventDrawerContainer,
@@ -9,23 +10,12 @@ import {
   Header,
   NavigationCrumbs,
 } from 'sentry/components/events/eventDrawer';
+import {ReleaseDrawerTable} from 'sentry/components/releases/releasesDrawerTable';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Release} from 'sentry/views/dashboards/widgets/common/types';
-import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-
-import {DateTime} from '../dateTime';
-
-import {ReleaseDrawerTable} from './releasesDrawerTable';
-
-type Bucket = [
-  start: number,
-  placeholder: number,
-  end: number,
-  numReleases: number,
-  releases: Release[],
-];
 
 interface ReleasesDrawerProps {
   /**
@@ -46,9 +36,11 @@ interface ReleasesDrawerProps {
    * it to make the props more generic, e.g. pass start/end timestamps and do
    * the series manipulation when we call the bubble hook.
    */
-  chartRenderer?: (
-    rendererProps: Partial<TimeSeriesWidgetVisualizationProps>
-  ) => ReactElement;
+  chartRenderer?: (rendererProps: {
+    end: Date;
+    releases: Release[];
+    start: Date;
+  }) => ReactElement;
 }
 
 export function ReleasesDrawer({
@@ -78,6 +70,11 @@ export function ReleasesDrawer({
                   <DateTime date={start} /> <span>{t('to')}</span> <DateTime date={end} />
                 </Fragment>
               }
+              Visualization={chartRenderer?.({
+                releases,
+                start,
+                end,
+              })}
             />
           </ChartContainer>
         ) : null}

--- a/static/app/components/releases/releasesDrawer.tsx
+++ b/static/app/components/releases/releasesDrawer.tsx
@@ -14,7 +14,6 @@ import {ReleaseDrawerTable} from 'sentry/components/releases/releasesDrawerTable
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ReleaseMetaBasic} from 'sentry/types/release';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
@@ -39,7 +38,7 @@ interface ReleasesDrawerProps {
    */
   chartRenderer?: (rendererProps: {
     end: Date;
-    releases: Release[];
+    releases: ReleaseMetaBasic[];
     start: Date;
   }) => ReactElement;
 }

--- a/static/app/components/releases/releasesDrawer.tsx
+++ b/static/app/components/releases/releasesDrawer.tsx
@@ -13,13 +13,14 @@ import {
 import {ReleaseDrawerTable} from 'sentry/components/releases/releasesDrawerTable';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {ReleaseMetaBasic} from 'sentry/types/release';
 import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
 interface ReleasesDrawerProps {
   /**
-   * This is a list of the release buckets used by eCharts to draw the release bubbles.
+   * This is a list of the release buckets used by ECharts to draw the release bubbles.
    * Currently unused, but we can use this to traverse through the release buckets within the drawer
    */
   buckets: Bucket[];
@@ -27,7 +28,7 @@ interface ReleasesDrawerProps {
   /**
    * A list of releases in the current release bucket
    */
-  releases: Release[];
+  releases: ReleaseMetaBasic[];
   startTs: number;
   /**
    * A renderer function that returns a chart. It is called with the trimmed

--- a/static/app/components/releases/releasesDrawerTable.tsx
+++ b/static/app/components/releases/releasesDrawerTable.tsx
@@ -5,9 +5,11 @@ import Count from 'sentry/components/count';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import type {GridColumnHeader, GridColumnOrder} from 'sentry/components/gridEditable';
 import GridEditable from 'sentry/components/gridEditable';
+import Pagination from 'sentry/components/pagination';
 import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHeaderCell';
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
 import useQueryBasedSorting from 'sentry/components/replays/useQueryBasedSorting';
+import TextOverflow from 'sentry/components/textOverflow';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -18,9 +20,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useOrganizationReleases from 'sentry/views/insights/sessions/queries/useOrganizationReleases';
 import {getReleaseNewIssuesUrl} from 'sentry/views/releases/utils';
-
-import Pagination from '../pagination';
-import TextOverflow from '../textOverflow';
 
 type ReleaseHealthItem = {
   adoption_stage: string;

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -131,6 +131,14 @@ export type ReleaseProject = {
   healthData?: Health;
 };
 
+/**
+ * From the `/releases/stats/` endpoint
+ */
+export type ReleaseMetaBasic = {
+  date: string;
+  version: string;
+};
+
 export type ReleaseMeta = {
   commitCount: number;
   commitFilesChanged: number;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
@@ -1,0 +1,1 @@
+export const BUBBLE_SERIES_ID = '__release_bubble__';

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants.tsx
@@ -1,1 +1,10 @@
 export const BUBBLE_SERIES_ID = '__release_bubble__';
+export const BUBBLE_AREA_SERIES_ID = '__release_bubble_area__';
+export const DEFAULT_BUBBLE_SIZE = 14;
+
+// "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
+// to move into `renderReleaseBubble` if it needs to be customizable
+export const RELEASE_BUBBLE_Y_PADDING = 8;
+export const RELEASE_BUBBLE_Y_HALF_PADDING = RELEASE_BUBBLE_Y_PADDING / 2;
+export const RELEASE_BUBBLE_X_PADDING = 2;
+export const RELEASE_BUBBLE_X_HALF_PADDING = RELEASE_BUBBLE_X_PADDING / 2;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -33,9 +33,9 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
       return;
     }
 
-    const bucketIndex = buckets.findIndex(([bucketStart, _, bucketEnd]: Bucket) => {
+    const bucketIndex = buckets.findIndex(({start, end}: Bucket) => {
       const ts = pointInGrid[0] ?? -1;
-      return ts >= bucketStart && ts < bucketEnd;
+      return ts >= start && ts < end;
     });
 
     // Already highlighted, no need to do anything

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -1,0 +1,72 @@
+import type {ElementEvent} from 'echarts';
+import type {EChartsInstance} from 'echarts-for-react';
+
+import type {Series} from 'sentry/types/echarts';
+import {BUBBLE_SERIES_ID} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
+import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
+
+/**
+ * Attaches an event listener to eCharts that will "highlight" a release bubble
+ * as the mouse moves around the main chart.
+ *
+ * Note: you cannot listen to "mousemove" events on echarts as they only
+ * contain events when the mouse interacts with a data item. This needs to
+ * listen to zrender (i.e. the `getZr()`) events.
+ */
+export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance) {
+  const highlightedBuckets = new Set();
+  function handleMouseMove(params: ElementEvent) {
+    // Tracks movement across the chart and highlights the corresponding release bubble
+    const pointInPixel = [params.offsetX, params.offsetY];
+    const pointInGrid = echartsInstance.convertFromPixel('grid', pointInPixel);
+    const series = echartsInstance.getOption().series;
+    const seriesIndex = series.findIndex((s: Series) => s.id === BUBBLE_SERIES_ID);
+
+    // No release bubble series found (shouldn't happen)
+    if (seriesIndex === -1) {
+      return;
+    }
+    const bubbleSeries = series[seriesIndex];
+    const buckets = bubbleSeries?.data;
+
+    if (!buckets) {
+      return;
+    }
+
+    const bucketIndex = buckets.findIndex(([bucketStart, _, bucketEnd]: Bucket) => {
+      const ts = pointInGrid[0] ?? -1;
+      return ts >= bucketStart && ts < bucketEnd;
+    });
+
+    // Already highlighted, no need to do anything
+    if (highlightedBuckets.has(bucketIndex)) {
+      return;
+    }
+
+    // If next bucket is not already highlighted, clear all existing
+    // highlights.
+    if (!highlightedBuckets.has(bucketIndex)) {
+      highlightedBuckets.forEach(dataIndex => {
+        echartsInstance.dispatchAction({
+          type: 'downplay',
+          seriesIndex,
+          dataIndex,
+        });
+      });
+      highlightedBuckets.clear();
+    }
+
+    // A bucket was found, dispatch "highlight" action --
+    // this is styled via `renderReleaseBubble` -> `emphasis`
+    if (bucketIndex > -1) {
+      highlightedBuckets.add(bucketIndex);
+      echartsInstance.dispatchAction({
+        type: 'highlight',
+        seriesIndex,
+        dataIndex: bucketIndex,
+      });
+    }
+  }
+
+  echartsInstance.getZr().on('mousemove', handleMouseMove);
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -69,8 +69,4 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
   }
 
   echartsInstance.getZr().on('mousemove', handleMouseMove);
-
-  return function highlighterCleanup() {
-    echartsInstance.getZr().off('mousemove', handleMouseMove);
-  };
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -69,4 +69,8 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
   }
 
   echartsInstance.getZr().on('mousemove', handleMouseMove);
+
+  return function highlighterCleanup() {
+    echartsInstance.getZr().off('mousemove', handleMouseMove);
+  };
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter.tsx
@@ -33,6 +33,7 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
       return;
     }
 
+    // Try to find the bucket that the mouse is hovered over
     const bucketIndex = buckets.findIndex(({start, end}: Bucket) => {
       const ts = pointInGrid[0] ?? -1;
       return ts >= start && ts < end;
@@ -44,7 +45,7 @@ export function createReleaseBubbleHighlighter(echartsInstance: EChartsInstance)
     }
 
     // If next bucket is not already highlighted, clear all existing
-    // highlights.
+    // highlights. We also want to clear if bucket was *not* found.
     if (!highlightedBuckets.has(bucketIndex)) {
       highlightedBuckets.forEach(dataIndex => {
         echartsInstance.dispatchAction({

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types.tsx
@@ -1,0 +1,9 @@
+import type {ReleaseMetaBasic} from 'sentry/types/release';
+
+export type Bucket = [
+  start: number,
+  placeholder: number,
+  end: number,
+  numReleases: number,
+  releases: ReleaseMetaBasic[],
+];

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types.tsx
@@ -1,9 +1,7 @@
 import type {ReleaseMetaBasic} from 'sentry/types/release';
 
-export type Bucket = [
-  start: number,
-  placeholder: number,
-  end: number,
-  numReleases: number,
-  releases: ReleaseMetaBasic[],
-];
+export type Bucket = {
+  end: number;
+  releases: ReleaseMetaBasic[];
+  start: number;
+};

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -151,6 +151,11 @@ function ReleaseBubbleSeries({
   theme,
   bubbleSize = DEFAULT_BUBBLE_SIZE,
 }: ReleaseBubbleSeriesProps): CustomSeriesOption | null {
+  const totalReleases = buckets.reduce(
+    (acc, [, , , numReleases]) => acc + numReleases,
+    0
+  );
+  const avgReleases = totalReleases / buckets.length;
   /**
    * Renders release bubbles underneath the main chart
    */
@@ -202,7 +207,7 @@ function ReleaseBubbleSeries({
       style: {
         fill: theme.blue400,
         // TODO: figure out correct opacity calculations
-        opacity: Number(numberReleases) * 0.1,
+        opacity: Math.round((Number(numberReleases) / avgReleases) * 50) / 100,
       },
       emphasis: {
         style: {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -24,6 +24,7 @@ import type {ReleaseMetaBasic} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import {BUBBLE_SERIES_ID} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
+import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {createReleaseBuckets} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets';
 import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -297,6 +298,7 @@ export function useReleaseBubbles({
 
   if (!releases || !buckets.length) {
     return {
+      createReleaseBubbleHighlighter: () => {},
       releaseBubbleEventHandlers: {},
       ReleaseBubbleSeries: null,
       releaseBubbleXAxis: {},
@@ -305,6 +307,8 @@ export function useReleaseBubbles({
   }
 
   return {
+    createReleaseBubbleHighlighter,
+
     /**
      * An object map of eCharts event handlers. These should be spread onto a Chart component
      */

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -1,0 +1,337 @@
+import type {ReactElement} from 'react';
+import type {Theme} from '@emotion/react';
+import type {
+  CustomSeriesOption,
+  CustomSeriesRenderItem,
+  CustomSeriesRenderItemAPI,
+  CustomSeriesRenderItemParams,
+  CustomSeriesRenderItemReturn,
+} from 'echarts';
+import type {EChartsInstance} from 'echarts-for-react';
+
+import {closeModal} from 'sentry/actionCreators/modal';
+import {isChartHovered} from 'sentry/components/charts/utils';
+import useDrawer, {type DrawerConfig} from 'sentry/components/globalDrawer';
+import {ReleasesDrawer} from 'sentry/components/releases/releasesDrawer';
+import {t} from 'sentry/locale';
+import type {
+  EChartClickHandler,
+  EChartMouseOutHandler,
+  EChartMouseOverHandler,
+  ReactEchartsRef,
+} from 'sentry/types/echarts';
+import type {ReleaseMetaBasic} from 'sentry/types/release';
+import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
+import {BUBBLE_SERIES_ID} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
+import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
+import {createReleaseBuckets} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets';
+import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+
+const BUBBLE_AREA_SERIES_ID = '__release_bubble_area__';
+const DEFAULT_BUBBLE_SIZE = 14;
+
+// "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
+// to move into `renderReleaseBubble` if it needs to be customizable
+const RELEASE_BUBBLE_Y_PADDING = 8;
+const RELEASE_BUBBLE_Y_HALF_PADDING = RELEASE_BUBBLE_Y_PADDING / 2;
+const RELEASE_BUBBLE_X_PADDING = 2;
+const RELEASE_BUBBLE_X_HALF_PADDING = RELEASE_BUBBLE_X_PADDING / 2;
+
+interface CreateReleaseBubbleMouseListenersParams {
+  buckets: Bucket[];
+  color: string;
+  openDrawer: (
+    renderer: DrawerConfig['renderer'],
+    options: DrawerConfig['options']
+  ) => void;
+  chartRenderer?: (
+    rendererProps: Partial<TimeSeriesWidgetVisualizationProps>
+  ) => ReactElement;
+}
+
+/**
+ * MouseListeners for echarts. This includes drawing a highlighted area on the
+ * main chart when a release bubble is hovered over.
+ */
+function createReleaseBubbleMouseListeners({
+  chartRenderer,
+  color,
+  openDrawer,
+  buckets,
+}: CreateReleaseBubbleMouseListenersParams) {
+  return {
+    onClick: (params: Parameters<EChartClickHandler>[0]) => {
+      if (params.seriesId !== BUBBLE_SERIES_ID) {
+        return;
+      }
+
+      const {data} = params;
+
+      // "Full Screen View" for Insights opens in a modal, close before opening
+      // drawer.
+      closeModal();
+
+      openDrawer(
+        () => (
+          <ReleasesDrawer
+            startTs={data[0]}
+            endTs={data[2]}
+            releases={data[4]}
+            buckets={buckets}
+            chartRenderer={chartRenderer}
+          />
+        ),
+        {
+          ariaLabel: t('Releases drawer'),
+          transitionProps: {stiffness: 1000},
+        }
+      );
+    },
+    onMouseOut: (
+      params: Parameters<EChartMouseOutHandler>[0],
+      instance: EChartsInstance
+    ) => {
+      if (params.seriesId !== BUBBLE_SERIES_ID) {
+        return;
+      }
+
+      instance.setOption({
+        series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
+      });
+    },
+    onMouseOver: (
+      params: Parameters<EChartMouseOverHandler>[0],
+      instance: EChartsInstance
+    ) => {
+      if (params.seriesId !== BUBBLE_SERIES_ID) {
+        return;
+      }
+
+      instance.setOption({
+        series: [
+          {
+            id: BUBBLE_AREA_SERIES_ID,
+            type: 'custom',
+            renderItem: () => {},
+            markArea: {
+              itemStyle: {color, opacity: 0.1},
+              data: [
+                [
+                  {
+                    xAxis: params.data[0],
+                  },
+                  {
+                    xAxis: params.data[2],
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      });
+    },
+  };
+}
+
+interface ReleaseBubbleSeriesProps {
+  buckets: Bucket[];
+  chartRef: React.RefObject<ReactEchartsRef>;
+  releases: ReleaseMetaBasic[];
+  theme: Theme;
+  bubbleSize?: number;
+}
+
+/**
+ * Creates a series item that is used to draw the release bubbles in a chart
+ */
+function ReleaseBubbleSeries({
+  buckets,
+  chartRef,
+  theme,
+  bubbleSize = DEFAULT_BUBBLE_SIZE,
+}: ReleaseBubbleSeriesProps): CustomSeriesOption | null {
+  /**
+   * Renders release bubbles underneath the main chart
+   */
+  const renderReleaseBubble: CustomSeriesRenderItem = (
+    _params: CustomSeriesRenderItemParams,
+    api: CustomSeriesRenderItemAPI
+  ) => {
+    // api.value(index) returns the value at Bucket[index]
+    // Unfortunately, it seems only integer values are allowed, it'll otherwise
+    // return NaN (this could be due to the chart being a timeseries).
+    //
+    // Because we are drawing rectangles with a known height, we don't care
+    // about the y-value (which I think is the 2nd tuple value passed to
+    // `api.coord()`).
+    const [bubbleStartX, bubbleStartY] = api.coord([api.value(0), 0]);
+    const [bubbleEndX, bubbleEndY] = api.coord([api.value(2), 0]);
+
+    if (
+      !defined(bubbleStartX) ||
+      !defined(bubbleStartY) ||
+      !defined(bubbleEndX) ||
+      !defined(bubbleEndY)
+    ) {
+      return null;
+    }
+
+    const numberReleases = api.value(3);
+
+    // Width between two timestamps for timeSeries
+    const width = bubbleEndX - bubbleStartX;
+
+    //
+    const shape = {
+      x: bubbleStartX + RELEASE_BUBBLE_X_HALF_PADDING,
+      y: bubbleStartY + RELEASE_BUBBLE_Y_HALF_PADDING,
+      width: width - RELEASE_BUBBLE_X_PADDING,
+      // currently we have a static height, but this may need to change since
+      // we have charts of different dimensions
+      height: bubbleSize - RELEASE_BUBBLE_Y_PADDING,
+
+      // border radius
+      r: 4,
+    };
+
+    return {
+      type: 'rect',
+      transition: ['shape'],
+      shape,
+      style: {
+        fill: theme.blue400,
+        // TODO: figure out correct opacity calculations
+        opacity: Number(numberReleases) * 0.1,
+      },
+      emphasis: {
+        style: {
+          stroke: theme.blue300,
+        },
+      },
+    } satisfies CustomSeriesRenderItemReturn;
+  };
+
+  return {
+    id: BUBBLE_SERIES_ID,
+    type: 'custom',
+    renderItem: renderReleaseBubble,
+    data: buckets,
+    tooltip: {
+      trigger: 'item',
+      position: 'bottom',
+      formatter: params => {
+        // Only show the tooltip of the current chart. Otherwise, all tooltips
+        // in the chart group appear.
+        if (!isChartHovered(chartRef?.current)) {
+          return '';
+        }
+
+        const bucket = params.data as Bucket;
+        const numberReleases = Number(bucket[3]);
+        return `
+<div class="tooltip-series">
+<div>
+${numberReleases} Releases
+</div>
+</div>
+
+${
+  numberReleases > 0
+    ? `<div class="tooltip-footer">
+Tap to view
+</div>`
+    : ''
+}
+<div class="tooltip-arrow arrow-top"></div>
+`;
+      },
+    },
+  };
+}
+
+interface UseReleaseBubblesParams {
+  chartRef: React.RefObject<ReactEchartsRef>;
+  /**
+   * Color of the highlighted area in main chart when mousehovers over a bubble
+   */
+  highlightAreaColor: string;
+  theme: Theme;
+  bubbleSize?: number;
+  chartRenderer?: (rendererProps: Partial<TimeSeriesWidgetVisualizationProps>) => any;
+  maxTime?: number;
+  minTime?: number;
+  releases?: ReleaseMetaBasic[];
+}
+export function useReleaseBubbles({
+  chartRef,
+  chartRenderer,
+  highlightAreaColor,
+  releases,
+  minTime,
+  maxTime,
+  theme,
+  bubbleSize,
+}: UseReleaseBubblesParams) {
+  const organization = useOrganization();
+  const {openDrawer} = useDrawer();
+  const hasReleaseBubbles = organization.features.includes('release-bubbles-ui');
+  const buckets =
+    (hasReleaseBubbles &&
+      releases?.length &&
+      minTime &&
+      maxTime &&
+      createReleaseBuckets(minTime, maxTime, releases)) ||
+    [];
+
+  if (!releases || !buckets.length) {
+    return {
+      releaseBubbleEventHandlers: {},
+      ReleaseBubbleSeries: null,
+      releaseBubbleXAxis: {},
+      releaseBubbleGrid: {},
+    };
+  }
+
+  return {
+    /**
+     * An object map of eCharts event handlers. These should be spread onto a Chart component
+     */
+    releaseBubbleEventHandlers: createReleaseBubbleMouseListeners({
+      buckets,
+      chartRenderer,
+      color: highlightAreaColor,
+      openDrawer,
+    }),
+
+    /**
+     * Series to append to a chart's existing `series`
+     */
+    releaseBubbleSeries: ReleaseBubbleSeries({
+      buckets,
+      bubbleSize,
+      chartRef,
+      theme,
+      releases,
+    }),
+
+    /**
+     * eCharts xAxis configuration. Spread/override charts `xAxis` prop
+     */
+    releaseBubbleXAxis: {
+      // configure `axisLine` and `offset` to move axis line below 0 so that
+      // bubbles sit between bottom of the main chart and the axis line
+      axisLine: {onZero: false},
+      offset: bubbleSize,
+    },
+
+    /**
+     * eCharts grid configuration. Spread/override charts `grid` prop
+     */
+    releaseBubbleGrid: {
+      // Moves bottom of grid "up" `bubbleSize` pixels so that bubbles are
+      // drawn below grid (but above x axis label)
+      bottom: bubbleSize,
+    },
+  };
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -1,4 +1,4 @@
-import {type ReactElement, useCallback, useEffect, useRef} from 'react';
+import type {ReactElement} from 'react';
 import type {Theme} from '@emotion/react';
 import type {
   CustomSeriesOption,
@@ -8,7 +8,6 @@ import type {
   CustomSeriesRenderItemReturn,
 } from 'echarts';
 import type {EChartsInstance} from 'echarts-for-react';
-import type EChartsReactCore from 'echarts-for-react/lib/core';
 
 import {closeModal} from 'sentry/actionCreators/modal';
 import {isChartHovered} from 'sentry/components/charts/utils';
@@ -25,7 +24,6 @@ import type {ReleaseMetaBasic} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import {BUBBLE_SERIES_ID} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
-import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {createReleaseBuckets} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets';
 import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -264,6 +262,7 @@ Tap to view
 }
 
 interface UseReleaseBubblesParams {
+  chartRef: React.RefObject<ReactEchartsRef>;
   /**
    * Color of the highlighted area in main chart when mousehovers over a bubble
    */
@@ -273,13 +272,10 @@ interface UseReleaseBubblesParams {
   chartRenderer?: (rendererProps: Partial<TimeSeriesWidgetVisualizationProps>) => any;
   maxTime?: number;
   minTime?: number;
-  /**
-   * This is a ref callback function that is called on mount/unmount.
-   */
-  onChartMount?: (e: ReactEchartsRef) => void;
   releases?: ReleaseMetaBasic[];
 }
 export function useReleaseBubbles({
+  chartRef,
   chartRenderer,
   highlightAreaColor,
   releases,
@@ -287,12 +283,9 @@ export function useReleaseBubbles({
   maxTime,
   theme,
   bubbleSize,
-  onChartMount,
 }: UseReleaseBubblesParams) {
   const organization = useOrganization();
-  const highlighterCleanupRef = useRef<(() => void) | null>(null);
   const {openDrawer} = useDrawer();
-  const chartRef = useRef<EChartsReactCore | null>(null);
   const hasReleaseBubbles = organization.features.includes('release-bubbles-ui');
   const buckets =
     (hasReleaseBubbles &&
@@ -302,40 +295,8 @@ export function useReleaseBubbles({
       createReleaseBuckets(minTime, maxTime, releases)) ||
     [];
 
-  useEffect(() => {
-    // Cleanup highlighter on unmount
-    const cleanupFn = highlighterCleanupRef.current;
-    return () => {
-      if (typeof cleanupFn === 'function') {
-        cleanupFn();
-      }
-    };
-  }, []);
-
-  const handleChartMount = useCallback(
-    (e: ReactEchartsRef) => {
-      // Need to call this regardless of `hasReleaseBubbles`, since this hook
-      // needs to act as a proxy to capture the chart ref.
-      onChartMount?.(e);
-
-      chartRef.current = e;
-
-      if (!e?.getEchartsInstance) {
-        return;
-      }
-
-      if (hasReleaseBubbles) {
-        highlighterCleanupRef.current = createReleaseBubbleHighlighter(
-          e.getEchartsInstance()
-        );
-      }
-    },
-    [hasReleaseBubbles, onChartMount]
-  );
-
   if (!releases || !buckets.length) {
     return {
-      handleChartMount,
       releaseBubbleEventHandlers: {},
       ReleaseBubbleSeries: null,
       releaseBubbleXAxis: {},
@@ -344,8 +305,6 @@ export function useReleaseBubbles({
   }
 
   return {
-    handleChartMount,
-
     /**
      * An object map of eCharts event handlers. These should be spread onto a Chart component
      */

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -35,7 +35,6 @@ import {
 import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {createReleaseBuckets} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets';
-import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
 interface CreateReleaseBubbleMouseListenersParams {
   buckets: Bucket[];
@@ -44,9 +43,11 @@ interface CreateReleaseBubbleMouseListenersParams {
     renderer: DrawerConfig['renderer'],
     options: DrawerConfig['options']
   ) => void;
-  chartRenderer?: (
-    rendererProps: Partial<TimeSeriesWidgetVisualizationProps>
-  ) => ReactElement;
+  chartRenderer?: (rendererProps: {
+    end: Date;
+    releases: ReleaseMetaBasic[];
+    start: Date;
+  }) => ReactElement;
 }
 
 /**
@@ -272,7 +273,11 @@ Tap to view
 interface UseReleaseBubblesParams {
   chartRef: React.RefObject<ReactEchartsRef>;
   bubbleSize?: number;
-  chartRenderer?: (rendererProps: Partial<TimeSeriesWidgetVisualizationProps>) => any;
+  chartRenderer?: (rendererProps: {
+    end: Date;
+    releases: ReleaseMetaBasic[];
+    start: Date;
+  }) => ReactElement;
   maxTime?: number;
   minTime?: number;
   releases?: ReleaseMetaBasic[];

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -23,21 +23,19 @@ import type {
 import type {ReleaseMetaBasic} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
-import {BUBBLE_SERIES_ID} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
+import {
+  BUBBLE_AREA_SERIES_ID,
+  BUBBLE_SERIES_ID,
+  DEFAULT_BUBBLE_SIZE,
+  RELEASE_BUBBLE_X_HALF_PADDING,
+  RELEASE_BUBBLE_X_PADDING,
+  RELEASE_BUBBLE_Y_HALF_PADDING,
+  RELEASE_BUBBLE_Y_PADDING,
+} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/constants';
 import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
 import {createReleaseBuckets} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets';
 import type {TimeSeriesWidgetVisualizationProps} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
-
-const BUBBLE_AREA_SERIES_ID = '__release_bubble_area__';
-const DEFAULT_BUBBLE_SIZE = 14;
-
-// "padding" around the bubbles as it is drawn on canvas vs CSS, this may need
-// to move into `renderReleaseBubble` if it needs to be customizable
-const RELEASE_BUBBLE_Y_PADDING = 8;
-const RELEASE_BUBBLE_Y_HALF_PADDING = RELEASE_BUBBLE_Y_PADDING / 2;
-const RELEASE_BUBBLE_X_PADDING = 2;
-const RELEASE_BUBBLE_X_HALF_PADDING = RELEASE_BUBBLE_X_PADDING / 2;
 
 interface CreateReleaseBubbleMouseListenersParams {
   buckets: Bucket[];

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -97,6 +97,7 @@ function createReleaseBubbleMouseListeners({
         return;
       }
 
+      // Clear the `markArea` that was drawn during mouse over
       instance.setOption({
         series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
       });
@@ -109,6 +110,10 @@ function createReleaseBubbleMouseListeners({
         return;
       }
 
+      // Create an empty series that has a `markArea` which is then
+      // rectangular area of the "release bucket" that was hovered over (in
+      // the release bubbles). This is drawn on the main chart so that users
+      // can visualize the time block of the set of relases.
       instance.setOption({
         series: [
           {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -313,7 +313,7 @@ export function useReleaseBubbles({
     createReleaseBubbleHighlighter,
 
     /**
-     * An object map of eCharts event handlers. These should be spread onto a Chart component
+     * An object map of ECharts event handlers. These should be spread onto a Chart component
      */
     releaseBubbleEventHandlers: createReleaseBubbleMouseListeners({
       buckets,
@@ -334,7 +334,7 @@ export function useReleaseBubbles({
     }),
 
     /**
-     * eCharts xAxis configuration. Spread/override charts `xAxis` prop
+     * ECharts xAxis configuration. Spread/override charts `xAxis` prop
      */
     releaseBubbleXAxis: {
       // configure `axisLine` and `offset` to move axis line below 0 so that
@@ -344,7 +344,7 @@ export function useReleaseBubbles({
     },
 
     /**
-     * eCharts grid configuration. Spread/override charts `grid` prop
+     * ECharts grid configuration. Spread/override charts `grid` prop
      */
     releaseBubbleGrid: {
       // Moves bottom of grid "up" `bubbleSize` pixels so that bubbles are

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -65,18 +65,22 @@ function createReleaseBubbleMouseListeners({
         return;
       }
 
-      const {data} = params;
+      // `data` is typed as Record<string, any> by ECharts, with no generics
+      // to override
+      const data = params.data as unknown as Bucket;
 
       // "Full Screen View" for Insights opens in a modal, close before opening
       // drawer.
       closeModal();
 
+      const oldPath = window.location.pathname;
+      console.log('open drawer', window.location.pathname);
       openDrawer(
         () => (
           <ReleasesDrawer
-            startTs={data[0]}
-            endTs={data[2]}
-            releases={data[4]}
+            startTs={data.start}
+            endTs={data.end}
+            releases={data.releases}
             buckets={buckets}
             chartRenderer={chartRenderer}
           />
@@ -108,6 +112,8 @@ function createReleaseBubbleMouseListeners({
         return;
       }
 
+      const data = params.data as unknown as Bucket;
+
       // Create an empty series that has a `markArea` which is then
       // rectangular area of the "release bucket" that was hovered over (in
       // the release bubbles). This is drawn on the main chart so that users
@@ -123,10 +129,10 @@ function createReleaseBubbleMouseListeners({
               data: [
                 [
                   {
-                    xAxis: params.data.start,
+                    xAxis: data.start,
                   },
                   {
-                    xAxis: params.data.end,
+                    xAxis: data.end,
                   },
                 ],
               ],

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -73,8 +73,6 @@ function createReleaseBubbleMouseListeners({
       // drawer.
       closeModal();
 
-      const oldPath = window.location.pathname;
-      console.log('open drawer', window.location.pathname);
       openDrawer(
         () => (
           <ReleasesDrawer

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles.tsx
@@ -1,5 +1,5 @@
 import type {ReactElement} from 'react';
-import type {Theme} from '@emotion/react';
+import {type Theme, useTheme} from '@emotion/react';
 import type {
   CustomSeriesOption,
   CustomSeriesRenderItem,
@@ -267,11 +267,6 @@ Tap to view
 
 interface UseReleaseBubblesParams {
   chartRef: React.RefObject<ReactEchartsRef>;
-  /**
-   * Color of the highlighted area in main chart when mousehovers over a bubble
-   */
-  highlightAreaColor: string;
-  theme: Theme;
   bubbleSize?: number;
   chartRenderer?: (rendererProps: Partial<TimeSeriesWidgetVisualizationProps>) => any;
   maxTime?: number;
@@ -281,15 +276,14 @@ interface UseReleaseBubblesParams {
 export function useReleaseBubbles({
   chartRef,
   chartRenderer,
-  highlightAreaColor,
   releases,
   minTime,
   maxTime,
-  theme,
   bubbleSize,
 }: UseReleaseBubblesParams) {
   const organization = useOrganization();
   const {openDrawer} = useDrawer();
+  const theme = useTheme();
   const hasReleaseBubbles = organization.features.includes('release-bubbles-ui');
   const buckets =
     (hasReleaseBubbles &&
@@ -318,7 +312,7 @@ export function useReleaseBubbles({
     releaseBubbleEventHandlers: createReleaseBubbleMouseListeners({
       buckets,
       chartRenderer,
-      color: highlightAreaColor,
+      color: theme.blue400,
       openDrawer,
     }),
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.spec.tsx
@@ -1,0 +1,169 @@
+import {createReleaseBuckets} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets';
+
+function createTimeSeries(numItems: number, intervalMs = 1000, start = new Date()) {
+  const timeSeries = [
+    {
+      data: Array.from(Array(numItems)).map((_, i) => ({
+        value: 0, // don't care about value
+        timestamp: new Date(start.getTime() + i * intervalMs).toISOString(),
+      })),
+    },
+  ];
+
+  // find min/max timestamp of *all* timeSeries
+  let minTime: Date | undefined;
+  let maxTime: Date | undefined;
+
+  for (const currentSeries of timeSeries) {
+    if (currentSeries.data.length < 2) {
+      continue;
+    }
+
+    const firstData = currentSeries.data[0];
+    const lastData = currentSeries.data[currentSeries.data.length - 1];
+    // I hope `data` is sorted
+    if (!minTime || new Date(firstData!.timestamp) < minTime) {
+      minTime = new Date(firstData!.timestamp);
+    }
+    if (!maxTime || new Date(lastData!.timestamp) > maxTime) {
+      maxTime = new Date(lastData!.timestamp);
+    }
+  }
+
+  return {minTime: minTime?.getTime(), maxTime: maxTime?.getTime()};
+}
+
+describe('createReleaseBuckets', () => {
+  it.each([
+    [0, 0],
+    [1, 0],
+    [2, 10],
+    [10, 10],
+    [20, 10],
+    [50, 10],
+    [100, 10],
+    [300, 10],
+  ])(
+    'creates correct # of buckets for timeSeries with %d items',
+    (numItems, expectedBuckets) => {
+      const {minTime, maxTime} = createTimeSeries(numItems);
+      const buckets = createReleaseBuckets(minTime, maxTime, []);
+      expect(buckets).toHaveLength(expectedBuckets);
+    }
+  );
+
+  it('creates the correct buckets', () => {
+    const {minTime, maxTime} = createTimeSeries(13);
+    // let's change the last timeseries
+    const newEndingTs = maxTime + 2235;
+
+    const buckets = createReleaseBuckets(minTime, newEndingTs, []);
+    expect(buckets).toEqual([
+      [1508208080000, 0, 1508208081424, 0, []],
+      [1508208081424, 0, 1508208082848, 0, []],
+      [1508208082848, 0, 1508208084272, 0, []],
+      [1508208084272, 0, 1508208085696, 0, []],
+      [1508208085696, 0, 1508208087120, 0, []],
+      [1508208087120, 0, 1508208088544, 0, []],
+      [1508208088544, 0, 1508208089968, 0, []],
+      [1508208089968, 0, 1508208091392, 0, []],
+      [1508208091392, 0, 1508208092816, 0, []],
+      [1508208092816, 0, 1508208094235, 0, []],
+    ]);
+  });
+
+  it('buckets releases correctly', () => {
+    const {minTime, maxTime} = createTimeSeries(13);
+    // let's change the last timeseries
+    const newEndingTs = maxTime + 2235;
+
+    const releases = [
+      {
+        version: 'ui@0.1.2',
+        date: 1508208080000,
+      },
+      {
+        version: 'ui@0.1.22',
+        date: 1508208081323,
+      },
+      {
+        version: 'ui@0.1.3',
+        date: 1508208081423,
+      },
+      {
+        version: 'ui@0.1.4',
+        date: 1508208083000,
+      },
+      {
+        version: 'ui@0.1.41',
+        date: 1508208084269,
+      },
+      {
+        version: 'ui@0.1.51',
+        date: 1508208092816,
+      },
+      {
+        version: 'ui@0.1.52',
+        date: 1508208094230,
+      },
+      {
+        version: 'ui@0.1.53',
+        date: 1508208094235,
+      },
+      {
+        version: 'ui@0.1.54',
+        date: 1508208094235,
+      },
+      // Should not be included
+      {
+        version: 'ui@0.1.6',
+        date: 1508208094236,
+      },
+    ];
+
+    const buckets = createReleaseBuckets(
+      minTime,
+      newEndingTs,
+      releases
+
+      //   .map(release => ({
+      //   ...release,
+      //   timestamp: new Date(release.timestamp).toISOString(),
+      // }))
+    );
+
+    expect(buckets).toEqual([
+      [
+        1508208080000,
+        0,
+        1508208081424,
+        3,
+        [
+          {version: 'ui@0.1.2', date: 1508208080000},
+          {version: 'ui@0.1.22', date: 1508208081323},
+          {version: 'ui@0.1.3', date: 1508208081423},
+        ],
+      ],
+      [1508208081424, 0, 1508208082848, 0, []],
+      [1508208082848, 0, 1508208084272, 2, [expect.any(Object), expect.any(Object)]],
+      [1508208084272, 0, 1508208085696, 0, []],
+      [1508208085696, 0, 1508208087120, 0, []],
+      [1508208087120, 0, 1508208088544, 0, []],
+      [1508208088544, 0, 1508208089968, 0, []],
+      [1508208089968, 0, 1508208091392, 0, []],
+      [1508208091392, 0, 1508208092816, 0, []],
+      [
+        1508208092816,
+        0,
+        1508208094235,
+        4,
+        [
+          {version: 'ui@0.1.51', date: 1508208092816},
+          {version: 'ui@0.1.52', date: 1508208094230},
+          {version: 'ui@0.1.53', date: 1508208094235},
+          {version: 'ui@0.1.54', date: 1508208094235},
+        ],
+      ],
+    ]);
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.spec.tsx
@@ -55,7 +55,7 @@ describe('createReleaseBuckets', () => {
   it('creates the correct buckets', () => {
     const {minTime, maxTime} = createTimeSeries(13);
     // let's change the last timeseries
-    const newEndingTs = maxTime + 2235;
+    const newEndingTs = maxTime! + 2235;
 
     const buckets = createReleaseBuckets(minTime, newEndingTs, []);
     expect(buckets).toEqual([
@@ -80,57 +80,48 @@ describe('createReleaseBuckets', () => {
     const releases = [
       {
         version: 'ui@0.1.2',
-        date: 1508208080000,
+        date: new Date(1508208080000).toISOString(),
       },
       {
         version: 'ui@0.1.22',
-        date: 1508208081323,
+        date: new Date(1508208081323).toISOString(),
       },
       {
         version: 'ui@0.1.3',
-        date: 1508208081423,
+        date: new Date(1508208081423).toISOString(),
       },
       {
         version: 'ui@0.1.4',
-        date: 1508208083000,
+        date: new Date(1508208083000).toISOString(),
       },
       {
         version: 'ui@0.1.41',
-        date: 1508208084269,
+        date: new Date(1508208084269).toISOString(),
       },
       {
         version: 'ui@0.1.51',
-        date: 1508208092816,
+        date: new Date(1508208092816).toISOString(),
       },
       {
         version: 'ui@0.1.52',
-        date: 1508208094230,
+        date: new Date(1508208094230).toISOString(),
       },
       {
         version: 'ui@0.1.53',
-        date: 1508208094235,
+        date: new Date(1508208094235).toISOString(),
       },
       {
         version: 'ui@0.1.54',
-        date: 1508208094235,
+        date: new Date(1508208094235).toISOString(),
       },
       // Should not be included
       {
         version: 'ui@0.1.6',
-        date: 1508208094236,
+        date: new Date(1508208094236).toISOString(),
       },
     ];
 
-    const buckets = createReleaseBuckets(
-      minTime,
-      newEndingTs,
-      releases
-
-      //   .map(release => ({
-      //   ...release,
-      //   timestamp: new Date(release.timestamp).toISOString(),
-      // }))
-    );
+    const buckets = createReleaseBuckets(minTime, newEndingTs, releases);
 
     expect(buckets).toEqual([
       [
@@ -139,9 +130,9 @@ describe('createReleaseBuckets', () => {
         1508208081424,
         3,
         [
-          {version: 'ui@0.1.2', date: 1508208080000},
-          {version: 'ui@0.1.22', date: 1508208081323},
-          {version: 'ui@0.1.3', date: 1508208081423},
+          {version: 'ui@0.1.2', date: new Date(1508208080000).toISOString()},
+          {version: 'ui@0.1.22', date: new Date(1508208081323).toISOString()},
+          {version: 'ui@0.1.3', date: new Date(1508208081423).toISOString()},
         ],
       ],
       [1508208081424, 0, 1508208082848, 0, []],
@@ -158,10 +149,10 @@ describe('createReleaseBuckets', () => {
         1508208094235,
         4,
         [
-          {version: 'ui@0.1.51', date: 1508208092816},
-          {version: 'ui@0.1.52', date: 1508208094230},
-          {version: 'ui@0.1.53', date: 1508208094235},
-          {version: 'ui@0.1.54', date: 1508208094235},
+          {version: 'ui@0.1.51', date: new Date(1508208092816).toISOString()},
+          {version: 'ui@0.1.52', date: new Date(1508208094230).toISOString()},
+          {version: 'ui@0.1.53', date: new Date(1508208094235).toISOString()},
+          {version: 'ui@0.1.54', date: new Date(1508208094235).toISOString()},
         ],
       ],
     ]);

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.spec.tsx
@@ -59,16 +59,16 @@ describe('createReleaseBuckets', () => {
 
     const buckets = createReleaseBuckets(minTime, newEndingTs, []);
     expect(buckets).toEqual([
-      [1508208080000, 0, 1508208081424, 0, []],
-      [1508208081424, 0, 1508208082848, 0, []],
-      [1508208082848, 0, 1508208084272, 0, []],
-      [1508208084272, 0, 1508208085696, 0, []],
-      [1508208085696, 0, 1508208087120, 0, []],
-      [1508208087120, 0, 1508208088544, 0, []],
-      [1508208088544, 0, 1508208089968, 0, []],
-      [1508208089968, 0, 1508208091392, 0, []],
-      [1508208091392, 0, 1508208092816, 0, []],
-      [1508208092816, 0, 1508208094235, 0, []],
+      {start: 1508208080000, end: 1508208081424, releases: []},
+      {start: 1508208081424, end: 1508208082848, releases: []},
+      {start: 1508208082848, end: 1508208084272, releases: []},
+      {start: 1508208084272, end: 1508208085696, releases: []},
+      {start: 1508208085696, end: 1508208087120, releases: []},
+      {start: 1508208087120, end: 1508208088544, releases: []},
+      {start: 1508208088544, end: 1508208089968, releases: []},
+      {start: 1508208089968, end: 1508208091392, releases: []},
+      {start: 1508208091392, end: 1508208092816, releases: []},
+      {start: 1508208092816, end: 1508208094235, releases: []},
     ]);
   });
 
@@ -124,37 +124,37 @@ describe('createReleaseBuckets', () => {
     const buckets = createReleaseBuckets(minTime, newEndingTs, releases);
 
     expect(buckets).toEqual([
-      [
-        1508208080000,
-        0,
-        1508208081424,
-        3,
-        [
+      {
+        start: 1508208080000,
+        end: 1508208081424,
+        releases: [
           {version: 'ui@0.1.2', date: new Date(1508208080000).toISOString()},
           {version: 'ui@0.1.22', date: new Date(1508208081323).toISOString()},
           {version: 'ui@0.1.3', date: new Date(1508208081423).toISOString()},
         ],
-      ],
-      [1508208081424, 0, 1508208082848, 0, []],
-      [1508208082848, 0, 1508208084272, 2, [expect.any(Object), expect.any(Object)]],
-      [1508208084272, 0, 1508208085696, 0, []],
-      [1508208085696, 0, 1508208087120, 0, []],
-      [1508208087120, 0, 1508208088544, 0, []],
-      [1508208088544, 0, 1508208089968, 0, []],
-      [1508208089968, 0, 1508208091392, 0, []],
-      [1508208091392, 0, 1508208092816, 0, []],
-      [
-        1508208092816,
-        0,
-        1508208094235,
-        4,
-        [
+      },
+      {start: 1508208081424, end: 1508208082848, releases: []},
+      {
+        start: 1508208082848,
+        end: 1508208084272,
+        releases: [expect.any(Object), expect.any(Object)],
+      },
+      {start: 1508208084272, end: 1508208085696, releases: []},
+      {start: 1508208085696, end: 1508208087120, releases: []},
+      {start: 1508208087120, end: 1508208088544, releases: []},
+      {start: 1508208088544, end: 1508208089968, releases: []},
+      {start: 1508208089968, end: 1508208091392, releases: []},
+      {start: 1508208091392, end: 1508208092816, releases: []},
+      {
+        start: 1508208092816,
+        end: 1508208094235,
+        releases: [
           {version: 'ui@0.1.51', date: new Date(1508208092816).toISOString()},
           {version: 'ui@0.1.52', date: new Date(1508208094230).toISOString()},
           {version: 'ui@0.1.53', date: new Date(1508208094235).toISOString()},
           {version: 'ui@0.1.54', date: new Date(1508208094235).toISOString()},
         ],
-      ],
+      },
     ]);
   });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.tsx
@@ -42,7 +42,7 @@ export function createReleaseBuckets(
     // Ending timestamp will clump in the remaining bits if it's not
     // evenly distributed
     const bucketEndTs = i === desiredBuckets - 1 ? maxTime : bucketStartTs + interval;
-    buckets.push([bucketStartTs, 0, bucketEndTs, 0, []]);
+    buckets.push({start: bucketStartTs, end: bucketEndTs, releases: []});
   }
 
   // Loop through releases and update its bucket's counters
@@ -56,17 +56,14 @@ export function createReleaseBuckets(
     const releaseTs = new Date(release.date).getTime();
     const bucketIndex = Math.floor((releaseTs - minTime) / interval);
     const currentBucket = buckets[bucketIndex];
-    const bucketEndTs = currentBucket?.[2];
+    const bucketEndTs = currentBucket?.end;
 
     // Note we need to check that the release ts is within the ending bounds, solely for
     // the last bucket, as the last buckets width can be less than the
     // others. (i.e. if the total time difference is not perfectly divible by
     // `desiredBuckets`, the last bucket will be the remainder)
     if (bucketEndTs && releaseTs <= bucketEndTs) {
-      // Update numReleases
-      currentBucket[3] = currentBucket[3] + 1;
-      // Update the list of releases
-      currentBucket[4].push(release);
+      currentBucket.releases.push(release);
     }
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.tsx
@@ -1,0 +1,74 @@
+import type {ReleaseMetaBasic} from 'sentry/types/release';
+import type {Bucket} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/types';
+
+//
+// Note: You probably don't want to use this directly, use `useReleaseBubbles`
+// instead.
+//
+// Create `desiredBuckets` number of release buckets using the
+// min()/max() of timestamps in all `timeSeries`'s `data`.
+//
+// The timestamp inclusivity is as follows:
+//
+// [
+//  [inclusive, inclusive],
+//  [exclusive, inclusive],
+//  ...
+//  [exclusive, inclusive],
+// ]
+//
+// where only the first bucket's starting timestamp is inclusive.
+//
+export function createReleaseBuckets(
+  minTime: number | undefined,
+  maxTime: number | undefined,
+  releases: ReleaseMetaBasic[],
+  desiredBuckets = 10
+): Bucket[] {
+  const buckets: Bucket[] = [];
+
+  if (!minTime || !maxTime) {
+    return [];
+  }
+
+  // We need to create <desiredBuckets> number of buckets between
+  // [minDate, maxDate]. Last bucket always ends at maxDate and does not
+  // necessarily have the same bucket width as the other buckets.
+  const timeDiff = maxTime - minTime;
+  const interval = Math.ceil(timeDiff / desiredBuckets);
+
+  for (let i = 0; i < desiredBuckets; i++) {
+    const bucketStartTs = minTime + i * interval;
+    // Ending timestamp will clump in the remaining bits if it's not
+    // evenly distributed
+    const bucketEndTs = i === desiredBuckets - 1 ? maxTime : bucketStartTs + interval;
+    buckets.push([bucketStartTs, 0, bucketEndTs, 0, []]);
+  }
+
+  // Loop through releases and update its bucket's counters
+  for (const release of releases) {
+    if (!release) {
+      break;
+    }
+
+    // We can determine the releaase's bucket location by using its timestamp
+    // relative to the series starting timestamp.
+    const releaseTs = new Date(release.date).getTime();
+    const bucketIndex = Math.floor((releaseTs - minTime) / interval);
+    const currentBucket = buckets[bucketIndex];
+    const bucketEndTs = currentBucket?.[2];
+
+    // Note we need to check that the release ts is within the ending bounds, solely for
+    // the last bucket, as the last buckets width can be less than the
+    // others. (i.e. if the total time difference is not perfectly divible by
+    // `desiredBuckets`, the last bucket will be the remainder)
+    if (bucketEndTs && releaseTs <= bucketEndTs) {
+      // Update numReleases
+      currentBucket[3] = currentBucket[3] + 1;
+      // Update the list of releases
+      currentBucket[4].push(release);
+    }
+  }
+
+  return buckets;
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/utils/createReleaseBuckets.tsx
@@ -35,6 +35,11 @@ export function createReleaseBuckets(
   // [minDate, maxDate]. Last bucket always ends at maxDate and does not
   // necessarily have the same bucket width as the other buckets.
   const timeDiff = maxTime - minTime;
+
+  if (timeDiff <= 0) {
+    return [];
+  }
+
   const interval = Math.ceil(timeDiff / desiredBuckets);
 
   for (let i = 0; i < desiredBuckets; i++) {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -27,6 +27,7 @@ import type {
 import {isTimeSeriesOther} from 'sentry/utils/timeSeries/isTimeSeriesOther';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import {useReleaseBubbles} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
@@ -134,25 +135,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     }
   }
 
-  const handleChartRef = useCallback(
-    (e: ReactEchartsRef) => {
-      chartRef.current = e;
-
-      if (!e?.getEchartsInstance) {
-        return;
-      }
-
-      registerWithWidgetSyncContext(e.getEchartsInstance());
-    },
-    [registerWithWidgetSyncContext]
-  );
-
   const {
     releaseBubbleEventHandlers,
     releaseBubbleSeries,
     releaseBubbleXAxis,
     releaseBubbleGrid,
-    handleChartMount,
   } = useReleaseBubbles({
     bubbleSize: RELEASE_BUBBLE_SIZE,
     chartRef,
@@ -161,7 +148,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     maxTime: maxTime?.getTime(),
     releases: props.releases?.map(({timestamp, version}) => ({date: timestamp, version})),
     theme,
-    onChartMount: handleChartRef,
   });
 
   const releaseSeries = props.releases
@@ -181,6 +167,26 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           utc ?? false
         )
     : null;
+
+  const hasReleaseBubblesSeries = hasReleaseBubbles && releaseSeries;
+
+  const handleChartRef = useCallback(
+    (e: ReactEchartsRef) => {
+      chartRef.current = e;
+
+      if (!e?.getEchartsInstance) {
+        return;
+      }
+
+      const echartsInstance = e.getEchartsInstance();
+      registerWithWidgetSyncContext(echartsInstance);
+
+      if (hasReleaseBubblesSeries) {
+        createReleaseBubbleHighlighter(echartsInstance);
+      }
+    },
+    [hasReleaseBubblesSeries, registerWithWidgetSyncContext]
+  );
 
   const chartZoomProps = useChartZoom({
     saveOnZoom: true,
@@ -339,7 +345,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   return (
     <BaseChart
-      ref={handleChartMount}
+      ref={handleChartRef}
       {...releaseBubbleEventHandlers}
       autoHeightResize
       series={[...dataSeries, releaseSeries].filter(defined)}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -27,7 +27,6 @@ import type {
 import {isTimeSeriesOther} from 'sentry/utils/timeSeries/isTimeSeriesOther';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {createReleaseBubbleHighlighter} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/createReleaseBubbleHighlighter';
 import {useReleaseBubbles} from 'sentry/views/dashboards/widgets/timeSeriesWidget/releaseBubbles/useReleaseBubbles';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
@@ -136,6 +135,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   }
 
   const {
+    createReleaseBubbleHighlighter,
     releaseBubbleEventHandlers,
     releaseBubbleSeries,
     releaseBubbleXAxis,
@@ -185,7 +185,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         createReleaseBubbleHighlighter(echartsInstance);
       }
     },
-    [hasReleaseBubblesSeries, registerWithWidgetSyncContext]
+    [
+      hasReleaseBubblesSeries,
+      createReleaseBubbleHighlighter,
+      registerWithWidgetSyncContext,
+    ]
   );
 
   const chartZoomProps = useChartZoom({

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -143,9 +143,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   } = useReleaseBubbles({
     bubbleSize: RELEASE_BUBBLE_SIZE,
     chartRef,
-    chartRenderer: (rendererProps: Partial<TimeSeriesWidgetVisualizationProps>) => {
-      return <TimeSeriesWidgetVisualization {...props} {...rendererProps} />;
-    },
     highlightAreaColor: theme.blue400,
     minTime: minTime?.getTime(),
     maxTime: maxTime?.getTime(),

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -359,7 +359,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         left: 2,
         top: showLegend ? 25 : 10,
         right: 8,
-        // See xAxis.axisLine/offset comments
         bottom: 0,
         containLabel: true,
         ...releaseBubbleGrid,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -81,7 +81,10 @@ export interface TimeSeriesWidgetVisualizationProps {
    * Array of `Release` objects. If provided, they are plotted on line and area visualizations as vertical lines
    */
   releases?: Release[];
-  showReleaseLines?: boolean;
+  /**
+   * Show releases as either lines per release or a bubble for a group of releases.
+   */
+  showReleaseAs?: 'bubble' | 'line';
   /**
    * Only available for `visualizationType="bar"`. If `true`, the bars are stacked
    */
@@ -113,7 +116,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const organization = useOrganization();
   const navigate = useNavigate();
   const hasReleaseBubbles =
-    organization.features.includes('release-bubbles-ui') && !props.showReleaseLines;
+    organization.features.includes('release-bubbles-ui') &&
+    props.showReleaseAs === 'bubble';
 
   // find min/max timestamp of *all* timeSeries
   const allTimestamps = props.timeSeries

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -116,23 +116,12 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     organization.features.includes('release-bubbles-ui') && !props.showReleaseLines;
 
   // find min/max timestamp of *all* timeSeries
-  let minTime: Date | undefined;
-  let maxTime: Date | undefined;
-  for (const currentSeries of props.timeSeries) {
-    if (currentSeries.data.length < 2) {
-      continue;
-    }
-
-    const firstData = currentSeries.data[0];
-    const lastData = currentSeries.data[currentSeries.data.length - 1];
-    // I hope `data` is sorted
-    if (!minTime || new Date(firstData!.timestamp) < minTime) {
-      minTime = new Date(firstData!.timestamp);
-    }
-    if (!maxTime || new Date(lastData!.timestamp) > maxTime) {
-      maxTime = new Date(lastData!.timestamp);
-    }
-  }
+  const allTimestamps = props.timeSeries
+    .flatMap(timeSeries => timeSeries.data)
+    .map(datum => datum.timestamp)
+    .toSorted();
+  const earliestTimeStamp = allTimestamps.at(0);
+  const latestTimeStamp = allTimestamps.at(-1);
 
   const {
     createReleaseBubbleHighlighter,
@@ -144,8 +133,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     bubbleSize: RELEASE_BUBBLE_SIZE,
     chartRef,
     highlightAreaColor: theme.blue400,
-    minTime: minTime?.getTime(),
-    maxTime: maxTime?.getTime(),
+    minTime: earliestTimeStamp ? new Date(earliestTimeStamp).getTime() : undefined,
+    maxTime: latestTimeStamp ? new Date(latestTimeStamp).getTime() : undefined,
     releases: props.releases?.map(({timestamp, version}) => ({date: timestamp, version})),
     theme,
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -132,11 +132,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   } = useReleaseBubbles({
     bubbleSize: RELEASE_BUBBLE_SIZE,
     chartRef,
-    highlightAreaColor: theme.blue400,
     minTime: earliestTimeStamp ? new Date(earliestTimeStamp).getTime() : undefined,
     maxTime: latestTimeStamp ? new Date(latestTimeStamp).getTime() : undefined,
     releases: props.releases?.map(({timestamp, version}) => ({date: timestamp, version})),
-    theme,
   });
 
   const releaseSeries = props.releases

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -5,6 +5,7 @@ import {Button} from 'sentry/components/button';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
@@ -37,6 +38,7 @@ export interface InsightsTimeSeriesWidgetProps {
 }
 
 export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
+  const organization = useOrganization();
   const pageFilters = usePageFilters();
   const {releases: releasesWithDate} = useReleaseStats(pageFilters.selection);
   const releases =
@@ -100,7 +102,12 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
     <ChartContainer>
       <Widget
         Title={Title}
-        Visualization={<TimeSeriesWidgetVisualization {...visualizationProps} />}
+        Visualization={
+          <TimeSeriesWidgetVisualization
+            {...(organization.features.includes('release-bubbles-ui') ? {releases} : {})}
+            {...visualizationProps}
+          />
+        }
         Actions={
           <Widget.WidgetToolbar>
             <Button

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -104,7 +104,9 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
         Title={Title}
         Visualization={
           <TimeSeriesWidgetVisualization
-            {...(organization.features.includes('release-bubbles-ui') ? {releases} : {})}
+            {...(organization.features.includes('release-bubbles-ui')
+              ? {releases, showReleaseAs: 'bubble'}
+              : {})}
             {...visualizationProps}
           />
         }


### PR DESCRIPTION
Adds release bubbles to `<TimeSeriesWidgetVisualization`
![image](https://github.com/user-attachments/assets/247bad87-4262-4596-b553-59b851848b74)

Clicking on a bubble opens up a drawer.
![image](https://github.com/user-attachments/assets/a4a47f48-521f-449a-9f77-7eb4f13763e3)


requires https://github.com/getsentry/sentry/pull/86076
ref: https://github.com/getsentry/sentry/issues/85775