### PR TITLE
chore(issue-details): Add analytics for copying event id

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -390,6 +390,13 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
               <strong>Event ID:</strong>
               <Button
                 aria-label={t('Copy')}
+                analyticsEventKey="issue_details.copy_event_id_clicked"
+                analyticsEventName="Issue Details: Copy Event ID Clicked"
+                analyticsParams={{
+                  ...getAnalyticsDataForGroup(group),
+                  ...getAnalyticsDataForEvent(event),
+                  streamline: false,
+                }}
                 borderless
                 onClick={copyEventId}
                 size="zero"


### PR DESCRIPTION
this pr adds tracking for the second way of copying the event id in the old issue details experience