### PR TITLE
ref(seer grouping): Add ability to ignore useless filenames

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -43,6 +43,8 @@ BASE64_ENCODED_PREFIXES = [
     "javascript;base64",
 ]
 
+IGNORED_FILENAMES = ["<compiler-generated>"]
+
 
 class ReferrerOptions(StrEnum):
     INGEST = "ingest"
@@ -239,6 +241,8 @@ def extract_filename(frame_dict: Mapping[str, Any]) -> str:
     Extract the filename from the frame dictionary. Fallback to module if filename is not present.
     """
     filename = frame_dict["filename"]
+    if filename in IGNORED_FILENAMES:
+        filename = ""
     if filename == "" and frame_dict["module"] != "":
         filename = frame_dict["module"]
     return filename


### PR DESCRIPTION
A customer recently switched the build tool for their iOS app, and it changed their app's stacktraces such that new groups are now being created when ideally they wouldn't be. There were multiple differences in the stacktraces, not all easily mitigated, but one straightforward one was that some frames went from having no filename property to having a filename property of `<compiler-generated>`. 

To make it so that at least Seer will ignore this particular difference, this PR adds a list of filenames for us to ignore when constructing the stacktrace string we send it. We should also consider marking filename components with such filenames as non-contributing, but that will have to wait for a separate PR.