### PR TITLE
feat(issues): Encode stacktrace url file path

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -175,9 +175,11 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             scope.set_tag("stacktrace_link.used_version", False)
             source_url = self.check_file(repo, filepath, default)
 
-            # Encode elements of the filepath like square brackets
-            # Preserve path separators and query params etc.
-            return urlquote(source_url, safe="/:?=&")
+            if source_url:
+                # Encode elements of the filepath like square brackets
+                # Preserve path separators and query params etc.
+                return urlquote(source_url, safe="/:?=&")
+            return None
 
     def get_codeowner_file(
         self, repo: Repository, ref: str | None = None

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -171,11 +171,12 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                 source_url = self.check_file(repo, filepath, version)
                 if source_url:
                     scope.set_tag("stacktrace_link.used_version", True)
-                    return source_url
+                    return urlquote(source_url, safe="/:?=&")
             scope.set_tag("stacktrace_link.used_version", False)
             source_url = self.check_file(repo, filepath, default)
 
-            # Encode elements of the filepath that are not safe for urls
+            # Encode elements of the filepath like square brackets
+            # Preserve path separators and query params etc.
             return urlquote(source_url, safe="/:?=&")
 
     def get_codeowner_file(

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import quote as urlquote
 
 import sentry_sdk
 
@@ -174,7 +175,8 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             scope.set_tag("stacktrace_link.used_version", False)
             source_url = self.check_file(repo, filepath, default)
 
-            return source_url
+            # Encode elements of the filepath that are not safe for urls
+            return urlquote(source_url, safe="/:?=&")
 
     def get_codeowner_file(
         self, repo: Repository, ref: str | None = None

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1163,3 +1163,35 @@ class GitHubIntegrationTest(IntegrationTestCase):
             installation.extract_source_path_from_source_url(repo, source_url)
             == "src/sentry/integrations/github/integration.py"
         )
+
+    @responses.activate
+    def test_get_stacktrace_link_with_special_chars(self):
+        """Test that URLs with special characters (like square brackets) are properly encoded"""
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+        with assume_test_silo_mode(SiloMode.REGION):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="Test-Organization/foo",
+                url="https://github.com/Test-Organization/foo",
+                provider="integrations:github",
+                external_id=123,
+                config={"name": "Test-Organization/foo"},
+                integration_id=integration.id,
+            )
+
+        installation = get_installation_of_type(
+            GitHubIntegration, integration, self.organization.id
+        )
+
+        filepath = "src/components/[id]/test.py"
+        branch = "master"
+        responses.add(
+            responses.HEAD,
+            f"{self.base_url}/repos/{repo.name}/contents/{filepath}?ref={branch}",
+        )
+        source_url = installation.get_stacktrace_link(repo, filepath, branch, branch)
+        assert (
+            source_url
+            == "https://github.com/Test-Organization/foo/blob/master/src/components/%5Bid%5D/test.py"
+        )

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
@@ -213,31 +213,6 @@ class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
         assert response.data["error"] == "stack_root_mismatch"
         assert response.data["integrations"] == [serialized_integration(self.integration)]
 
-    @patch.object(ExampleIntegration, "get_stacktrace_link")
-    def test_file_with_square_brackets(self, mock_integration: MagicMock) -> None:
-        """
-        File paths with square brackets should be encoded in the source url
-        """
-        # Add a code mapping that matches the test file path
-        code_mapping = self.create_code_mapping(
-            organization_integration=self.oi,
-            project=self.project,
-            repo=self.repo,
-            stack_root="src/sentry/",
-            source_root="",
-        )
-        file_path = "src/sentry/api/projects/[projectId]/event_id.py"
-        encoded_path = quote(file_path)
-        mock_integration.side_effect = [f"{example_base_url}/{encoded_path}"]
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, qs_params={"file": file_path}
-        )
-        assert response.data["config"] == self.expected_configurations(code_mapping)
-        assert (
-            response.data["sourceUrl"]
-            == "https://example.com/getsentry/sentry/blob/master/src/sentry/api/projects/%5BprojectId%5D/event_id.py"
-        )
-
 
 class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):
     def setUp(self) -> None:

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 from unittest.mock import MagicMock, patch
+from urllib.parse import quote
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.models.integration import Integration
@@ -211,6 +212,31 @@ class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
         assert not response.data["sourceUrl"]
         assert response.data["error"] == "stack_root_mismatch"
         assert response.data["integrations"] == [serialized_integration(self.integration)]
+
+    @patch.object(ExampleIntegration, "get_stacktrace_link")
+    def test_file_with_square_brackets(self, mock_integration: MagicMock) -> None:
+        """
+        File paths with square brackets should be encoded in the source url
+        """
+        # Add a code mapping that matches the test file path
+        code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="src/sentry/",
+            source_root="",
+        )
+        file_path = "src/sentry/api/projects/[projectId]/event_id.py"
+        encoded_path = quote(file_path)
+        mock_integration.side_effect = [f"{example_base_url}/{encoded_path}"]
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, qs_params={"file": file_path}
+        )
+        assert response.data["config"] == self.expected_configurations(code_mapping)
+        assert (
+            response.data["sourceUrl"]
+            == "https://example.com/getsentry/sentry/blob/master/src/sentry/api/projects/%5BprojectId%5D/event_id.py"
+        )
 
 
 class ProjectStacktraceLinkTestMobile(BaseProjectStacktraceLink):

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
 from typing import Any
 from unittest.mock import MagicMock, patch
-from urllib.parse import quote
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.models.integration import Integration


### PR DESCRIPTION
Support nextjs style square brackets in paths `pages/posts/[id].js` properly encodes a valid url

fixes #82802
