### PR TITLE
:recycle: ref(discord): call message builder build in handlers instead of client

### DIFF
--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -49,7 +49,9 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
 
         def send_notification(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             rules = [f.rule for f in futures]
-            message = DiscordIssuesMessageBuilder(event.group, event=event, tags=tags, rules=rules)
+            message = DiscordIssuesMessageBuilder(
+                event.group, event=event, tags=tags, rules=rules
+            ).build(notification_uuid=notification_uuid)
 
             client = DiscordClient()
             with MessagingInteractionEvent(
@@ -58,7 +60,7 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
             ).capture() as lifecycle:
                 try:
                     lifecycle.add_extras({"integration_id": integration.id, "channel": channel_id})
-                    client.send_message(channel_id, message, notification_uuid=notification_uuid)
+                    client.send_message(channel_id, message)
                 except ApiError as error:
                     # Errors that we recieve from the Discord API
                     record_lifecycle_termination_level(lifecycle, error)

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -26,6 +26,7 @@ def send_incident_alert_notification(
     incident: Incident,
     metric_value: float,
     new_status: IncidentStatus,
+    notification_uuid: str | None = None,
 ) -> bool:
     chart_url = None
     if features.has("organizations:metric-alert-chartcuterie", incident.organization):
@@ -55,7 +56,7 @@ def send_incident_alert_notification(
         new_status=new_status,
         metric_value=metric_value,
         chart_url=chart_url,
-    )
+    ).build(notification_uuid=notification_uuid)
 
     client = DiscordClient()
     with MessagingInteractionEvent(

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -11,7 +11,6 @@ from rest_framework import status
 
 from sentry import options
 from sentry.integrations.client import ApiClient
-from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
 from sentry.integrations.discord.utils.consts import DISCORD_ERROR_CODES, DISCORD_USER_ERRORS
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -231,15 +230,13 @@ class DiscordClient(ApiClient):
         )
         self.logger.info("handled discord success", extra=log_params)
 
-    def send_message(
-        self, channel_id: str, message: DiscordMessageBuilder, notification_uuid: str | None = None
-    ) -> None:
+    def send_message(self, channel_id: str, message: dict[str, object]) -> None:
         """
         Send a message to the specified channel.
         """
         self.post(
             MESSAGE_URL.format(channel_id=channel_id),
-            data=message.build(notification_uuid=notification_uuid),
+            data=message,
             timeout=5,
             headers=self.prepare_auth_header(),
         )

--- a/src/sentry/integrations/discord/spec.py
+++ b/src/sentry/integrations/discord/spec.py
@@ -47,7 +47,9 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
             send_incident_alert_notification,
         )
 
-        return send_incident_alert_notification(action, incident, metric_value, new_status)
+        return send_incident_alert_notification(
+            action, incident, metric_value, new_status, notification_uuid
+        )
 
     @property
     def notify_service_action(self) -> type[IntegrationEventAction] | None:

--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -102,7 +102,7 @@ class DiscordActionHandlerTest(FireTest):
         handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.OPEN)
+            handler.fire(metric_value, IncidentStatus.WARNING)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)
 
@@ -117,7 +117,7 @@ class DiscordActionHandlerTest(FireTest):
         handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.OPEN)
+            handler.fire(metric_value, IncidentStatus.WARNING)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
 
@@ -135,7 +135,7 @@ class DiscordActionHandlerTest(FireTest):
         handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.OPEN)
+            handler.fire(metric_value, IncidentStatus.WARNING)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
 
@@ -150,6 +150,6 @@ class DiscordActionHandlerTest(FireTest):
         handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.OPEN)
+            handler.fire(metric_value, IncidentStatus.WARNING)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)

--- a/tests/sentry/integrations/discord/test_client.py
+++ b/tests/sentry/integrations/discord/test_client.py
@@ -158,7 +158,7 @@ class DiscordClientTest(TestCase):
         message = DiscordMessageBuilder(
             content="test",
             flags=DiscordMessageFlags().set_ephemeral(),
-        )
+        ).build(notification_uuid=None)
 
         self.discord_client.send_message(
             channel_id=channel_id,


### PR DESCRIPTION
found this during aci research.

the client should never care about the message builder class, it should just send the payload directly. this updates the handlers for discord to be more in line with slack, msteams, etc.

an added bonus with this change is we will actually get analytics for discord now as it was broken since we didn't pass `notification_uuid` correctly for metric alerts before.