### PR TITLE
fix(sentry apps): Get organization from RpcOrganizationContext

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
@@ -106,9 +106,10 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
         subject = "Sentry Integration Publication Request from %s" % org_mapping.slug
         if features.has(
             "organizations:streamlined-publishing-flow",
-            organization,
+            organization.organization,
             actor=request.user,
         ):
+
             new_subject = f"We've received your integration submission for {sentry_app.slug}"
             new_context = {
                 "questionnaire": questionnaire,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
@@ -104,12 +104,13 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
             )
 
         subject = "Sentry Integration Publication Request from %s" % org_mapping.slug
+
+        assert organization is not None, "RpcOrganizationContext must exist to get the organization"
         if features.has(
             "organizations:streamlined-publishing-flow",
             organization.organization,
             actor=request.user,
         ):
-
             new_subject = f"We've received your integration submission for {sentry_app.slug}"
             new_context = {
                 "questionnaire": questionnaire,


### PR DESCRIPTION
Hey did you know that `organization_service.get_organization_by_id` returns an `RpcOrganizationContext` object not an `RpcOrganization`, I didn't 🫠 