### PR TITLE
chore(metrics): Use a hook across the app for metric rules

### DIFF
--- a/static/app/views/alerts/rules/metric/duplicate.tsx
+++ b/static/app/views/alerts/rules/metric/duplicate.tsx
@@ -7,7 +7,6 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
 import type EventView from 'sentry/utils/discover/eventView';
 import {uniqueId} from 'sentry/utils/guid';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -16,6 +15,7 @@ import {
   DuplicateTriggerFields,
 } from 'sentry/views/alerts/rules/metric/constants';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {useMetricRule} from 'sentry/views/alerts/rules/metric/utils/useMetricRule';
 import type {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
 
 import RuleForm from './ruleForm';
@@ -38,18 +38,16 @@ function MetricRuleDuplicate({
   ...otherProps
 }: MetricRuleDuplicateProps) {
   const organization = useOrganization();
+  const duplicateRuleId: string = otherProps.location.query.duplicateRuleId;
   const {
     data: duplicateTargetRule,
     isPending,
     isError,
     refetch,
-  } = useApiQuery<MetricRule>(
-    [
-      `/organizations/${organization.slug}/alert-rules/${otherProps.location.query.duplicateRuleId}/`,
-    ],
-    {staleTime: 0}
-  );
-
+  } = useMetricRule({
+    orgSlug: organization.slug,
+    ruleId: duplicateRuleId,
+  });
   const handleSubmitSuccess = (data: any) => {
     const alertRuleId: string | undefined = data
       ? (data.id as string | undefined)

--- a/static/app/views/alerts/rules/metric/edit.tsx
+++ b/static/app/views/alerts/rules/metric/edit.tsx
@@ -9,11 +9,10 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {metric} from 'sentry/utils/analytics';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import RuleForm from 'sentry/views/alerts/rules/metric/ruleForm';
-import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {useMetricRule} from 'sentry/views/alerts/rules/metric/utils/useMetricRule';
 
 type RouteParams = {
   projectId: string;
@@ -42,13 +41,12 @@ export function MetricRulesEdit({
     isError,
     data: rule,
     error,
-  } = useApiQuery<MetricRule>(
-    [`/organizations/${organization.slug}/alert-rules/${params.ruleId}/`],
+  } = useMetricRule(
     {
-      staleTime: 0,
-      retry: false,
-      refetchOnMount: true,
-    }
+      orgSlug: organization.slug,
+      ruleId: params.ruleId,
+    },
+    {refetchOnMount: true}
   );
 
   useEffect(() => {

--- a/static/app/views/alerts/rules/metric/utils/useMetricRule.tsx
+++ b/static/app/views/alerts/rules/metric/utils/useMetricRule.tsx
@@ -8,7 +8,9 @@ import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 interface MetricRuleParams {
   orgSlug: string;
   ruleId: string;
-  query?: Record<string, string>;
+  query?: {
+    expand?: 'latestIncident';
+  };
 }
 
 export function makeMetricRuleQueryKey({

--- a/static/app/views/alerts/rules/metric/utils/useMetricRule.tsx
+++ b/static/app/views/alerts/rules/metric/utils/useMetricRule.tsx
@@ -1,0 +1,30 @@
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+
+interface MetricRuleParams {
+  orgSlug: string;
+  ruleId: string;
+  query?: Record<string, string>;
+}
+
+export function makeMetricRuleQueryKey({
+  orgSlug,
+  ruleId,
+  query,
+}: MetricRuleParams): ApiQueryKey {
+  return [`/organizations/${orgSlug}/alert-rules/${ruleId}/`, {query}];
+}
+
+export function useMetricRule(
+  params: MetricRuleParams,
+  options: Partial<UseApiQueryOptions<MetricRule>> = {}
+) {
+  return useApiQuery<MetricRule>(makeMetricRuleQueryKey(params), {
+    staleTime: 0,
+    ...options,
+  });
+}

--- a/static/app/views/issueDetails/metricIssuesSection.tsx
+++ b/static/app/views/issueDetails/metricIssuesSection.tsx
@@ -8,18 +8,14 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import RelatedIssues from 'sentry/views/alerts/rules/metric/details/relatedIssues';
 import RelatedTransactions from 'sentry/views/alerts/rules/metric/details/relatedTransactions';
-import {
-  Dataset,
-  type MetricRule,
-  TimePeriod,
-} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
+import {useMetricRule} from 'sentry/views/alerts/rules/metric/utils/useMetricRule';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
@@ -38,18 +34,18 @@ export default function MetricIssuesSection({
 }: MetricIssuesSectionProps) {
   const location = useLocation();
   const ruleId = event.contexts?.metric_alert?.alert_rule_id;
-  const {data: rule} = useApiQuery<MetricRule>(
-    [
-      `/organizations/${organization.slug}/alert-rules/${ruleId}/`,
-      {
-        query: {
-          expand: 'latestIncident',
-        },
+  const {data: rule} = useMetricRule(
+    {
+      orgSlug: organization.slug,
+      ruleId: ruleId ?? '',
+      query: {
+        expand: 'latestIncident',
       },
-    ],
+    },
     {
       staleTime: Infinity,
       retry: false,
+      enabled: !!ruleId,
     }
   );
 

--- a/static/app/views/issueDetails/streamline/metricIssueChart.tsx
+++ b/static/app/views/issueDetails/streamline/metricIssueChart.tsx
@@ -10,7 +10,6 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
@@ -18,13 +17,10 @@ import {
   getFilter,
   getPeriodInterval,
 } from 'sentry/views/alerts/rules/metric/details/utils';
-import {
-  Dataset,
-  type MetricRule,
-  TimePeriod,
-} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
+import {useMetricRule} from 'sentry/views/alerts/rules/metric/utils/useMetricRule';
 
 const MetricChart = lazy(
   () => import('sentry/views/alerts/rules/metric/details/metricChart')
@@ -44,18 +40,19 @@ export function MetricIssueChart({
   const organization = useOrganization();
 
   const ruleId = event?.contexts?.metric_alert?.alert_rule_id;
-  const {data: rule} = useApiQuery<MetricRule>(
-    [
-      `/organizations/${organization.slug}/alert-rules/${ruleId}/`,
-      {
-        query: {
-          expand: 'latestIncident',
-        },
+
+  const {data: rule} = useMetricRule(
+    {
+      orgSlug: organization.slug,
+      ruleId: ruleId ?? '',
+      query: {
+        expand: 'latestIncident',
       },
-    ],
+    },
     {
       staleTime: Infinity,
       retry: false,
+      enabled: !!ruleId,
     }
   );
 


### PR DESCRIPTION
Adds a shared hook for metric rules and uses it across the app. Will be used in some of my upcoming metric charts changes.