### PR TITLE
New Unreal changes

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2025-02-18.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2025-02-18.txt
@@ -433,3 +433,18 @@ module:io.netty.* -app
 module:newrelic -app -group
 path:**/*newrelic*/** -app -group
 path:**/*LogRocket*/** -app -group
+
+## Unreal Engine
+
+### Unreal Engine internal assertion handling
+family:native stack.function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group
+
+### Unreal Engine internal ensure handling
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group
+
+### UE SDK USentrySubsystem event capturing
+family:native stack.function:USentrySubsystem::CaptureMessage* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::CaptureEvent* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::CaptureEventWithScope* ^-app -app v+app ^-group -group v+group
+family:native stack.function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2025-02-18.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2025-02-18.txt
@@ -448,3 +448,5 @@ family:native stack.function:USentrySubsystem::CaptureMessageWithScope* ^-app -a
 family:native stack.function:USentrySubsystem::CaptureEvent* ^-app -app v+app ^-group -group v+group
 family:native stack.function:USentrySubsystem::CaptureEventWithScope* ^-app -app v+app ^-group -group v+group
 family:native stack.function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group
+family:native function:__start_thread -app
+family:native function:__pthread_start -app

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-18T19:51:37.411041+00:00'
+created: '2025-02-18T19:53:15.411191+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,75 +18,67 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
-    hash: "f203e9bc12df86bb01fbd92a45643f86"
+  app*
+    hash: "a424c136c24c189dd19058d8caec08ef"
     contributing component: exception
     component:
-      system*
+      app*
         exception*
           stacktrace*
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "__start_thread"
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "__pthread_start"
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "android_main"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "AndroidMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FEngineLoop::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UGameEngine::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UWorld::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "AActor::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessInternal"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::execCallMathFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame*
-              function*
-                "FDebug::CheckVerifyFailedImpl2"
-            frame*
-              function*
-                "FOutputDevice::LogfImpl"
-            frame*
-              function*
-                "FSentryOutputDeviceError::Serialize"
-            frame*
-              function*
-                "TMulticastDelegateBase<T>::Broadcast<T>"
-            frame*
-              function*
-                "tgkill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-18T19:53:15.411191+00:00'
+created: '2025-02-18T19:55:28.190364+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,16 +24,69 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "a424c136c24c189dd19058d8caec08ef"
+    hash: "8c134ce2a43a0b2c55654902491307c2"
     contributing component: exception
     component:
       app*
         exception*
           stacktrace*
             frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "android_main"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "AndroidMain"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "FEngineLoop::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UGameEngine::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UWorld::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "FLatentActionManager::ProcessLatentActions"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "FLatentActionManager::TickLatentActionForObject"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "AActor::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UObject::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UFunction::Invoke"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UObject::ProcessInternal"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UObject::execCallMathFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "USentryPlaygroundUtils::execTerminate"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "USentryPlaygroundUtils::Terminate"
+  system*
+    hash: "a424c136c24c189dd19058d8caec08ef"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          stacktrace*
+            frame* (marked out of app by stack trace rule (family:native function:__start_thread -app))
               function*
                 "__start_thread"
-            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+            frame* (marked out of app by stack trace rule (family:native function:__pthread_start -app))
               function*
                 "__pthread_start"
             frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-18T19:51:37.446912+00:00'
+created: '2025-02-18T19:53:15.443095+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,129 +18,134 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
-    hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
+  app*
+    hash: "cff120f7ae1959d21fdecb3c912eac7c"
     contributing component: exception
     component:
-      system*
+      app*
         exception*
           stacktrace*
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "RtlUserThreadStart"
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "BaseThreadInitThunk"
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              filename*
+                "exe_common.inl"
+              function*
+                "__scrt_common_main_seh"
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              filename*
+                "exe_common.inl"
+              function*
+                "invoke_main"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "WinMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "LaunchWindowsStartup"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "GuardedMainWrapper"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "GuardedMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FEngineLoop::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "DispatchMessageWorker"
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UserCallWinProcCheckWow"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "`TArray<T>::Remove'::`2'::<T>::operator()"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "SButton::OnMouseButtonUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "SButton::ExecuteOnClick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UButton::SlateHandleClicked"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessInternal"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalFunction"
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+              function*
+                "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessScriptFunction<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::execCallMathFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame*
-              function*
-                "FDebug::CheckVerifyFailedImpl2"
-            frame*
-              function*
-                "FDebug::AssertFailed"
-            frame*
-              function*
-                "FOutputDevice::LogfImpl"
-            frame*
-              filename*
-                "sentryoutputdeviceerror.cpp"
-              function*
-                "FSentryOutputDeviceError::Serialize"
-            frame*
-              function*
-                "FWindowsErrorOutputDevice::Serialize"
-            frame*
-              function*
-                "RaiseException"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-18T19:51:37.482688+00:00'
+created: '2025-02-18T19:53:15.477153+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,155 +18,136 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
-  system*
-    hash: "65244b22630821cacd0be603ebcef671"
+  app*
+    hash: "1c053a21627de524cfd7490ede00cfe7"
     contributing component: exception
     component:
