### PR TITLE
feat(workflow_engine): Add an atomic cleanup of a Workflow and associated models

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -170,7 +170,6 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
 
 
 def delete_workflow(workflow: Workflow) -> bool:
-    # TODO - saponifi3d - add a sentry span here to measure the time it takes to delete a workflow
     with transaction.atomic(router.db_for_write(Workflow)):
         action_filters = DataConditionGroup.objects.filter(
             workflowdataconditiongroup__workflow=workflow
@@ -180,8 +179,13 @@ def delete_workflow(workflow: Workflow) -> bool:
             dataconditiongroupaction__condition_group__in=action_filters
         )
 
-        actions.delete()
-        action_filters.delete()
+        if actions:
+            actions.delete()
+
+        if action_filters:
+            action_filters.delete()
+
         workflow.when_condition_group.delete()
         workflow.delete()
+
     return True

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -179,13 +179,17 @@ def delete_workflow(workflow: Workflow) -> bool:
             dataconditiongroupaction__condition_group__in=action_filters
         )
 
+        # Delete the actions associated with a workflow, this is not a cascade delete
+        # because we want to create a UI to maintain notification actions separately
         if actions:
             actions.delete()
 
         if action_filters:
             action_filters.delete()
 
-        workflow.when_condition_group.delete()
+        if workflow.when_condition_group:
+            workflow.when_condition_group.delete()
+
         workflow.delete()
 
     return True

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -468,12 +468,9 @@ class TestDeleteWorkflow:
         cls = instance.__class__
 
         delete_workflow(self.workflow)
-
-        # Checks that all the models are deleted in individual test cases
         assert not cls.objects.filter(id=instance_id).exists()
 
     def test_delete_workflow__no_actions(self):
-        # Remove the assiaction action and reference to the action to the action conditions
         Action.objects.get(id=self.action.id).delete()
         assert not DataConditionGroupAction.objects.filter(id=self.action_and_filter.id).exists()
 


### PR DESCRIPTION
## Description
Since we have so many generic models, we have different enforcements in the schema.

To ensure the models are cleaned up correctly a `workflow`, this PR introduces `delete_workflow`

This method uses an atomic transaction to clean up the workflow, it's trigger conditions, and the action filters, and any actions. This also adds a test to ensure any reference tables and associations are also cleaned up.