### PR TITLE
fix(dashboards): Fix broken layout of visualization errors

### DIFF
--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -72,15 +72,15 @@ function WidgetLayout(props: Widget) {
       </Header>
 
       {props.Visualization && (
-        <ErrorBoundary
-          customComponent={({error}) => (
-            <WidgetError error={error?.message ?? undefined} />
-          )}
-        >
-          <VisualizationWrapper noPadding={props.noVisualizationPadding}>
+        <VisualizationWrapper noPadding={props.noVisualizationPadding}>
+          <ErrorBoundary
+            customComponent={({error}) => (
+              <WidgetError error={error?.message ?? undefined} />
+            )}
+          >
             {props.Visualization}
-          </VisualizationWrapper>
-        </ErrorBoundary>
+          </ErrorBoundary>
+        </VisualizationWrapper>
       )}
 
       {props.Footer && (


### PR DESCRIPTION
The wrapper should be around the boundary, not the other way around!

**Before:**
![Screenshot 2025-02-18 at 12 20 18 PM](https://github.com/user-attachments/assets/37f40527-151e-4919-b8eb-916f47a78ca4)

**After:**
![Screenshot 2025-02-18 at 12 22 47 PM](https://github.com/user-attachments/assets/4f5d5658-78d0-46b9-8963-20e0751ac248)
