### PR TITLE
feat(uptime): Allow failure and recovery thresholds to be configured via options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2899,6 +2899,36 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# When in active monitoring mode, overrides how many failures in a row we need to see to mark the monitor as down
+register(
+    "uptime.active-failure-threshold",
+    type=Int,
+    default=3,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# When in active monitoring mode, how many successes in a row do we need to mark it as up
+register(
+    "uptime.active-recovery-threshold",
+    type=Int,
+    default=1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "uptime.date_cutoff_epoch_seconds",
+    type=Int,
+    default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "uptime.snuba_uptime_results.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
 register(
     "releases.no_snuba_for_release_creation",
     type=Bool,
@@ -3015,23 +3045,9 @@ register(
 )
 
 register(
-    "uptime.snuba_uptime_results.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "taskworker.grpc_service_config",
     type=String,
     default="""{"loadBalancingConfig": [{"round_robin": {}}]}""",
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "uptime.date_cutoff_epoch_seconds",
-    type=Int,
-    default=0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -95,8 +95,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             self.feature(["organizations:uptime", "organizations:uptime-create-issues"]),
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-                new=2,
+                "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+                return_value=2,
             ),
         ):
             self.send_result(result)
@@ -165,8 +165,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             self.feature(["organizations:uptime", "organizations:uptime-create-issues"]),
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-                new=2,
+                "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+                return_value=2,
             ),
         ):
             self.send_result(result)
@@ -209,8 +209,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             self.feature(["organizations:uptime", "organizations:uptime-create-issues"]),
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-                new=1,
+                "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+                return_value=1,
             ),
             override_options({"uptime.restrict-issue-creation-by-hosting-provider-id": ["TEST"]}),
         ):
@@ -341,8 +341,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with (
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-                new=1,
+                "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+                return_value=1,
             ),
         ):
             self.send_result(result)
@@ -373,8 +373,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             self.feature(["organizations:uptime", "organizations:uptime-create-issues"]),
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-                new=2,
+                "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+                return_value=2,
             ),
         ):
             self.send_result(

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -906,8 +906,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             self.feature(["organizations:uptime", "organizations:uptime-create-issues"]),
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-                new=2,
+                "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+                return_value=2,
             ),
             mock.patch(
                 "sentry.uptime.consumers.results_consumer.TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS",
@@ -986,11 +986,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
     @mock.patch("sentry.uptime.consumers.results_consumer._snuba_uptime_checks_producer.produce")
     @mock.patch(
-        "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
-        new=1,
+        "sentry.uptime.consumers.results_consumer.get_active_failure_threshold",
+        return_value=1,
     )
     @override_options({"uptime.snuba_uptime_results.enabled": True})
-    def test_produces_snuba_uptime_results_in_incident(self, mock_produce) -> None:
+    def test_produces_snuba_uptime_results_in_incident(self, _, mock_produce) -> None:
         """
         Validates that the consumer produces a message to Snuba's Kafka topic for uptime check results
         """


### PR DESCRIPTION
This gives us more options when we see a high failure rate
