### PR TITLE
ref(theme): Darken `gray300`

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -583,7 +583,7 @@ const lightColors: Colors = {
 
   gray500: '#2B2233',
   gray400: '#3E3446',
-  gray300: '#80708F',
+  gray300: '#71637E',
   gray200: '#E0DCE5',
   gray100: '#F0ECF3',
 


### PR DESCRIPTION
Darken `gray300` (`subText` color) from 50% lightness (in the HSL color model) down to 44% for better contrast, especially against `backgroundSecondary`.

**Before ——**
![image](https://github.com/user-attachments/assets/22c55f61-1fe1-4a01-bc49-8b24d01dade8)

**After —**
![image](https://github.com/user-attachments/assets/8409cc96-d05d-480a-9c3b-7e5da59a1720)
