### PR TITLE
fix(dashboard-edit): Restrict to only superuser and owner

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -6,7 +6,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import features, roles
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -28,6 +28,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.dashboard_examples import DashboardExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.fields.text import CharField
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
 from sentry.models.organization import Organization
@@ -49,8 +50,12 @@ class OrganizationDashboardsPermission(OrganizationPermission):
             return super().has_object_permission(request, view, obj)
 
         if isinstance(obj, Dashboard):
-            # allow for Managers and Owners
-            if request.access.has_scope("org:write"):
+            is_superuser = is_active_superuser(request)
+            # allow strictly for Owners and superusers, this allows them to delete dashboards
+            # of users that no longer have access to the organization
+            if is_superuser or request.access.has_role_in_organization(
+                role=roles.get_top_dog().id, organization=obj.organization, user_id=request.user.id
+            ):
                 return True
 
             # check if user is restricted from editing dashboard

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -2265,11 +2265,22 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             in response.content.decode()
         )
 
-    def test_manager_or_owner_can_update_dashboard_edit_perms(self):
+    def test_only_owner_can_update_dashboard_edit_perms(self):
         DashboardPermissions.objects.create(is_editable_by_everyone=False, dashboard=self.dashboard)
 
         user = self.create_user(id=28193)
         self.create_member(user=user, organization=self.organization, role="manager")
+        self.login_as(user)
+
+        response = self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={"permissions": {"is_editable_by_everyone": False}},
+        )
+        assert response.status_code == 403
+
+        user = self.create_user(id=28194)
+        self.create_member(user=user, organization=self.organization, role="owner")
         self.login_as(user)
 
         response = self.do_request(


### PR DESCRIPTION
There was a scenario where an owner who creates a restricted dashboard to themselves, could have their dashboard edited by a manager in the org who has lesser privilege. This restricts the edit permission to just the org owner in the case where a user no longer has access to the org and the dashboard needs to be updated.

Docs don't need to be updated because they already only refer to the owners and creators, no managers. https://docs.sentry.io/product/dashboards/custom-dashboards/#dashboard-edit-access
