### PR TITLE
feat(onboarding-php): Uncheck profiling

### DIFF
--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -224,6 +224,58 @@ describe('Onboarding Product Selection', function () {
     expect(screen.getByRole('checkbox', {name: 'Session Replay'})).toBeDisabled();
   });
 
+  it('selects all products per default', async function () {
+    const {router} = initializeOrg({
+      router: {
+        location: {
+          query: {},
+        },
+        params: {},
+      },
+    });
+
+    render(<ProductSelection organization={organization} platform="python" />, {
+      router,
+    });
+
+    // router.replace is called to apply default product selection
+    await waitFor(() =>
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            product: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
+          }),
+        })
+      )
+    );
+  });
+
+  it('applies defined default product selection', async function () {
+    const {router} = initializeOrg({
+      router: {
+        location: {
+          query: {},
+        },
+        params: {},
+      },
+    });
+
+    render(<ProductSelection organization={organization} platform="php" />, {
+      router,
+    });
+
+    // router.replace is called to apply default product selection
+    await waitFor(() =>
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            product: [ProductSolution.PERFORMANCE_MONITORING],
+          }),
+        })
+      )
+    );
+  });
+
   it('triggers onChange callback', async function () {
     const {router} = initializeOrg({
       router: {

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -123,10 +123,7 @@ type OrganizationHeaderProps = {
   organization: Organization;
 };
 
-type ProductSelectionAvailabilityProps = Omit<
-  ProductSelectionProps,
-  'disabledProducts' | 'productsPerPlatform'
->;
+type ProductSelectionAvailabilityProps = Omit<ProductSelectionProps, 'disabledProducts'>;
 
 type FirstPartyIntegrationAlertProps = {
   integrations: Integration[];


### PR DESCRIPTION
Uncheck profiling during the onboarding of php platforms.
Add mechanism to define the default product selection of platforms.
