### PR TITLE
fix(widget-builder): Push a default when switching to chart type

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -689,6 +689,40 @@ describe('useWidgetBuilderState', () => {
         {field: 'crash_free_rate(session)', kind: 'desc'},
       ]);
     });
+
+    it('adds the default y-axis when switching a table to a chart with no aggregate', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.TRANSACTIONS,
+            displayType: DisplayType.TABLE,
+            field: ['transaction'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.LINE,
+        });
+      });
+
+      expect(result.current.state.yAxis).toEqual([
+        {
+          function: ['count_unique', 'user', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+      expect(result.current.state.fields).toEqual([
+        {field: 'transaction', alias: undefined, kind: 'field'},
+      ]);
+    });
   });
 
   describe('dataset', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -191,6 +191,7 @@ function useWidgetBuilderState(): {
 
   const dispatch = useCallback(
     (action: WidgetAction) => {
+      const currentDatasetConfig = getDatasetConfig(dataset);
       switch (action.type) {
         case BuilderStateAction.SET_TITLE:
           setTitle(action.payload);
@@ -267,10 +268,17 @@ function useWidgetBuilderState(): {
             setQuery(query?.slice(0, 1));
           } else {
             setFields(columnsWithoutAlias);
-            setYAxis([
+            const nextAggregates = [
               ...aggregatesWithoutAlias.slice(0, MAX_NUM_Y_AXES),
               ...(yAxisWithoutAlias?.slice(0, MAX_NUM_Y_AXES) ?? []),
-            ]);
+            ];
+            if (nextAggregates.length === 0) {
+              nextAggregates.push({
+                ...currentDatasetConfig.defaultField,
+                alias: undefined,
+              });
+            }
+            setYAxis(nextAggregates);
 
             if (dataset === WidgetType.RELEASE && sort?.length === 0) {
               setSort(


### PR DESCRIPTION
If you have a table and only apply a group by field, switching to a chart type leaves the visualize section blank since there are no aggregates. If there are none to carry over, push the default field (which is always an aggregate right now) into the state.