### PR TITLE
stories: fix sidebar overlap and tree search

### DIFF
--- a/static/app/stories/storyBook.tsx
+++ b/static/app/stories/storyBook.tsx
@@ -21,7 +21,7 @@ export default function storyBook(
     name: string;
     render: StoryRenderFunction;
   }> = [];
-  const APIDocumentation: TypeLoader.ComponentDocWithFilename[] = [];
+  const APIDocumentation: Array<TypeLoader.ComponentDocWithFilename | undefined> = [];
 
   const storyFn: StoryContext = (name: string, render: StoryRenderFunction) => {
     stories.push({name, render});
@@ -30,9 +30,7 @@ export default function storyBook(
   const apiReferenceFn: (
     documentation: TypeLoader.ComponentDocWithFilename | undefined
   ) => void = (documentation: TypeLoader.ComponentDocWithFilename | undefined) => {
-    if (documentation) {
-      APIDocumentation.push(documentation);
-    }
+    APIDocumentation.push(documentation);
   };
 
   setup(storyFn, apiReferenceFn);

--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -42,7 +42,7 @@ export default function Stories() {
   const story = useStoriesLoader({files: storyFiles});
   const [storyRepresentation, setStoryRepresentation] = useLocalStorageState<
     'category' | 'filesystem'
-  >('story-representation', 'filesystem');
+  >('story-representation', 'category');
 
   const nodes = useStoryTree(files, {
     query: location.query.query ?? '',
@@ -178,6 +178,7 @@ const SidebarContainer = styled('div')`
   gap: ${space(2)};
   min-height: 0;
   position: relative;
+  z-index: 10;
 `;
 
 const StoryTreeContainer = styled('div')`


### PR DESCRIPTION
Fixes sidebar tree overlap and a couple other minor details like moving images and icons into assets folder and fixing the default sort (which the tree data structure now manages)