### PR TITLE
chore(aci): add receiver to create detectors on project creation

### DIFF
--- a/src/sentry/receivers/__init__.py
+++ b/src/sentry/receivers/__init__.py
@@ -8,6 +8,7 @@ from .onboarding import *  # noqa: F401,F403
 from .outbox.control import *  # noqa: F401,F403
 from .outbox.region import *  # noqa: F401,F403
 from .owners import *  # noqa: F401,F403
+from .project_detectors import *  # noqa: F401,F403
 from .releases import *  # noqa: F401,F403
 from .rules import *  # noqa: F401,F403
 from .sentry_apps import *  # noqa: F401,F403

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -1,0 +1,31 @@
+import logging
+
+import sentry_sdk
+from django.db import IntegrityError
+from django.db.models.signals import post_save
+
+from sentry import features
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.project import Project
+from sentry.workflow_engine.models import Detector
+
+logger = logging.getLogger(__name__)
+
+
+def create_project_detectors(instance, created, **kwargs):
+    if created:
+        try:
+            if features.has(
+                "organizations:workflow-engine-issue-alert-dual-write", instance.organization
+            ):
+                Detector.objects.create(
+                    name="Error Detector", type=ErrorGroupType.slug, project=instance, config={}
+                )
+                logger.info("project.detector-created", extra={"project_id": instance.id})
+        except IntegrityError as e:
+            sentry_sdk.capture_exception(e)
+
+
+post_save.connect(
+    create_project_detectors, sender=Project, dispatch_uid="create_project_detectors", weak=False
+)


### PR DESCRIPTION
Error detectors should be created automatically when a new project is created. Add a feature-flagged receiver that does this.