### PR TITLE
ref(types): replace empty object type with better alternatives

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -33,7 +33,7 @@ export type TimeSeriesData = {
   originalPreviousTimeseriesData?: EventsStatsData | null;
   originalTimeseriesData?: EventsStatsData;
   previousTimeseriesData?: Series[] | null;
-  timeAggregatedData?: Series | {};
+  timeAggregatedData?: Series | Record<string, unknown>;
   timeframe?: {end: number; start: number};
   // timeseries data
   timeseriesData?: Series[];

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
@@ -338,7 +338,7 @@ function groupedErrors(
   event: Event,
   data?: ActionableItemsResponse,
   progaurdErrors?: EventErrorData[]
-): Record<ActionableItemTypes, ErrorMessageType[]> | {} {
+): Partial<Record<ActionableItemTypes, ErrorMessageType[]>> {
   if (!data || !progaurdErrors || !event) {
     return {};
   }

--- a/static/app/components/events/meta/metaProxy.tsx
+++ b/static/app/components/events/meta/metaProxy.tsx
@@ -23,12 +23,11 @@ export class MetaProxy {
     this.local = local;
   }
 
-  // @ts-expect-error TS(7023): 'get' implicitly has return type 'any' because it ... Remove this comment to see the full error message
-  get<T extends {}>(
+  get<T extends Record<string, unknown>>(
     obj: T | T[],
     prop: Extract<keyof T, string> | SymbolProp,
     receiver: T
-  ) {
+  ): any {
     // trap calls to `getMeta` to return meta object
     if (prop === GET_META) {
       return (key: any) => {
@@ -82,7 +81,7 @@ export function withMeta<T>(event: T): T {
   return new Proxy(event, new MetaProxy((event as any)._meta)) as T;
 }
 
-export function getMeta<T extends {}>(
+export function getMeta<T extends Record<string, unknown>>(
   obj: T | undefined,
   prop: Extract<keyof T, string>
 ): Meta | undefined {

--- a/static/app/components/forms/controls/selectAsyncControl.tsx
+++ b/static/app/components/forms/controls/selectAsyncControl.tsx
@@ -19,7 +19,7 @@ export type Result = {
 export interface SelectAsyncControlProps {
   forwardedRef: React.Ref<typeof ReactSelect<GeneralSelectValue>>;
   // TODO(ts): Improve data type
-  onQuery: (query: string | undefined) => {};
+  onQuery: (query: string | undefined) => Record<string, unknown>;
   onResults: (data: any) => Result[];
   url: string;
   value: ControlProps['value'];

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -60,8 +60,8 @@ interface FormFieldPropModel extends FormFieldProps {
   model: FormModel;
 }
 
-type ObservedFn<_P, T> = (props: FormFieldPropModel) => T;
-type ObservedFnOrValue<P, T> = T | ObservedFn<P, T>;
+type ObservedFn<T> = (props: FormFieldPropModel) => T;
+type ObservedFnOrValue<T> = T | ObservedFn<T>;
 
 type ObserverdPropNames = (typeof propsToObserve)[number];
 
@@ -74,12 +74,12 @@ type ObservedPropResolver = [
  * Construct the type for properties that may be given observed functions
  */
 interface ObservableProps {
-  disabled?: ObservedFnOrValue<{}, FieldGroupProps['disabled']>;
-  disabledReason?: ObservedFnOrValue<{}, FieldGroupProps['disabledReason']>;
-  help?: ObservedFnOrValue<{}, FieldGroupProps['help']>;
-  highlighted?: ObservedFnOrValue<{}, FieldGroupProps['highlighted']>;
-  inline?: ObservedFnOrValue<{}, FieldGroupProps['inline']>;
-  visible?: ObservedFnOrValue<{}, FieldGroupProps['visible']>;
+  disabled?: ObservedFnOrValue<FieldGroupProps['disabled']>;
+  disabledReason?: ObservedFnOrValue<FieldGroupProps['disabledReason']>;
+  help?: ObservedFnOrValue<FieldGroupProps['help']>;
+  highlighted?: ObservedFnOrValue<FieldGroupProps['highlighted']>;
+  inline?: ObservedFnOrValue<FieldGroupProps['inline']>;
+  visible?: ObservedFnOrValue<FieldGroupProps['visible']>;
 }
 
 /**
@@ -121,7 +121,7 @@ interface BaseProps {
   onBlur?: (value: any, event: any) => void;
   onChange?: (value: any, event: any) => void;
   onKeyDown?: (value: any, event: any) => void;
-  placeholder?: ObservedFnOrValue<{}, React.ReactNode>;
+  placeholder?: ObservedFnOrValue<React.ReactNode>;
 
   resetOnError?: boolean;
   /**
@@ -449,7 +449,7 @@ function FormField(props: FormFieldProps) {
     .filter(p => typeof props[p] === 'function')
     .map<ObservedPropResolver>(p => [
       p,
-      () => (props[p] as ObservedFn<{}, any>)({...props, model}),
+      () => (props[p] as ObservedFn<any>)({...props, model}),
     ]);
 
   // This field has no properties that require observation to compute their

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -34,7 +34,7 @@ type HookState<H extends HookName> = {
  *   </Hook>
  */
 function Hook<H extends HookName>({name, ...props}: Props<H>) {
-  class HookComponent extends Component<{}, HookState<H>> {
+  class HookComponent extends Component<Record<string, unknown>, HookState<H>> {
     static displayName = `Hook(${name})`;
 
     state = {

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -263,7 +263,7 @@ async function createEventIdLookupResult(
   };
 }
 
-type Props = WithRouterProps<{}> & {
+type Props = WithRouterProps & {
   children: (props: ChildProps) => React.ReactElement;
   /**
    * search term

--- a/static/app/components/search/sources/formSource.tsx
+++ b/static/app/components/search/sources/formSource.tsx
@@ -12,7 +12,7 @@ import withSentryRouter from 'sentry/utils/withSentryRouter';
 import type {ChildProps, Result, ResultItem} from './types';
 import {strGetFn} from './utils';
 
-interface Props extends WithRouterProps<{}> {
+interface Props extends WithRouterProps {
   children: (props: ChildProps) => React.ReactElement;
   /**
    * search term

--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -6,20 +6,18 @@ import type {SizingWindowProps} from 'sentry/components/stories/sizingWindow';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import {space} from 'sentry/styles/space';
 
-type RenderProps = {};
-
-export type PropMatrix<P extends RenderProps> = Partial<{
+export type PropMatrix<P> = Partial<{
   [Prop in keyof P]: Array<P[Prop]>;
 }>;
 
-interface Props<P extends RenderProps> {
+interface Props<P> {
   propMatrix: PropMatrix<P>;
   render: ElementType<P>;
   selectedProps: [keyof P] | [keyof P, keyof P];
   sizingWindowProps?: SizingWindowProps;
 }
 
-export default function Matrix<P extends RenderProps>({
+export default function Matrix<P>({
   propMatrix,
   render,
   selectedProps,

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -101,10 +101,10 @@ describe('StreamGroup', function () {
 
     expect(await screen.findByTestId('group')).toBeInTheDocument();
     expect(screen.queryByTestId('resolved-issue')).not.toBeInTheDocument();
-    const data: GroupStatusResolution = {
+    const data = {
       status: GroupStatus.RESOLVED,
       statusDetails: {},
-    };
+    } satisfies GroupStatusResolution;
     act(() => GroupStore.onUpdate('1337', undefined, data));
     act(() => GroupStore.onUpdateSuccess('1337', undefined, data));
     expect(screen.getByTestId('resolved-issue')).toBeInTheDocument();

--- a/static/app/plugins/pluginComponentBase.tsx
+++ b/static/app/plugins/pluginComponentBase.tsx
@@ -18,7 +18,7 @@ const callbackWithArgs = function (context: any, callback: any, ...args: any) {
 
 type GenericFieldProps = Parameters<typeof GenericField>[0];
 
-type Props = {};
+type Props = Record<string, unknown>;
 
 type State = {state: FormState};
 

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -118,9 +118,9 @@ export type DataPoint = Pick<SeriesDataUnit, 'name' | 'value'>;
 
 export type EChartRestoreHandler = EChartEventHandler<{type: 'restore'}>;
 
-export type EChartFinishedHandler = EChartEventHandler<{}>;
+export type EChartFinishedHandler = EChartEventHandler<Record<string, unknown>>;
 
-export type EChartRenderedHandler = EChartEventHandler<{}>;
+export type EChartRenderedHandler = EChartEventHandler<Record<string, unknown>>;
 
 type EchartBrushAreas = Array<{
   coordRange: number[][];

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -431,7 +431,7 @@ export interface GroupActivityNote extends GroupActivityBase {
 }
 
 interface GroupActivitySetResolved extends GroupActivityBase {
-  data: {};
+  data: Record<string, string>;
   type: GroupActivityType.SET_RESOLVED;
 }
 
@@ -454,7 +454,7 @@ interface GroupActivitySetResolvedIntegration extends GroupActivityBase {
 }
 
 interface GroupActivitySetUnresolved extends GroupActivityBase {
-  data: {};
+  data: Record<string, string>;
   type: GroupActivityType.SET_UNRESOLVED;
 }
 
@@ -672,7 +672,7 @@ export interface GroupActivityCreateIssue extends GroupActivityBase {
 }
 
 interface GroupActivityDeletedAttachment extends GroupActivityBase {
-  data: {};
+  data: Record<string, string>;
   type: GroupActivityType.DELETED_ATTACHMENT;
 }
 
@@ -779,7 +779,7 @@ export interface MarkReviewed {
 
 export interface GroupStatusResolution {
   status: GroupStatus.RESOLVED | GroupStatus.UNRESOLVED | GroupStatus.IGNORED;
-  statusDetails: ResolvedStatusDetails | IgnoredStatusDetails | {};
+  statusDetails: ResolvedStatusDetails | IgnoredStatusDetails | Record<string, unknown>;
   substatus?: GroupSubstatus | null;
 }
 
@@ -878,7 +878,7 @@ export interface GroupIgnored extends BaseGroup, GroupStats {
 
 export interface GroupUnresolved extends BaseGroup, GroupStats {
   status: GroupStatus.UNRESOLVED;
-  statusDetails: {};
+  statusDetails: Record<string, unknown>;
 }
 
 export type Group = GroupUnresolved | GroupResolved | GroupIgnored | GroupReprocessing;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -187,8 +187,8 @@ export type ComponentHooks = {
   'component:crons-onboarding-panel': () => React.ComponentType<CronsOnboardingPanelProps>;
   'component:dashboards-header': () => React.ComponentType<DashboardHeadersProps>;
   'component:data-consent-banner': () => React.ComponentType<{source: string}> | null;
-  'component:data-consent-org-creation-checkbox': () => React.ComponentType<{}> | null;
-  'component:data-consent-priority-learn-more': () => React.ComponentType<{}> | null;
+  'component:data-consent-org-creation-checkbox': () => React.ComponentType | null;
+  'component:data-consent-priority-learn-more': () => React.ComponentType | null;
   'component:ddm-metrics-samples-list': () => React.ComponentType<MetricsSamplesListProps>;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
   'component:disabled-member': () => React.ComponentType<DisabledMemberViewProps>;
@@ -198,7 +198,7 @@ export type ComponentHooks = {
   'component:first-party-integration-alert': () => React.ComponentType<FirstPartyIntegrationAlertProps>;
   'component:header-date-range': () => React.ComponentType<DateRangeProps>;
   'component:header-selector-items': () => React.ComponentType<SelectorItemsProps>;
-  'component:insights-date-range-query-limit-footer': () => React.ComponentType<{}>;
+  'component:insights-date-range-query-limit-footer': () => React.ComponentType;
   'component:insights-upsell-page': () => React.ComponentType<InsightsUpsellHook>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
@@ -214,7 +214,7 @@ export type ComponentHooks = {
   'component:replay-list-page-header': () => React.ComponentType<ReplayListPageHeaderProps> | null;
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
-  'component:replay-settings-alert': () => React.ComponentType<{}> | null;
+  'component:replay-settings-alert': () => React.ComponentType | null;
   'component:sentry-logo': () => React.ComponentType<SentryLogoProps>;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;
@@ -305,7 +305,7 @@ export type InterfaceChromeHooks = {
  * Onboarding experience hooks
  */
 export type OnboardingHooks = {
-  'onboarding-wizard:skip-help': () => React.ComponentType<{}>;
+  'onboarding-wizard:skip-help': () => React.ComponentType;
   'onboarding:block-hide-sidebar': () => boolean;
   'onboarding:targeted-onboarding-header': (opts: {source: string}) => React.ReactNode;
 };

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -19,7 +19,7 @@ export type SourceMapsArchive = {
 export type Artifact = {
   dateCreated: string;
   dist: string | null;
-  headers: {'Content-Type': string} | {};
+  headers: {'Content-Type': string} | Record<string, unknown>;
   id: string;
   name: string;
   sha1: string;
@@ -86,7 +86,7 @@ interface ReleaseData {
     sessionsLowerBound: string | null;
     sessionsUpperBound: string | null;
   };
-  data: {};
+  data: Record<string, unknown>;
   deployCount: number;
   fileCount: number | null;
   firstEvent: string;

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -8,7 +8,7 @@ type SearchEventBase = {
   search_source?: string;
 };
 
-type OpenEvent = {};
+type OpenEvent = Record<string, unknown>;
 type SelectEvent = {result_type: string; source_type: string; query?: string};
 type QueryEvent = {query: string};
 type ProjectSelectorEvent = {path: string};

--- a/static/app/utils/getDisplayName.tsx
+++ b/static/app/utils/getDisplayName.tsx
@@ -1,7 +1,7 @@
 // Attempts to get a display name from a Component
 //
 // Use for HoCs
-export default function getDisplayName<Props = {}>(
+export default function getDisplayName<Props>(
   WrappedComponent: React.ComponentType<Props>
 ): string {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuery.tsx
+++ b/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuery.tsx
@@ -30,7 +30,7 @@ function getRequestPayload({
 
 export default function MetricsCompatibilityQuery({children, ...props}: QueryProps) {
   return (
-    <GenericDiscoverQuery<MetricsCompatibilityData, {}>
+    <GenericDiscoverQuery<MetricsCompatibilityData, Record<string, unknown>>
       route="metrics-compatibility-sums"
       getRequestPayload={getRequestPayload}
       {...props}

--- a/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums.tsx
+++ b/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums.tsx
@@ -34,7 +34,7 @@ function getRequestPayload({
 
 export default function MetricsCompatibilitySumsQuery({children, ...props}: QueryProps) {
   return (
-    <GenericDiscoverQuery<MetricsCompatibilitySumData, {}>
+    <GenericDiscoverQuery<MetricsCompatibilitySumData, Record<string, unknown>>
       route="metrics-compatibility"
       getRequestPayload={getRequestPayload}
       {...props}

--- a/static/app/utils/performance/quickTrace/traceMetaQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceMetaQuery.tsx
@@ -42,7 +42,7 @@ function TraceMetaQuery({
   const eventView = makeEventView({start, end, statsPeriod});
 
   return (
-    <GenericDiscoverQuery<TraceMeta, {}>
+    <GenericDiscoverQuery<TraceMeta, Record<string, unknown>>
       route={`events-trace-meta/${traceId}`}
       getRequestPayload={getTraceRequestPayload}
       eventView={eventView}

--- a/static/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
@@ -1,5 +1,6 @@
 import type {EventQuery} from 'sentry/actionCreators/events';
 import type {LocationQuery} from 'sentry/utils/discover/eventView';
+import type {ColumnValueType} from 'sentry/utils/discover/fields';
 import type {
   DiscoverQueryProps,
   GenericChildrenProps,
@@ -21,7 +22,7 @@ export type TableDataRow = {
 
 export type TableData = {
   data: TableDataRow[];
-  meta: {};
+  meta: Record<string, ColumnValueType>;
 };
 
 /**

--- a/static/app/utils/performance/segmentExplorer/tagKeyHistogramQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/tagKeyHistogramQuery.tsx
@@ -22,7 +22,7 @@ export type HistogramTag = {
 
 export type TableData = {
   histogram: {data: TableDataRow[]};
-  meta: {};
+  meta: Record<string, unknown>;
   tags: {data: HistogramTag[]};
 };
 

--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -42,7 +42,7 @@ function withReactRouter3Props(Component: React.ComponentType<any>) {
     const router = useRouter();
     const routes = useRoutes();
     const location = useLocation();
-    const outletContext = useOutletContext<{}>();
+    const outletContext = useOutletContext<Record<string, unknown>>();
 
     return (
       <Component

--- a/static/app/utils/useDispatchingReducer.spec.tsx
+++ b/static/app/utils/useDispatchingReducer.spec.tsx
@@ -17,17 +17,16 @@ describe('useDispatchingReducer', () => {
     jest.useRealTimers();
   });
   it('initializes state with initializer', () => {
-    const reducer = jest.fn().mockImplementation(s => s) as () => {};
+    const reducer = jest.fn().mockImplementation(s => s);
     const initialState = {type: 'initial'};
     const {result} = renderHook(() => useDispatchingReducer(reducer, initialState));
 
     expect(result.current[0]).toBe(initialState);
   });
   it('initializes state with fn initializer arg', () => {
-    const reducer = jest.fn().mockImplementation(s => s) as () => {};
+    const reducer = jest.fn().mockImplementation(s => s);
     const initialState = {type: 'initial'};
     const {result} = renderHook(() =>
-      // @ts-expect-error force undfined
       useDispatchingReducer(reducer, undefined, () => initialState)
     );
 

--- a/static/app/utils/useMutateApiToken.tsx
+++ b/static/app/utils/useMutateApiToken.tsx
@@ -34,7 +34,7 @@ export default function useMutateApiToken({
 }: UseMutateApiTokenProps) {
   const api = useApi();
   const queryClient = useQueryClient();
-  return useMutation<{}, RequestError, UpdateTokenQueryVariables>({
+  return useMutation<unknown, RequestError, UpdateTokenQueryVariables>({
     mutationFn: ({name}) =>
       api.requestPromise(`/api-tokens/${token.id}/`, {
         method: 'PUT',

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -61,7 +61,7 @@ const maxSize: Modifier<'maxSize', NonNullable<PreventOverflowModifier['options'
   },
 };
 
-const applyMaxSize: Modifier<'applyMaxSize', {}> = {
+const applyMaxSize: Modifier<'applyMaxSize', Record<string, unknown>> = {
   name: 'applyMaxSize',
   phase: 'beforeWrite',
   requires: ['maxSize'],
@@ -73,7 +73,7 @@ const applyMaxSize: Modifier<'applyMaxSize', {}> = {
   },
 };
 
-const applyMinWidth: Modifier<'applyMinWidth', {}> = {
+const applyMinWidth: Modifier<'applyMinWidth', Record<string, unknown>> = {
   name: 'applyMinWidth',
   phase: 'beforeWrite',
   enabled: false, // will be enabled when overlay is open

--- a/static/app/utils/withExperiment.tsx
+++ b/static/app/utils/withExperiment.tsx
@@ -33,7 +33,7 @@ type Options<E extends ExperimentKey, L extends boolean> = {
 
 type ExpectedProps<T extends ExperimentType> = T extends 'organization'
   ? {organization: Organization}
-  : {};
+  : never;
 
 type InjectedExperimentProps<E extends ExperimentKey, L extends boolean> = {
   /**
@@ -41,7 +41,7 @@ type InjectedExperimentProps<E extends ExperimentKey, L extends boolean> = {
    * your component depending on the value.
    */
   experimentAssignment: ExperimentAssignment[E];
-} & (L extends true ? LogExperimentProps : {});
+} & (L extends true ? LogExperimentProps : never);
 
 type LogExperimentProps = {
   /**

--- a/static/app/views/discover/table/quickContext/releaseContext.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.tsx
@@ -203,7 +203,7 @@ const ReleaseContextContainer = styled(ContextContainer)`
   }
 `;
 
-const ReleaseBody = styled(ContextBody)<{}>`
+const ReleaseBody = styled(ContextBody)`
   font-size: 13px;
   color: ${p => p.theme.subText};
 `;

--- a/static/app/views/organizationStats/usageTable.tsx
+++ b/static/app/views/organizationStats/usageTable.tsx
@@ -33,7 +33,7 @@ type Props = {
   isError?: boolean;
   isLoading?: boolean;
   showStoredOutcome?: boolean;
-} & WithRouterProps<{}, {}>;
+} & WithRouterProps;
 
 export type TableStat = {
   accepted: number;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -135,7 +135,7 @@ const TitleText = styled('div')`
   font-weight: bold;
 `;
 
-function TitleWithTestId(props: PropsWithChildren<{}>) {
+function TitleWithTestId(props: PropsWithChildren) {
   return <Title data-test-id="trace-drawer-title">{props.children}</Title>;
 }
 

--- a/static/app/views/performance/transactionDetails/traceLink.tsx
+++ b/static/app/views/performance/transactionDetails/traceLink.tsx
@@ -52,6 +52,6 @@ export function TraceLink({event, traceMeta, source, quickTrace}: TraceLinkProps
   );
 }
 
-const StyledLink = styled(Link)<{}>`
+const StyledLink = styled(Link)`
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -23,7 +23,10 @@ jest.mock('sentry/utils/useLocation');
 
 const mockUseLocation = jest.mocked(useLocation);
 
-function initializeData(options: {query: {}; additionalFeatures?: string[]}) {
+function initializeData(options: {
+  query: Record<string, unknown>;
+  additionalFeatures?: string[];
+}) {
   const {query, additionalFeatures} = options;
 
   const defaultFeatures = ['performance-view'];

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -144,8 +144,7 @@ const getFields = ({
   return null;
 };
 
-type Props = DeprecatedAsyncComponent['props'] &
-  WithRouterProps<{authId: string}, {}> & {};
+type Props = DeprecatedAsyncComponent['props'] & WithRouterProps<{authId: string}>;
 
 type State = DeprecatedAsyncComponent['state'] & {
   authenticator: Authenticator | null;

--- a/static/app/views/settings/featureFlags/index.tsx
+++ b/static/app/views/settings/featureFlags/index.tsx
@@ -88,7 +88,7 @@ export function OrganizationFeatureFlagsIndex() {
   );
 
   const {mutate: handleRemoveSecret, isPending: isRemoving} = useMutation<
-    {},
+    unknown,
     RequestError,
     RemoveSecretQueryVariables
   >({

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -78,7 +78,11 @@ function AuthTokenDetailsForm({
     [navigate, organization.slug]
   );
 
-  const {mutate: submitToken} = useMutation<{}, RequestError, UpdateTokenQueryVariables>({
+  const {mutate: submitToken} = useMutation<
+    unknown,
+    RequestError,
+    UpdateTokenQueryVariables
+  >({
     mutationFn: ({name}) =>
       api.requestPromise(
         `/organizations/${organization.slug}/org-auth-tokens/${token.id}/`,

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -111,7 +111,7 @@ export function OrganizationAuthTokensIndex({
   );
 
   const {mutate: handleRevokeToken, isPending: isRevoking} = useMutation<
-    {},
+    unknown,
     RequestError,
     RevokeTokenQueryVariables
   >({

--- a/static/app/views/settings/organizationIntegrations/pluginDeprecationAlert.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDeprecationAlert.tsx
@@ -13,7 +13,7 @@ type Props = {
   plugin: PluginWithProjectList;
 };
 
-type State = {};
+type State = Record<string, unknown>;
 
 class PluginDeprecationAlert extends Component<Props, State> {
   render() {

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -41,7 +41,7 @@ export default function TempestSettings({organization, project}: Props) {
 
   const api = useApi();
   const {mutate: handleRemoveCredential, isPending: isRemoving} = useMutation<
-    {},
+    unknown,
     RequestError,
     {id: number}
   >({

--- a/static/app/views/stories/storyTree.tsx
+++ b/static/app/views/stories/storyTree.tsx
@@ -301,7 +301,7 @@ function File(props: {node: StoryTreeNode}) {
 }
 
 function StoryIcon(props: {
-  category: 'components' | 'icons' | 'styles' | 'utils' | 'views' | string | {};
+  category: 'components' | 'icons' | 'styles' | 'utils' | 'views' | (string & {});
 }) {
   const iconProps: SVGIconProps = {size: 'xs'};
   switch (props.category) {

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -19,7 +19,7 @@ export interface InitializeDataSettings {
   features?: string[];
   project?: any; // TODO(k-fish): Fix this project type.
   projects?: Project[];
-  query?: {};
+  query?: Record<string, unknown>;
   selectedProject?: any;
 }
 


### PR DESCRIPTION
usually, those alternatives are `Record<string, unknown>` if the usage shows that we wanted to work with "any object", or simply `unknown` if the usage isn't clear.
