### PR TITLE
fix(dashboards): Handle series colours in `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -5,6 +5,7 @@ import type {ThresholdsConfig} from '../../widgetBuilder/buildSteps/thresholdsSt
 export type Meta = {
   fields: Record<string, string | null>;
   units: Record<string, string | null>;
+  isOther?: boolean;
 };
 
 type TableRow = Record<string, number | string | undefined>;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/isTimeSeriesOther.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/isTimeSeriesOther.spec.tsx
@@ -1,0 +1,29 @@
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+
+import {isTimeSeriesOther} from './isTimeSeriesOther';
+
+describe('isTimeSeriesOther', () => {
+  it('treats normal time series as not other', () => {
+    expect(isTimeSeriesOther(TimeSeriesFixture())).toBeFalsy();
+  });
+
+  it('treats the title "Other" as other', () => {
+    expect(
+      isTimeSeriesOther(
+        TimeSeriesFixture({
+          field: 'Other',
+        })
+      )
+    ).toBeTruthy();
+  });
+
+  it('treats top N "Other" as other', () => {
+    expect(
+      isTimeSeriesOther(
+        TimeSeriesFixture({
+          field: 'eps() : Other',
+        })
+      )
+    ).toBeTruthy();
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/isTimeSeriesOther.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/isTimeSeriesOther.tsx
@@ -1,0 +1,8 @@
+import type {TimeSeries} from '../common/types';
+
+const OTHER = 'Other';
+const otherRegex = new RegExp(`(?:.* : ${OTHER}$)|^${OTHER}$`);
+
+export function isTimeSeriesOther(timeSeries: TimeSeries): boolean {
+  return Boolean(timeSeries.field.match(otherRegex));
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -183,9 +183,13 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // This code can be safely removed once we can render dotted incomplete lines
   // using a single series
   const numberOfSeriesNeedingColor = props.timeSeries.filter(needsColor).length;
-  const palette = [...theme.charts.getColorPalette(numberOfSeriesNeedingColor - 2)!]; // -2 because getColorPalette artificially adds 1, I'm not sure why
-  let seriesColorIndex = -1;
 
+  const palette =
+    numberOfSeriesNeedingColor > 1
+      ? theme.charts.getColorPalette(numberOfSeriesNeedingColor - 2)! // -2 because getColorPalette artificially adds 1, I'm not sure why
+      : [];
+
+  let seriesColorIndex = -1;
   const colorizedSeries = scaledSeries.map(timeSeries => {
     if (isTimeSeriesOther(timeSeries)) {
       return {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -16,7 +16,6 @@ import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingM
 import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {isChartHovered, truncationFormatter} from 'sentry/components/charts/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import type {EChartDataZoomHandler, Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import {uniq} from 'sentry/utils/array/uniq';
@@ -184,8 +183,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // This code can be safely removed once we can render dotted incomplete lines
   // using a single series
   const numberOfSeriesNeedingColor = props.timeSeries.filter(needsColor).length;
-  const palette = CHART_PALETTE[numberOfSeriesNeedingColor - 1]!;
-  let paletteIndex = -1;
+  const palette = [...theme.charts.getColorPalette(numberOfSeriesNeedingColor - 2)!]; // -2 because getColorPalette artificially adds 1, I'm not sure why
+  let seriesColorIndex = -1;
 
   const colorizedSeries = scaledSeries.map(timeSeries => {
     if (isTimeSeriesOther(timeSeries)) {
@@ -196,11 +195,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     }
 
     if (needsColor(timeSeries)) {
-      paletteIndex += 1;
+      seriesColorIndex += 1;
 
       return {
         ...timeSeries,
-        color: palette[paletteIndex],
+        color: palette[seriesColorIndex % palette.length], // Mod the index in case the number of series exceeds the number of colors in the palette
       };
     }
 

--- a/tests/js/fixtures/timeSeries.ts
+++ b/tests/js/fixtures/timeSeries.ts
@@ -1,0 +1,27 @@
+import { TimeSeries } from "sentry/views/dashboards/widgets/common/types";
+
+export function TimeSeriesFixture(params: Partial<TimeSeries> = {}): TimeSeries {
+  return {
+    field: 'eps()',
+    meta: {
+      fields: {
+        'eps()': 'rate',
+      },
+      units: {
+        'eps()': '1/second',
+      },
+    },
+    data: [
+      {
+        value: 7456.966666666666,
+        timestamp: '2024-10-24T15:00:00-04:00',
+      },
+      {
+        value: 8217.8,
+        timestamp: '2024-10-24T15:30:00-04:00',
+      },
+    ],
+    ...params,
+  };
+
+}


### PR DESCRIPTION
Two problems in `TimeSeriesWidgetVisualization`:

1. When adding "incomplete" series, we increase the number of `series` objects passed to `BaseChart`, which skews the color palette. This causes the palette to be mismatched from tables that show the same data, since there's no skewing there
2. No "Other" handling!

This PR fixes both. You can see in the screenshot that the colours in the legend/chart match the rows in the table, which isn't the case right now (affects Explore!)

**e.g.,**
![Screenshot 2025-02-20 at 1 33 37 PM](https://github.com/user-attachments/assets/00dd4645-f6fa-444a-afef-3ae391b1ce46)
