### PR TITLE
fix(query-builder): Add middle ellipsis to long filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
@@ -18,6 +18,7 @@ import type {
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 
 type FilterKeyProps = {
   item: Node<ParseResultToken>;
@@ -68,7 +69,8 @@ export function FilterKey({item, state, token, onActiveChange}: FilterKeyProps) 
       {...filterButtonProps}
     >
       <InteractionStateLayer />
-      {token.key.text}
+      {/* Filter keys have no expected format, so we attempt to split by whitespace, dash, colon, and underscores. */}
+      {middleEllipsis(getKeyName(token.key), 40, /[\s-_:]/)}
     </KeyButton>
   );
 }


### PR DESCRIPTION
Before:

![CleanShot 2025-02-19 at 10 36 34](https://github.com/user-attachments/assets/aad2b97f-5bf4-4d20-9e38-e47da6a22544)

After:

![CleanShot 2025-02-19 at 10 37 12](https://github.com/user-attachments/assets/2c814890-8aa1-4d40-95b1-8fff3d6cac1b)
