### PR TITLE
chore(aci): issue alert migration dry run helper

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -39,7 +39,9 @@ from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
 from sentry.utils import metrics
-from sentry.workflow_engine.migration_helpers.rule import delete_migrated_issue_alert
+from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
+    delete_migrated_issue_alert,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -9,7 +9,7 @@ from sentry import features
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.rule import migrate_issue_alert
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 
 
 @dataclass
@@ -33,7 +33,7 @@ class ProjectRuleCreator:
                 "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
             ):
                 # TODO(cathy): handle errors from broken actions
-                migrate_issue_alert(self.rule, self.request.user.id if self.request else None)
+                IssueAlertMigrator(self.rule, self.request.user.id if self.request else None).run()
 
             return self.rule
 

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -8,7 +8,9 @@ from sentry import features
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.rule import update_migrated_issue_alert
+from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
+    update_migrated_issue_alert,
+)
 
 
 @dataclass

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -1,0 +1,222 @@
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.rule import Rule
+from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
+from sentry.rules.processing.processor import split_conditions_and_filters
+from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
+    create_event_unique_user_frequency_condition_with_conditions,
+    translate_to_data_condition,
+)
+from sentry.workflow_engine.migration_helpers.rule_action import (
+    build_notification_actions_from_rule_data_actions,
+)
+from sentry.workflow_engine.models import (
+    AlertRuleDetector,
+    AlertRuleWorkflow,
+    DataCondition,
+    DataConditionGroup,
+    DataConditionGroupAction,
+    Detector,
+    DetectorWorkflow,
+    Workflow,
+    WorkflowDataConditionGroup,
+)
+from sentry.workflow_engine.models.data_condition import (
+    Condition,
+    enforce_data_condition_json_schema,
+)
+
+logger = logging.getLogger(__name__)
+
+SKIPPED_CONDITIONS = [Condition.EVERY_EVENT]
+
+
+@dataclass
+class IssueAlertMigrator:
+    def __init__(self, rule: Rule, user_id: int | None = None, is_dry_run: bool | None = False):
+        self.rule = rule
+        self.user_id = user_id
+        self.is_dry_run = is_dry_run
+        self.data = rule.data
+        self.project = rule.project
+        self.organization = self.project.organization
+
+    def run(self) -> None:
+        error_detector = self._create_detector_lookup()
+        conditions, filters = split_conditions_and_filters(self.data["conditions"])
+        workflow = self._create_workflow_and_lookup(
+            conditions=conditions,
+            filters=filters,
+            action_match=self.data["action_match"],
+            detector=error_detector,
+        )
+        if_dcg = self._create_if_dcg(
+            filter_match=self.data["filter_match"],
+            workflow=workflow,
+            conditions=conditions,
+            filters=filters,
+        )
+        self._create_workflow_actions(if_dcg=if_dcg, actions=self.data["actions"])
+
+    def _create_detector_lookup(self) -> Detector:
+        if self.is_dry_run:
+            created = True
+            error_detector = Detector.objects.filter(
+                type=ErrorGroupType.slug, project=self.project
+            ).first()
+            if error_detector:
+                created = not AlertRuleDetector.objects.filter(
+                    detector=error_detector, rule=self.rule
+                ).exists()
+            else:
+                error_detector = Detector(type=ErrorGroupType.slug, project=self.project)
+
+        else:
+            error_detector, _ = Detector.objects.get_or_create(
+                type=ErrorGroupType.slug,
+                project=self.project,
+                defaults={"config": {}, "name": "Error Detector"},
+            )
+            _, created = AlertRuleDetector.objects.get_or_create(
+                detector=error_detector, rule=self.rule
+            )
+
+        if not created:
+            raise Exception("Issue alert already migrated")
+
+        return error_detector
+
+    def _bulk_create_data_conditions(
+        self,
+        conditions: list[dict[str, Any]],
+        dcg: DataConditionGroup,
+        filters: list[dict[str, Any]] | None = None,
+    ):
+        dcg_conditions: list[DataCondition] = []
+
+        for condition in conditions:
+            if (
+                condition["id"] == EventUniqueUserFrequencyConditionWithConditions.id
+            ):  # special case
+                dcg_conditions.append(
+                    create_event_unique_user_frequency_condition_with_conditions(
+                        dict(condition), dcg, filters
+                    )
+                )
+            else:
+                dcg_conditions.append(translate_to_data_condition(dict(condition), dcg=dcg))
+
+        filtered_data_conditions = [
+            dc for dc in dcg_conditions if dc.type not in SKIPPED_CONDITIONS
+        ]
+
+        if self.is_dry_run:
+            for dc in filtered_data_conditions:
+                dc.full_clean(
+                    exclude=["condition_group"]
+                )  # condition_group will be null, which is not allowed
+                enforce_data_condition_json_schema(dc)
+        else:
+            DataCondition.objects.bulk_create(filtered_data_conditions)
+
+    def _create_when_dcg(
+        self,
+        action_match: str,
+    ):
+        if action_match == "any":
+            logic_type = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
+        else:
+            logic_type = DataConditionGroup.Type(action_match)
+
+        kwargs = {"organization": self.organization, "logic_type": logic_type}
+
+        if self.is_dry_run:
+            when_dcg = DataConditionGroup(**kwargs)
+            when_dcg.full_clean()
+        else:
+            when_dcg = DataConditionGroup.objects.create(**kwargs)
+
+        return when_dcg
+
+    def _create_workflow_and_lookup(
+        self,
+        conditions: list[dict[str, Any]],
+        filters: list[dict[str, Any]],
+        action_match: str,
+        detector: Detector,
+    ) -> Workflow:
+        when_dcg = self._create_when_dcg(action_match=action_match)
+        self._bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=when_dcg)
+
+        config = {"frequency": self.rule.data.get("frequency") or Workflow.DEFAULT_FREQUENCY}
+        kwargs = {
+            "organization": self.organization,
+            "name": self.rule.label,
+            "environment_id": self.rule.environment_id,
+            "when_condition_group": when_dcg,
+            "created_by_id": self.user_id,
+            "owner_user_id": self.rule.owner_user_id,
+            "owner_team": self.rule.owner_team,
+            "config": config,
+        }
+
+        if self.is_dry_run:
+            workflow = Workflow(**kwargs)
+            workflow.full_clean(exclude=["when_condition_group"])
+            workflow.validate_config(workflow.config_schema)
+        else:
+            workflow = Workflow.objects.create(**kwargs)
+            DetectorWorkflow.objects.create(detector=detector, workflow=workflow)
+            AlertRuleWorkflow.objects.create(rule=self.rule, workflow=workflow)
+
+        return workflow
+
+    def _create_if_dcg(
+        self,
+        filter_match: str,
+        workflow: Workflow,
+        conditions: list[dict[str, Any]],
+        filters: list[dict[str, Any]],
+    ) -> DataConditionGroup:
+        if (
+            filter_match == "any" or filter_match is None
+        ):  # must create IF DCG even if it's empty, to attach actions
+            logic_type = DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        else:
+            logic_type = DataConditionGroup.Type(filter_match)
+
+        kwargs = {
+            "organization": self.organization,
+            "logic_type": logic_type,
+        }
+
+        if self.is_dry_run:
+            if_dcg = DataConditionGroup(**kwargs)
+            if_dcg.full_clean()
+        else:
+            if_dcg = DataConditionGroup.objects.create(**kwargs)
+            WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=if_dcg)
+
+        conditions_ids = [condition["id"] for condition in conditions]
+        # skip migrating filters for special case
+        if EventUniqueUserFrequencyConditionWithConditions.id not in conditions_ids:
+            self._bulk_create_data_conditions(conditions=filters, dcg=if_dcg)
+
+        return if_dcg
+
+    def _create_workflow_actions(
+        self, if_dcg: DataConditionGroup, actions: list[dict[str, Any]]
+    ) -> None:
+        pass
+        notification_actions = build_notification_actions_from_rule_data_actions(
+            actions, is_dry_run=self.is_dry_run or False
+        )
+        dcg_actions = [
+            DataConditionGroupAction(action=action, condition_group=if_dcg)
+            for action in notification_actions
+        ]
+        if not self.is_dry_run:
+            DataConditionGroupAction.objects.bulk_create(dcg_actions)

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -208,7 +208,6 @@ class IssueAlertMigrator:
     def _create_workflow_actions(
         self, if_dcg: DataConditionGroup, actions: list[dict[str, Any]]
     ) -> None:
