### PR TITLE
feat(trace-view): update breadcrumbs for insights transaction summary

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -9,7 +9,10 @@ import type {
   RoutableModuleNames,
   URLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
-import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
+import {
+  DOMAIN_VIEW_BASE_TITLE,
+  DOMAIN_VIEW_BASE_URL,
+} from 'sentry/views/insights/pages/settings';
 import {DOMAIN_VIEW_TITLES} from 'sentry/views/insights/pages/types';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -36,6 +39,7 @@ export const enum TraceViewSources {
   MOBILE_SCREENS_MODULE = 'mobile_screens_module',
   SCREEN_RENDERING_MODULE = 'screen_rendering_module',
   PERFORMANCE_TRANSACTION_SUMMARY = 'performance_transaction_summary',
+  INSIGHTS_TRANSACTION_SUMMARY = 'insights_transaction_summary',
   ISSUE_DETAILS = 'issue_details',
   DASHBOARDS = 'dashboards',
   FEEDBACK_DETAILS = 'feedback_details',
@@ -89,13 +93,24 @@ function getPerformanceBreadCrumbs(
 ) {
   const crumbs: Crumb[] = [];
 
+  const hasPerfLandingRemovalFlag = organization.features.includes(
+    'insights-performance-landing-removal'
+  );
+
   const performanceUrl = getPerformanceBaseUrl(organization.slug, view, true);
   const transactionSummaryUrl = getTransactionSummaryBaseUrl(organization, view, true);
 
-  crumbs.push({
-    label: (view && DOMAIN_VIEW_TITLES[view]) || t('Performance'),
-    to: getBreadCrumbTarget(performanceUrl, location.query, organization),
-  });
+  if (!view && hasPerfLandingRemovalFlag) {
+    crumbs.push({
+      label: DOMAIN_VIEW_BASE_TITLE,
+      to: undefined,
+    });
+  } else {
+    crumbs.push({
+      label: (view && DOMAIN_VIEW_TITLES[view]) || t('Performance'),
+      to: getBreadCrumbTarget(performanceUrl, location.query, organization),
+    });
+  }
 
   switch (location.query.tab) {
     case Tab.EVENTS:
@@ -429,6 +444,7 @@ export function getTraceViewBreadcrumbs(
     case TraceViewSources.ISSUE_DETAILS:
       return getIssuesBreadCrumbs(organization, location);
     case TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY:
+    case TraceViewSources.INSIGHTS_TRANSACTION_SUMMARY:
       return getPerformanceBreadCrumbs(organization, location, view);
     default:
       return [{label: t('Trace View')}];

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -39,7 +39,6 @@ export const enum TraceViewSources {
   MOBILE_SCREENS_MODULE = 'mobile_screens_module',
   SCREEN_RENDERING_MODULE = 'screen_rendering_module',
   PERFORMANCE_TRANSACTION_SUMMARY = 'performance_transaction_summary',
-  INSIGHTS_TRANSACTION_SUMMARY = 'insights_transaction_summary',
   ISSUE_DETAILS = 'issue_details',
   DASHBOARDS = 'dashboards',
   FEEDBACK_DETAILS = 'feedback_details',
@@ -444,7 +443,6 @@ export function getTraceViewBreadcrumbs(
     case TraceViewSources.ISSUE_DETAILS:
       return getIssuesBreadCrumbs(organization, location);
     case TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY:
-    case TraceViewSources.INSIGHTS_TRANSACTION_SUMMARY:
       return getPerformanceBreadCrumbs(organization, location, view);
     default:
       return [{label: t('Trace View')}];

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -79,6 +79,37 @@ describe('TraceMetaDataHeader', () => {
       expect(breadcrumbsItems[0]).toHaveTextContent('Trace View');
     });
 
+    it('should show insights from transaction summary with feature', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/123',
+          query: {
+            source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY,
+            transaction: 'transaction-name',
+          },
+        })
+      );
+      const props = {...baseProps} as TraceMetadataHeaderProps;
+      organization.features.push('insights-performance-landing-removal');
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      const breadcrumbs = screen.getByTestId('breadcrumb-list');
+      const breadcrumbsLinks = screen.getAllByTestId('breadcrumb-link');
+      const breadcrumbsItems = screen.getAllByTestId('breadcrumb-item');
+
+      expect(breadcrumbs.childElementCount).toBe(5);
+
+      expect(breadcrumbsLinks).toHaveLength(1);
+      expect(breadcrumbsLinks[0]).toHaveTextContent('Transaction Summary');
+      expect(breadcrumbsLinks[0]).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/insights/summary?source=performance_transaction_summary&transaction=transaction-name'
+      );
+      expect(breadcrumbsItems).toHaveLength(2);
+      expect(breadcrumbsItems[0]).toHaveTextContent('Insights');
+      expect(breadcrumbsItems[1]).toHaveTextContent('Trace View');
+    });
+
     it('should render domain overview breadcrumbs', () => {
       useLocationMock.mockReturnValue(
         LocationFixture({

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -79,7 +79,7 @@ describe('TraceMetaDataHeader', () => {
       expect(breadcrumbsItems[0]).toHaveTextContent('Trace View');
     });
 
-    it('should show insights from transaction summary with feature', () => {
+    it('should show insights from transaction summary with perf removal feature', () => {
       useLocationMock.mockReturnValue(
         LocationFixture({
           pathname: '/organizations/org-slug/traces/trace/123',
@@ -108,6 +108,40 @@ describe('TraceMetaDataHeader', () => {
       expect(breadcrumbsItems).toHaveLength(2);
       expect(breadcrumbsItems[0]).toHaveTextContent('Insights');
       expect(breadcrumbsItems[1]).toHaveTextContent('Trace View');
+    });
+
+    it('should show performance from transaction summary', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/123',
+          query: {
+            source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY,
+            transaction: 'transaction-name',
+          },
+        })
+      );
+      const props = {...baseProps} as TraceMetadataHeaderProps;
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      const breadcrumbs = screen.getByTestId('breadcrumb-list');
+      const breadcrumbsLinks = screen.getAllByTestId('breadcrumb-link');
+      const breadcrumbsItems = screen.getAllByTestId('breadcrumb-item');
+
+      expect(breadcrumbs.childElementCount).toBe(5);
+
+      expect(breadcrumbsLinks).toHaveLength(2);
+      expect(breadcrumbsLinks[0]).toHaveTextContent('Performance');
+      expect(breadcrumbsLinks[0]).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance?source=performance_transaction_summary&transaction=transaction-name'
+      );
+      expect(breadcrumbsLinks[1]).toHaveTextContent('Transaction Summary');
+      expect(breadcrumbsLinks[1]).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/summary?source=performance_transaction_summary&transaction=transaction-name'
+      );
+      expect(breadcrumbsItems).toHaveLength(1);
+      expect(breadcrumbsItems[0]).toHaveTextContent('Trace View');
     });
 
     it('should render domain overview breadcrumbs', () => {


### PR DESCRIPTION
Work for #84021 

Updates the trace view breadcrumbs to show `Insights > Transaction Summary` when you navigate from the insights transaction summary. Note, we are sharing the same source for the performance transaction summary and the insights transaction summary because eventually the performance transaction summary will go away.