### PR TITLE
fix(explore): Add explicit handling for missing chart data

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -207,6 +207,21 @@ export function ExploreCharts({
             );
           }
 
+          if (chartInfo.data.length === 0) {
+            // This happens when the `/events-stats/` endpoint returns a blank
+            // response. This is a rare error condition that happens when
+            // proxying to RPC. Adding explicit handling with a "better" message
+            return (
+              <Widget
+                key={index}
+                height={CHART_HEIGHT}
+                Title={Title}
+                Visualization={<Widget.WidgetError error={t('No data')} />}
+                revealActions="always"
+              />
+            );
+          }
+
           return (
             <Widget
               key={index}


### PR DESCRIPTION
Closes https://sentry.sentry.io/issues/6300659631/

On the "Aggregates" pane, the `/events-stats/` endpoint sometimes returns a blank response, which causes the chart to fail. This is benign, since an error message is shown, but explicit error handling here is better since it provides a friendlier message.

Actually an _even friendlier_ message would be better if someone has an idea!
