### PR TITLE
chore(uptime): Tidy up default region code

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -174,10 +174,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         if subscription is None:
             # If no subscription in the Postgres, this subscription has been orphaned. Remove
             # from the checker
-            # TODO: Send to region specifically from this check result once we update the schema
-            send_uptime_config_deletion(
-                get_active_region_configs()[0].slug, result["subscription_id"]
-            )
+            send_uptime_config_deletion(result["region"], result["subscription_id"])
             metrics.incr(
                 "uptime.result_processor.subscription_not_found",
                 sample_rate=1.0,

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -14,8 +14,4 @@ def get_active_region_configs() -> list[UptimeRegionConfig]:
 
 
 def get_region_config(region_slug: str) -> UptimeRegionConfig | None:
-    region = next((r for r in settings.UPTIME_REGIONS if r.slug == region_slug), None)
-    if region is None:
-        # XXX: Temporary hack to guarantee we get a config
-        region = get_active_region_configs()[0]
-    return region
+    return next((r for r in settings.UPTIME_REGIONS if r.slug == region_slug), None)

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -11,7 +11,6 @@ from sentry.snuba.models import QuerySubscription
 from sentry.tasks.base import instrumented_task
 from sentry.uptime.config_producer import produce_config, produce_config_removal
 from sentry.uptime.models import UptimeRegionScheduleMode, UptimeSubscription
-from sentry.uptime.subscriptions.regions import get_active_region_configs
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -39,10 +38,6 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         return
 
     region_slugs = [s.region_slug for s in subscription.regions.all()]
-    if not region_slugs:
-        # XXX: Hack to make sure that region configs are sent even if we don't have region rows present.
-        # Remove once everything is in place
-        region_slugs = [get_active_region_configs()[0].slug]
 
     for region_slug in region_slugs:
         send_uptime_subscription_config(region_slug, subscription)
@@ -72,10 +67,6 @@ def update_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         return
 
     region_slugs = [s.region_slug for s in subscription.regions.all()]
-    if not region_slugs:
-        # XXX: Hack to make sure that region configs are sent even if we don't have region rows present.
-        # Remove once everything is in place
-        region_slugs = [get_active_region_configs()[0].slug]
 
     for region_slug in region_slugs:
         send_uptime_subscription_config(region_slug, subscription)
@@ -106,10 +97,6 @@ def delete_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         return
 
     region_slugs = [s.region_slug for s in subscription.regions.all()]
-    if not region_slugs:
-        # XXX: Hack to make sure that region configs are sent even if we don't have regions present.
-        # Remove once everything is in place
-        region_slugs = [get_active_region_configs()[0].slug]
 
     subscription_id = subscription.subscription_id
     if subscription.status == QuerySubscription.Status.DELETING.value:

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -460,7 +460,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
     def test_no_subscription(self):
         subscription_id = uuid.uuid4().hex
-        result = self.create_uptime_result(subscription_id)
+        result = self.create_uptime_result(subscription_id, uptime_region="default")
         with (
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
             self.feature(["organizations:uptime", "organizations:uptime-create-issues"]),
@@ -470,7 +470,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 [
                     call(
                         "uptime.result_processor.subscription_not_found",
-                        tags={"uptime_region": "us-west"},
+                        tags={"uptime_region": "default"},
                         sample_rate=1.0,
                     )
                 ]

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -49,9 +49,3 @@ class GetRegionConfigTest(TestBase):
             assert region is not None
             assert region.slug == "us"
             assert region.name == "United States"
-
-    def test_returns_first_active_region_for_invalid_slug(self):
-        with override_settings(UPTIME_REGIONS=self.test_regions):
-            region = get_region_config("invalid")
-            assert region is not None
-            assert region.slug == "us"  # First active region

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -96,13 +96,14 @@ class BaseUptimeSubscriptionTaskTest(ConfigPusherTestMixin, metaclass=abc.ABCMet
     def create_subscription(
         self, status: UptimeSubscription.Status, subscription_id: str | None = None
     ):
-        return UptimeSubscription.objects.create(
-            status=status.value,
+        return self.create_uptime_subscription(
+            status=status,
             type="something",
             subscription_id=subscription_id,
             url="http://sentry.io",
             interval_seconds=300,
             timeout_ms=500,
+            region_slugs=["default"],
         )
 
     def test_no_subscription(self):
@@ -322,6 +323,7 @@ class SubscriptionCheckerTest(UptimeTestCase):
                 status=status,
                 date_updated=timezone.now() - (SUBSCRIPTION_STATUS_MAX_AGE * 2),
                 url=f"http://sentry{status}.io",
+                region_slugs=["default"],
             )
             sub_new = self.create_uptime_subscription(
                 status=status, date_updated=timezone.now(), url=f"http://santry{status}.io"


### PR DESCRIPTION
We had code in place to make sure that a default region is always available. Now that all uptime checkers and configs are set correctly to have regions, we can remove this code.

This is a precursor to implementing shadow regions, to reduce the complexity of region handling.

<!-- Describe your PR here. -->