### PR TITLE
ref(grouping): Make grouping component `description` a cached property

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Generator, Iterator, Sequence
+from functools import cached_property
 from typing import Any, Self
 
 from sentry.grouping.utils import hash_from_values
@@ -66,7 +67,7 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
     def name(self) -> str | None:
         return KNOWN_MAJOR_COMPONENT_NAMES.get(self.id)
 
-    @property
+    @cached_property
     def description(self) -> str:
         """
         Build the component description by walking its component tree and collecting the names of


### PR DESCRIPTION
To get the `description` value for a given grouping component object, we walk the entire component tree which the grouping algorithm creates from event data. Normally this is a fast process (under a millisecond), but in extreme cases (think a stacktrace with tons of frames, for example), it can take much longer (15-20 ms). While that's still obviously quite fast, we sometimes do it more than once during ingest, so it'd be great to speed that up if possible. 

As a first step in that direction, this changes `description` to a cached property, so that we only ever do the tree traversal once. We'll be able to tell if this has had an effect by looking at the p99 for grouphash metadata collection, which should hopefully decrease.