### PR TITLE
fix(integrations): check org membership at finish_pipeline

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -99,10 +99,8 @@ class IntegrationPipeline(Pipeline):
             id=self.organization.id, user_id=self.request.user.id
         )
 
-        if (
-            org_context
-            and org_context.member
-            and "org:integrations" not in org_context.member.scopes
+        if org_context and (
+            not org_context.member or "org:integrations" not in org_context.member.scopes
         ):
             error_message = (
                 "You must be an organization owner, manager or admin to install this integration."

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -12,6 +12,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.repository import Repository
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
@@ -23,7 +24,7 @@ from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.region import override_regions
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.types.region import Region, RegionCategory
 from sentry.users.models.identity import Identity
 
@@ -483,6 +484,51 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.state.data = data
 
         # attempt to finish pipeline with no 'org:integrations' scope
+        resp = self.pipeline.finish_pipeline()
+        assert (
+            "You must be an organization owner, manager or admin to install this integration."
+            in resp.content.decode()
+        )
+
+        extra = {
+            "error_message": "You must be an organization owner, manager or admin to install this integration.",
+            "organization_id": self.organization.id,
+            "user_id": member_user.id,
+            "provider_key": "example",
+        }
+        mock_logger.info.assert_called_with("build-integration.permission_error", extra=extra)
+
+    @patch("sentry.integrations.pipeline.logger")
+    def test_disallow_with_removed_membership(self, mock_logger, *args):
+        member_user = self.create_user()
+        om = self.create_member(user=member_user, organization=self.organization, role="manager")
+        self.login_as(member_user)
+
+        # partially copied from IntegrationTestCase.setUp()
+        # except the user is not an owner
+        with assume_test_silo_mode(SiloMode.REGION):
+            rpc_organization = serialize_rpc_organization(self.organization)
+
+        self.request = self.make_request(member_user)
+
+        self.pipeline = IntegrationPipeline(
+            request=self.request,
+            organization=rpc_organization,
+            provider_key=self.provider.key,
+        )
+        self.pipeline.initialize()
+        self.save_session()
+
+        data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+        }
+        self.pipeline.state.data = data
+        with outbox_runner(), assume_test_silo_mode_of(OrganizationMember):
+            om.delete()
+
+        # attempt to finish pipeline without org membership
         resp = self.pipeline.finish_pipeline()
         assert (
             "You must be an organization owner, manager or admin to install this integration."


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/82295
Missed the case where `org_context.member` is None (i.e. user was removed in the middle of an integration setup).