### PR TITLE
fix(issue-details): Fix edge case with tag preview 

### DIFF
--- a/static/app/views/issueDetails/streamline/issueTagsPreview.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.spec.tsx
@@ -2,7 +2,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import IssueTagsPreview from './issueTagsPreview';
 
@@ -40,5 +40,99 @@ describe('IssueTagsPreview', () => {
     expect(
       await screen.findByRole('button', {name: 'View issue tag distributions'})
     ).toBeInTheDocument();
+  });
+
+  it('renders tags edge case correctly with prefetching', async () => {
+    const group = GroupFixture();
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [
+        {
+          topValues: [
+            {
+              count: 2,
+              name: 'Chrome',
+              value: 'Chrome',
+              lastSeen: '2018-11-16T22:52:24Z',
+              key: 'browser',
+              firstSeen: '2018-05-06T03:48:28.855Z',
+            },
+            {
+              count: 1,
+              name: 'Firefox',
+              value: 'Firefox',
+              lastSeen: '2018-12-20T23:32:25Z',
+              key: 'browser',
+              firstSeen: '2018-12-20T23:32:43.811Z',
+            },
+          ],
+          name: 'Browser',
+          key: 'browser',
+          totalValues: 3,
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/browser/values/`,
+      body: [
+        {
+          count: 2,
+          name: 'Chrome',
+          value: 'Chrome',
+          lastSeen: '2018-11-16T22:52:24Z',
+          key: 'browser',
+          firstSeen: '2018-05-06T03:48:28.855Z',
+        },
+        {
+          count: 1,
+          name: 'Firefox',
+          value: 'Firefox',
+          lastSeen: '2018-12-20T23:32:25Z',
+          key: 'browser',
+          firstSeen: '2018-12-20T23:32:43.811Z',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/browser/`,
+      body: {
+        topValues: [
+          {
+            count: 2,
+            name: 'Chrome',
+            value: 'Chrome',
+            lastSeen: '2018-11-16T22:52:24Z',
+            key: 'browser',
+            firstSeen: '2018-05-06T03:48:28.855Z',
+          },
+          {
+            count: 1,
+            name: 'Firefox',
+            value: 'Firefox',
+            lastSeen: '2018-12-20T23:32:25Z',
+            key: 'browser',
+            firstSeen: '2018-12-20T23:32:43.811Z',
+          },
+        ],
+        name: 'Browser',
+        key: 'browser',
+        totalValues: 3,
+      },
+    });
+
+    render(
+      <IssueTagsPreview groupId={group.id} environments={[]} project={group.project} />
+    );
+
+    expect(await screen.findByText('Chrome')).toBeInTheDocument();
+    expect(await screen.findByText('66%')).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('Chrome'));
+    expect(await screen.findByText('Firefox')).toBeInTheDocument(); // tooltip description
+    expect(await screen.findByText('33%')).toBeInTheDocument();
+
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -102,9 +102,12 @@ function TagPreviewProgressBar({tag, groupId}: {groupId: string; tag: GroupTag})
   }
 
   const topPercentageString = getRoundedPercentage(topSegment.percentage);
-  const otherPercentage = segments.reduce((sum, s) => sum - s.percentage, 100);
-  const otherPercentageString =
-    otherPercentage === 0 ? null : getRoundedPercentage(otherPercentage);
+  const totalVisible = segments.reduce((sum, value) => sum + value.count, 0);
+  const hasOther = totalVisible < tag.totalValues;
+  const otherPercentage = Math.floor(
+    percent(tag.totalValues - totalVisible, tag.totalValues)
+  );
+  const otherPercentageString = getRoundedPercentage(otherPercentage);
 
   const tooltipContent = (
     <TooltipLegend>
@@ -121,7 +124,7 @@ function TagPreviewProgressBar({tag, groupId}: {groupId: string; tag: GroupTag})
             </LegendPercentage>
           </Fragment>
         ))}
-        {otherPercentageString && (
+        {hasOther && (
           <Fragment>
             <LegendColor style={{backgroundColor: theme.gray200}} />
             <LegendText>{t('Other')}</LegendText>


### PR DESCRIPTION
this pr fixes an edge case in the tag preview tooltip. Because we were using percentages to calculate other, if we ever had 33/66, it would think that there's 1% "other" when there wasn't. using values to determine the "other" should avoid this. 