### PR TITLE
ci: run release action only on getsentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: 'Release a new version'
+    if: github.repository_owner == 'getsentry'
     steps:
       - name: Get auth token
         id: token


### PR DESCRIPTION
Not much impact for now. This shouldn't be triggered on fork repositories. If someone change this file to the wrong direction, at least it'll be some kind of another safety layer.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
