### PR TITLE
ref(grouping): Clean up fingerprinting helpers

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -514,7 +514,7 @@ class FingerprintRule:
 
         for match_type, matchers in matchers_by_match_type.items():
             for values in event_datastore.get_values(match_type):
-                if all(x.matches(values) for x in matchers):
+                if all(matcher.matches(values) for matcher in matchers):
                     break
             else:
                 return None

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -487,7 +487,7 @@ class FingerprintMatcher:
     @property
     def text(self) -> str:
         return '{}{}:"{}"'.format(
-            self.negated and "!" or "",
+            "!" if self.negated else "",
             self.key,
             self.pattern,
         )

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -160,6 +160,12 @@ class EventDatastore:
         self._family: list[_FamilyInfo] | None = None
         self._release: list[_ReleaseInfo] | None = None
 
+    def get_values(self, match_type: str) -> list[dict[str, Any]]:
+        """
+        Pull values from all the spots in the event appropriate to the given match type.
+        """
+        return getattr(self, "_get_" + match_type)()
+
     def _get_messages(self) -> list[_MessageInfo]:
         if self._messages is None:
             self._messages = []
@@ -242,12 +248,6 @@ class EventDatastore:
     def _get_release(self) -> list[_ReleaseInfo]:
         self._release = self._release or [{"release": self.event.get("release")}]
         return self._release
-
-    def get_values(self, match_type: str) -> list[dict[str, Any]]:
-        """
-        Pull values from all the spots in the event appropriate to the given match type.
-        """
-        return getattr(self, "_get_" + match_type)()
 
 
 class FingerprintingRules:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -478,11 +478,10 @@ class FingerprintMatcher:
     @classmethod
     def _from_config_structure(cls, matcher: list[str]) -> Self:
         key, pattern = matcher
-        if key.startswith("!"):
-            key = key[1:]
-            negated = True
-        else:
-            negated = False
+
+        negated = key.startswith("!")
+        key = key.lstrip("!")
+
         return cls(key, pattern, negated)
 
     @property

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -418,9 +418,7 @@ class FingerprintMatcher:
 
     def matches(self, values: dict[str, Any]) -> bool:
         rv = self._positive_match(values)
-        if self.negated:
-            rv = not rv
-        return rv
+        return not rv if self.negated else rv
 
     def _positive_path_match(self, value: str | None) -> bool:
         if value is None:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -417,8 +417,8 @@ class FingerprintMatcher:
         return "frames"
 
     def matches(self, values: dict[str, Any]) -> bool:
-        rv = self._positive_match(values)
-        return not rv if self.negated else rv
+        match_found = self._positive_match(values)
+        return not match_found if self.negated else match_found
 
     def _positive_path_match(self, value: str | None) -> bool:
         if value is None:

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -582,6 +582,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         changelog = []
         rules = []
         in_header = True
+
         for child in children:
             if isinstance(child, str):
                 if in_header and child.startswith("##"):
@@ -591,6 +592,7 @@ class FingerprintingVisitor(NodeVisitorBase):
             elif child is not None:
                 rules.append(child)
                 in_header = False
