### PR TITLE
feat(projects): add RPC method to allow to update projects

### DIFF
--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -194,9 +194,10 @@ class DatabaseBackedProjectService(ProjectService):
 
         serializer = ProjectUpdateArgsSerializer(data=attrs)
         serializer.is_valid(raise_exception=True)
+        serializer.validated_data
 
-        if attrs:
-            for key, value in attrs.items():
+        if serializer.validated_data:
+            for key, value in serializer.validated_data.items():
                 setattr(project, key, value)
             project.save()
 

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -6,7 +6,6 @@ from sentry.api.helpers.default_symbol_sources import set_default_symbol_sources
 from sentry.api.serializers import ProjectSerializer
 from sentry.auth.services.auth import AuthenticationContext
 from sentry.constants import ObjectStatus
-from sentry.db.models.query import update
 from sentry.hybridcloud.rpc import OptionValue
 from sentry.hybridcloud.rpc.filter_query import OpaqueSerializedResponse
 from sentry.models.options.project_option import ProjectOption
@@ -196,5 +195,9 @@ class DatabaseBackedProjectService(ProjectService):
         invalid_fields = [field for field in updates if field not in allowed_fields]
         if invalid_fields:
             raise ValueError(f"Invalid fields: {', '.join(invalid_fields)}")
-        update(project, **updates)
+
+        for key, value in updates.items():
+            setattr(project, key, value)
+        project.save()
+
         return serialize_project(project)

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -192,5 +192,9 @@ class DatabaseBackedProjectService(ProjectService):
             id=project_id,
             organization_id=organization_id,
         )
+        allowed_fields = set(ProjectUpdates.__annotations__.keys())
+        invalid_fields = [field for field in updates if field not in allowed_fields]
+        if invalid_fields:
+            raise ValueError(f"Invalid fields: {', '.join(invalid_fields)}")
         update(project, **updates)
         return serialize_project(project)

--- a/src/sentry/projects/services/project/model.py
+++ b/src/sentry/projects/services/project/model.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from collections.abc import Callable
-from typing import Any, NotRequired, TypedDict
+from typing import Any, TypedDict
 
 from pydantic.fields import Field
 
@@ -20,11 +20,11 @@ class ProjectFilterArgs(TypedDict, total=False):
     project_ids: list[int]
 
 
-class ProjectUpdates(TypedDict):
-    name: NotRequired[str]
-    slug: NotRequired[str]
-    platform: NotRequired[str]
-    external_id: NotRequired[str]
+class ProjectUpdateArgs(TypedDict, total=False):
+    name: str
+    slug: str
+    platform: str | None
+    external_id: str | None
 
 
 class RpcProjectFlags(RpcModel):

--- a/src/sentry/projects/services/project/model.py
+++ b/src/sentry/projects/services/project/model.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from collections.abc import Callable
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic.fields import Field
 
@@ -18,6 +18,13 @@ def _project_status_visible() -> int:
 
 class ProjectFilterArgs(TypedDict, total=False):
     project_ids: list[int]
+
+
+class ProjectUpdates(TypedDict):
+    name: NotRequired[str]
+    slug: NotRequired[str]
+    platform: NotRequired[str]
+    external_id: NotRequired[str]
 
 
 class RpcProjectFlags(RpcModel):

--- a/src/sentry/projects/services/project/serial.py
+++ b/src/sentry/projects/services/project/serial.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from rest_framework import serializers
 
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
-from sentry.models.project import PROJECT_SLUG_MAX_LENGTH, Project
+from sentry.constants import PROJECT_SLUG_MAX_LENGTH
+from sentry.models.project import Project
 from sentry.projects.services.project import RpcProject
+from sentry.projects.services.project.model import ProjectUpdateArgs
 
 
-class ProjectUpdateArgsSerializer(serializers.Serializer):
+class ProjectUpdateArgsSerializer(serializers.Serializer[ProjectUpdateArgs]):
     name = serializers.CharField(
         help_text="The name for the project",
         max_length=200,

--- a/src/sentry/projects/services/project/serial.py
+++ b/src/sentry/projects/services/project/serial.py
@@ -1,7 +1,35 @@
 from __future__ import annotations
 
-from sentry.models.project import Project
+from rest_framework import serializers
+
+from sentry.api.fields.sentry_slug import SentrySerializerSlugField
+from sentry.models.project import PROJECT_SLUG_MAX_LENGTH, Project
 from sentry.projects.services.project import RpcProject
+
+
+class ProjectUpdateArgsSerializer(serializers.Serializer):
+    name = serializers.CharField(
+        help_text="The name for the project",
+        max_length=200,
+        required=False,
+    )
+    slug = SentrySerializerSlugField(
+        help_text="Uniquely identifies a project and is used for the interface.",
+        max_length=PROJECT_SLUG_MAX_LENGTH,
+        required=False,
+    )
+    platform = serializers.CharField(
+        help_text="The platform for the project",
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+    )
+    external_id = serializers.CharField(
+        help_text="The external ID for the project",
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+    )
 
 
 def serialize_project(project: Project) -> RpcProject:

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -15,6 +15,7 @@ from sentry.hybridcloud.rpc.resolvers import (
 )
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.projects.services.project import ProjectFilterArgs, RpcProject, RpcProjectOptionValue
+from sentry.projects.services.project.model import ProjectUpdates
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
 
@@ -106,6 +107,17 @@ class ProjectService(RpcService):
         user_id: int,
         add_org_default_team: bool | None = False,
         external_id: str | None = None,
+    ) -> RpcProject:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def update_project(
+        self,
+        *,
+        organization_id: int,
+        project_id: int,
+        updates: ProjectUpdates,
     ) -> RpcProject:
         pass
 

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -15,7 +15,7 @@ from sentry.hybridcloud.rpc.resolvers import (
 )
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.projects.services.project import ProjectFilterArgs, RpcProject, RpcProjectOptionValue
-from sentry.projects.services.project.model import ProjectUpdates
+from sentry.projects.services.project.model import ProjectUpdateArgs
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
 
@@ -117,7 +117,7 @@ class ProjectService(RpcService):
         *,
         organization_id: int,
         project_id: int,
-        updates: ProjectUpdates,
+        attrs: ProjectUpdateArgs,
     ) -> RpcProject:
         pass
 

--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -117,3 +117,12 @@ def test_update_project() -> None:
         project_id=project.id,
         attrs={"does_not_exist": "test"},
     )
+
+    # assert that we cannot change any fields not in the serializer
+    project_service.update_project(
+        organization_id=org.id,
+        project_id=project.id,
+        attrs={"status": 99},
+    )
+    project = Project.objects.get(id=project.id)
+    assert project.external_id != 99

--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.project import Project
 from sentry.projects.services.project.service import project_service
 from sentry.testutils.factories import Factories
@@ -71,13 +73,9 @@ def test_update_project() -> None:
     project = Project.objects.get(id=project.id)
     assert project.external_id == "abcde"
 
-    import pytest
-
     with pytest.raises(Exception):
         project_service.update_project(
             organization_id=org.id,
             project_id=project.id,
             updates={"does_not_exist": "test"},
         )
-        project = Project.objects.get(id=project.id)
-        assert project.external_id == "abcde"


### PR DESCRIPTION
Add a new RPC method `update_project` on the `ProjectService` that allows modifications on a project for certain limited fields. 