### PR TITLE
ref(lint): turn on no-empty-object-type rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -414,7 +414,7 @@ export default typescript.config([
       '@typescript-eslint/prefer-enum-initializers': 'error',
 
       // Recommended overrides
-      '@typescript-eslint/no-empty-object-type': 'off', // TODO(ryan953): Fix violations and delete this line
+      '@typescript-eslint/no-empty-object-type': ['error', {allowInterfaces: 'always'}],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-namespace': 'off',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'off', // TODO(ryan953): Fix violations and delete this line

--- a/static/app/utils/performance/suspectSpans/spanOpsQuery.tsx
+++ b/static/app/utils/performance/suspectSpans/spanOpsQuery.tsx
@@ -8,6 +8,7 @@ import GenericDiscoverQuery from 'sentry/utils/discover/genericDiscoverQuery';
 
 import type {SpanOps} from './types';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type SpanOpsProps = {};
 
 type RequestProps = DiscoverQueryProps & SpanOpsProps;


### PR DESCRIPTION
I've opted for allowing empty interfaces, as there isn't really any harm to that, and we have a lot of them