### PR TITLE
chore(grouping): Add log for errors when collecting grouphash metadata

### DIFF
--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -236,7 +236,13 @@ def get_or_create_grouphashes(
                     event, project, grouphash, created, grouping_config, variants
                 )
             except Exception as exc:
-                sentry_sdk.capture_exception(exc)
+                event_id = sentry_sdk.capture_exception(exc)
+                # Temporary log to try to debug why two metrics which should be equivalent are
+                # consistently unequal - maybe the code is erroring out between incrementing the
+                # first one and the second one?
+                logger.warning(
+                    "grouphash_metadata.exception", extra={"event_id": event_id, "error": repr(exc)}
+                )
 
         if grouphash.metadata:
             record_grouphash_metadata_metrics(grouphash.metadata, event.platform)


### PR DESCRIPTION
In our grouphash metadata code path, we have code which looks roughly like this:

```python
def get_or_create_grouphashes(...):
    ...
    
    try:
        create_or_update_grouphash_metadata_if_needed(...)
    except Exception as exc:
        sentry_sdk.capture_exception(exc)
        
        
        
def create_or_update_grouphash_metadata_if_needed(...):
    db_hit_metadata = {}

    if grouphash_is_new:
        new_data = get_grouphash_metadata_data(event, project, variants, grouping_config)
        db_hit_metadata = {"reason": "new_grouphash"}
        GroupHashMetadata.objects.create(**new_data)

    ...

    if db_hit_metadata:
        metrics.incr("grouping.grouphash_metadata.db_hit", tags=db_hit_metadata)
        
        
def get_grouphash_metadata_data(...):
    ...

    with metrics.timer(
        "grouping.grouphashmetadata.get_grouphash_metadata_data"
    ) as metrics_timer_tags:
        ...
```

(The real code is [here](https://github.com/getsentry/sentry/blob/08addf3d04b61c8f73f5b9c025235b77165e8467/src/sentry/grouping/ingest/hashing.py#L232-L239), [here](https://github.com/getsentry/sentry/blob/08addf3d04b61c8f73f5b9c025235b77165e8467/src/sentry/grouping/ingest/grouphash_metadata.py#L126-L155), and [here](https://github.com/getsentry/sentry/blob/08addf3d04b61c8f73f5b9c025235b77165e8467/src/sentry/grouping/ingest/grouphash_metadata.py#L197-L199).)

We collect two metrics here: `grouping.grouphash_metadata.db_hit` and `grouping.grouphashmetadata.get_grouphash_metadata_data`. (The former is a counter, and while the latter isn't, we can look at its `.count` variation in DD to compare them.) Given that `create_or_update_grouphash_metadata_if_needed` is the only place `get_grouphash_metadata_data` is called, that there's no early exit path inside of `get_grouphash_metadata_data` before we get to the timer metric, and that both metrics are sampled at the default 10% sample rate, we'd expect the metrics to be pretty much in lockstep - maybe with some tiny variations because of the sampling, but overall essentially equal.

And yet... we don't. Instead what we see is this, where the `db_hit` metric (dark blue) is consistently below the `get_grouphash_metadata_data` metric (light blue), implying that in some cases, within `create_or_update_grouphash_metadata_if_needed`, we're making it as far as the `get_grouphash_metadata_data` call, but not as far as the `db_hit` metric collection:

![image](https://github.com/user-attachments/assets/43aa8e67-38e9-491c-a966-87780fe4e764)

There's no explicit codepath matches that scenario, though, so... maybe it's erroring out somewhere between those two spots? To test that hypothesis, this adds a temporary log to the `except` block in `get_or_create_grouphashes`. 