### PR TITLE
feat(uptime): Add failure_incident status type

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -41,6 +41,7 @@ import {
   type CheckStatusBucket,
   type UptimeRule,
 } from 'sentry/views/alerts/rules/uptime/types';
+import {statusToText} from 'sentry/views/insights/uptime/timelineConfig';
 
 import {DetailsTimeline} from './detailsTimeline';
 import {StatusToggleButton} from './statusToggleButton';
@@ -201,12 +202,12 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
             <CheckLegendItem>
               <CheckIndicator status={CheckStatus.SUCCESS} />
               <LegendText>
-                {t('Check succeeded')}
+                {statusToText[CheckStatus.SUCCESS]}
                 <QuestionTooltip
                   isHoverable
                   size="sm"
                   title={tct(
-                    "A check status is successful when it meets uptime's check criteria. [link:Learn more].",
+                    'A check status is considered uptime when it meets the uptime check criteria. [link:Learn more].',
                     {
                       link: (
                         <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-criteria" />
@@ -219,12 +220,30 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
             <CheckLegendItem>
               <CheckIndicator status={CheckStatus.FAILURE} />
               <LegendText>
-                {t('Check failed')}
+                {statusToText[CheckStatus.FAILURE]}
                 <QuestionTooltip
                   isHoverable
                   size="sm"
                   title={tct(
-                    "A check status is failed when it does't meet uptime's check criteria. A downtime issue is created after three consecutive failures. [link:Learn more].",
+                    'A check status is marked as flakiness when it fails but has not yet met the threshold to be considered downtime. [link:Learn more].',
+                    {
+                      link: (
+                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                      ),
+                    }
+                  )}
+                />
+              </LegendText>
+            </CheckLegendItem>
+            <CheckLegendItem>
+              <CheckIndicator status={CheckStatus.FAILURE_INCIDENT} />
+              <LegendText>
+                {statusToText[CheckStatus.FAILURE_INCIDENT]}
+                <QuestionTooltip
+                  isHoverable
+                  size="sm"
+                  title={tct(
+                    'A check status is considered downtime when it fails 3 consecutive times, meeting the downtime threshold. [link:Learn more].',
                     {
                       link: (
                         <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
@@ -238,7 +257,7 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
               <CheckLegendItem>
                 <CheckIndicator status={CheckStatus.MISSED_WINDOW} />
                 <LegendText>
-                  {t('Did not perform check')}
+                  {statusToText[CheckStatus.MISSED_WINDOW]}
                   <QuestionTooltip
                     isHoverable
                     size="sm"

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -48,12 +48,14 @@ export interface UptimeCheck {
 export enum CheckStatus {
   SUCCESS = 'success',
   FAILURE = 'failure',
+  FAILURE_INCIDENT = 'failure_incident',
   MISSED_WINDOW = 'missed_window',
 }
 
 type StatsBucket = {
   [CheckStatus.SUCCESS]: number;
   [CheckStatus.FAILURE]: number;
+  [CheckStatus.FAILURE_INCIDENT]: number;
   [CheckStatus.MISSED_WINDOW]: number;
 };
 

--- a/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
@@ -33,7 +33,8 @@ export const checkStatusToIndicatorStatus: Record<
   StatusIndicatorProps['status']
 > = {
   [CheckStatus.SUCCESS]: 'success',
-  [CheckStatus.FAILURE]: 'error',
+  [CheckStatus.FAILURE]: 'warning',
+  [CheckStatus.FAILURE_INCIDENT]: 'error',
   [CheckStatus.MISSED_WINDOW]: 'muted',
 };
 

--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -4,14 +4,16 @@ import {CheckStatus} from 'sentry/views/alerts/rules/uptime/types';
 
 // Orders the status in terms of ascending precedence for showing to the user
 export const checkStatusPrecedent: CheckStatus[] = [
+  CheckStatus.FAILURE_INCIDENT,
   CheckStatus.FAILURE,
   CheckStatus.MISSED_WINDOW,
   CheckStatus.SUCCESS,
 ];
 
 export const statusToText: Record<CheckStatus, string> = {
-  [CheckStatus.SUCCESS]: t('Success'),
-  [CheckStatus.FAILURE]: t('Failed'),
+  [CheckStatus.SUCCESS]: t('Uptime'),
+  [CheckStatus.FAILURE]: t('Flakiness'),
+  [CheckStatus.FAILURE_INCIDENT]: t('Downtime'),
   [CheckStatus.MISSED_WINDOW]: t('Unknown'),
 };
 
@@ -21,6 +23,10 @@ export const tickStyle: Record<CheckStatus, TickStyle> = {
     tickColor: 'green300',
   },
   [CheckStatus.FAILURE]: {
+    labelColor: 'green300',
+    tickColor: 'green200',
+  },
+  [CheckStatus.FAILURE_INCIDENT]: {
     labelColor: 'red400',
     tickColor: 'red300',
   },

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -151,8 +151,7 @@ describe('EventDetailsHeader', () => {
       />,
       {organization, router}
     );
-    expect(await screen.findByText('Downtime')).toBeInTheDocument();
-    expect(screen.getByText('Status Code')).toBeInTheDocument();
+    expect(await screen.findByText('Status Code')).toBeInTheDocument();
     expect(screen.getByText('500')).toBeInTheDocument();
     expect(screen.getByText('Reason')).toBeInTheDocument();
     expect(screen.getByText('bad things')).toBeInTheDocument();

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.spec.tsx
@@ -77,6 +77,7 @@ describe('IssueUptimeCheckTimeline', () => {
               [CheckStatus.SUCCESS]: 1,
               [CheckStatus.MISSED_WINDOW]: 1,
               [CheckStatus.FAILURE]: 1,
+              [CheckStatus.FAILURE_INCIDENT]: 1,
             },
           ],
         ],
@@ -95,6 +96,9 @@ describe('IssueUptimeCheckTimeline', () => {
     ).toBeInTheDocument();
     expect(
       within(legend).getByText(statusToText[CheckStatus.FAILURE])
+    ).toBeInTheDocument();
+    expect(
+      within(legend).getByText(statusToText[CheckStatus.FAILURE_INCIDENT])
     ).toBeInTheDocument();
 
     expect(screen.getByRole('figure')).toBeInTheDocument();
@@ -143,6 +147,9 @@ describe('IssueUptimeCheckTimeline', () => {
     ).not.toBeInTheDocument();
     expect(
       within(legend).getByText(statusToText[CheckStatus.FAILURE])
+    ).toBeInTheDocument();
+    expect(
+      within(legend).getByText(statusToText[CheckStatus.FAILURE_INCIDENT])
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
@@ -79,9 +79,18 @@ export function IssueUptimeCheckTimeline({group}: {group: Group}) {
       uptimeStats?.[uptimeAlertId]?.some(
         ([_, stats]) => stats[CheckStatus.MISSED_WINDOW] > 0
       );
-    return [CheckStatus.SUCCESS, CheckStatus.MISSED_WINDOW, CheckStatus.FAILURE].filter(
-      status => (hasUnknownStatus ? true : status !== CheckStatus.MISSED_WINDOW)
-    );
+
+    const statuses = [
+      CheckStatus.SUCCESS,
+      CheckStatus.FAILURE,
+      CheckStatus.FAILURE_INCIDENT,
+    ];
+
+    if (hasUnknownStatus) {
+      statuses.push(CheckStatus.MISSED_WINDOW);
+    }
+
+    return statuses;
   }, [uptimeAlertId, uptimeStats]);
 
   return (


### PR DESCRIPTION
This does a couple things:

 - Failure is renamed to "Flakiness"
 - A new status type of `failure_incident` that is labeled as
   "Downtime". This indicates we are confident the URL is actually not
   healthy.