### PR TITLE
fix(issues): Add check for left nav

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1071,13 +1071,14 @@ function IssueListOverview({router}: Props) {
   const displayReprocessingActions = showReprocessingTab && query === Query.REPROCESSING;
 
   const hasLeftNavIssueViews = organization.features.includes('left-nav-issue-views');
+  const hasNavigationSidebarV2 = organization.features.includes('navigation-sidebar-v2');
 
   const {numPreviousIssues, numIssuesOnPage} = getPageCounts();
 
   return (
     <NewTabContextProvider>
       <Layout.Page>
-        {hasLeftNavIssueViews && (
+        {hasLeftNavIssueViews && hasNavigationSidebarV2 && (
           <LeftNavViewsHeader selectedProjectIds={selection.projects} />
         )}
         {!hasLeftNavIssueViews &&


### PR DESCRIPTION
if you had the left-nav-issue-views flag, but your org didn't have the navigation-sidebar-v2 flag, you would see the old sentry, but with no tabs. (There were only a handful of internal users with these conditions) 