### PR TITLE
:sparkles: feat(integrations): add external issue comment slos

### DIFF
--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -46,6 +46,10 @@ class SCMIntegrationInteractionType(StrEnum):
     DERIVE_CODEMAPPINGS = "derive_codemappings"
     STUDENT_PACK = "student_pack"
 
+    # External Issue Comment Sync
+    SYNC_EXTERNAL_ISSUE_COMMENT_CREATE = "sync_external_issue_comment_create"
+    SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE = "sync_external_issue_comment_update"
+
 
 @dataclass
 class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -1,9 +1,14 @@
 from sentry import analytics
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.metrics import (
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
+)
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
 from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.types.activity import ActivityType
 
 
@@ -14,13 +19,19 @@ from sentry.types.activity import ActivityType
     max_retries=5,
     silo_mode=SiloMode.REGION,
 )
+@retry(exclude=(Integration.DoesNotExist))
 def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
     try:
         external_issue = ExternalIssue.objects.get(id=external_issue_id)
     except ExternalIssue.DoesNotExist:
         return
 
-    installation = external_issue.get_installation()
+    assert isinstance(external_issue, ExternalIssue)
+
+    try:
+        installation = external_issue.get_installation()
+    except AssertionError:
+        return
 
     if not should_comment_sync(installation, external_issue):
         return
@@ -30,14 +41,29 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
     except Activity.DoesNotExist:
         return
 
-    comment = installation.create_comment(external_issue.key, user_id, note)
-    note.data["external_id"] = installation.get_comment_id(comment)
-    note.save()
-    analytics.record(
-        # TODO(lb): this should be changed and/or specified?
-        "integration.issue.comments.synced",
-        provider=installation.model.provider,
-        id=installation.model.id,
-        organization_id=external_issue.organization_id,
-        user_id=user_id,
-    )
+    with SCMIntegrationInteractionEvent(
+        interaction_type=SCMIntegrationInteractionType.SYNC_EXTERNAL_ISSUE_COMMENT_CREATE,
+        organization=external_issue.organization,
+        provider_key=installation.model.get_provider().name,
+        org_integration=installation.org_integration,
+    ).capture() as lifecycle:
+        lifecycle.add_extras(
+            {
+                "external_issue_id": external_issue_id,
+                "integration_id": external_issue.integration_id,
+                "group_note_id": group_note_id,
+                "user_id": user_id,
+            }
+        )
+
+        comment = installation.create_comment(external_issue.key, user_id, note)
+        note.data["external_id"] = installation.get_comment_id(comment)
+        note.save()
+        analytics.record(
+            # TODO(lb): this should be changed and/or specified?
+            "integration.issue.comments.synced",
+            provider=installation.model.provider,
+            id=installation.model.id,
+            organization_id=external_issue.organization_id,
+            user_id=user_id,
+        )

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -26,8 +26,6 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
     except ExternalIssue.DoesNotExist:
         return
 
-    assert isinstance(external_issue, ExternalIssue)
-
     try:
         installation = external_issue.get_installation()
     except AssertionError:

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -1,6 +1,10 @@
 from sentry import analytics
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.metrics import (
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
+)
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
 from sentry.silo.base import SiloMode
@@ -22,7 +26,13 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
         external_issue = ExternalIssue.objects.get(id=external_issue_id)
     except ExternalIssue.DoesNotExist:
         return
-    installation = external_issue.get_installation()
+
+    assert isinstance(external_issue, ExternalIssue)
+
+    try:
+        installation = external_issue.get_installation()
+    except AssertionError:
+        return
 
     if not should_comment_sync(installation, external_issue):
         return
@@ -32,12 +42,26 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
     except Activity.DoesNotExist:
         return
 
