### PR TITLE
feat(metric-issues): Set assignee based on alert rule owner

### DIFF
--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -61,6 +61,7 @@ def _build_occurrence_from_incident(
         # TODO(snigdha): Add more data here as needed
         evidence_data={"metric_value": metric_value, "alert_rule_id": incident.alert_rule.id},
         evidence_display=[],
+        assignee=incident.alert_rule.owner if incident.alert_rule else None,
     )
 
 

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -65,6 +65,7 @@ class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
         assert group.substatus == GroupSubStatus.NEW
         assert group.priority == PriorityLevel.HIGH
         assignee = group.get_assignee()
+        assert assignee is not None
         assert Actor.from_identifier(assignee.id) == self.alert_rule.owner
 
     @django_db_all

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -20,7 +20,7 @@ class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
 
         self.user = self.create_user()
         self.member = self.create_member(user=self.user, organization=self.organization)
-        self.team = self.create_team(organization=self.organization, members=[self.user])
+        self.create_team(organization=self.organization, members=[self.user])
         self.actor = Actor.from_identifier(self.user.id)
 
         self.alert_rule = self.create_alert_rule(


### PR DESCRIPTION
Assign the issue to the user/team that owns the alert rule.