### PR TITLE
feat(aci): update detectors and workflows when RuleSnooze is updated

### DIFF
--- a/src/sentry/receivers/__init__.py
+++ b/src/sentry/receivers/__init__.py
@@ -9,6 +9,7 @@ from .outbox.control import *  # noqa: F401,F403
 from .outbox.region import *  # noqa: F401,F403
 from .owners import *  # noqa: F401,F403
 from .releases import *  # noqa: F401,F403
+from .rule_snooze import *  # noqa: F401,F403
 from .rules import *  # noqa: F401,F403
 from .sentry_apps import *  # noqa: F401,F403
 from .stats import *  # noqa: F401,F403

--- a/src/sentry/receivers/rule_snooze.py
+++ b/src/sentry/receivers/rule_snooze.py
@@ -5,6 +5,9 @@ from sentry.workflow_engine.models import AlertRuleDetector, AlertRuleWorkflow
 
 
 def _update_workflow_engine_models(instance: RuleSnooze, is_enabled: bool) -> None:
+    if instance.user_id is not None:
+        return
+
     if instance.rule:
         alert_rule_workflow = AlertRuleWorkflow.objects.filter(rule=instance.rule).first()
         if alert_rule_workflow and alert_rule_workflow.workflow:

--- a/src/sentry/receivers/rule_snooze.py
+++ b/src/sentry/receivers/rule_snooze.py
@@ -1,0 +1,42 @@
+from django.db.models.signals import post_save, pre_delete
+
+from sentry.models.rulesnooze import RuleSnooze
+from sentry.workflow_engine.models import AlertRuleDetector, AlertRuleWorkflow
+
+
+def _update_workflow_engine_models(instance: RuleSnooze, is_enabled: bool) -> None:
+    if instance.rule:
+        alert_rule_workflow = AlertRuleWorkflow.objects.filter(rule=instance.rule).first()
+        if alert_rule_workflow and alert_rule_workflow.workflow:
+            alert_rule_workflow.workflow.update(enabled=is_enabled)
+
+    elif instance.alert_rule:
+        alert_rule_detector = AlertRuleDetector.objects.filter(
+            alert_rule=instance.alert_rule
+        ).first()
+        if alert_rule_detector and alert_rule_detector.detector:
+            alert_rule_detector.detector.update(enabled=is_enabled)
+
+
+def disable_workflow_engine_models(instance: RuleSnooze, created, **kwargs):
+    if not created:
+        return
+    _update_workflow_engine_models(instance, is_enabled=False)
+
+
+def enable_workflow_engine_models(instance: RuleSnooze, **kwargs) -> None:
+    _update_workflow_engine_models(instance, is_enabled=True)
+
+
+post_save.connect(
+    disable_workflow_engine_models,
+    sender=RuleSnooze,
+    dispatch_uid="disable_workflow_engine_models",
+    weak=False,
+)
+pre_delete.connect(
+    enable_workflow_engine_models,
+    sender=RuleSnooze,
+    dispatch_uid="enable_workflow_engine_models",
+    weak=False,
+)

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -159,7 +159,7 @@ class IssueAlertMigrator:
         self._bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=when_dcg)
 
         enabled = True
-        rule_snooze = RuleSnooze.objects.filter(rule=self.rule).first()
+        rule_snooze = RuleSnooze.objects.filter(rule=self.rule, user_id=None).first()
         if rule_snooze and rule_snooze.until is None:
             enabled = False
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -419,8 +419,11 @@ class DualWriteAlertRuleTest(APITestCase):
         metric_detector.refresh_from_db()
         assert metric_detector.enabled is True
 
-        # per-user snooze doesn't disable detector
+    def test_ignores_per_user_rule_snooze(self):
+        aci_objects = migrate_alert_rule(self.metric_alert, self.rpc_user)
         RuleSnooze.objects.create(alert_rule=self.metric_alert, user_id=self.user.id)
+
+        metric_detector = aci_objects[3]
         metric_detector.refresh_from_db()
         assert metric_detector.enabled is True
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -419,6 +419,11 @@ class DualWriteAlertRuleTest(APITestCase):
         metric_detector.refresh_from_db()
         assert metric_detector.enabled is True
 
