### PR TITLE
chore(explore): Do not send nulls for analytics

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -1,4 +1,3 @@
-import type {Confidence} from 'sentry/types/organization';
 import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import type {TraceWaterFallSource} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import type {TraceDrawerActionKind} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
@@ -10,7 +9,7 @@ export type TracingEventParameters = {
   'trace.explorer.metadata': {
     columns: string[];
     columns_count: number;
-    confidences: Confidence[];
+    confidences: string[];
     dataset: string;
     has_exceeded_performance_usage_limit: boolean | null;
     query_status: 'success' | 'error' | 'pending';

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -202,6 +202,6 @@ function computeConfidence(
   return visualizes.map(visualize => {
     const dedupedYAxes = dedupeArray(visualize.yAxes);
     const series = dedupedYAxes.flatMap(yAxis => data[yAxis]).filter(defined);
-    return combineConfidenceForSeries(series);
+    return String(combineConfidenceForSeries(series));
   });
 }


### PR DESCRIPTION
We suspect amplitude may be filter out nulls from arrays.