### PR TITLE
ref(onboarding): fix flutter doc link

### DIFF
--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -182,7 +182,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                   'Alternatively, you can also [manualSetupLink:set up the SDK manually].',
                   {
                     manualSetupLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/flutter/manual-setup/" />
+                      <ExternalLink href="https://docs.sentry.io/platforms/flutter/" />
                     ),
                   }
                 ),


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-docs/issues/12790

the current link 404s