### PR TITLE
fix(issue-details): Remove extra `'` in fold section key 

### DIFF
--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -23,6 +23,9 @@ import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 
 export function getFoldSectionKey(key: SectionKey) {
+  if (localStorage.getItem(`'issue-details-fold-section-collapse:${key}`)) {
+    return `'issue-details-fold-section-collapse:${key}`;
+  }
   return `issue-details-fold-section-collapse:${key}`;
 }
 

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -23,7 +23,7 @@ import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 
 export function getFoldSectionKey(key: SectionKey) {
-  return `'issue-details-fold-section-collapse:${key}`;
+  return `issue-details-fold-section-collapse:${key}`;
 }
 
 export interface FoldSectionProps {

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -23,8 +23,12 @@ import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 
 export function getFoldSectionKey(key: SectionKey) {
-  if (localStorage.getItem(`'issue-details-fold-section-collapse:${key}`)) {
-    return `'issue-details-fold-section-collapse:${key}`;
+  const localStorageValue = localStorage.getItem(
+    `'issue-details-fold-section-collapse:${key}`
+  );
+  if (localStorageValue) {
+    localStorage.removeItem(`'issue-details-fold-section-collapse:${key}`);
+    localStorage.setItem(`issue-details-fold-section-collapse:${key}`, localStorageValue);
   }
   return `issue-details-fold-section-collapse:${key}`;
 }

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -23,6 +23,7 @@ import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 
 export function getFoldSectionKey(key: SectionKey) {
+  // Original key had a typo, this will migrate existing keys to the correct key
   const localStorageValue = localStorage.getItem(
     `'issue-details-fold-section-collapse:${key}`
   );


### PR DESCRIPTION
fixes a typo by checking if that wrong key is being used and if it is, updating it to have the correct key