### PR TITLE
fix(ui): Unblock cleanup old bootstrap process

### DIFF
--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -129,8 +129,8 @@ async function fetchProjectsAndTeams(
 export async function fetchOrganizationDetails(
   api: Client,
   slug: string,
-  silent: boolean,
-  usePreload?: boolean
+  silent = true,
+  usePreload = false
 ): Promise<void> {
   if (!silent) {
     OrganizationStore.reset();


### PR DESCRIPTION
Trying to remove these two arguments, but getsentry is using them. This makes them optional

Helps unblock #85392
