### PR TITLE
ref: guard JEST_TESTS subprocess with CI

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -43,7 +43,7 @@ let JEST_TESTS;
 
 // prevents forkbomb as we don't want jest --listTests --json
 // to reexec itself here
-if (!process.env.JEST_LIST_TESTS_INNER) {
+if (CI && !process.env.JEST_LIST_TESTS_INNER) {
   try {
     const stdout = execFileSync('yarn', ['-s', 'jest', '--listTests', '--json'], {
       stdio: 'pipe',


### PR DESCRIPTION
f/u to https://github.com/getsentry/sentry/pull/85197, forgot to make it clear this should only be relevant to CI as this will noop locally but make jest calls in local dev slower due to the extra proc