### PR TITLE
fix(widget-builder): Update Add Field to reference new default

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -58,7 +58,7 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
 };
 
 const DEFAULT_FIELD: QueryFieldValue = {
-  function: ['count', '', undefined, undefined],
+  function: ['count_unique', 'user', undefined, undefined],
   kind: FieldValueKind.FUNCTION,
 };
 

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -62,7 +62,7 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
 };
 
 const DEFAULT_FIELD: QueryFieldValue = {
-  function: ['count', '', undefined, undefined],
+  function: ['count_unique', 'user', undefined, undefined],
   kind: FieldValueKind.FUNCTION,
 };
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -619,17 +619,17 @@ describe('Visualize', () => {
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
-              field: ['count_unique(user)'],
+              field: ['p50(transaction.duration)'],
             },
           }),
         }),
       }
     );
 
-    expect(await screen.findByLabelText('Aggregate Selection')).toHaveTextContent(
-      'count_unique'
+    expect(await screen.findByLabelText('Aggregate Selection')).toHaveTextContent('p50');
+    expect(screen.getByLabelText('Column Selection')).toHaveTextContent(
+      'transaction.duration'
     );
-    expect(screen.getByLabelText('Column Selection')).toHaveTextContent('user');
 
     // Add 3 fields
     await userEvent.click(screen.getByRole('button', {name: 'Add Column'}));
@@ -637,15 +637,15 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Add Column'}));
 
     // count() is the default aggregate when adding a field
-    expect(screen.getAllByText('count')).toHaveLength(3);
+    expect(screen.getAllByText('count_unique')).toHaveLength(3);
 
     // Change the last field
-    await userEvent.click(screen.getAllByText('count')[2]!);
+    await userEvent.click(screen.getAllByText('count_unique')[2]!);
     await userEvent.click(screen.getByRole('option', {name: 'epm'}));
 
     // The other fields should not be affected
-    expect(screen.getByText('count_unique')).toBeInTheDocument();
-    expect(screen.getAllByText('count')).toHaveLength(2);
+    expect(screen.getByText('p50')).toBeInTheDocument();
+    expect(screen.getAllByText('count_unique')).toHaveLength(2);
     expect(screen.getAllByText('epm')).toHaveLength(1);
   });
 


### PR DESCRIPTION
Fixes a bug where I forgot to update the old default aggregate, `count` to `count_unique(users)` to match the default when switching datasets.