### PR TITLE
fix(github): fix spacing on configuration page

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationItem.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationItem.tsx
@@ -45,6 +45,7 @@ const Labels = styled('div')<{compact: boolean}>`
 const IntegrationName = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: ${p => p.theme.fontWeightBold};
+  line-height: ${p => p.theme.text.lineHeightHeading};
 `;
 
 // Not using the overflowEllipsis style import here
@@ -57,4 +58,5 @@ const DomainName = styled('div')<{compact: boolean}>`
   font-size: ${p => p.theme.fontSizeSmall};
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: ${p => p.theme.text.lineHeightBody};
 `;


### PR DESCRIPTION
## before
<img width="482" alt="Screenshot 2025-02-20 at 10 08 02 AM" src="https://github.com/user-attachments/assets/c1e2ed6b-344f-4b8e-bd91-419b014695e0" />

## after
<img width="475" alt="Screenshot 2025-02-20 at 10 07 05 AM" src="https://github.com/user-attachments/assets/1724ac14-5678-4b2b-8bb9-1d5431d3d2c4" />