-      system*
+      app*
         exception*
           stacktrace*
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              function*
+                "RtlUserThreadStart"
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              function*
+                "BaseThreadInitThunk"
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              filename*
+                "exe_common.inl"
+              function*
+                "__scrt_common_main_seh"
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              filename*
+                "exe_common.inl"
+              function*
+                "invoke_main"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "WinMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "LaunchWindowsStartup"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "GuardedMainWrapper"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "GuardedMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FEngineLoop::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "DispatchMessageWorker"
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              function*
+                "UserCallWinProcCheckWow"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              function*
+                "`TArray<T>::Remove'::`2'::<T>::operator()"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "SButton::OnMouseButtonUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "SButton::ExecuteOnClick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "UButton::SlateHandleClicked"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessInternal"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalFunction"
-            frame*
+            frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
+              function*
+                "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessScriptFunction<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::execCallMathFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame*
-              function*
-                "UE::Assert::Private::ExecCheckImplInternal"
-            frame*
-              function*
-                "CheckVerifyImpl"
-            frame*
-              function*
-                "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-            frame*
-              function*
-                "FDebug::EnsureFailed"
-            frame*
-              function*
-                "TMulticastDelegate<T>::Broadcast"
-            frame*
-              filename*
-                "delegateinstancesimpl.h"
-              function*
-                "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-            frame*
-              filename*
-                "tuple.h"
-              function*
-                "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-            frame*
-              filename*
-                "invoke.h"
-              function*
-                "Invoke"
-            frame*
-              filename*
-                "sentrysubsystemdesktop.cpp"
-              function*
-                "SentrySubsystemDesktop::CaptureEnsure"
-            frame*
-              function*
-                "sentry_value_set_stacktrace"
-            frame*
-              function*
-                "sentry_value_new_stacktrace"
-            frame*
-              function*
-                "sentry_unwind_stack_from_ucontext"
           type*
             "Ensure failed"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2025_02_18/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-18T19:51:37.516068+00:00'
+created: '2025-02-18T19:53:15.514884+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,96 +24,99 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "9e04decaf79ecba9dc0314dc0edd3993"
+    hash: "13f1f72e98ef8b2a197d8176d5e69d2e"
     contributing component: threads
     component:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
+              function*
+                "thread_start"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
+              function*
+                "_pthread_start"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
+              function*
+                "__NSThread__start__"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
+              function*
+                "ProcessLocalFunction::lambda::operator()"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
               function*
                 "UFunction::Invoke"
-            frame*
-              function*
-                "USentrySubsystem::execCaptureEventWithScope"
-            frame*
-              function*
-                "USentrySubsystem::CaptureEventWithScope"
-            frame*
-              function*
-                "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-17T13:44:03.340010+00:00'
+created: '2025-02-18T20:16:15.432147+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
           frame*
@@ -403,7 +403,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
@@ -1,19 +1,19 @@
 ---
-created: '2025-02-18T19:53:18.539610+00:00'
+created: '2025-02-18T19:55:31.288048+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a424c136c24c189dd19058d8caec08ef"
+  hash: "8c134ce2a43a0b2c55654902491307c2"
   contributing component: exception
   component:
     app*
       exception*
         stacktrace*
-          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame (marked out of app by stack trace rule (family:native function:__start_thread -app))
             function*
               "__start_thread"
-          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
           frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
@@ -84,16 +84,16 @@ app:
           "Trap"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "a424c136c24c189dd19058d8caec08ef"
+  contributing component: exception
   component:
-    system (exception of app takes precedence)
-      exception (ignored because hash matches app variant)
+    system*
+      exception*
         stacktrace*
-          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame* (marked out of app by stack trace rule (family:native function:__start_thread -app))
             function*
               "__start_thread"
