### PR TITLE
feat(insights): Add count_(publish|process) and avg_if_(publish|process) functions in span metrics discover dataset

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -376,6 +376,8 @@ DEFAULT_METRIC_TAGS = {
     "span.op",
     "trace.status",
     "messaging.destination.name",
+    "messaging.operation.name",
+    "messaging.operation.type",
 }
 SPAN_MESSAGING_LATENCY = "g:spans/messaging.message.receive.latency@millisecond"
 SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -1249,6 +1249,39 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             alias,
         )
 
+    def _is_messaging_op(self, op: str, operation_name: str, operation_type: str) -> Function:
+        return Function(
+            "or",
+            [
+                Function(
+                    "equals",
+                    [
+                        self.builder.column("span.op"),
+                        self.builder.resolve_tag_value(op),
+                    ],
+                ),
+                Function(
+                    "or",
+                    [
+                        Function(
+                            "equals",
+                            [
+                                self.builder.column("messaging.operation.type"),
+                                self.builder.resolve_tag_value(operation_type),
+                            ],
+                        ),
+                        Function(
+                            "equals",
+                            [
+                                self.builder.column("messaging.operation.name"),
+                                self.builder.resolve_tag_value(operation_name),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
     def _resolve_count_publish(self, args, alias):
         op = "queue.publish"
         operation_name = "publish"
@@ -1262,37 +1295,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     self.resolve_metric("span.self_time"),
                 ],
             ),
-            Function(
-                "or",
-                [
-                    Function(
-                        "equals",
-                        [
-                            self.builder.column("span.op"),
-                            self.builder.resolve_tag_value(op),
-                        ],
-                    ),
-                    Function(
-                        "or",
-                        [
-                            Function(
-                                "equals",
-                                [
-                                    self.builder.column("messaging.operation.type"),
-                                    self.builder.resolve_tag_value(operation_type),
-                                ],
-                            ),
-                            Function(
-                                "equals",
-                                [
-                                    self.builder.column("messaging.operation.name"),
-                                    self.builder.resolve_tag_value(operation_name),
-                                ],
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+            self._is_messaging_op(op, operation_name, operation_type),
             alias,
         )
 
@@ -1309,37 +1312,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     self.resolve_metric("span.self_time"),
                 ],
             ),
-            Function(
-                "or",
-                [
-                    Function(
-                        "equals",
-                        [
-                            self.builder.column("span.op"),
-                            self.builder.resolve_tag_value(op),
-                        ],
-                    ),
-                    Function(
-                        "or",
-                        [
-                            Function(
-                                "equals",
-                                [
-                                    self.builder.column("messaging.operation.type"),
-                                    self.builder.resolve_tag_value(operation_type),
-                                ],
-                            ),
-                            Function(
-                                "equals",
-                                [
-                                    self.builder.column("messaging.operation.name"),
-                                    self.builder.resolve_tag_value(operation_name),
-                                ],
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+            self._is_messaging_op(op, operation_name, operation_type),
             alias,
         )
 

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -1250,6 +1250,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         )
 
     def _is_messaging_op(self, op: str, operation_name: str, operation_type: str) -> Function:
+        hasOperationNameColumn = self.builder.resolve_tag_key("messaging.operation.name")
+        hasOperationTypeColumn = self.builder.resolve_tag_key("messaging.operation.type")
         return Function(
             "or",
             [
@@ -1260,23 +1262,20 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                         self.builder.resolve_tag_value(op),
                     ],
                 ),
-                Function(
-                    "or",
+                hasOperationTypeColumn
+                and Function(
+                    "equals",
                     [
-                        Function(
-                            "equals",
-                            [
-                                self.builder.column("messaging.operation.type"),
-                                self.builder.resolve_tag_value(operation_type),
-                            ],
-                        ),
-                        Function(
-                            "equals",
-                            [
-                                self.builder.column("messaging.operation.name"),
-                                self.builder.resolve_tag_value(operation_name),
-                            ],
-                        ),
+                        self.builder.column("messaging.operation.type"),
+                        self.builder.resolve_tag_value(operation_type),
+                    ],
+                ),
+                hasOperationNameColumn
+                and Function(
+                    "equals",
+                    [
+                        self.builder.column("messaging.operation.name"),
+                        self.builder.resolve_tag_value(operation_name),
                     ],
                 ),
             ],

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -170,6 +170,8 @@ SPAN_COLUMN_MAP = {
     "trace.status": "sentry_tags[trace.status]",
     "messaging.destination.name": "sentry_tags[messaging.destination.name]",
     "messaging.message.id": "sentry_tags[messaging.message.id]",
+    "messaging.operation.name": "sentry_tags[messaging.operation.name]",
+    "messaging.operation.type": "sentry_tags[messaging.operation.type]",
     "tags.key": "tags.key",
     "tags.value": "tags.value",
     "user.geo.subregion": "sentry_tags[user.geo.subregion]",

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1789,6 +1789,44 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {"count_publish()": 3},
         ]
 
+    def test_count_process(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.op": "queue.process"},
+        )
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.name": "process"},
+        )
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.type": "process"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "count_process()",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [
+            {"count_process()": 3},
+        ]
+
     def test_project_mapping(self):
         self.store_span_metric(
             1,
@@ -2253,3 +2291,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_count_publish(self):
         super().test_count_publish()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_count_process(self):
+        super().test_count_process()

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1751,6 +1751,44 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {"count_op(queue.publish)": 1, "count_op(queue.process)": 1},
         ]
 
+    def test_count_publish(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"span.op": "queue.publish"},
+        )
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.name": "publish"},
+        )
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.type": "create"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "count_publish()",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [
+            {"count_publish()": 3},
+        ]
+
     def test_project_mapping(self):
         self.store_span_metric(
             1,
@@ -2211,3 +2249,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_count_op(self):
         super().test_count_op()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_count_publish(self):
+        super().test_count_publish()

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1827,6 +1827,80 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {"count_process()": 3},
         ]
 
+    def test_avg_if_publish(self):
+        self.store_span_metric(
+            0,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"span.op": "queue.publish"},
+        )
+        self.store_span_metric(
+            10,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.name": "publish"},
+        )
+        self.store_span_metric(
+            20,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.type": "create"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "avg_if_publish(span.duration)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [
+            {"avg_if_publish(span.duration)": 10.0},
+        ]
+
+    def test_avg_if_process(self):
+        self.store_span_metric(
+            0,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"span.op": "queue.process"},
+        )
+        self.store_span_metric(
+            10,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.name": "process"},
+        )
+        self.store_span_metric(
+            20,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"messaging.operation.type": "process"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "avg_if_process(span.duration)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [{"avg_if_process(span.duration)": 10.0}]
+
     def test_project_mapping(self):
         self.store_span_metric(
             1,
@@ -2295,3 +2369,11 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_count_process(self):
         super().test_count_process()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_avg_if_publish(self):
+        super().test_avg_if_publish()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_avg_if_process(self):
+        super().test_avg_if_process()


### PR DESCRIPTION
OTel spans don't provide a sentry span.op which is what we currently use to help determine if a span is a messaging span. Instead, OTel specifies a `messaging.operation.name` and `messaging.operation.type` attribute, which we can use. The logic to determine a messaging span is a little more complicated now, so we can't use `count_op` or `avg_if`, so we must create new `count_publish`, `count_process`, `avg_if_publish`, and `avg_if_process` functions.