-        pass
         notification_actions = build_notification_actions_from_rule_data_actions(
             actions, is_dry_run=self.is_dry_run or False
         )

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -34,10 +34,17 @@ SKIPPED_CONDITIONS = [Condition.EVERY_EVENT]
 
 
 class IssueAlertMigrator:
-    def __init__(self, rule: Rule, user_id: int | None = None, is_dry_run: bool | None = False):
+    def __init__(
+        self,
+        rule: Rule,
+        user_id: int | None = None,
+        is_dry_run: bool | None = False,
+        should_create_actions: bool | None = True,
+    ):
         self.rule = rule
         self.user_id = user_id
         self.is_dry_run = is_dry_run
+        self.should_create_actions = should_create_actions
         self.data = rule.data
         self.project = rule.project
         self.organization = self.project.organization
@@ -57,7 +64,8 @@ class IssueAlertMigrator:
             conditions=conditions,
             filters=filters,
         )
-        self._create_workflow_actions(if_dcg=if_dcg, actions=self.data["actions"])
+        if self.should_create_actions:
+            self._create_workflow_actions(if_dcg=if_dcg, actions=self.data["actions"])
 
     def _create_detector_lookup(self) -> Detector:
         if self.is_dry_run:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -54,7 +54,7 @@ class IssueAlertMigrator:
             detector=error_detector,
         )
         if_dcg = self._create_if_dcg(
-            filter_match=self.data["filter_match"],
+            filter_match=self.data.get("filter_match", "all"),
             workflow=workflow,
             conditions=conditions,
             filters=filters,

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 from typing import Any
 
 from sentry.grouping.grouptype import ErrorGroupType
@@ -34,7 +33,6 @@ logger = logging.getLogger(__name__)
 SKIPPED_CONDITIONS = [Condition.EVERY_EVENT]
 
 
-@dataclass
 class IssueAlertMigrator:
     def __init__(self, rule: Rule, user_id: int | None = None, is_dry_run: bool | None = False):
         self.rule = rule

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -29,7 +29,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.rule import migrate_issue_alert
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import AlertRuleWorkflow
 from sentry.workflow_engine.models.data_condition import DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
@@ -1684,7 +1684,7 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 },
             ],
         )
