### PR TITLE
feat(issue-views): Add Issue Views skeleton to left nav (feature flagged)

### DIFF
--- a/static/app/components/nav/issueViews/iconAllProjects.tsx
+++ b/static/app/components/nav/issueViews/iconAllProjects.tsx
@@ -1,0 +1,32 @@
+export function IconAllProjects() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+    >
+      <rect width="13" height="13" rx="2" fill="#E0DCE5" />
+      <rect
+        x="0.5"
+        y="0.5"
+        width="12"
+        height="12"
+        rx="1.5"
+        stroke="#3A115F"
+        strokeOpacity="0.14"
+      />
+      <rect x="4" y="4" width="13" height="13" rx="2" fill="#E0DCE5" />
+      <rect
+        x="4.5"
+        y="4.5"
+        width="12"
+        height="12"
+        rx="1.5"
+        stroke="#3A115F"
+        strokeOpacity="0.14"
+      />
+    </svg>
+  );
+}

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -1,0 +1,129 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {IconEllipsis, IconMegaphone} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+
+export function IssueViewNavEllipsisMenu({
+  sectionBodyRef,
+  setIsEditing,
+}: {
+  setIsEditing: (isEditing: boolean) => void;
+  sectionBodyRef?: React.RefObject<HTMLDivElement>;
+}) {
+  return (
+    <DropdownMenu
+      position="bottom-start"
+      trigger={props => (
+        <TriggerWrapper {...props} data-ellipsis-menu-trigger>
+          <InteractionStateLayer />
+          <IconEllipsis compact color="gray500" />
+          <UnsavedChangesIndicator
+            role="presentation"
+            data-test-id="unsaved-changes-indicator"
+          />
+        </TriggerWrapper>
+      )}
+      items={[
+        {
+          key: 'save-changes',
+          label: t('Save Changes'),
+          priority: 'primary',
+          onAction: () => {},
+        },
+        {
+          key: 'discard-changes',
+          label: t('Discard Changes'),
+          onAction: () => {},
+        },
+        {
+          key: 'rename-tab',
+          label: t('Rename'),
+          onAction: () => setIsEditing(true),
+        },
+        {
+          key: 'duplicate-tab',
+          label: t('Duplicate'),
+          onAction: () => {},
+        },
+        {
+          key: 'delete-tab',
+          label: t('Delete'),
+          priority: 'danger',
+          onAction: () => {},
+        },
+      ]}
+      onInteractOutside={() => true}
+      menuFooter={<FeedbackFooter />}
+      usePortal
+      portalContainerRef={sectionBodyRef}
+    />
+  );
+}
+
+function FeedbackFooter() {
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+
+  return (
+    <SectionedOverlayFooter>
+      <Button
+        size="xs"
+        icon={<IconMegaphone />}
+        onClick={() =>
+          openForm({
+            messagePlaceholder: t('How can we make custom views better for you?'),
+            tags: {
+              ['feedback.source']: 'custom_views',
+              ['feedback.owner']: 'issues',
+            },
+          })
+        }
+      >
+        {t('Give Feedback')}
+      </Button>
+    </SectionedOverlayFooter>
+  );
+}
+
+const TriggerWrapper = styled('div')`
+  position: relative;
+  width: 24px;
+  height: 20px;
+  border: 1px solid ${p => p.theme.gray200};
+  border-radius: ${p => p.theme.borderRadius};
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background-color: inherit;
+  opacity: inherit;
+  display: none;
+`;
+
+const SectionedOverlayFooter = styled('div')`
+  grid-area: footer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${space(1)};
+  border-top: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const UnsavedChangesIndicator = styled('div')`
+  border-radius: 50%;
+  background: ${p => p.theme.purple400};
+  border: solid 1px ${p => p.theme.background};
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  top: -3px;
+  right: -3px;
+  opacity: 1;
+`;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -1,0 +1,94 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import type {DraggableProps} from 'framer-motion';
+
+import {IssueViewNavEllipsisMenu} from 'sentry/components/nav/issueViews/issueViewNavEllipsisMenu';
+import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
+import IssueViewProjectIcons from 'sentry/components/nav/issueViews/issueViewProjectIcons';
+import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import EditableTabTitle from 'sentry/views/issueList/issueViews/editableTabTitle';
+import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+
+export interface IssueViewNavItemContentProps {
+  /**
+   * The issue view to display
+   */
+  view: IssueViewPF;
+  /**
+   * Ref that constrains where each nav item can be dragged.
+   */
+  dragConstraints?: DraggableProps['dragConstraints'];
+  /**
+   * Ref to the body of the section that contains the reorderable items.
+   * This is used as the portal container for the ellipsis menu.
+   */
+  sectionBodyRef?: React.RefObject<HTMLDivElement>;
+}
+
+export function IssueViewNavItemContent({
+  view,
+  dragConstraints,
+  sectionBodyRef,
+}: IssueViewNavItemContentProps) {
+  const organization = useOrganization();
+  const baseUrl = `/organizations/${organization.slug}/issues`;
+  const [isEditing, setIsEditing] = useState(false);
+
+  const {projects} = useProjects();
+
+  const projectPlatforms = projects
+    .filter(p => view.projects.map(String).includes(p.id))
+    .map(p => p.platform)
+    .filter(defined);
+
+  return (
+    <StyledSecondaryNavReordableItem
+      to={`${baseUrl}/?viewId=${view.id}`}
+      value={view}
+      leadingItems={<IssueViewProjectIcons projectPlatforms={projectPlatforms} />}
+      trailingItems={
+        <TrailingItemsWrapper>
+          <IssueViewNavQueryCount view={view} />
+          <IssueViewNavEllipsisMenu
+            sectionBodyRef={sectionBodyRef}
+            setIsEditing={setIsEditing}
+          />
+        </TrailingItemsWrapper>
+      }
+      dragConstraints={dragConstraints}
+    >
+      <EditableTabTitle
+        label={view.label}
+        isEditing={isEditing}
+        isSelected={false}
+        onChange={() => {}}
+        setIsEditing={setIsEditing}
+      />
+    </StyledSecondaryNavReordableItem>
+  );
+}
+
+const TrailingItemsWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
+
+const StyledSecondaryNavReordableItem = styled(SecondaryNav.ReordableItem)`
+  position: relative;
+  padding-right: ${space(0.5)};
+
+  :hover {
+    [data-ellipsis-menu-trigger] {
+      display: flex;
+    }
+  }
+
+  [data-ellipsis-menu-trigger][aria-expanded='true'] {
+    display: flex;
+  }
+`;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -86,9 +86,16 @@ const StyledSecondaryNavReordableItem = styled(SecondaryNav.ReordableItem)`
     [data-ellipsis-menu-trigger] {
       display: flex;
     }
