### PR TITLE
feat(vercel): hide Vercel non native integration behind feature flag

### DIFF
--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -263,4 +263,3 @@ if "SENTRY_RUNNING_UWSGI" not in os.environ and len(secret_key) < 32:
 
 SENTRY_OPTIONS["system.secret-key"] = secret_key
 SENTRY_USE_RELAY = True
-SENTRY_FEATURES["organizations:integrations-vercel"] = True

--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -263,3 +263,4 @@ if "SENTRY_RUNNING_UWSGI" not in os.environ and len(secret_key) < 32:
 
 SENTRY_OPTIONS["system.secret-key"] = secret_key
 SENTRY_USE_RELAY = True
+SENTRY_FEATURES["organizations:integrations-vercel"] = True

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -321,6 +321,7 @@ class VercelIntegrationProvider(IntegrationProvider):
     integration_cls = VercelIntegration
     features = frozenset([IntegrationFeatures.DEPLOYMENT])
     oauth_redirect_url = "/extensions/vercel/configure/"
+    # feature flag handler is in getsentry
     requires_feature_flag = True
 
     def get_pipeline_views(self):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -321,6 +321,7 @@ class VercelIntegrationProvider(IntegrationProvider):
     integration_cls = VercelIntegration
     features = frozenset([IntegrationFeatures.DEPLOYMENT])
     oauth_redirect_url = "/extensions/vercel/configure/"
+    requires_feature_flag = True
 
     def get_pipeline_views(self):
         identity_pipeline_config = {"redirect_url": absolute_uri(self.oauth_redirect_url)}


### PR DESCRIPTION
- follow up from https://github.com/getsentry/getsentry/pull/16517 <-- after the feature handler change is merged, we can flip the boolean and allow access to non-native Vercel integration only to organizations that were not provisioned through Vercel native integration

Self-hosted organizations do not have access to native Vercel integration, so we have to set the feature flag to always be `True` for them

- closes https://github.com/getsentry/projects/issues/695