### PR TITLE
:bug: fix(gitlab slos): update gitlab slos to make user config errors halts

### DIFF
--- a/src/sentry/integrations/gitlab/metrics.py
+++ b/src/sentry/integrations/gitlab/metrics.py
@@ -1,0 +1,11 @@
+from sentry.integrations.utils.metrics import EventLifecycle
+from sentry.shared_integrations.exceptions import ApiError
+
+GITLAB_HALT_MESSAGES = ["file_path should be a valid file path"]
+
+
+def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiError) -> None:
+    if error.json and error.json.get("error") in GITLAB_HALT_MESSAGES:
+        lifecycle.record_halt(error)
+    else:
+        lifecycle.record_failure(error)


### PR DESCRIPTION
after discussing with the issues team, turns out we get 404: Invalid Paths when the user has incorrect source code mappings. we should probably surface this a lot more, but until we do that, lets record this as halts so we don't tank slos


a todo is to make sure the celery task doesn't retry for this error. it would reduce our RPC load by a decent chunk.