### PR TITLE
ref(flags): add view n more flags button to issue details section

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -13,6 +13,8 @@ import {EventFeatureFlagList} from 'sentry/components/events/featureFlags/eventF
 import {
   EMPTY_STATE_SECTION_PROPS,
   MOCK_DATA_SECTION_PROPS,
+  MOCK_DATA_SECTION_PROPS_MANY_FLAGS,
+  MOCK_DATA_SECTION_PROPS_ONE_EXTRA_FLAG,
   MOCK_FLAGS,
   NO_FLAG_CONTEXT_SECTION_PROPS_CTA,
   NO_FLAG_CONTEXT_SECTION_PROPS_NO_CTA,
@@ -55,17 +57,17 @@ describe('EventFeatureFlagList', function () {
       body: TagsFixture(),
     });
   });
-  it('renders a list of feature flags with a button to view all', async function () {
-    render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
+  it('renders a list of feature flags with a button to view more flags', async function () {
+    render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS_ONE_EXTRA_FLAG} />);
 
     for (const {flag, result} of MOCK_FLAGS) {
       if (result) {
-        expect(screen.getByText(flag)).toBeInTheDocument();
+        expect(screen.getAllByText(flag)[0]).toBeInTheDocument();
       }
     }
 
     // When expanded, all should be visible
-    const viewAllButton = screen.getByRole('button', {name: 'View All'});
+    const viewAllButton = screen.getByRole('button', {name: 'View 1 More Flag'});
     await userEvent.click(viewAllButton);
     const drawer = screen.getByRole('complementary', {name: 'Feature flags drawer'});
     expect(drawer).toBeInTheDocument();
@@ -76,9 +78,9 @@ describe('EventFeatureFlagList', function () {
     }
   });
 
-  it('toggles the drawer when view all is clicked', async function () {
-    render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
-    const viewAllButton = screen.getByRole('button', {name: 'View All'});
+  it('toggles the drawer when `view n flags` is clicked', async function () {
+    render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS_MANY_FLAGS} />);
+    const viewAllButton = screen.getByRole('button', {name: 'View 4 More Flags'});
     await userEvent.click(viewAllButton);
     const drawer = screen.getByRole('complementary', {name: 'Feature flags drawer'});
     expect(drawer).toBeInTheDocument();

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -80,7 +80,7 @@ describe('EventFeatureFlagList', function () {
 
   it('toggles the drawer when `view n flags` is clicked', async function () {
     render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS_MANY_FLAGS} />);
-    const viewAllButton = screen.getByRole('button', {name: 'View 4 More Flags'});
+    const viewAllButton = screen.getByRole('button', {name: 'View 3 More Flags'});
     await userEvent.click(viewAllButton);
     const drawer = screen.getByRole('complementary', {name: 'Feature flags drawer'});
     expect(drawer).toBeInTheDocument();

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -236,15 +236,20 @@ export function EventFeatureFlagList({
     </ButtonBar>
   );
 
+  const NUM_PREVIEW_FLAGS = 20;
+
   // Split the flags list into two columns for display
-  const truncatedItems = sortedFlags({flags: hydratedFlags, sort: orderBy}).slice(0, 20);
-  const columnOne = truncatedItems.slice(0, 10);
+  const truncatedItems = sortedFlags({flags: hydratedFlags, sort: orderBy}).slice(
+    0,
+    NUM_PREVIEW_FLAGS
+  );
+  const columnOne = truncatedItems.slice(0, NUM_PREVIEW_FLAGS / 2);
   let columnTwo: typeof truncatedItems = [];
-  if (truncatedItems.length > 10) {
-    columnTwo = truncatedItems.slice(10, 20);
+  if (truncatedItems.length > NUM_PREVIEW_FLAGS / 2) {
+    columnTwo = truncatedItems.slice(NUM_PREVIEW_FLAGS / 2, NUM_PREVIEW_FLAGS);
   }
 
-  const extraFlags = hydratedFlags.length - 20;
+  const extraFlags = hydratedFlags.length - NUM_PREVIEW_FLAGS;
   const label =
     extraFlags === 1 ? t('View 1 More Flag') : t('View %d More Flags', extraFlags);
 

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -20,8 +20,9 @@ import {
 import useDrawer from 'sentry/components/globalDrawer';
 import KeyValueData from 'sentry/components/keyValueData';
 import {featureFlagOnboardingPlatforms} from 'sentry/data/platformCategories';
-import {IconMegaphone, IconSearch} from 'sentry/icons';
+import {IconEllipsis, IconMegaphone, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Event, FeatureFlag} from 'sentry/types/event';
 import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
@@ -217,21 +218,6 @@ export function EventFeatureFlagList({
         {hasFlags && (
           <Fragment>
             <Button
-              size="xs"
-              aria-label={t('View All')}
-              ref={viewAllButtonRef}
-              title={t('View All Flags')}
-              onClick={() => {
-                if (isDrawerOpen) {
-                  closeDrawer();
-                } else {
-                  onViewAllFlags();
-                }
-              }}
-            >
-              {t('View All')}
-            </Button>
-            <Button
               aria-label={t('Open Feature Flag Search')}
               icon={<IconSearch size="xs" />}
               size="xs"
@@ -278,6 +264,23 @@ export function EventFeatureFlagList({
           {t('No feature flags were found for this event')}
         </StyledEmptyStateWarning>
       )}
+      {hydratedFlags.length > 20 && (
+        <ViewAllContainer>
+          <VerticalEllipsis />
+          <div>
+            <ViewAllButton
+              size="sm"
+              // Since we've disabled the button as an 'outside click' for the drawer we can change
+              // the operation based on the drawer state.
+              onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllFlags())}
+              aria-label={t('View All Breadcrumbs')}
+              ref={viewAllButtonRef}
+            >
+              {t('View %d More Flags', hydratedFlags.length - 20)}
+            </ViewAllButton>
+          </div>
+        </ViewAllContainer>
+      )}
     </InterimSection>
   );
 }
@@ -297,4 +300,30 @@ const StyledEmptyStateWarning = styled(EmptyStateWarning)`
   display: flex;
   flex-direction: column;
   align-items: center;
+`;
+
+const ViewAllContainer = styled('div')`
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  &::after {
+    content: '';
+    position: absolute;
+    left: 10.5px;
+    width: 1px;
+    top: -${space(1)};
+    height: ${space(1)};
+    background: ${p => p.theme.border};
+  }
+`;
+
+const VerticalEllipsis = styled(IconEllipsis)`
+  height: 22px;
+  color: ${p => p.theme.subText};
+  margin: ${space(0.5)};
+  transform: rotate(90deg);
+`;
+
+const ViewAllButton = styled(Button)`
+  padding: ${space(0.75)} ${space(1)};
 `;

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -244,6 +244,10 @@ export function EventFeatureFlagList({
     columnTwo = truncatedItems.slice(10, 20);
   }
 
+  const extraFlags = hydratedFlags.length - 20;
+  const label =
+    extraFlags === 1 ? t('View 1 More Flag') : t('View %d More Flags', extraFlags);
+
   return (
     <InterimSection
       help={t(
@@ -264,7 +268,7 @@ export function EventFeatureFlagList({
           {t('No feature flags were found for this event')}
         </StyledEmptyStateWarning>
       )}
-      {hydratedFlags.length > 20 && (
+      {extraFlags > 0 && (
         <ViewAllContainer>
           <VerticalEllipsis />
           <div>
@@ -273,10 +277,10 @@ export function EventFeatureFlagList({
               // Since we've disabled the button as an 'outside click' for the drawer we can change
               // the operation based on the drawer state.
               onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllFlags())}
-              aria-label={t('View All Breadcrumbs')}
+              aria-label={label}
               ref={viewAllButtonRef}
             >
-              {t('View %d More Flags', hydratedFlags.length - 20)}
+              {label}
             </ViewAllButton>
           </div>
         </ViewAllContainer>

--- a/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 import {EventFeatureFlagList} from 'sentry/components/events/featureFlags/eventFeatureFlagList';
 import {
   MOCK_DATA_SECTION_PROPS,
+  MOCK_DATA_SECTION_PROPS_ONE_EXTRA_FLAG,
   MOCK_FLAGS,
 } from 'sentry/components/events/featureFlags/testUtils';
 
@@ -23,8 +24,8 @@ async function renderFlagDrawer() {
       bottom: 0,
       toJSON: jest.fn(),
     }));
-  render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
-  await userEvent.click(screen.getByRole('button', {name: 'View All'}));
+  render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS_ONE_EXTRA_FLAG} />);
+  await userEvent.click(screen.getByRole('button', {name: 'View 1 More Flag'}));
   return screen.getByRole('complementary', {name: 'Feature flags drawer'});
 }
 

--- a/static/app/components/events/featureFlags/testUtils.tsx
+++ b/static/app/components/events/featureFlags/testUtils.tsx
@@ -32,6 +32,24 @@ export const MOCK_DATA_SECTION_PROPS = {
   group: GroupFixture(),
 };
 
+export const MOCK_DATA_SECTION_PROPS_MANY_FLAGS = {
+  event: EventFixture({
+    id: 'abc123def456ghi789jkl',
+    contexts: {flags: {values: Array(6).fill(MOCK_FLAGS).flat()}},
+  }),
+  project: ProjectFixture(),
+  group: GroupFixture(),
+};
+
+export const MOCK_DATA_SECTION_PROPS_ONE_EXTRA_FLAG = {
+  event: EventFixture({
+    id: 'abc123def456ghi789jkl',
+    contexts: {flags: {values: Array(6).fill(MOCK_FLAGS).flat().splice(0, 21)}},
+  }),
+  project: ProjectFixture(),
+  group: GroupFixture(),
+};
+
 export const EMPTY_STATE_SECTION_PROPS = {
   event: EventFixture({
     id: 'abc123def456ghi789jkl',

--- a/static/app/components/events/featureFlags/testUtils.tsx
+++ b/static/app/components/events/featureFlags/testUtils.tsx
@@ -23,6 +23,101 @@ export const MOCK_FLAGS: Array<Required<FeatureFlag>> = [
   },
 ];
 
+export const MOCK_FLAGS_MANY: Array<Required<FeatureFlag>> = [
+  {
+    flag: 'mobile-replay-ui',
+    result: false,
+  },
+  {
+    flag: 'web-vitals-ui',
+    result: true,
+  },
+  {
+    flag: 'enable-replay',
+    result: true,
+  },
+  {
+    flag: 'secret-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+  {
+    flag: 'test-feature',
+    result: false,
+  },
+];
+
 export const MOCK_DATA_SECTION_PROPS = {
   event: EventFixture({
     id: 'abc123def456ghi789jkl',
@@ -35,7 +130,7 @@ export const MOCK_DATA_SECTION_PROPS = {
 export const MOCK_DATA_SECTION_PROPS_MANY_FLAGS = {
   event: EventFixture({
     id: 'abc123def456ghi789jkl',
-    contexts: {flags: {values: Array(6).fill(MOCK_FLAGS).flat()}},
+    contexts: {flags: {values: MOCK_FLAGS_MANY}},
   }),
   project: ProjectFixture(),
   group: GroupFixture(),
@@ -44,7 +139,7 @@ export const MOCK_DATA_SECTION_PROPS_MANY_FLAGS = {
 export const MOCK_DATA_SECTION_PROPS_ONE_EXTRA_FLAG = {
   event: EventFixture({
     id: 'abc123def456ghi789jkl',
-    contexts: {flags: {values: Array(6).fill(MOCK_FLAGS).flat().splice(0, 21)}},
+    contexts: {flags: {values: MOCK_FLAGS_MANY.slice(0, 21)}},
   }),
   project: ProjectFixture(),
   group: GroupFixture(),


### PR DESCRIPTION
the button opens up the drawer - same behavior as before, but the old "view all" button is removed from the action header.

<img width="995" alt="SCR-20250219-jylo" src="https://github.com/user-attachments/assets/1fb26acd-2f7f-44a1-8f18-c4a3bd90eebc" />

only shows up if there are actually more flags to view.

<img width="1036" alt="SCR-20250219-kagu" src="https://github.com/user-attachments/assets/576d1f2f-69e4-4aac-b7a3-ed26efc7916d" />


similar to the breadcrumbs section in issue details:

<img width="538" alt="SCR-20250219-jyrn" src="https://github.com/user-attachments/assets/f705cc7f-9042-478f-97f0-8e6355a4b556" />

closes https://github.com/getsentry/team-replay/issues/546