### PR TITLE
feat(grouping): Unreal Engine enhancer rules

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -437,16 +437,16 @@ path:**/*LogRocket*/** -app -group
 ## Unreal Engine
 
 ### Unreal Engine internal assertion handling
-family:native stack.function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app
+family:native stack.function:FDebug::CheckVerifyFailedImpl* v+app
 
 ### Unreal Engine internal ensure handling
-family:native stack.function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal* v+app
 
 ### UE SDK USentrySubsystem event capturing
-family:native stack.function:USentrySubsystem::CaptureMessage* ^-app -app v+app
-family:native stack.function:USentrySubsystem::CaptureMessageWithScope* ^-app -app v+app
-family:native stack.function:USentrySubsystem::CaptureEvent* ^-app -app v+app
-family:native stack.function:USentrySubsystem::CaptureEventWithScope* ^-app -app v+app
-family:native stack.function:USentrySubsystem::*execCapture* ^-app -app v+app
+family:native stack.function:USentrySubsystem::CaptureMessage* v+app
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope* v+app
+family:native stack.function:USentrySubsystem::CaptureEvent* v+app
+family:native stack.function:USentrySubsystem::CaptureEventWithScope* v+app
+family:native stack.function:USentrySubsystem::*execCapture* v+app
 family:native function:__start_thread -app
 family:native function:__pthread_start -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -448,5 +448,4 @@ family:native stack.function:USentrySubsystem::CaptureMessageWithScope* v+app
 family:native stack.function:USentrySubsystem::CaptureEvent* v+app
 family:native stack.function:USentrySubsystem::CaptureEventWithScope* v+app
 family:native stack.function:USentrySubsystem::*execCapture* v+app
-family:native function:__start_thread -app
-family:native function:__pthread_start -app
+family:native function:__pthread_start -app v-app

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -433,3 +433,20 @@ module:io.netty.* -app
 module:newrelic -app -group
 path:**/*newrelic*/** -app -group
 path:**/*LogRocket*/** -app -group