+        # per-user snooze doesn't disable detector
+        RuleSnooze.objects.create(alert_rule=self.metric_alert, user_id=self.user.id)
+        metric_detector.refresh_from_db()
+        assert metric_detector.enabled is True
+
 
 class DualDeleteAlertRuleTest(BaseMetricAlertMigrationTest):
     def setUp(self):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -129,8 +129,13 @@ class RuleMigrationHelpersTest(TestCase):
         workflow.refresh_from_db()
         assert workflow.enabled is True
 
-        # per-user snooze doesn't disable detector
+    def test_ignores_per_user_rule_snooze(self):
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
         RuleSnooze.objects.create(rule=self.issue_alert, user_id=self.user.id)
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+
+        workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
         workflow.refresh_from_db()
         assert workflow.enabled is True
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -4,6 +4,7 @@ import pytest
 from jsonschema.exceptions import ValidationError
 
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.event_frequency import (
     ComparisonType,
@@ -113,6 +114,20 @@ class RuleMigrationHelpersTest(TestCase):
                 "value": self.filters[2]["value"],
             },
         ]
+
+    def test_rule_snooze_updates_workflow(self):
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        rule_snooze = RuleSnooze.objects.create(rule=self.issue_alert)
+
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=self.issue_alert)
+        workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+
+        assert workflow.enabled is False
+
+        rule_snooze.delete()
+
+        workflow.refresh_from_db()
+        assert workflow.enabled is True
 
     def test_update_issue_alert(self):
         IssueAlertMigrator(self.issue_alert, self.user.id).run()
@@ -381,7 +396,7 @@ class IssueAlertMigratorTest(TestCase):
         assert DataCondition.objects.all().count() == 0
         assert Action.objects.all().count() == 0
 
-    def assert_issue_alert_migrated(self, issue_alert):
+    def assert_issue_alert_migrated(self, issue_alert, is_enabled=True):
         issue_alert_workflow = AlertRuleWorkflow.objects.get(rule=issue_alert)
         issue_alert_detector = AlertRuleDetector.objects.get(rule=issue_alert)
 
@@ -390,6 +405,8 @@ class IssueAlertMigratorTest(TestCase):
         assert issue_alert.project
         assert workflow.organization_id == issue_alert.project.organization.id
         assert workflow.config == {"frequency": 5}
+        assert workflow.date_added == issue_alert.date_added
+        assert workflow.enabled == is_enabled
 
         detector = Detector.objects.get(id=issue_alert_detector.detector.id)
         assert detector.name == "Error Detector"
@@ -429,8 +446,7 @@ class IssueAlertMigratorTest(TestCase):
         ).exists()
 
     def test_run(self):
-        migrator = IssueAlertMigrator(self.issue_alert, self.user.id)
-        migrator.run()
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
         self.assert_issue_alert_migrated(self.issue_alert)
 
@@ -438,9 +454,18 @@ class IssueAlertMigratorTest(TestCase):
         action = dcg_actions.action
         assert action.type == Action.Type.SLACK
 
+    def test_run__snoozed_rule(self):
+        RuleSnooze.objects.create(rule=self.issue_alert)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
+        self.assert_issue_alert_migrated(self.issue_alert, is_enabled=False)
+
+        dcg_actions = DataConditionGroupAction.objects.all()[0]
+        action = dcg_actions.action
+        assert action.type == Action.Type.SLACK
+
     def test_run__skip_actions(self):
-        migrator = IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False)
-        migrator.run()
+        IssueAlertMigrator(self.issue_alert, self.user.id, should_create_actions=False).run()
 
         self.assert_issue_alert_migrated(self.issue_alert)
 


### PR DESCRIPTION
Creating a `RuleSnooze` (for `AlertRule` and `Rule`, they use the same model) means that the corresponding metric detector or workflow should be disabled. Deleting a `RuleSnooze` should enable the corresponding metric detector or workflow. Added a receiver that does this.

We should ignore making changes to detectors and workflows if RuleSnooze only applies to a single user.

Also updated `IssueAlertMigrator` to account for a snoozed Rule and to update `Workflow.date_added` to the date the `Rule` was added, not when the `Rule` is migrated.