### PR TITLE
fix(widget-builder): Accept decimals in threshold fields

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -117,4 +117,27 @@ describe('Thresholds', () => {
     expect(await screen.findByText('error on max 1')).toBeInTheDocument();
     expect(await screen.findByText('error on max 2')).toBeInTheDocument();
   });
+
+  it('accepts decimal values', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Thresholds dataType="duration" dataUnit="millisecond" />
+      </WidgetBuilderProvider>
+    );
+
+    await userEvent.type(screen.getByLabelText('First Maximum'), '0.5');
+    await userEvent.type(screen.getByLabelText('Second Maximum'), '100.5456');
+
+    expect((await screen.findAllByDisplayValue('0.5'))[0]).toBeInTheDocument();
+    expect((await screen.findAllByDisplayValue('100.5456'))[0]).toBeInTheDocument();
+
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          thresholds: '{"max_values":{"max1":0.5,"max2":100.5456},"unit":null}',
+        }),
+      }),
+      {replace: true}
+    );
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -51,7 +51,7 @@ function ThresholdsSection({
 
           if (newThresholds) {
             if (value) {
-              newThresholds.max_values[maxKey] = parseInt(value, 10);
+              newThresholds.max_values[maxKey] = Number(value);
             } else {
               delete newThresholds.max_values[maxKey];
             }


### PR DESCRIPTION
We were parsing out the threshold values with `parseInt(value, 10)` in the new widget builder and this was wiping out all decimals. Took a look at how it was being parsed in the old widget builder and it was using `Number(value)` so i've changed it to use that. Seems like it's working now!

![image](https://github.com/user-attachments/assets/878ff50d-c44b-4a16-9b81-f93915d49b78)
