### PR TITLE
fix(insights): Restore querying for span op in web vitals samples

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -87,6 +87,7 @@ export function useSpanSamplesWebVitalsQuery({
         SpanIndexedField.TIMESTAMP,
         SpanIndexedField.SPAN_SELF_TIME,
         SpanIndexedField.TRANSACTION,
+        SpanIndexedField.SPAN_OP,
       ],
       enabled,
       limit,

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -169,6 +169,7 @@ describe('PageOverview', function () {
               'timestamp',
               'span.self_time',
               'transaction',
+              'span.op',
             ],
             query:
               'has:message !span.description:<unknown> transaction:/  span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press]',
@@ -218,6 +219,7 @@ describe('PageOverview', function () {
               'timestamp',
               'span.self_time',
               'transaction',
+              'span.op',
             ],
             query:
               'has:message !span.description:<unknown> transaction:"/page-with-a-\\*/"  span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press]',


### PR DESCRIPTION
Updates span samples query to also query for span op. This is needed for some conditional link rendering in the webvitals page overview samples table.