-    installation.update_comment(external_issue.key, user_id, note)
-    analytics.record(
-        # TODO(lb): this should be changed and/or specified?
-        "integration.issue.comments.synced",
-        provider=installation.model.provider,
-        id=installation.model.id,
-        organization_id=external_issue.organization_id,
-        user_id=user_id,
-    )
+    with SCMIntegrationInteractionEvent(
+        interaction_type=SCMIntegrationInteractionType.SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE,
+        organization=external_issue.organization,
+        provider_key=installation.model.get_provider().name,
+        org_integration=installation.org_integration,
+    ).capture() as lifecycle:
+        lifecycle.add_extras(
+            {
+                "external_issue_id": external_issue_id,
+                "integration_id": external_issue.integration_id,
+                "group_note_id": group_note_id,
+                "user_id": user_id,
+            }
+        )
+        installation.update_comment(external_issue.key, user_id, note)
+        analytics.record(
+            # TODO(lb): this should be changed and/or specified?
+            "integration.issue.comments.synced",
+            provider=installation.model.provider,
+            id=installation.model.id,
+            organization_id=external_issue.organization_id,
+            user_id=user_id,
+        )

--- a/tests/sentry/integrations/tasks/test_create_comment.py
+++ b/tests/sentry/integrations/tasks/test_create_comment.py
@@ -1,0 +1,152 @@
+from unittest import mock
+
+import pytest
+
+from sentry.integrations.example import ExampleIntegration
+from sentry.integrations.models import ExternalIssue, Integration
+from sentry.integrations.tasks import create_comment
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.models.activity import Activity
+from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.types.activity import ActivityType
+
+
+def raise_create_comment_exception(*args, **kwargs):
+    raise Exception("Something went wrong creating comment")
+
+
+class TestCreateComment(TestCase):
+    def setUp(self):
+        self.example_integration = self.create_integration(
+            organization=self.group.organization,
+            external_id="123456",
+            provider="example",
+            oi_params={
+                "config": {
+                    "sync_comments": True,
+                    "sync_status_outbound": True,
+                    "sync_status_inbound": True,
+                    "sync_assignee_outbound": True,
+                    "sync_assignee_inbound": True,
+                }
+            },
+        )
+        self.activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.NOTE.value,
+            data={"text": "Test comment"},
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "create_comment")
+    def test_creates_comment(self, mock_create_comment, mock_record_event):
+        mock_create_comment.return_value = {"id": "123"}
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        create_comment(external_issue.id, self.user.id, self.activity.id)
+
+        mock_create_comment.assert_called_once_with(external_issue.key, self.user.id, self.activity)
+
+        # Verify the activity was updated with the external comment ID
+        updated_activity = Activity.objects.get(id=self.activity.id)
+        assert updated_activity.data["external_id"] == "123"
+
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.SUCCESS)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "create_comment")
+    def test_missing_external_issue(self, mock_create_comment, mock_record_event):
+        create_comment(999999, self.user.id, self.activity.id)
+        mock_create_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for missing external issues
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "create_comment")
+    def test_missing_activity(self, mock_create_comment, mock_record_event):
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        create_comment(external_issue.id, self.user.id, 999999)
+        mock_create_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for missing activities
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "create_comment")
+    def test_missing_integration_installation(self, mock_create_comment, mock_record_event):
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        # Delete all integrations, but ensure we still have an external issue
+        with assume_test_silo_mode_of(Integration):
+            Integration.objects.filter().delete()
+
+        assert ExternalIssue.objects.filter(id=external_issue.id).exists()
+
+        create_comment(external_issue.id, self.user.id, self.activity.id)
+        mock_create_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for missing integrations
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "create_comment")
+    def test_comment_sync_disabled(self, mock_create_comment, mock_record_event):
+        # Create integration with sync_comments disabled
+        integration = self.create_integration(
+            organization=self.group.organization,
+            external_id="654321",
+            provider="example",
+            oi_params={
+                "config": {
+                    "sync_comments": False,
+                }
+            },
+        )
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=integration,
+        )
+
+        create_comment(external_issue.id, self.user.id, self.activity.id)
+        mock_create_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for disabled syncs
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "create_comment")
+    def test_create_comment_failure(self, mock_create_comment, mock_record_event):
+        mock_create_comment.side_effect = raise_create_comment_exception
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_comment(external_issue.id, self.user.id, self.activity.id)
+
+        assert exc.match("Something went wrong creating comment")
+
+        assert_failure_metric(mock_record_event, Exception("Something went wrong creating comment"))

