### PR TITLE
fix(onboarding): Use `@SentryExceptionCaptured` in nestjs onboarding

### DIFF
--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -63,11 +63,11 @@ getError() {
 
 const getDecoratedGlobalFilter =
   () => `import { Catch, ExceptionFilter } from '@nestjs/common';
-import { WithSentry } from '@sentry/nestjs';
+import { SentryExceptionCaptured } from '@sentry/nestjs';
 
 @Catch()
 export class YourCatchAllExceptionFilter implements ExceptionFilter {
-  @WithSentry()
+  @SentryExceptionCaptured()
   catch(exception, host): void {
     // your implementation here
   }
@@ -169,7 +169,7 @@ const onboarding: OnboardingConfig = {
         },
         {
           description: tct(
-            'If you are using a global catch-all exception filter add a [code:@WithSentry()] decorator to the [code:catch()] method of this global error filter. This will report all unhandled errors to Sentry',
+            'If you are using a global catch-all exception filter add a [code:@SentryExceptionCaptured()] decorator to the [code:catch()] method of this global error filter. This will report all unhandled errors to Sentry',
             {
               code: <code />,
             }


### PR DESCRIPTION
The onboarding docs of nestjs still had the deprecated `@WithSentry` decorator that was removed with v9 as pointed out by https://github.com/getsentry/sentry-javascript/issues/13455#issuecomment-2658202500.