### PR TITLE
ref(metrics): Simplify helper for extra query params

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -55,6 +55,7 @@ import {getViableDateRange} from 'sentry/views/alerts/rules/metric/details/utils
 import {makeDefaultCta} from 'sentry/views/alerts/rules/metric/metricRulePresets';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {AlertRuleTriggerType, Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {shouldUseErrorsDiscoverDataset} from 'sentry/views/alerts/rules/utils';
 import {getChangeStatus} from 'sentry/views/alerts/utils/getChangeStatus';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
@@ -139,10 +140,6 @@ function getRuleChangeSeries(
   ];
 }
 
-function shouldUseErrorsDataset(dataset: Dataset, query: string): boolean {
-  return dataset === Dataset.ERRORS && /\bis:unresolved\b/.test(query);
-}
-
 export default function MetricChart({
   rule,
   project,
@@ -212,7 +209,7 @@ export default function MetricChart({
       waitingForDataDuration: number
     ) => {
       let dataset: DiscoverDatasets | undefined = undefined;
-      if (shouldUseErrorsDataset(rule.dataset, query)) {
+      if (shouldUseErrorsDiscoverDataset(query, rule.dataset, organization)) {
         dataset = DiscoverDatasets.ERRORS;
       }
 
@@ -549,14 +546,11 @@ export default function MetricChart({
       organization,
       location,
       dataset,
+      query,
       newAlertOrQuery: false,
       useOnDemandMetrics: isOnDemandAlert,
     }),
   };
-
-  if (shouldUseErrorsDataset(dataset, query)) {
-    queryExtras.dataset = 'errors';
-  }
 
   return isCrashFreeAlert(dataset) ? (
     <SessionsRequest

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -557,17 +557,13 @@ class TriggersChart extends PureComponent<Props, State> {
       organization.features.includes('change-alerts') && comparisonDelta
     );
 
-    const queryExtras = {
-      ...getMetricDatasetQueryExtras({
-        organization,
-        location,
-        dataset,
-        newAlertOrQuery,
-      }),
-      ...(shouldUseErrorsDiscoverDataset(query, dataset, organization)
-        ? {dataset: DiscoverDatasets.ERRORS}
-        : {}),
-    };
+    const queryExtras = getMetricDatasetQueryExtras({
+      organization,
+      location,
+      dataset,
+      query,
+      newAlertOrQuery,
+    });
 
     if (isOnDemandMetricAlert) {
       const {sampleRate} = this.state;

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -6,6 +6,7 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   FieldKey,
   makeTagCollection,
@@ -46,12 +47,6 @@ export enum MEPAlertsQueryType {
   ERROR = 0,
   PERFORMANCE = 1,
   CRASH_RATE = 2,
-}
-
-export enum MEPAlertsDataset {
-  DISCOVER = 'discover',
-  METRICS = 'metrics',
-  METRICS_ENHANCED = 'metricsEnhanced',
 }
 
 export type MetricAlertType = Exclude<
@@ -408,22 +403,22 @@ export function getSupportedAndOmittedTags(
   }, {});
 }
 
-export function getMEPAlertsDataset(
+export function getDiscoverDataset(
   dataset: Dataset,
   newAlert: boolean
-): MEPAlertsDataset {
+): DiscoverDatasets {
   // Dataset.ERRORS overrides all cases
   if (dataset === Dataset.ERRORS) {
-    return MEPAlertsDataset.DISCOVER;
+    return DiscoverDatasets.DISCOVER;
   }
 
   if (newAlert) {
-    return MEPAlertsDataset.METRICS_ENHANCED;
+    return DiscoverDatasets.METRICS_ENHANCED;
   }
 
   if (dataset === Dataset.GENERIC_METRICS) {
-    return MEPAlertsDataset.METRICS_ENHANCED;
+    return DiscoverDatasets.METRICS_ENHANCED;
   }
 
-  return MEPAlertsDataset.DISCOVER;
+  return DiscoverDatasets.DISCOVER;
 }


### PR DESCRIPTION
Found this while working on hooks to replace the render prop queries in `<MetricChart/>`. Both call sites for this function do the same thing afterward so I just moved that logic into the `getMetricDatasetQueryExtras` helper.

There was also a method called `getMEPAlertsDataset` which was only used in this one place and used an enum that none of the others referenced, so I aligned that.