### PR TITLE
ref(grouping): Grouphash metadata refactors to prepare for backfill

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -124,7 +124,9 @@ def create_or_update_grouphash_metadata_if_needed(
     # we'll have to override the metadata creation date for them.
 
     if grouphash_is_new:
-        hash_basis, hashing_metadata = get_grouphash_metadata_data(event, project, variants)
+        hash_basis, hashing_metadata = get_grouphash_metadata_data(
+            event, project, variants, grouping_config
+        )
 
         GroupHashMetadata.objects.create(
             grouphash=grouphash,
@@ -144,6 +146,7 @@ def get_grouphash_metadata_data(
     event: Event,
     project: Project,
     variants: dict[str, BaseVariant],
+    grouping_config: str,
 ) -> tuple[HashBasis, HashingMetadata]:
     hashing_metadata: HashingMetadata = {}
     # TODO: These are typed as `Any` so that we don't have to cast them to whatever specific

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -124,7 +124,7 @@ def create_or_update_grouphash_metadata_if_needed(
     # we'll have to override the metadata creation date for them.
 
     if grouphash_is_new:
-        hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants)
+        hash_basis, hashing_metadata = get_grouphash_metadata_data(event, project, variants)
 
         GroupHashMetadata.objects.create(
             grouphash=grouphash,
@@ -140,7 +140,7 @@ def create_or_update_grouphash_metadata_if_needed(
         grouphash.metadata.update(latest_grouping_config=grouping_config)
 
 
-def get_hash_basis_and_metadata(
+def get_grouphash_metadata_data(
     event: Event,
     project: Project,
     variants: dict[str, BaseVariant],
@@ -162,7 +162,7 @@ def get_hash_basis_and_metadata(
     method_description = contributing_variant.description.replace("modified ", "")
 
     with metrics.timer(
-        "grouping.grouphashmetadata.get_hash_basis_and_metadata"
+        "grouping.grouphashmetadata.get_grouphash_metadata_data"
     ) as metrics_timer_tags:
         try:
             hash_basis = GROUPING_METHODS_BY_DESCRIPTION[method_description]

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -129,11 +129,17 @@ def create_or_update_grouphash_metadata_if_needed(
 
         GroupHashMetadata.objects.create(**new_data)
 
-    elif grouphash.metadata and grouphash.metadata.latest_grouping_config != grouping_config:
-        # Keep track of the most recent config which computed this hash, so that once a
-        # config is deprecated, we can clear out the GroupHash records which are no longer
-        # being produced
-        grouphash.metadata.update(latest_grouping_config=grouping_config)
+    elif grouphash.metadata:
+        updated_data: dict[str, Any] = {}
+
+        # Keep track of the most recent config which computed this hash, so that once a config is
+        # deprecated, we can clear out the GroupHash records which are no longer being produced
+        if grouphash.metadata.latest_grouping_config != grouping_config:
+            updated_data = {"latest_grouping_config": grouping_config}
+
+        # Only hit the DB if there's something to change
+        if updated_data:
+            grouphash.metadata.update(**updated_data)
 
 
 def get_grouphash_metadata_data(

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import ANY
 
 from sentry.models.grouphash import GroupHash
-from sentry.models.grouphashmetadata import GroupHashMetadata
+from sentry.models.grouphashmetadata import GroupHashMetadata, HashBasis
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import Feature
@@ -60,13 +61,21 @@ class GroupHashMetadataTest(TestCase):
             assert grouphash and grouphash.metadata is None
 
     @with_feature("organizations:grouphash-metadata-creation")
-    def test_stores_grouping_config(self):
-        event = save_new_event({"message": "Dogs are great!"}, self.project)
+    def test_stores_expected_properties(self):
+        event = save_new_event({"message": "Dogs are great!", "platform": "python"}, self.project)
         grouphash = GroupHash.objects.filter(
             project=self.project, hash=event.get_primary_hash()
         ).first()
 
-        self.assert_metadata_values(grouphash, {"latest_grouping_config": DEFAULT_GROUPING_CONFIG})
+        self.assert_metadata_values(
+            grouphash,
+            {
+                "latest_grouping_config": DEFAULT_GROUPING_CONFIG,
+                "hash_basis": HashBasis.MESSAGE,
+                "hashing_metadata": ANY,  # Tested extensively with snapshots
+                "platform": "python",
+            },
+        )
 
     @with_feature("organizations:grouphash-metadata-creation")
     @override_options({"grouping.grouphash_metadata.backfill_sample_rate": 1.0})

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
@@ -16,7 +18,9 @@ pytestmark = [requires_snuba]
 class GroupHashMetadataTest(TestCase):
     # Helper method to save us from having to assert the existence of `grouphash` and
     # `grouphash.metadata` every time we want to check a value
-    def assert_metadata_value(self, grouphash, value_name, value):
+    def assert_metadata_value(
+        self, grouphash: GroupHash | None, value_name: str, value: Any
+    ) -> None:
         assert grouphash and grouphash.metadata
         assert getattr(grouphash.metadata, value_name) == value
 

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -139,7 +139,7 @@ def _assert_and_snapshot_results(
     lines: list[str] = []
     variants = event.get_grouping_variants()
 
-    hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants, {})
+    hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants)
 
     with patch("sentry.grouping.ingest.grouphash_metadata.metrics.incr") as mock_metrics_incr:
         record_grouphash_metadata_metrics(

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -9,7 +9,7 @@ from sentry.eventstore.models import Event
 from sentry.grouping.component import DefaultGroupingComponent, MessageGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import (
     check_grouphashes_for_positive_fingerprint_match,
-    get_hash_basis_and_metadata,
+    get_grouphash_metadata_data,
     record_grouphash_metadata_metrics,
 )
 from sentry.grouping.strategies.base import StrategyConfiguration
@@ -139,7 +139,7 @@ def _assert_and_snapshot_results(
     lines: list[str] = []
     variants = event.get_grouping_variants()
 
-    hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants)
+    hash_basis, hashing_metadata = get_grouphash_metadata_data(event, project, variants)
 
     with patch("sentry.grouping.ingest.grouphash_metadata.metrics.incr") as mock_metrics_incr:
         record_grouphash_metadata_metrics(

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -139,9 +139,9 @@ def _assert_and_snapshot_results(
     lines: list[str] = []
     variants = event.get_grouping_variants()
 
-    hash_basis, hashing_metadata = get_grouphash_metadata_data(
-        event, project, variants, config_name
-    )
+    metadata = get_grouphash_metadata_data(event, project, variants, config_name)
+    hash_basis = metadata["hash_basis"]
+    hashing_metadata = metadata["hashing_metadata"]
 
     with patch("sentry.grouping.ingest.grouphash_metadata.metrics.incr") as mock_metrics_incr:
         record_grouphash_metadata_metrics(

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -139,7 +139,9 @@ def _assert_and_snapshot_results(
     lines: list[str] = []
     variants = event.get_grouping_variants()
 
-    hash_basis, hashing_metadata = get_grouphash_metadata_data(event, project, variants)
+    hash_basis, hashing_metadata = get_grouphash_metadata_data(
+        event, project, variants, config_name
+    )
 
     with patch("sentry.grouping.ingest.grouphash_metadata.metrics.incr") as mock_metrics_incr:
         record_grouphash_metadata_metrics(


### PR DESCRIPTION
This makes a number of changes to the code handling grouphash metadata, in preparation for enabling schema versioning and backfill. No behavior changes yet, just refactoring.

- Move the timer surrounding the call to `get_hash_basis_and_metadata` into the function itself. Also, make it return more data, and therefore rename it to `get_grouphash_metadata_data`. Finally, update the `test_stores_grouping_config` test to test all properties returned by the newly-reamed helper.

- Restructure `create_or_update_grouphash_metadata_if_needed` so that rather than hard-coding the values passed to the `create` and `update` methods, we now pass previously-created dictionaries.

- Update the test helper `assert_metadata_value` to assert multiple values at once, and therefore rename it to `assert_metadata_values`.

- Do some minor cleanup on the test for updating grouping config.