-          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame* (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
           frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_assertion_check_fail_android.pysnap
@@ -1,161 +1,161 @@
 ---
-created: '2025-02-18T19:51:40.970658+00:00'
+created: '2025-02-18T19:53:18.539610+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
-  contributing component: null
+  hash: "a424c136c24c189dd19058d8caec08ef"
+  contributing component: exception
   component:
-    app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+    app*
+      exception*
+        stacktrace*
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "__start_thread"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "__pthread_start"
-          frame (non app frame)
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "android_main"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "AndroidMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UGameEngine::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UWorld::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "AActor::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessInternal"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execCallMathFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FOutputDevice::LogfImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "tgkill"
         type (ignored because exception is synthetic)
           "SIGTRAP"
-        value*
+        value (ignored because stacktrace takes precedence)
           "Trap"
 --------------------------------------------------------------------------
 system:
-  hash: "f203e9bc12df86bb01fbd92a45643f86"
-  contributing component: exception
+  hash: null
+  contributing component: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "__start_thread"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "__pthread_start"
-          frame
-          frame*
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "android_main"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "AndroidMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UGameEngine::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UWorld::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "AActor::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessInternal"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execCallMathFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FOutputDevice::LogfImpl"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "tgkill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,303 +1,303 @@
 ---
-created: '2025-02-18T19:51:40.998292+00:00'
+created: '2025-02-18T19:53:18.566759+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
-  contributing component: null
+  hash: "cff120f7ae1959d21fdecb3c912eac7c"
+  contributing component: exception
   component:
-    app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+    app*
+      exception*
+        stacktrace*
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "RtlUserThreadStart"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "BaseThreadInitThunk"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "WinMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "LaunchWindowsStartup"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMainWrapper"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "DispatchMessageWorker"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UserCallWinProcCheckWow"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::AppWndProc"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::DeferMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::OnMouseUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::OnMouseButtonUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::ExecuteOnClick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UButton::SlateHandleClicked"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessInternal"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessScriptFunction<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execCallMathFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::AssertFailed"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FOutputDevice::LogfImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "RaiseException"
         type (ignored because exception is synthetic)
           "unknown 0x00004000 / 0x7ff89574837a"
-        value* (stripped event-specific values)
+        value (ignored because stacktrace takes precedence)
           "Fatal Error: unknown <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
-  contributing component: exception
+  hash: null
+  contributing component: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "WinMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "LaunchWindowsStartup"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMainWrapper"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "DispatchMessageWorker"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UserCallWinProcCheckWow"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::AppWndProc"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::DeferMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::OnMouseUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::OnMouseButtonUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::ExecuteOnClick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UButton::SlateHandleClicked"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessInternal"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame* (un-ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessScriptFunction<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execCallMathFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::AssertFailed"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FOutputDevice::LogfImpl"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame*
+          frame (ignored by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app ^-group -group v+group))
             function*
               "RaiseException"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,361 +1,361 @@
 ---
-created: '2025-02-18T19:51:41.029609+00:00'
+created: '2025-02-18T19:53:18.597016+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
-  contributing component: null
+  hash: "1c053a21627de524cfd7490ede00cfe7"
+  contributing component: exception
   component:
-    app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+    app*
+      exception*
+        stacktrace*
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "RtlUserThreadStart"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "BaseThreadInitThunk"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "WinMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "LaunchWindowsStartup"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMainWrapper"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "DispatchMessageWorker"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UserCallWinProcCheckWow"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::AppWndProc"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::DeferMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::OnMouseUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::OnMouseButtonUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::ExecuteOnClick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UButton::SlateHandleClicked"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessInternal"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction"
-          frame (non app frame)
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessScriptFunction<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execCallMathFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "CheckVerifyImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::EnsureFailed"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "sentry_value_set_stacktrace"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "sentry_value_new_stacktrace"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "sentry_unwind_stack_from_ucontext"
         type*
           "Ensure failed"
-        value* (stripped event-specific values)
+        value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
 --------------------------------------------------------------------------
 system:
-  hash: "65244b22630821cacd0be603ebcef671"
-  contributing component: exception
+  hash: null
+  contributing component: null
   component:
-    system*
-      exception*
+    system (exception of app takes precedence)
+      exception (ignored because hash matches app variant)
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "RtlUserThreadStart"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "WinMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "LaunchWindowsStartup"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMainWrapper"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "DispatchMessageWorker"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UserCallWinProcCheckWow"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::AppWndProc"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::DeferMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::OnMouseUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::OnMouseButtonUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::ExecuteOnClick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UButton::SlateHandleClicked"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessInternal"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame* (un-ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessScriptFunction<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execCallMathFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "CheckVerifyImpl"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "FDebug::EnsureFailed"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "sentry_value_set_stacktrace"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "sentry_value_new_stacktrace"
-          frame*
+          frame (ignored by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app ^-group -group v+group))
             function*
               "sentry_unwind_stack_from_ucontext"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2025_02_18/unreal_event_capture_mac.pysnap
@@ -1,136 +1,136 @@
 ---
-created: '2025-02-18T19:51:41.058782+00:00'
+created: '2025-02-18T19:53:18.625488+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9e04decaf79ecba9dc0314dc0edd3993"
+  hash: "13f1f72e98ef8b2a197d8176d5e69d2e"
   contributing component: threads
   component:
     app*
       threads*
         stacktrace*
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "thread_start"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "_pthread_start"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame*
+          frame (non app frame)
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame (non app frame)
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -149,126 +149,126 @@ system:
     system (threads of app take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "thread_start"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "_pthread_start"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "UFunction::Invoke"
-          frame*
+          frame (ignored by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame (ignored by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app ^-group -group v+group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"


### PR DESCRIPTION
This PR introduces stack trace rules specific to Unreal Engine. Having these set by default will allow us to merge https://github.com/getsentry/sentry-unreal/pull/744 and resolve https://github.com/getsentry/sentry-unreal/issues/669.

Essentially, the suggested set of rules addresses grouping issues we encountered with assertion/ensure events. It also takes care of cutting off redundant call stack frames for regular events sent via the UE SDK interface.

Original rules by @tustanivsky .

Supersedes:
* https://github.com/getsentry/sentry/pull/83813