### PR TITLE
fix(oauth): add locking to prevent race conditions in grant exchange

### DIFF
--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -15,6 +15,14 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 DEFAULT_EXPIRATION = timedelta(minutes=10)
 
 
+class InvalidGrantError(Exception):
+    pass
+
+
+class ExpiredGrantError(Exception):
+    pass
+
+
 def default_expiration():
     return timezone.now() + DEFAULT_EXPIRATION
 
@@ -96,6 +104,10 @@ class ApiGrant(Model):
 
     def redirect_uri_allowed(self, uri):
         return uri == self.redirect_uri
+
+    @classmethod
+    def get_lock_key(cls, grant_id):
+        return f"api_grant:{grant_id}"
 
     @classmethod
     def sanitize_relocation_json(

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -19,7 +19,9 @@ from sentry.db.models import FlexibleForeignKey, control_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.hybridcloud.outbox.base import ControlOutboxProducingManager, ReplicatedControlModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.models.apigrant import ApiGrant
+from sentry.locks import locks
+from sentry.models.apiapplication import ApiApplicationStatus
+from sentry.models.apigrant import ApiGrant, ExpiredGrantError, InvalidGrantError
 from sentry.models.apiscopes import HasApiScopes
 from sentry.types.region import find_all_region_names
 from sentry.types.token import AuthTokenType
@@ -276,17 +278,33 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
 
     @classmethod
     def from_grant(cls, grant: ApiGrant):
-        with transaction.atomic(router.db_for_write(cls)):
-            api_token = cls.objects.create(
-                application=grant.application,
-                user=grant.user,
-                scope_list=grant.get_scopes(),
-                scoping_organization_id=grant.organization_id,
-            )
+        if grant.application.status != ApiApplicationStatus.active:
+            raise InvalidGrantError()
 
-            # remove the ApiGrant from the database to prevent reuse of the same
-            # authorization code
-            grant.delete()
+        if grant.is_expired():
+            raise ExpiredGrantError()
+
+        lock = locks.get(
+            ApiGrant.get_lock_key(grant.id),
+            duration=10,
+            name="api_grant",
+        )
+
+        # we use a lock to prevent race conditions when creating the ApiToken
+        # an attacker could send two requests to create an access/refresh token pair
+        # at the same time, using the same grant, and get two different tokens
+        with lock.acquire():
+            with transaction.atomic(router.db_for_write(cls)):
+                api_token = cls.objects.create(
+                    application=grant.application,
+                    user=grant.user,
+                    scope_list=grant.get_scopes(),
+                    scoping_organization_id=grant.organization_id,
+                )
+
+                # remove the ApiGrant from the database to prevent reuse of the same
+                # authorization code
+                grant.delete()
 
             return api_token
 

--- a/src/sentry/sentry_apps/token_exchange/grant_exchanger.py
+++ b/src/sentry/sentry_apps/token_exchange/grant_exchanger.py
@@ -6,6 +6,7 @@ from django.db import router, transaction
 from django.utils.functional import cached_property
 
 from sentry import analytics
+from sentry.locks import locks
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apigrant import ApiGrant
 from sentry.models.apitoken import ApiToken
@@ -35,12 +36,22 @@ class GrantExchanger:
     def run(self):
         with transaction.atomic(using=router.db_for_write(ApiToken)):
             try:
-                self._validate()
-                token = self._create_token()
+                lock = locks.get(
+                    ApiGrant.get_lock_key(self.grant.id),
+                    duration=10,
+                    name="api_grant",
+                )
 
-                # Once it's exchanged it's no longer valid and should not be
-                # exchangeable, so we delete it.
-                self._delete_grant()
+                # we use a lock to prevent race conditions when creating the ApiToken
+                # an attacker could send two requests to create an access/refresh token pair
+                # at the same time, using the same grant, and get two different tokens
+                with lock.acquire():
+                    self._validate()
+                    token = self._create_token()
+
+                    # Once it's exchanged it's no longer valid and should not be
+                    # exchangeable, so we delete it.
+                    self._delete_grant()
             except SentryAppIntegratorError:
                 logger.info(
                     "grant-exchanger.context",


### PR DESCRIPTION
Pulled from #82052 to break out these changes into smaller PRs.

Use locks to ensure an `ApiGrant` cannot be used twice during a race condition that would result in multiple access/refresh token pairs.
