### PR TITLE
ref(quick-start): Do not open quick start sidebar by clicking on 'take me to issues'

### DIFF
--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -11,10 +11,7 @@ import NotFound from 'sentry/components/errors/notFound';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {SdkDocumentation} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {platformProductAvailability} from 'sentry/components/onboarding/productSelection';
-import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
-import {taskIsDone} from 'sentry/components/onboardingWizard/utils';
 import {setPageFiltersStorage} from 'sentry/components/organizations/pageFilters/persistence';
 import {performance as performancePlatforms} from 'sentry/data/platformCategories';
 import type {Platform} from 'sentry/data/platformPickerCategories';
@@ -27,13 +24,11 @@ import type {IssueAlertRule} from 'sentry/types/alerts';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformIntegration, PlatformKey, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isDemoModeEnabled} from 'sentry/utils/demoMode';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 import {GettingStartedWithProjectContext} from 'sentry/views/projects/gettingStartedWithProjectContext';
 
 import {OtherPlatformsInfo} from './otherPlatformsInfo';
@@ -60,8 +55,6 @@ export function ProjectInstallPlatform({
   const location = useLocation();
   const navigate = useNavigate();
   const gettingStartedWithProjectContext = useContext(GettingStartedWithProjectContext);
-  const onboardingContext = useContext(OnboardingContext);
-  const {activateSidebar} = useOnboardingSidebar();
 
   const isSelfHosted = ConfigStore.get('isSelfHosted');
 
@@ -127,25 +120,6 @@ export function ProjectInstallPlatform({
     name: currentPlatform?.name,
     link: currentPlatform?.link,
   };
-
-  const openOnboardingSidebar = useCallback(() => {
-    if (isDemoModeEnabled()) {
-      return;
-    }
-
-    const tasks = getMergedTasks({
-      organization,
-      projects: project ? [project] : undefined,
-      onboardingContext,
-    });
-
-    const allDisplayedTasks = tasks.filter(task => task.display);
-    const doneTasks = allDisplayedTasks.filter(taskIsDone);
-
-    if (!(doneTasks.length >= allDisplayedTasks.length)) {
-      activateSidebar();
-    }
-  }, [onboardingContext, organization, project, activateSidebar]);
 
   const redirectWithProjectSelection = useCallback(
     (to: LocationDescriptorObject) => {
@@ -244,7 +218,6 @@ export function ProjectInstallPlatform({
               redirectWithProjectSelection({
                 pathname: issueStreamLink,
               });
-              openOnboardingSidebar();
             }}
           >
             {t('Take me to Issues')}


### PR DESCRIPTION
We don't want the quick start sidebar to be displayed when users click the "Take me to issues" button right after creating a project. The quick start will only open in the following cases:

- If users click on it manually
- When users visit the organization for the second time
- When users skip the onboarding

- Contributes to https://github.com/getsentry/sentry/issues/84062