### PR TITLE
feat(issue-views): Add URL reactivity, most navigation logic, and ellipsis menu functionality

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
@@ -1,0 +1,172 @@
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {GrowingInput} from 'sentry/components/growingInput';
+import {Tooltip} from 'sentry/components/tooltip';
+
+interface IssueViewNavEditableTitleProps {
+  isEditing: boolean;
+  isSelected: boolean;
+  label: string;
+  onChange: (newLabel: string) => void;
+  setIsEditing: (isEditing: boolean) => void;
+}
+
+function IssueViewNavEditableTitle({
+  label,
+  onChange,
+  isEditing,
+  isSelected,
+  setIsEditing,
+}: IssueViewNavEditableTitleProps) {
+  const [inputValue, setInputValue] = useState(label);
+
+  useEffect(() => {
+    setInputValue(label);
+  }, [label]);
+
+  const theme = useTheme();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isEmpty = !inputValue.trim();
+
+  const memoizedStyles = useMemo(() => {
+    return {fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal};
+  }, [isSelected, theme.fontWeightBold, theme.fontWeightNormal]);
+
+  const handleOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const trimmedInputValue = inputValue.trim();
+    if (!isEditing) {
+      return;
+    }
+
+    if (isEmpty) {
+      setInputValue(label);
+      setIsEditing(false);
+      return;
+    }
+    if (trimmedInputValue !== label) {
+      onChange(trimmedInputValue);
+      setInputValue(trimmedInputValue);
+    }
+    setIsEditing(false);
+  };
+
+  const handleOnKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      inputRef.current?.blur();
+    }
+    if (e.key === 'Escape') {
+      setInputValue(label.trim());
+      setIsEditing(false);
+    }
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === ' ') {
+      e.stopPropagation();
+    }
+  };
+
+  useEffect(() => {
+    if (isEditing) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    } else {
+      inputRef.current?.blur();
+    }
+  }, [isEditing, inputRef]);
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  return (
+    <Tooltip title={label} disabled={isEditing} showOnlyOnOverflow skipWrapper>
+      <motion.div layout="position" transition={{duration: 0.2}}>
+        {isEditing ? (
+          <StyledGrowingInput
+            value={inputValue}
+            onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+            onBlur={handleOnBlur}
+            ref={inputRef}
+            style={memoizedStyles}
+            isEditing={isEditing}
+            maxLength={128}
+            onPointerDown={e => {
+              e.stopPropagation();
+              if (!isEditing) {
+                e.preventDefault();
+              }
+            }}
+            onMouseDown={e => {
+              e.stopPropagation();
+              if (!isEditing) {
+                e.preventDefault();
+              }
+            }}
+          />
+        ) : (
+          <UnselectedTabTitle
+            onDoubleClick={() => setIsEditing(true)}
+            onPointerDown={e => {
+              if (isSelected) {
+                e.stopPropagation();
+                e.preventDefault();
+              }
+            }}
+            onMouseDown={e => {
+              if (isSelected) {
+                e.stopPropagation();
+                e.preventDefault();
+              }
+            }}
+            isSelected={isSelected}
+          >
+            {label}
+          </UnselectedTabTitle>
+        )}
+      </motion.div>
+    </Tooltip>
+  );
+}
+
+export default IssueViewNavEditableTitle;
+
+const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
+  height: 20px;
+  max-width: ${p => (p.isSelected ? '325px' : '310px')};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 1px;
+  cursor: pointer;
+  line-height: 1.45;
+`;
+
+const StyledGrowingInput = styled(GrowingInput)<{
+  isEditing: boolean;
+}>`
+  position: relative;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  min-height: 0px;
+  height: 20px;
+  border-radius: 0px;
+  text-overflow: ellipsis;
+  cursor: text;
+  max-width: 325px;
+  line-height: 1.45;
+
+  &,
+  &:focus,
+  &:active,
+  &:hover {
+    box-shadow: none;
+  }
+`;

--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
@@ -160,7 +160,6 @@ const StyledGrowingInput = styled(GrowingInput)<{
   border-radius: 0px;
   text-overflow: ellipsis;
   cursor: text;
-  max-width: 325px;
   line-height: 1.45;
 
   &,

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -19,7 +19,19 @@ export function IssueViewNavEllipsisMenu({
     <DropdownMenu
       position="bottom-start"
       trigger={props => (
-        <TriggerWrapper {...props} data-ellipsis-menu-trigger>
+        <TriggerWrapper
+          {...props}
+          data-ellipsis-menu-trigger
+          onPointerDownCapture={e => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          onPointerUp={e => {
+            e.stopPropagation();
+            e.preventDefault();
+            e.currentTarget.click();
+          }}
+        >
           <InteractionStateLayer />
           <IconEllipsis compact color="gray500" />
           <UnsavedChangesIndicator

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -3,18 +3,59 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {IconEllipsis, IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+
+interface IssueViewNavEllipsisMenuProps {
+  baseUrl: string;
+  deleteView: () => void;
+  duplicateView: () => void;
+  setIsEditing: (isEditing: boolean) => void;
+  updateView: (view: IssueViewPF) => void;
+  view: IssueViewPF;
+  sectionRef?: React.RefObject<HTMLDivElement>;
+}
 
 export function IssueViewNavEllipsisMenu({
   sectionRef,
   setIsEditing,
-}: {
-  setIsEditing: (isEditing: boolean) => void;
-  sectionRef?: React.RefObject<HTMLDivElement>;
-}) {
+  view,
+  deleteView,
+  duplicateView,
+  updateView,
+  baseUrl,
+}: IssueViewNavEllipsisMenuProps) {
+  const navigate = useNavigate();
+
+  const handleSaveChanges = () => {
+    const updatedView = {
+      ...view,
+      query: view.unsavedChanges?.query ?? view.query,
+      querySort: view.unsavedChanges?.querySort ?? view.querySort,
+      projects: view.unsavedChanges?.projects ?? view.projects,
+      environments: view.unsavedChanges?.environments ?? view.environments,
+      timeFilters: view.unsavedChanges?.timeFilters ?? view.timeFilters,
+      unsavedChanges: undefined,
+    };
+    updateView(updatedView);
+    navigate(constructViewLink(baseUrl, updatedView));
+  };
+
+  const handleDiscardChanges = () => {
+    const updatedView = {
+      ...view,
+      unsavedChanges: undefined,
+    };
+    updateView(updatedView);
+    navigate(constructViewLink(baseUrl, updatedView));
+  };
+
   return (
     <DropdownMenu
       position="bottom-start"
@@ -26,7 +67,7 @@ export function IssueViewNavEllipsisMenu({
             e.stopPropagation();
             e.preventDefault();
           }}
-          onPointerUp={e => {
+          onPointerUpCapture={e => {
             e.stopPropagation();
             e.preventDefault();
             e.currentTarget.click();
@@ -34,42 +75,49 @@ export function IssueViewNavEllipsisMenu({
         >
           <InteractionStateLayer />
           <IconEllipsis compact color="gray500" />
-          <UnsavedChangesIndicator
-            role="presentation"
-            data-test-id="unsaved-changes-indicator"
-          />
         </TriggerWrapper>
       )}
       items={[
         {
-          key: 'save-changes',
-          label: t('Save Changes'),
-          priority: 'primary',
-          onAction: () => {},
+          key: 'changed',
+          children: [
+            {
+              key: 'save-changes',
+              label: t('Save Changes'),
+              priority: 'primary',
+              onAction: handleSaveChanges,
+            },
+            {
+              key: 'discard-changes',
+              label: t('Discard Changes'),
+              onAction: handleDiscardChanges,
+            },
+          ],
+          hidden: !view.unsavedChanges,
         },
         {
-          key: 'discard-changes',
-          label: t('Discard Changes'),
-          onAction: () => {},
-        },
-        {
-          key: 'rename-tab',
-          label: t('Rename'),
-          onAction: () => setIsEditing(true),
-        },
-        {
-          key: 'duplicate-tab',
-          label: t('Duplicate'),
-          onAction: () => {},
-        },
-        {
-          key: 'delete-tab',
-          label: t('Delete'),
-          priority: 'danger',
-          onAction: () => {},
+          key: 'default',
+          children: [
+            {
+              key: 'rename-tab',
+              label: t('Rename'),
+              onAction: () => setIsEditing(true),
+            },
+            {
+              key: 'duplicate-tab',
+              label: t('Duplicate'),
+              onAction: duplicateView,
+            },
+            {
+              key: 'delete-tab',
+              label: t('Delete'),
+              priority: 'danger',
+              onAction: deleteView,
+            },
+          ],
         },
       ]}
-      onInteractOutside={() => true}
+      shouldCloseOnInteractOutside={() => true}
       menuFooter={<FeedbackFooter />}
       usePortal
       portalContainerRef={sectionRef}
@@ -93,7 +141,7 @@ function FeedbackFooter() {
           openForm({
             messagePlaceholder: t('How can we make custom views better for you?'),
             tags: {
-              ['feedback.source']: 'custom_views',
+              ['feedback.source']: 'left_nav_issue_views',
               ['feedback.owner']: 'issues',
             },
           })
@@ -104,6 +152,21 @@ function FeedbackFooter() {
     </SectionedOverlayFooter>
   );
 }
+
+const constructViewLink = (baseUrl: string, view: IssueViewPF) => {
+  return normalizeUrl({
+    pathname: `${baseUrl}/views/${view.id}/`,
+    query: {
+      query: view.unsavedChanges?.query ?? view.query,
+      sort: view.unsavedChanges?.querySort ?? view.querySort,
+      project: view.unsavedChanges?.projects ?? view.projects,
+      environment: view.unsavedChanges?.environments ?? view.environments,
+      ...normalizeDateTimeParams(view.unsavedChanges?.timeFilters ?? view.timeFilters),
+      cursor: undefined,
+      page: undefined,
+    },
+  });
+};
 
 const TriggerWrapper = styled('div')`
   position: relative;
