### PR TITLE
ref(replay): add back flutter onboarding

### DIFF
--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -11,6 +11,10 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getReplayMobileConfigureDescription,
+  getReplayVerifyStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {feedbackOnboardingCrashApiDart} from 'sentry/gettingStartedDocs/dart/dart';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -127,6 +131,25 @@ Future<void> processOrderBatch(ISentrySpan span) async {
     await innerSpan.finish();
   }
 }`;
+
+const getInstallReplaySnippet = () => `
+await SentryFlutter.init(
+  (options) {
+    ...
+    options.experimental.replay.sessionSampleRate = 1.0;
+    options.experimental.replay.onErrorSampleRate = 1.0;
+  },
+  appRunner: () => runApp(
+      SentryWidget(
+        child: MyApp(),
+      ),
+    ),
+);
+`;
+
+const getConfigureReplaySnippet = () => `
+options.experimental.replay.maskAllText = true;
+options.experimental.replay.maskAllImages = true;`;
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   install: params =>
@@ -342,11 +365,81 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   ],
 };
 
+const replayOnboarding: OnboardingConfig<PlatformOptions> = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Make sure your Sentry Flutter SDK version is at least 8.9.0, which is required for Session Replay. You can update your [code:pubspec.yaml] to the matching version:',
+        {code: <code />}
+      ),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'YAML',
+              value: 'yaml',
+              language: 'yaml',
+              code: getInstallSnippet(params),
+            },
+          ],
+        },
+        {
+          description: t(
+            'To set up the integration, add the following to your Sentry initialization:'
+          ),
+        },
+        {
+          code: [
+            {
+              label: 'Dart',
+              value: 'dart',
+              language: 'dart',
+              code: getInstallReplaySnippet(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getReplayMobileConfigureDescription({
+        link: 'https://docs.sentry.io/platforms/flutter/session-replay/#privacy',
+      }),
+      configurations: [
+        {
+          description: t(
+            'The following code is the default configuration, which masks and blocks everything.'
+          ),
+          code: [
+            {
+              label: 'Dart',
+              value: 'dart',
+              language: 'dart',
+              code: getConfigureReplaySnippet(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: getReplayVerifyStep({
+    replayOnErrorSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.onErrorSampleRate',
+    replaySessionSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.sessionSampleRate',
+  }),
+  nextSteps: () => [],
+};
+
 const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiDart,
   crashReportOnboarding: feedbackOnboardingCrashApiDart,
   platformOptions,
+  replayOnboarding,
 };
 
 export default docs;


### PR DESCRIPTION
this got accidentally deleted in https://github.com/getsentry/sentry/pull/85523

![SCR-20250220-jxrp](https://github.com/user-attachments/assets/085d96d4-e1bd-4e74-aaa1-ad3a11df4a2e)
