### PR TITLE
fix(uptime): Add back random check to `check_and_update_regions`

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -119,6 +119,13 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         if not subscription.subscription_id:
             # Edge case where we can have no subscription_id here
             return
+
+        # XXX: Randomly check for updates once an hour - this is a hack to fix a bug where we're seeing some checks
+        # not update correctly.
+        chance_to_run = subscription.interval_seconds / timedelta(hours=1).total_seconds()
+        if random.random() >= chance_to_run:
+            return
+
         # Run region checks and updates once an hour
         runs_per_hour = UptimeSubscription.IntervalSeconds.ONE_HOUR / subscription.interval_seconds
         subscription_run = UUID(subscription.subscription_id).int % runs_per_hour

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -1027,6 +1027,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             override_options({"uptime.disabled-checker-regions": disabled_regions}),
             self.tasks(),
             freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=current_minute)),
+            mock.patch("random.random", return_value=0),
         ):
             result = self.create_uptime_result(
                 sub.subscription_id,


### PR DESCRIPTION
This puts the random checks for regions back in place. This will fix a couple of problems:
- During rollout, if we want to revert the region changes at the moment we need to wait for the next hour to roll around. Having the randomness here allows us to start rolling back faster
- We've seen a bug where not all regions get migrated, which this will also mitigate

<!-- Describe your PR here. -->