### PR TITLE
feat(uptime): Allow regions to be configured as shadow mode

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2021,10 +2021,14 @@ class Factories:
 
     @staticmethod
     def create_uptime_subscription_region(
-        subscription: UptimeSubscription, region_slug: str
+        subscription: UptimeSubscription,
+        region_slug: str,
+        mode: UptimeSubscriptionRegion.RegionMode,
     ) -> UptimeSubscriptionRegion:
         return UptimeSubscriptionRegion.objects.create(
-            uptime_subscription=subscription, region_slug=region_slug
+            uptime_subscription=subscription,
+            region_slug=region_slug,
+            mode=mode,
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -50,6 +50,7 @@ from sentry.uptime.models import (
     ProjectUptimeSubscriptionMode,
     UptimeStatus,
     UptimeSubscription,
+    UptimeSubscriptionRegion,
 )
 from sentry.users.models.identity import Identity, IdentityProvider
 from sentry.users.models.user import User
@@ -716,9 +717,17 @@ class Fixtures:
             trace_sampling=trace_sampling,
         )
         for region_slug in region_slugs:
-            Factories.create_uptime_subscription_region(subscription, region_slug)
+            self.create_uptime_subscription_region(subscription, region_slug)
 
         return subscription
+
+    def create_uptime_subscription_region(
+        self,
+        subscription: UptimeSubscription,
+        region_slug: str,
+        mode: UptimeSubscriptionRegion.RegionMode = UptimeSubscriptionRegion.RegionMode.ACTIVE,
+    ):
+        Factories.create_uptime_subscription_region(subscription, region_slug, mode)
 
     def create_project_uptime_subscription(
         self,

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -144,21 +144,21 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         if not self.should_run_region_checks(subscription, result):
             return
 
-        subscription_regions = {
+        subscription_region_modes = {
             r.region_slug: UptimeSubscriptionRegion.RegionMode(r.mode)
             for r in subscription.regions.all()
         }
         active_regions = {c.slug: mode for c, mode in get_active_region_configs()}
-        if subscription_regions == active_regions:
+        if subscription_region_modes == active_regions:
             # Regions haven't changed, exit early.
             return
 
         new_or_updated_regions = {
             slug: mode
             for slug, mode in active_regions.items()
-            if slug not in subscription_regions or subscription_regions[slug] != mode
+            if slug not in subscription_region_modes or subscription_region_modes[slug] != mode
         }
-        removed_regions = subscription_regions.keys() - active_regions.keys()
+        removed_regions = subscription_region_modes.keys() - active_regions.keys()
         if new_or_updated_regions:
             new_or_updated_region_objs = [
                 UptimeSubscriptionRegion(

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -122,8 +122,13 @@ class UptimeSubscriptionRegion(DefaultFieldsModel):
     __relocation_scope__ = RelocationScope.Excluded
 
     class RegionMode(enum.StrEnum):
+        # Region is running as usual
         ACTIVE = "active"
+        # Region is disabled and not running
         INACTIVE = "inactive"
+        # Region is running in shadow mode. This means it is performing checks, but results are
+        # ignored.
+        SHADOW = "shadow"
 
     uptime_subscription = FlexibleForeignKey("uptime.UptimeSubscription", related_name="regions")
     region_slug = models.CharField(max_length=255, db_index=True, db_default="")

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -7,15 +7,22 @@ from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.uptime.models import UptimeSubscriptionRegion
 
 
-def get_active_region_configs() -> list[UptimeRegionConfig]:
+def get_active_region_configs() -> (
+    list[tuple[UptimeRegionConfig, UptimeSubscriptionRegion.RegionMode]]
+):
     configured_regions: Sequence[UptimeRegionConfig] = settings.UPTIME_REGIONS
     region_mode_override: Mapping[str, str] = options.get("uptime.checker-regions-mode-override")
 
     return [
-        c
+        (
+            c,
+            UptimeSubscriptionRegion.RegionMode(
+                region_mode_override.get(c.slug, UptimeSubscriptionRegion.RegionMode.ACTIVE)
+            ),
+        )
         for c in configured_regions
         if region_mode_override.get(c.slug, UptimeSubscriptionRegion.RegionMode.ACTIVE)
-        == UptimeSubscriptionRegion.RegionMode.ACTIVE
+        in [UptimeSubscriptionRegion.RegionMode.ACTIVE, UptimeSubscriptionRegion.RegionMode.SHADOW]
     ]
 
 

--- a/src/sentry/uptime/subscriptions/regions.py
+++ b/src/sentry/uptime/subscriptions/regions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import dataclasses
 from collections.abc import Mapping, Sequence
 
 from django.conf import settings
@@ -7,18 +10,24 @@ from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.uptime.models import UptimeSubscriptionRegion
 
 
-def get_active_region_configs() -> (
-    list[tuple[UptimeRegionConfig, UptimeSubscriptionRegion.RegionMode]]
-):
+@dataclasses.dataclass(frozen=True)
+class UptimeRegionWithMode:
+    slug: str
+    mode: UptimeSubscriptionRegion.RegionMode = UptimeSubscriptionRegion.RegionMode.ACTIVE
+
+
+def get_active_regions() -> list[UptimeRegionWithMode]:
     configured_regions: Sequence[UptimeRegionConfig] = settings.UPTIME_REGIONS
     region_mode_override: Mapping[str, str] = options.get("uptime.checker-regions-mode-override")
 
     return [
         (
-            c,
-            UptimeSubscriptionRegion.RegionMode(
-                region_mode_override.get(c.slug, UptimeSubscriptionRegion.RegionMode.ACTIVE)
-            ),
+            UptimeRegionWithMode(
+                c.slug,
+                UptimeSubscriptionRegion.RegionMode(
+                    region_mode_override.get(c.slug, UptimeSubscriptionRegion.RegionMode.ACTIVE)
+                ),
+            )
         )
         for c in configured_regions
         if region_mode_override.get(c.slug, UptimeSubscriptionRegion.RegionMode.ACTIVE)

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -22,7 +22,7 @@ from sentry.uptime.models import (
     headers_json_encoder,
 )
 from sentry.uptime.rdap.tasks import fetch_subscription_rdap_info
-from sentry.uptime.subscriptions.regions import get_active_region_configs
+from sentry.uptime.subscriptions.regions import get_active_regions
 from sentry.uptime.subscriptions.tasks import (
     create_remote_uptime_subscription,
     delete_remote_uptime_subscription,
@@ -158,12 +158,12 @@ def get_or_create_uptime_subscription(
         created = True
 
     # Associate active regions with this subscription
-    for region_config, region_mode in get_active_region_configs():
+    for region in get_active_regions():
         # If we add a region here we need to resend the subscriptions
         created |= UptimeSubscriptionRegion.objects.update_or_create(
             uptime_subscription=subscription,
-            region_slug=region_config.slug,
-            defaults={"mode": region_mode},
+            region_slug=region.slug,
+            defaults={"mode": region.mode},
         )[1]
 
     if created:

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -10,7 +10,11 @@ from sentry_kafka_schemas.schema_types.uptime_configs_v1 import CheckConfig
 from sentry.snuba.models import QuerySubscription
 from sentry.tasks.base import instrumented_task
 from sentry.uptime.config_producer import produce_config, produce_config_removal
-from sentry.uptime.models import UptimeRegionScheduleMode, UptimeSubscription
+from sentry.uptime.models import (
+    UptimeRegionScheduleMode,
+    UptimeSubscription,
+    UptimeSubscriptionRegion,
+)
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -37,10 +41,8 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         metrics.incr("uptime.subscriptions.create.incorrect_status", sample_rate=1.0)
         return
 
-    region_slugs = [s.region_slug for s in subscription.regions.all()]
-
-    for region_slug in region_slugs:
-        send_uptime_subscription_config(region_slug, subscription)
+    for region in subscription.regions.all():
+        send_uptime_subscription_config(region, subscription)
     subscription.update(
         status=QuerySubscription.Status.ACTIVE.value,
         subscription_id=subscription.subscription_id,
@@ -66,10 +68,8 @@ def update_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         metrics.incr("uptime.subscriptions.update.incorrect_status", sample_rate=1.0)
         return
 
-    region_slugs = [s.region_slug for s in subscription.regions.all()]
-
-    for region_slug in region_slugs:
-        send_uptime_subscription_config(region_slug, subscription)
+    for region in subscription.regions.all():
+        send_uptime_subscription_config(region, subscription)
     subscription.update(
         status=QuerySubscription.Status.ACTIVE.value,
         subscription_id=subscription.subscription_id,
@@ -109,16 +109,25 @@ def delete_remote_uptime_subscription(uptime_subscription_id, **kwargs):
             send_uptime_config_deletion(region_slug, subscription_id)
 
 
-def send_uptime_subscription_config(region_slug: str, subscription: UptimeSubscription):
+def send_uptime_subscription_config(
+    region: UptimeSubscriptionRegion, subscription: UptimeSubscription
+):
     if subscription.subscription_id is None:
         subscription.subscription_id = uuid4().hex
     produce_config(
-        region_slug, uptime_subscription_to_check_config(subscription, subscription.subscription_id)
+        region.region_slug,
+        uptime_subscription_to_check_config(
+            subscription,
+            subscription.subscription_id,
+            UptimeSubscriptionRegion.RegionMode(region.mode),
+        ),
     )
 
 
 def uptime_subscription_to_check_config(
-    subscription: UptimeSubscription, subscription_id: str
+    subscription: UptimeSubscription,
+    subscription_id: str,
+    region_mode: UptimeSubscriptionRegion.RegionMode,
 ) -> CheckConfig:
     headers = subscription.headers
     # XXX: Temporary translation code. We want to support headers with the same keys, so convert to a list
@@ -133,7 +142,7 @@ def uptime_subscription_to_check_config(
         "request_method": subscription.method,
         "request_headers": headers,
         "trace_sampling": subscription.trace_sampling,
-        "active_regions": [r.region_slug for r in subscription.regions.all()],
+        "active_regions": [r.region_slug for r in subscription.regions.filter(mode=region_mode)],
         "region_schedule_mode": UptimeRegionScheduleMode.ROUND_ROBIN.value,
     }
     if subscription.body is not None:

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -477,7 +477,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
             self.assert_redis_config(
-                "default", UptimeSubscription(subscription_id=subscription_id), "delete"
+                "default", UptimeSubscription(subscription_id=subscription_id), "delete", None
             )
 
     def test_multiple_project_subscriptions_with_disabled(self):
@@ -1012,10 +1012,12 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self,
         sub: UptimeSubscription,
         regions: list[str],
-        disabled_regions: list[str],
-        expected_regions_before: set[str],
-        expected_regions_after: set[str],
-        expected_config_updates: list[tuple[str, str | None]],
+        region_overrides: dict[str, UptimeSubscriptionRegion.RegionMode],
+        expected_regions_before: dict[str, UptimeSubscriptionRegion.RegionMode],
+        expected_regions_after: dict[str, UptimeSubscriptionRegion.RegionMode],
+        expected_config_updates: list[
+            tuple[str, str | None, UptimeSubscriptionRegion.RegionMode | None]
+        ],
         current_minute=5,
     ):
         region_configs = [
@@ -1025,14 +1027,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
         with (
             override_settings(UPTIME_REGIONS=region_configs),
-            override_options(
-                {
-                    "uptime.checker-regions-mode-override": {
-                        region: UptimeSubscriptionRegion.RegionMode.INACTIVE.value
-                        for region in disabled_regions
-                    }
-                }
-            ),
+            override_options({"uptime.checker-regions-mode-override": region_overrides}),
             self.tasks(),
             freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=current_minute)),
             mock.patch("random.random", return_value=1),
@@ -1041,12 +1036,18 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 sub.subscription_id,
                 scheduled_check_time=datetime.now(),
             )
-            assert {r.region_slug for r in sub.regions.all()} == expected_regions_before
+            assert {
+                r.region_slug: UptimeSubscriptionRegion.RegionMode(r.mode)
+                for r in sub.regions.all()
+            } == expected_regions_before
             self.send_result(result)
             sub.refresh_from_db()
-            assert {r.region_slug for r in sub.regions.all()} == expected_regions_after
-            for expected_region, expected_action in expected_config_updates:
-                self.assert_redis_config(expected_region, sub, expected_action)
+            assert {
+                r.region_slug: UptimeSubscriptionRegion.RegionMode(r.mode)
+                for r in sub.regions.all()
+            } == expected_regions_after
+            for expected_region, expected_action, expected_mode in expected_config_updates:
+                self.assert_redis_config(expected_region, sub, expected_action, expected_mode)
             assert sub.status == UptimeSubscription.Status.ACTIVE.value
 
     def test_check_and_update_regions(self):
@@ -1057,19 +1058,49 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.run_check_and_update_region_test(
             sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1"},
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
             [],
             4,
         )
         self.run_check_and_update_region_test(
             sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1", "region2"},
-            [("region1", "upsert"), ("region2", "upsert")],
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            [
+                ("region1", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                ("region2", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+            ],
+            5,
+        )
+
+    def test_check_and_update_regions_active_shadow(self):
+        sub = self.create_uptime_subscription(
+            subscription_id=uuid.UUID(int=5).hex,
+            region_slugs=["region1", "region2"],
+        )
+        self.run_check_and_update_region_test(
+            sub,
+            ["region1", "region2"],
+            {"region2": UptimeSubscriptionRegion.RegionMode.SHADOW},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.SHADOW,
+            },
+            [
+                ("region1", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                ("region2", "upsert", UptimeSubscriptionRegion.RegionMode.SHADOW),
+            ],
             5,
         )
 
@@ -1083,10 +1114,16 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.run_check_and_update_region_test(
             hour_sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1", "region2"},
-            [("region1", "upsert"), ("region2", "upsert")],
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            [
+                ("region1", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                ("region2", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+            ],
             37,
         )
 
@@ -1098,37 +1135,43 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.run_check_and_update_region_test(
             five_min_sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1"},
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
             [],
             current_minute=6,
         )
         self.run_check_and_update_region_test(
             five_min_sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1"},
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
             [],
             current_minute=35,
         )
         self.run_check_and_update_region_test(
             five_min_sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1"},
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
             [],
             current_minute=49,
         )
         self.run_check_and_update_region_test(
             five_min_sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1", "region2"},
-            [("region1", "upsert"), ("region2", "upsert")],
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            [
+                ("region1", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                ("region2", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+            ],
             current_minute=30,
         )
         # Make sure it works any time within the valid window
@@ -1140,10 +1183,16 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.run_check_and_update_region_test(
             five_min_sub,
             ["region1", "region2"],
-            [],
-            {"region1"},
-            {"region1", "region2"},
-            [("region1", "upsert"), ("region2", "upsert")],
+            {},
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            [
+                ("region1", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                ("region2", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+            ],
             current_minute=34,
         )
 
@@ -1154,19 +1203,31 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.run_check_and_update_region_test(
             sub,
             ["region1", "region2"],
-            ["region2"],
-            {"region1", "region2"},
-            {"region1", "region2"},
+            {"region2": UptimeSubscriptionRegion.RegionMode.INACTIVE},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
             [],
             current_minute=4,
         )
         self.run_check_and_update_region_test(
             sub,
             ["region1", "region2"],
-            ["region2"],
-            {"region1", "region2"},
-            {"region1"},
-            [("region1", "upsert"), ("region2", "delete")],
+            {"region2": UptimeSubscriptionRegion.RegionMode.INACTIVE},
+            {
+                "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "region2": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            },
+            {"region1": UptimeSubscriptionRegion.RegionMode.ACTIVE},
+            [
+                ("region1", "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                ("region2", "delete", None),
+            ],
             current_minute=5,
         )
 

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -45,7 +45,10 @@ class GetActiveRegionConfigsTest(TestBase):
         ):
             active_regions = get_active_region_configs()
             assert len(active_regions) == 2
-            assert {region.slug for region in active_regions} == {"us", "ap"}
+            assert {region.slug: mode for region, mode in active_regions} == {
+                "us": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "ap": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            }
 
         with (
             override_settings(UPTIME_REGIONS=self.test_regions),
@@ -54,13 +57,17 @@ class GetActiveRegionConfigsTest(TestBase):
                     "uptime.checker-regions-mode-override": {
                         "eu": UptimeSubscriptionRegion.RegionMode.INACTIVE.value,
                         "us": UptimeSubscriptionRegion.RegionMode.ACTIVE.value,
+                        "ap": UptimeSubscriptionRegion.RegionMode.SHADOW.value,
                     }
                 }
             ),
         ):
             active_regions = get_active_region_configs()
             assert len(active_regions) == 2
-            assert {region.slug for region in active_regions} == {"us", "ap"}
+            assert {region.slug: mode for region, mode in active_regions} == {
+                "us": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+                "ap": UptimeSubscriptionRegion.RegionMode.SHADOW,
+            }
 
 
 class GetRegionConfigTest(TestBase):

--- a/tests/sentry/uptime/subscriptions/test_regions.py
+++ b/tests/sentry/uptime/subscriptions/test_regions.py
@@ -4,7 +4,11 @@ from django.test import TestCase, override_settings
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.testutils.helpers import override_options
 from sentry.uptime.models import UptimeSubscriptionRegion
-from sentry.uptime.subscriptions.regions import get_active_region_configs, get_region_config
+from sentry.uptime.subscriptions.regions import (
+    UptimeRegionWithMode,
+    get_active_regions,
+    get_region_config,
+)
 
 
 class TestBase(TestCase):
@@ -31,7 +35,7 @@ class TestBase(TestCase):
         ]
 
 
-class GetActiveRegionConfigsTest(TestBase):
+class GetActiveRegionsTest(TestBase):
     def test_returns_only_enabled_regions(self):
         with (
             override_settings(UPTIME_REGIONS=self.test_regions),
@@ -43,11 +47,10 @@ class GetActiveRegionConfigsTest(TestBase):
                 }
             ),
         ):
-            active_regions = get_active_region_configs()
-            assert len(active_regions) == 2
-            assert {region.slug: mode for region, mode in active_regions} == {
-                "us": UptimeSubscriptionRegion.RegionMode.ACTIVE,
-                "ap": UptimeSubscriptionRegion.RegionMode.ACTIVE,
+            active_regions = get_active_regions()
+            assert set(active_regions) == {
+                UptimeRegionWithMode("us", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                UptimeRegionWithMode("ap", UptimeSubscriptionRegion.RegionMode.ACTIVE),
             }
 
         with (
@@ -62,11 +65,10 @@ class GetActiveRegionConfigsTest(TestBase):
                 }
             ),
         ):
-            active_regions = get_active_region_configs()
-            assert len(active_regions) == 2
-            assert {region.slug: mode for region, mode in active_regions} == {
-                "us": UptimeSubscriptionRegion.RegionMode.ACTIVE,
-                "ap": UptimeSubscriptionRegion.RegionMode.SHADOW,
+            active_regions = get_active_regions()
+            assert set(active_regions) == {
+                UptimeRegionWithMode("us", UptimeSubscriptionRegion.RegionMode.ACTIVE),
+                UptimeRegionWithMode("ap", UptimeSubscriptionRegion.RegionMode.SHADOW),
             }
 
 

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -16,9 +16,10 @@ from rediscluster import RedisCluster
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import UptimeTestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.skips import requires_kafka
 from sentry.uptime.config_producer import get_partition_keys
-from sentry.uptime.models import UptimeSubscription
+from sentry.uptime.models import UptimeSubscription, UptimeSubscriptionRegion
 from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.uptime.subscriptions.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
@@ -42,6 +43,7 @@ class ConfigPusherTestMixin(UptimeTestCase):
         region: str,
         sub: UptimeSubscription,
         action: str | None,
+        region_mode: UptimeSubscriptionRegion.RegionMode | None,
     ):
         region_config = get_region_config(region)
         assert region_config is not None
@@ -54,8 +56,9 @@ class ConfigPusherTestMixin(UptimeTestCase):
         if action == "upsert":
             config_bytes = cluster.hget(config_key, sub.subscription_id)
             assert config_bytes is not None
+            assert region_mode is not None
             assert msgpack.unpackb(config_bytes) == uptime_subscription_to_check_config(
-                sub, sub.subscription_id
+                sub, sub.subscription_id, region_mode
             )
         else:
             assert not cluster.hexists(config_key, sub.subscription_id)
@@ -126,7 +129,7 @@ class BaseUptimeSubscriptionTaskTest(ConfigPusherTestMixin, metaclass=abc.ABCMet
             ),
             sample_rate=1.0,
         )
-        self.assert_redis_config("default", sub, None)
+        self.assert_redis_config("default", sub, None, None)
 
 
 class CreateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
@@ -139,7 +142,9 @@ class CreateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         sub.refresh_from_db()
         assert sub.status == UptimeSubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
-        self.assert_redis_config("default", sub, "upsert")
+        self.assert_redis_config(
+            "default", sub, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+        )
 
     def test_with_regions(self):
         sub = self.create_uptime_subscription(
@@ -149,7 +154,9 @@ class CreateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         sub.refresh_from_db()
         assert sub.status == UptimeSubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
-        self.assert_redis_config("default", sub, "upsert")
+        self.assert_redis_config(
+            "default", sub, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+        )
 
     def test_multi_overlapping_regions(self):
         regions = [
@@ -186,10 +193,83 @@ class CreateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
             )
             create_remote_uptime_subscription(sub2.id)
             sub2.refresh_from_db()
-            self.assert_redis_config("region1", sub1, "upsert")
-            self.assert_redis_config("region2", sub1, "upsert")
-            self.assert_redis_config("region2", sub2, "upsert")
-            self.assert_redis_config("region3", sub2, "upsert")
+            self.assert_redis_config(
+                "region1", sub1, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+            )
+            self.assert_redis_config(
+                "region2", sub1, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+            )
+            self.assert_redis_config(
+                "region2", sub2, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+            )
+            self.assert_redis_config(
+                "region3", sub2, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+            )
+
+    def test_active_shadow_regions(self):
+        regions = [
+            UptimeRegionConfig(
+                slug="region1",
+                name="Region 1",
+                config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="r1",
+            ),
+            UptimeRegionConfig(
+                slug="region2",
+                name="Region 2",
+                config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="r2",
+            ),
+            UptimeRegionConfig(
+                slug="region3",
+                name="Region 3",
+                config_redis_cluster=settings.SENTRY_UPTIME_DETECTOR_CLUSTER,
+                config_redis_key_prefix="r3",
+            ),
+        ]
+        with (
+            override_settings(UPTIME_REGIONS=regions),
+            override_options(
+                {
+                    "uptime.checker-regions-mode-override": {
+                        "region1": UptimeSubscriptionRegion.RegionMode.ACTIVE.value,
+                        "region2": UptimeSubscriptionRegion.RegionMode.SHADOW.value,
+                        "region3": UptimeSubscriptionRegion.RegionMode.ACTIVE.value,
+                    }
+                }
+            ),
+        ):
+            # First subscription with regions 1 and 2
+            sub1 = self.create_uptime_subscription(
+                status=UptimeSubscription.Status.CREATING, region_slugs=["region1"]
+            )
+            self.create_uptime_subscription_region(
+                sub1, "region2", UptimeSubscriptionRegion.RegionMode.SHADOW
+            )
+            create_remote_uptime_subscription(sub1.id)
+            sub1.refresh_from_db()
+
+            # Second subscription with regions 2 and 3
+            sub2 = self.create_uptime_subscription(
+                status=UptimeSubscription.Status.CREATING, region_slugs=["region3"]
+            )
+            self.create_uptime_subscription_region(
+                sub2, "region2", UptimeSubscriptionRegion.RegionMode.SHADOW
+            )
+            create_remote_uptime_subscription(sub2.id)
+            sub2.refresh_from_db()
+            self.assert_redis_config(
+                "region1", sub1, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+            )
+            self.assert_redis_config(
+                "region2", sub1, "upsert", UptimeSubscriptionRegion.RegionMode.SHADOW
+            )
+            self.assert_redis_config(
+                "region2", sub2, "upsert", UptimeSubscriptionRegion.RegionMode.SHADOW
+            )
+            self.assert_redis_config(
+                "region3", sub2, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+            )
 
 
 class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
@@ -203,7 +283,7 @@ class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         )
         delete_remote_uptime_subscription(sub.id)
         assert not UptimeSubscription.objects.filter(id=sub.id).exists()
-        self.assert_redis_config("default", sub, "delete")
+        self.assert_redis_config("default", sub, "delete", None)
 
     def test_no_subscription_id(self):
         sub = self.create_subscription(UptimeSubscription.Status.DELETING)
@@ -219,7 +299,7 @@ class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         )
         delete_remote_uptime_subscription(sub.id)
         assert sub.subscription_id is not None
-        self.assert_redis_config("default", sub, "delete")
+        self.assert_redis_config("default", sub, "delete", None)
         with pytest.raises(UptimeSubscription.DoesNotExist):
             sub.refresh_from_db()
 
@@ -229,7 +309,9 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
         sub = self.create_uptime_subscription(region_slugs=["default"])
 
         subscription_id = uuid4().hex
-        assert uptime_subscription_to_check_config(sub, subscription_id) == {
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        ) == {
             "subscription_id": subscription_id,
             "url": sub.url,
             "interval_seconds": sub.interval_seconds,
@@ -255,7 +337,9 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
         sub.refresh_from_db()
 
         subscription_id = uuid4().hex
-        assert uptime_subscription_to_check_config(sub, subscription_id) == {
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        ) == {
             "subscription_id": subscription_id,
             "url": sub.url,
             "interval_seconds": sub.interval_seconds,
@@ -274,7 +358,9 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
         sub.refresh_from_db()
 
         subscription_id = uuid4().hex
-        assert uptime_subscription_to_check_config(sub, subscription_id) == {
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        ) == {
             "subscription_id": subscription_id,
             "url": sub.url,
             "interval_seconds": sub.interval_seconds,
@@ -289,7 +375,9 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
     def test_no_regions(self):
         sub = self.create_uptime_subscription()
         subscription_id = uuid4().hex
-        assert uptime_subscription_to_check_config(sub, subscription_id) == {
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        ) == {
             "subscription_id": subscription_id,
             "url": sub.url,
             "interval_seconds": sub.interval_seconds,
@@ -301,6 +389,33 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "region_schedule_mode": "round_robin",
         }
 
+    def test_region_mode(self):
+        sub = self.create_uptime_subscription(region_slugs=["default"])
+
+        subscription_id = uuid4().hex
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        )["active_regions"] == ["default"]
+
+        assert (
+            uptime_subscription_to_check_config(
+                sub, subscription_id, UptimeSubscriptionRegion.RegionMode.SHADOW
+            )["active_regions"]
+            == []
+        )
+
+        self.create_uptime_subscription_region(
+            sub, "shadow_slug", UptimeSubscriptionRegion.RegionMode.SHADOW
+        )
+
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.ACTIVE
+        )["active_regions"] == ["default"]
+
+        assert uptime_subscription_to_check_config(
+            sub, subscription_id, UptimeSubscriptionRegion.RegionMode.SHADOW
+        )["active_regions"] == ["shadow_slug"]
+
 
 class SendUptimeConfigDeletionTest(ConfigPusherTestMixin):
     def test_with_region(self):
@@ -308,7 +423,7 @@ class SendUptimeConfigDeletionTest(ConfigPusherTestMixin):
         region_slug = "default"
         send_uptime_config_deletion(region_slug, subscription_id)
         self.assert_redis_config(
-            region_slug, UptimeSubscription(subscription_id=subscription_id), "delete"
+            region_slug, UptimeSubscription(subscription_id=subscription_id), "delete", None
         )
 
 
@@ -359,4 +474,6 @@ class UpdateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         assert sub.status == UptimeSubscription.Status.ACTIVE.value
 
         # Verify config was sent to the region
-        self.assert_redis_config("default", sub, "upsert")
+        self.assert_redis_config(
+            "default", sub, "upsert", UptimeSubscriptionRegion.RegionMode.ACTIVE
+        )


### PR DESCRIPTION
This introduces shadow mode to our uptime region system. Configs are partitioned separately between shadow/active. So if regions 1, 2 are active, and 3,4 are shadow, then configs going to regions 1/2 will have just regions 1/2 as their active regions. Configs going 3/4 will also only have regions 3/4 as their active regions.

This uses the same override system we use to disable regions. Regions will be slowly migrated over to shadow mode over time.

Note that this pr doesn't handle the last piece required here - we need to ignore results produced by shadow regions. That will be handled in a follow up pr.

<!-- Describe your PR here. -->