### PR TITLE
fix(insight-charts): Loading with missing data

### DIFF
--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -58,17 +58,6 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
   const Title = <Widget.WidgetTitle title={props.title} />;
 
   // TODO: Instead of using `ChartContainer`, enforce the height from the parent layout
-  if (visualizationProps.timeSeries.length === 0) {
-    return (
-      <ChartContainer>
-        <Widget
-          Title={Title}
-          Visualization={<Widget.WidgetError error={MISSING_DATA_MESSAGE} />}
-        />
-      </ChartContainer>
-    );
-  }
-
   if (props.isLoading) {
     return (
       <ChartContainer>
@@ -86,6 +75,17 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
         <Widget
           Title={Title}
           Visualization={<Widget.WidgetError error={props.error} />}
+        />
+      </ChartContainer>
+    );
+  }
+
+  if (visualizationProps.timeSeries.length === 0) {
+    return (
+      <ChartContainer>
+        <Widget
+          Title={Title}
+          Visualization={<Widget.WidgetError error={MISSING_DATA_MESSAGE} />}
         />
       </ChartContainer>
     );


### PR DESCRIPTION
**Problem:** When passing an empty array for time series while data is still loading the widget shows an error message.
**Solution:** Move the check for missing data after the checks for loading and error state.