### PR TITLE
fix(eap-alerts): typed numeric tags support in validation

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -60,7 +60,7 @@ from sentry.search.events.constants import (
     METRICS_LAYER_UNSUPPORTED_TRANSACTION_METRICS_FUNCTIONS,
     SPANS_METRICS_FUNCTIONS,
 )
-from sentry.search.events.fields import is_function, resolve_field
+from sentry.search.events.fields import is_function, is_typed_numeric_tag, resolve_field
 from sentry.search.events.types import SnubaParams
 from sentry.seer.anomaly_detection.delete_rule import delete_rule_in_seer
 from sentry.seer.anomaly_detection.store_data import send_new_rule_data, update_rule_data
@@ -1813,6 +1813,7 @@ def check_aggregate_column_support(
             and column in INSIGHTS_FUNCTION_VALID_ARGS_MAP.get(function, [])
         )
         or (column in EAP_COLUMNS and allow_eap)
+        or (is_typed_numeric_tag(column) and allow_eap)
     )
 
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -670,6 +670,13 @@ def is_function(field: str) -> Match[str] | None:
     return FUNCTION_PATTERN.search(field)
 
 
+def is_typed_numeric_tag(key: str) -> bool:
+    match = TYPED_TAG_KEY_RE.search(key)
+    if match and match.group("type") == "number":
+        return True
+    return False
+
+
 def get_function_alias(field: str) -> str:
     match = FUNCTION_PATTERN.search(field)
     if match is None:


### PR DESCRIPTION
Allow typed numeric tags for EAP in validation.
I'll add tests in a follow up so we can get the fix out