### PR TITLE
feat(nav): Convert links from /releases/ to /explore/releases/

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -31,6 +31,7 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {useHasTraceNewUi} from 'sentry/views/performance/newTraceDetails/useHasTraceNewUi';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 interface EventTagTreeRowConfig {
@@ -233,7 +234,10 @@ function EventTagsTreeRowDropdown({
       hidden: originalTag.key !== 'release',
       to:
         originalTag.key === 'release'
-          ? `/organizations/${organization.slug}/releases/${encodeURIComponent(content.value)}/`
+          ? makeReleasesPathname({
+              organization,
+              path: `/${encodeURIComponent(content.value)}/`,
+            })
           : undefined,
     },
     {

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -19,6 +19,7 @@ import type {Commit} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Release} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 type Props = {
   /**
@@ -143,9 +144,10 @@ function SuggestedOwnerHovercard(props: Props) {
                           // Link to release commits
                           <Link
                             to={{
-                              pathname: `/organizations/${
-                                organization?.slug
-                              }/releases/${encodeURIComponent(release.version)}/commits/`,
+                              pathname: makeReleasesPathname({
+                                organization,
+                                path: `/${encodeURIComponent(release.version)}/commits/`,
+                              }),
                               query: {project: projectId},
                             }}
                           >

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -24,6 +24,7 @@ import {isDemoModeEnabled} from 'sentry/utils/demoMode';
 import {getDemoWalkthroughTasks} from 'sentry/utils/demoMode/guides';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 function hasPlatformWithSourceMaps(projects: Project[] | undefined) {
@@ -133,7 +134,10 @@ export function getOnboardingTasks({
         ),
         skippable: false,
         actionType: 'app',
-        location: `/organizations/${organization.slug}/releases/`,
+        location: makeReleasesPathname({
+          organization,
+          path: '/',
+        }),
         display: true,
         group: OnboardingTaskGroup.GETTING_STARTED,
       },
@@ -327,7 +331,10 @@ export function getOnboardingTasks({
       ),
       skippable: true,
       actionType: 'app',
-      location: `/organizations/${organization.slug}/releases/`,
+      location: makeReleasesPathname({
+        organization,
+        path: '/',
+      }),
       display: true,
       group: OnboardingTaskGroup.GETTING_STARTED,
     },

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
@@ -28,6 +28,7 @@ import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {ProfilingDetailsFrameTabs, ProfilingDetailsListItem} from './flamegraphDrawer';
 
@@ -456,9 +457,10 @@ function ProfileEventDetails({
               <strong>{label}:</strong>
               <Link
                 to={{
-                  pathname: `/organizations/${
-                    organization.slug
-                  }/releases/${encodeURIComponent(release.version)}/`,
+                  pathname: makeReleasesPathname({
+                    organization,
+                    path: `/${encodeURIComponent(release.version)}/`,
+                  }),
                   query: {
                     project: profileGroup.metadata.projectID,
                   },

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -25,9 +25,9 @@ import type {
   RateUnit,
   SizeUnit,
 } from 'sentry/utils/discover/fields';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {useWidgetSyncContext} from '../../contexts/widgetSyncContext';
 import {NO_PLOTTABLE_VALUES, X_GUTTER, Y_GUTTER} from '../common/settings';
@@ -117,10 +117,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   if (props.releases) {
     const onClick = (release: Release) => {
       navigate(
-        normalizeUrl({
-          pathname: `/organizations/${
-            organization.slug
-          }/releases/${encodeURIComponent(release.version)}/`,
+        makeReleasesPathname({
+          organization,
+          path: `/${encodeURIComponent(release.version)}/`,
         })
       );
     };

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -56,6 +56,7 @@ import {appendQueryDatasetParam, hasDatasetSelector} from 'sentry/views/dashboar
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {generateReplayLink} from 'sentry/views/performance/transactionSummary/utils';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {
   getExpandedResults,
@@ -583,9 +584,10 @@ function TableView(props: TableViewProps) {
 
           browserHistory.push(
             normalizeUrl({
-              pathname: `/organizations/${
-                organization.slug
-              }/releases/${encodeURIComponent(value)}/`,
+              pathname: makeReleasesPathname({
+                organization,
+                path: `/${encodeURIComponent(value)}/`,
+              }),
               query: {
                 ...nextView.getPageFiltersQuery(),
 

--- a/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
@@ -10,6 +10,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 interface ReleaseStat {
   date: string;
@@ -66,11 +67,12 @@ export function useReleaseMarkLineSeries({group}: {group: Group}) {
       name: formatVersion(release.version, true),
       value: formatVersion(release.version, true),
       onClick: () => {
-        navigate({
-          pathname: `/organizations/${
-            organization.slug
-          }/releases/${encodeURIComponent(release.version)}/`,
-        });
+        navigate(
+          makeReleasesPathname({
+            organization,
+            path: `/${encodeURIComponent(release.version)}/`,
+          })
+        );
       },
       label: {
         formatter: () => formatVersion(release.version, true),

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -21,6 +21,7 @@ import type {Project} from 'sentry/types/project';
 import toArray from 'sentry/utils/array/toArray';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {ColorOrAlias} from 'sentry/utils/theme';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {barAxisLabel, groupByTrend, sortSeriesByDay} from './utils';
@@ -261,7 +262,10 @@ function TeamReleases({
                 avatarSize={18}
                 project={project}
                 to={{
-                  pathname: `/organizations/${organization.slug}/releases/`,
+                  pathname: makeReleasesPathname({
+                    organization,
+                    path: '/',
+                  }),
                   query: {project: project.id},
                 }}
               />
@@ -271,7 +275,10 @@ function TeamReleases({
             <ScoreWrapper>
               <Link
                 to={{
-                  pathname: `/organizations/${organization.slug}/releases/`,
+                  pathname: makeReleasesPathname({
+                    organization,
+                    path: '/',
+                  }),
                   query: {project: project.id, statsPeriod: '7d'},
                 }}
               >

--- a/static/app/views/projectDetail/projectLatestReleases.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.tsx
@@ -18,6 +18,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import MissingReleasesButtons from './missingFeatureButtons/missingReleasesButtons';
 import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';
@@ -114,7 +115,10 @@ class ProjectLatestReleases extends DeprecatedAsyncComponent<Props, State> {
 
     // as this is a link to latest releases, we want to only preserve project and environment
     return {
-      pathname: `/organizations/${organization.slug}/releases/`,
+      pathname: makeReleasesPathname({
+        organization,
+        path: '/',
+      }),
       query: {
         statsPeriod: undefined,
         start: undefined,

--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -18,8 +18,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {Release, ReleaseMeta} from 'sentry/types/release';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {isReleaseArchived} from '../../utils';
 
@@ -47,7 +47,12 @@ function ReleaseActions({
         projectSlug,
         releaseVersion: release.version,
       });
-      browserHistory.push(normalizeUrl(`/organizations/${organization.slug}/releases/`));
+      browserHistory.push(
+        makeReleasesPathname({
+          organization,
+          path: '/',
+        })
+      );
     } catch {
       // do nothing, action creator is already displaying error message
     }

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -19,6 +19,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Release, ReleaseMeta, ReleaseProject} from 'sentry/types/release';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import ReleaseActions from './releaseActions';
 
@@ -91,7 +92,10 @@ function ReleaseHeader({
         <Breadcrumbs
           crumbs={[
             {
-              to: `/organizations/${organization.slug}/releases/`,
+              to: makeReleasesPathname({
+                organization,
+                path: '/',
+              }),
               label: t('Releases'),
               preservePageFilters: true,
             },

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -43,9 +43,10 @@ function ReleaseHeader({
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
 
-  const releasePath = `/organizations/${organization.slug}/releases/${encodeURIComponent(
-    version
-  )}/`;
+  const releasePath = makeReleasesPathname({
+    organization,
+    path: `/${encodeURIComponent(version)}/`,
+  });
 
   const tabs = [
     {title: t('Overview'), to: ''},

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -34,6 +34,7 @@ import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import type {ReleaseBounds} from '../utils';
 import {getReleaseBounds, searchReleaseVersion} from '../utils';
@@ -370,7 +371,10 @@ class ReleasesDetailContainer extends DeprecatedAsyncComponent<
               params.release
             )}/`,
           }}
-          noProjectRedirectPath={`/organizations/${organization.slug}/releases/`}
+          noProjectRedirectPath={makeReleasesPathname({
+            organization,
+            path: '/',
+          })}
         />
       );
     }

--- a/static/app/views/releases/detail/overview/sidebar/otherProjects.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/otherProjects.tsx
@@ -10,6 +10,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {ReleaseProject} from 'sentry/types/release';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 type Props = {
   location: Location;
@@ -46,9 +47,10 @@ function OtherProjects({projects, location, version, organization}: Props) {
               <LinkButton
                 size="xs"
                 to={{
-                  pathname: `/organizations/${
-                    organization.slug
-                  }/releases/${encodeURIComponent(version)}/`,
+                  pathname: makeReleasesPathname({
+                    organization,
+                    path: `/${encodeURIComponent(version)}/`,
+                  }),
                   query: {
                     ...extractSelectionParameters(location.query),
                     project: project.id,

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -19,6 +19,7 @@ import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Release} from 'sentry/types/release';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import type {ReleasesDisplayOption} from '../releasesDisplayOptions';
 import type {ReleasesRequestRenderProps} from '../releasesRequest';
@@ -111,9 +112,10 @@ function ReleaseCard({
         <ReleaseInfoHeader>
           <GlobalSelectionLink
             to={{
-              pathname: `/organizations/${
-                organization.slug
-              }/releases/${encodeURIComponent(version)}/`,
+              pathname: makeReleasesPathname({
+                organization,
+                path: `/${encodeURIComponent(version)}/`,
+              }),
               query: {project: getReleaseProjectId(release, selection)},
             }}
           >

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -23,6 +23,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Release, ReleaseProject} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
 import type {IconSize} from 'sentry/utils/theme';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {
   ADOPTION_STAGE_LABELS,
@@ -123,7 +124,10 @@ function ReleaseCardProjectRow({
               <Tooltip title={adoptionStageLabel.tooltipTitle} isHoverable>
                 <Link
                   to={{
-                    pathname: `/organizations/${organization.slug}/releases/`,
+                    pathname: makeReleasesPathname({
+                      organization,
+                      path: '/',
+                    }),
                     query: {
                       ...location.query,
                       query: `release.stage:${adoptionStage}`,
@@ -215,9 +219,10 @@ function ReleaseCardProjectRow({
             <LinkButton
               size="xs"
               to={{
-                pathname: `/organizations/${
-                  organization.slug
-                }/releases/${encodeURIComponent(releaseVersion)}/`,
+                pathname: makeReleasesPathname({
+                  organization,
+                  path: `/${encodeURIComponent(releaseVersion)}/`,
+                }),
                 query: {
                   ...extractSelectionParameters(location.query),
                   project: project.id,

--- a/static/app/views/releases/utils/pathnames.tsx
+++ b/static/app/views/releases/utils/pathnames.tsx
@@ -1,0 +1,19 @@
+import type {Organization} from 'sentry/types/organization';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+const LEGACY_RELEASES_BASE_PATHNAME = 'releases';
+const RELEASES_BASE_PATHNAME = 'explore/releases';
+
+export function makeReleasesPathname({
+  path,
+  organization,
+}: {
+  organization: Organization;
+  path: '/' | `/${string}/`;
+}) {
+  return normalizeUrl(
+    organization.features.includes('navigation-sidebar-v2')
+      ? `/organizations/${organization.slug}/${RELEASES_BASE_PATHNAME}${path}`
+      : `/organizations/${organization.slug}/${LEGACY_RELEASES_BASE_PATHNAME}${path}`
+  );
+}

--- a/static/app/views/settings/projectProguard/associations.tsx
+++ b/static/app/views/settings/projectProguard/associations.tsx
@@ -11,6 +11,7 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 import type {ProguardMappingAssociation} from 'sentry/views/settings/projectProguard';
 
 function ProguardAssociationsBody({
@@ -37,7 +38,10 @@ function ProguardAssociationsBody({
           <ListItem key={release}>
             <ReleaseContent>
               <ReleaseLink
-                to={`/organizations/${organization.slug}/releases/${release}/`}
+                to={makeReleasesPathname({
+                  organization,
+                  path: `/${release}/`,
+                })}
               >
                 <TextOverflow>{release}</TextOverflow>
               </ReleaseLink>

--- a/static/app/views/settings/projectSourceMaps/debugIdBundleDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/debugIdBundleDetails.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import type {KeyValueListData} from 'sentry/types/group';
 import type {DebugIdBundle, DebugIdBundleArtifact} from 'sentry/types/sourceMaps';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 const formatDist = (dist: string | string[] | null) => {
   if (Array.isArray(dist)) {
@@ -50,7 +51,10 @@ export function DebugIdBundleDetails({
               {visibleAssociations.map(association => (
                 <Fragment key={association.release}>
                   <Link
-                    to={`/organizations/${organization.slug}/releases/${association.release}/`}
+                    to={makeReleasesPathname({
+                      organization,
+                      path: `/${association.release}/`,
+                    })}
                   >
                     {association.release}
                   </Link>
@@ -73,7 +77,13 @@ export function DebugIdBundleDetails({
         ),
       },
     ];
-  }, [debugIdBundle, organization.slug, showAll]);
+  }, [
+    debugIdBundle.associations,
+    debugIdBundle.date,
+    debugIdBundle.fileCount,
+    organization,
+    showAll,
+  ]);
 
   return <StyledKeyValueList data={detailsData} shouldSort={false} />;
 }


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

Similar to other similar PRs. Releases is being moved from `/releases/` to `/explore/releases/` with the new nav, so I'm adding a util for generating the pathname and using it everywhere generate release links.