+
         return FingerprintingRules(
             rules=rules,
             changelog=inspect.cleandoc("\n".join(changelog)).rstrip() or None,

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -477,13 +477,13 @@ class FingerprintMatcher:
 
     @classmethod
     def _from_config_structure(cls, matcher: list[str]) -> Self:
-        key = matcher[0]
+        key, pattern = matcher
         if key.startswith("!"):
             key = key[1:]
             negated = True
         else:
             negated = False
-        return cls(key, matcher[1], negated)
+        return cls(key, pattern, negated)
 
     @property
     def text(self) -> str:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -160,10 +160,10 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
             return DEFAULT_FINGERPRINT_VARIABLE
         if variable_key is None:
             return entry
-        rv = get_fingerprint_value(variable_key, event_data)
-        if rv is None:
+        resolved_value = get_fingerprint_value(variable_key, event_data)
+        if resolved_value is None:
             return entry
-        return rv
+        return resolved_value
 
     return [_resolve_single_entry(entry) for entry in fingerprint]
 
@@ -171,9 +171,9 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
 def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:
     def _handle_match(match: Match[str]) -> str:
         variable_key = match.group(1)
-        rv = get_fingerprint_value(variable_key, event_data)
-        if rv is not None:
-            return rv
+        resolved_value = get_fingerprint_value(variable_key, event_data)
+        if resolved_value is not None:
+            return resolved_value
         return match.group(0)
 
     return _fingerprint_var_re.sub(_handle_match, template)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -133,6 +133,7 @@ def resolve_fingerprint_variable(
         frame = get_crash_frame_from_event_data(event_data)
         pkg = frame.get("package") if frame else None
         if pkg:
+            # If the package is formatted as either a POSIX or Windows path, grab the last segment
             pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
         return pkg or "<no-package>"
 
@@ -156,12 +157,12 @@ def resolve_fingerprint_variable(
 def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> list[str]:
     def _resolve_single_entry(entry: str) -> str:
         variable_key = parse_fingerprint_entry_as_variable(entry)
-        if variable_key == "default":
+        if variable_key == "default":  # entry is some variation of `{{ default }}`
             return DEFAULT_FINGERPRINT_VARIABLE
-        if variable_key is None:
+        if variable_key is None:  # entry isn't a variable
             return entry
         resolved_value = resolve_fingerprint_variable(variable_key, event_data)
-        if resolved_value is None:
+        if resolved_value is None:  # variable wasn't recognized
             return entry
         return resolved_value
 
@@ -174,6 +175,7 @@ def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:
         resolved_value = resolve_fingerprint_variable(variable_key, event_data)
         if resolved_value is not None:
             return resolved_value
+        # If the variable can't be resolved, return it as is
         return match.group(0)
 
     return _fingerprint_var_re.sub(_handle_match, template)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -154,7 +154,7 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
             return entry
         return rv
 
-    return [_resolve_single_entry(x) for x in fingerprint]
+    return [_resolve_single_entry(entry) for entry in fingerprint]
 
 
 def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -87,52 +87,54 @@ def bool_from_string(value: str) -> bool | None:
     return None
 
 
-def get_fingerprint_value(variable_key: str, data: NodeData | Mapping[str, Any]) -> str | None:
+def get_fingerprint_value(
+    variable_key: str, event_data: NodeData | Mapping[str, Any]
+) -> str | None:
     if variable_key == "transaction":
-        return data.get("transaction") or "<no-transaction>"
+        return event_data.get("transaction") or "<no-transaction>"
     elif variable_key == "message":
         message = (
-            get_path(data, "logentry", "formatted")
-            or get_path(data, "logentry", "message")
-            or get_path(data, "exception", "values", -1, "value")
+            get_path(event_data, "logentry", "formatted")
+            or get_path(event_data, "logentry", "message")
+            or get_path(event_data, "exception", "values", -1, "value")
         )
         return message or "<no-message>"
     elif variable_key in ("type", "error.type"):
-        ty = get_path(data, "exception", "values", -1, "type")
+        ty = get_path(event_data, "exception", "values", -1, "type")
         return ty or "<no-type>"
     elif variable_key in ("value", "error.value"):
-        value = get_path(data, "exception", "values", -1, "value")
+        value = get_path(event_data, "exception", "values", -1, "value")
         return value or "<no-value>"
     elif variable_key in ("function", "stack.function"):
-        frame = get_crash_frame_from_event_data(data)
+        frame = get_crash_frame_from_event_data(event_data)
         func = frame.get("function") if frame else None
         return func or "<no-function>"
     elif variable_key in ("path", "stack.abs_path"):
-        frame = get_crash_frame_from_event_data(data)
+        frame = get_crash_frame_from_event_data(event_data)
         abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
         return abs_path or "<no-abs-path>"
     elif variable_key == "stack.filename":
-        frame = get_crash_frame_from_event_data(data)
+        frame = get_crash_frame_from_event_data(event_data)
         filename = frame.get("filename") or frame.get("abs_path") if frame else None
         return filename or "<no-filename>"
     elif variable_key in ("module", "stack.module"):
-        frame = get_crash_frame_from_event_data(data)
+        frame = get_crash_frame_from_event_data(event_data)
         mod = frame.get("module") if frame else None
         return mod or "<no-module>"
     elif variable_key in ("package", "stack.package"):
-        frame = get_crash_frame_from_event_data(data)
+        frame = get_crash_frame_from_event_data(event_data)
         pkg = frame.get("package") if frame else None
         if pkg:
             pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
         return pkg or "<no-package>"
     elif variable_key == "level":
-        return data.get("level") or "<no-level>"
+        return event_data.get("level") or "<no-level>"
     elif variable_key == "logger":
-        return data.get("logger") or "<no-logger>"
+        return event_data.get("logger") or "<no-logger>"
     elif variable_key.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
         tag = variable_key[5:]
-        for tag_name, value in data.get("tags") or ():
+        for tag_name, value in event_data.get("tags") or ():
             if tag_name == tag and value is not None:
                 return value
         return "<no-value-for-tag-%s>" % tag

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -87,7 +87,7 @@ def bool_from_string(value: str) -> bool | None:
     return None
 
 
-def get_fingerprint_value(
+def resolve_fingerprint_variable(
     variable_key: str, event_data: NodeData | Mapping[str, Any]
 ) -> str | None:
     if variable_key == "transaction":
@@ -160,7 +160,7 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
             return DEFAULT_FINGERPRINT_VARIABLE
         if variable_key is None:
             return entry
-        resolved_value = get_fingerprint_value(variable_key, event_data)
+        resolved_value = resolve_fingerprint_variable(variable_key, event_data)
         if resolved_value is None:
             return entry
         return resolved_value
@@ -171,7 +171,7 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
 def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:
     def _handle_match(match: Match[str]) -> str:
         variable_key = match.group(1)
-        resolved_value = get_fingerprint_value(variable_key, event_data)
+        resolved_value = resolve_fingerprint_variable(variable_key, event_data)
         if resolved_value is not None:
             return resolved_value
         return match.group(0)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -126,8 +126,8 @@ def get_fingerprint_value(
 
     elif variable_key in ("module", "stack.module"):
         frame = get_crash_frame_from_event_data(event_data)
-        mod = frame.get("module") if frame else None
-        return mod or "<no-module>"
+        module = frame.get("module") if frame else None
+        return module or "<no-module>"
 
     elif variable_key in ("package", "stack.package"):
         frame = get_crash_frame_from_event_data(event_data)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -135,7 +135,7 @@ def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str |
         return None
 
 
-def resolve_fingerprint_values(values: list[str], event_data: NodeData) -> list[str]:
+def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> list[str]:
     def _get_fingerprint_value(value: str) -> str:
         var = parse_fingerprint_var(value)
         if var == "default":
@@ -147,7 +147,7 @@ def resolve_fingerprint_values(values: list[str], event_data: NodeData) -> list[
             return value
         return rv
 
-    return [_get_fingerprint_value(x) for x in values]
+    return [_get_fingerprint_value(x) for x in fingerprint]
 
 
 def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -143,7 +143,7 @@ def get_fingerprint_value(
 
 
 def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> list[str]:
-    def _get_fingerprint_value(value: str) -> str:
+    def _resolve_single_entry(value: str) -> str:
         variable_key = parse_fingerprint_entry_as_variable(value)
         if variable_key == "default":
             return DEFAULT_FINGERPRINT_VARIABLE
@@ -154,7 +154,7 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
             return value
         return rv
 
-    return [_get_fingerprint_value(x) for x in fingerprint]
+    return [_resolve_single_entry(x) for x in fingerprint]
 
 
 def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -22,6 +22,11 @@ DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
 def parse_fingerprint_entry_as_variable(value: str) -> str | None:
+    """
+    Determine if the given fingerprint entry is a variable, and if it is, return its key (that is,
+    extract the variable name from a variable string of the form "{{ var_name }}"). If the given
+    entry isn't the correct form to be a variable, return None.
+    """
     match = _fingerprint_var_re.match(value)
     if match is not None and match.end() == len(value):
         return match.group(1)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -143,15 +143,15 @@ def get_fingerprint_value(
 
 
 def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> list[str]:
-    def _resolve_single_entry(value: str) -> str:
-        variable_key = parse_fingerprint_entry_as_variable(value)
+    def _resolve_single_entry(entry: str) -> str:
+        variable_key = parse_fingerprint_entry_as_variable(entry)
         if variable_key == "default":
             return DEFAULT_FINGERPRINT_VARIABLE
         if variable_key is None:
-            return value
+            return entry
         rv = get_fingerprint_value(variable_key, event_data)
         if rv is None:
-            return value
+            return entry
         return rv
 
     return [_resolve_single_entry(x) for x in fingerprint]

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -144,11 +144,11 @@ def get_fingerprint_value(
 
     elif variable_key.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
-        tag = variable_key[5:]
+        requested_tag = variable_key[5:]
         for tag_name, value in event_data.get("tags") or ():
-            if tag_name == tag and value is not None:
+            if tag_name == requested_tag and value is not None:
                 return value
-        return "<no-value-for-tag-%s>" % tag
+        return "<no-value-for-tag-%s>" % requested_tag
     else:
         return None
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -21,14 +21,14 @@ _fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
 DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
-def parse_fingerprint_entry_as_variable(value: str) -> str | None:
+def parse_fingerprint_entry_as_variable(entry: str) -> str | None:
     """
     Determine if the given fingerprint entry is a variable, and if it is, return its key (that is,
     extract the variable name from a variable string of the form "{{ var_name }}"). If the given
     entry isn't the correct form to be a variable, return None.
     """
-    match = _fingerprint_var_re.match(value)
-    if match is not None and match.end() == len(value):
+    match = _fingerprint_var_re.match(entry)
+    if match is not None and match.end() == len(entry):
         return match.group(1)
     return None
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -127,8 +127,8 @@ def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str |
     elif var.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
         tag = var[5:]
-        for t, value in data.get("tags") or ():
-            if t == tag and value is not None:
+        for tag_name, value in data.get("tags") or ():
+            if tag_name == tag and value is not None:
                 return value
         return "<no-value-for-tag-%s>" % tag
     else:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -87,51 +87,51 @@ def bool_from_string(value: str) -> bool | None:
     return None
 
 
-def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str | None:
-    if var == "transaction":
+def get_fingerprint_value(variable_key: str, data: NodeData | Mapping[str, Any]) -> str | None:
+    if variable_key == "transaction":
         return data.get("transaction") or "<no-transaction>"
-    elif var == "message":
+    elif variable_key == "message":
         message = (
             get_path(data, "logentry", "formatted")
             or get_path(data, "logentry", "message")
             or get_path(data, "exception", "values", -1, "value")
         )
         return message or "<no-message>"
-    elif var in ("type", "error.type"):
+    elif variable_key in ("type", "error.type"):
         ty = get_path(data, "exception", "values", -1, "type")
         return ty or "<no-type>"
-    elif var in ("value", "error.value"):
+    elif variable_key in ("value", "error.value"):
         value = get_path(data, "exception", "values", -1, "value")
         return value or "<no-value>"
-    elif var in ("function", "stack.function"):
+    elif variable_key in ("function", "stack.function"):
         frame = get_crash_frame_from_event_data(data)
         func = frame.get("function") if frame else None
         return func or "<no-function>"
-    elif var in ("path", "stack.abs_path"):
+    elif variable_key in ("path", "stack.abs_path"):
         frame = get_crash_frame_from_event_data(data)
         abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
         return abs_path or "<no-abs-path>"
-    elif var == "stack.filename":
+    elif variable_key == "stack.filename":
         frame = get_crash_frame_from_event_data(data)
         filename = frame.get("filename") or frame.get("abs_path") if frame else None
         return filename or "<no-filename>"
-    elif var in ("module", "stack.module"):
+    elif variable_key in ("module", "stack.module"):
         frame = get_crash_frame_from_event_data(data)
         mod = frame.get("module") if frame else None
         return mod or "<no-module>"
-    elif var in ("package", "stack.package"):
+    elif variable_key in ("package", "stack.package"):
         frame = get_crash_frame_from_event_data(data)
         pkg = frame.get("package") if frame else None
         if pkg:
             pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
         return pkg or "<no-package>"
-    elif var == "level":
+    elif variable_key == "level":
         return data.get("level") or "<no-level>"
-    elif var == "logger":
+    elif variable_key == "logger":
         return data.get("logger") or "<no-logger>"
-    elif var.startswith("tags."):
+    elif variable_key.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
-        tag = var[5:]
+        tag = variable_key[5:]
         for tag_name, value in data.get("tags") or ():
             if tag_name == tag and value is not None:
                 return value
@@ -142,12 +142,12 @@ def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str |
 
 def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> list[str]:
     def _get_fingerprint_value(value: str) -> str:
-        var = parse_fingerprint_entry_as_variable(value)
-        if var == "default":
+        variable_key = parse_fingerprint_entry_as_variable(value)
+        if variable_key == "default":
             return DEFAULT_FINGERPRINT_VARIABLE
-        if var is None:
+        if variable_key is None:
             return value
-        rv = get_fingerprint_value(var, event_data)
+        rv = get_fingerprint_value(variable_key, event_data)
         if rv is None:
             return value
         return rv
@@ -157,8 +157,8 @@ def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> 
 
 def expand_title_template(template: str, event_data: Mapping[str, Any]) -> str:
     def _handle_match(match: Match[str]) -> str:
-        var = match.group(1)
-        rv = get_fingerprint_value(var, event_data)
+        variable_key = match.group(1)
+        rv = get_fingerprint_value(variable_key, event_data)
         if rv is not None:
             return rv
         return match.group(0)

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -145,9 +145,9 @@ def resolve_fingerprint_variable(
     elif variable_key.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
         requested_tag = variable_key[5:]
-        for tag_name, value in event_data.get("tags") or ():
-            if tag_name == requested_tag and value is not None:
-                return value
+        for tag_name, tag_value in event_data.get("tags") or ():
+            if tag_name == requested_tag and tag_value is not None:
+                return tag_value
         return "<no-value-for-tag-%s>" % requested_tag
     else:
         return None

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -21,7 +21,7 @@ _fingerprint_var_re = re.compile(r"\{\{\s*(\S+)\s*\}\}")
 DEFAULT_FINGERPRINT_VARIABLE = "{{ default }}"
 
 
-def parse_fingerprint_var(value: str) -> str | None:
+def parse_fingerprint_entry_as_variable(value: str) -> str | None:
     match = _fingerprint_var_re.match(value)
     if match is not None and match.end() == len(value):
         return match.group(1)
@@ -29,7 +29,7 @@ def parse_fingerprint_var(value: str) -> str | None:
 
 
 def is_default_fingerprint_var(value: str) -> bool:
-    return parse_fingerprint_var(value) == "default"
+    return parse_fingerprint_entry_as_variable(value) == "default"
 
 
 def hash_from_values(values: Iterable[str | int | UUID | ExceptionGroupingComponent]) -> str:
@@ -137,7 +137,7 @@ def get_fingerprint_value(var: str, data: NodeData | Mapping[str, Any]) -> str |
 
 def resolve_fingerprint_values(fingerprint: list[str], event_data: NodeData) -> list[str]:
     def _get_fingerprint_value(value: str) -> str:
-        var = parse_fingerprint_var(value)
+        var = parse_fingerprint_entry_as_variable(value)
         if var == "default":
             return DEFAULT_FINGERPRINT_VARIABLE
         if var is None:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -102,8 +102,8 @@ def get_fingerprint_value(
         return message or "<no-message>"
 
     elif variable_key in ("type", "error.type"):
-        ty = get_path(event_data, "exception", "values", -1, "type")
-        return ty or "<no-type>"
+        exception_type = get_path(event_data, "exception", "values", -1, "type")
+        return exception_type or "<no-type>"
 
     elif variable_key in ("value", "error.value"):
         value = get_path(event_data, "exception", "values", -1, "value")

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -92,6 +92,7 @@ def get_fingerprint_value(
 ) -> str | None:
     if variable_key == "transaction":
         return event_data.get("transaction") or "<no-transaction>"
+
     elif variable_key == "message":
         message = (
             get_path(event_data, "logentry", "formatted")
@@ -99,38 +100,48 @@ def get_fingerprint_value(
             or get_path(event_data, "exception", "values", -1, "value")
         )
         return message or "<no-message>"
+
     elif variable_key in ("type", "error.type"):
         ty = get_path(event_data, "exception", "values", -1, "type")
         return ty or "<no-type>"
+
     elif variable_key in ("value", "error.value"):
         value = get_path(event_data, "exception", "values", -1, "value")
         return value or "<no-value>"
+
     elif variable_key in ("function", "stack.function"):
         frame = get_crash_frame_from_event_data(event_data)
         func = frame.get("function") if frame else None
         return func or "<no-function>"
+
     elif variable_key in ("path", "stack.abs_path"):
         frame = get_crash_frame_from_event_data(event_data)
         abs_path = frame.get("abs_path") or frame.get("filename") if frame else None
         return abs_path or "<no-abs-path>"
+
     elif variable_key == "stack.filename":
         frame = get_crash_frame_from_event_data(event_data)
         filename = frame.get("filename") or frame.get("abs_path") if frame else None
         return filename or "<no-filename>"
+
     elif variable_key in ("module", "stack.module"):
         frame = get_crash_frame_from_event_data(event_data)
         mod = frame.get("module") if frame else None
         return mod or "<no-module>"
+
     elif variable_key in ("package", "stack.package"):
         frame = get_crash_frame_from_event_data(event_data)
         pkg = frame.get("package") if frame else None
         if pkg:
             pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
         return pkg or "<no-package>"
+
     elif variable_key == "level":
         return event_data.get("level") or "<no-level>"
+
     elif variable_key == "logger":
         return event_data.get("logger") or "<no-logger>"
+
     elif variable_key.startswith("tags."):
         # Turn "tags.some_tag" into just "some_tag"
         tag = variable_key[5:]


### PR DESCRIPTION
This is some refactoring I did back when I was digging around in the grouping code, which I just rediscovered on an old branch. Mostly just things I renamed for clarity as I was trying to understand the code, but also a bit of simplification/clarification of code (things like using an explicit ternary rather than relying on the precedence order of `and` and `or`, stripping a specific character from a string rather than slicing it, using `any` rather than testing a boolean condition in a for loop, etc.). No behavior changes.