+    [data-issue-view-query-count] {
+      display: none;
+    }
   }
 
   [data-ellipsis-menu-trigger][aria-expanded='true'] {
     display: flex;
+  }
+  &:has([data-ellipsis-menu-trigger][aria-expanded='true'])
+    [data-issue-view-query-count] {
+    display: none;
   }
 `;

--- a/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
@@ -79,6 +79,7 @@ export function IssueViewNavQueryCount({view}: IssueViewNavQueryCountProps) {
           ease: 'easeInOut',
         },
       }}
+      data-issue-view-query-count
     >
       <motion.span
         // Prevents count from fading in if it's already cached on mount

--- a/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
@@ -1,0 +1,108 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {space} from 'sentry/styles/space';
+import type {PageFilters} from 'sentry/types/core';
+import {getUtcDateString} from 'sentry/utils/dates';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
+
+const TAB_MAX_COUNT = 99;
+
+const constructCountTimeFrame = (
+  timeFilters: PageFilters['datetime']
+): {
+  end?: string;
+  start?: string;
+  statsPeriod?: string;
+} => {
+  if (timeFilters.period) {
+    return {statsPeriod: timeFilters.period};
+  }
+  return {
+    ...(timeFilters.start ? {start: getUtcDateString(timeFilters.start)} : {}),
+    ...(timeFilters.end ? {end: getUtcDateString(timeFilters.end)} : {}),
+    ...(timeFilters.utc ? {utc: timeFilters.utc} : {}),
+  };
+};
+
+interface IssueViewNavQueryCountProps {
+  view: IssueViewPF;
+}
+
+export function IssueViewNavQueryCount({view}: IssueViewNavQueryCountProps) {
+  const organization = useOrganization();
+  const theme = useTheme();
+
+  const {
+    data: queryCount,
+    isLoading,
+    isFetching,
+    isError,
+  } = useFetchIssueCounts({
+    orgSlug: organization.slug,
+    query: [view.unsavedChanges?.query ?? view.query],
+    project: view.unsavedChanges?.projects ?? view.projects,
+    environment: view.unsavedChanges?.environments ?? view.environments,
+    ...constructCountTimeFrame(view.unsavedChanges?.timeFilters ?? view.timeFilters),
+  });
+
+  // The endpoint's response type looks like this: { <query1>: <count>, <query2>: <count> }
+  // But this component only ever sends one query, so we can just get the count of the first key.
+  // This is a bit hacky, but it avoids having to use a state to store the previous query
+  // when the query changes and the new data is still being fetched.
+  const defaultQuery =
+    Object.keys(queryCount ?? {}).length > 0
+      ? Object.keys(queryCount ?? {})[0]
+      : undefined;
+  const count = isError
+    ? 0
+    : queryCount?.[view.unsavedChanges?.query ?? view.query] ??
+      queryCount?.[defaultQuery ?? ''] ??
+      0;
+
+  return (
+    <QueryCountBubble
+      layout="preserve-aspect"
+      animate={{
+        backgroundColor: isFetching
+          ? [theme.surface400, theme.surface100, theme.surface400]
+          : `#00000000`,
+      }}
+      transition={{
+        default: {
+          // Cuts animation short once the query has finished fetching
+          duration: isFetching ? 2 : 0,
+          repeat: isFetching ? Infinity : 0,
+          ease: 'easeInOut',
+        },
+      }}
+    >
+      <motion.span
+        // Prevents count from fading in if it's already cached on mount
+        initial={{opacity: isLoading ? 0 : 1}}
+        animate={{opacity: isFetching ? 0 : 1}}
+      >
+        {count > TAB_MAX_COUNT ? `${TAB_MAX_COUNT}+` : count}
+      </motion.span>
+    </QueryCountBubble>
+  );
+}
+
+const QueryCountBubble = styled(motion.span)`
+  line-height: 20px;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 0 ${space(0.5)};
+  min-width: 20px;
+  display: flex;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 1px solid ${p => p.theme.gray200};
+  color: ${p => p.theme.gray300};
+  margin-left: 0;
+  font-weight: ${p => p.theme.fontWeightBold};
+`;

