### PR TITLE
fix(settings): team admin is allowed to update project JS scraping

### DIFF
--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -262,6 +262,7 @@ class ProjectGeneralSettings extends DeprecatedAsyncComponent<Props, State> {
     const jsonFormProps = {
       additionalFieldProps: {
         organization,
+        project,
       },
       features: new Set(organization.features),
       access,


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/81881

# Before
For the Team Admin:
![image](https://github.com/user-attachments/assets/353b5440-27e1-4a41-8b49-c64c92285877)
This happens because without `project` passed as props, its value is `undefined` here:
https://github.com/getsentry/sentry/blob/a4b5e4cb030154d94269edd079d262accc4f3a3b/static/app/data/forms/projectGeneralSettings.tsx#L153-L154

# After
![image](https://github.com/user-attachments/assets/335fef49-0997-468c-8e27-c30094ca75aa)
