### PR TITLE
fix(identity): make analytics record correct provider

### DIFF
--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -108,7 +108,7 @@ class IdentityManager(BaseManager["Identity"]):
 
         analytics.record(
             "integrations.identity_linked",
-            provider="slack",
+            provider=idp.type,
             # Note that prior to circa March 2023 this was user.actor_id. It changed
             # when actor ids were no longer stable between regions for the same user
             actor_id=user.id,


### PR DESCRIPTION
Previously slack was hardcoded.

This causes problems in our local installation, as we patch out  slack due to https://github.com/getsentry/sentry/issues/26134  and is generally probably also not the idea of this line

Untested, but I will try this patch

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
