### PR TITLE
feat(issues): Disable delete on missing permission

### DIFF
--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -65,7 +65,7 @@ interface GroupStoreDefinition extends StrictStoreDefinition<Item[]>, InternalDe
   onAssignToSuccess: (changeId: string, itemId: string, response: any) => void;
 
   onDelete: (changeId: string, itemIds: ItemIds) => void;
-  onDeleteError: (changeId: string, itemIds: ItemIds, error: Error) => void;
+  onDeleteError: (changeId: string, itemIds: ItemIds, response: RequestError) => void;
   onDeleteSuccess: (changeId: string, itemIds: ItemIds, response: any) => void;
 
   onDiscard: (changeId: string, itemId: string) => void;
@@ -347,8 +347,12 @@ const storeConfig: GroupStoreDefinition = {
     this.updateItems(ids);
   },
 
-  onDeleteError(_changeId, itemIds, _response) {
-    showAlert(t('Unable to delete events. Please try again.'), 'error');
+  onDeleteError(_changeId, itemIds, response) {
+    if (response.status === 403) {
+      showAlert(t('You do not have permission to delete issues'), 'error');
+    } else {
+      showAlert(t('Unable to delete events. Please try again.'), 'error');
+    }
 
     if (!itemIds) {
       return;

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -67,8 +67,13 @@ function ActionSet({
   const multipleIssueProjectsSelected = multiSelected && !selectedProjectSlug;
   const {enabled: mergeSupported, disabledReason: mergeDisabledReason} =
     isActionSupported(selectedIssues, 'merge');
-  const {enabled: deleteSupported, disabledReason: deleteDisabledReason} =
-    isActionSupported(selectedIssues, 'delete');
+
+  // Members may or may not have access to delete events based on organization settings
+  const hasDeleteAccess = organization.access.includes('event:admin');
+  const {enabled: deleteSupported, disabledReason: deleteDisabledReason} = hasDeleteAccess
+    ? isActionSupported(selectedIssues, 'delete')
+    : {enabled: false, disabledReason: t('You do not have permission to delete issues')};
+
   const mergeDisabled =
     !multiSelected || multipleIssueProjectsSelected || !mergeSupported;
   const ignoreDisabled = !anySelected;

--- a/static/app/views/issueList/actions/index.spec.tsx
+++ b/static/app/views/issueList/actions/index.spec.tsx
@@ -466,9 +466,30 @@ describe('IssueListActions', function () {
       );
     });
 
+    it('disables delete if user does not have permission to delete issues', async () => {
+      jest
+        .spyOn(SelectedGroupStore, 'getSelectedIds')
+        .mockImplementation(() => new Set(['1', '2']));
+      jest.spyOn(GroupStore, 'get').mockImplementation(id => {
+        return GroupFixture({id});
+      });
+
+      render(<WrappedComponent />);
+
+      await userEvent.click(screen.getByRole('button', {name: 'More issue actions'}));
+      expect(screen.getByRole('menuitemradio', {name: 'Delete'})).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('menuitemradio', {name: 'Delete'})).toHaveTextContent(
+        'You do not have permission to delete issues'
+      );
+    });
+
     describe('bulk action performance issues', function () {
       const orgWithPerformanceIssues = OrganizationFixture({
         features: ['performance-issues'],
+        access: ['event:admin'],
       });
 
       it('silently filters out performance issues when bulk deleting', async function () {


### PR DESCRIPTION
Organizations can turn off delete permissions for members. This checks that value instead of letting them make the request. Also adds an error state if permission is denied.

fixes #85147