### PR TITLE
ref(dashboards): Remove duplicate `transformSessionsResponseToSeries` function

### DIFF
--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -6,11 +6,9 @@ import {doSessionsRequest} from 'sentry/actionCreators/sessions';
 import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
-import type {Series} from 'sentry/types/echarts';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import type {SessionsMeta} from 'sentry/types/sessions';
 import {SessionField} from 'sentry/types/sessions';
-import {defined} from 'sentry/utils';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {
@@ -26,7 +24,7 @@ import {FieldValueKind} from 'sentry/views/discover/table/types';
 import type {Widget, WidgetQuery} from '../types';
 import {DisplayType} from '../types';
 import {getWidgetInterval} from '../utils';
-import {getSeriesName} from '../utils/transformSessionsResponseToSeries';
+import {transformSessionsResponseToSeries} from '../utils/transformSessionsResponseToSeries';
 import {
   changeObjectValuesToTypes,
   getDerivedMetrics,
@@ -34,7 +32,6 @@ import {
 } from '../utils/transformSessionsResponseToTable';
 import {ReleaseSearchBar} from '../widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar';
 import {
-  DERIVED_STATUS_METRICS_PATTERN,
   DerivedStatusFields,
   DISABLED_SORT,
   FIELD_TO_METRICS_EXPRESSION,
@@ -44,7 +41,6 @@ import {
   TAG_SORT_DENY_LIST,
 } from '../widgetBuilder/releaseWidget/fields';
 import {
-  derivedMetricsToField,
   requiresCustomReleaseSorting,
   resolveDerivedStatusFields,
 } from '../widgetCard/releaseWidgetQueries';
@@ -305,85 +301,6 @@ export function transformSessionsResponseToTable(
     fields: changeObjectValuesToTypes(omit(singleRow, 'id')),
   };
   return {meta, data: rows};
-}
-
-export function transformSessionsResponseToSeries(
-  data: SessionApiResponse,
-  widgetQuery: WidgetQuery
-) {
-  if (data === null) {
-    return [];
-  }
-
-  const queryAlias = widgetQuery.name;
-
-  const useSessionAPI = widgetQuery.columns.includes('session.status');
-  const {derivedStatusFields: requestedStatusMetrics, injectedFields} =
-    resolveDerivedStatusFields(
-      widgetQuery.aggregates,
-      widgetQuery.orderby,
-      useSessionAPI
-    );
-
-  const results: Series[] = [];
-
-  if (!data.groups.length) {
-    return [
-      {
-        seriesName: `(${t('no results')})`,
-        data: data.intervals.map(interval => ({
-          name: interval,
-          value: 0,
-        })),
-      },
-    ];
-  }
-
-  data.groups.forEach(group => {
-    Object.keys(group.series).forEach(field => {
-      // if `sum(session)` or `count_unique(user)` are not
-      // requested as a part of the payload for
-      // derived status metrics through the Sessions API,
-      // they are injected into the payload and need to be
-      // stripped.
-      if (!injectedFields.includes(derivedMetricsToField(field))) {
-        results.push({
-          seriesName: getSeriesName(field, group, queryAlias),
-          data: data.intervals.map((interval, index) => ({
-            name: interval,
-            value: group.series[field]?.[index] ?? 0,
-          })),
-        });
-      }
-    });
-    // if session.status is a groupby, some post processing
-    // is needed to calculate the status derived metrics
-    // from grouped results of `sum(session)` or `count_unique(user)`
-    if (requestedStatusMetrics.length && defined(group.by['session.status'])) {
-      requestedStatusMetrics.forEach(status => {
-        const result = status.match(DERIVED_STATUS_METRICS_PATTERN);
-        if (result) {
-          let metricField: string | undefined = undefined;
-          if (group.by['session.status'] === result[1]) {
-            if (result[2] === 'session') {
-              metricField = 'sum(session)';
-            } else if (result[2] === 'user') {
-              metricField = 'count_unique(user)';
-            }
-          }
-          results.push({
-            seriesName: getSeriesName(status, group, queryAlias),
-            data: data.intervals.map((interval, index) => ({
-              name: interval,
-              value: metricField ? group.series[metricField]?.[index] ?? 0 : 0,
-            })),
-          });
-        }
-      });
-    }
-  });
-
-  return results;
 }
 
 function fieldsToDerivedMetrics(field: string): string {

--- a/static/app/views/dashboards/utils/transformSessionsResponseToSeries.spec.tsx
+++ b/static/app/views/dashboards/utils/transformSessionsResponseToSeries.spec.tsx
@@ -2,16 +2,21 @@ import {
   SessionEmptyGroupedResponseFixture,
   SessionUserCountByStatusByReleaseFixture,
 } from 'sentry-fixture/sessions';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {transformSessionsResponseToSeries} from 'sentry/views/dashboards/utils/transformSessionsResponseToSeries';
 
 describe('transformSessionsResponseToSeries', function () {
   it('transforms sessions into series', () => {
+    const widgetQuery = WidgetQueryFixture({
+      aggregates: [],
+      orderby: '',
+    });
+
     expect(
       transformSessionsResponseToSeries(
         SessionUserCountByStatusByReleaseFixture(),
-        [],
-        []
+        widgetQuery
       )
     ).toEqual([
       {
@@ -322,11 +327,14 @@ describe('transformSessionsResponseToSeries', function () {
   });
 
   it('adds derived status series', () => {
+    const widgetQuery = WidgetQueryFixture({
+      aggregates: ['count_crashed(session)'],
+      orderby: '',
+    });
     expect(
       transformSessionsResponseToSeries(
         SessionUserCountByStatusByReleaseFixture(),
-        ['count_crashed(session)'],
-        []
+        widgetQuery
       )
     ).toEqual([
       {
@@ -788,11 +796,14 @@ describe('transformSessionsResponseToSeries', function () {
     ]);
   });
   it('omits injected fields', () => {
+    const widgetQuery = WidgetQueryFixture({
+      aggregates: ['count_crashed(session)'],
+      orderby: 'sum(session)',
+    });
     expect(
       transformSessionsResponseToSeries(
         SessionUserCountByStatusByReleaseFixture(),
-        ['count_crashed(session)'],
-        ['sum(session)']
+        widgetQuery
       )
     ).toEqual([
       {
@@ -1103,8 +1114,12 @@ describe('transformSessionsResponseToSeries', function () {
   });
 
   it('returns a single series with 0 as values when there are no groups returned', () => {
+    const widgetQuery = WidgetQueryFixture({
+      aggregates: [],
+      orderby: '',
+    });
     expect(
-      transformSessionsResponseToSeries(SessionEmptyGroupedResponseFixture(), [], [])
+      transformSessionsResponseToSeries(SessionEmptyGroupedResponseFixture(), widgetQuery)
     ).toEqual([
       {
         seriesName: '(no results)',
@@ -1129,12 +1144,16 @@ describe('transformSessionsResponseToSeries', function () {
   });
 
   it('supports legend aliases', () => {
+    const widgetQuery = WidgetQueryFixture({
+      name: 'Lorem',
+      aggregates: [],
+      orderby: '',
+    });
+
     expect(
       transformSessionsResponseToSeries(
         SessionUserCountByStatusByReleaseFixture(),
-        [],
-        [],
-        'Lorem'
+        widgetQuery
       )[0]
     ).toEqual(
       expect.objectContaining({

--- a/static/app/views/dashboards/utils/transformSessionsResponseToSeries.tsx
+++ b/static/app/views/dashboards/utils/transformSessionsResponseToSeries.tsx
@@ -3,7 +3,7 @@ import type {Series} from 'sentry/types/echarts';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 
-import {WidgetQuery} from '../types';
+import type {WidgetQuery} from '../types';
 import {DERIVED_STATUS_METRICS_PATTERN} from '../widgetBuilder/releaseWidget/fields';
 import {
   derivedMetricsToField,

--- a/static/app/views/dashboards/utils/transformSessionsResponseToSeries.tsx
+++ b/static/app/views/dashboards/utils/transformSessionsResponseToSeries.tsx
@@ -3,8 +3,12 @@ import type {Series} from 'sentry/types/echarts';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 
+import {WidgetQuery} from '../types';
 import {DERIVED_STATUS_METRICS_PATTERN} from '../widgetBuilder/releaseWidget/fields';
-import {derivedMetricsToField} from '../widgetCard/releaseWidgetQueries';
+import {
+  derivedMetricsToField,
+  resolveDerivedStatusFields,
+} from '../widgetCard/releaseWidgetQueries';
 
 export function getSeriesName(
   field: string,
@@ -21,22 +25,30 @@ export function getSeriesName(
 }
 
 export function transformSessionsResponseToSeries(
-  response: SessionApiResponse | null,
-  requestedStatusMetrics: string[],
-  injectedFields: string[],
-  queryAlias?: string
-): Series[] {
-  if (response === null) {
+  data: SessionApiResponse,
+  widgetQuery: WidgetQuery
+) {
+  if (data === null) {
     return [];
   }
 
+  const queryAlias = widgetQuery.name;
+
+  const useSessionAPI = widgetQuery.columns.includes('session.status');
+  const {derivedStatusFields: requestedStatusMetrics, injectedFields} =
+    resolveDerivedStatusFields(
+      widgetQuery.aggregates,
+      widgetQuery.orderby,
+      useSessionAPI
+    );
+
   const results: Series[] = [];
 
-  if (!response.groups.length) {
+  if (!data.groups.length) {
     return [
       {
         seriesName: `(${t('no results')})`,
-        data: response.intervals.map(interval => ({
+        data: data.intervals.map(interval => ({
           name: interval,
           value: 0,
         })),
@@ -44,7 +56,7 @@ export function transformSessionsResponseToSeries(
     ];
   }
 
-  response.groups.forEach(group => {
+  data.groups.forEach(group => {
     Object.keys(group.series).forEach(field => {
       // if `sum(session)` or `count_unique(user)` are not
       // requested as a part of the payload for
@@ -54,7 +66,7 @@ export function transformSessionsResponseToSeries(
       if (!injectedFields.includes(derivedMetricsToField(field))) {
         results.push({
           seriesName: getSeriesName(field, group, queryAlias),
-          data: response.intervals.map((interval, index) => ({
+          data: data.intervals.map((interval, index) => ({
             name: interval,
             value: group.series[field]?.[index] ?? 0,
           })),
@@ -78,7 +90,7 @@ export function transformSessionsResponseToSeries(
           }
           results.push({
             seriesName: getSeriesName(status, group, queryAlias),
-            data: response.intervals.map((interval, index) => ({
+            data: data.intervals.map((interval, index) => ({
               name: interval,
               value: metricField ? group.series[metricField]?.[index] ?? 0 : 0,
             })),


### PR DESCRIPTION
There are two! There's one `transformSessionsResponseToSeries` in `releases.tsx` and another one in its own file. The one in its own file has specs, but isn't in use. It's also _exactly the same_ as the one in `releases.tsx`, just accepts parameters a little differently.

I'm taking the one in `releases.tsx` and moving it into its own file, and updating the specs to pass parameters the same way as before.
