### PR TITLE
feat: Add assigneeName to issue assigned activities

### DIFF
--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -41,6 +41,7 @@ class GroupAssigneeManager(BaseManager["GroupAssignee"]):
         data = {
             "assignee": str(assigned_to.id),
             "assigneeEmail": getattr(assigned_to, "email", None),
+            "assigneeName": getattr(assigned_to, "name", None),
             "assigneeType": assignee_type,
         }
         if extra:

--- a/src/sentry/web/frontend/debug/debug_assigned_email.py
+++ b/src/sentry/web/frontend/debug/debug_assigned_email.py
@@ -12,6 +12,7 @@ class DebugAssignedEmailView(ActivityMailDebugView):
             "data": {
                 "assignee": "10000000",
                 "assigneeEmail": "foo@example.com",
+                "assigneeName": "Example User",
                 "assigneeType": "user",
             },
         }
@@ -25,6 +26,7 @@ class DebugSelfAssignedEmailView(ActivityMailDebugView):
             "data": {
                 "assignee": str(request.user.id),
                 "assigneeEmail": request.user.email,
+                "assigneeName": request.user.name,
                 "assigneeType": "user",
             },
         }
@@ -35,5 +37,10 @@ class DebugSelfAssignedTeamEmailView(ActivityMailDebugView):
         return {
             "type": ActivityType.ASSIGNED.value,
             "user_id": request.user.id,
-            "data": {"assignee": "1", "assigneeEmail": None, "assigneeType": "team"},
+            "data": {
+                "assignee": "1",
+                "assigneeEmail": None,
+                "assigneeName": "example-team",
+                "assigneeType": "team",
+            },
         }

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -223,6 +223,7 @@ class StatusActionTest(APITestCase):
         assert activity.data == {
             "assignee": str(self.team.id),
             "assigneeEmail": None,
+            "assigneeName": self.team.name,
             "assigneeType": "team",
             "integration": ActivityIntegration.MSTEAMS.value,
         }
@@ -242,6 +243,7 @@ class StatusActionTest(APITestCase):
         assert activity.data == {
             "assignee": str(self.user.id),
             "assigneeEmail": self.user.email,
+            "assigneeName": self.user.name,
             "assigneeType": "user",
             "integration": ActivityIntegration.MSTEAMS.value,
         }

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -506,12 +506,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert group_activity[0].data == {
             "assignee": str(user2.id),
             "assigneeEmail": user2.email,
+            "assigneeName": user2.name,
             "assigneeType": "user",
             "integration": ActivityIntegration.SLACK.value,
         }
         assert group_activity[-1].data == {
             "assignee": str(self.team.id),
             "assigneeEmail": None,
+            "assigneeName": self.team.name,
             "assigneeType": "team",
             "integration": ActivityIntegration.SLACK.value,
         }
@@ -547,6 +549,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert group_activity[0].data == {
             "assignee": str(user2.id),
             "assigneeEmail": user2.email,
+            "assigneeName": user2.name,
             "assigneeType": "user",
             "integration": ActivityIntegration.SLACK.value,
         }
@@ -584,12 +587,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert group_activity[0].data == {
             "assignee": str(user2.id),
             "assigneeEmail": user2.email,
+            "assigneeName": user2.name,
             "assigneeType": "user",
             "integration": ActivityIntegration.SLACK.value,
         }
         assert group_activity[-1].data == {
             "assignee": str(self.team.id),
             "assigneeEmail": None,
+            "assigneeName": self.team.name,
             "assigneeType": "team",
             "integration": ActivityIntegration.SLACK.value,
         }

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -44,6 +44,7 @@ class GroupAssigneeTestCase(TestCase):
 
         assert activity.data["assignee"] == str(self.user.id)
         assert activity.data["assigneeEmail"] == self.user.email
+        assert activity.data["assigneeName"] == self.user.name
         assert activity.data["assigneeType"] == "user"
 
     def test_assign_team(self):
@@ -59,6 +60,7 @@ class GroupAssigneeTestCase(TestCase):
 
         assert activity.data["assignee"] == str(self.team.id)
         assert activity.data["assigneeEmail"] is None
+        assert activity.data["assigneeName"] == self.team.name
         assert activity.data["assigneeType"] == "team"
 
     def test_create_only(self):
@@ -73,6 +75,7 @@ class GroupAssigneeTestCase(TestCase):
         )
         assert activity.data["assignee"] == str(self.user.id)
         assert activity.data["assigneeEmail"] == self.user.email
+        assert activity.data["assigneeName"] == self.user.name
         assert activity.data["assigneeType"] == "user"
 
         other_user = self.create_user()
@@ -88,6 +91,7 @@ class GroupAssigneeTestCase(TestCase):
         )
         assert activity.data["assignee"] == str(self.user.id)
         assert activity.data["assigneeEmail"] == self.user.email
+        assert activity.data["assigneeName"] == self.user.name
         assert activity.data["assigneeType"] == "user"
 
     def test_reassign_user_to_team(self):
@@ -111,10 +115,12 @@ class GroupAssigneeTestCase(TestCase):
 
         assert activity[0].data["assignee"] == str(self.user.id)
         assert activity[0].data["assigneeEmail"] == self.user.email
