### PR TITLE
♻️ ref(aci): add dry run flag for migrating rule actions to actions

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -78,7 +78,7 @@ def translate_rule_data_actions_to_notification_actions(
 
 
 def build_notification_actions_from_rule_data_actions(
-    actions: list[dict[str, Any]]
+    actions: list[dict[str, Any]], dry_run: bool = False
 ) -> list[Action]:
     """
     Builds notification actions from action field in Rule's data blob.
@@ -90,7 +90,8 @@ def build_notification_actions_from_rule_data_actions(
 
     notification_actions = translate_rule_data_actions_to_notification_actions(actions)
 
-    # Bulk create the actions
-    Action.objects.bulk_create(notification_actions)
+    # Bulk create the actions if not a dry run
+    if not dry_run:
+        Action.objects.bulk_create(notification_actions)
 
     return notification_actions

--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -78,7 +78,7 @@ def translate_rule_data_actions_to_notification_actions(
 
 
 def build_notification_actions_from_rule_data_actions(
-    actions: list[dict[str, Any]], dry_run: bool = False
+    actions: list[dict[str, Any]], is_dry_run: bool = False
 ) -> list[Action]:
     """
     Builds notification actions from action field in Rule's data blob.
@@ -91,7 +91,7 @@ def build_notification_actions_from_rule_data_actions(
     notification_actions = translate_rule_data_actions_to_notification_actions(actions)
 
     # Bulk create the actions if not a dry run
-    if not dry_run:
+    if not is_dry_run:
         Action.objects.bulk_create(notification_actions)
 
     return notification_actions

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1093,7 +1093,7 @@ class TestNotificationActionMigrationUtils(TestCase):
             }
         ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data, dry_run=True)
+        actions = build_notification_actions_from_rule_data_actions(action_data, is_dry_run=True)
         assert len(actions) == 1
         assert Action.objects.count() == 0
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1080,3 +1080,30 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         with pytest.raises(ValueError):
             build_notification_actions_from_rule_data_actions(action_data)
+
+    def test_dry_run_flag(self):
+        """Test that the dry_run flag prevents database writes."""
+        action_data = [
+            {
+                "workspace": "1",
+                "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                "channel": "#test-channel",
+                "channel_id": "C123456",
+                "uuid": "test-uuid",
+            }
+        ]
+
+        actions = build_notification_actions_from_rule_data_actions(action_data, dry_run=True)
+        assert len(actions) == 1
+        assert Action.objects.count() == 0
+
+        # With dry_run=False (default)
+        actions = build_notification_actions_from_rule_data_actions(action_data)
+        assert len(actions) == 1
+        assert Action.objects.count() == 1
+
+        # Verify the actions passed to bulk_create
+        action = Action.objects.get(id=actions[0].id)
+        assert action.type == Action.Type.SLACK
+        assert action.target_display == "#test-channel"
+        assert action.target_identifier == "C123456"


### PR DESCRIPTION
if dry_run is set to True, the migration util won't bulk create actions.