@@ -126,16 +189,4 @@ const SectionedOverlayFooter = styled('div')`
   justify-content: center;
   padding: ${space(1)};
   border-top: 1px solid ${p => p.theme.innerBorder};
-`;
-
-const UnsavedChangesIndicator = styled('div')`
-  border-radius: 50%;
-  background: ${p => p.theme.purple400};
-  border: solid 1px ${p => p.theme.background};
-  position: absolute;
-  width: 7px;
-  height: 7px;
-  top: -3px;
-  right: -3px;
-  opacity: 1;
 `;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -1,22 +1,50 @@
-import {useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import type {DraggableProps} from 'framer-motion';
 import {Reorder} from 'framer-motion';
+import type {Location} from 'history';
+import isEqual from 'lodash/isEqual';
 
 import {useNavContext} from 'sentry/components/nav/context';
 import {IssueViewNavEllipsisMenu} from 'sentry/components/nav/issueViews/issueViewNavEllipsisMenu';
+import {constructViewLink} from 'sentry/components/nav/issueViews/issueViewNavItems';
 import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
 import IssueViewProjectIcons from 'sentry/components/nav/issueViews/issueViewProjectIcons';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import EditableTabTitle from 'sentry/views/issueList/issueViews/editableTabTitle';
-import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {normalizeProjectsEnvironments} from 'sentry/views/issueList/issueViewsHeaderPF';
+import type {
+  IssueViewPF,
+  IssueViewPFParams,
+} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 export interface IssueViewNavItemContentProps {
+  /**
+   * A callback function that deletes the view.
+   */
+  deleteView: () => void;
+  /**
+   * A callback function that duplicates the view.
+   */
+  duplicateView: () => void;
+  /**
+   * Whether the item is active.
+   */
+  isActive: boolean;
+  /**
+   * A callback function that updates the view with new params.
+   */
+  updateView: (updatedView: IssueViewPF) => void;
   /**
    * The issue view to display
    */
@@ -32,12 +60,42 @@ export interface IssueViewNavItemContentProps {
 export function IssueViewNavItemContent({
   view,
   sectionRef,
+  isActive,
+  updateView,
+  deleteView,
+  duplicateView,
 }: IssueViewNavItemContentProps) {
   const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const [isEditing, setIsEditing] = useState(false);
 
   const {projects} = useProjects();
+
+  useEffect(() => {
+    if (isActive) {
+      if (Object.keys(location.query).length === 0) {
+        navigate(constructViewLink(baseUrl, view), {replace: true});
+        return;
+      }
+      const unsavedChanges = hasUnsavedChanges(view, location.query);
+
+      if (unsavedChanges && !isEqual(unsavedChanges, view.unsavedChanges)) {
+        updateView({
+          ...view,
+          unsavedChanges,
+        });
+      } else if (!unsavedChanges && view.unsavedChanges) {
+        updateView({
+          ...view,
+          unsavedChanges: undefined,
+        });
+      }
+    }
+    return;
+  }, [view, isActive, location.query, navigate, baseUrl, updateView]);
 
   const projectPlatforms = projects
     .filter(p => view.projects.map(String).includes(p.id))
@@ -67,11 +125,20 @@ export function IssueViewNavItemContent({
         to={`${baseUrl}/?viewId=${view.id}`}
         leadingItems={<IssueViewProjectIcons projectPlatforms={projectPlatforms} />}
         trailingItems={
-          <TrailingItemsWrapper>
+          <TrailingItemsWrapper
+            onPointerUp={e => {
+              e.stopPropagation();
+            }}
+          >
             <IssueViewNavQueryCount view={view} />
             <IssueViewNavEllipsisMenu
-              sectionRef={sectionRef}
               setIsEditing={setIsEditing}
+              view={view}
+              updateView={updateView}
+              deleteView={deleteView}
+              duplicateView={duplicateView}
+              baseUrl={baseUrl}
+              sectionRef={sectionRef}
             />
           </TrailingItemsWrapper>
         }
@@ -91,10 +158,129 @@ export function IssueViewNavItemContent({
           onChange={() => {}}
           setIsEditing={setIsEditing}
         />
+        {view.unsavedChanges && (
+          <Tooltip
+            title={constructUnsavedTooltipTitle(view.unsavedChanges)}
+            position="top"
+            skipWrapper
+          >
+            <UnsavedChangesIndicator
+              role="presentation"
+              data-test-id="unsaved-changes-indicator"
+              isActive={isActive}
+            />
+          </Tooltip>
+        )}
       </StyledSecondaryNavItem>
     </Reorder.Item>
   );
 }
+
+const READABLE_PARAM_MAPPING = {
+  query: t('query'),
+  querySort: t('sort'),
+  projects: t('projects'),
+  environments: t('environments'),
+  timeFilters: t('time range'),
+};
+
+const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewPFParams>) => {
+  return (
+    <Fragment>
+      {t(`This view's `)}
+      {Object.keys(unsavedChanges).map((key, idx) => {
+        const validKeys = Object.keys(unsavedChanges).filter(
+          k => unsavedChanges[k as keyof IssueViewPFParams] !== undefined
+        );
+        return unsavedChanges[key as keyof IssueViewPFParams] ? (
+          <b key={key}>
+            {idx === validKeys.length - 1 ? 'and ' : ''}
+            {READABLE_PARAM_MAPPING[key as keyof IssueViewPFParams]}
+            {idx < validKeys.length - 1 && validKeys.length !== 1 ? ', ' : ''}
+          </b>
+        ) : null;
+      })}
+      {t(` filters are not saved.`)}
+    </Fragment>
+  );
+};
+
+// TODO(msun): Once nuqs supports native array query params, we can replace this absurd function
+const hasUnsavedChanges = (
+  view: IssueViewPF,
+  queryParams: Location['query']
+): false | Partial<IssueViewPFParams> => {
+  const {
+    query: originalQuery,
+    querySort: originalSort,
+    projects: originalProjects,
+    environments: originalEnvironments,
+    timeFilters: originalTimeFilters,
+  } = view;
+  const {
+    query: queryQuery,
+    sort: querySort,
+    project,
+    environment,
+    start,
+    end,
+    statsPeriod,
+    utc,
+  } = queryParams;
+
+  const queryTimeFilters =
+    start || end || statsPeriod || utc
+      ? {
+          start: statsPeriod ? null : start?.toString() ?? null,
+          end: statsPeriod ? null : end?.toString() ?? null,
+          period: statsPeriod?.toString() ?? null,
+          utc: statsPeriod ? null : utc?.toString() === 'true',
+        }
+      : undefined;
+
+  const {queryEnvs, queryProjects} = normalizeProjectsEnvironments(
+    project ?? [],
+    environment ?? []
+  );
+
+  const issueSortOption = Object.values(IssueSortOptions).includes(
+    querySort?.toString() as IssueSortOptions
+  )
+    ? (querySort as IssueSortOptions)
+    : undefined;
+
+  const newUnsavedChanges: Partial<IssueViewPFParams> = {
+    query:
+      queryQuery && queryQuery.toString() !== originalQuery
+        ? queryQuery.toString()
+        : undefined,
+    querySort:
+      querySort && issueSortOption !== originalSort ? issueSortOption : undefined,
+    projects: !isEqual(queryProjects.sort(), originalProjects.sort())
+      ? queryProjects
+      : undefined,
+    environments: !isEqual(queryEnvs.sort(), originalEnvironments.sort())
+      ? queryEnvs
+      : undefined,
+    timeFilters:
+      queryTimeFilters &&
+      !isEqual(
+        normalizeDateTimeParams(originalTimeFilters),
+        normalizeDateTimeParams(queryTimeFilters)
+      )
+        ? queryTimeFilters
+        : undefined,
+  };
+
+  const hasNoChanges = Object.values(newUnsavedChanges).every(
+    value => value === undefined
+  );
+  if (hasNoChanges) {
+    return false;
+  }
+
+  return newUnsavedChanges;
+};
 
 const TrailingItemsWrapper = styled('div')`
   display: flex;
@@ -123,4 +309,21 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
     [data-issue-view-query-count] {
     display: none;
   }
+`;
+
+const UnsavedChangesIndicator = styled('div')<{isActive: boolean}>`
+  opacity: ${p => (p.isActive ? 1 : 0)};
+
+  ${StyledSecondaryNavReordableItem}:hover & {
+    opacity: ${p => (p.isActive ? 1 : 0.75)};
+  }
+
+  border-radius: 50%;
+  background: ${p => p.theme.purple400};
+  border: solid 2px ${p => p.theme.background};
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  top: -3px;
+  right: -3px;
 `;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -1,11 +1,11 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import type {DraggableProps} from 'framer-motion';
 import {Reorder} from 'framer-motion';
 import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {useNavContext} from 'sentry/components/nav/context';
+import IssueViewNavEditableTitle from 'sentry/components/nav/issueViews/issueViewNavEditableTitle';
 import {IssueViewNavEllipsisMenu} from 'sentry/components/nav/issueViews/issueViewNavEllipsisMenu';
 import {constructViewLink} from 'sentry/components/nav/issueViews/issueViewNavItems';
 import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
@@ -21,7 +21,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import EditableTabTitle from 'sentry/views/issueList/issueViews/editableTabTitle';
 import {normalizeProjectsEnvironments} from 'sentry/views/issueList/issueViewsHeaderPF';
 import type {
   IssueViewPF,
@@ -152,11 +151,13 @@ export function IssueViewNavItemContent({
           }
         }}
       >
-        <EditableTabTitle
+        <IssueViewNavEditableTitle
           label={view.label}
           isEditing={isEditing}
-          isSelected={false}
-          onChange={() => {}}
+          isSelected={isActive}
+          onChange={value => {
+            updateView({...view, label: value});
+          }}
           setIsEditing={setIsEditing}
         />
         {view.unsavedChanges && (
@@ -315,7 +316,7 @@ const BoldTooltipText = styled('span')`
 const UnsavedChangesIndicator = styled('div')<{isActive: boolean}>`
   opacity: ${p => (p.isActive ? 1 : 0)};
 
-  ${StyledSecondaryNavReordableItem}:hover & {
+  ${StyledSecondaryNavItem}:hover & {
     opacity: ${p => (p.isActive ? 1 : 0.75)};
   }
 

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -122,12 +122,12 @@ export function IssueViewNavItemContent({
       }}
     >
       <StyledSecondaryNavItem
-        to={`${baseUrl}/?viewId=${view.id}`}
+        to={constructViewLink(baseUrl, view)}
         leadingItems={<IssueViewProjectIcons projectPlatforms={projectPlatforms} />}
         trailingItems={
           <TrailingItemsWrapper
-            onPointerUp={e => {
-              e.stopPropagation();
+            onClickCapture={e => {
+              e.preventDefault();
             }}
           >
             <IssueViewNavQueryCount view={view} />

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -16,6 +16,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -185,21 +186,14 @@ const READABLE_PARAM_MAPPING = {
 };
 
 const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewPFParams>) => {
+  const changedParams = Object.keys(unsavedChanges)
+    .filter(k => unsavedChanges[k as keyof IssueViewPFParams] !== undefined)
+    .map(k => READABLE_PARAM_MAPPING[k as keyof IssueViewPFParams]);
+
   return (
     <Fragment>
       {t(`This view's `)}
-      {Object.keys(unsavedChanges).map((key, idx) => {
-        const validKeys = Object.keys(unsavedChanges).filter(
-          k => unsavedChanges[k as keyof IssueViewPFParams] !== undefined
-        );
-        return unsavedChanges[key as keyof IssueViewPFParams] ? (
-          <b key={key}>
-            {idx === validKeys.length - 1 ? 'and ' : ''}
-            {READABLE_PARAM_MAPPING[key as keyof IssueViewPFParams]}
-            {idx < validKeys.length - 1 && validKeys.length !== 1 ? ', ' : ''}
-          </b>
-        ) : null;
-      })}
+      <b>{oxfordizeArray(changedParams)}</b>
       {t(` filters are not saved.`)}
     </Fragment>
   );

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -7,8 +7,10 @@ import {IssueViewNavEllipsisMenu} from 'sentry/components/nav/issueViews/issueVi
 import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
 import IssueViewProjectIcons from 'sentry/components/nav/issueViews/issueViewProjectIcons';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import EditableTabTitle from 'sentry/views/issueList/issueViews/editableTabTitle';
@@ -98,6 +100,7 @@ const TrailingItemsWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
+  margin-right: ${space(0.5)};
 `;
 
 const StyledSecondaryNavItem = styled(SecondaryNav.Item)`

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -192,14 +192,15 @@ const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewPFParams>
 
   return (
     <Fragment>
-      {t(`This view's `)}
-      <b>{oxfordizeArray(changedParams)}</b>
-      {t(` filters are not saved.`)}
+      {t(
+        "This view's %s filters are not saved.",
+        <BoldTooltipText>{oxfordizeArray(changedParams)}</BoldTooltipText>
+      )}
     </Fragment>
   );
 };
 
-// TODO(msun): Once nuqs supports native array query params, we can replace this absurd function
+// TODO(msun): Once nuqs supports native array query params, we can use that here and replace this absurd function
 const hasUnsavedChanges = (
   view: IssueViewPF,
   queryParams: Location['query']
@@ -305,6 +306,10 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
     [data-issue-view-query-count] {
     display: none;
   }
+`;
+
+const BoldTooltipText = styled('span')`
+  font-weight: ${p => p.theme.fontWeightBold};
 `;
 
 const UnsavedChangesIndicator = styled('div')<{isActive: boolean}>`

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -245,7 +245,9 @@ const hasUnsavedChanges = (
 
   const newUnsavedChanges: Partial<IssueViewPFParams> = {
     query:
-      queryQuery && queryQuery.toString() !== originalQuery
+      queryQuery !== null &&
+      queryQuery !== undefined &&
+      queryQuery.toString() !== originalQuery
         ? queryQuery.toString()
         : undefined,
     querySort:

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -12,7 +12,6 @@ import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF
 
 interface IssueViewNavItemsProps {
   baseUrl: string;
-  bodyRef: React.RefObject<HTMLDivElement>;
   sectionRef: React.RefObject<HTMLDivElement>;
   setViews: (views: IssueViewPF[]) => void;
   views: IssueViewPF[];
@@ -22,7 +21,6 @@ export function IssueViewNavItems({
   views,
   setViews,
   sectionRef,
-  bodyRef,
   baseUrl,
 }: IssueViewNavItemsProps) {
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
@@ -57,8 +55,7 @@ export function IssueViewNavItems({
         <AnimatePresence key={view.id}>
           <IssueViewNavItemContent
             view={view}
-            dragConstraints={sectionRef}
-            sectionBodyRef={bodyRef}
+            sectionRef={sectionRef}
             isActive={view.id === viewId}
             updateView={updatedView => {
               const newViews = views.map(v => {
@@ -72,10 +69,11 @@ export function IssueViewNavItems({
             deleteView={() => {
               const newViews = views.filter(v => v.id !== view.id);
               setViews(newViews);
+              // Only redirect if the deleted view is the active view
               if (view.id === viewId) {
                 const newUrl =
                   newViews.length > 0
-                    ? `${baseUrl}/views/${newViews[0]!.id}/`
+                    ? constructViewLink(baseUrl, newViews[0]!)
                     : `${baseUrl}/`;
                 navigate(newUrl);
               }

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -1,0 +1,119 @@
+import {useEffect} from 'react';
+import {AnimatePresence, Reorder} from 'framer-motion';
+
+import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useParams} from 'sentry/utils/useParams';
+import {generateTempViewId} from 'sentry/views/issueList/issueViews/issueViews';
+import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+
+interface IssueViewNavItemsProps {
+  baseUrl: string;
+  bodyRef: React.RefObject<HTMLDivElement>;
+  sectionRef: React.RefObject<HTMLDivElement>;
+  setViews: (views: IssueViewPF[]) => void;
+  views: IssueViewPF[];
+}
+
+export function IssueViewNavItems({
+  views,
+  setViews,
+  sectionRef,
+  bodyRef,
+  baseUrl,
+}: IssueViewNavItemsProps) {
+  const {viewId} = useParams<{orgId?: string; viewId?: string}>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryParams = location.query;
+
+  // If the `viewId` (from `/issues/views/:viewId`) is not found in the views array,
+  // then redirect to the "All Issues" page
+  useEffect(() => {
+    if (viewId && !views.find(v => v.id === viewId)) {
+      navigate(
+        normalizeUrl({
+          pathname: `${baseUrl}/`,
+          query: queryParams,
+        })
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewId]);
+
+  return (
+    <Reorder.Group
+      as="div"
+      axis="y"
+      values={views ?? []}
+      onReorder={setViews}
+      initial={false}
+      ref={sectionRef}
+    >
+      {views.map(view => (
+        <AnimatePresence key={view.id}>
+          <IssueViewNavItemContent
+            view={view}
+            dragConstraints={sectionRef}
+            sectionBodyRef={bodyRef}
+            isActive={view.id === viewId}
+            updateView={updatedView => {
+              const newViews = views.map(v => {
+                if (v.id === view.id) {
+                  return updatedView;
+                }
+                return v;
+              });
+              setViews(newViews);
+            }}
+            deleteView={() => {
+              const newViews = views.filter(v => v.id !== view.id);
+              setViews(newViews);
+              if (view.id === viewId) {
+                const newUrl =
+                  newViews.length > 0
+                    ? `${baseUrl}/views/${newViews[0]!.id}/`
+                    : `${baseUrl}/`;
+                navigate(newUrl);
+              }
+            }}
+            duplicateView={() => {
+              const newViewId = generateTempViewId();
+              const idx = views.findIndex(v => v.id === view.id);
+              if (idx !== -1) {
+                const duplicatedView = {
+                  ...views[idx]!,
+                  id: newViewId,
+                  label: `${views[idx]!.label} (Copy)`,
+                };
+                setViews([
+                  ...views.slice(0, idx + 1),
+                  duplicatedView,
+                  ...views.slice(idx + 1),
+                ]);
+              }
+            }}
+          />
+        </AnimatePresence>
+      ))}
+    </Reorder.Group>
+  );
+}
+
+export const constructViewLink = (baseUrl: string, view: IssueViewPF) => {
+  return normalizeUrl({
+    pathname: `${baseUrl}/views/${view.id}/`,
+    query: {
+      query: view.unsavedChanges?.query ?? view.query,
+      sort: view.unsavedChanges?.querySort ?? view.querySort,
+      project: view.unsavedChanges?.projects ?? view.projects,
+      environment: view.unsavedChanges?.environments ?? view.environments,
+      ...normalizeDateTimeParams(view.unsavedChanges?.timeFilters ?? view.timeFilters),
+      cursor: undefined,
+      page: undefined,
+    },
+  });
+};

--- a/static/app/components/nav/issueViews/issueViewProjectIcons.tsx
+++ b/static/app/components/nav/issueViews/issueViewProjectIcons.tsx
@@ -45,7 +45,7 @@ const IconWrap = styled('div')`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-right: ${space(0.5)};
+  margin-right: ${space(1)};
 `;
 
 const IconContainer = styled('div')`

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2105,6 +2105,7 @@ function buildRoutes() {
   const issueRoutes = (
     <Route path="/issues" component={errorHandler(IssueNavigation)} withOrgPath>
       <IndexRoute component={errorHandler(OverviewWrapper)} />
+      <Route path="views/:viewId/" component={errorHandler(OverviewWrapper)} />
       <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
       <Route
         path=":groupId/"

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -75,16 +75,13 @@ function IssueViewsPFIssueListHeader({
 
   const openForm = useFeedbackForm();
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
-  const hasLeftNavIssueViews = organization.features.includes('left-nav-issue-views');
 
   return (
     <Layout.Header
       noActionWrap
       // No viewId in the URL query means that a temp view is selected, which has a dashed border
       borderStyle={
-        !hasLeftNavIssueViews && groupSearchViews && !router?.location.query.viewId
-          ? 'dashed'
-          : 'solid'
+        groupSearchViews && !router?.location.query.viewId ? 'dashed' : 'solid'
       }
     >
       <Layout.HeaderContent>
@@ -133,45 +130,44 @@ function IssueViewsPFIssueListHeader({
         </ButtonBar>
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-      {!organization.features.includes('left-nav-issue-views') &&
-        (groupSearchViews ? (
-          <StyledIssueViews
-            router={router}
-            initialViews={groupSearchViews.map(
-              (
-                {
-                  id,
-                  name,
-                  query: viewQuery,
-                  querySort: viewQuerySort,
-                  environments: viewEnvironments,
-                  projects: viewProjects,
-                  timeFilters: viewTimeFilters,
-                  isAllProjects,
-                },
-                index
-              ): IssueViewPF => {
-                const tabId = id ?? `default${index.toString()}`;
+      {groupSearchViews ? (
+        <StyledIssueViews
+          router={router}
+          initialViews={groupSearchViews.map(
+            (
+              {
+                id,
+                name,
+                query: viewQuery,
+                querySort: viewQuerySort,
+                environments: viewEnvironments,
+                projects: viewProjects,
+                timeFilters: viewTimeFilters,
+                isAllProjects,
+              },
+              index
+            ): IssueViewPF => {
+              const tabId = id ?? `default${index.toString()}`;
 
-                return {
-                  id: tabId,
-                  key: tabId,
-                  label: name,
-                  query: viewQuery,
-                  querySort: viewQuerySort,
-                  environments: viewEnvironments,
-                  projects: isAllProjects ? [-1] : viewProjects,
-                  timeFilters: viewTimeFilters,
-                  isCommitted: true,
-                };
-              }
-            )}
-          >
-            <IssueViewsIssueListHeaderTabsContent router={router} />
-          </StyledIssueViews>
-        ) : (
-          <div style={{height: 33}} />
-        ))}
+              return {
+                id: tabId,
+                key: tabId,
+                label: name,
+                query: viewQuery,
+                querySort: viewQuerySort,
+                environments: viewEnvironments,
+                projects: isAllProjects ? [-1] : viewProjects,
+                timeFilters: viewTimeFilters,
+                isCommitted: true,
+              };
+            }
+          )}
+        >
+          <IssueViewsIssueListHeaderTabsContent router={router} />
+        </StyledIssueViews>
+      ) : (
+        <div style={{height: 33}} />
+      )}
     </Layout.Header>
   );
 }

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -82,7 +82,7 @@ function IssueViewsPFIssueListHeader({
       noActionWrap
       // No viewId in the URL query means that a temp view is selected, which has a dashed border
       borderStyle={
-        hasLeftNavIssueViews && groupSearchViews && !router?.location.query.viewId
+        !hasLeftNavIssueViews && groupSearchViews && !router?.location.query.viewId
           ? 'dashed'
           : 'solid'
       }
@@ -133,7 +133,7 @@ function IssueViewsPFIssueListHeader({
         </ButtonBar>
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-      {organization.features.includes('left-nav-issue-views') &&
+      {!organization.features.includes('left-nav-issue-views') &&
         (groupSearchViews ? (
           <StyledIssueViews
             router={router}
@@ -497,7 +497,7 @@ export default IssueViewsPFIssueListHeader;
  * If project/environemnts is undefined, it equates to an empty array. If it is a single value,
  * it is converted to single element array.
  */
-const normalizeProjectsEnvironments = (
+export const normalizeProjectsEnvironments = (
   project: string[] | string | undefined,
   env: string[] | string | undefined
 ): {queryEnvs: string[]; queryProjects: number[]} => {

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -75,13 +75,16 @@ function IssueViewsPFIssueListHeader({
 
   const openForm = useFeedbackForm();
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+  const hasLeftNavIssueViews = organization.features.includes('left-nav-issue-views');
 
   return (
     <Layout.Header
       noActionWrap
       // No viewId in the URL query means that a temp view is selected, which has a dashed border
       borderStyle={
-        groupSearchViews && !router?.location.query.viewId ? 'dashed' : 'solid'
+        hasLeftNavIssueViews && groupSearchViews && !router?.location.query.viewId
+          ? 'dashed'
+          : 'solid'
       }
     >
       <Layout.HeaderContent>
@@ -130,44 +133,45 @@ function IssueViewsPFIssueListHeader({
         </ButtonBar>
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-      {groupSearchViews ? (
-        <StyledIssueViews
-          router={router}
-          initialViews={groupSearchViews.map(
-            (
-              {
-                id,
-                name,
-                query: viewQuery,
-                querySort: viewQuerySort,
-                environments: viewEnvironments,
-                projects: viewProjects,
-                timeFilters: viewTimeFilters,
-                isAllProjects,
-              },
-              index
-            ): IssueViewPF => {
-              const tabId = id ?? `default${index.toString()}`;
+      {organization.features.includes('left-nav-issue-views') &&
+        (groupSearchViews ? (
+          <StyledIssueViews
+            router={router}
+            initialViews={groupSearchViews.map(
+              (
+                {
+                  id,
+                  name,
+                  query: viewQuery,
+                  querySort: viewQuerySort,
+                  environments: viewEnvironments,
+                  projects: viewProjects,
+                  timeFilters: viewTimeFilters,
+                  isAllProjects,
+                },
+                index
+              ): IssueViewPF => {
+                const tabId = id ?? `default${index.toString()}`;
 
-              return {
-                id: tabId,
-                key: tabId,
-                label: name,
-                query: viewQuery,
-                querySort: viewQuerySort,
-                environments: viewEnvironments,
-                projects: isAllProjects ? [-1] : viewProjects,
-                timeFilters: viewTimeFilters,
-                isCommitted: true,
-              };
-            }
-          )}
-        >
-          <IssueViewsIssueListHeaderTabsContent router={router} />
-        </StyledIssueViews>
-      ) : (
-        <div style={{height: 33}} />
-      )}
+                return {
+                  id: tabId,
+                  key: tabId,
+                  label: name,
+                  query: viewQuery,
+                  querySort: viewQuerySort,
+                  environments: viewEnvironments,
+                  projects: isAllProjects ? [-1] : viewProjects,
+                  timeFilters: viewTimeFilters,
+                  isCommitted: true,
+                };
+              }
+            )}
+          >
+            <IssueViewsIssueListHeaderTabsContent router={router} />
+          </StyledIssueViews>
+        ) : (
+          <div style={{height: 33}} />
+        ))}
     </Layout.Header>
   );
 }

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -815,7 +815,11 @@ function IssueListOverview({router}: Props) {
         queryData.sort = newSavedSearch.sort;
       }
     } else {
-      path = `/organizations/${organization.slug}/issues/`;
+      if (organization.features.includes('navigation-sidebar-v2')) {
+        path = location.pathname;
+      } else {
+        path = `/organizations/${organization.slug}/issues/`;
+      }
     }
 
     if (

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
+import {useNavigate, useParams} from 'react-router-dom';
 import {Reorder} from 'framer-motion';
 
 import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
@@ -6,6 +7,8 @@ import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
@@ -16,6 +19,10 @@ interface IssuesWrapperProps extends RouteComponentProps {
 
 export function IssueNavigation({children}: IssuesWrapperProps) {
   const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const {viewId} = useParams();
+  const queryParams = location.query;
   const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
   const hasIssueViewsInLeftNav = organization?.features.includes('left-nav-issue-views');
 
@@ -67,6 +74,18 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
     }
   }, [groupSearchViews]);
 
+  useEffect(() => {
+    if (viewId && !views?.find(v => v.id === viewId)) {
+      navigate(
+        normalizeUrl({
+          pathname: `${baseUrl}/`,
+          query: queryParams,
+        })
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewId]);
+
   if (!hasNavigationV2) {
     return children;
   }
@@ -86,7 +105,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
               {t('Feedback')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
-          {hasIssueViewsInLeftNav && (
+          {
             <SecondaryNav.Section title={t('Views')}>
               <Reorder.Group
                 as="div"
@@ -96,18 +115,16 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
                 initial={false}
                 ref={sectionRef}
               >
-                {views &&
-                  views.length > 0 &&
-                  views.map(view => (
-                    <IssueViewNavItemContent
-                      key={view.id}
-                      view={view}
-                      sectionRef={sectionRef}
-                    />
-                  ))}
+                {views?.map(view => (
+                  <IssueViewNavItemContent
+                    key={view.id}
+                    view={view}
+                    sectionRef={sectionRef}
+                  />
+                ))}
               </Reorder.Group>
             </SecondaryNav.Section>
-          )}
+          }
         </SecondaryNav.Body>
         <SecondaryNav.Footer>
           <SecondaryNav.Item

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -1,14 +1,10 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
-import {Reorder} from 'framer-motion';
 
-import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
+import {IssueViewNavItems} from 'sentry/components/nav/issueViews/issueViewNavItems';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
@@ -19,10 +15,6 @@ interface IssuesWrapperProps extends RouteComponentProps {
 
 export function IssueNavigation({children}: IssuesWrapperProps) {
   const organization = useOrganization();
-  const location = useLocation();
-  const navigate = useNavigate();
-  const {viewId} = useParams();
-  const queryParams = location.query;
   const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
   const hasIssueViewsInLeftNav = organization?.features.includes('left-nav-issue-views');
 
@@ -74,18 +66,6 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
     }
   }, [groupSearchViews]);
 
-  useEffect(() => {
-    if (viewId && !views?.find(v => v.id === viewId)) {
-      navigate(
-        normalizeUrl({
-          pathname: `${baseUrl}/`,
-          query: queryParams,
-        })
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewId]);
-
   if (!hasNavigationV2) {
     return children;
   }
@@ -105,26 +85,16 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
               {t('Feedback')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
-          {
+          {hasIssueViewsInLeftNav && views && (
             <SecondaryNav.Section title={t('Views')}>
-              <Reorder.Group
-                as="div"
-                axis="y"
-                values={views ?? []}
-                onReorder={setViews}
-                initial={false}
-                ref={sectionRef}
-              >
-                {views?.map(view => (
-                  <IssueViewNavItemContent
-                    key={view.id}
-                    view={view}
-                    sectionRef={sectionRef}
-                  />
-                ))}
-              </Reorder.Group>
+              <IssueViewNavItems
+                views={views}
+                setViews={setViews}
+                sectionRef={sectionRef}
+                baseUrl={baseUrl}
+              />
             </SecondaryNav.Section>
-          }
+          )}
         </SecondaryNav.Body>
         <SecondaryNav.Footer>
           <SecondaryNav.Item


### PR DESCRIPTION
This PR adds several major pieces of functionality to left nav issue views, mostly around reacting to the URL and navigating appropriately, as well as many of the ellipsis menu functions. 

Note that  **None of the changes you make to the left nav issue views will persist.** I have not wired up the views with the backend yet, so any state changes to the views are ephemeral.

Here's a more exhaustive list of changes: 

* View routes are now `issues/views/:viewId`. Navigating to a route with a known viewId will select the view, and populate the issue stream filters with the view's filters. Navigating to a route with an unknown viewId will redirect you to "All Issues" 
* Clicking on an issue view will now correctly load the issue stream with that view's filters. (Currently, all tabs will appear as a "temporary tab" in the horizontal issue view tabs, which is a little janky, but expected) 
* Views will react to changes in the issue stream filters, and will show the unsaved changes indicator correctly. 
* All ellipsis menu options now work properly (state changes are not persisted). Duplicating and deleting will also animate the tabs in and out!
* The unsaved changes indicator has been relocated to the tab itself (rather than on the ellipsis menu), and shows a hover tooltip that indicates what filters have been changed. This is because the ellipsis menu only appears on hover, and because many users were confused as a result of the unsaved changes indicator not being visible enough. (see below) 
![image](https://github.com/user-attachments/assets/e0a923e5-7395-49d4-8d42-d155d2ecad62)
