### PR TITLE
ref(vercel): [Part 1] Move `organizations:integrations-vercel` feature registration to sentry

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -119,6 +119,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:sentry-pride-logo-footer": False,
         # Enable priority calculations using Seer's severity endpoint
         "organizations:seer-based-priority": False,
+        # Enable Vercel integration - there is a custom handler in getsentry
+        "organizations:integrations-vercel": True,
     }
 
     permanent_project_features = {

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -84,6 +84,7 @@ class OrganizationSerializerTest(TestCase):
             "integrations-issue-sync",
             "integrations-stacktrace-link",
             "integrations-ticket-rules",
+            "integrations-vercel",
             "invite-members",
             "minute-resolution-sessions",
             "new-page-filter",


### PR DESCRIPTION
Part 1 of moving the feature registration to sentry codebase, preparation for https://github.com/getsentry/getsentry/pull/16530