### PR TITLE
:recycle: ref(metric alerts): use typed dict return types for attachment_info functions

### DIFF
--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -9,15 +9,15 @@ from sentry.integrations.discord.message_builder import INCIDENT_COLOR_MAPPING, 
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
 from sentry.integrations.discord.message_builder.base.embed.base import DiscordMessageEmbed
 from sentry.integrations.discord.message_builder.base.embed.image import DiscordMessageEmbedImage
-from sentry.integrations.metric_alerts import metric_alert_attachment_info
+from sentry.integrations.metric_alerts import incident_attachment_info
 
 
 class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
     def __init__(
         self,
         alert_rule: AlertRule,
-        incident: Incident | None = None,
-        new_status: IncidentStatus | None = None,
+        incident: Incident,
+        new_status: IncidentStatus,
         metric_value: float | None = None,
         chart_url: str | None = None,
     ) -> None:
@@ -28,18 +28,21 @@ class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
         self.chart_url = chart_url
 
     def build(self, notification_uuid: str | None = None) -> dict[str, object]:
-        data = metric_alert_attachment_info(
-            self.alert_rule, self.incident, self.new_status, self.metric_value
+        data = incident_attachment_info(
+            self.incident,
+            self.new_status,
+            self.metric_value,
+            notification_uuid,
+            referrer="metric_alert_discord",
         )
-        url = f"{data['title_link']}&referrer=discord"
-        if notification_uuid:
-            url += f"&notification_uuid={notification_uuid}"
+
+        description = f"{data['text']}{get_started_at(data['date_started'])}"
 
         embeds = [
             DiscordMessageEmbed(
                 title=data["title"],
-                url=url,
-                description=f"{data['text']}{get_started_at(data['date_started'])}",
+                url=data["title_link"],
+                description=description,
                 color=LEVEL_TO_COLOR[INCIDENT_COLOR_MAPPING.get(data["status"], "")],
                 image=DiscordMessageEmbedImage(url=self.chart_url) if self.chart_url else None,
             )
@@ -48,8 +51,8 @@ class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
         return self._build(embeds=embeds)
 
 
-def get_started_at(timestamp: datetime) -> str:
-    if timestamp:
-        unix_timestamp = int(time.mktime(timestamp.timetuple()))
-        return f"\nStarted <t:{unix_timestamp}:R>"
-    return ""
+def get_started_at(timestamp: datetime | None) -> str:
+    if timestamp is None:
+        return ""
+    unix_timestamp = int(time.mktime(timestamp.timetuple()))
+    return f"\nStarted <t:{unix_timestamp}:R>"

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import TypedDict
 from urllib import parse
 
 from django.db.models import Max
@@ -36,6 +37,15 @@ TEXT_COMPARISON_DELTA = {
     10080: ("same time one week ago"),  # one week
     43200: ("same time one month ago"),  # 30 days
 }
+
+
+class AttachmentInfo(TypedDict):
+    title_link: str
+    title: str
+    text: str
+    status: str
+    logo_url: str
+    date_started: datetime | None
 
 
 def logo_url() -> str:
@@ -109,7 +119,7 @@ def incident_attachment_info(
     metric_value=None,
     notification_uuid=None,
     referrer="metric_alert",
-):
+) -> AttachmentInfo:
     alert_rule = incident.alert_rule
 
     status = INCIDENT_STATUS[new_status]
@@ -144,14 +154,14 @@ def incident_attachment_info(
         query=parse.urlencode(title_link_params),
     )
 
-    return {
-        "title": title,
-        "text": text,
-        "logo_url": logo_url(),
-        "status": status,
-        "ts": incident.date_started,
-        "title_link": title_link,
-    }
+    return AttachmentInfo(
+        title=title,
+        text=text,
+        logo_url=logo_url(),
+        status=status,
+        date_started=incident.date_started,
+        title_link=title_link,
+    )
 
 
 def metric_alert_attachment_info(
@@ -159,7 +169,7 @@ def metric_alert_attachment_info(
     selected_incident: Incident | None = None,
     new_status: IncidentStatus | None = None,
     metric_value: float | None = None,
-):
+) -> AttachmentInfo:
     latest_incident = None
     if selected_incident is None:
         try:
@@ -225,16 +235,11 @@ def metric_alert_attachment_info(
     if selected_incident:
         date_started = selected_incident.date_started
 
-    last_triggered_date = None
-    if latest_incident:
-        last_triggered_date = latest_incident.date_started
-
-    return {
-        "title": title,
-        "text": text,
-        "logo_url": logo_url(),
-        "status": status,
-        "date_started": date_started,
-        "last_triggered_date": last_triggered_date,
-        "title_link": title_link,
-    }
+    return AttachmentInfo(
+        title_link=title_link,
+        title=title,
+        text=text,
+        status=status,
+        logo_url=logo_url(),
+        date_started=date_started,
+    )

--- a/src/sentry/integrations/msteams/card_builder/incident_attachment.py
+++ b/src/sentry/integrations/msteams/card_builder/incident_attachment.py
@@ -29,7 +29,11 @@ def build_incident_attachment(
     colors: dict[str, Literal["good", "warning", "attention"]]
     colors = {"Resolved": "good", "Warning": "warning", "Critical": "attention"}
 
-    footer_text = "Sentry Incident | {}".format(data["ts"].strftime("%b %d"))
+    footer_text = (
+        "Sentry Incident | {}".format(data["date_started"].strftime("%b %d"))
+        if data["date_started"] is not None
+        else "Sentry Incident"
+    )
 
     return {
         "type": "AdaptiveCard",

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -13,7 +13,9 @@ from sentry.integrations.slack.message_builder.types import (
 from sentry.integrations.slack.utils.escape import escape_slack_text
 
 
-def get_started_at(timestamp: datetime) -> str:
+def get_started_at(timestamp: datetime | None) -> str:
+    if timestamp is None:
+        return ""
     return "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
         timestamp.timestamp(), "{date_pretty}", "{time}"
     )
@@ -54,7 +56,7 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
             self.notification_uuid,
             referrer="metric_alert_slack",
         )
-        incident_text = f"{data['text']}\n{get_started_at(data['ts'])}"
+        incident_text = f"{data['text']}\n{get_started_at(data['date_started'])}"
         blocks = [
             self.get_markdown_block(text=incident_text),
         ]

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -29,6 +29,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
         super().setUp()
         self.alert_rule = self.create_alert_rule()
 
+    def get_url(self, link, identifier, detection_type, uuid: str | None):
+        if uuid is None:
+            return f"{link}?alert={identifier}&referrer=metric_alert_discord&detection_type={detection_type}"
+        return f"{link}?alert={identifier}&referrer=metric_alert_discord&detection_type={detection_type}&notification_uuid={uuid}"
+
     def test_metric_alert_with_selected_incident(self):
         new_status = IncidentStatus.CLOSED.value
         incident = self.create_incident(alert_rule=self.alert_rule, status=new_status)
@@ -58,7 +63,9 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": f"0 events in the last 10 minutes{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=metric_alert_discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": self.get_url(
+                        link, incident.identifier, self.alert_rule.detection_type, uuid
+                    ),
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                 }
             ],
@@ -94,7 +101,9 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": f"0 events in the last 10 minutes{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=metric_alert_discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": self.get_url(
+                        link, incident.identifier, self.alert_rule.detection_type, uuid
+                    ),
                 }
             ],
             "components": [],
