### PR TITLE
chore(replays): Separate processing from IO and logging

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -225,10 +225,6 @@ def should_skip_billing(org_id: int, is_replay_video: bool) -> bool:
     return is_replay_video and org_id in options.get("replay.replay-video.billing-skip-org-ids")
 
 
-def replay_recording_segment_cache_id(project_id: int, replay_id: str, segment_id: str) -> str:
-    return f"{project_id}:{replay_id}:{segment_id}"
-
-
 def _report_size_metrics(
     size_compressed: int | None = None, size_uncompressed: int | None = None
 ) -> None:

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -115,6 +115,7 @@ def _ingest_recording(message_bytes: bytes) -> None:
 
     headers, compressed_segment = parse_headers(message.payload_with_headers, message.replay_id)
     compressed_segment, recording_segment = decompress_segment(compressed_segment)
+    _report_size_metrics(len(compressed_segment), len(recording_segment))
 
     # Normalize ingest data into a standardized ingest format.
     segment_data = RecordingSegmentStorageMeta(

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -373,6 +373,7 @@ def parse_recording_actions(
             message.replay_id,
             headers["segment_id"],
         )
+        return None
 
 
 @sentry_sdk.trace

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -8,6 +8,8 @@ from collections.abc import Generator
 from hashlib import md5
 from typing import Any, Literal, TypedDict
 
+import sentry_sdk
+
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.models.project import Project
@@ -77,11 +79,13 @@ def parse_and_emit_replay_actions(
             emit_replay_actions(message)
 
 
+@sentry_sdk.trace
 def emit_replay_actions(action: ReplayActionsEvent) -> None:
     publisher = _initialize_publisher()
     publisher.publish("ingest-replay-events", json.dumps(action))
 
 
+@sentry_sdk.trace
 def parse_replay_actions(
     project: Project,
     replay_id: str,


### PR DESCRIPTION
Separates processing, logging, and IO operations.  This will give us stronger categorization of our consumer's behavior and allow us to understand with greater detail the costs of processing and the costs of I/O and logging separately.

Tangentially, this separation of compute from I/O is an important first step for performance optimizations to the consumer.

Depends on https://github.com/getsentry/sentry/pull/85447