### PR TITLE
feat(laravel-insights): Placeholder page

### DIFF
--- a/static/app/utils/project/useSelectedProjectsHaveField.tsx
+++ b/static/app/utils/project/useSelectedProjectsHaveField.tsx
@@ -18,7 +18,9 @@ export function getSelectedProjectList(
     acc[project.id] = project;
     return acc;
   }, {});
-  return selectedProjects.map(id => projectsByProjectId[id]).filter(Boolean);
+  return selectedProjects
+    .map(id => projectsByProjectId[id])
+    .filter((project): project is Project => !!project);
 }
 
 export default function useSelectedProjectsHaveField(field: keyof Project) {

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -33,6 +34,7 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
+import {LaravelOverviewPage} from 'sentry/views/insights/pages/backend/laravelOverviewPage';
 import {
   BACKEND_LANDING_TITLE,
   OVERVIEW_PAGE_ALLOWED_OPS,
@@ -87,6 +89,27 @@ export const BACKEND_COLUMN_TITLES = [
 ];
 
 function BackendOverviewPage() {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
+
+  const selectedProjects: Project[] = useMemo(
+    () => getSelectedProjectList(selection.projects, projects),
+    [projects, selection.projects]
+  );
+
+  const selectedProject = selectedProjects.length === 1 ? selectedProjects[0] : null;
+  if (
+    selectedProject?.platform === 'php-laravel' &&
+    organization.features.includes('laravel-insights')
+  ) {
+    return <LaravelOverviewPage />;
+  }
+
+  return <GenericBackendOverviewPage />;
+}
+
+function GenericBackendOverviewPage() {
   const organization = useOrganization();
   const location = useLocation();
   const {setPageError} = usePageAlert();

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -1,0 +1,216 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {NoAccess} from 'sentry/components/noAccess';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {PanelTable} from 'sentry/components/panels/panelTable';
+import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
+import {space} from 'sentry/styles/space';
+import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
+import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
+import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
+import {generateBackendPerformanceEventView} from 'sentry/views/performance/data';
+import Onboarding from 'sentry/views/performance/onboarding';
+import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
+
+function getFreeTextFromQuery(query: string) {
+  const conditions = new MutableSearch(query);
+  const transactionValues = conditions.getFilterValues('transaction');
+  if (transactionValues.length) {
+    return transactionValues[0];
+  }
+  if (conditions.freeText.length > 0) {
+    // raw text query will be wrapped in wildcards in generatePerformanceEventView
+    // so no need to wrap it here
+    return conditions.freeText.join(' ');
+  }
+  return '';
+}
+
+function PlaceholderWidget() {
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title="Placeholder" />}
+      Visualization={'No content'}
+    />
+  );
+}
+
+export function LaravelOverviewPage() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const onboardingProject = useOnboardingProject();
+  const navigate = useNavigate();
+
+  const withStaticFilters = canUseMetricsData(organization);
+  const eventView = generateBackendPerformanceEventView(
+    location,
+    withStaticFilters,
+    organization
+  );
+
+  const showOnboarding = onboardingProject !== undefined;
+
+  function handleSearch(searchQuery: string) {
+    navigate({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        cursor: undefined,
+        query: String(searchQuery).trim() || undefined,
+        isDefaultQuery: false,
+      },
+    });
+  }
+
+  const derivedQuery = getTransactionSearchQuery(location, eventView.query);
+
+  return (
+    <Feature
+      features="performance-view"
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <BackendHeader
+        headerTitle={BACKEND_LANDING_TITLE}
+        headerActions={<ViewTrendsButton />}
+      />
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <ModuleLayout.Layout>
+            <ModuleLayout.Full>
+              <ToolRibbon>
+                <PageFilterBar condensed>
+                  <ProjectPageFilter />
+                  <EnvironmentPageFilter />
+                  <DatePageFilter />
+                </PageFilterBar>
+                {!showOnboarding && (
+                  <StyledTransactionNameSearchBar
+                    organization={organization}
+                    eventView={eventView}
+                    onSearch={(query: string) => {
+                      handleSearch(query);
+                    }}
+                    query={getFreeTextFromQuery(derivedQuery)!}
+                  />
+                )}
+              </ToolRibbon>
+            </ModuleLayout.Full>
+            <ModuleLayout.Full>
+              {!showOnboarding && (
+                <Fragment>
+                  <WidgetGrid>
+                    <RequestsContainer>
+                      <PlaceholderWidget />
+                    </RequestsContainer>
+                    <IssuesContainer>
+                      <PlaceholderWidget />
+                    </IssuesContainer>
+                    <DurationContainer>
+                      <PlaceholderWidget />
+                    </DurationContainer>
+                    <JobsContainer>
+                      <PlaceholderWidget />
+                    </JobsContainer>
+                    <QueriesContainer>
+                      <PlaceholderWidget />
+                    </QueriesContainer>
+                    <CachesContainer>
+                      <PlaceholderWidget />
+                    </CachesContainer>
+                  </WidgetGrid>
+                  <PanelTable
+                    headers={['Method', 'Route', 'Throughput', 'AVG', 'P95']}
+                    isEmpty
+                  />
+                </Fragment>
+              )}
+
+              {showOnboarding && (
+                <Onboarding project={onboardingProject} organization={organization} />
+              )}
+            </ModuleLayout.Full>
+          </ModuleLayout.Layout>
+        </Layout.Main>
+      </Layout.Body>
+    </Feature>
+  );
+}
+
+const WidgetGrid = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+  padding-bottom: ${space(2)};
+
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(6, 180px);
+  grid-template-areas:
+    'requests'
+    'issues'
+    'duration'
+    'jobs'
+    'queries'
+    'caches';
+
+  @media (min-width: ${p => p.theme.breakpoints.xsmall}) {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 180px 270px repeat(2, 180px);
+    grid-template-areas:
+      'requests duration'
+      'issues issues'
+      'jobs queries'
+      'caches caches';
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: repeat(3, 180px);
+    grid-template-areas:
+      'requests issues issues'
+      'duration issues issues'
+      'jobs queries caches';
+  }
+`;
+
+const RequestsContainer = styled('div')`
+  grid-area: requests;
+`;
+
+const IssuesContainer = styled('div')`
+  grid-area: issues;
+`;
+
+const DurationContainer = styled('div')`
+  grid-area: duration;
+`;
+
+const JobsContainer = styled('div')`
+  grid-area: jobs;
+`;
+
+const QueriesContainer = styled('div')`
+  grid-area: queries;
+`;
+
+const CachesContainer = styled('div')`
+  grid-area: caches;
+`;
+
+const StyledTransactionNameSearchBar = styled(TransactionNameSearchBar)`
+  flex: 2;
+`;


### PR DESCRIPTION
Add placeholder page with rough responsive layout for Laravel specific insights.

<img width="1452" alt="Screenshot 2025-02-18 at 14 48 52" src="https://github.com/user-attachments/assets/805a82dd-0440-4b16-beec-1387dadc5083" />


**Note:** This is WIP. All changes are behind the feature flag `organizations:laravel-insights`.

- part of https://github.com/getsentry/projects/issues/679