### PR TITLE
ref: register fly provider in tests with its proper id

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -28,8 +28,8 @@ class OrganizationAuthProviders(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
-        auth.register("Fly IO", FlyOAuth2Provider)
-        self.addCleanup(auth.unregister, "Fly IO", FlyOAuth2Provider)
+        auth.register(ChannelName.FLY_IO.value, FlyOAuth2Provider)
+        self.addCleanup(auth.unregister, ChannelName.FLY_IO.value, FlyOAuth2Provider)
 
         auth.register(ChannelName.FLY_NON_PARTNER.value, NonPartnerFlyOAuth2Provider)
         self.addCleanup(
@@ -39,6 +39,7 @@ class OrganizationAuthProviders(APITestCase):
     def test_get_list_of_auth_providers(self):
         with self.feature("organizations:sso-basic"):
             response = self.get_success_response(self.organization.slug)
-        assert any(d["key"] == "dummy" for d in response.data)
-        assert any(d["key"] == "Fly IO" for d in response.data) is False
-        assert any(d["key"] == ChannelName.FLY_NON_PARTNER.value for d in response.data) is False
+        providers = {d["key"] for d in response.data}
+        assert "dummy" in providers
+        assert ChannelName.FLY_IO.value not in providers
+        assert ChannelName.FLY_NON_PARTNER.value not in providers


### PR DESCRIPTION
fixing another case where the provider id mismatched when registered

<!-- Describe your PR here. -->