### PR TITLE
fix(grouping): Include more operations when timing grouphash metadata calculation

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -174,29 +174,29 @@ def get_grouphash_metadata_data(
     variants: dict[str, BaseVariant],
     grouping_config: str,
 ) -> dict[str, Any]:
-    base_data = {
-        "latest_grouping_config": grouping_config,
-        "platform": event.platform or "unknown",
-    }
-    hashing_metadata: HashingMetadata = {}
-    # TODO: These are typed as `Any` so that we don't have to cast them to whatever specific
-    # subtypes of `BaseVariant` and `GroupingComponent` (respectively) each of the helper calls
-    # below requires. Casting once, to a type retrieved from a look-up, doesn't work, but maybe
-    # there's a better way?
-    contributors = get_contributing_variant_and_component(variants)
-    contributing_variant: Any = contributors[0]
-    contributing_component: Any = contributors[1]
-
-    # Hybrid fingerprinting adds 'modified' to the beginning of the description of whatever method
-    # was used before the extra fingerprint was added. We classify events with hybrid fingerprints
-    # by the `{{ default }}` portion of their grouping, so strip the prefix before doing the
-    # look-up.
-    is_hybrid_fingerprint = contributing_variant.description.startswith("modified")
-    method_description = contributing_variant.description.replace("modified ", "")
-
     with metrics.timer(
         "grouping.grouphashmetadata.get_grouphash_metadata_data"
     ) as metrics_timer_tags:
+        base_data = {
+            "latest_grouping_config": grouping_config,
+            "platform": event.platform or "unknown",
+        }
+        hashing_metadata: HashingMetadata = {}
+        # TODO: These are typed as `Any` so that we don't have to cast them to whatever specific
+        # subtypes of `BaseVariant` and `GroupingComponent` (respectively) each of the helper calls
+        # below requires. Casting once, to a type retrieved from a look-up, doesn't work, but maybe
+        # there's a better way?
+        contributors = get_contributing_variant_and_component(variants)
+        contributing_variant: Any = contributors[0]
+        contributing_component: Any = contributors[1]
+
+        # Hybrid fingerprinting adds 'modified' to the beginning of the description of whatever
+        # method was used before the extra fingerprint was added. We classify events with hybrid
+        # fingerprints by the `{{ default }}` portion of their grouping, so strip the prefix before
+        # doing the look-up.
+        is_hybrid_fingerprint = contributing_variant.description.startswith("modified")
+        method_description = contributing_variant.description.replace("modified ", "")
+
         try:
             hash_basis = GROUPING_METHODS_BY_DESCRIPTION[method_description]
         except KeyError:


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/85283, the timer timing grouphash metadata calculation, which had been surrounding the call to the calculation function, was moved inside the function, in preparation for the function being called in more places. When I did that, I didn't include a few lines of code at the top of the function because I was thinking of them as set up for the real work of calculation. This was a mistake, which I discovered when a) the average time went down more than I would have expected it to if all it was skipping was the overhead of the function call, and b) the p99 time went _way_ down once I subsequently [made component description a cached property](https://github.com/getsentry/sentry/pull/85481), so much so that it seemed not to be doing the work of description calculation at all. 

Upon closer inspection, that "set up code" I'd excluded from the timer does indeed include the first `description` access. Now that I've inadvertently proven just how much description calculation contributes to overall grouphash metadata calculation time, it seems appropriate to include that code in the timer. This PR therefore moves the timer to the top of the function, bringing it back in line with what it was doing before the initial refactor.