### PR TITLE
ref(dashboards): Use better series name formatting in `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -38,6 +38,7 @@ import {CompleteAreaChartWidgetSeries} from './seriesConstructors/completeAreaCh
 import {CompleteLineChartWidgetSeries} from './seriesConstructors/completeLineChartWidgetSeries';
 import {IncompleteAreaChartWidgetSeries} from './seriesConstructors/incompleteAreaChartWidgetSeries';
 import {IncompleteLineChartWidgetSeries} from './seriesConstructors/incompleteLineChartWidgetSeries';
+import {formatSeriesName} from './formatSeriesName';
 import {formatTooltipValue} from './formatTooltipValue';
 import {formatXAxisTimestamp} from './formatXAxisTimestamp';
 import {formatYAxisValue} from './formatYAxisValue';
@@ -127,10 +128,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
     releaseSeries = ReleaseSeries(theme, props.releases, onClick, utc ?? false);
   }
-
-  const formatSeriesName: (string: string) => string = name => {
-    return props.aliases?.[name] ?? name;
-  };
 
   const chartZoomProps = useChartZoom({
     saveOnZoom: true,
@@ -274,7 +271,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           timeserie?.meta?.units?.[field] ?? undefined
         );
       },
-      nameFormatter: formatSeriesName,
+      nameFormatter: seriesName => {
+        return props.aliases?.[seriesName] ?? formatSeriesName(seriesName);
+      },
       truncate: true,
       utc: utc ?? false,
     })(deDupedParams, asyncTicket);
@@ -321,9 +320,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           ? {
               top: 0,
               left: 0,
-              formatter(name: string) {
+              formatter(seriesName: string) {
                 return truncationFormatter(
-                  props.aliases?.[name] ?? formatSeriesName(name),
+                  props.aliases?.[seriesName] ?? formatSeriesName(seriesName),
                   true,
                   // Escaping the legend string will cause some special
                   // characters to render as their HTML equivalents.


### PR DESCRIPTION
I added the better formatter in https://github.com/getsentry/sentry/pull/83393 but didn't use it yet. Here, I'm pulling it in and using it.
