### PR TITLE
feat(grouping): Add grouphash metadata creation/update metric and log

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -154,6 +154,19 @@ def create_or_update_grouphash_metadata_if_needed(
     if db_hit_metadata:
         metrics.incr("grouping.grouphash_metadata.db_hit", tags=db_hit_metadata)
 
+        if db_hit_metadata["reason"] != "new_grouphash":
+            # Temporary log to get a sense of how often we're encountering a race condition and
+            # backfilling the same grouphash more than once. Note that this data won't be reliable
+            # until we increase the sample rate to 100%.
+            logger.info(
+                "grouping.grouphash_metadata.handle_existing_grouphash",
+                extra={
+                    "grouphash": grouphash.id,
+                    "group_id": grouphash.group_id,
+                    "reason": db_hit_metadata["reason"],
+                },
+            )
+
 
 def get_grouphash_metadata_data(
     event: Event,


### PR DESCRIPTION
This adds a new metric, `grouping.grouphash_metadata.db_hit`, to track calls to the database for either creation or updating of grouphash metadata records. 

Grouphash metadata creation as a part of group creation is protected by a lock, but we chose not to do the same thing for grouphash metadata for existing groups. (The worry is that we might hit a burst of events from the same group, that that group might end up being one whose metadata is in the p99 range in terms of how long calculation takes, and that we'd thereby end up blocking processing for a large amount of aggregate time.) To get a sense for how often we hit a race condition and end up updating the same record multiple times (in other words, how often locking would have come into play), this also adds a temporary log to track which grouphashes get updated.