### PR TITLE
chore(issue-detaills): Update for new org experiment ending 

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -61,7 +61,7 @@ describe('NewIssueExperienceButton', function () {
         },
       }
     );
-    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
+    expect(screen.getByTestId('test-id')).not.toBeEmptyDOMElement();
     unmountOptionFalse();
   });
 

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -35,7 +35,7 @@ describe('NewIssueExperienceButton', function () {
     expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
   });
 
-  it('does not appear when an organization has the single interface option', function () {
+  it('appears correctly when organization has the single interface option', function () {
     const {unmount: unmountOptionTrue} = render(
       <div data-test-id="test-id">
         <NewIssueExperienceButton />

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -22,7 +22,7 @@ export function NewIssueExperienceButton() {
   const hasEnforceStreamlinedUIFlag = organization.features.includes(
     'issue-details-streamline-enforce'
   );
-  const hasOnlyOneUIOption = defined(organization.streamlineOnly);
+  const hasNewUIOnly = organization.streamlineOnly === true;
 
   const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();
@@ -42,8 +42,8 @@ export function NewIssueExperienceButton() {
     !hasStreamlinedUIFlag ||
     // has the 'remove opt-out' flag,
     hasEnforceStreamlinedUIFlag ||
-    // has access to only one interface (via the organization option).
-    hasOnlyOneUIOption
+    // has access to only the updated experience through the experiment
+    hasNewUIOnly
   ) {
     return null;
   }

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -22,7 +22,7 @@ export function NewIssueExperienceButton() {
   const hasEnforceStreamlinedUIFlag = organization.features.includes(
     'issue-details-streamline-enforce'
   );
-  const hasNewUIOnly = organization.streamlineOnly === true;
+  const hasNewUIOnly = organization.streamlineOnly;
 
   const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -83,7 +83,7 @@ describe('useHasStreamlinedUI', () => {
     expect(result.current).toBe(true);
   });
 
-  it('ignores preferences if organization option is set', () => {
+  it('ignores preferences if organization option is set to true', () => {
     jest.mocked(useLocation).mockReturnValue(LocationFixture());
 
     const streamlineOrg = OrganizationFixture({streamlineOnly: true});
@@ -104,7 +104,7 @@ describe('useHasStreamlinedUI', () => {
     act(() => ConfigStore.set('user', user));
 
     const {result: legacyResult} = renderHook(useHasStreamlinedUI);
-    expect(legacyResult.current).toBe(false);
+    expect(legacyResult.current).toBe(true);
   });
 
   it('ignores the option if unset', () => {

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -278,7 +278,7 @@ export function useHasStreamlinedUI() {
     return location.query.streamline === '1';
   }
 
-  // If the organzation option is set, it determines which interface is used.
+  // If the organzation option is set to true, the new UI is used.
   if (organization.streamlineOnly) {
     return true;
   }

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -279,8 +279,8 @@ export function useHasStreamlinedUI() {
   }
 
   // If the organzation option is set, it determines which interface is used.
-  if (defined(organization.streamlineOnly)) {
-    return organization.streamlineOnly;
+  if (organization.streamlineOnly === true) {
+    return true;
   }
 
   // If the enforce flag is set for the organization, ignore user preferences and enable the UI

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -279,7 +279,7 @@ export function useHasStreamlinedUI() {
   }
 
   // If the organzation option is set, it determines which interface is used.
-  if (organization.streamlineOnly === true) {
+  if (organization.streamlineOnly) {
     return true;
   }
 


### PR DESCRIPTION
once all new orgs get the updated ui, there are a few changes we have to make: 
1) orgs in the legacy group should be able to see the new ui button
2) we want to go off the user preference for those orgs in the legacy group instead of looking at the org option 