### PR TITLE
feat(dashboards): Improve `TimeSeriesVisualization` X axis label selection and rendering

### DIFF
--- a/static/app/components/charts/components/xAxis.tsx
+++ b/static/app/components/charts/components/xAxis.tsx
@@ -34,7 +34,7 @@ function XAxis({
   addSecondsToTimeFormat = false,
   ...props
 }: XAxisProps): XAXisComponentOption {
-  function axisLabelFormatter(value: string | number, index: number): string | undefined {
+  const AxisLabelFormatter = (value: string | number, index: number) => {
     const firstItem = index === 0;
     // Always show the date of the first item. Otherwise check the interval duration
     const showDate = firstItem ? true : !computeShortInterval({start, end, period});
@@ -56,7 +56,7 @@ function XAxis({
     }
 
     return undefined;
-  }
+  };
 
   const defaults: XAXisComponentOption = {
     type: isGroupedByDate ? 'time' : 'category',
@@ -85,7 +85,7 @@ function XAxis({
       showMaxLabel: false,
       showMinLabel: false,
 
-      formatter: axisLabelFormatter as TimeAxisLabelFormatterOption,
+      formatter: AxisLabelFormatter as TimeAxisLabelFormatterOption,
     },
     axisPointer: {
       show: true,

--- a/static/app/components/charts/components/xAxis.tsx
+++ b/static/app/components/charts/components/xAxis.tsx
@@ -34,7 +34,7 @@ function XAxis({
   addSecondsToTimeFormat = false,
   ...props
 }: XAxisProps): XAXisComponentOption {
-  const AxisLabelFormatter = (value: string | number, index: number) => {
+  function axisLabelFormatter(value: string | number, index: number): string | undefined {
     const firstItem = index === 0;
     // Always show the date of the first item. Otherwise check the interval duration
     const showDate = firstItem ? true : !computeShortInterval({start, end, period});
@@ -56,7 +56,7 @@ function XAxis({
     }
 
     return undefined;
-  };
+  }
 
   const defaults: XAXisComponentOption = {
     type: isGroupedByDate ? 'time' : 'category',
@@ -85,7 +85,7 @@ function XAxis({
       showMaxLabel: false,
       showMinLabel: false,
 
-      formatter: AxisLabelFormatter as TimeAxisLabelFormatterOption,
+      formatter: axisLabelFormatter as TimeAxisLabelFormatterOption,
     },
     axisPointer: {
       show: true,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatXAxisTimestamp.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatXAxisTimestamp.spec.tsx
@@ -1,0 +1,30 @@
+import moment from 'moment-timezone';
+
+import {formatXAxisTimestamp} from './formatXAxisTimestamp';
+
+describe('formatXAxisTimestamp', () => {
+  it.each([
+    // Year starts
+    ['2025-01-01T00:00:00', 'Jan 1st 2025'],
+    ['2024-01-01T00:00:00', 'Jan 1st 2024'],
+    // // Month starts
+    ['2025-02-01T00:00:00', 'Feb 1st'],
+    ['2024-03-01T00:00:00', 'Mar 1st'],
+    // // Day starts
+    ['2025-02-05T00:00:00', 'Feb 5th'],
+    // // Hour starts
+    ['2025-02-05T12:00:00', '12:00 PM'],
+    ['2025-02-05T05:00:00', '5:00 AM'],
+    ['2025-02-01T01:00:00', '1:00 AM'],
+    // Minute starts
+    ['2025-02-05T12:11:00', '12:11 PM'],
+    ['2025-02-05T05:25:00', '5:25 AM'],
+    // Seconds
+    ['2025-02-05T12:10:05', '12:10:05 PM'],
+    ['2025-02-05T12:10:06', '12:10:06 PM'],
+    ['2025-02-05T05:25:10', '5:25:10 AM'],
+  ])('formats %s as %s', (raw, formatted) => {
+    const timestamp = moment(raw).unix() * 1000;
+    expect(formatXAxisTimestamp(timestamp)).toEqual(formatted);
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatXAxisTimestamp.tsx
@@ -1,0 +1,61 @@
+import moment from 'moment-timezone';
+
+/**
+ * A "cascading" formatter, based on the recommendations in [ECharts documentation](https://echarts.apache.org/en/option.html#xAxis.axisLabel.formatter). Given a timestamp of an X axis of type `"time"`, return a formatted string, to show under the axis tick.
+ *
+ * The fidelity of the formatted value depends on the fidelity of the tick mark timestamp. ECharts will intelligently choose the location of tick marks based on the total time range, and any significant intervals inside. It always chooses tick marks that fall on a "round" time values (starts of days, starts of hours, 15 minute intervals, etc.). This formatter is called on the time stamps of the selected ticks. Here are some examples of output labels sets you can expect:
+ *
+ * ["Feb 1st", "Feb 2nd", "Feb 3rd"] when ECharts aligns ticks with days of the month
+ * ["11:00pm", "Feb 2nd", "1:00am"] when ECharts aligns ticks with hours across a day boundary
+ * ["Mar 1st", "Apr 1st", "May 1st"] when ECharts aligns ticks with starts of month
+ * ["Dec 1st", "Jan 1st 2025", "Feb 1st"] when ECharts aligns markers with starts of month across a year boundary
+ * ["12:00pm", "1:00am", "2:00am", "3:00am"] when ECharts aligns ticks with hours starts
+ *
+ * @param value
+ * @param options
+ * @returns Formatted X axis label string
+ */
+export function formatXAxisTimestamp(
+  value: number,
+  options: {utc?: boolean} = {utc: false}
+): string {
+  const parsed = getParser(!options.utc)(value);
+
+  // Granularity-aware parsing, adjusts the format based on the
+  // granularity of the object This works well with ECharts since the
+  // parser is not aware of the other ticks
+  let format = 'MMM Do';
+
+  if (
+    parsed.dayOfYear() === 1 &&
+    parsed.hour() === 0 &&
+    parsed.minute() === 0 &&
+    parsed.second() === 0
+  ) {
+    // Start of a year
+    format = 'MMM Do YYYY';
+  } else if (
+    parsed.day() === 0 &&
+    parsed.hour() === 0 &&
+    parsed.minute() === 0 &&
+    parsed.second() === 0
+  ) {
+    // Start of a month
+    format = 'MMM Do';
+  } else if (parsed.hour() === 0 && parsed.minute() === 0 && parsed.second() === 0) {
+    // Start of a day
+    format = 'MMM Do';
+  } else if (parsed.second() === 0) {
+    // Hours, minutes
+    format = 'LT';
+  } else {
+    // Hours, minutes, seconds
+    format = 'LTS';
+  }
+
+  return parsed.format(format);
+}
+
+function getParser(local = false): typeof moment | typeof moment.utc {
+  return local ? moment : moment.utc;
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -39,6 +39,7 @@ import {CompleteLineChartWidgetSeries} from './seriesConstructors/completeLineCh
 import {IncompleteAreaChartWidgetSeries} from './seriesConstructors/incompleteAreaChartWidgetSeries';
 import {IncompleteLineChartWidgetSeries} from './seriesConstructors/incompleteLineChartWidgetSeries';
 import {formatTooltipValue} from './formatTooltipValue';
+import {formatXAxisTimestamp} from './formatXAxisTimestamp';
 import {formatYAxisValue} from './formatYAxisValue';
 import {markDelayedData} from './markDelayedData';
 import {ReleaseSeries} from './releaseSeries';
@@ -321,6 +322,10 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         axisLabel: {
           padding: [0, 10, 0, 10],
           width: 60,
+          formatter: (value: number) => {
+            const string = formatXAxisTimestamp(value, {utc: utc ?? undefined});
+            return string;
+          },
         },
         splitNumber: 5,
       }}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -283,7 +283,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         // https://github.com/apache/echarts/issues/15562
         left: 2,
         top: showLegend ? 25 : 10,
-        right: 4,
+        right: 8,
         bottom: 0,
         containLabel: true,
       }}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -324,7 +324,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           width: 60,
           formatter: (value: number) => {
             const string = formatXAxisTimestamp(value, {utc: utc ?? undefined});
-            return string;
+
+            // Adding whitespace around the label is equivalent to padding.
+            // ECharts doesn't respect padding when calculating overlaps, but it
+            // does respect whitespace. This prevents overlapping X axis labels
+            return ` ${string} `;
           },
         },
         splitNumber: 5,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -322,7 +322,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           padding: [0, 10, 0, 10],
           width: 60,
         },
-        splitNumber: 0,
+        splitNumber: 5,
       }}
       yAxis={{
         animation: false,


### PR DESCRIPTION
The current setup has a few downsides:

- too many tick labels. There are lots of labels, they're very busy and take up a lot of screen
- redundant labels. Every label has the time and date, even when looking at 60 days when the time isn't relevant

This PR uses a different approach, called a "cascading" formatter. The code explains in detail what's happening, but I think the results are better shown using screenshots.

The end result is nice single-line labels, no overlap, sparse axes, and simple behaviour.

**e.g.,**
![Screenshot 2025-02-18 at 4 51 33 PM](https://github.com/user-attachments/assets/8f5c7c5f-ce4e-4b4f-973c-95e1f38a7810)
![Screenshot 2025-02-18 at 4 51 43 PM](https://github.com/user-attachments/assets/6412ab6c-6ffc-4661-aa8b-89f67a985560)
![Screenshot 2025-02-18 at 4 51 51 PM](https://github.com/user-attachments/assets/c0b8420e-0784-4f54-88d7-553a43fe6d99)
![Screenshot 2025-02-18 at 4 51 57 PM](https://github.com/user-attachments/assets/a9d93024-4355-4d76-8d5d-66f4f2a3f071)
![Screenshot 2025-02-18 at 4 52 08 PM](https://github.com/user-attachments/assets/9ed1f6e9-a8b6-4b3e-90f1-6dc61f57312f)
![Screenshot 2025-02-18 at 4 52 49 PM](https://github.com/user-attachments/assets/db9ac726-361c-4cb7-a627-8464fc38bf46)
![Screenshot 2025-02-18 at 4 53 01 PM](https://github.com/user-attachments/assets/833bcd9d-ef5b-4a12-82bb-4a703ff0fdbe)
![Screenshot 2025-02-18 at 4 53 29 PM](https://github.com/user-attachments/assets/5ffd669c-7155-4951-957a-d3b1d0d1ed7b)

