### PR TITLE
feat(aci): register delayed workflow task to buffer round 2

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2851,6 +2851,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "delayed_workflow.rollout",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "celery_split_queue_task_rollout",
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/rules/processing/__init__.py
+++ b/src/sentry/rules/processing/__init__.py
@@ -1,0 +1,6 @@
+__all__ = [
+    "DelayedRule",
+    "apply_delayed",
+]
+
+from .delayed_processing import DelayedRule, apply_delayed

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -289,7 +289,7 @@ class TestRedisBuffer:
         redis_buffer_registry.callback(BufferHookEvent.FLUSH)
         assert mock.call_count == 1
 
-    @mock.patch("sentry.rules.processing.delayed_processing.metrics.timer")
+    @mock.patch("sentry.rules.processing.buffer_processing.metrics.timer")
     def test_callback(self, mock_metrics_timer):
         redis_buffer_registry.add_handler(BufferHookEvent.FLUSH, process_buffer)
         self.buf.process_batch()

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -10,7 +10,9 @@ from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.rules.conditions.event_frequency import ComparisonType
+from sentry.rules.processing.buffer_processing import process_in_batches
 from sentry.rules.processing.delayed_processing import fetch_project
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import json
@@ -35,6 +37,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     DataConditionGroupGroups,
     UniqueConditionQuery,
     bulk_fetch_events,
+    cleanup_redis_buffer,
     fetch_group_to_event_data,
     fetch_workflows_envs,
     fire_actions_for_groups,
@@ -769,3 +772,57 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.event2.for_group(self.group2),
             WorkflowDataConditionGroupType.ACTION_FILTER,
         )
+
+
+class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
+    def test_cleanup_redis(self):
+        self._push_base_events()
+
+        data = buffer.backend.get_hash(Workflow, {"project_id": self.project.id})
+        assert set(data.keys()) == self.workflow_group_dcg_mapping
+
+        cleanup_redis_buffer(self.project.id, data, None)
+        data = buffer.backend.get_hash(Workflow, {"project_id": self.project.id})
+        assert data == {}
+
+    @override_options({"delayed_processing.batch_size": 2})
+    @patch("sentry.workflow_engine.processors.delayed_workflow.process_delayed_workflows.delay")
+    def test_batched_cleanup(self, mock_process_delayed):
+        self._push_base_events()
+
+        process_in_batches(self.project.id, "delayed_workflow")
+        batch_one_key = mock_process_delayed.call_args_list[0][0][1]
+        batch_two_key = mock_process_delayed.call_args_list[1][0][1]
+
+        # Verify we removed the data from the buffer
+        data = buffer.backend.get_hash(Workflow, {"project_id": self.project.id})
+        assert data == {}
+
+        first_batch = {
+            f"{self.workflow1.id}:{self.group1.id}:{self.workflow1_dcgs[1].id}:{DataConditionHandlerType.ACTION_FILTER}": json.dumps(
+                {"event_id": self.event1.event_id, "occurrence_id": None}
+            ),
+            f"{self.workflow2.id}:{self.group2.id}:{self.workflow2_dcgs[0].id}:{DataConditionHandlerType.WORKFLOW_TRIGGER}": json.dumps(
+                {"event_id": self.event2.event_id, "occurrence_id": None}
+            ),
+        }
+        cleanup_redis_buffer(self.project.id, first_batch, batch_one_key)
+
+        # Verify the batch we "executed" is removed
+        data = buffer.backend.get_hash(
+            Workflow, {"project_id": self.project.id, "batch_key": batch_one_key}
+        )
+        assert data == {}
+
+        # Verify the batch we didn't execute is still in redis
+        data = buffer.backend.get_hash(
+            Workflow, {"project_id": self.project.id, "batch_key": batch_two_key}
+        )
+        assert data == {
+            f"{self.workflow1.id}:{self.group1.id}:{self.workflow1_dcgs[0].id}:{DataConditionHandlerType.WORKFLOW_TRIGGER}": json.dumps(
+                {"event_id": self.event1.event_id, "occurrence_id": None}
+            ),
+            f"{self.workflow2.id}:{self.group2.id}:{self.workflow2_dcgs[1].id}:{DataConditionHandlerType.ACTION_FILTER}": json.dumps(
+                {"event_id": self.event2.event_id, "occurrence_id": None}
+            ),
+        }


### PR DESCRIPTION
The previous one (https://github.com/getsentry/sentry/pull/85289) was failing master. Sometimes it passes locally, seems like the test is a little flakey so I fixed it to not be.