--- a/static/app/components/nav/issueViews/issueViewProjectIcons.tsx
+++ b/static/app/components/nav/issueViews/issueViewProjectIcons.tsx
@@ -1,0 +1,91 @@
+import styled from '@emotion/styled';
+import PlatformIcon from 'platformicons/build/platformIcon';
+
+import {IconAllProjects} from 'sentry/components/nav/issueViews/iconAllProjects';
+import {space} from 'sentry/styles/space';
+
+interface IssueViewProjectIconsProps {
+  projectPlatforms: string[];
+}
+
+function IssueViewProjectIcons({projectPlatforms}: IssueViewProjectIconsProps) {
+  let renderedIcons: React.ReactNode;
+
+  switch (projectPlatforms.length) {
+    case 0:
+      renderedIcons = <IconAllProjects />;
+      break;
+    case 1:
+      renderedIcons = (
+        <IconContainer>
+          <StyledPlatformIcon platform={projectPlatforms[0]!} size={18} />
+          <BorderOverlay />
+        </IconContainer>
+      );
+      break;
+    default:
+      renderedIcons = (
+        <IconContainer>
+          {projectPlatforms.slice(0, 2).map((platform, index) => (
+            <PlatformIconWrapper key={platform} index={index}>
+              <StyledPlatformIcon platform={platform} size={14} />
+              <BorderOverlay />
+            </PlatformIconWrapper>
+          ))}
+        </IconContainer>
+      );
+  }
+
+  return <IconWrap>{renderedIcons}</IconWrap>;
+}
+
+const IconWrap = styled('div')`
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-right: ${space(0.5)};
+`;
+
+const IconContainer = styled('div')`
+  position: relative;
+  display: grid;
+  width: 18px;
+  height: 18px;
+`;
+
+const BorderOverlay = styled('div')`
+  position: absolute;
+  inset: 0;
+  border: 1px solid ${p => p.theme.translucentGray200};
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 1;
+`;
+
+const StyledPlatformIcon = styled(PlatformIcon)`
+  display: block;
+`;
+
+const PlatformIconWrapper = styled('div')<{index: number}>`
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  ${p =>
+    p.index === 0 &&
+    `
+    top: 0;
+    left: 0;
+    z-index: 1;
+  `}
+  ${p =>
+    p.index === 1 &&
+    `
+    bottom: 0;
+    right: 0;
+    z-index: 2;
+  `}
+`;
+
+export default IssueViewProjectIcons;

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -1,8 +1,10 @@
-import {type ReactNode, useLayoutEffect} from 'react';
+import {forwardRef, type ReactNode, useLayoutEffect} from 'react';
 import {createPortal} from 'react-dom';
 import type {To} from 'react-router-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import type {DraggableProps} from 'framer-motion';
