### PR TITLE
chore(autofix): Increase index for rethinking on main output cards

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -68,7 +68,7 @@ function AutofixRepoChange({
           retainInsightCardIndex={
             previousInsightCount !== undefined && previousInsightCount >= 0
               ? previousInsightCount
-              : -1
+              : null
           }
         />
       )}

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -67,7 +67,7 @@ function AutofixRepoChange({
           stepIndex={previousDefaultStepIndex ?? 0}
           retainInsightCardIndex={
             previousInsightCount !== undefined && previousInsightCount >= 0
-              ? previousInsightCount - 1
+              ? previousInsightCount
               : -1
           }
         />

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -134,7 +134,7 @@ describe('AutofixInsightCards', () => {
             type: 'restart_from_point_with_feedback',
             message: 'Here is my insight.',
             step_index: 0,
-            retain_insight_card_index: 0,
+            retain_insight_card_index: 1,
           }),
         }),
       })

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -133,11 +133,10 @@ function AutofixInsightCard({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setIsEditing(false);
-    const insightCardAboveIndex = index - 1 >= 0 ? index - 1 : null;
     updateInsight({
       message: editText,
       step_index: stepIndex,
-      retain_insight_card_index: insightCardAboveIndex,
+      retain_insight_card_index: index,
     });
   };
 
@@ -483,7 +482,7 @@ function ChainLink({
     updateInsight({
       message: newInsightText,
       step_index: stepIndex,
-      retain_insight_card_index: insightCount - 1,
+      retain_insight_card_index: insightCount,
     });
     setNewInsightText('');
   };

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -179,7 +179,7 @@ function RootCauseDescription({
             stepIndex={previousDefaultStepIndex ?? 0}
             retainInsightCardIndex={
               previousInsightCount !== undefined && previousInsightCount >= 0
-                ? previousInsightCount - 1
+                ? previousInsightCount
                 : -1
             }
           />

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -180,7 +180,7 @@ function RootCauseDescription({
             retainInsightCardIndex={
               previousInsightCount !== undefined && previousInsightCount >= 0
                 ? previousInsightCount
-                : -1
+                : null
             }
           />
         )}

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -251,7 +251,7 @@ function SolutionDescription({
             stepIndex={previousDefaultStepIndex ?? 0}
             retainInsightCardIndex={
               previousInsightCount !== undefined && previousInsightCount >= 0
-                ? previousInsightCount - 1
+                ? previousInsightCount
                 : -1
             }
           />

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -252,7 +252,7 @@ function SolutionDescription({
             retainInsightCardIndex={
               previousInsightCount !== undefined && previousInsightCount >= 0
                 ? previousInsightCount
-                : -1
+                : null
             }
           />
         )}


### PR DESCRIPTION
Once the Seer-side change goes in, this will allow users to rethink the final output cards with Autofix remembering the previous version, making iteration and small changes easier.