### PR TITLE
chore(autofix): Remove solution timeline truncation

### DIFF
--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -14,20 +14,12 @@ import {
   type AutofixSolutionTimelineEvent,
   AutofixStatus,
   AutofixStepType,
-  type AutofixTimelineEvent,
 } from 'sentry/components/events/autofix/types';
 import {
   type AutofixResponse,
   makeAutofixQueryKey,
 } from 'sentry/components/events/autofix/useAutofix';
-import {
-  IconCheckmark,
-  IconChevron,
-  IconClose,
-  IconEdit,
-  IconEllipsis,
-  IconFix,
-} from 'sentry/icons';
+import {IconCheckmark, IconChevron, IconClose, IconEdit, IconFix} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
@@ -147,19 +139,6 @@ const cardAnimationProps: AnimationProps = {
   }),
 };
 
-const VerticalEllipsis = styled(IconEllipsis)`
-  height: 16px;
-  color: ${p => p.theme.subText};
-  transform: rotate(90deg);
-  position: relative;
-  left: -1px;
-`;
-
-type ExtendedTimelineEvent = AutofixTimelineEvent & {
-  isTruncated?: boolean;
-  originalIndex?: number;
-};
-
 function SolutionDescription({
   solution,
   groupId,
@@ -176,68 +155,11 @@ function SolutionDescription({
   const containerRef = useRef<HTMLDivElement>(null);
   const selection = useTextSelection(containerRef);
 
-  // Filter events to keep only 1 event before and after modified events
-  const filteredEvents = (() => {
-    const events = solution.map((event, index) => ({
-      ...event,
-      is_most_important_event: event.is_new_event,
-      originalIndex: index,
-    }));
-
-    const firstModifiedIndex = events.findIndex(e => e.is_new_event);
-    const lastModifiedIndex = events.findLastIndex(e => e.is_new_event);
-
-    if (firstModifiedIndex === -1) {
-      return events;
-    }
-
-    const startIndex = Math.max(0, firstModifiedIndex - 1);
-    const endIndex = Math.min(events.length - 1, lastModifiedIndex + 1);
-
-    const truncatedEvents = events.slice(startIndex, endIndex + 1);
-
-    if (truncatedEvents.length === 0) {
-      return events;
-    }
-
-    // Add truncation indicators if needed
-    const finalEvents: ExtendedTimelineEvent[] = [];
-
-    // Add truncation at start if we removed events
-    if (startIndex > 0) {
-      const firstEvent = truncatedEvents[0];
-      if (firstEvent) {
-        finalEvents.push({
-          title: '',
-          timeline_item_type: 'internal_code' as const,
-          code_snippet_and_analysis: '',
-          relevant_code_file: firstEvent.relevant_code_file,
-          is_most_important_event: false,
-          isTruncated: true,
-        });
-      }
-    }
-
-    // Add all filtered events
-    finalEvents.push(...truncatedEvents);
-
-    // Add truncation at end if we removed events
-    if (endIndex < events.length - 1) {
-      const lastEvent = truncatedEvents[truncatedEvents.length - 1];
-      if (lastEvent) {
-        finalEvents.push({
-          title: '',
-          timeline_item_type: 'internal_code' as const,
-          code_snippet_and_analysis: '',
-          relevant_code_file: lastEvent.relevant_code_file,
-          is_most_important_event: false,
-          isTruncated: true,
-        });
-      }
-    }
-
-    return finalEvents;
-  })();
+  const events = solution.map((event, index) => ({
+    ...event,
+    is_most_important_event: event.is_new_event,
+    originalIndex: index,
+  }));
 
   return (
     <SolutionDescriptionWrapper>
@@ -258,13 +180,7 @@ function SolutionDescription({
         )}
       </AnimatePresence>
       <div ref={containerRef}>
-        <AutofixTimeline
-          events={filteredEvents}
-          activeColor="green400"
-          getCustomIcon={(event: AutofixTimelineEvent & {isTruncated?: boolean}) =>
-            event.isTruncated ? <VerticalEllipsis /> : undefined
-          }
-        />
+        <AutofixTimeline events={events} activeColor="green400" />
       </div>
     </SolutionDescriptionWrapper>
   );

--- a/static/app/components/events/autofix/autofixTimeline.tsx
+++ b/static/app/components/events/autofix/autofixTimeline.tsx
@@ -12,14 +12,10 @@ import type {Color} from 'sentry/utils/theme';
 
 import type {AutofixTimelineEvent} from './types';
 
-type ExtendedTimelineEvent = AutofixTimelineEvent & {
-  isTruncated?: boolean;
-};
-
 type Props = {
-  events: ExtendedTimelineEvent[];
+  events: AutofixTimelineEvent[];
   activeColor?: Color;
-  getCustomIcon?: (event: ExtendedTimelineEvent) => React.ReactNode;
+  getCustomIcon?: (event: AutofixTimelineEvent) => React.ReactNode;
 };
 
 function getEventIcon(eventType: AutofixTimelineEvent['timeline_item_type']) {
@@ -66,16 +62,14 @@ export function AutofixTimeline({events, activeColor, getCustomIcon}: Props) {
     <Timeline.Container>
       {events.map((event, index) => {
         const isActive = event.is_most_important_event && index !== events.length - 1;
-        const isTruncated = event.isTruncated;
 
         return (
           <Timeline.Item
             key={index}
             title={
               <StyledTimelineHeader
-                onClick={isTruncated ? undefined : () => toggleItem(index)}
+                onClick={() => toggleItem(index)}
                 isActive={isActive}
-                isTruncated={isTruncated}
                 data-test-id={`autofix-root-cause-timeline-item-${index}`}
               >
                 <div
@@ -83,12 +77,10 @@ export function AutofixTimeline({events, activeColor, getCustomIcon}: Props) {
                     __html: singleLineRenderer(event.title),
                   }}
                 />
-                {!isTruncated && (
-                  <StyledIconChevron
-                    direction={expandedItems.includes(index) ? 'down' : 'right'}
-                    size="xs"
-                  />
-                )}
+                <StyledIconChevron
+                  direction={expandedItems.includes(index) ? 'down' : 'right'}
+                  size="xs"
+                />
               </StyledTimelineHeader>
             }
             isActive={isActive}
@@ -96,7 +88,7 @@ export function AutofixTimeline({events, activeColor, getCustomIcon}: Props) {
             colorConfig={getEventColor(isActive, activeColor)}
           >
             <AnimatePresence>
-              {!isTruncated && expandedItems.includes(index) && (
+              {expandedItems.includes(index) && (
                 <AnimatedContent
                   initial={{height: 0, opacity: 0}}
                   animate={{height: 'auto', opacity: 1}}
@@ -133,14 +125,14 @@ const StyledSpan = styled('span')`
   }
 `;
 
-const StyledTimelineHeader = styled('div')<{isActive?: boolean; isTruncated?: boolean}>`
+const StyledTimelineHeader = styled('div')<{isActive?: boolean}>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   padding: ${space(0.25)};
   border-radius: ${p => p.theme.borderRadius};
-  cursor: ${p => (p.isTruncated ? 'default' : 'pointer')};
+  cursor: pointer;
   font-weight: ${p => (p.isActive ? p.theme.fontWeightBold : p.theme.fontWeightNormal)};
   gap: ${space(1)};
 
@@ -151,8 +143,7 @@ const StyledTimelineHeader = styled('div')<{isActive?: boolean; isTruncated?: bo
   }
 
   &:hover {
-    background-color: ${p =>
-      p.isTruncated ? 'transparent' : p.theme.backgroundSecondary};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
 `;
 


### PR DESCRIPTION
Removes the truncation on the timeline because we want to show all the timeline events once the backend prompt changes for the solution timeline.