### PR TITLE
fix(aci): handle cases found in dry run

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -134,7 +134,7 @@ def create_new_high_priority_issue_data_condition(
 @data_condition_translator_registry.register(LevelCondition.id)
 @data_condition_translator_registry.register(LevelFilter.id)
 def create_level_data_condition(data: dict[str, Any], dcg: DataConditionGroup) -> DataCondition:
-    comparison = {"match": data["match"], "level": data["level"]}
+    comparison = {"match": data["match"], "level": int(data["level"])}
 
     return DataCondition(
         type=Condition.LEVEL,
@@ -204,7 +204,7 @@ def create_issue_category_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
     comparison = {
-        "value": data["value"],
+        "value": int(data["value"]),
     }
 
     return DataCondition(

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -54,28 +54,14 @@ class IssueAlertMigrator:
     def run(self) -> None:
         error_detector = self._create_detector_lookup()
         conditions, filters = split_conditions_and_filters(self.data["conditions"])
-
-        # handle action_match being None but existing as a key
-        action_match = (
-            str(self.data["action_match"]).lower()
-            if "action_match" in self.data
-            else Rule.DEFAULT_CONDITION_MATCH
-        )
         workflow = self._create_workflow_and_lookup(
             conditions=conditions,
             filters=filters,
-            action_match=action_match,
+            action_match=self.data.get("action_match", Rule.DEFAULT_CONDITION_MATCH),
             detector=error_detector,
         )
-
-        # handle filter_match being None but existing as a key
-        filter_match = (
-            str(self.data["filter_match"]).lower()
-            if "filter_match" in self.data
-            else Rule.DEFAULT_FILTER_MATCH
-        )
         if_dcg = self._create_if_dcg(
-            filter_match=filter_match,
+            filter_match=self.data.get("filter_match", Rule.DEFAULT_FILTER_MATCH),
             workflow=workflow,
             conditions=conditions,
             filters=filters,
@@ -151,7 +137,7 @@ class IssueAlertMigrator:
         if action_match == "any":
             logic_type = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
         else:
-            logic_type = DataConditionGroup.Type(action_match or "none")
+            logic_type = DataConditionGroup.Type(action_match)
 
         kwargs = {"organization": self.organization, "logic_type": logic_type}
 
@@ -217,7 +203,7 @@ class IssueAlertMigrator:
         ):  # must create IF DCG even if it's empty, to attach actions
             logic_type = DataConditionGroup.Type.ANY_SHORT_CIRCUIT
         else:
-            logic_type = DataConditionGroup.Type(filter_match or "none")
+            logic_type = DataConditionGroup.Type(filter_match)
 
         kwargs = {
             "organization": self.organization,

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -56,11 +56,11 @@ class IssueAlertMigrator:
         workflow = self._create_workflow_and_lookup(
             conditions=conditions,
             filters=filters,
-            action_match=self.data["action_match"],
+            action_match=self.data.get("action_match", Rule.DEFAULT_CONDITION_MATCH),
             detector=error_detector,
         )
         if_dcg = self._create_if_dcg(
-            filter_match=self.data.get("filter_match", "all"),
+            filter_match=self.data.get("filter_match", Rule.DEFAULT_FILTER_MATCH),
             workflow=workflow,
             conditions=conditions,
             filters=filters,

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
@@ -161,6 +162,8 @@ class IssueAlertMigrator:
         enabled = True
         rule_snooze = RuleSnooze.objects.filter(rule=self.rule, user_id=None).first()
         if rule_snooze and rule_snooze.until is None:
+            enabled = False
+        if self.rule.status == ObjectStatus.DISABLED:
             enabled = False
 
         config = {"frequency": self.rule.data.get("frequency") or Workflow.DEFAULT_FREQUENCY}

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -14,7 +14,7 @@ class TestIssueCategoryCondition(ConditionTestCase):
     condition = Condition.ISSUE_CATEGORY
     payload = {
         "id": IssueCategoryFilter.id,
-        "value": 1,
+        "value": "1",
     }
 
     def setUp(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -14,7 +14,7 @@ class TestLevelCondition(ConditionTestCase):
     payload = {
         "id": LevelCondition.id,
         "match": MatchType.EQUAL,
-        "level": 20,
+        "level": "20",
     }
 
     def setup_group_event_and_job(self):

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -471,23 +471,9 @@ class IssueAlertMigratorTest(TestCase):
         data = self.issue_alert.data
         del data["action_match"]
         del data["filter_match"]
-        self.issue_alert.update(data=data)
         IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
         self.assert_issue_alert_migrated(self.issue_alert, logic_type=DataConditionGroup.Type.ALL)
-
-        dcg_actions = DataConditionGroupAction.objects.all()[0]
-        action = dcg_actions.action
-        assert action.type == Action.Type.SLACK
-
-    def test_run__none_match(self):
-        data = self.issue_alert.data
-        data["action_match"] = None
-        data["filter_match"] = None
-        self.issue_alert.update(data=data)
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
-        self.assert_issue_alert_migrated(self.issue_alert, logic_type=DataConditionGroup.Type.NONE)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule.py
@@ -471,9 +471,23 @@ class IssueAlertMigratorTest(TestCase):
         data = self.issue_alert.data
         del data["action_match"]
         del data["filter_match"]
+        self.issue_alert.update(data=data)
         IssueAlertMigrator(self.issue_alert, self.user.id).run()
 
         self.assert_issue_alert_migrated(self.issue_alert, logic_type=DataConditionGroup.Type.ALL)
+
+        dcg_actions = DataConditionGroupAction.objects.all()[0]
+        action = dcg_actions.action
+        assert action.type == Action.Type.SLACK
+
+    def test_run__none_match(self):
+        data = self.issue_alert.data
+        data["action_match"] = None
+        data["filter_match"] = None
+        self.issue_alert.update(data=data)
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
+        self.assert_issue_alert_migrated(self.issue_alert, logic_type=DataConditionGroup.Type.NONE)
 
         dcg_actions = DataConditionGroupAction.objects.all()[0]
         action = dcg_actions.action


### PR DESCRIPTION
`IssueCategoryFilter` and `LevelCondition/Filter` might have their integer values stored as strings, so we'll need to convert them.
A lot of `Rules` don't have `action_match` set, we use the default in that case in the code -- add that to `IssueAlertMigrator`.
I also noticed I was not accounting for `Rule.status` when migrating the rule, if the `Rule` is disabled we should disable the `Workflow`.