### PR TITLE
fix(api): Clean up API grants when revoking authorizations

### DIFF
--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -12,6 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.models.apiapplication import ApiApplicationStatus
 from sentry.models.apiauthorization import ApiAuthorization
+from sentry.models.apigrant import ApiGrant
 from sentry.models.apitoken import ApiToken
 
 
@@ -44,18 +45,33 @@ class ApiAuthorizationsEndpoint(Endpoint):
             return Response({"authorization": ""}, status=400)
 
         try:
-            auth = ApiAuthorization.objects.get(user_id=request.user.id, id=authorization)
+            api_authorization = ApiAuthorization.objects.get(
+                user_id=request.user.id, id=authorization
+            )
         except ApiAuthorization.DoesNotExist:
             return Response(status=404)
 
         with outbox_context(transaction.atomic(using=router.db_for_write(ApiToken)), flush=False):
             for token in ApiToken.objects.filter(
                 user_id=request.user.id,
-                application=auth.application_id,
-                scoping_organization_id=auth.organization_id,
+                application=api_authorization.application_id,
+                scoping_organization_id=api_authorization.organization_id,
             ):
                 token.delete()
 
-            auth.delete()
+        # remove any grants that were created from this authorization
+        # that may not have been exchanged for a token yet
+        with outbox_context(transaction.atomic(using=router.db_for_write(ApiGrant)), flush=False):
+            for grant in ApiGrant.objects.filter(
+                user_id=request.user.id,
+                application=api_authorization.application_id,
+                organization_id=api_authorization.organization_id,
+            ):
+                grant.delete()
+
+        with outbox_context(
+            transaction.atomic(using=router.db_for_write(ApiAuthorization)), flush=False
+        ):
+            api_authorization.delete()
 
         return Response(status=204)

--- a/tests/sentry/api/endpoints/test_api_authorizations.py
+++ b/tests/sentry/api/endpoints/test_api_authorizations.py
@@ -1,5 +1,10 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apiauthorization import ApiAuthorization
+from sentry.models.apigrant import ApiGrant
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
@@ -43,6 +48,17 @@ class ApiAuthorizationsListTest(ApiAuthorizationsTest):
 class ApiAuthorizationsDeleteTest(ApiAuthorizationsTest):
     method = "delete"
 
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(email="test@example.com")
+        self.login_as(user=self.user)
+
+        self.application = ApiApplication.objects.create(owner=self.create_user(), name="test")
+        self.authorization = ApiAuthorization.objects.create(
+            user=self.user,
+            application=self.application,
+        )
+
     def test_simple(self):
         app = ApiApplication.objects.create(name="test", owner=self.user)
         auth = ApiAuthorization.objects.create(application=app, user=self.user)
@@ -77,3 +93,77 @@ class ApiAuthorizationsDeleteTest(ApiAuthorizationsTest):
 
         assert ApiAuthorization.objects.filter(id=org2_auth.id).exists()
         assert ApiToken.objects.filter(id=org2_token.id).exists()
+
+    def test_delete_authorization_cleans_up_grants(self):
+        # Create an API grant associated with this authorization
+        grant = ApiGrant.objects.create(
+            user=self.user,
+            application=self.application,
+            redirect_uri="https://example.com",
+            expires_at=timezone.now() + timedelta(minutes=10),
+        )
+
+        # Create an API token associated with this authorization
+        token = ApiToken.objects.create(
+            user=self.user,
+            application=self.application,
+        )
+
+        # Make the delete request
+        self.get_success_response(
+            authorization=self.authorization.id,
+            status_code=204,
+        )
+
+        # Verify the authorization is deleted
+        assert not ApiAuthorization.objects.filter(id=self.authorization.id).exists()
+
+        # Verify associated grants are deleted
+        assert not ApiGrant.objects.filter(id=grant.id).exists()
+
+        # Verify associated tokens are deleted
+        assert not ApiToken.objects.filter(id=token.id).exists()
+
+    def test_delete_authorization_with_no_grants(self):
+        """Test that deletion works when there are no associated grants"""
+        self.get_success_response(
+            authorization=self.authorization.id,
+            status_code=204,
+        )
+        assert not ApiAuthorization.objects.filter(id=self.authorization.id).exists()
+
+    def test_delete_authorization_with_organization_scoped_grants(self):
+        """Test that only grants for the specific org are deleted"""
+        org1 = self.create_organization()
+        org2 = self.create_organization()
+
+        # Create grants for different orgs
+        grant1 = ApiGrant.objects.create(
+            user=self.user,
+            application=self.application,
+            organization_id=org1.id,
+            redirect_uri="https://example.com",
+        )
+        grant2 = ApiGrant.objects.create(
+            user=self.user,
+            application=self.application,
+            organization_id=org2.id,
+            redirect_uri="https://example.com",
+        )
+
+        # Create authorization for org1
+        auth1 = ApiAuthorization.objects.create(
+            user=self.user,
+            application=self.application,
+            organization_id=org1.id,
+        )
+
+        # Delete authorization for org1
+        self.get_success_response(
+            authorization=auth1.id,
+            status_code=204,
+        )
+
+        # Verify only org1's grant is deleted
+        assert not ApiGrant.objects.filter(id=grant1.id).exists()
+        assert ApiGrant.objects.filter(id=grant2.id).exists()


### PR DESCRIPTION
Pulled from https://github.com/getsentry/sentry/pull/82052 to break out these changes into smaller PRs.

- Delete associated grant when revoking API authorizations
- Use proper transaction management with outbox_context