@@ -133,7 +142,9 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "title": title,
                     "color": LEVEL_TO_COLOR["fatal"],
                     "description": f"{metric_value} events in the last 10 minutes{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=metric_alert_discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": self.get_url(
+                        link, incident.identifier, self.alert_rule.detection_type, uuid
+                    ),
                 }
             ],
             "components": [],
@@ -167,7 +178,9 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": f"0 events in the last 10 minutes{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=metric_alert_discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": self.get_url(
+                        link, incident.identifier, self.alert_rule.detection_type, uuid
+                    ),
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                     "image": {"url": "chart_url"},
                 }
@@ -204,7 +217,9 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": f"0 events in the last 10 minutes{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=metric_alert_discord&detection_type={self.alert_rule.detection_type}",
+                    "url": self.get_url(
+                        link, incident.identifier, self.alert_rule.detection_type, None
+                    ),
                 }
             ],
             "components": [],
@@ -251,7 +266,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": f"0 events in the last 30 minutes\nThreshold: {alert_rule.detection_type.title()}{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=metric_alert_discord&detection_type={alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": self.get_url(link, incident.identifier, alert_rule.detection_type, uuid),
                 }
             ],
             "components": [],

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -46,7 +46,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "123 events in the last 10 minutes"
-        assert data["ts"] == date_started
+        assert data["date_started"] == date_started
         assert (
             data["title_link"]
             == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer={referrer}&detection_type=static&notification_uuid={notification_uuid}"
@@ -91,7 +91,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         )  # Pulls from trigger, not incident
         assert data["status"] == "Critical"  # Should pull from the action/trigger.
         assert data["text"] == "4 events in the last 10 minutes"
-        assert data["ts"] == date_started
+        assert data["date_started"] == date_started
         assert (
             data["title_link"]
             == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert&detection_type=static"
@@ -106,7 +106,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "4 events in the last 10 minutes"
-        assert data["ts"] == date_started
+        assert data["date_started"] == date_started
         assert (
             data["title_link"]
             == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert&detection_type=static"
@@ -121,7 +121,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "4 events in the last 10 minutes"
-        assert data["ts"] == date_started
+        assert data["date_started"] == date_started
         assert (
             data["title_link"]
             == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert&detection_type=static"
@@ -272,7 +272,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         assert data["title"] == f"Critical: {self.alert_rule.name}"
         assert data["status"] == "Critical"
         assert data["text"] == "92% sessions crash free rate in the last hour"
-        assert data["ts"] == self.date_started
+        assert data["date_started"] == self.date_started
         assert (
             data["logo_url"]
             == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
@@ -284,7 +284,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "100.0% sessions crash free rate in the last hour"
-        assert data["ts"] == self.date_started
+        assert data["date_started"] == self.date_started
         assert (
             data["logo_url"]
             == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
@@ -296,7 +296,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         assert data["title"] == f"Critical: {self.alert_rule.name}"
         assert data["status"] == "Critical"
         assert data["text"] == "92% users crash free rate in the last hour"
-        assert data["ts"] == self.date_started
+        assert data["date_started"] == self.date_started
         assert (
             data["logo_url"]
             == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
@@ -308,7 +308,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "100.0% users crash free rate in the last hour"
-        assert data["ts"] == self.date_started
+        assert data["date_started"] == self.date_started
         assert (
             data["logo_url"]
             == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
@@ -320,7 +320,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         assert data["title"] == f"Resolved: {self.daily_alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "100.0% users crash free rate in the last day"
-        assert data["ts"] == self.date_started
+        assert data["date_started"] == self.date_started
         assert (
             data["logo_url"]
             == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"


### PR DESCRIPTION
this pr does a couple things
* create a typed dict for `incident_attachment_info` and `metric_alert_attachment_info`
* switch Discord to use `metric_alert_attachment_info` so it matches the rest of our logic

the bonus with the second bullet is we just added feature parity to the discord messages for free.