--- a/tests/sentry/integrations/tasks/test_update_comment.py
+++ b/tests/sentry/integrations/tasks/test_update_comment.py
@@ -1,0 +1,145 @@
+from unittest import mock
+
+import pytest
+
+from sentry.integrations.example import ExampleIntegration
+from sentry.integrations.models import ExternalIssue, Integration
+from sentry.integrations.tasks import update_comment
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.models.activity import Activity
+from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.types.activity import ActivityType
+
+
+def raise_update_comment_exception(*args, **kwargs):
+    raise Exception("Something went wrong updating comment")
+
+
+class TestUpdateComment(TestCase):
+    def setUp(self):
+        self.example_integration = self.create_integration(
+            organization=self.group.organization,
+            external_id="123456",
+            provider="example",
+            oi_params={
+                "config": {
+                    "sync_comments": True,
+                    "sync_status_outbound": True,
+                    "sync_status_inbound": True,
+                    "sync_assignee_outbound": True,
+                    "sync_assignee_inbound": True,
+                }
+            },
+        )
+        self.activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.NOTE.value,
+            data={"text": "Test comment", "external_id": "123"},
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "update_comment")
+    def test_updates_comment(self, mock_update_comment, mock_record_event):
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        update_comment(external_issue.id, self.user.id, self.activity.id)
+
+        mock_update_comment.assert_called_once_with(external_issue.key, self.user.id, self.activity)
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.SUCCESS)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "update_comment")
+    def test_missing_external_issue(self, mock_update_comment, mock_record_event):
+        update_comment(999999, self.user.id, self.activity.id)
+        mock_update_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for missing external issues
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "update_comment")
+    def test_missing_activity(self, mock_update_comment, mock_record_event):
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        update_comment(external_issue.id, self.user.id, 999999)
+        mock_update_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for missing activities
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "update_comment")
+    def test_missing_integration_installation(self, mock_update_comment, mock_record_event):
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        # Delete all integrations, but ensure we still have an external issue
+        with assume_test_silo_mode_of(Integration):
+            Integration.objects.filter().delete()
+
+        assert ExternalIssue.objects.filter(id=external_issue.id).exists()
+
+        update_comment(external_issue.id, self.user.id, self.activity.id)
+        mock_update_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for missing integrations
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "update_comment")
+    def test_comment_sync_disabled(self, mock_update_comment, mock_record_event):
+        # Create integration with sync_comments disabled
+        integration = self.create_integration(
+            organization=self.group.organization,
+            external_id="654321",
+            provider="example",
+            oi_params={
+                "config": {
+                    "sync_comments": False,
+                }
+            },
+        )
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=integration,
+        )
+
+        update_comment(external_issue.id, self.user.id, self.activity.id)
+        mock_update_comment.assert_not_called()
+
+        # No events should be recorded, since we don't record events for disabled syncs
+        assert len(mock_record_event.mock_calls) == 0
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "update_comment")
+    def test_update_comment_failure(self, mock_update_comment, mock_record_event):
+        mock_update_comment.side_effect = raise_update_comment_exception
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="foo-1234",
+            integration=self.example_integration,
+        )
+
+        with pytest.raises(Exception) as exc:
+            update_comment(external_issue.id, self.user.id, self.activity.id)
+
+        assert exc.match("Something went wrong updating comment")
+
+        assert_failure_metric(mock_record_event, Exception("Something went wrong updating comment"))


### PR DESCRIPTION
just found 2 tasks that didn't have slos, lets add them for observability.

also caught an assertion error for when the integration doesn't exist, which should resolve [SENTRY-3MVK](https://sentry.sentry.io/issues/6252965156/)