### PR TITLE
chore(metrics): Implement some hooks for the metric alert graph APIs

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -562,8 +562,11 @@ export default function MetricChart({
       end={viableEndDate}
       query={query}
       interval={interval}
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      field={SESSION_AGGREGATE_TO_FIELD[aggregate]}
+      field={
+        SESSION_AGGREGATE_TO_FIELD[aggregate]
+          ? [SESSION_AGGREGATE_TO_FIELD[aggregate]]
+          : []
+      }
       groupBy={['session.status']}
     >
       {({loading, response}) =>

--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -126,7 +126,7 @@ export function isSessionAggregate(aggregate: string) {
   return Object.values(SessionsAggregate).includes(aggregate as SessionsAggregate);
 }
 
-export const SESSION_AGGREGATE_TO_FIELD = {
+export const SESSION_AGGREGATE_TO_FIELD: Record<string, SessionFieldWithOperation> = {
   [SessionsAggregate.CRASH_FREE_SESSIONS]: SessionFieldWithOperation.SESSIONS,
   [SessionsAggregate.CRASH_FREE_USERS]: SessionFieldWithOperation.USERS,
 };

--- a/static/app/views/issueDetails/metricIssues/useMetricAnomalies.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricAnomalies.tsx
@@ -1,0 +1,30 @@
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import type {Anomaly} from 'sentry/views/alerts/types';
+
+interface MetricAnomaliesParams {
+  orgSlug: string;
+  ruleId: string;
+  query?: {
+    end?: string;
+    start?: string;
+  };
+}
+
+export function makeMetricAnomaliesQueryKey(params: MetricAnomaliesParams): ApiQueryKey {
+  const {orgSlug, ruleId, query} = params;
+  return [`/organizations/${orgSlug}/alert-rules/${ruleId}/anomalies/`, {query}];
+}
+
+export function useMetricAnomalies(
+  params: MetricAnomaliesParams,
+  options: Partial<UseApiQueryOptions<Anomaly[]>> = {}
+) {
+  return useApiQuery<Anomaly[]>(makeMetricAnomaliesQueryKey(params), {
+    staleTime: 0,
+    ...options,
+  });
+}

--- a/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
@@ -1,0 +1,110 @@
+import type {EventsStats} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {getPeriod} from 'sentry/utils/duration/getPeriod';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
+import {
+  getPeriodInterval,
+  getViableDateRange,
+} from 'sentry/views/alerts/rules/metric/details/utils';
+import {Dataset, type MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
+import {getMetricDatasetQueryExtras} from 'sentry/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras';
+import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
+
+interface MetricEventStatsParams {
+  project: Project;
+  referrer: string;
+  rule: MetricRule;
+  timePeriod: TimePeriodType;
+}
+
+export interface EventRequestQueryParams {
+  comparisonDelta?: number;
+  dataset?: DiscoverDatasets;
+  end?: string;
+  environment?: string[];
+  excludeOther?: '1';
+  field?: string[];
+  interval?: string;
+  orderby?: string;
+  partial?: '1';
+  project?: number[];
+  query?: string;
+  referrer?: string;
+  start?: string;
+  statsPeriod?: string;
+  team?: string | string[];
+  topEvents?: number;
+  // XXX: This is the literal string 'true', not a boolean
+  useOnDemandMetrics?: 'true';
+  useRpc?: '1';
+  withoutZerofill?: '1';
+  yAxis?: string | string[];
+}
+
+export function useMetricEventStats(
+  {project, rule, timePeriod, referrer}: MetricEventStatsParams,
+  options: Partial<UseApiQueryOptions<EventsStats>> = {}
+) {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  const {dataset, aggregate, query: ruleQuery, environment: ruleEnvironment} = rule;
+  const interval = getPeriodInterval(timePeriod, rule);
+  const isOnDemandAlert = isOnDemandMetricAlert(dataset, aggregate, ruleQuery);
+  const eventType = extractEventTypeFilterFromRule(rule);
+
+  const query =
+    dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
+      ? ruleQuery
+      : (ruleQuery ? `(${ruleQuery}) AND (${eventType})` : eventType).trim();
+
+  const {start: viableStartDate, end: viableEndDate} = getViableDateRange({
+    rule,
+    interval,
+    timePeriod,
+  });
+
+  const queryExtras: Record<string, string> = {
+    ...getMetricDatasetQueryExtras({
+      organization,
+      location,
+      dataset,
+      newAlertOrQuery: false,
+      useOnDemandMetrics: isOnDemandAlert,
+    }),
+  };
+
+  const queryObject: EventRequestQueryParams = Object.fromEntries(
+    Object.entries({
+      ...getPeriod({start: viableStartDate, end: viableEndDate}),
+      interval,
+      comparisonDelta: rule.comparisonDelta ? rule.comparisonDelta * 60 : undefined,
+      project: project.id ? [Number(project.id)] : [],
+      environment: ruleEnvironment ? [ruleEnvironment] : undefined,
+      query,
+      yAxis: aggregate,
+      useRpc: dataset === Dataset.EVENTS_ANALYTICS_PLATFORM ? '1' : undefined,
+      referrer,
+      ...queryExtras,
+    }).filter(([, value]) => typeof value !== 'undefined')
+  );
+
+  const queryKey: ApiQueryKey = [
+    `/organizations/${organization.slug}/events-stats/`,
+    {query: queryObject},
+  ];
+
+  return useApiQuery<EventsStats>(queryKey, {
+    staleTime: 0,
+    ...options,
+  });
+}

--- a/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
@@ -73,15 +73,13 @@ export function useMetricEventStats(
     timePeriod,
   });
 
-  const queryExtras: Record<string, string> = {
-    ...getMetricDatasetQueryExtras({
-      organization,
-      location,
-      dataset,
-      newAlertOrQuery: false,
-      useOnDemandMetrics: isOnDemandAlert,
-    }),
-  };
+  const queryExtras: Record<string, string> = getMetricDatasetQueryExtras({
+    organization,
+    location,
+    dataset,
+    newAlertOrQuery: false,
+    useOnDemandMetrics: isOnDemandAlert,
+  });
 
   const queryObject: EventRequestQueryParams = Object.fromEntries(
     Object.entries({

--- a/static/app/views/issueDetails/metricIssues/useMetricIncidents.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricIncidents.tsx
@@ -1,0 +1,43 @@
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import type {Incident} from 'sentry/views/alerts/types';
+
+interface MetricIncidentsParams {
+  orgSlug: string;
+  query?: {
+    alertRule?: string;
+    end?: string;
+    expand?: string[];
+    includeSnapshots?: boolean;
+    project?: string;
+    start?: string;
+  };
+}
+
+export function makeMetricIncidentsQueryKey(params: MetricIncidentsParams): ApiQueryKey {
+  const {orgSlug, query} = params;
+  return [
+    `/organizations/${orgSlug}/incidents/`,
+    {
+      query: {
+        project: '-1',
+        includeSnapshots: true,
+        expand: ['activities', 'original_alert_rule'],
+        ...query,
+      },
+    },
+  ];
+}
+
+export function useMetricIncidents(
+  params: MetricIncidentsParams,
+  options: Partial<UseApiQueryOptions<Incident[]>> = {}
+) {
+  return useApiQuery<Incident[]>(makeMetricIncidentsQueryKey(params), {
+    staleTime: 0,
+    ...options,
+  });
+}

--- a/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
@@ -1,0 +1,57 @@
+import type {SessionApiResponse} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
+import {
+  getPeriodInterval,
+  getViableDateRange,
+} from 'sentry/views/alerts/rules/metric/details/utils';
+import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {SESSION_AGGREGATE_TO_FIELD} from 'sentry/views/alerts/utils';
+
+interface MetricSessionStatsParams {
+  project: Project;
+  rule: MetricRule;
+  timePeriod: TimePeriodType;
+}
+
+export function useMetricSessionStats(
+  {project, rule, timePeriod}: MetricSessionStatsParams,
+  options: Partial<UseApiQueryOptions<SessionApiResponse>> = {}
+) {
+  const organization = useOrganization();
+  const {aggregate, query, environment} = rule;
+  const interval = getPeriodInterval(timePeriod, rule);
+  const {start: viableStartDate, end: viableEndDate} = getViableDateRange({
+    rule,
+    interval,
+    timePeriod,
+  });
+
+  const queryKey: ApiQueryKey = [
+    `/organizations/${organization.slug}/sessions/`,
+    {
+      query: {
+        project,
+        environment,
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        field: SESSION_AGGREGATE_TO_FIELD[aggregate],
+        query,
+        groupBy: ['session.status'],
+        start: viableStartDate,
+        end: viableEndDate,
+        interval,
+      },
+    },
+  ];
+
+  return useApiQuery<SessionApiResponse>(queryKey, {
+    staleTime: 0,
+    ...options,
+  });
+}

--- a/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
@@ -39,7 +39,6 @@ export function useMetricSessionStats(
       query: {
         project,
         environment,
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         field: SESSION_AGGREGATE_TO_FIELD[aggregate],
         query,
         groupBy: ['session.status'],


### PR DESCRIPTION
These API hooks aren't currently being used, but will be for a follow up PR.

Requires https://github.com/getsentry/sentry/pull/85496