### PR TITLE
:wrench: chore(msteams): use SLO metric util for msteams webhooks

### DIFF
--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -12,7 +12,10 @@ MSTEAMS_HALT_ERROR_CODES = [
 
 
 def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiError) -> None:
-    if isinstance(error, ApiRateLimitedError):
+    # permission_denied
+    if error.code == 403:
+        lifecycle.record_halt(error)
+    elif isinstance(error, ApiRateLimitedError):
         # TODO(ecosystem): We should batch this on a per-organization basis
         lifecycle.record_halt(error)
     elif error.json:

--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -12,10 +12,7 @@ MSTEAMS_HALT_ERROR_CODES = [
 
 
 def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiError) -> None:
-    # permission_denied
-    if error.code == 403:
-        lifecycle.record_halt(error)
-    elif isinstance(error, ApiRateLimitedError):
+    if isinstance(error, ApiRateLimitedError):
         # TODO(ecosystem): We should batch this on a per-organization basis
         lifecycle.record_halt(error)
     elif error.json:

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -37,6 +37,7 @@ from sentry.integrations.messaging.metrics import (
 )
 from sentry.integrations.messaging.spec import MessagingIntegrationSpec
 from sentry.integrations.msteams import parsing
+from sentry.integrations.msteams.metrics import record_lifecycle_termination_level
 from sentry.integrations.msteams.spec import PROVIDER, MsTeamsMessagingSpec
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import EventLifecycleOutcome, IntegrationResponse
@@ -497,8 +498,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
                 user=user_service.get_user(user_id=identity.user_id),
                 auth=event_write_key,
             )
-            if response.status_code >= 400:
-                lifecycle.record_failure()
+            record_lifecycle_termination_level(lifecycle, response)
             return response
 
     def _handle_action_submitted(self, request: Request) -> Response:


### PR DESCRIPTION
will resolve [SENTRY-3GMZ](https://sentry.sentry.io/issues/5994588654/events/74628f4cc48749a08bf8703e5ba14bd1/) 

`permission_denied` is a weird one since the base ApiError updates the message we get from msteams and adds its own message (since we receive a 403) so needed to do this error code check.