+        assert activity[0].data["assigneeName"] == self.user.name
         assert activity[0].data["assigneeType"] == "user"
 
         assert activity[1].data["assignee"] == str(self.team.id)
         assert activity[1].data["assigneeEmail"] is None
+        assert activity[1].data["assigneeName"] == self.team.name
         assert activity[1].data["assigneeType"] == "team"
 
     @mock.patch.object(ExampleIntegration, "sync_assignee_outbound")
@@ -174,6 +180,7 @@ class GroupAssigneeTestCase(TestCase):
 
                 assert activity.data["assignee"] == str(self.user.id)
                 assert activity.data["assigneeEmail"] == self.user.email
+                assert activity.data["assigneeName"] == self.user.name
                 assert activity.data["assigneeType"] == "user"
 
     @mock.patch.object(ExampleIntegration, "sync_assignee_outbound")
@@ -233,6 +240,7 @@ class GroupAssigneeTestCase(TestCase):
 
                 assert activity.data["assignee"] == str(self.user.id)
                 assert activity.data["assigneeEmail"] == self.user.email
+                assert activity.data["assigneeName"] == self.user.name
                 assert activity.data["assigneeType"] == "user"
 
     @mock.patch.object(ExampleIntegration, "sync_assignee_outbound")

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -122,7 +122,12 @@ class AssignedNotificationAPITest(APITestCase):
                 data={"assignedTo": user1.username, "assignedBy": user1.username},
             )
         assert response.status_code == 200, response.content
-        data = {"assignee": str(user1.id), "assigneeEmail": user1.email, "assigneeType": "user"}
+        data = {
+            "assignee": str(user1.id),
+            "assigneeEmail": user1.email,
+            "assigneeName": user1.name,
+            "assigneeType": "user",
+        }
         assert Activity.objects.filter(
             group_id=self.group.id, type=ActivityType.ASSIGNED.value, user_id=user1.id, data=data
         ).exists()
@@ -143,7 +148,12 @@ class AssignedNotificationAPITest(APITestCase):
                 data={"assignedTo": user2.username, "assignedBy": user1.username},
             )
         assert response.status_code == 200, response.content
-        data = {"assignee": str(user2.id), "assigneeEmail": user2.email, "assigneeType": "user"}
+        data = {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeName": user2.name,
+            "assigneeType": "user",
+        }
         assert Activity.objects.filter(
             group_id=self.group.id, type=ActivityType.ASSIGNED.value, user_id=user1.id, data=data
         ).exists()
@@ -190,7 +200,12 @@ class AssignedNotificationAPITest(APITestCase):
                 data={"assignedTo": f"team:{team1.id}", "assignedBy": self.user.username},
             )
         assert response.status_code == 200, response.content
-        data = {"assignee": str(team1.id), "assigneeEmail": None, "assigneeType": "team"}
+        data = {
+            "assignee": str(team1.id),
+            "assigneeEmail": None,
+            "assigneeName": team1.name,
+            "assigneeType": "team",
+        }
         assert Activity.objects.filter(
             group_id=group.id, user_id=user1.id, type=ActivityType.ASSIGNED.value, data=data
         ).exists()
@@ -213,7 +228,12 @@ class AssignedNotificationAPITest(APITestCase):
                 data={"assignedTo": f"team:{team2.id}", "assignedBy": self.user.username},
             )
         assert response.status_code == 200, response.content
-        data = {"assignee": str(team2.id), "assigneeEmail": None, "assigneeType": "team"}
+        data = {
+            "assignee": str(team2.id),
+            "assigneeEmail": None,
+            "assigneeName": team2.name,
+            "assigneeType": "team",
+        }
         assert Activity.objects.filter(
             group_id=group.id, user_id=user1.id, type=ActivityType.ASSIGNED.value, data=data
         ).exists()

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -190,6 +190,7 @@ class ResolvedInCommitTest(TestCase):
         )[0].data == {
             "assignee": str(user.id),
             "assigneeEmail": user.email,
+            "assigneeName": user.name,
             "assigneeType": "user",
         }
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -823,6 +823,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         assert activity.data == {
             "assignee": str(self.user.id),
             "assigneeEmail": self.user.email,
+            "assigneeName": self.user.name,
             "assigneeType": "user",
             "integration": ActivityIntegration.PROJECT_OWNERSHIP.value,
             "rule": str(Rule(Matcher("path", "src/*"), [Owner("user", self.user.email)])),


### PR DESCRIPTION
Originally written by: @gabriellanata; It supersedes: #85399

> When an issue is assigned to a team, the activity only shows the team ID which is not very visual. I'm adding assigneeName (which matches the `assignedTo` when requesting an issue's details) to activity data.

If you visit [this URL](https://us.sentry.io/api/0/organizations/sentry/issues/4704765109/activities/) you can see the current format of the activity (trimmed data):
```
{
  "activity": [
    {
      "type": "assigned",
      "data": {
        "assignee": "2006237",
        "assigneeEmail": null,
        "assigneeType": "team"
      }
    }
  ]
}
```
The `issues` team is not mentioned in the API, however, the UI handles it well:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/fbe76b20-ad50-40a8-b32c-35189a44ed39" />

Ideally, we would store less information in `data` and make the serializer smarter by fetching the models it is indirectly referring to (see [code](https://github.com/getsentry/sentry/blob/e96e32a095e1e2ff89c8fb0ea2681848decaf4c3/src/sentry/models/activity.py#L57-L66)).

