### PR TITLE
ref(eap): Prepare change in EAP reliability calculation

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1920,9 +1920,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[0]["count()"] == 10
         assert confidence[0]["count()"] == "low"
         assert data[1]["count()"] == 1
-        # While logically the confidence for 1 event at 100% sample rate should be high, we're going with low until we
-        # get customer feedback
-        assert confidence[1]["count()"] == "low"
+        assert confidence[1]["count()"] == "high"
 
     def test_span_duration(self):
         spans = [

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1920,7 +1920,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[0]["count()"] == 10
         assert confidence[0]["count()"] == "low"
         assert data[1]["count()"] == 1
-        assert confidence[1]["count()"] == "high"
+        assert confidence[1]["count()"] in ("high", "low")
 
     def test_span_duration(self):
         spans = [

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -842,14 +842,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             sample_rate = accuracy["samplingRate"]
             for expected, actual in zip(event_counts, confidence[0:6]):
                 if expected != 0:
-                    assert actual["value"] == "low"
+                    assert actual["value"] in ("high", "low")
                 else:
                     assert actual["value"] is None
 
             old_confidence = response.data["confidence"]
             for expected, actual in zip(event_counts, old_confidence[0:6]):
                 if expected != 0:
-                    assert actual[1][0][y_axis] == "low"
+                    assert actual[1][0][y_axis] in ("high", "low")
                 else:
                     assert actual[1][0][y_axis] is None
 
@@ -908,14 +908,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
             sample_rate = accuracy["samplingRate"]
             for expected, actual in zip(event_counts, confidence[0:6]):
                 if expected != 0:
-                    assert actual["value"] == "low"
+                    assert actual["value"] in ("high", "low")
                 else:
                     assert actual["value"] is None
 
             old_confidence = response.data[column]["confidence"]
             for expected, actual in zip(event_counts, old_confidence[0:6]):
                 if expected != 0:
-                    assert actual[1][0]["count"] == "low"
+                    assert actual[1][0]["count"] in ("high", "low")
                 else:
                     assert actual[1][0]["count"] is None
 


### PR DESCRIPTION
EAP will stop to check for a static sample count threshold (count > 100) when
calculating the reliability flag. Instead, it will only calculate the CI-based
accuracy of the extrapolated data.

This PR updates tests to be independent of the EAP's confidence response.

See https://github.com/getsentry/snuba/pull/6892

