### PR TITLE
fix(storybook): Wrap API documentation in `StorySection`

### DIFF
--- a/static/app/stories/storyBook.tsx
+++ b/static/app/stories/storyBook.tsx
@@ -64,7 +64,7 @@ function Story(props: {name: string; render: StoryRenderFunction}) {
   );
 }
 
-const StorySection = styled('section')`
+export const StorySection = styled('section')`
   margin-top: ${space(4)};
 
   & > p {

--- a/static/app/views/stories/storyTypes.tsx
+++ b/static/app/views/stories/storyTypes.tsx
@@ -7,7 +7,7 @@ import {InputGroup} from 'sentry/components/inputGroup';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron} from 'sentry/icons';
 import {IconSearch} from 'sentry/icons/iconSearch';
-import {StoryTitle} from 'sentry/stories/storyBook';
+import {StorySection, StoryTitle} from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 import {fzf} from 'sentry/utils/profiling/fzf/fzf';
 
@@ -20,7 +20,7 @@ export function StoryTypes(props: StoryTypesProps) {
   const nodes = usePropTree(props.types?.props ?? {}, query);
 
   return (
-    <Fragment>
+    <StorySection>
       <StoryTitle>API Reference</StoryTitle>
       <p>{props.types?.description}</p>
       <StoryTypesSearchContainer>
@@ -87,7 +87,7 @@ export function StoryTypes(props: StoryTypesProps) {
           </tbody>
         </StoryTypesTable>
       </StoryTableContainer>
-    </Fragment>
+    </StorySection>
   );
 }
 


### PR DESCRIPTION
That's the component that wraps all the story contents. It creates some needed breathing room between the API documentation and the content above it.

**e.g.,**

<img width="310" alt="Screenshot 2025-02-14 at 5 02 23 PM" src="https://github.com/user-attachments/assets/62128890-9867-4978-868e-77d867906258" />