+
+## Unreal Engine
+
+### Unreal Engine internal assertion handling
+family:native stack.function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app
+
+### Unreal Engine internal ensure handling
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app
+
+### UE SDK USentrySubsystem event capturing
+family:native stack.function:USentrySubsystem::CaptureMessage* ^-app -app v+app
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope* ^-app -app v+app
+family:native stack.function:USentrySubsystem::CaptureEvent* ^-app -app v+app
+family:native stack.function:USentrySubsystem::CaptureEventWithScope* ^-app -app v+app
+family:native stack.function:USentrySubsystem::*execCapture* ^-app -app v+app
+family:native function:__start_thread -app
+family:native function:__pthread_start -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -8,6 +8,24 @@ family:native package:/private/var/containers/Bundle/Application/**  +app
 family:native package:**/Developer/CoreSimulator/Devices/**          +app
 family:native package:**/Containers/Bundle/Application/**            +app
 
+# Unreal Engine
+
+## UE internal assertion handling
+family:native stack.function:FDebug::CheckVerifyFailedImpl*                v+app
+
+## UE internal ensure handling
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal*   v+app
+
+## UE SDK USentrySubsystem event capturing
+family:native stack.function:USentrySubsystem::CaptureMessage*             v+app
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope*    v+app
+family:native stack.function:USentrySubsystem::CaptureEvent*               v+app
+family:native stack.function:USentrySubsystem::CaptureEventWithScope*      v+app
+family:native stack.function:USentrySubsystem::*execCapture*               v+app
+
+## rules that undo some of the wide-spread v+app
+family:native function:__pthread_start                                     v-app -app
+
 # known well locations for unix paths
 family:native package:/lib/**                                        -app
 family:native package:/usr/lib/**                                    -app
@@ -433,19 +451,3 @@ module:io.netty.* -app
 module:newrelic -app -group
 path:**/*newrelic*/** -app -group
 path:**/*LogRocket*/** -app -group
-
-## Unreal Engine
-
-### Unreal Engine internal assertion handling
-family:native stack.function:FDebug::CheckVerifyFailedImpl* v+app
-
-### Unreal Engine internal ensure handling
-family:native stack.function:UE::Assert::Private::ExecCheckImplInternal* v+app
-
-### UE SDK USentrySubsystem event capturing
-family:native stack.function:USentrySubsystem::CaptureMessage* v+app
-family:native stack.function:USentrySubsystem::CaptureMessageWithScope* v+app
-family:native stack.function:USentrySubsystem::CaptureEvent* v+app
-family:native stack.function:USentrySubsystem::CaptureEventWithScope* v+app
-family:native stack.function:USentrySubsystem::*execCapture* v+app
-family:native function:__pthread_start -app v-app

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -23,9 +23,6 @@ family:native stack.function:USentrySubsystem::CaptureEvent*               v+app
 family:native stack.function:USentrySubsystem::CaptureEventWithScope*      v+app
 family:native stack.function:USentrySubsystem::*execCapture*               v+app
 
-## rules that undo some of the wide-spread v+app
-family:native function:__pthread_start                                     v-app -app
-
 # known well locations for unix paths
 family:native package:/lib/**                                        -app
 family:native package:/usr/lib/**                                    -app

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:18:54.886839+00:00'
+created: '2025-02-19T20:50:32.725476+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,49 +30,49 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "android_main"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "AndroidMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UGameEngine::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UWorld::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "AActor::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "USentryPlaygroundUtils::Terminate"
   system*
@@ -82,63 +82,63 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "android_main"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "AndroidMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UGameEngine::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UWorld::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "AActor::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FOutputDevice::LogfImpl"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "TMulticastDelegateBase<T>::Broadcast<T>"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "tgkill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:24:52.069343+00:00'
+created: '2025-02-19T18:18:54.886839+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,11 +18,63 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
+  app*
+    hash: "8c134ce2a43a0b2c55654902491307c2"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "android_main"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "AndroidMain"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FEngineLoop::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UGameEngine::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UWorld::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FLatentActionManager::ProcessLatentActions"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FLatentActionManager::TickLatentActionForObject"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "AActor::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UObject::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UFunction::Invoke"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UObject::ProcessInternal"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UObject::execCallMathFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "USentryPlaygroundUtils::execTerminate"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "USentryPlaygroundUtils::Terminate"
   system*
     hash: "f203e9bc12df86bb01fbd92a45643f86"
     contributing component: exception
@@ -30,63 +82,63 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "android_main"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "AndroidMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FEngineLoop::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UGameEngine::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UWorld::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "AActor::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UObject::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UObject::ProcessInternal"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FOutputDevice::LogfImpl"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "TMulticastDelegateBase<T>::Broadcast<T>"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "tgkill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:24:52.403064+00:00'
+created: '2025-02-19T18:18:55.253715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,11 +18,112 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
+  app*
+    hash: "21f12614b98d6dd2c5d5303e452b4c6b"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "WinMain"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "LaunchWindowsStartup"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "GuardedMainWrapper"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "GuardedMain"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FEngineLoop::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FWindowsPlatformApplicationMisc::PumpMessages"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "DispatchMessageWorker"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FWindowsApplication::AppWndProc"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FWindowsApplication::ProcessMessage"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FWindowsApplication::DeferMessage"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FWindowsApplication::ProcessDeferredMessage"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FSlateApplication::OnMouseUp"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FSlateApplication::ProcessMouseButtonUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "FSlateApplication::RoutePointerUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "SharedPointerInternals::NewIntrusiveReferenceController<T>"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "SButton::OnMouseButtonUp"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "SButton::ExecuteOnClick"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "TBaseUObjectMethodDelegateInstance<T>::Execute"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UButton::SlateHandleClicked"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UObject::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UFunction::Invoke"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UObject::ProcessInternal"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "ProcessLocalFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "ProcessScriptFunction<T>"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              function*
+                "UObject::execCallMathFunction"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              filename*
+                "sentryplaygroundutils.gen.cpp"
+              function*
+                "USentryPlaygroundUtils::execTerminate"
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+              filename*
+                "sentryplaygroundutils.cpp"
+              function*
+                "USentryPlaygroundUtils::Terminate"
   system*
     hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
     contributing component: exception
@@ -30,117 +131,117 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "WinMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "LaunchWindowsStartup"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "GuardedMainWrapper"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "GuardedMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FEngineLoop::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "DispatchMessageWorker"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UObject::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UObject::ProcessInternal"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "ProcessLocalFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FDebug::AssertFailed"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FOutputDevice::LogfImpl"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               filename*
                 "sentryoutputdeviceerror.cpp"
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "FWindowsErrorOutputDevice::Serialize"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
               function*
                 "RaiseException"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:18:55.253715+00:00'
+created: '2025-02-19T20:50:33.015855+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,96 +30,96 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "WinMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "DispatchMessageWorker"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
@@ -131,117 +131,117 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "WinMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "DispatchMessageWorker"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FDebug::AssertFailed"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FOutputDevice::LogfImpl"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               filename*
                 "sentryoutputdeviceerror.cpp"
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "FWindowsErrorOutputDevice::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+            frame*
               function*
                 "RaiseException"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:24:52.829769+00:00'
+created: '2025-02-19T18:18:55.638353+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -7,7 +7,7 @@ hash_basis: stacktrace
 hashing_metadata: {
   "num_stacktraces": 1,
   "stacktrace_location": "exception",
-  "stacktrace_type": "system"
+  "stacktrace_type": "in_app"
 }
 ---
 metrics with tags: {
@@ -18,11 +18,114 @@ metrics with tags: {
   "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
     "chained_exception": "False",
     "stacktrace_location": "exception",
-    "stacktrace_type": "system"
+    "stacktrace_type": "in_app"
   }
 }
 ---
 contributing variants:
+  app*
+    hash: "a27e168f67ce2d3f12bba36eba67d076"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          stacktrace*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "WinMain"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "LaunchWindowsStartup"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "GuardedMainWrapper"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "GuardedMain"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FEngineLoop::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FWindowsPlatformApplicationMisc::PumpMessages"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "DispatchMessageWorker"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FWindowsApplication::AppWndProc"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FWindowsApplication::ProcessMessage"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FWindowsApplication::DeferMessage"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FWindowsApplication::ProcessDeferredMessage"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FSlateApplication::OnMouseUp"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FSlateApplication::ProcessMouseButtonUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "FSlateApplication::RoutePointerUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "SharedPointerInternals::NewIntrusiveReferenceController<T>"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "SButton::OnMouseButtonUp"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "SButton::ExecuteOnClick"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "TBaseUObjectMethodDelegateInstance<T>::Execute"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "UButton::SlateHandleClicked"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "UObject::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "UFunction::Invoke"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "UObject::ProcessInternal"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "ProcessLocalFunction"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "ProcessScriptFunction<T>"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              function*
+                "UObject::execCallMathFunction"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              filename*
+                "sentryplaygroundutils.gen.cpp"
+              function*
+                "USentryPlaygroundUtils::execTerminate"
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+              filename*
+                "sentryplaygroundutils.cpp"
+              function*
+                "USentryPlaygroundUtils::Terminate"
+          type*
+            "Ensure failed"
   system*
     hash: "65244b22630821cacd0be603ebcef671"
     contributing component: exception
@@ -30,142 +133,142 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "WinMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "LaunchWindowsStartup"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "GuardedMainWrapper"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "GuardedMain"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FEngineLoop::Tick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "DispatchMessageWorker"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "UObject::ProcessEvent"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "UObject::ProcessInternal"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "ProcessLocalFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "UE::Assert::Private::ExecCheckImplInternal"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "CheckVerifyImpl"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "FDebug::EnsureFailed"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "TMulticastDelegate<T>::Broadcast"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               filename*
                 "delegateinstancesimpl.h"
               function*
                 "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               filename*
                 "tuple.h"
               function*
                 "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               filename*
                 "invoke.h"
               function*
                 "Invoke"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               filename*
                 "sentrysubsystemdesktop.cpp"
               function*
                 "SentrySubsystemDesktop::CaptureEnsure"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "sentry_value_set_stacktrace"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "sentry_value_new_stacktrace"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
               function*
                 "sentry_unwind_stack_from_ucontext"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:18:55.638353+00:00'
+created: '2025-02-19T20:50:33.309522+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,96 +30,96 @@ contributing variants:
       app*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "WinMain"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "DispatchMessageWorker"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
@@ -133,142 +133,142 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "WinMain"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "DispatchMessageWorker"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "UE::Assert::Private::ExecCheckImplInternal"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "CheckVerifyImpl"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "FDebug::EnsureFailed"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "TMulticastDelegate<T>::Broadcast"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               filename*
                 "delegateinstancesimpl.h"
               function*
                 "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               filename*
                 "tuple.h"
               function*
                 "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               filename*
                 "invoke.h"
               function*
                 "Invoke"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               filename*
                 "sentrysubsystemdesktop.cpp"
               function*
                 "SentrySubsystemDesktop::CaptureEnsure"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "sentry_value_set_stacktrace"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "sentry_value_new_stacktrace"
-            frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+            frame*
               function*
                 "sentry_unwind_stack_from_ucontext"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T20:50:33.776649+00:00'
+created: '2025-02-20T15:17:58.268855+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,82 +30,82 @@ contributing variants:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UFunction::Invoke"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:24:53.183703+00:00'
+created: '2025-02-19T18:18:55.994901+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,96 +24,181 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "9e04decaf79ecba9dc0314dc0edd3993"
+    hash: "54e8028fb2526cf31b12dd66c01ad9e2"
     contributing component: threads
     component:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "UFunction::Invoke"
-            frame*
+  system*
+    hash: "9e04decaf79ecba9dc0314dc0edd3993"
+    contributing component: threads
+    component:
+      system*
+        threads*
+          stacktrace*
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "-[FCocoaGameThread main]"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "-[UEAppDelegate runGameThread:]"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "GuardedMain"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FEngineLoop::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FSlateApplication::Tick"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FSlateApplication::TickPlatform"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FMacApplication::ProcessDeferredEvents"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FMacApplication::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FMacApplication::ProcessMouseUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FSlateApplication::OnMouseUp"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FSlateApplication::ProcessMouseButtonUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "FSlateApplication::RoutePointerUpEvent"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "SButton::OnMouseButtonUp"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "SButton::ExecuteOnClick"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UButton::SlateHandleClicked"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UObject::ProcessEvent"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UFunction::Invoke"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "ProcessLocalFunction"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "ProcessScriptFunction<T>"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "ProcessLocalScriptFunction"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UObject::execLetObj"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UObject::ProcessContextOpcode"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UObject::CallFunction"
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+              function*
+                "UFunction::Invoke"
+            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:18:55.994901+00:00'
+created: '2025-02-19T20:50:33.776649+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,181 +24,96 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "54e8028fb2526cf31b12dd66c01ad9e2"
+    hash: "9e04decaf79ecba9dc0314dc0edd3993"
     contributing component: threads
     component:
       app*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
               function*
                 "UFunction::Invoke"
-  system*
-    hash: "9e04decaf79ecba9dc0314dc0edd3993"
-    contributing component: threads
-    component:
-      system*
-        threads*
-          stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
-              function*
-                "UFunction::Invoke"
-            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame*
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame*
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+            frame*
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:19:05.870922+00:00'
+created: '2025-02-20T16:46:32.037299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame*
@@ -403,7 +403,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.048826+00:00'
+created: '2025-02-19T18:19:05.870922+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
           frame*
@@ -403,7 +403,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-20T15:18:55.542955+00:00'
+created: '2025-02-20T15:26:41.187921+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,10 +10,10 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start v-app -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__start_thread"
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start v-app -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:20:18.082127+00:00'
+created: '2025-02-19T20:50:34.307802+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,66 +16,66 @@ app:
           frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "android_main"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "AndroidMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UGameEngine::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UWorld::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "AActor::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
+          frame (non app frame)
             function*
               "tgkill"
         type (ignored because exception is synthetic)
@@ -96,66 +96,66 @@ system:
           frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "android_main"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "AndroidMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UGameEngine::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UWorld::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "AActor::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FOutputDevice::LogfImpl"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame
+          frame*
             function*
               "tgkill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,86 +1,86 @@
 ---
-created: '2025-02-19T15:26:15.126513+00:00'
+created: '2025-02-19T18:20:18.082127+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
-  contributing component: null
+  hash: "8c134ce2a43a0b2c55654902491307c2"
+  contributing component: exception
   component:
-    app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+    app*
+      exception*
+        stacktrace*
+          frame (marked out of app by stack trace rule (family:native function:__start_thread -app))
             function*
               "__start_thread"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "android_main"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "AndroidMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UGameEngine::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UWorld::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "AActor::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessInternal"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::execCallMathFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "tgkill"
         type (ignored because exception is synthetic)
           "SIGTRAP"
-        value*
+        value (ignored because stacktrace takes precedence)
           "Trap"
 --------------------------------------------------------------------------
 system:
@@ -90,72 +90,72 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:__start_thread -app))
             function*
               "__start_thread"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
             function*
               "__pthread_start"
-          frame
-          frame*
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "android_main"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "AndroidMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UGameEngine::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UWorld::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "AActor::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessInternal"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::execCallMathFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FOutputDevice::LogfImpl"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "tgkill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T20:50:34.307802+00:00'
+created: '2025-02-19T21:03:01.610282+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,10 +10,10 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__start_thread -app))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
             function*
               "__start_thread"
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
             function*
               "__pthread_start"
           frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -90,10 +90,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__start_thread -app))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
             function*
               "__start_thread"
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
             function*
               "__pthread_start"
           frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T21:03:01.610282+00:00'
+created: '2025-02-20T15:18:55.542955+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,10 +10,10 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start v-app -app))
             function*
               "__start_thread"
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
+          frame (marked out of app by stack trace rule (family:native function:__pthread_start v-app -app))
             function*
               "__pthread_start"
           frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -90,10 +90,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__start_thread"
-          frame (marked out of app by stack trace rule (family:native function:__pthread_start -app v-app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T20:50:34.594140+00:00'
+created: '2025-02-20T15:17:59.123080+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,18 +10,18 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -47,7 +47,7 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -74,7 +74,7 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -107,7 +107,7 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -161,18 +161,18 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -198,7 +198,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -225,7 +225,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
@@ -258,7 +258,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:20:18.514902+00:00'
+created: '2025-02-19T20:50:34.594140+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,143 +10,143 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "WinMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FDebug::AssertFailed"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FOutputDevice::LogfImpl"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (non app frame)
             function*
               "RaiseException"
         type (ignored because exception is synthetic)
@@ -161,143 +161,143 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "WinMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FDebug::AssertFailed"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FOutputDevice::LogfImpl"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
+          frame*
             function*
               "RaiseException"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,157 +1,157 @@
 ---
-created: '2025-02-19T15:26:15.524825+00:00'
+created: '2025-02-19T18:20:18.514902+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
-  contributing component: null
+  hash: "21f12614b98d6dd2c5d5303e452b4c6b"
+  contributing component: exception
   component:
-    app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+    app*
+      exception*
+        stacktrace*
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "RtlUserThreadStart"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "BaseThreadInitThunk"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "WinMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "LaunchWindowsStartup"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "GuardedMainWrapper"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "GuardedMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "DispatchMessageWorker"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessInternal"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalFunction"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::execCallMathFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FDebug::AssertFailed"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FOutputDevice::LogfImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "RaiseException"
         type (ignored because exception is synthetic)
           "unknown 0x00004000 / 0x7ff89574837a"
-        value* (stripped event-specific values)
+        value (ignored because stacktrace takes precedence)
           "Fatal Error: unknown <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
@@ -161,143 +161,143 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "RtlUserThreadStart"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "WinMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "LaunchWindowsStartup"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "GuardedMainWrapper"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "GuardedMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "DispatchMessageWorker"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::ProcessInternal"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalFunction"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "UObject::execCallMathFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FDebug::AssertFailed"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FOutputDevice::LogfImpl"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* ^-app -app v+app))
             function*
               "RaiseException"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T20:50:34.914976+00:00'
+created: '2025-02-20T15:17:59.479604+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,18 +10,18 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -47,7 +47,7 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
@@ -74,7 +74,7 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
@@ -107,7 +107,7 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
@@ -190,18 +190,18 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
@@ -227,7 +227,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
@@ -254,7 +254,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
@@ -287,7 +287,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,186 +1,186 @@
 ---
-created: '2025-02-19T15:26:15.892520+00:00'
+created: '2025-02-19T18:20:18.877769+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
-  contributing component: null
+  hash: "a27e168f67ce2d3f12bba36eba67d076"
+  contributing component: exception
   component:
-    app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+    app*
+      exception*
+        stacktrace*
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "RtlUserThreadStart"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "BaseThreadInitThunk"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "WinMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "LaunchWindowsStartup"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "GuardedMainWrapper"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "GuardedMain"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "DispatchMessageWorker"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UObject::ProcessInternal"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessLocalFunction"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UObject::execCallMathFunction"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame (non app frame)
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "CheckVerifyImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FDebug::EnsureFailed"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "sentry_value_set_stacktrace"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "sentry_value_new_stacktrace"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "sentry_unwind_stack_from_ucontext"
         type*
           "Ensure failed"
-        value* (stripped event-specific values)
+        value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
 --------------------------------------------------------------------------
 system:
@@ -190,172 +190,172 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "RtlUserThreadStart"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "BaseThreadInitThunk"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "WinMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "LaunchWindowsStartup"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "GuardedMainWrapper"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "GuardedMain"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "DispatchMessageWorker"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UObject::ProcessInternal"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessLocalFunction"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UObject::execCallMathFunction"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "CheckVerifyImpl"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "FDebug::EnsureFailed"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "sentry_value_set_stacktrace"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "sentry_value_new_stacktrace"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
             function*
               "sentry_unwind_stack_from_ucontext"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T18:20:18.877769+00:00'
+created: '2025-02-19T20:50:34.914976+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,172 +10,172 @@ app:
     app*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "WinMain"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "CheckVerifyImpl"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "FDebug::EnsureFailed"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "sentry_value_set_stacktrace"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "sentry_value_new_stacktrace"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (non app frame)
             function*
               "sentry_unwind_stack_from_ucontext"
         type*
@@ -190,172 +190,172 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "RtlUserThreadStart"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "BaseThreadInitThunk"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "WinMain"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalFunction"
-          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "UE::Assert::Private::ExecCheckImplInternal"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "CheckVerifyImpl"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "FDebug::EnsureFailed"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "TMulticastDelegate<T>::Broadcast"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             filename*
               "delegateinstancesimpl.h"
             function*
               "TBaseFunctorDelegateInstance<T>::ExecuteIfSafe"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             filename*
               "tuple.h"
             function*
               "UE::Core::Private::Tuple::TTupleBase<T>::ApplyAfter"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             filename*
               "invoke.h"
             function*
               "Invoke"
-          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "sentrysubsystem.cpp"
             function*
               "`USentrySubsystem::Initialize'::`2'::<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             filename*
               "sentrysubsystemdesktop.cpp"
             function*
               "SentrySubsystemDesktop::CaptureEnsure"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "sentry_value_set_stacktrace"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "sentry_value_new_stacktrace"
-          frame* (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* ^-app -app v+app))
+          frame*
             function*
               "sentry_unwind_stack_from_ucontext"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,136 +1,136 @@
 ---
-created: '2025-02-19T18:20:19.256096+00:00'
+created: '2025-02-19T20:50:35.195376+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "54e8028fb2526cf31b12dd66c01ad9e2"
+  hash: "9e04decaf79ecba9dc0314dc0edd3993"
   contributing component: threads
   component:
     app*
       threads*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "thread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "_pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UFunction::Invoke"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame*
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame*
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored due to recursion)
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame*
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -138,137 +138,137 @@ default:
   hash: null
   contributing component: null
   component:
-    default (threads of app/system take precedence)
-      message (threads of app/system take precedence)
+    default (threads of app take precedence)
+      message (threads of app take precedence)
         "Message for scoped event"
 --------------------------------------------------------------------------
 system:
-  hash: "9e04decaf79ecba9dc0314dc0edd3993"
-  contributing component: threads
+  hash: null
+  contributing component: null
   component:
-    system*
-      threads*
+    system (threads of app take precedence)
+      threads (ignored because hash matches app variant)
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "thread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "_pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame*
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame*
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored due to recursion)
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame*
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
+          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T20:50:35.195376+00:00'
+created: '2025-02-20T15:17:59.790275+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,94 +10,94 @@ app:
     app*
       threads*
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame (non app frame)
             function*
               "thread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame (non app frame)
             function*
               "_pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
           frame*
@@ -149,94 +149,94 @@ system:
     system (threads of app take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app))
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,136 +1,136 @@
 ---
-created: '2025-02-19T15:26:16.298627+00:00'
+created: '2025-02-19T18:20:19.256096+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9e04decaf79ecba9dc0314dc0edd3993"
+  hash: "54e8028fb2526cf31b12dd66c01ad9e2"
   contributing component: threads
   component:
     app*
       threads*
         stacktrace*
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "thread_start"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "_pthread_start"
-          frame (non app frame)
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
@@ -138,137 +138,137 @@ default:
   hash: null
   contributing component: null
   component:
-    default (threads of app take precedence)
-      message (threads of app take precedence)
+    default (threads of app/system take precedence)
+      message (threads of app/system take precedence)
         "Message for scoped event"
 --------------------------------------------------------------------------
 system:
-  hash: null
-  contributing component: null
+  hash: "9e04decaf79ecba9dc0314dc0edd3993"
+  contributing component: threads
   component:
-    system (threads of app take precedence)
-      threads (ignored because hash matches app variant)
+    system*
+      threads*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "thread_start"
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "_pthread_start"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "+[SentrySDK captureEvent:withScopeBlock:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "+[SentrySDK captureEvent:withScope:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryHub captureEvent:withScope:additionalEnvelopeItems:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryClient sendEvent:withScope:alwaysAttachStacktrace:isCrashEvent:additionalEnvelopeItems:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryThreadInspector getCurrentThreads]"
-          frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* ^-app -app v+app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"


### PR DESCRIPTION
This will not change system hashes, thus, we can deploy it without a project transition. It's based on #85452.

This PR introduces stack trace rules specific to Unreal Engine. Having these set by default will allow us to merge https://github.com/getsentry/sentry-unreal/pull/744 and resolve https://github.com/getsentry/sentry-unreal/issues/669.

Essentially, the suggested set of rules addresses grouping issues we encountered with assertion/ensure events. It also takes care of cutting off redundant call stack frames for regular events sent via the UE SDK interface.

Original rules by @tustanivsky .

Supersedes:
* https://github.com/getsentry/sentry/pull/83813