### PR TITLE
wip(insights): perf landing links removal

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -97,7 +97,12 @@ export function getOnboardingTasks({
   projects,
   onboardingContext,
 }: Options): OnboardingTaskDescriptor[] {
-  const performanceUrl = `${getPerformanceBaseUrl(organization.slug)}/`;
+  const hasPerfLandingRemovalFlag = organization.features?.includes(
+    'insights-performance-landing-removal'
+  );
+  const performanceUrl = hasPerfLandingRemovalFlag
+    ? `${getPerformanceBaseUrl(organization.slug, 'frontend')}/`
+    : `${getPerformanceBaseUrl(organization.slug)}/`;
 
   if (isDemoModeEnabled()) {
     return [

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -359,10 +359,15 @@ export function redirectToPerformanceHomepage(
   organization: Organization,
   location: Location
 ) {
+  const hasPerfLandingRemovalFlag = organization.features.includes(
+    'insights-performance-landing-removal'
+  );
   // If there is no transaction name, redirect to the Performance landing page
   browserHistory.replace(
     normalizeUrl({
-      pathname: getPerformanceBaseUrl(organization.slug),
+      pathname: hasPerfLandingRemovalFlag
+        ? getPerformanceBaseUrl(organization.slug, 'backend')
+        : getPerformanceBaseUrl(organization.slug),
       query: {
         ...location.query,
       },

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -6,9 +6,15 @@ import FeatureTourModal from 'sentry/components/modals/featureTourModal';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {PERFORMANCE_TOUR_STEPS} from 'sentry/views/performance/onboarding';
-import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
+import {
+  getPerformanceBaseUrl,
+  platformToDomainView,
+} from 'sentry/views/performance/utils';
 
 const DOCS_URL = 'https://docs.sentry.io/performance-monitoring/getting-started/';
 
@@ -18,6 +24,10 @@ type Props = {
 
 function MissingPerformanceButtons({organization}: Props) {
   const router = useRouter();
+  const {projects} = useProjects();
+  const {
+    selection: {projects: selectedProjects},
+  } = usePageFilters();
 
   function handleTourAdvance(step: number, duration: number) {
     trackAnalytics('project_detail.performance_tour.advance', {
@@ -34,6 +44,13 @@ function MissingPerformanceButtons({organization}: Props) {
       duration,
     });
   }
+  const hasPerfLandingRemovalFlag = organization.features?.includes(
+    'insights-performance-landing-removal'
+  );
+  const domainView: DomainView | undefined = platformToDomainView(
+    projects,
+    selectedProjects
+  );
 
   return (
     <Feature
@@ -49,7 +66,7 @@ function MissingPerformanceButtons({organization}: Props) {
             event.preventDefault();
             // TODO: add analytics here for this specific action.
             navigateTo(
-              `${getPerformanceBaseUrl(organization.slug)}/?project=:project#performance-sidequest`,
+              `${hasPerfLandingRemovalFlag ? getPerformanceBaseUrl(organization.slug) : getPerformanceBaseUrl(organization.slug, domainView)}/?project=:project#performance-sidequest`,
               router
             );
           }}

--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -11,10 +11,12 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {DEFAULT_MAX_DURATION} from 'sentry/views/performance/trends/utils';
 import {
-  getPerformanceLandingUrl,
+  getPerformanceBaseUrl,
   getPerformanceTrendsUrl,
+  platformToDomainView,
 } from 'sentry/views/performance/utils';
 
 import {SidebarSection} from './styles';
@@ -45,6 +47,13 @@ function ProjectQuickLinks({organization, project, location}: Props) {
     };
   }
 
+  const hasPerfLandingRemovalFlag = organization.features?.includes(
+    'insights-performance-landing-removal'
+  );
+  const domainView: DomainView | undefined = project
+    ? platformToDomainView([project], [parseInt(project.id, 10)])
+    : 'backend';
+
   const quickLinks = [
     {
       title: t('User Feedback'),
@@ -56,7 +65,9 @@ function ProjectQuickLinks({organization, project, location}: Props) {
     {
       title: t('View Transactions'),
       to: {
-        pathname: getPerformanceLandingUrl(organization),
+        pathname: hasPerfLandingRemovalFlag
+          ? `${getPerformanceBaseUrl(organization.slug, domainView)}/`
+          : `${getPerformanceBaseUrl(organization.slug)}/`,
         query: {project: project?.id},
       },
       disabled: !organization.features.includes('performance-view'),

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -29,7 +29,11 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
-import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
+import {
+  getPerformanceBaseUrl,
+  platformToDomainView,
+} from 'sentry/views/performance/utils';
 import MissingReleasesButtons from 'sentry/views/projectDetail/missingFeatureButtons/missingReleasesButtons';
 import {
   CRASH_FREE_DECIMAL_THRESHOLD,
@@ -123,6 +127,12 @@ class ProjectCard extends Component<Props> {
       transactionStats?.reduce((sum, [_, value]) => sum + value, 0) ?? 0;
     const zeroTransactions = totalTransactions === 0;
     const hasFirstEvent = Boolean(project.firstEvent || project.firstTransactionEvent);
+    const hasPerfLandingRemovalFlag = organization.features?.includes(
+      'insights-performance-landing-removal'
+    );
+    const domainView: DomainView | undefined = project
+      ? platformToDomainView([project], [parseInt(project.id, 10)])
+      : 'backend';
 
     return (
       <div data-test-id={slug}>
@@ -159,7 +169,11 @@ class ProjectCard extends Component<Props> {
                       <em>|</em>
                       <TransactionsLink
                         data-test-id="project-transactions"
-                        to={`${getPerformanceBaseUrl(organization.slug)}/?project=${project.id}`}
+                        to={`${
+                          hasPerfLandingRemovalFlag
+                            ? getPerformanceBaseUrl(organization.slug, domainView)
+                            : getPerformanceBaseUrl(organization.slug)
+                        }/?project=${project.id}`}
                       >
                         {t(
                           'Transactions: %s',


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/84021

There are several links that needed to be updated that still link to the old performance page