### PR TITLE
fix(issue-views): Fixes only project in URL case

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -254,10 +254,10 @@ const hasUnsavedChanges = (
         : undefined,
     querySort:
       querySort && issueSortOption !== originalSort ? issueSortOption : undefined,
-    projects: !isEqual(queryProjects.sort(), originalProjects.sort())
+    projects: !isEqual(queryProjects?.sort(), originalProjects.sort())
       ? queryProjects
       : undefined,
-    environments: !isEqual(queryEnvs.sort(), originalEnvironments.sort())
+    environments: !isEqual(queryEnvs?.sort(), originalEnvironments.sort())
       ? queryEnvs
       : undefined,
     timeFilters:

--- a/static/app/views/issueList/issueViewsHeaderPF.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.spec.tsx
@@ -75,6 +75,15 @@ describe('IssueViewsHeader', () => {
     }),
   });
 
+  const projectsOnlyRouter = RouterFixture({
+    location: LocationFixture({
+      pathname: `/organizations/${organization.slug}/issues/`,
+      query: {
+        project: '1',
+      },
+    }),
+  });
+
   const unsavedTabRouter = RouterFixture({
     location: LocationFixture({
       pathname: `/organizations/${organization.slug}/issues/`,
@@ -147,6 +156,29 @@ describe('IssueViewsHeader', () => {
             query: getRequestViews[0]!.query,
             viewId: getRequestViews[0]!.id,
             sort: getRequestViews[0]!.querySort,
+          }),
+        })
+      );
+    });
+
+    it('renders the first tab with the projects from the query params if no other query params are present', async () => {
+      render(
+        <IssueViewsPFIssueListHeader {...defaultProps} router={projectsOnlyRouter} />,
+        {
+          organization,
+          router: projectsOnlyRouter,
+        }
+      );
+
+      expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
+
+      expect(projectsOnlyRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: getRequestViews[0]!.query,
+            viewId: getRequestViews[0]!.id,
+            sort: getRequestViews[0]!.querySort,
+            project: [1],
           }),
         })
       );

--- a/static/app/views/issueList/issueViewsHeaderPF.tsx
+++ b/static/app/views/issueList/issueViewsHeaderPF.tsx
@@ -198,35 +198,6 @@ function IssueViewsIssueListHeaderTabsContent({
       statsPeriod,
       utc,
     } = router.location.query;
-    // If no query, sort, or viewId is present, set the first tab as the selected tab, update query accordingly
-    if (!query && !sort && !viewId) {
-      const {
-        id,
-        query: viewQuery,
-        querySort,
-        projects,
-        environments,
-        timeFilters,
-      } = views[0]!;
-
-      navigate(
-        normalizeUrl({
-          ...location,
-          query: {
-            ...router.location.query,
-            query: viewQuery,
-            sort: querySort,
-            viewId: id,
-            project: projects,
-            environment: environments,
-            ...normalizeDateTimeParams(timeFilters),
-          },
-        }),
-        {replace: true}
-      );
-      tabListState?.setSelectedKey(views[0]!.key);
-      return;
-    }
     const {queryEnvs, queryProjects} = normalizeProjectsEnvironments(project, env);
     const queryTimeFilters =
       start || end || statsPeriod || utc
@@ -237,6 +208,54 @@ function IssueViewsIssueListHeaderTabsContent({
             utc: statsPeriod ? null : utc,
           }
         : undefined;
+    if (!viewId) {
+      const {
+        id,
+        query: viewQuery,
+        querySort,
+        projects,
+        environments,
+        timeFilters,
+      } = views[0]!;
+      if (queryProjects || queryTimeFilters) {
+        navigate(
+          normalizeUrl({
+            ...location,
+            query: {
+              ...router.location.query,
+              viewId: id,
+              query: query ?? viewQuery,
+              sort: sort ?? querySort,
+              project: queryProjects ?? projects,
+              environment: queryEnvs ?? environments,
+              ...normalizeDateTimeParams(queryTimeFilters ?? timeFilters),
+            },
+          }),
+          {replace: true}
+        );
+        tabListState?.setSelectedKey(views[0]!.key);
+        return;
+      }
+      if (!query && !sort) {
+        navigate(
+          normalizeUrl({
+            ...location,
+            query: {
+              ...router.location.query,
+              viewId: id,
+              query: viewQuery,
+              sort: querySort,
+              project: projects,
+              environment: environments,
+              ...normalizeDateTimeParams(timeFilters),
+            },
+          }),
+          {replace: true}
+        );
+        tabListState?.setSelectedKey(views[0]!.key);
+        return;
+      }
+    }
     // if a viewId is present, check the frontend is aware of a view with that id.
     if (viewId) {
       const selectedView = views.find(tab => tab.id === viewId);
@@ -258,10 +277,10 @@ function IssueViewsIssueListHeaderTabsContent({
         const newUnsavedChanges: Partial<IssueViewPFParams> = {
           query: query === originalQuery ? undefined : query,
           querySort: sort === originalSort ? undefined : issueSortOption,
-          projects: isEqual(queryProjects.sort(), originalProjects.sort())
+          projects: isEqual(queryProjects?.sort(), originalProjects.sort())
             ? undefined
             : queryProjects,
-          environments: isEqual(queryEnvs.sort(), originalEnvironments.sort())
+          environments: isEqual(queryEnvs?.sort(), originalEnvironments.sort())
             ? undefined
             : queryEnvs,
           timeFilters:
@@ -496,8 +515,8 @@ export default IssueViewsPFIssueListHeader;
 export const normalizeProjectsEnvironments = (
   project: string[] | string | undefined,
   env: string[] | string | undefined
-): {queryEnvs: string[]; queryProjects: number[]} => {
-  let queryProjects: number[] = [];
+): {queryEnvs: string[] | undefined; queryProjects: number[] | undefined} => {
+  let queryProjects: number[] | undefined = undefined;
   if (Array.isArray(project)) {
     queryProjects = project.map(p => parseInt(p, 10)).filter(p => !isNaN(p));
   } else if (project) {
@@ -507,7 +526,7 @@ export const normalizeProjectsEnvironments = (
     }
   }
 
-  let queryEnvs: string[] = [];
+  let queryEnvs: string[] | undefined = undefined;
   if (Array.isArray(env)) {
     queryEnvs = env;
   } else if (env) {


### PR DESCRIPTION
Fixes a bug where having only a project query param in your URL would overwrite the project and just redirect you to your first view. This PR includes some new product logic that is detailed in the diff. 

Fixes #85100 and #85629