### PR TITLE
feat(laravel-insights): Request and duration widgets

### DIFF
--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -1,9 +1,12 @@
+import {useCallback, useMemo} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import pick from 'lodash/pick';
 
 import type {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
+import {getInterval} from 'sentry/components/charts/utils';
 import GroupList from 'sentry/components/issues/groupList';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
@@ -18,12 +21,14 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
+import type {MultiSeriesEventsStats, Organization} from 'sentry/types/organization';
 import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
@@ -32,6 +37,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {BarChartWidget} from 'sentry/views/dashboards/widgets/barChartWidget/barChartWidget';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {LineChartWidget} from 'sentry/views/dashboards/widgets/lineChartWidget/lineChartWidget';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -164,19 +172,19 @@ export function LaravelOverviewPage() {
                 >
                   <WidgetGrid>
                     <RequestsContainer>
-                      <PlaceholderWidget title="Requests" />
+                      <RequestsWidget query={derivedQuery} />
                     </RequestsContainer>
                     <IssuesContainer>
                       <IssuesWidget
                         organization={organization}
                         location={location}
                         projectId={selection.projects[0]!}
-                        query={getFreeTextFromQuery(derivedQuery)!}
+                        query={derivedQuery}
                         api={api}
                       />
                     </IssuesContainer>
                     <DurationContainer>
-                      <PlaceholderWidget title="Duration" />
+                      <DurationWidget query={derivedQuery} />
                     </DurationContainer>
                     <JobsContainer>
                       <PlaceholderWidget title="Jobs" />
@@ -270,7 +278,7 @@ const IssuesContainer = styled('div')`
     margin-bottom: 0 !important;
   }
 
-  $ ${PanelHeader} {
+  & ${PanelHeader} {
     position: sticky;
     top: 0;
     z-index: ${p => p.theme.zIndex.header};
@@ -380,6 +388,144 @@ function IssuesWidget({
       renderEmptyMessage={renderEmptyMessage}
       withChart={breakpoints.xlarge}
       withPagination={false}
+    />
+  );
+}
+
+function RequestsWidget({query}: {query?: string}) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const theme = useTheme();
+
+  const normalizedDateTime = useMemo(
+    () => normalizeDateTimeParams(selection.datetime),
+    [selection.datetime]
+  );
+
+  const {data, isLoading} = useApiQuery<MultiSeriesEventsStats>(
+    [
+      `/organizations/${organization.slug}/events-stats/`,
+      {
+        query: {
+          ...normalizedDateTime,
+          interval: getInterval(selection.datetime, 'low'),
+          dataset: 'spans',
+          field: ['http.status_code', 'count(span.duration)'],
+          yAxis: 'count(span.duration)',
+          orderby: '-count(span.duration)',
+          partial: 1,
+          project: selection.projects,
+          query: `has:http.status_code ${query}`.trim(),
+          useRpc: 1,
+          topEvents: 10,
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+
+  const getTimeSeries = useCallback(
+    (codePrefix: string, color?: string): TimeSeries | undefined => {
+      if (!data) {
+        return undefined;
+      }
+      const filteredSeries = Object.keys(data)
+        .filter(key => key.startsWith(codePrefix))
+        .map(key => data[key]!);
+
+      const firstSeries = filteredSeries[0];
+      if (!firstSeries) {
+        return undefined;
+      }
+
+      return {
+        data: firstSeries.data.map(([time], index) => ({
+          value: filteredSeries.reduce(
+            (acc, series) => acc + series.data[index]?.[1][0]?.count!,
+            0
+          ),
+          timestamp: new Date(time).toISOString(),
+        })),
+        field: `${codePrefix}xx`,
+        meta: firstSeries.meta!,
+        color,
+      } satisfies TimeSeries;
+    },
+    [data]
+  );
+
+  return (
+    <BarChartWidget
+      isLoading={isLoading}
+      title="Requests"
+      timeSeries={[
+        getTimeSeries('2', theme.gray200),
+        getTimeSeries('5', theme.error),
+      ].filter(series => !!series)}
+      stacked
+    />
+  );
+}
+
+function DurationWidget({query}: {query?: string}) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const normalizedDateTime = useMemo(
+    () => normalizeDateTimeParams(selection.datetime),
+    [selection.datetime]
+  );
+
+  const {data, isLoading} = useApiQuery<MultiSeriesEventsStats>(
+    [
+      `/organizations/${organization.slug}/events-stats/`,
+      {
+        query: {
+          ...normalizedDateTime,
+          interval: getInterval(selection.datetime, 'low'),
+          dataset: 'spans',
+          yAxis: ['avg(span.duration)', 'p95(span.duration)'],
+          orderby: 'avg(span.duration)',
+          partial: 1,
+          useRpc: 1,
+          project: selection.projects,
+          query: `has:http.status_code ${query}`.trim(),
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+
+  const getTimeSeries = useCallback(
+    (field: string, color?: string): TimeSeries | undefined => {
+      const series = data?.[field];
+      if (!series) {
+        return undefined;
+      }
+
+      return {
+        data: series.data.map(([time, [value]]) => ({
+          value: value?.count!,
+          timestamp: new Date(time).toISOString(),
+        })),
+        // Inside the returned response the field name changes
+        // therefore we need to map it here
+        field,
+        meta: series.meta!,
+        color,
+      } satisfies TimeSeries;
+    },
+    [data]
+  );
+
+  return (
+    <LineChartWidget
+      isLoading={isLoading}
+      title="Duration"
+      timeSeries={[
+        getTimeSeries('avg(span.duration)', CHART_PALETTE[1][0]),
+        getTimeSeries('p95(span.duration)', CHART_PALETTE[1][1]),
+      ].filter(series => !!series)}
     />
   );
 }

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -508,8 +508,6 @@ function DurationWidget({query}: {query?: string}) {
           value: value?.count!,
           timestamp: new Date(time).toISOString(),
         })),
-        // Inside the returned response the field name changes
-        // therefore we need to map it here
         field,
         meta: series.meta!,
         color,


### PR DESCRIPTION
Add widgets for requests and duration.
The request widget uses a simple bar chart for now, as the underlying components do not support mixing bar and line series.

![Screenshot 2025-02-20 at 08 21 35](https://github.com/user-attachments/assets/3c25d11e-c5ad-4dca-bd08-f35841aca06b)

**Note:** This is WIP and aims to build a quick POC.

- part of https://github.com/getsentry/projects/issues/679