### PR TITLE
fix(cleanup): Use correct expiration thresholds for API model cleanup

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -362,7 +362,9 @@ def remove_expired_values_for_org_members(
 
 
 def delete_api_models(is_filtered: Callable[[type[Model]], bool]) -> None:
+    from sentry.models.apigrant import DEFAULT_EXPIRATION as API_GRANT_EXPIRATION
     from sentry.models.apigrant import ApiGrant
+    from sentry.models.apitoken import DEFAULT_EXPIRATION as API_TOKEN_EXPIRATION
     from sentry.models.apitoken import ApiToken
 
     for model_tp in (ApiGrant, ApiToken):
@@ -371,8 +373,11 @@ def delete_api_models(is_filtered: Callable[[type[Model]], bool]) -> None:
         if is_filtered(model_tp):
             debug_output(f">> Skipping {model_tp.__name__}")
         else:
+            expiration_threshold = (
+                API_GRANT_EXPIRATION if model_tp is ApiGrant else API_TOKEN_EXPIRATION
+            )
             queryset = model_tp.objects.filter(
-                expires_at__lt=(timezone.now() - timedelta(days=API_TOKEN_TTL_IN_DAYS))
+                expires_at__lt=(timezone.now() - expiration_threshold)
             )
 
             # SentryAppInstallations are associated to ApiTokens. We're okay


### PR DESCRIPTION
Pulled from https://github.com/getsentry/sentry/pull/82052 to break out these changes into smaller PRs.

- Update `delete_api_models `to use model-specific `DEFAULT_EXPIRATION` values
- Use `API_GRANT_EXPIRATION` for `ApiGrant` and `API_TOKEN_EXPIRATION` for `ApiToken`
- Fix potential over-deletion of valid tokens
