### PR TITLE
feat(uptime): Add new option for changing the mode regions run in.

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2904,6 +2904,12 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "uptime.checker-regions-mode-override",
+    type=Dict,
+    default={},
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # When in active monitoring mode, overrides how many failures in a row we need to see to mark the monitor as down
 register(


### PR DESCRIPTION
Just adding this option separately so that I can update the value in options automator before landing changes to which option we use.