### PR TITLE
:recycle: ref(slack): remove alert rule description logic

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -349,8 +349,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-session-health-tab-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Enable description field in Slack metric alerts
-    manager.add("organizations:slack-metric-alert-description", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
 
 import orjson
 import sentry_sdk
@@ -26,6 +25,7 @@ from sentry.integrations.repository.metric_alert import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
+from sentry.integrations.slack.message_builder.types import SlackBlock
 from sentry.integrations.slack.metrics import (
     SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
     SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
@@ -70,8 +70,8 @@ def send_incident_alert_notification(
             sentry_sdk.capture_exception(e)
 
     channel = action.target_identifier
-    attachment: Any = SlackIncidentsMessageBuilder(
-        action, incident, new_status, metric_value, chart_url, notification_uuid
+    attachment: SlackBlock = SlackIncidentsMessageBuilder(
+        incident, new_status, metric_value, chart_url, notification_uuid
     ).build()
     text = str(attachment["text"])
     blocks = {"blocks": attachment["blocks"], "color": attachment["color"]}

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -95,7 +95,7 @@ class SlackActionHandlerTest(FireTest):
 
     def _assert_blocks(self, mock_post, incident, metric_value, chart_url):
         slack_body = SlackIncidentsMessageBuilder(
-            self.action, incident, IncidentStatus(incident.status), metric_value, chart_url
+            incident, IncidentStatus(incident.status), metric_value, chart_url
         ).build()
         assert isinstance(slack_body, dict)
         attachments = orjson.loads(mock_post.call_args.kwargs["attachments"])

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -216,17 +216,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         assert resp.data["latestIncident"]["id"] == str(incident.id)
         assert "latestIncident" not in no_expand_resp.data
 
-    @with_feature("organizations:slack-metric-alert-description")
-    @with_feature("organizations:incidents")
-    def test_with_description(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-        rule = self.create_alert_rule(description="howdy")
-        trigger = self.create_alert_rule_trigger(rule, "hi", 1000)
-        self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
-        resp = self.get_success_response(self.organization.slug, rule.id)
-        assert rule.description == resp.data.get("description")
-
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @with_feature("organizations:incidents")
@@ -932,22 +921,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
         # resolve threshold changes to the warning threshold
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
-
-    @with_feature("organizations:slack-metric-alert-description")
-    @with_feature("organizations:incidents")
-    def test_with_description(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-        alert_rule = self.alert_rule
-        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
-        description = "yeehaw"
-        serialized_alert_rule = self.get_serialized_alert_rule()
-        serialized_alert_rule["description"] = description
-
-        resp = self.get_success_response(
-            self.organization.slug, alert_rule.id, **serialized_alert_rule
-        )
-        assert description == resp.data.get("description")
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -256,25 +256,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert_alert_rule_trigger_action_migrated(actions[0], Action.Type.EMAIL)
         assert_alert_rule_trigger_action_migrated(actions[1], Action.Type.EMAIL)
 
-    @with_feature("organizations:slack-metric-alert-description")
-    @with_feature("organizations:incidents")
-    def test_with_description(self):
-        data = {
-            **self.alert_rule_dict,
-            "description": "yeehaw",
-        }
-
-        with outbox_runner():
-            resp = self.get_success_response(
-                self.organization.slug,
-                status_code=201,
-                **data,
-            )
-        assert "id" in resp.data
-        alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
-        assert alert_rule.description == resp.data.get("description")
-
     @with_feature("organizations:incidents")
     def test_invalid_threshold_type(self):
         """

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -785,58 +785,9 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(ret, dict)
         assert "<https://example.com/|*Click Here*>" in ret["blocks"][1]["text"]["text"]
 
-    @with_feature("organizations:slack-metric-alert-description")
-    def test_description_in_notification(self):
-        alert_rule = self.create_alert_rule(description="yeehaw")
-        incident = self.create_incident(alert_rule=alert_rule, status=2)
-        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
-        title = f"Critical: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
-            incident.date_started.timestamp(), "{date_pretty}", "{time}"
-        )
-        link = (
-            absolute_uri(
-                reverse(
-                    "sentry-metric-alert-details",
-                    kwargs={
-                        "organization_slug": self.organization.slug,
-                        "alert_rule_id": alert_rule.id,
-                    },
-                )
-            )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
-        )
-        assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
-            "blocks": [
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"0 events in the last 10 minutes\n{timestamp}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"*Notes*: {alert_rule.description}",
-                    },
-                },
-            ],
-            "color": LEVEL_TO_COLOR["fatal"],
-            "text": f"<{link}|*{title}*>",
-        }
-
     def test_no_description_in_notification(self):
         alert_rule = self.create_alert_rule(description="yeehaw")
         incident = self.create_incident(alert_rule=alert_rule, status=2)
-        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
         title = f"Critical: {alert_rule.name}"
         timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
@@ -853,7 +804,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
-        assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
+        assert SlackIncidentsMessageBuilder(incident, IncidentStatus.CRITICAL).build() == {
             "blocks": [
                 {
                     "type": "section",
@@ -864,44 +815,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                 },
             ],
             "color": LEVEL_TO_COLOR["fatal"],
-            "text": f"<{link}|*{title}*>",
-        }
-
-    @with_feature("organizations:slack-metric-alert-description")
-    def test_description_not_in_notification_closed_alerts(self):
-        alert_rule = self.create_alert_rule()
-        incident = self.create_incident(alert_rule=alert_rule, status=2)
-        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
-        title = f"Resolved: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
-            incident.date_started.timestamp(), "{date_pretty}", "{time}"
-        )
-        link = (
-            absolute_uri(
-                reverse(
-                    "sentry-metric-alert-details",
-                    kwargs={
-                        "organization_slug": self.organization.slug,
-                        "alert_rule_id": alert_rule.id,
-                    },
-                )
-            )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
-        )
-        assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CLOSED).build() == {
-            "blocks": [
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"0 events in the last 10 minutes\n{timestamp}",
-                    },
-                },
-            ],
-            "color": LEVEL_TO_COLOR["_incident_resolved"],
             "text": f"<{link}|*{title}*>",
         }
 
@@ -939,10 +852,6 @@ class BuildIncidentAttachmentTest(TestCase):
     def test_simple(self):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=2)
-        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
         title = f"Resolved: {alert_rule.name}"
         timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
@@ -959,7 +868,7 @@ class BuildIncidentAttachmentTest(TestCase):
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
-        assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CLOSED).build() == {
+        assert SlackIncidentsMessageBuilder(incident, IncidentStatus.CLOSED).build() == {
             "blocks": [
                 {
                     "type": "section",
@@ -980,10 +889,6 @@ class BuildIncidentAttachmentTest(TestCase):
         # This test will use the action/method and not the incident to build status
         title = f"Critical: {alert_rule.name}"
         metric_value = 5000
-        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
         timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
@@ -1001,7 +906,7 @@ class BuildIncidentAttachmentTest(TestCase):
         )
         # This should fail because it pulls status from `action` instead of `incident`
         assert SlackIncidentsMessageBuilder(
-            action, incident, IncidentStatus.CRITICAL, metric_value=metric_value
+            incident, IncidentStatus.CRITICAL, metric_value=metric_value
         ).build() == {
             "blocks": [
                 {
@@ -1019,10 +924,6 @@ class BuildIncidentAttachmentTest(TestCase):
     def test_chart(self):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=2)
-        trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
         title = f"Resolved: {alert_rule.name}"
         timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
@@ -1040,7 +941,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
-            action, incident, IncidentStatus.CLOSED, chart_url="chart-url"
+            incident, IncidentStatus.CLOSED, chart_url="chart-url"
         ).build() == {
             "blocks": [
                 {
@@ -1071,10 +972,6 @@ class BuildIncidentAttachmentTest(TestCase):
             seasonality=AlertRuleSeasonality.AUTO,
         )
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
-        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule, alert_threshold=0)
-        action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger, triggered_for_incident=incident
-        )
         title = f"Critical: {alert_rule.name}"
         timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
@@ -1092,7 +989,7 @@ class BuildIncidentAttachmentTest(TestCase):
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={detection_type}"
         )
-        assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
+        assert SlackIncidentsMessageBuilder(incident, IncidentStatus.CRITICAL).build() == {
             "blocks": [
                 {
                     "type": "section",


### PR DESCRIPTION
this logic was added about a year ago as part of rotation to add descriptions field for metric alerts. we never shipped this and there isn't any frontend component to even set descriptions.

this will probably be encapsulated by notification platform as we don't want to build these features 1-off anymore. i would like to clean up this logic as it reduces a dependency to the legacy `AlertRuleTriggerAction` model.