-        migrate_issue_alert(rule, user_id=self.user.id)
+        IssueAlertMigrator(rule, user_id=self.user.id).run()
 
         alert_rule_workflow = AlertRuleWorkflow.objects.get(rule=rule)
         workflow = alert_rule_workflow.workflow

--- a/tests/sentry/projects/project_rules/test_updater.py
+++ b/tests/sentry/projects/project_rules/test_updater.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.actor import Actor
 from sentry.users.models.user import User
-from sentry.workflow_engine.migration_helpers.rule import migrate_issue_alert
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import (
     Action,
     AlertRuleDetector,
@@ -118,7 +118,7 @@ class TestUpdater(TestCase):
 
     @with_feature("organizations:workflow-engine-issue-alert-dual-write")
     def test_dual_create_workflow_engine(self):
-        migrate_issue_alert(self.rule, user_id=self.user.id)
+        IssueAlertMigrator(self.rule, user_id=self.user.id).run()
 
         conditions = [
             {

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from jsonschema.exceptions import ValidationError
 
@@ -16,13 +18,13 @@ from sentry.rules.filters.event_attribute import EventAttributeFilter
 from sentry.rules.filters.latest_release import LatestReleaseFilter
 from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.rules.match import MatchType
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
-from sentry.workflow_engine.migration_helpers.rule import (
+from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
     delete_migrated_issue_alert,
-    migrate_issue_alert,
     update_migrated_issue_alert,
 )
+from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import (
     Action,
     AlertRuleDetector,
@@ -38,7 +40,7 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import Condition
 
 
-class RuleMigrationHelpersTest(APITestCase):
+class RuleMigrationHelpersTest(TestCase):
     def setUp(self):
         conditions = [
             {"id": ReappearedEventCondition.id},
@@ -112,121 +114,8 @@ class RuleMigrationHelpersTest(APITestCase):
             },
         ]
 
-    def test_create_issue_alert(self):
-        migrate_issue_alert(self.issue_alert, self.user.id)
-
-        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
-        issue_alert_detector = AlertRuleDetector.objects.get(rule=self.issue_alert)
-
-        workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
-        assert workflow.name == self.issue_alert.label
-        assert self.issue_alert.project
-        assert workflow.organization_id == self.issue_alert.project.organization.id
-        assert workflow.config == {"frequency": 5}
-
-        detector = Detector.objects.get(id=issue_alert_detector.detector.id)
-        assert detector.name == "Error Detector"
-        assert detector.project_id == self.project.id
-        assert detector.enabled is True
-        assert detector.owner_user_id is None
-        assert detector.owner_team is None
-        assert detector.type == ErrorGroupType.slug
-        assert detector.config == {}
-
-        detector_workflow = DetectorWorkflow.objects.get(detector=detector)
-        assert detector_workflow.workflow == workflow
-
-        assert workflow.when_condition_group
-        assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
-        conditions = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
-        assert conditions.count() == 2
-        assert conditions.filter(
-            type=Condition.REAPPEARED_EVENT, comparison=True, condition_result=True
-        ).exists()
-        assert conditions.filter(
-            type=Condition.REGRESSION_EVENT, comparison=True, condition_result=True
-        ).exists()
-
-        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
-        assert if_dcg.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
-        filters = DataCondition.objects.filter(condition_group=if_dcg)
-        assert filters.count() == 1
-        assert filters.filter(
-            type=Condition.AGE_COMPARISON,
-            comparison={
-                "comparison_type": AgeComparisonType.OLDER,
-                "value": 10,
-                "time": "hour",
-            },
-            condition_result=True,
-        ).exists()
-
-        dcg_actions = DataConditionGroupAction.objects.get(condition_group=if_dcg)
-        action = dcg_actions.action
-        assert action.type == Action.Type.SLACK  # tested fully in test_migrate_rule_action.py
-
-    def test_create_issue_alert__detector_exists(self):
-        project_detector = self.create_detector(project=self.project)
-        migrate_issue_alert(self.issue_alert, self.user.id)
-
-        # does not create a new error detector
-
-        detector = Detector.objects.get(project_id=self.project.id)
-        assert detector == project_detector
-
-    def test_create_issue_alert__with_conditions(self):
-        issue_alert = self.create_project_rule(
-            condition_data=self.conditions,
-            action_match="all",
-            filter_match="any",
-            action_data=self.action_data,
-        )
-
-        migrate_issue_alert(issue_alert, self.user.id)
-        assert DataCondition.objects.all().count() == 1
-        dc = DataCondition.objects.get(type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
-        assert dc.comparison == {
-            "interval": "1h",
-            "value": 50,
-            "filters": self.expected_filters,
-        }
-
-    def test_skip_every_event_condition__any(self):
-        conditions = [
-            {"id": EveryEventCondition.id},
-            {"id": RegressionEventCondition.id},
-        ]
-        issue_alert = self.create_project_rule(
-            condition_data=conditions,
-            action_match="any",
-            filter_match="any",
-            action_data=self.action_data,
-        )
-
-        migrate_issue_alert(issue_alert, self.user.id)
-        assert DataCondition.objects.all().count() == 1
-        dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
-        assert dc.condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
-
-    def test_skip_every_event_condition__all(self):
-        conditions = [
-            {"id": EveryEventCondition.id},
-            {"id": RegressionEventCondition.id},
-        ]
-        issue_alert = self.create_project_rule(
-            condition_data=conditions,
-            action_match="all",
-            filter_match="any",
-            action_data=self.action_data,
-        )
-
-        migrate_issue_alert(issue_alert, self.user.id)
-        assert DataCondition.objects.all().count() == 1
-        dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
-        assert dc.condition_group.logic_type == DataConditionGroup.Type.ALL
-
     def test_update_issue_alert(self):
-        migrate_issue_alert(self.issue_alert, self.user.id)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
         conditions_payload = [
             {
                 "id": FirstSeenEventCondition.id,
@@ -294,7 +183,7 @@ class RuleMigrationHelpersTest(APITestCase):
         assert action.type == Action.Type.PLUGIN  # tested fully in test_migrate_rule_action.py
 
     def test_update_issue_alert__with_conditions(self):
-        migrate_issue_alert(self.issue_alert, self.user.id)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
         rule_data = self.issue_alert.data
         rule_data.update(
@@ -329,7 +218,7 @@ class RuleMigrationHelpersTest(APITestCase):
         }
 
     def test_required_fields_only(self):
-        migrate_issue_alert(self.issue_alert, self.user.id)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
         # None fields are not updated
 
         rule_data = self.issue_alert.data
@@ -374,14 +263,14 @@ class RuleMigrationHelpersTest(APITestCase):
         assert filters.count() == 0
 
     def test_invalid_frequency(self):
-        migrate_issue_alert(self.issue_alert, self.user.id)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
         self.issue_alert.data["frequency"] = -1
         self.issue_alert.save()
         with pytest.raises(ValidationError):
             update_migrated_issue_alert(self.issue_alert)
 
     def test_delete_issue_alert(self):
-        migrate_issue_alert(self.issue_alert, self.user.id)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
         alert_rule_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
         workflow = alert_rule_workflow.workflow
@@ -406,3 +295,292 @@ class RuleMigrationHelpersTest(APITestCase):
         assert not DataCondition.objects.filter(condition_group=if_dcg).exists()
         assert not DataConditionGroupAction.objects.filter(condition_group=if_dcg).exists()
         assert not Action.objects.all().exists()
+
+
+class IssueAlertMigratorTest(TestCase):
+    def setUp(self):
+        conditions = [
+            {"id": ReappearedEventCondition.id},
+            {"id": RegressionEventCondition.id},
+            {
+                "id": AgeComparisonFilter.id,
+                "comparison_type": AgeComparisonType.OLDER,
+                "value": "10",
+                "time": "hour",
+            },
+        ]
+        integration = install_slack(self.organization)
+        self.action_data = [
+            {
+                "channel": "#my-channel",
+                "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                "workspace": str(integration.id),
+                "uuid": "test-uuid",
+                "channel_id": "C01234567890",
+            },
+        ]
+        self.issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=conditions,
+            action_match="any",
+            filter_match="any",
+            action_data=self.action_data,
+        )
+        self.issue_alert.data["frequency"] = 5
+        self.issue_alert.save()
+
+        self.filters = [
+            {
+                "id": TaggedEventFilter.id,
+                "match": MatchType.EQUAL,
+                "key": "LOGGER",
+                "value": "sentry.example",
+            },
+            {
+                "id": TaggedEventFilter.id,
+                "match": MatchType.IS_SET,
+                "key": "environment",
+            },
+            {
+                "id": EventAttributeFilter.id,
+                "match": MatchType.EQUAL,
+                "value": "hi",
+                "attribute": "message",
+            },
+        ]
+        self.conditions = [
+            {
+                "interval": "1h",
+                "id": EventUniqueUserFrequencyConditionWithConditions.id,
+                "value": 50,
+                "comparisonType": ComparisonType.COUNT,
+            }
+        ] + self.filters
+
+        self.expected_filters = [
+            {
+                "match": MatchType.EQUAL,
+                "key": self.filters[0]["key"],
+                "value": self.filters[0]["value"],
+            },
+            {"match": MatchType.IS_SET, "key": self.filters[1]["key"]},
+            {
+                "match": MatchType.EQUAL,
+                "key": self.filters[2]["attribute"],
+                "value": self.filters[2]["value"],
+            },
+        ]
+
+    def test_run(self):
+        migrator = IssueAlertMigrator(self.issue_alert, self.user.id)
+        migrator.run()
+
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+        issue_alert_detector = AlertRuleDetector.objects.get(rule=self.issue_alert)
+
+        workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+        assert workflow.name == self.issue_alert.label
+        assert self.issue_alert.project
+        assert workflow.organization_id == self.issue_alert.project.organization.id
+        assert workflow.config == {"frequency": 5}
+
+        detector = Detector.objects.get(id=issue_alert_detector.detector.id)
+        assert detector.name == "Error Detector"
+        assert detector.project_id == self.project.id
+        assert detector.enabled is True
+        assert detector.owner_user_id is None
+        assert detector.owner_team is None
+        assert detector.type == ErrorGroupType.slug
+        assert detector.config == {}
+
+        detector_workflow = DetectorWorkflow.objects.get(detector=detector)
+        assert detector_workflow.workflow == workflow
+
+        assert workflow.when_condition_group
+        assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        conditions = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
+        assert conditions.count() == 2
+        assert conditions.filter(
+            type=Condition.REAPPEARED_EVENT, comparison=True, condition_result=True
+        ).exists()
+        assert conditions.filter(
+            type=Condition.REGRESSION_EVENT, comparison=True, condition_result=True
+        ).exists()
+
+        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        assert if_dcg.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        filters = DataCondition.objects.filter(condition_group=if_dcg)
+        assert filters.count() == 1
+        assert filters.filter(
+            type=Condition.AGE_COMPARISON,
+            comparison={
+                "comparison_type": AgeComparisonType.OLDER,
+                "value": 10,
+                "time": "hour",
+            },
+            condition_result=True,
+        ).exists()
+
+        dcg_actions = DataConditionGroupAction.objects.get(condition_group=if_dcg)
+        action = dcg_actions.action
+        assert action.type == Action.Type.SLACK
+
+    def test_run_no_double_migrate(self):
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
+        # there should be only 1
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+        issue_alert_detector = AlertRuleDetector.objects.get(rule=self.issue_alert)
+        Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+        Detector.objects.get(id=issue_alert_detector.detector.id)
+
+    def test_run__detector_exists(self):
+        project_detector = self.create_detector(project=self.project)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
+        # does not create a new error detector
+
+        detector = Detector.objects.get(project_id=self.project.id)
+        assert detector == project_detector
+
+    def test_run__with_conditions(self):
+        issue_alert = self.create_project_rule(
+            condition_data=self.conditions,
+            action_match="all",
+            filter_match="any",
+            action_data=self.action_data,
+        )
+
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        assert DataCondition.objects.all().count() == 1
+        dc = DataCondition.objects.get(type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
+        assert dc.comparison == {
+            "interval": "1h",
+            "value": 50,
+            "filters": self.expected_filters,
+        }
+
+    def test_run__every_event_condition__any(self):
+        conditions = [
+            {"id": EveryEventCondition.id},
+            {"id": RegressionEventCondition.id},
+        ]
+        issue_alert = self.create_project_rule(
+            condition_data=conditions,
+            action_match="any",
+            filter_match="any",
+            action_data=self.action_data,
+        )
+
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        assert DataCondition.objects.all().count() == 1
+        dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
+        assert dc.condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+
+    def test_run__every_event_condition__all(self):
+        conditions = [
+            {"id": EveryEventCondition.id},
+            {"id": RegressionEventCondition.id},
+        ]
+        issue_alert = self.create_project_rule(
+            condition_data=conditions,
+            action_match="all",
+            filter_match="any",
+            action_data=self.action_data,
+        )
+
+        IssueAlertMigrator(issue_alert, self.user.id).run()
+        assert DataCondition.objects.all().count() == 1
+        dc = DataCondition.objects.get(type=Condition.REGRESSION_EVENT)
+        assert dc.condition_group.logic_type == DataConditionGroup.Type.ALL
+
+    def test_dry_run(self):
+        IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+
+        assert not AlertRuleWorkflow.objects.filter(rule=self.issue_alert).exists()
+        assert not AlertRuleDetector.objects.filter(rule=self.issue_alert).exists()
+
+        assert Workflow.objects.all().count() == 0
+        assert Detector.objects.all().count() == 0
+        assert DataConditionGroup.objects.all().count() == 0
+        assert DataCondition.objects.all().count() == 0
+        assert Action.objects.all().count() == 0
+
+    def test_dry_run__already_exists(self):
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
+        with pytest.raises(Exception):
+            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+        issue_alert_detector = AlertRuleDetector.objects.get(rule=self.issue_alert)
+        Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+        Detector.objects.get(id=issue_alert_detector.detector.id)
+
+    @patch("sentry.workflow_engine.migration_helpers.rule.enforce_data_condition_json_schema")
+    def test_dry_run__data_condition_validation_fails(self, mock_enforce):
+        mock_enforce.side_effect = ValidationError("oopsie")
+
+        with pytest.raises(ValidationError):
+            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+
+        assert not AlertRuleWorkflow.objects.filter(rule=self.issue_alert).exists()
+        assert not AlertRuleDetector.objects.filter(rule=self.issue_alert).exists()
+
+        assert Workflow.objects.all().count() == 0
+        assert Detector.objects.all().count() == 0
+        assert DataConditionGroup.objects.all().count() == 0
+        assert DataCondition.objects.all().count() == 0
+        assert Action.objects.all().count() == 0
+
+    def test_dry_run__dcg_validation_fails(self):
+        self.issue_alert.data["action_match"] = "asdf"
+
+        with pytest.raises(ValueError):
+            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+
+        assert not AlertRuleWorkflow.objects.filter(rule=self.issue_alert).exists()
+        assert not AlertRuleDetector.objects.filter(rule=self.issue_alert).exists()
+
+        assert Workflow.objects.all().count() == 0
+        assert Detector.objects.all().count() == 0
+        assert DataConditionGroup.objects.all().count() == 0
+        assert DataCondition.objects.all().count() == 0
+        assert Action.objects.all().count() == 0
+
+    def test_dry_run__workflow_validation_fails(self):
+        self.issue_alert.data["frequency"] = -1
+
+        with pytest.raises(ValidationError):
+            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+
+        assert not AlertRuleWorkflow.objects.filter(rule=self.issue_alert).exists()
+        assert not AlertRuleDetector.objects.filter(rule=self.issue_alert).exists()
+
+        assert Workflow.objects.all().count() == 0
+        assert Detector.objects.all().count() == 0
+        assert DataConditionGroup.objects.all().count() == 0
+        assert DataCondition.objects.all().count() == 0
+        assert Action.objects.all().count() == 0
+
+    def test_dry_run__action_validation_fails(self):
+        self.issue_alert.data["actions"] = [
+            {
+                "channel": "#my-channel",
+                "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                "uuid": "test-uuid",
+                "channel_id": "C01234567890",
+            },
+        ]
+
+        with pytest.raises(ValueError):
+            IssueAlertMigrator(self.issue_alert, self.user.id, is_dry_run=True).run()
+
+        assert not AlertRuleWorkflow.objects.filter(rule=self.issue_alert).exists()
+        assert not AlertRuleDetector.objects.filter(rule=self.issue_alert).exists()
+
+        assert Workflow.objects.all().count() == 0
+        assert Detector.objects.all().count() == 0
+        assert DataConditionGroup.objects.all().count() == 0
+        assert DataCondition.objects.all().count() == 0
+        assert Action.objects.all().count() == 0

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -517,7 +517,9 @@ class IssueAlertMigratorTest(TestCase):
         Workflow.objects.get(id=issue_alert_workflow.workflow.id)
         Detector.objects.get(id=issue_alert_detector.detector.id)
 
-    @patch("sentry.workflow_engine.migration_helpers.rule.enforce_data_condition_json_schema")
+    @patch(
+        "sentry.workflow_engine.migration_helpers.issue_alert_migration.enforce_data_condition_json_schema"
+    )
     def test_dry_run__data_condition_validation_fails(self, mock_enforce):
         mock_enforce.side_effect = ValidationError("oopsie")
 


### PR DESCRIPTION
Replace `migrate_issue_alert` standalone function with an `IssueAlertMigrator` class that can handle both the dry run logic and the dual create in issue alert APIs.

The dry run mode creates instances of model classes, runs `Model.full_clean()`, manually enforces the json schema on applicable models. If there is an issue there, an exception will be raised that should be caught in the dry run script.

The `IssueAlertMigrator` can be used in the API. We can't import Django models into the db migration, so we may have to do something different there -- but the logic is already written out here.