### PR TITLE
feat(uptime): Switch `get_active_region_configs` over to use `uptime checker-regions-mode-override` option

### DIFF
--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -123,6 +123,7 @@ class UptimeSubscriptionRegion(DefaultFieldsModel):
 
     class RegionMode(enum.StrEnum):
         ACTIVE = "active"
+        INACTIVE = "inactive"
 
     uptime_subscription = FlexibleForeignKey("uptime.UptimeSubscription", related_name="regions")
     region_slug = models.CharField(max_length=255, db_index=True, db_default="")

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -9,7 +9,7 @@ from sentry.uptime.models import UptimeSubscriptionRegion
 
 def get_active_region_configs() -> list[UptimeRegionConfig]:
     configured_regions: Sequence[UptimeRegionConfig] = settings.UPTIME_REGIONS
-    region_mode_override: Mapping[str] = options.get("uptime.checker-regions-mode-override")
+    region_mode_override: Mapping[str, str] = options.get("uptime.checker-regions-mode-override")
 
     return [
         c

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -1,16 +1,22 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from django.conf import settings
 
 from sentry import options
 from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.uptime.models import UptimeSubscriptionRegion
 
 
 def get_active_region_configs() -> list[UptimeRegionConfig]:
     configured_regions: Sequence[UptimeRegionConfig] = settings.UPTIME_REGIONS
-    disabled_region_slugs: Sequence[str] = options.get("uptime.disabled-checker-regions")
+    region_mode_override: Mapping[str] = options.get("uptime.checker-regions-mode-override")
 
-    return [c for c in configured_regions if c.slug not in disabled_region_slugs]
+    return [
+        c
+        for c in configured_regions
+        if region_mode_override.get(c.slug, UptimeSubscriptionRegion.RegionMode.ACTIVE)
+        == UptimeSubscriptionRegion.RegionMode.ACTIVE
+    ]
 
 
 def get_region_config(region_slug: str) -> UptimeRegionConfig | None:

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -42,6 +42,7 @@ from sentry.uptime.models import (
     ProjectUptimeSubscriptionMode,
     UptimeStatus,
     UptimeSubscription,
+    UptimeSubscriptionRegion,
 )
 from sentry.utils import json
 from tests.sentry.uptime.subscriptions.test_tasks import ConfigPusherTestMixin
@@ -1024,7 +1025,14 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
         with (
             override_settings(UPTIME_REGIONS=region_configs),
-            override_options({"uptime.disabled-checker-regions": disabled_regions}),
+            override_options(
+                {
+                    "uptime.checker-regions-mode-override": {
+                        region: UptimeSubscriptionRegion.RegionMode.INACTIVE.value
+                        for region in disabled_regions
+                    }
+                }
+            ),
             self.tasks(),
             freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=current_minute)),
             mock.patch("random.random", return_value=0),

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -38,7 +38,7 @@ class GetActiveRegionConfigsTest(TestBase):
             override_options(
                 {
                     "uptime.checker-regions-mode-override": {
-                        "eu": UptimeSubscriptionRegion.RegionMode.INACTIVE
+                        "eu": UptimeSubscriptionRegion.RegionMode.INACTIVE.value
                     }
                 }
             ),
@@ -52,8 +52,8 @@ class GetActiveRegionConfigsTest(TestBase):
             override_options(
                 {
                     "uptime.checker-regions-mode-override": {
-                        "eu": UptimeSubscriptionRegion.RegionMode.INACTIVE,
-                        "us": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                        "eu": UptimeSubscriptionRegion.RegionMode.INACTIVE.value,
+                        "us": UptimeSubscriptionRegion.RegionMode.ACTIVE.value,
                     }
                 }
             ),

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -16,6 +16,7 @@ from sentry.uptime.models import (
     ProjectUptimeSubscription,
     ProjectUptimeSubscriptionMode,
     UptimeSubscription,
+    UptimeSubscriptionRegion,
 )
 from sentry.uptime.subscriptions.subscriptions import (
     UPTIME_SUBSCRIPTION_TYPE,
@@ -292,7 +293,13 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         ]
         with (
             override_settings(UPTIME_REGIONS=regions),
-            override_options({"uptime.disabled-checker-regions": ["region3"]}),
+            override_options(
+                {
+                    "uptime.checker-regions-mode-override": {
+                        "region3": UptimeSubscriptionRegion.RegionMode.INACTIVE.value
+                    }
+                }
+            ),
         ):
             subscription = get_or_create_uptime_subscription(
                 url="https://example.com",


### PR DESCRIPTION
This switches us to use the new option. This shouldn't be merged until we add the new values to options automator here: https://github.com/getsentry/sentry-options-automator/pull/3189

<!-- Describe your PR here. -->