### PR TITLE
feat(nav): Use drawer for profiling onboarding

### DIFF
--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
@@ -56,16 +56,20 @@ export function useProfilingOnboardingDrawer() {
   const currentPanel = useLegacyStore(SidebarPanelStore);
   const isActive = currentPanel === SidebarPanelKey.PROFILING_ONBOARDING;
   const hasProjectAccess = organization.access.includes('project:read');
+  const initialPathname = useRef<string | null>(null);
 
   const {openDrawer} = useDrawer();
 
   useLayoutEffect(() => {
     if (isActive && hasProjectAccess) {
+      initialPathname.current = window.location.pathname;
+
       openDrawer(() => <DrawerContent />, {
         ariaLabel: t('Profile Code'),
         // Prevent the drawer from closing when the query params change
-        shouldCloseOnLocationChange: location =>
-          location.pathname !== window.location.pathname,
+        shouldCloseOnLocationChange: location => {
+          return location.pathname !== initialPathname.current;
+        },
       });
     }
   }, [isActive, hasProjectAccess, openDrawer]);

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
@@ -59,7 +59,7 @@ export function useProfilingOnboardingDrawer() {
 
   const {openDrawer} = useDrawer();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isActive && hasProjectAccess) {
       openDrawer(() => <DrawerContent />, {
         ariaLabel: t('Profile Code'),
@@ -72,7 +72,7 @@ export function useProfilingOnboardingDrawer() {
 }
 
 function DrawerContent() {
-  useEffect(() => {
+  useLayoutEffect(() => {
     return () => {
       SidebarPanelStore.hidePanel();
     };
@@ -81,6 +81,9 @@ function DrawerContent() {
   return <SidebarContent />;
 }
 
+/**
+ * @deprecated Use useProfilingOnboardingDrawer instead.
+ */
 export function LegacyProfilingOnboardingSidebar(props: CommonSidebarProps) {
   if (props.currentPanel !== SidebarPanelKey.PROFILING_ONBOARDING) {
     return null;

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -1,8 +1,9 @@
-import {useEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
+import useDrawer from 'sentry/components/globalDrawer';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -20,6 +21,7 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import platforms from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
@@ -49,7 +51,37 @@ const PROFILING_ONBOARDING_STEPS = [
   ProductSolution.PROFILING,
 ];
 
-export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
+export function useProfilingOnboardingDrawer() {
+  const organization = useOrganization();
+  const currentPanel = useLegacyStore(SidebarPanelStore);
+  const isActive = currentPanel === SidebarPanelKey.PROFILING_ONBOARDING;
+  const hasProjectAccess = organization.access.includes('project:read');
+
+  const {openDrawer} = useDrawer();
+
+  useEffect(() => {
+    if (isActive && hasProjectAccess) {
+      openDrawer(() => <DrawerContent />, {
+        ariaLabel: t('Profile Code'),
+        // Prevent the drawer from closing when the query params change
+        shouldCloseOnLocationChange: location =>
+          location.pathname !== window.location.pathname,
+      });
+    }
+  }, [isActive, hasProjectAccess, openDrawer]);
+}
+
+function DrawerContent() {
+  useEffect(() => {
+    return () => {
+      SidebarPanelStore.hidePanel();
+    };
+  }, []);
+
+  return <SidebarContent />;
+}
+
+export function LegacyProfilingOnboardingSidebar(props: CommonSidebarProps) {
   if (props.currentPanel !== SidebarPanelKey.PROFILING_ONBOARDING) {
     return null;
   }
@@ -58,6 +90,20 @@ export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
 }
 
 function ProfilingOnboarding(props: CommonSidebarProps) {
+  return (
+    <TaskSidebar
+      orientation={props.orientation}
+      collapsed={props.collapsed}
+      hidePanel={() => {
+        props.hidePanel();
+      }}
+    >
+      <SidebarContent />
+    </TaskSidebar>
+  );
+}
+
+function SidebarContent() {
   const pageFilters = usePageFilters();
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -68,6 +114,15 @@ function ProfilingOnboarding(props: CommonSidebarProps) {
     () => splitProjectsByProfilingSupport(projects),
     [projects]
   );
+
+  useEffect(() => {
+    return () => {
+      trackAnalytics('profiling_views.onboarding_action', {
+        organization,
+        action: 'dismissed',
+      });
+    };
+  }, [organization]);
 
   useEffect(() => {
     if (currentProject) {
@@ -163,17 +218,7 @@ function ProfilingOnboarding(props: CommonSidebarProps) {
     : undefined;
 
   return (
-    <TaskSidebar
-      orientation={props.orientation}
-      collapsed={props.collapsed}
-      hidePanel={() => {
-        trackAnalytics('profiling_views.onboarding_action', {
-          organization,
-          action: 'dismissed',
-        });
-        props.hidePanel();
-      }}
-    >
+    <Fragment>
       <Content>
         <Heading>{t('Profile Code')}</Heading>
         <div
@@ -215,7 +260,7 @@ function ProfilingOnboarding(props: CommonSidebarProps) {
           />
         ) : null}
       </Content>
-    </TaskSidebar>
+    </Fragment>
   );
 }
 

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -83,7 +83,7 @@ import {
 } from 'sentry/views/performance/utils';
 
 import {DEMO_HEADER_HEIGHT_PX} from '../demo/demoHeader';
-import {ProfilingOnboardingSidebar} from '../profiling/profilingOnboardingSidebar';
+import {LegacyProfilingOnboardingSidebar} from '../profiling/profilingOnboardingSidebar';
 
 import {Broadcasts} from './broadcasts';
 import SidebarHelp from './help';
@@ -580,7 +580,7 @@ function Sidebar() {
               hidePanel={hidePanel}
               {...sidebarItemProps}
             />
-            <ProfilingOnboardingSidebar
+            <LegacyProfilingOnboardingSidebar
               currentPanel={activePanel}
               onShowPanel={() => togglePanel(SidebarPanelKey.PROFILING_ONBOARDING)}
               hidePanel={hidePanel}

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -5,6 +5,7 @@ import Footer from 'sentry/components/footer';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import Nav from 'sentry/components/nav';
 import {NavContextProvider} from 'sentry/components/nav/context';
+import {useProfilingOnboardingDrawer} from 'sentry/components/profiling/profilingOnboardingSidebar';
 import {useReplaysOnboardingDrawer} from 'sentry/components/replaysOnboarding/sidebar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Sidebar from 'sentry/components/sidebar';
@@ -60,6 +61,7 @@ interface LayoutProps extends Props {
 function AppLayout({children, organization}: LayoutProps) {
   useFeedbackOnboardingDrawer();
   useReplaysOnboardingDrawer();
+  useProfilingOnboardingDrawer();
 
   return (
     <NavContextProvider>


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

The old navigation sidebar has been the component responsible for displaying the onboarding panels. Since we are moving to a new nav component, I'm going to be moving all the existing onboarding panels over to useDrawer().