### PR TITLE
alerts: remove deprecated export

### DIFF
--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -1,5 +1,0 @@
-/**
- * @deprecated Import from `sentry/components/core/alert` instead.
- */
-// biome-ignore lint/performance/noBarrelFile: Remove this once imports are fixed
-export * from 'sentry/components/core/alert';

--- a/static/app/components/core/alert.stories.tsx
+++ b/static/app/components/core/alert.stories.tsx
@@ -11,7 +11,7 @@ import storyBook from 'sentry/stories/storyBook';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
-import types from '!!type-loader!sentry/components/alert';
+import types from '!!type-loader!sentry/components/core/alert';
 
 export default storyBook('Alert', (story, APIReference) => {
   APIReference(types.Alert);

--- a/static/app/components/core/alert.tsx
+++ b/static/app/components/core/alert.tsx
@@ -302,5 +302,3 @@ const Container = styled('div')`
 `;
 
 Alert.Container = Container;
-
-export default Alert;

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 
 import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.svg';
 
-import {Alert} from 'sentry/components/alert';
 import {LinkButton} from 'sentry/components/button';
+import {Alert} from 'sentry/components/core/alert';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import useDrawer from 'sentry/components/globalDrawer';


### PR DESCRIPTION
Remove deprecated export and default export for alert component - requires https://github.com/getsentry/getsentry/pull/16531 to land first