### PR TITLE
alertlink: remove backcompat export

### DIFF
--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -1,6 +1,0 @@
-/**
- * @deprecated Use `sentry/components/core/alertLink` instead.
- */
-// biome-ignore lint/performance/noBarrelFile: Remove this once imports are fixed
-export * from 'sentry/components/core/alertLink';
-export {default} from 'sentry/components/core/alertLink';


### PR DESCRIPTION
No longer required as getsentry import has been fixed