+import {Reorder} from 'framer-motion';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link, {type LinkProps} from 'sentry/components/links/link';
@@ -30,6 +32,7 @@ interface SecondaryNavItemProps extends Omit<LinkProps, 'ref' | 'to'> {
    */
   end?: boolean;
   isActive?: boolean;
+  leadingItems?: ReactNode;
   trailingItems?: ReactNode;
 }
 
@@ -61,11 +64,17 @@ SecondaryNav.Header = function SecondaryNavHeader({children}: {children: ReactNo
   return <Header>{children}</Header>;
 };
 
-SecondaryNav.Body = function SecondaryNavBody({children}: {children: ReactNode}) {
-  const {layout} = useNavContext();
+SecondaryNav.Body = forwardRef<HTMLDivElement, {children: ReactNode}>(
+  ({children}, ref) => {
+    const {layout} = useNavContext();
 
-  return <Body layout={layout}>{children}</Body>;
-};
+    return (
+      <Body layout={layout} ref={ref}>
+        {children}
+      </Body>
+    );
+  }
+);
 
 SecondaryNav.Section = function SecondaryNavSection({
   title,
@@ -91,6 +100,7 @@ SecondaryNav.Item = function SecondaryNavItem({
   activeTo = to,
   isActive: incomingIsActive,
   end = false,
+  leadingItems,
   trailingItems,
   ...linkProps
 }: SecondaryNavItemProps) {
@@ -107,10 +117,57 @@ SecondaryNav.Item = function SecondaryNavItem({
       aria-selected={isActive}
       layout={layout}
     >
-      <InteractionStateLayer hasSelectedBackground={isActive} />
+      {leadingItems}
+      <InteractionStateLayer data-isl hasSelectedBackground={isActive} />
       <ItemText>{children}</ItemText>
       {trailingItems}
     </Item>
+  );
+};
+
+interface SecondaryNavReordableItemProps<T> extends SecondaryNavItemProps {
+  value: T;
+  dragConstraints?: DraggableProps['dragConstraints'];
+}
+
+// TODO(msun): Try to remove this and just make <Item/> more generalizable in the future.
+SecondaryNav.ReordableItem = function SecondaryNavReordableItem<T>({
+  children,
+  to,
+  activeTo = to,
+  isActive: incomingIsActive,
+  end = false,
+  trailingItems,
+  dragConstraints,
+  value,
+  leadingItems,
+  className,
+}: SecondaryNavReordableItemProps<T>) {
+  const location = useLocation();
+  const isActive = incomingIsActive || isLinkActive(activeTo, location.pathname, {end});
+
+  const {layout: navLayout} = useNavContext();
+
+  return (
+    <ReorderableItem
+      as="div"
+      dragConstraints={dragConstraints}
+      dragElastic={0.03}
+      dragTransition={{bounceStiffness: 400, bounceDamping: 40}}
+      value={value}
+      whileDrag={{
+        cursor: 'grabbing',
+      }}
+      navLayout={navLayout}
+      aria-current={isActive ? 'page' : undefined}
+      aria-selected={isActive}
+      className={className}
+    >
+      <InteractionStateLayer data-isl hasSelectedBackground={isActive} />
+      {leadingItems}
+      <ItemText>{children}</ItemText>
+      {trailingItems}
+    </ReorderableItem>
   );
 };
 
@@ -188,7 +245,7 @@ const Item = styled(Link)<{layout: NavLayout}>`
     color: inherit;
   }
 
-  ${InteractionStateLayer} {
+  [data-isl] {
     transform: translate(0, 0);
     top: 1px;
     bottom: 1px;
@@ -200,6 +257,47 @@ const Item = styled(Link)<{layout: NavLayout}>`
 
   ${p =>
     p.layout === NavLayout.MOBILE &&
+    css`
+      padding: 0 ${space(1.5)} 0 48px;
+      border-radius: 0;
+    `}
+`;
+
+// TODO(msun): These styles are duplicated from <Item/>. Remove these once we figure out a better abstraction for <Item/>
+const ReorderableItem = styled(Reorder.Item)<{navLayout: NavLayout}>`
+  position: relative;
+  display: flex;
+  padding: 4px ${space(1.5)};
+  height: 34px;
+  align-items: center;
+  color: inherit;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  line-height: 177.75%;
+  border-radius: ${p => p.theme.borderRadius};
+  cursor: pointer;
+
+  &[aria-selected='true'] {
+    color: ${p => p.theme.gray500};
+    font-weight: ${p => p.theme.fontWeightBold};
+  }
+
+  &:hover {
+    color: inherit;
+  }
+
+  [data-isl] {
+    transform: translate(0, 0);
+    top: 1px;
+    bottom: 1px;
+    right: 0;
+    left: 0;
+    width: initial;
+    height: initial;
+  }
+
+  ${p =>
+    p.navLayout === NavLayout.MOBILE &&
     css`
       padding: 0 ${space(1.5)} 0 48px;
       border-radius: 0;

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -87,27 +87,29 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
               {t('Feedback')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
-          <SecondaryNav.Section title={t('Views')}>
-            <Reorder.Group
-              as="div"
-              axis="y"
-              values={views ?? []}
-              onReorder={setViews}
-              initial={false}
-              ref={sectionRef}
-            >
-              {views &&
-                views.length > 0 &&
-                views.map(view => (
-                  <IssueViewNavItemContent
-                    key={view.id}
-                    view={view}
-                    dragConstraints={sectionRef}
-                    sectionBodyRef={bodyRef}
-                  />
-                ))}
-            </Reorder.Group>
-          </SecondaryNav.Section>
+          {hasIssueViewsInLeftNav && (
+            <SecondaryNav.Section title={t('Views')}>
+              <Reorder.Group
+                as="div"
+                axis="y"
+                values={views ?? []}
+                onReorder={setViews}
+                initial={false}
+                ref={sectionRef}
+              >
+                {views &&
+                  views.length > 0 &&
+                  views.map(view => (
+                    <IssueViewNavItemContent
+                      key={view.id}
+                      view={view}
+                      dragConstraints={sectionRef}
+                      sectionBodyRef={bodyRef}
+                    />
+                  ))}
+              </Reorder.Group>
+            </SecondaryNav.Section>
+          )}
         </SecondaryNav.Body>
         <SecondaryNav.Footer>
           <SecondaryNav.Item

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -1,10 +1,14 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
+import {Reorder} from 'framer-motion';
 
+import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 
 interface IssuesWrapperProps extends RouteComponentProps {
   children: React.ReactNode;
@@ -13,6 +17,56 @@ interface IssuesWrapperProps extends RouteComponentProps {
 export function IssueNavigation({children}: IssuesWrapperProps) {
   const organization = useOrganization();
   const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+  const hasIssueViewsInLeftNav = organization?.features.includes('left-nav-issue-views');
+
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [views, setViews] = useState<IssueViewPF[] | null>(null);
+
+  const {data: groupSearchViews} = useFetchGroupSearchViews(
+    {
+      orgSlug: organization.slug,
+    },
+    {
+      enabled: hasIssueViewsInLeftNav,
+    }
+  );
+
+  useEffect(() => {
+    if (groupSearchViews) {
+      setViews(
+        groupSearchViews?.map(
+          (
+            {
+              id,
+              name,
+              query: viewQuery,
+              querySort: viewQuerySort,
+              environments: viewEnvironments,
+              projects: viewProjects,
+              timeFilters: viewTimeFilters,
+              isAllProjects,
+            },
+            index
+          ): IssueViewPF => {
+            const tabId = id ?? `default${index.toString()}`;
+
+            return {
+              id: tabId,
+              key: tabId,
+              label: name,
+              query: viewQuery,
+              querySort: viewQuerySort,
+              environments: viewEnvironments,
+              projects: isAllProjects ? [-1] : viewProjects,
+              timeFilters: viewTimeFilters,
+              isCommitted: true,
+            };
+          }
+        )
+      );
+    }
+  }, [groupSearchViews]);
 
   if (!hasNavigationV2) {
     return children;
@@ -24,7 +78,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
     <Fragment>
       <SecondaryNav group={PrimaryNavGroup.ISSUES}>
         <SecondaryNav.Header>{t('Issues')}</SecondaryNav.Header>
-        <SecondaryNav.Body>
+        <SecondaryNav.Body ref={bodyRef}>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/`} end>
               {t('All')}
@@ -32,6 +86,27 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
             <SecondaryNav.Item to={`${baseUrl}/feedback/`}>
               {t('Feedback')}
             </SecondaryNav.Item>
+          </SecondaryNav.Section>
+          <SecondaryNav.Section title={t('Views')}>
+            <Reorder.Group
+              as="div"
+              axis="y"
+              values={views ?? []}
+              onReorder={setViews}
+              initial={false}
+              ref={sectionRef}
+            >
+              {views &&
+                views.length > 0 &&
+                views.map(view => (
+                  <IssueViewNavItemContent
+                    key={view.id}
+                    view={view}
+                    dragConstraints={sectionRef}
+                    sectionBodyRef={bodyRef}
+                  />
+                ))}
+            </Reorder.Group>
           </SecondaryNav.Section>
         </SecondaryNav.Body>
         <SecondaryNav.Footer>


### PR DESCRIPTION
Adds a skeleton of Issue Views to the left navigation. "Skeleton" meaning they are for visual purposes only. Thus: 

* Routing functionality does not work. Clicking on the views does nothing 
* None of the ellipsis menu options work (but the options do appear) 
* "Add View" has not been implemented 

This feature is gated by a [feature flag](https://github.com/getsentry/sentry-options-automator/pull/3163).

Things I'm thinking about next: 

* Testing... probably going to do this as part of adding the routing behavior 
* For some reason dragging an item doesn't bring it above the other items, even though this is supposed to work OOB with framer-motion. 
