### PR TITLE
:bug: fix: allow superusers to install integrations

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 
 from sentry import features
 from sentry.api.serializers import serialize
+from sentry.auth.superuser import superuser_has_permission
 from sentry.constants import ObjectStatus
 from sentry.integrations.manager import default_manager
 from sentry.integrations.models.integration import Integration
@@ -99,8 +100,10 @@ class IntegrationPipeline(Pipeline):
             id=self.organization.id, user_id=self.request.user.id
         )
 
-        if org_context and (
-            not org_context.member or "org:integrations" not in org_context.member.scopes
+        if (
+            org_context
+            and (not org_context.member or "org:integrations" not in org_context.member.scopes)
+            and not superuser_has_permission(self.request, ["org:integrations"])
         ):
             error_message = (
                 "You must be an organization owner, manager or admin to install this integration."


### PR DESCRIPTION
in https://github.com/getsentry/sentry/pull/85345, we broke the ability for superusers to install an integration if they don't already have `org:integration` scope inside the org. 

though this is an edge case, we should make sure that superuser can complete superuser actions especially for support.