### PR TITLE
ref(trace-view): make default trace view route /traces/trace

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -64,7 +64,7 @@ export const TRACE_SOURCE_TO_NON_INSIGHT_ROUTES: Partial<
   metrics: 'metrics',
   discover: 'discover',
   profiling_flamegraph: 'profiling',
-  performance_transaction_summary: 'performance',
+  performance_transaction_summary: 'traces',
   issue_details: 'issues',
   feedback_details: 'feedback',
   dashboards: 'dashboards',

--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -37,7 +37,7 @@ function getBaseTraceUrl(
   const url =
     source && source in TRACE_SOURCE_TO_NON_INSIGHT_ROUTES
       ? TRACE_SOURCE_TO_NON_INSIGHT_ROUTES[source]
-      : 'performance';
+      : 'traces';
 
   return normalizeUrl(`/organizations/${organization.slug}/${url}`);
 }

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -246,7 +246,7 @@ describe('Performance GridEditable Table', function () {
 
     expect(screen.getByRole('link', {name: '1234'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/trace/1234/?project=1&tab=events&transaction=%2Fperformance&transactionCursor=1%3A0%3A0'
+      '/organizations/org-slug/traces/trace/1234/?project=1&tab=events&transaction=%2Fperformance&transactionCursor=1%3A0%3A0'
     );
   });
 


### PR DESCRIPTION
We are removing all the `/performance` routes, therefore we should never end up in `/performance/traces`
1. Make default route `/traces/trace` for links to trace view
2. Change performance transaction summary to use `/traces/trace`