### PR TITLE
chore: add year formatter

### DIFF
--- a/static/app/utils/duration/getDuration.spec.tsx
+++ b/static/app/utils/duration/getDuration.spec.tsx
@@ -23,6 +23,9 @@ describe('getDuration()', () => {
     expect(getDuration(604800 * 4)).toBe('4 weeks');
     expect(getDuration(2629800)).toBe('1 month');
     expect(getDuration(604800 * 12)).toBe('3 months');
+    expect(getDuration(2629800 * 12)).toBe('1 year');
+    expect(getDuration(2629800 * 25)).toBe('2 years');
+    expect(getDuration(2629800 * 61)).toBe('5 years');
   });
 
   it('should format negative durations', () => {
@@ -44,6 +47,9 @@ describe('getDuration()', () => {
     expect(getDuration(-604800 * 4)).toBe('-4 weeks');
     expect(getDuration(-2629800)).toBe('-1 month');
     expect(getDuration(-604800 * 12)).toBe('-3 months');
+    expect(getDuration(-2629800 * 12)).toBe('-1 year');
+    expect(getDuration(-2629800 * 25)).toBe('-2 years');
+    expect(getDuration(-2629800 * 61)).toBe('-5 years');
   });
 
   it('should format numbers and abbreviate units', () => {
@@ -61,6 +67,9 @@ describe('getDuration()', () => {
     expect(getDuration(604800 * 2, 0, true)).toBe('2wk');
     expect(getDuration(2629800, 0, true)).toBe('1mo');
     expect(getDuration(604800 * 12, 0, true)).toBe('3mo');
+    expect(getDuration(2629800 * 12, 0, true)).toBe('1yr');
+    expect(getDuration(2629800 * 25, 0, true)).toBe('2yr');
+    expect(getDuration(2629800 * 61, 0, true)).toBe('5yr');
   });
 
   it('should format numbers and abbreviate units with one letter', () => {
@@ -76,8 +85,11 @@ describe('getDuration()', () => {
     expect(getDuration(86400 * 2, 0, false, true)).toBe('2d');
     expect(getDuration(604800, 0, false, true)).toBe('1w');
     expect(getDuration(604800 * 2, 0, false, true)).toBe('2w');
-    expect(getDuration(2629800, 0, false, true)).toBe('4w');
-    expect(getDuration(604800 * 12, 0, false, true)).toBe('12w');
+    expect(getDuration(2629800, 0, false, true)).toBe('1m');
+    expect(getDuration(604800 * 12, 0, false, true)).toBe('3m');
+    expect(getDuration(2629800 * 12, 0, false, true)).toBe('1y');
+    expect(getDuration(2629800 * 25, 0, false, true)).toBe('2y');
+    expect(getDuration(2629800 * 61, 0, false, true)).toBe('5y');
   });
 
   it('should format negative durations with absolute', () => {
@@ -95,5 +107,8 @@ describe('getDuration()', () => {
     expect(getDuration(-604800 * 4, 0, false, false, true)).toBe('4 weeks');
     expect(getDuration(-2629800, 0, false, false, true)).toBe('1 month');
     expect(getDuration(-604800 * 12, 0, false, false, true)).toBe('3 months');
+    expect(getDuration(-2629800 * 12, 0, false, false, true)).toBe('1 year');
+    expect(getDuration(-2629800 * 25, 0, false, false, true)).toBe('2 years');
+    expect(getDuration(-2629800 * 61, 0, false, false, true)).toBe('5 years');
   });
 });

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -85,13 +85,25 @@ export default function getDuration(
   // value in milliseconds
   const msValue = absolute ? absValue : seconds * 1000;
 
-  if ((absValue >= YEAR && !extraShort) || minimumUnit === YEAR) {
+  if (absValue >= YEAR || minimumUnit === YEAR) {
     const {label, result} = roundWithFixed(msValue / YEAR, fixedDigits);
+    if (extraShort) {
+      return `${label}${DURATION_LABELS.y}`;
+    }
+    if (abbreviation) {
+      return `${label}${DURATION_LABELS.yr}`;
+    }
     return `${label}${abbreviation ? DURATION_LABELS.yr : ` ${tn('year', 'years', result)}`}`;
   }
 
-  if ((absValue >= MONTH && !extraShort) || minimumUnit === MONTH) {
+  if (absValue >= MONTH || minimumUnit === MONTH) {
     const {label, result} = roundWithFixed(msValue / MONTH, fixedDigits);
+    if (extraShort) {
+      return `${label}${DURATION_LABELS.m}`;
+    }
+    if (abbreviation) {
+      return `${label}${DURATION_LABELS.mo}`;
+    }
     return `${label}${abbreviation ? DURATION_LABELS.mo : ` ${tn('month', 'months', result)}`}`;
   }
 

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -9,6 +9,7 @@ import {
   MONTH,
   SECOND,
   WEEK,
+  YEAR,
 } from '../formatters';
 
 function roundWithFixed(
@@ -29,6 +30,9 @@ function roundWithFixed(
  * Use `getExactDuration` for exact durations
  */
 const DURATION_LABELS = {
+  y: t('y'),
+  yr: t('yr'),
+  year: t('year'),
   mo: t('mo'),
   w: t('w'),
   wk: t('wk'),
@@ -80,6 +84,11 @@ export default function getDuration(
 
   // value in milliseconds
   const msValue = absolute ? absValue : seconds * 1000;
+
+  if ((absValue >= YEAR && !extraShort) || minimumUnit === YEAR) {
+    const {label, result} = roundWithFixed(msValue / YEAR, fixedDigits);
+    return `${label}${abbreviation ? DURATION_LABELS.yr : ` ${tn('year', 'years', result)}`}`;
+  }
 
   if ((absValue >= MONTH && !extraShort) || minimumUnit === MONTH) {
     const {label, result} = roundWithFixed(msValue / MONTH, fixedDigits);

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -20,6 +20,7 @@ export function userDisplayName(user: User | CommitAuthor, includeEmail = true):
 }
 
 // in milliseconds
+export const YEAR = 31536000000;
 export const MONTH = 2629800000;
 export const WEEK = 604800000;
 export const DAY = 86400000;


### PR DESCRIPTION
- Add a formatter that displays time periods as years when longer than 365 days

Before:
<img width="110" alt="Screenshot 2025-02-18 at 15 37 43" src="https://github.com/user-attachments/assets/f18f1856-ecd7-4ee0-be35-d3feab6beb54" />


After:
<img width="86" alt="Screenshot 2025-02-18 at 15 38 28" src="https://github.com/user-attachments/assets/84c730f7-a6ec-48ff-b53b-983bc75929d5" />
