### PR TITLE
fix(ourlogs): Add endpoint test for logs

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -30,6 +30,7 @@ from sentry.models.transaction_threshold import (
 from sentry.search.events import constants
 from sentry.testutils.cases import (
     APITransactionTestCase,
+    OurLogTestCase,
     PerformanceIssueTestCase,
     ProfilesSnubaTestCase,
     SnubaTestCase,
@@ -48,7 +49,9 @@ MAX_QUERYABLE_TRANSACTION_THRESHOLDS = 1
 pytestmark = pytest.mark.sentry_metrics
 
 
-class OrganizationEventsEndpointTestBase(APITransactionTestCase, SnubaTestCase, SpanTestCase):
+class OrganizationEventsEndpointTestBase(
+    APITransactionTestCase, SnubaTestCase, SpanTestCase, OurLogTestCase
+):
     viewname = "sentry-api-0-organization-events"
     referrer = "api.organization-events"
 

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+
+
+class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
+    dataset = "ourlogs"
+
+    def do_request(self, query, features=None, **kwargs):
+        query["useRpc"] = "1"
+        return super().do_request(query, features, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+        self.features = {
+            "organizations:ourlogs-enabled": True,
+        }
+
+    @pytest.mark.querybuilder
+    def test_simple(self):
+        logs = [
+            self.create_ourlog(
+                {"body": "foo"},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "bar"},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        response = self.do_request(
+            {
+                "field": ["log.body"],
+                "query": "",
+                "orderby": "log.body",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {"log.body": "bar"},
+            {"log.body": "foo"},
+        ]
+        assert meta["dataset"] == self.dataset
+
+    @pytest.mark.querybuilder
+    def test_timestamp_order(self):
+        logs = [
+            self.create_ourlog(
+                {"body": "bar"},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "foo"},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        response = self.do_request(
+            {
+                "field": ["log.body", "timestamp"],
+                "query": "",
+                "orderby": "timestamp",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+
+        for log, source in zip(data, logs):
+            assert log["log.body"] == source["body"]
+            ts = datetime.fromisoformat(log["timestamp"])
+            assert ts.tzinfo == timezone.utc
+            timestamp_from_nanos = source["timestamp_nanos"] / 1_000_000_000
+            assert ts.timestamp() == pytest.approx(timestamp_from_nanos, abs=5), "timestamp"
+
+        assert meta["dataset"] == self.dataset


### PR DESCRIPTION
### Summary
Adds a test case, storage, and two tests; a simple test, and one ordered by timestamp.
