### PR TITLE
feat(left-nav-views): Connect left nav views to backend

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -123,6 +123,7 @@ export function IssueViewNavItemContent({
     >
       <StyledSecondaryNavItem
         to={constructViewLink(baseUrl, view)}
+        isActive={isActive}
         leadingItems={<IssueViewProjectIcons projectPlatforms={projectPlatforms} />}
         trailingItems={
           <TrailingItemsWrapper

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -1,32 +1,39 @@
-import {useEffect} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import {AnimatePresence, Reorder} from 'framer-motion';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 
 import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {generateTempViewId} from 'sentry/views/issueList/issueViews/issueViews';
 import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {generateTempViewId} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 interface IssueViewNavItemsProps {
   baseUrl: string;
+  loadedViews: IssueViewPF[];
   sectionRef: React.RefObject<HTMLDivElement>;
-  setViews: (views: IssueViewPF[]) => void;
-  views: IssueViewPF[];
 }
 
 export function IssueViewNavItems({
-  views,
-  setViews,
+  loadedViews,
   sectionRef,
   baseUrl,
 }: IssueViewNavItemsProps) {
-  const {viewId} = useParams<{orgId?: string; viewId?: string}>();
+  const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
+  const {viewId} = useParams<{orgId?: string; viewId?: string}>();
+
   const queryParams = location.query;
+
+  const [views, setViews] = useState<IssueViewPF[]>(loadedViews);
 
   // If the `viewId` (from `/issues/views/:viewId`) is not found in the views array,
   // then redirect to the "All Issues" page
@@ -42,12 +49,157 @@ export function IssueViewNavItems({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewId]);
 
+  const replaceWithPersistentViewIds = useCallback(
+    (responseViews: GroupSearchView[]) => {
+      const newlyCreatedViews = responseViews.filter(
+        view => !views.find(tab => tab.id === view.id)
+      );
+      if (newlyCreatedViews.length > 0) {
+        const assignedIds = new Set();
+
+        const currentView = views.find(tab => tab.id === viewId);
+        const updatedViews = views.map(tab => {
+          if (tab.id && tab.id[0] === '_') {
+            const matchingView = newlyCreatedViews.find(
+              view =>
+                view.id &&
+                !assignedIds.has(view.id) &&
+                tab.query === view.query &&
+                tab.querySort === view.querySort &&
+                tab.label === view.name
+            );
+            if (matchingView?.id) {
+              assignedIds.add(matchingView.id);
+              return {...tab, id: matchingView.id, key: matchingView.id};
+            }
+          }
+          return tab;
+        });
+        setViews(updatedViews);
+
+        if (viewId?.startsWith('_') && currentView) {
+          const matchingView = newlyCreatedViews.find(
+            view =>
+              view.id &&
+              currentView.query === view.query &&
+              currentView.querySort === view.querySort
+          );
+          if (matchingView?.id) {
+            navigate(
+              normalizeUrl({
+                pathname: `${baseUrl}/views/${matchingView.id}/`,
+                query: queryParams,
+              }),
+              {replace: true}
+            );
+          }
+        }
+      }
+      return;
+    },
+    [baseUrl, navigate, queryParams, viewId, views]
+  );
+
+  const {mutate: updateViews} = useUpdateGroupSearchViews({
+    onSuccess: replaceWithPersistentViewIds,
+  });
+
+  const debounceUpdateViews = useMemo(
+    () =>
+      debounce((newTabs: IssueViewPF[]) => {
+        if (newTabs) {
+          updateViews({
+            orgSlug: organization.slug,
+            groupSearchViews: newTabs
+              .filter(tab => tab.isCommitted)
+              .map(tab => ({
+                // Do not send over an ID if it's a temporary or default tab so that
+                // the backend will save these and generate permanent Ids for them
+                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
+                  ? {id: tab.id}
+                  : {}),
+                name: tab.label,
+                query: tab.query,
+                querySort: tab.querySort,
+                projects: isEqual(tab.projects, [-1]) ? [] : tab.projects,
+                isAllProjects: isEqual(tab.projects, [-1]),
+                environments: tab.environments,
+                timeFilters: tab.timeFilters,
+              })),
+          });
+        }
+      }, 500),
+    [organization.slug, updateViews]
+  );
+
+  const handleReorder = useCallback(
+    (newOrder: IssueViewPF[]) => {
+      setViews(newOrder);
+      debounceUpdateViews(newOrder);
+    },
+    [debounceUpdateViews]
+  );
+
+  const handleUpdateView = useCallback(
+    (view: IssueViewPF, updatedView: IssueViewPF) => {
+      const newViews = views.map(v => {
+        if (v.id === view.id) {
+          return updatedView;
+        }
+        return v;
+      });
+      debounceUpdateViews(newViews);
+      setViews(newViews);
+    },
+    [debounceUpdateViews, views]
+  );
+
+  const handleDeleteView = useCallback(
+    (view: IssueViewPF) => {
+      const newViews = views.filter(v => v.id !== view.id);
+      setViews(newViews);
+      debounceUpdateViews(newViews);
+      // Only redirect if the deleted view is the active view
+      if (view.id === viewId) {
+        const newUrl =
+          newViews.length > 0 ? constructViewLink(baseUrl, newViews[0]!) : `${baseUrl}/`;
+        navigate(newUrl);
+      }
+    },
+    [views, debounceUpdateViews, viewId, baseUrl, navigate]
+  );
+
+  const handleDuplicateView = useCallback(
+    (view: IssueViewPF) => {
+      const idx = views.findIndex(v => v.id === view.id);
+      if (idx !== -1) {
+        const newViewId = generateTempViewId();
+        const duplicatedView = {
+          ...views[idx]!,
+          id: newViewId,
+          label: `${views[idx]!.label} (Copy)`,
+        };
+        const newViews = [
+          ...views.slice(0, idx + 1),
+          duplicatedView,
+          ...views.slice(idx + 1),
+        ];
+        setViews(newViews);
+        debounceUpdateViews(newViews);
+        if (view.id === viewId) {
+          navigate(constructViewLink(baseUrl, duplicatedView));
+        }
+      }
+    },
+    [views, viewId, baseUrl, navigate, debounceUpdateViews]
+  );
+
   return (
     <Reorder.Group
       as="div"
       axis="y"
       values={views ?? []}
-      onReorder={setViews}
+      onReorder={handleReorder}
       initial={false}
       ref={sectionRef}
     >
@@ -57,43 +209,9 @@ export function IssueViewNavItems({
             view={view}
             sectionRef={sectionRef}
             isActive={view.id === viewId}
-            updateView={updatedView => {
-              const newViews = views.map(v => {
-                if (v.id === view.id) {
-                  return updatedView;
-                }
-                return v;
-              });
-              setViews(newViews);
-            }}
-            deleteView={() => {
-              const newViews = views.filter(v => v.id !== view.id);
-              setViews(newViews);
-              // Only redirect if the deleted view is the active view
-              if (view.id === viewId) {
-                const newUrl =
-                  newViews.length > 0
-                    ? constructViewLink(baseUrl, newViews[0]!)
-                    : `${baseUrl}/`;
-                navigate(newUrl);
-              }
-            }}
-            duplicateView={() => {
-              const newViewId = generateTempViewId();
-              const idx = views.findIndex(v => v.id === view.id);
-              if (idx !== -1) {
-                const duplicatedView = {
-                  ...views[idx]!,
-                  id: newViewId,
-                  label: `${views[idx]!.label} (Copy)`,
-                };
-                setViews([
-                  ...views.slice(0, idx + 1),
-                  duplicatedView,
-                  ...views.slice(idx + 1),
-                ]);
-              }
-            }}
+            updateView={updatedView => handleUpdateView(view, updatedView)}
+            deleteView={() => handleDeleteView(view)}
+            duplicateView={() => handleDuplicateView(view)}
           />
         </AnimatePresence>
       ))}

--- a/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
+++ b/static/app/views/issueList/issueViewsPF/issueViewsPF.tsx
@@ -443,7 +443,7 @@ export function IssueViewsPFStateProvider({
 
   // This function is fired upon receiving new views from the backend - it replaces any previously
   // generated temporary view ids with the permanent view ids from the backend
-  const replaceWithPersistantViewIds = (views: GroupSearchView[]) => {
+  const replaceWithPersistentViewIds = (views: GroupSearchView[]) => {
     const newlyCreatedViews = views.filter(
       view => !state.views.find(tab => tab.id === view.id)
     );
@@ -476,7 +476,7 @@ export function IssueViewsPFStateProvider({
   };
 
   const {mutate: updateViews} = useUpdateGroupSearchViews({
-    onSuccess: replaceWithPersistantViewIds,
+    onSuccess: replaceWithPersistentViewIds,
   });
 
   const debounceUpdateViews = useMemo(

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -1,39 +1,26 @@
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
-import ButtonBar from 'sentry/components/buttonBar';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {IconPause, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 
 type LeftNavViewsHeaderProps = {
-  onRealtimeChange: (realtime: boolean) => void;
-  organization: Organization;
-  realtimeActive: boolean;
   selectedProjectIds: number[];
 };
 
-function LeftNavViewsHeader({
-  organization,
-  realtimeActive,
-  onRealtimeChange,
-  selectedProjectIds,
-}: LeftNavViewsHeaderProps) {
+function LeftNavViewsHeader({selectedProjectIds}: LeftNavViewsHeaderProps) {
   const {projects} = useProjects();
+  const organization = useOrganization();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
 
   const selectedProjects = projects.filter(({id}) =>
     selectedProjectIds.includes(Number(id))
   );
-  const realtimeTitle = realtimeActive
-    ? t('Pause real-time updates')
-    : t('Enable real-time updates');
 
   const {data: groupSearchViews} = useFetchGroupSearchViews({
     orgSlug: organization.slug,
@@ -42,28 +29,26 @@ function LeftNavViewsHeader({
   const viewTitle = groupSearchViews?.find(v => v.id === viewId)?.name;
 
   return (
-    <Layout.Header noActionWrap>
-      <Layout.HeaderContent>
+    <StyledHeader noActionWrap>
+      <StyledHeaderContent>
         <Layout.Title>{viewTitle ?? t('Issues')}</Layout.Title>
-      </Layout.HeaderContent>
-      <Layout.HeaderActions>
-        <ButtonBar gap={1}>
-          <Button
-            size="sm"
-            data-test-id="real-time"
-            title={realtimeTitle}
-            aria-label={realtimeTitle}
-            icon={realtimeActive ? <IconPause /> : <IconPlay />}
-            onClick={() => onRealtimeChange(!realtimeActive)}
-          />
-        </ButtonBar>
-      </Layout.HeaderActions>
+      </StyledHeaderContent>
+      <Layout.HeaderActions />
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-    </Layout.Header>
+    </StyledHeader>
   );
 }
 
 export default LeftNavViewsHeader;
+
+const StyledHeader = styled(Layout.Header)`
+  background-color: ${p => p.theme.background};
+  border: 0;
+`;
+
+const StyledHeaderContent = styled(Layout.HeaderContent)`
+  margin-bottom: 0;
+`;
 
 const StyledGlobalEventProcessingAlert = styled(GlobalEventProcessingAlert)`
   grid-column: 1/-1;

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {IconPause, IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+
+type LeftNavViewsHeaderProps = {
+  onRealtimeChange: (realtime: boolean) => void;
+  organization: Organization;
+  realtimeActive: boolean;
+  selectedProjectIds: number[];
+};
+
+function LeftNavViewsHeader({
+  organization,
+  realtimeActive,
+  onRealtimeChange,
+  selectedProjectIds,
+}: LeftNavViewsHeaderProps) {
+  const {projects} = useProjects();
+  const {viewId} = useParams<{orgId?: string; viewId?: string}>();
+
+  const selectedProjects = projects.filter(({id}) =>
+    selectedProjectIds.includes(Number(id))
+  );
+  const realtimeTitle = realtimeActive
+    ? t('Pause real-time updates')
+    : t('Enable real-time updates');
+
+  const {data: groupSearchViews} = useFetchGroupSearchViews({
+    orgSlug: organization.slug,
+  });
+
+  const viewTitle = groupSearchViews?.find(v => v.id === viewId)?.name;
+
+  return (
+    <Layout.Header noActionWrap>
+      <Layout.HeaderContent>
+        <Layout.Title>{viewTitle ?? t('Issues')}</Layout.Title>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions>
+        <ButtonBar gap={1}>
+          <Button
+            size="sm"
+            data-test-id="real-time"
+            title={realtimeTitle}
+            aria-label={realtimeTitle}
+            icon={realtimeActive ? <IconPause /> : <IconPlay />}
+            onClick={() => onRealtimeChange(!realtimeActive)}
+          />
+        </ButtonBar>
+      </Layout.HeaderActions>
+      <StyledGlobalEventProcessingAlert projects={selectedProjects} />
+    </Layout.Header>
+  );
+}
+
+export default LeftNavViewsHeader;
+
+const StyledGlobalEventProcessingAlert = styled(GlobalEventProcessingAlert)`
+  grid-column: 1/-1;
+  margin-top: ${space(1)};
+  margin-bottom: ${space(1)};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    margin-top: ${space(2)};
+    margin-bottom: 0;
+  }
+`;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -51,6 +51,7 @@ import IssueListTable from 'sentry/views/issueList/issueListTable';
 import {IssuesDataConsentBanner} from 'sentry/views/issueList/issuesDataConsentBanner';
 import IssueViewsIssueListHeader from 'sentry/views/issueList/issueViewsHeader';
 import IssueViewsPFIssueListHeader from 'sentry/views/issueList/issueViewsHeaderPF';
+import LeftNavViewsHeader from 'sentry/views/issueList/leftNavViewsHeader';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
 import SavedIssueSearches from 'sentry/views/issueList/savedIssueSearches';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
@@ -1069,45 +1070,56 @@ function IssueListOverview({router}: Props) {
   const showReprocessingTab = !!queryCounts?.[Query.REPROCESSING]?.count;
   const displayReprocessingActions = showReprocessingTab && query === Query.REPROCESSING;
 
+  const hasLeftNavIssueViews = organization.features.includes('left-nav-issue-views');
+
   const {numPreviousIssues, numIssuesOnPage} = getPageCounts();
 
   return (
     <NewTabContextProvider>
       <Layout.Page>
-        {organization.features.includes('issue-stream-custom-views') ? (
-          organization.features.includes('issue-views-page-filter') ? (
-            <ErrorBoundary message={'Failed to load custom tabs'} mini>
-              <IssueViewsPFIssueListHeader
-                router={router}
-                selectedProjectIds={selection.projects}
-                realtimeActive={realtimeActive}
-                onRealtimeChange={onRealtimeChange}
-              />
-            </ErrorBoundary>
-          ) : (
-            <ErrorBoundary message={'Failed to load custom tabs'} mini>
-              <IssueViewsIssueListHeader
-                router={router}
-                selectedProjectIds={selection.projects}
-                realtimeActive={realtimeActive}
-                onRealtimeChange={onRealtimeChange}
-              />
-            </ErrorBoundary>
-          )
-        ) : (
-          <IssueListHeader
+        {hasLeftNavIssueViews && (
+          <LeftNavViewsHeader
             organization={organization}
-            query={query}
-            sort={sort}
-            queryCount={queryCount}
-            queryCounts={queryCounts}
             realtimeActive={realtimeActive}
-            router={router}
-            displayReprocessingTab={showReprocessingTab}
             selectedProjectIds={selection.projects}
             onRealtimeChange={onRealtimeChange}
           />
         )}
+        {!hasLeftNavIssueViews &&
+          (organization.features.includes('issue-stream-custom-views') ? (
+            organization.features.includes('issue-views-page-filter') ? (
+              <ErrorBoundary message={'Failed to load custom tabs'} mini>
+                <IssueViewsPFIssueListHeader
+                  router={router}
+                  selectedProjectIds={selection.projects}
+                  realtimeActive={realtimeActive}
+                  onRealtimeChange={onRealtimeChange}
+                />
+              </ErrorBoundary>
+            ) : (
+              <ErrorBoundary message={'Failed to load custom tabs'} mini>
+                <IssueViewsIssueListHeader
+                  router={router}
+                  selectedProjectIds={selection.projects}
+                  realtimeActive={realtimeActive}
+                  onRealtimeChange={onRealtimeChange}
+                />
+              </ErrorBoundary>
+            )
+          ) : (
+            <IssueListHeader
+              organization={organization}
+              query={query}
+              sort={sort}
+              queryCount={queryCount}
+              queryCounts={queryCounts}
+              realtimeActive={realtimeActive}
+              router={router}
+              displayReprocessingTab={showReprocessingTab}
+              selectedProjectIds={selection.projects}
+              onRealtimeChange={onRealtimeChange}
+            />
+          ))}
 
         <StyledBody>
           <StyledMain>

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1078,12 +1078,7 @@ function IssueListOverview({router}: Props) {
     <NewTabContextProvider>
       <Layout.Page>
         {hasLeftNavIssueViews && (
-          <LeftNavViewsHeader
-            organization={organization}
-            realtimeActive={realtimeActive}
-            selectedProjectIds={selection.projects}
-            onRealtimeChange={onRealtimeChange}
-          />
+          <LeftNavViewsHeader selectedProjectIds={selection.projects} />
         )}
         {!hasLeftNavIssueViews &&
           (organization.features.includes('issue-stream-custom-views') ? (

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef, useState} from 'react';
+import {Fragment, useRef} from 'react';
 
 import {IssueViewNavItems} from 'sentry/components/nav/issueViews/issueViewNavItems';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
@@ -19,7 +19,6 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
   const hasIssueViewsInLeftNav = organization?.features.includes('left-nav-issue-views');
 
   const sectionRef = useRef<HTMLDivElement>(null);
-  const [views, setViews] = useState<IssueViewPF[] | null>(null);
 
   const {data: groupSearchViews} = useFetchGroupSearchViews(
     {
@@ -29,42 +28,6 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
       enabled: hasIssueViewsInLeftNav,
     }
   );
-
-  useEffect(() => {
-    if (groupSearchViews) {
-      setViews(
-        groupSearchViews?.map(
-          (
-            {
-              id,
-              name,
-              query: viewQuery,
-              querySort: viewQuerySort,
-              environments: viewEnvironments,
-              projects: viewProjects,
-              timeFilters: viewTimeFilters,
-              isAllProjects,
-            },
-            index
-          ): IssueViewPF => {
-            const tabId = id ?? `default${index.toString()}`;
-
-            return {
-              id: tabId,
-              key: tabId,
-              label: name,
-              query: viewQuery,
-              querySort: viewQuerySort,
-              environments: viewEnvironments,
-              projects: isAllProjects ? [-1] : viewProjects,
-              timeFilters: viewTimeFilters,
-              isCommitted: true,
-            };
-          }
-        )
-      );
-    }
-  }, [groupSearchViews]);
 
   if (!hasNavigationV2) {
     return children;
@@ -85,11 +48,38 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
               {t('Feedback')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
-          {hasIssueViewsInLeftNav && views && (
+          {hasIssueViewsInLeftNav && groupSearchViews && (
             <SecondaryNav.Section title={t('Views')}>
               <IssueViewNavItems
-                views={views}
-                setViews={setViews}
+                loadedViews={groupSearchViews.map(
+                  (
+                    {
+                      id,
+                      name,
+                      query: viewQuery,
+                      querySort: viewQuerySort,
+                      environments: viewEnvironments,
+                      projects: viewProjects,
+                      timeFilters: viewTimeFilters,
+                      isAllProjects,
+                    },
+                    index
+                  ): IssueViewPF => {
+                    const tabId = id ?? `default${index.toString()}`;
+
+                    return {
+                      id: tabId,
+                      key: tabId,
+                      label: name,
+                      query: viewQuery,
+                      querySort: viewQuerySort,
+                      environments: viewEnvironments,
+                      projects: isAllProjects ? [-1] : viewProjects,
+                      timeFilters: viewTimeFilters,
+                      isCommitted: true,
+                    };
+                  }
+                )}
                 sectionRef={sectionRef}
                 baseUrl={baseUrl}
               />


### PR DESCRIPTION
This PR adds persistence functionality to all of the view mutation actions and removes the horizontal views from the issues page (for those that have the feature flag, of course)

Also updates the header design to have the same background as the container body, as per a impromptu conversation with Rachel & Vu 