### PR TITLE
storybook: add flattened representation option

### DIFF
--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -933,13 +933,6 @@ const SECTIONS: TSection[] = [
         },
       },
       {
-        id: 'toggle',
-        groups: ['action'],
-        keywords: ['switch', 'form', 'disable', 'enable'],
-        name: 'Toggle',
-        defaultProps: {},
-      },
-      {
         id: 'fix',
         groups: ['action'],
         keywords: ['wrench', 'resolve'],
@@ -1362,6 +1355,13 @@ function Section({section}: {section: TSection}) {
           const name = icon.name.startsWith('Icon') ? icon.name : `Icon${icon.name}`;
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           const Component = Icons[name];
+
+          if (!Component) {
+            // The definition is not type safe, so lets log the icon instead of throwing an error
+            // eslint-disable-next-line no-console
+            console.log('Missing icon', name);
+            return null;
+          }
 
           const props = {color: 'gray500', size: 'sm', ...icon.defaultProps};
           return (

--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -143,9 +143,10 @@ function StoryRepresentationToggle(props: {
           {...triggerProps}
         />
       )}
+      defaultValue={props.storyRepresentation}
       options={[
-        {label: 'Category', value: 'category'},
         {label: 'Filesystem', value: 'filesystem'},
+        {label: 'Category', value: 'category'},
       ]}
       onChange={option => props.setStoryRepresentation(option.value)}
     />
@@ -176,6 +177,7 @@ const SidebarContainer = styled('div')`
   flex-direction: column;
   gap: ${space(2)};
   min-height: 0;
+  position: relative;
 `;
 
 const StoryTreeContainer = styled('div')`

--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -35,7 +35,10 @@ export default function Stories() {
   }, [files, location.query.name]);
 
   const story = useStoriesLoader({files: storyFiles});
-  const nodes = useStoryTree(files, location.query.query ?? '');
+  const nodes = useStoryTree(files, {
+    query: location.query.query ?? '',
+    representation: 'logical',
+  });
 
   const navigate = useNavigate();
   const onSearchInputChange = useCallback(


### PR DESCRIPTION
Add a toggle inside storybook search that enables representing these in generic buckets (components/styles/icons/views) as opposed to their direct file system representations. This can be helpful for getting an overview of the components in a flattened list and not having to deal with folder structure.

https://github.com/user-attachments/assets/710d289f-45c1-4f6b-8736-70f0394ef683

The values of the preference is stored in local storage so it persists. The UI needs some polishing works (persisting the sidebar expanded state and making the list smaller is something I'd like to tackle in the future). 
