### PR TITLE
feat(nav): Add starred dashboards

### DIFF
--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -77,6 +77,7 @@ export function PrimaryNavigationItems() {
         >
           <SidebarLink
             to={`/${prefix}/dashboards/`}
+            activeTo={`/${prefix}/dashboard`}
             analyticsKey="customizable-dashboards"
             label={NAV_GROUP_LABELS[PrimaryNavGroup.DASHBOARDS]}
           >

--- a/static/app/views/dashboards/navigation.tsx
+++ b/static/app/views/dashboards/navigation.tsx
@@ -4,21 +4,31 @@ import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
 type DashboardsNavigationProps = {
   children: React.ReactNode;
 };
 
-export default function DashboardsNavigation({children}: DashboardsNavigationProps) {
+function DashboardsSecondaryNav({children}: DashboardsNavigationProps) {
   const organization = useOrganization();
-  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
-
-  if (!hasNavigationV2) {
-    return children;
-  }
-
   const baseUrl = `/organizations/${organization.slug}/dashboards`;
+
+  const starredDashboards = useApiQuery<DashboardListItem[]>(
+    [
+      `/organizations/${organization.slug}/dashboards/`,
+      {
+        query: {
+          filter: 'onlyFavorites',
+        },
+      },
+    ],
+    {
+      staleTime: Infinity,
+    }
+  );
 
   return (
     <Fragment>
@@ -32,9 +42,30 @@ export default function DashboardsNavigation({children}: DashboardsNavigationPro
               {t('All')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
+          <SecondaryNav.Section title={t('Starred')}>
+            {starredDashboards.data?.map(dashboard => (
+              <SecondaryNav.Item
+                key={dashboard.id}
+                to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+              >
+                {dashboard.title}
+              </SecondaryNav.Item>
+            )) ?? null}
+          </SecondaryNav.Section>
         </SecondaryNav.Body>
       </SecondaryNav>
       {children}
     </Fragment>
   );
+}
+
+export default function DashboardsNavigation({children}: DashboardsNavigationProps) {
+  const organization = useOrganization();
+  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+  if (!hasNavigationV2) {
+    return children;
+  }
+
+  return <DashboardsSecondaryNav>{children}</DashboardsSecondaryNav>;
 }


### PR DESCRIPTION
Very simple placeholder for displaying starred dashboards in the new nav:

![CleanShot 2025-02-19 at 15 11 08](https://github.com/user-attachments/assets/05d6bfa1-c51a-48d9-9715-3f66d5f3d239)
