### PR TITLE
ref(autofix): Solution timeline event alignment

### DIFF
--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -155,12 +155,6 @@ function SolutionDescription({
   const containerRef = useRef<HTMLDivElement>(null);
   const selection = useTextSelection(containerRef);
 
-  const events = solution.map((event, index) => ({
-    ...event,
-    is_most_important_event: event.is_new_event,
-    originalIndex: index,
-  }));
-
   return (
     <SolutionDescriptionWrapper>
       <AnimatePresence>
@@ -180,7 +174,7 @@ function SolutionDescription({
         )}
       </AnimatePresence>
       <div ref={containerRef}>
-        <AutofixTimeline events={events} activeColor="green400" />
+        <AutofixTimeline events={solution} activeColor="green400" />
       </div>
     </SolutionDescriptionWrapper>
   );

--- a/static/app/components/events/autofix/autofixTimeline.tsx
+++ b/static/app/components/events/autofix/autofixTimeline.tsx
@@ -37,7 +37,7 @@ function getEventIcon(eventType: AutofixTimelineEvent['timeline_item_type']) {
   }
 }
 
-function getEventColor(isActive: boolean, activeColor?: Color): ColorConfig {
+function getEventColor(isActive?: boolean, activeColor?: Color): ColorConfig {
   return {
     title: 'gray400',
     icon: isActive ? activeColor ?? 'pink400' : 'gray400',

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -171,18 +171,18 @@ export type AutofixRelevantCodeFile = {
 
 export type AutofixTimelineEvent = {
   code_snippet_and_analysis: string;
-  is_most_important_event: boolean;
   relevant_code_file: AutofixRelevantCodeFile;
   timeline_item_type: 'internal_code' | 'external_system' | 'human_action';
   title: string;
+  is_most_important_event?: boolean;
 };
 
 export type AutofixSolutionTimelineEvent = {
   code_snippet_and_analysis: string;
-  is_new_event: boolean;
   relevant_code_file: AutofixRelevantCodeFile;
-  timeline_item_type: 'internal_code' | 'external_system' | 'human_action';
+  timeline_item_type: 'internal_code';
   title: string;
+  is_most_important_event?: boolean;
 };
 
 export type AutofixRootCauseData = {


### PR DESCRIPTION
Aligns the frontend solution type with what we're gonna be sending from the backend, and makes some boolean fields optional for good practice.

This will make bolding not backwards compatible but I guess it makes the code much cleaner without needing the array map anymore


