### PR TITLE
feat(widget-builder): Add progressive selection for aggregates

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -274,7 +274,7 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
     await userEvent.click(screen.getByRole('option', {name: 'field (no aggregate)'}));
 
-    await userEvent.click(screen.getByRole('button', {name: 'Column Selection'}));
+    // The column selection is automatically opened for aggregates
     await userEvent.click(screen.getByRole('option', {name: 'transaction.duration'}));
 
     expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
@@ -283,6 +283,35 @@ describe('Visualize', () => {
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
       'field (no aggregate)'
     );
+  });
+
+  it('automatically opens the column selection for aggregates', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              field: ['count()'],
+              dataset: WidgetType.TRANSACTIONS,
+              displayType: DisplayType.TABLE,
+            },
+          }),
+        }),
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'p50'}));
+
+    // Indicate that the column selection is open, and multiple options are available
+    expect(
+      screen.getByRole('option', {name: 'transaction.duration'})
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('option').length).toBeGreaterThan(1);
   });
 
   it('allows setting an equation in tables', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -58,7 +58,7 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 export const NONE = 'none';
 
-const NONE_AGGREGATE = {
+export const NONE_AGGREGATE = {
   textValue: t('field (no aggregate)'),
   label: tct('[emphasis:field (no aggregate)]', {
     emphasis: <em />,
@@ -810,7 +810,7 @@ function Visualize({error, setError}: VisualizeProps) {
 
 export default Visualize;
 
-function renderTag(kind: FieldValueKind, label: string, dataType?: string) {
+export function renderTag(kind: FieldValueKind, label: string, dataType?: string) {
   if (dataType) {
     switch (dataType) {
       case 'boolean':
@@ -907,12 +907,12 @@ export const PrimarySelectRow = styled('div')<{hasColumnParameter: boolean}>`
   width: 100%;
   min-width: 0;
 
-  & > ${ColumnCompactSelect} > button {
+  & ${ColumnCompactSelect} button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
 
-  & > ${AggregateCompactSelect} > button {
+  & ${AggregateCompactSelect} button {
     ${p =>
       p.hasColumnParameter &&
       `

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -121,7 +121,9 @@ export function SelectRow({
     : BuilderStateAction.SET_FIELDS;
 
   const openColumnSelect = useCallback(() => {
-    columnSelectRef.current?.querySelector('button')?.click();
+    requestAnimationFrame(() => {
+      columnSelectRef.current?.querySelector('button')?.click();
+    });
   }, []);
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -1,3 +1,5 @@
+import {useMemo, useState} from 'react';
+import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -15,6 +17,7 @@ import {
   parseFunction,
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -23,8 +26,10 @@ import {
   getAggregateValueKey,
   getColumnOptions,
   NONE,
+  NONE_AGGREGATE,
   parseAggregateFromValueKey,
   PrimarySelectRow,
+  renderTag,
 } from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
@@ -109,6 +114,9 @@ export function SelectRow({
   const organization = useOrganization();
   const {state, dispatch} = useWidgetBuilderContext();
   const datasetConfig = getDatasetConfig(state.dataset);
+  const aggregateSelectRef = useRef<HTMLDivElement>(null);
+  const columnSelectRef = useRef<HTMLDivElement>(null);
+  const [filterAggregates, setFilterAggregates] = useState(false);
 
   const isChartWidget =
     state.displayType !== DisplayType.TABLE &&
@@ -118,294 +126,349 @@ export function SelectRow({
     ? BuilderStateAction.SET_Y_AXIS
     : BuilderStateAction.SET_FIELDS;
 
+  useOnClickOutside(aggregateSelectRef, () => setFilterAggregates(false));
+  useOnClickOutside(columnSelectRef, () => setFilterAggregates(false));
+
+  const openColumnSelect = useCallback(() => {
+    requestAnimationFrame(() => {
+      columnSelectRef.current?.querySelector('button')?.click();
+    });
+  }, []);
+
+  const openAggregateSelect = useCallback(() => {
+    setFilterAggregates(true);
+    requestAnimationFrame(() => {
+      aggregateSelectRef.current?.querySelector('button')?.click();
+    });
+  }, []);
+
+  const aggregateDropdownOptions = useMemo(() => {
+    if (filterAggregates) {
+      const filteredAggregateOptions: Array<
+        | {
+            label: string | React.ReactNode;
+            trailingItems: React.ReactNode | null;
+            value: string;
+            textValue?: string;
+          }
+        | SelectValue<string>
+      > = aggregates.map(option => ({
+        value:
+          option.value.kind === FieldValueKind.FUNCTION
+            ? getAggregateValueKey(option.value.meta.name)
+            : option.value.meta.name,
+        label: option.value.meta.name,
+        trailingItems: renderTag(option.value.kind, option.value.meta.name) ?? null,
+      }));
+      return [NONE_AGGREGATE, ...filteredAggregateOptions];
+    }
+
+    return aggregateOptions;
+  }, [aggregateOptions, filterAggregates, aggregates]);
+
   return (
     <PrimarySelectRow hasColumnParameter={hasColumnParameter}>
-      <AggregateCompactSelect
-        searchable
-        hasColumnParameter={hasColumnParameter}
-        disabled={aggregateOptions.length <= 1}
-        options={aggregateOptions}
-        value={
-          parseFunction(stringFields?.[index] ?? '')?.name
-            ? getAggregateValueKey(parseFunction(stringFields?.[index] ?? '')?.name)
-            : NONE
-        }
-        position="bottom-start"
-        menuFooter={
-          state.displayType === DisplayType.TABLE ? renderDropdownMenuFooter : undefined
-        }
-        onChange={dropdownSelection => {
-          const isNone = dropdownSelection.value === NONE;
-          let newFields = cloneDeep(fields);
-          const currentField = newFields[index]!;
-          const selectedAggregate = aggregates.find(
-            option =>
-              // Convert the aggregate key to the same format as the dropdown value
-              // when checking for a match
-              getAggregateValueKey(option.value.meta.name) === dropdownSelection.value
-          );
-          // Update the current field's aggregate with the new aggregate
-          if (!selectedAggregate && !isNone) {
-            const functionFields = newFields.filter(
-              newField => newField.kind === FieldValueKind.FUNCTION
-            );
-            // Handles selection of release tags from aggregate dropdown
-            if (
-              state.dataset === WidgetType.RELEASE &&
-              state.displayType === DisplayType.TABLE &&
-              functionFields.length === 1
-            ) {
-              newFields = [
-                {
-                  kind: FieldValueKind.FIELD,
-                  field: dropdownSelection.value as string,
-                },
-                ...newFields,
-              ];
-
-              const atLeastOneFunction = newFields.some(
-                newField => newField.kind === FieldValueKind.FUNCTION
-              );
-
-              // add a function in the off chance the user gets into a state where
-              // they don't already have a function there
-              if (!atLeastOneFunction) {
-                newFields = [...newFields, datasetConfig.defaultField];
-              }
-            } else {
-              // Handles new selection of a field from the aggregate dropdown
-              newFields[index] = {
-                kind: FieldValueKind.FIELD,
-                field: dropdownSelection.value as string,
-              };
-            }
-            trackAnalytics('dashboards_views.widget_builder.change', {
-              builder_version: WidgetBuilderVersion.SLIDEOUT,
-              field: 'visualize.updateAggregate',
-              from: source,
-              new_widget: !isEditing,
-              value: 'direct_column',
-              widget_type: state.dataset ?? '',
-              organization,
-            });
-          } else if (!isNone) {
-            if (currentField.kind === FieldValueKind.FUNCTION) {
-              // Handle setting an aggregate from an aggregate
-              currentField.function[0] = parseAggregateFromValueKey(
-                dropdownSelection.value as string
-              ) as AggregationKeyWithAlias;
-              if (
-                selectedAggregate?.value.meta &&
-                'parameters' in selectedAggregate.value.meta
-              ) {
-                // There are aggregates that have no parameters, so wipe out the argument
-                // if it's supposed to be empty
-                if (selectedAggregate.value.meta.parameters.length === 0) {
-                  currentField.function[1] = '';
-                } else {
-                  // Check if the column is a valid column for the new aggregate
-                  const newColumnOptions = getColumnOptions(
-                    state.dataset ?? WidgetType.ERRORS,
-                    currentField,
-                    fieldOptions,
-                    // If no column filter method is provided, show all options
-                    columnFilterMethod ?? (() => true)
-                  );
-                  const selectedAggregateIsApdexOrUserMisery =
-                    selectedAggregate?.value.meta.name === 'apdex' ||
-                    selectedAggregate?.value.meta.name === 'user_misery';
-                  const isValidColumn =
-                    !selectedAggregateIsApdexOrUserMisery &&
-                    Boolean(
-                      newColumnOptions.find(
-                        option => option.value === currentField.function[1]
-                      )?.value
-                    );
-                  currentField.function[1] =
-                    (isValidColumn
-                      ? currentField.function[1]
-                      : selectedAggregate.value.meta.parameters[0]!.defaultValue) ?? '';
-
-                  // Set the remaining parameters for the new aggregate
-                  for (
-                    let i = 1; // The first parameter is the column selection
-                    i < selectedAggregate.value.meta.parameters.length;
-                    i++
-                  ) {
-                    // Increment by 1 to skip past the aggregate name
-                    currentField.function[i + 1] =
-                      selectedAggregate.value.meta.parameters[i]!.defaultValue;
-                  }
-                }
-
-                // Wipe out the remaining parameters that are unnecessary
-                // This is necessary for transitioning between aggregates that have
-                // more parameters to ones of fewer parameters
-                for (
-                  let i = selectedAggregate.value.meta.parameters.length;
-                  i < MAX_FUNCTION_PARAMETERS;
-                  i++
-                ) {
-                  currentField.function[i + 1] = undefined;
-                }
-              }
-            } else {
-              if (!selectedAggregate || !('parameters' in selectedAggregate.value.meta)) {
-                return;
-              }
-
-              // Handle setting an aggregate from a field
-              const newFunction: AggregateFunction = [
-                parseAggregateFromValueKey(
-                  dropdownSelection.value as string
-                ) as AggregationKeyWithAlias,
-                ((selectedAggregate?.value.meta?.parameters.length > 0 &&
-                  currentField.field) ||
-                  selectedAggregate?.value.meta?.parameters?.[0]?.defaultValue) ??
-                  '',
-                selectedAggregate?.value.meta?.parameters?.[1]?.defaultValue ?? undefined,
-                selectedAggregate?.value.meta?.parameters?.[2]?.defaultValue ?? undefined,
-              ];
-              const newColumnOptions = getColumnOptions(
-                state.dataset ?? WidgetType.ERRORS,
-                {
-                  kind: FieldValueKind.FUNCTION,
-                  function: newFunction,
-                },
-                fieldOptions,
-                // If no aggregate filter method is provided, show all options
-                datasetConfig.filterAggregateParams ?? (() => true)
-              );
-              if (
-                selectedAggregate?.value.meta &&
-                'parameters' in selectedAggregate.value.meta
-              ) {
-                selectedAggregate?.value.meta.parameters.forEach(
-                  (parameter, parameterIndex) => {
-                    const isValidParameter = validateParameter(
-                      newColumnOptions,
-                      parameter,
-                      newFunction[parameterIndex + 1]
-                    );
-                    // Increment by 1 to skip past the aggregate name
-                    newFunction[parameterIndex + 1] =
-                      (isValidParameter
-                        ? newFunction[parameterIndex + 1]
-                        : parameter.defaultValue) ?? '';
-                  }
-                );
-              }
-              newFields[index] = {
-                kind: FieldValueKind.FUNCTION,
-                function: newFunction,
-              };
-            }
-            trackAnalytics('dashboards_views.widget_builder.change', {
-              builder_version: WidgetBuilderVersion.SLIDEOUT,
-              field: 'visualize.updateAggregate',
-              from: source,
-              new_widget: !isEditing,
-              value: 'aggregate',
-              widget_type: state.dataset ?? '',
-              organization,
-            });
-          } else {
-            // Handle selecting NONE so we can select just a field, e.g. for samples
-            // If NONE is selected, set the field to a field value
-
-            // When selecting NONE, the next possible columns may be different from the
-            // possible columns for the previous aggregate. Calculate the valid columns,
-            // see if the current field's function argument is in the valid columns, and if so,
-            // set the field to a field value. Otherwise, set the field to the first valid column.
-            const validColumnFields = getColumnOptions(
-              state.dataset ?? WidgetType.ERRORS,
-              {
-                kind: FieldValueKind.FIELD,
-                field: '',
-              },
-              fieldOptions,
-              // If no column filter method is provided, show all options
-              columnFilterMethod ?? (() => true)
-            );
-            const functionArgInValidColumnFields =
-              (currentField.kind === FieldValueKind.FUNCTION &&
-                validColumnFields.find(
-                  option => option.value === currentField.function[1]
-                )) ||
-              undefined;
-            const validColumn =
-              functionArgInValidColumnFields?.value ??
-              validColumnFields?.[0]?.value ??
-              '';
-            newFields[index] = {
-              kind: FieldValueKind.FIELD,
-              field: validColumn,
-            };
-
-            trackAnalytics('dashboards_views.widget_builder.change', {
-              builder_version: WidgetBuilderVersion.SLIDEOUT,
-              field: 'visualize.updateAggregate',
-              from: source,
-              new_widget: !isEditing,
-              value: 'column',
-              widget_type: state.dataset ?? '',
-              organization,
-            });
-          }
-          dispatch({
-            type: updateAction,
-            payload: newFields,
-          });
-          setError?.({...error, queries: []});
-        }}
-        triggerProps={{
-          'aria-label': t('Aggregate Selection'),
-        }}
-      />
-      {hasColumnParameter && (
-        <ColumnCompactSelect
+      <SelectWrapper ref={aggregateSelectRef}>
+        <AggregateCompactSelect
           searchable
+          hasColumnParameter={hasColumnParameter}
+          disabled={aggregateDropdownOptions.length <= 1}
+          options={aggregateDropdownOptions}
+          value={
+            parseFunction(stringFields?.[index] ?? '')?.name
+              ? getAggregateValueKey(parseFunction(stringFields?.[index] ?? '')?.name)
+              : NONE
+          }
           position="bottom-start"
           menuFooter={
-            state.displayType === DisplayType.TABLE &&
-            field.kind !== FieldValueKind.FUNCTION
-              ? renderDropdownMenuFooter
-              : undefined
+            state.displayType === DisplayType.TABLE ? renderDropdownMenuFooter : undefined
           }
-          options={columnOptions}
-          value={
-            field.kind === FieldValueKind.FUNCTION
-              ? parseFunction(stringFields?.[index] ?? '')?.arguments[0] ?? ''
-              : field.field
-          }
-          onChange={newField => {
-            const newFields = cloneDeep(fields);
+          onChange={dropdownSelection => {
+            const isNone = dropdownSelection.value === NONE;
+            let newFields = cloneDeep(fields);
             const currentField = newFields[index]!;
-            if (currentField.kind === FieldValueKind.FUNCTION) {
-              currentField.function[1] = newField.value as string;
-            }
-            if (currentField.kind === FieldValueKind.FIELD) {
-              currentField.field = newField.value as string;
+            const selectedAggregate = aggregates.find(
+              option =>
+                // Convert the aggregate key to the same format as the dropdown value
+                // when checking for a match
+                getAggregateValueKey(option.value.meta.name) === dropdownSelection.value
+            );
+            // Update the current field's aggregate with the new aggregate
+            if (!selectedAggregate && !isNone) {
+              const functionFields = newFields.filter(
+                newField => newField.kind === FieldValueKind.FUNCTION
+              );
+              // Handles selection of release tags from aggregate dropdown
+              if (
+                state.dataset === WidgetType.RELEASE &&
+                state.displayType === DisplayType.TABLE &&
+                functionFields.length === 1
+              ) {
+                newFields = [
+                  {
+                    kind: FieldValueKind.FIELD,
+                    field: dropdownSelection.value as string,
+                  },
+                  ...newFields,
+                ];
+
+                const atLeastOneFunction = newFields.some(
+                  newField => newField.kind === FieldValueKind.FUNCTION
+                );
+
+                // add a function in the off chance the user gets into a state where
+                // they don't already have a function there
+                if (!atLeastOneFunction) {
+                  newFields = [...newFields, datasetConfig.defaultField];
+                }
+              } else {
+                // Handles new selection of a field from the aggregate dropdown
+                newFields[index] = {
+                  kind: FieldValueKind.FIELD,
+                  field: dropdownSelection.value as string,
+                };
+              }
+              trackAnalytics('dashboards_views.widget_builder.change', {
+                builder_version: WidgetBuilderVersion.SLIDEOUT,
+                field: 'visualize.updateAggregate',
+                from: source,
+                new_widget: !isEditing,
+                value: 'direct_column',
+                widget_type: state.dataset ?? '',
+                organization,
+              });
+              setFilterAggregates(true);
+              openAggregateSelect();
+            } else if (!isNone) {
+              if (currentField.kind === FieldValueKind.FUNCTION) {
+                // Handle setting an aggregate from an aggregate
+                currentField.function[0] = parseAggregateFromValueKey(
+                  dropdownSelection.value as string
+                ) as AggregationKeyWithAlias;
+                if (
+                  selectedAggregate?.value.meta &&
+                  'parameters' in selectedAggregate.value.meta
+                ) {
+                  // There are aggregates that have no parameters, so wipe out the argument
+                  // if it's supposed to be empty
+                  if (selectedAggregate.value.meta.parameters.length === 0) {
+                    currentField.function[1] = '';
+                  } else {
+                    // Check if the column is a valid column for the new aggregate
+                    const newColumnOptions = getColumnOptions(
+                      state.dataset ?? WidgetType.ERRORS,
+                      currentField,
+                      fieldOptions,
+                      // If no column filter method is provided, show all options
+                      columnFilterMethod ?? (() => true)
+                    );
+                    const selectedAggregateIsApdexOrUserMisery =
+                      selectedAggregate?.value.meta.name === 'apdex' ||
+                      selectedAggregate?.value.meta.name === 'user_misery';
+                    const isValidColumn =
+                      !selectedAggregateIsApdexOrUserMisery &&
+                      Boolean(
+                        newColumnOptions.find(
+                          option => option.value === currentField.function[1]
+                        )?.value
+                      );
+                    currentField.function[1] =
+                      (isValidColumn
+                        ? currentField.function[1]
+                        : selectedAggregate.value.meta.parameters[0]!.defaultValue) ?? '';
+
+                    // Set the remaining parameters for the new aggregate
+                    for (
+                      let i = 1; // The first parameter is the column selection
+                      i < selectedAggregate.value.meta.parameters.length;
+                      i++
+                    ) {
+                      // Increment by 1 to skip past the aggregate name
+                      currentField.function[i + 1] =
+                        selectedAggregate.value.meta.parameters[i]!.defaultValue;
+                    }
+                  }
+
+                  // Wipe out the remaining parameters that are unnecessary
+                  // This is necessary for transitioning between aggregates that have
+                  // more parameters to ones of fewer parameters
+                  for (
+                    let i = selectedAggregate.value.meta.parameters.length;
+                    i < MAX_FUNCTION_PARAMETERS;
+                    i++
+                  ) {
+                    currentField.function[i + 1] = undefined;
+                  }
+                }
+
+                if (!filterAggregates) {
+                  openColumnSelect();
+                }
+              } else {
+                if (
+                  !selectedAggregate ||
+                  !('parameters' in selectedAggregate.value.meta)
+                ) {
+                  return;
+                }
+
+                // Handle setting an aggregate from a field
+                const newFunction: AggregateFunction = [
+                  parseAggregateFromValueKey(
+                    dropdownSelection.value as string
+                  ) as AggregationKeyWithAlias,
+                  ((selectedAggregate?.value.meta?.parameters.length > 0 &&
+                    currentField.field) ||
+                    selectedAggregate?.value.meta?.parameters?.[0]?.defaultValue) ??
+                    '',
+                  selectedAggregate?.value.meta?.parameters?.[1]?.defaultValue ??
+                    undefined,
+                  selectedAggregate?.value.meta?.parameters?.[2]?.defaultValue ??
+                    undefined,
+                ];
+                const newColumnOptions = getColumnOptions(
+                  state.dataset ?? WidgetType.ERRORS,
+                  {
+                    kind: FieldValueKind.FUNCTION,
+                    function: newFunction,
+                  },
+                  fieldOptions,
+                  // If no aggregate filter method is provided, show all options
+                  datasetConfig.filterAggregateParams ?? (() => true)
+                );
+                if (
+                  selectedAggregate?.value.meta &&
+                  'parameters' in selectedAggregate.value.meta
+                ) {
+                  selectedAggregate?.value.meta.parameters.forEach(
+                    (parameter, parameterIndex) => {
+                      const isValidParameter = validateParameter(
+                        newColumnOptions,
+                        parameter,
+                        newFunction[parameterIndex + 1]
+                      );
+                      // Increment by 1 to skip past the aggregate name
+                      newFunction[parameterIndex + 1] =
+                        (isValidParameter
+                          ? newFunction[parameterIndex + 1]
+                          : parameter.defaultValue) ?? '';
+                    }
+                  );
+                }
+                newFields[index] = {
+                  kind: FieldValueKind.FUNCTION,
+                  function: newFunction,
+                };
+                if (!filterAggregates) {
+                  openColumnSelect();
+                }
+              }
+              trackAnalytics('dashboards_views.widget_builder.change', {
+                builder_version: WidgetBuilderVersion.SLIDEOUT,
+                field: 'visualize.updateAggregate',
+                from: source,
+                new_widget: !isEditing,
+                value: 'aggregate',
+                widget_type: state.dataset ?? '',
+                organization,
+              });
+            } else {
+              // Handle selecting NONE so we can select just a field, e.g. for samples
+              // If NONE is selected, set the field to a field value
+
+              // When selecting NONE, the next possible columns may be different from the
+              // possible columns for the previous aggregate. Calculate the valid columns,
+              // see if the current field's function argument is in the valid columns, and if so,
+              // set the field to a field value. Otherwise, set the field to the first valid column.
+              const validColumnFields = getColumnOptions(
+                state.dataset ?? WidgetType.ERRORS,
+                {
+                  kind: FieldValueKind.FIELD,
+                  field: '',
+                },
+                fieldOptions,
+                // If no column filter method is provided, show all options
+                columnFilterMethod ?? (() => true)
+              );
+              const functionArgInValidColumnFields =
+                (currentField.kind === FieldValueKind.FUNCTION &&
+                  validColumnFields.find(
+                    option => option.value === currentField.function[1]
+                  )) ||
+                undefined;
+              const validColumn =
+                functionArgInValidColumnFields?.value ??
+                validColumnFields?.[0]?.value ??
+                '';
+              newFields[index] = {
+                kind: FieldValueKind.FIELD,
+                field: validColumn,
+              };
+
+              trackAnalytics('dashboards_views.widget_builder.change', {
+                builder_version: WidgetBuilderVersion.SLIDEOUT,
+                field: 'visualize.updateAggregate',
+                from: source,
+                new_widget: !isEditing,
+                value: 'column',
+                widget_type: state.dataset ?? '',
+                organization,
+              });
+              if (!filterAggregates) {
+                openColumnSelect();
+              }
             }
             dispatch({
               type: updateAction,
               payload: newFields,
             });
             setError?.({...error, queries: []});
-            trackAnalytics('dashboards_views.widget_builder.change', {
-              builder_version: WidgetBuilderVersion.SLIDEOUT,
-              field: 'visualize.updateColumn',
-              from: source,
-              new_widget: !isEditing,
-              value: currentField.kind === FieldValueKind.FIELD ? 'column' : 'aggregate',
-              widget_type: state.dataset ?? '',
-              organization,
-            });
           }}
           triggerProps={{
-            'aria-label': t('Column Selection'),
+            'aria-label': t('Aggregate Selection'),
           }}
         />
+      </SelectWrapper>
+      {hasColumnParameter && (
+        <SelectWrapper ref={columnSelectRef}>
+          <ColumnCompactSelect
+            searchable
+            options={columnOptions}
+            value={
+              field.kind === FieldValueKind.FUNCTION
+                ? parseFunction(stringFields?.[index] ?? '')?.arguments[0] ?? ''
+                : field.field
+            }
+            onChange={newField => {
+              const newFields = cloneDeep(fields);
+              const currentField = newFields[index]!;
+              if (currentField.kind === FieldValueKind.FUNCTION) {
+                currentField.function[1] = newField.value as string;
+              }
+              if (currentField.kind === FieldValueKind.FIELD) {
+                currentField.field = newField.value as string;
+              }
+              dispatch({
+                type: updateAction,
+                payload: newFields,
+              });
+              setError?.({...error, queries: []});
+              trackAnalytics('dashboards_views.widget_builder.change', {
+                builder_version: WidgetBuilderVersion.SLIDEOUT,
+                field: 'visualize.updateColumn',
+                from: source,
+                new_widget: !isEditing,
+                value:
+                  currentField.kind === FieldValueKind.FIELD ? 'column' : 'aggregate',
+                widget_type: state.dataset ?? '',
+                organization,
+              });
+            }}
+            triggerProps={{
+              'aria-label': t('Column Selection'),
+            }}
+          />
+        </SelectWrapper>
       )}
     </PrimarySelectRow>
   );
@@ -428,4 +491,8 @@ const FooterWrapper = styled('div')`
   justify-content: center;
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const SelectWrapper = styled('div')`
+  display: contents;
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -110,7 +110,6 @@ export function SelectRow({
   const organization = useOrganization();
   const {state, dispatch} = useWidgetBuilderContext();
   const datasetConfig = getDatasetConfig(state.dataset);
-  const aggregateSelectRef = useRef<HTMLDivElement>(null);
   const columnSelectRef = useRef<HTMLDivElement>(null);
 
   const isChartWidget =
@@ -122,14 +121,12 @@ export function SelectRow({
     : BuilderStateAction.SET_FIELDS;
 
   const openColumnSelect = useCallback(() => {
-    requestAnimationFrame(() => {
-      columnSelectRef.current?.querySelector('button')?.click();
-    });
+    columnSelectRef.current?.querySelector('button')?.click();
   }, []);
 
   return (
     <PrimarySelectRow hasColumnParameter={hasColumnParameter}>
-      <SelectWrapper ref={aggregateSelectRef}>
+      <SelectWrapper>
         <AggregateCompactSelect
           searchable
           hasColumnParameter={hasColumnParameter}


### PR DESCRIPTION
Adds progressive selection for aggregates. Applies to both tables and charts. When a user selects an aggregate we will automatically open the column selector so they can fill it in.

My next PR is going to show all of the strings/number fields in the dropdown and disable the ones that are inapplicable.

For tables, the behaviour of opening the aggregate was disruptive so we are going to avoid opening the aggregate dropdown for now, although in a future PR I may add it to the charts if we can expose all of the field options in the primary selector. I will look into it after the next PR.


https://github.com/user-attachments/assets/f5cf489a-9000-4dd5-9330-48a54ad4040b

