### PR TITLE
feat(widget-builder): Sort the column and aggregate options

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -483,7 +483,8 @@ function Visualize({error, setError}: VisualizeProps) {
                             option.value.kind,
                             option.value.meta.name
                           ),
-                        })),
+                        }))
+                        .sort(_sortFn),
                     ];
                   } else {
                     // Add column options to the aggregate dropdown for non-Issue and non-Spans datasets
@@ -506,7 +507,8 @@ function Visualize({error, setError}: VisualizeProps) {
                               ? option.value.meta.dataType!
                               : undefined
                           ),
-                        })),
+                        }))
+                        .sort(_sortFn),
                     ];
                   }
                 }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, type ReactNode, useMemo, useState} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import type {Theme} from '@emotion/react';
@@ -109,6 +109,30 @@ function formatColumnOptions(
     });
 }
 
+function _sortFn(
+  a: SelectValue<string> & {value: string; label?: string | ReactNode},
+  b: SelectValue<string> & {value: string; label?: string | ReactNode}
+) {
+  // The labels should always be strings in this component, but we'll
+  // handle the cases where they are not.
+  if (typeof a.label !== 'string' && typeof b.label !== 'string') {
+    return 0;
+  }
+  if (!defined(a.label) || !defined(b.label)) {
+    return 0;
+  }
+
+  if (a.label < b.label) {
+    return -1;
+  }
+
+  if (a.label > b.label) {
+    return 1;
+  }
+
+  return 0;
+}
+
 export function getColumnOptions(
   dataset: WidgetType,
   selectedField: QueryFieldValue,
@@ -120,7 +144,12 @@ export function getColumnOptions(
 ) {
   const fieldValues = Object.values(fieldOptions);
   if (selectedField.kind !== FieldValueKind.FUNCTION || dataset === WidgetType.SPANS) {
-    return formatColumnOptions(dataset, fieldValues, columnFilterMethod, selectedField);
+    return formatColumnOptions(
+      dataset,
+      fieldValues,
+      columnFilterMethod,
+      selectedField
+    ).sort(_sortFn);
   }
 
   const fieldData = fieldValues.find(
@@ -168,11 +197,16 @@ export function getColumnOptions(
             option.value.kind === FieldValueKind.BREAKDOWN) &&
           validateColumnTypes(parameter.columnTypes as ValidateColumnTypes, option.value),
         selectedField
-      );
+      ).sort(_sortFn);
     }
   }
 
-  return formatColumnOptions(dataset, fieldValues, columnFilterMethod, selectedField);
+  return formatColumnOptions(
+    dataset,
+    fieldValues,
+    columnFilterMethod,
+    selectedField
+  ).sort(_sortFn);
 }
 
 function canDeleteField(
@@ -287,17 +321,7 @@ function Visualize({error, setError}: VisualizeProps) {
         };
       }),
     ];
-    spanColumnOptions.sort((a, b) => {
-      if (a.label < b.label) {
-        return -1;
-      }
-
-      if (a.label > b.label) {
-        return 1;
-      }
-
-      return 0;
-    });
+    spanColumnOptions.sort(_sortFn);
   }
 
   const datasetConfig = useMemo(() => getDatasetConfig(state.dataset), [state.dataset]);

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -115,22 +115,14 @@ function _sortFn(
 ) {
   // The labels should always be strings in this component, but we'll
   // handle the cases where they are not.
-  if (typeof a.label !== 'string' && typeof b.label !== 'string') {
+  if (typeof a.label !== 'string' || typeof b.label !== 'string') {
     return 0;
   }
   if (!defined(a.label) || !defined(b.label)) {
     return 0;
   }
 
-  if (a.label < b.label) {
-    return -1;
-  }
-
-  if (a.label > b.label) {
-    return 1;
-  }
-
-  return 0;
+  return a.label.localeCompare(b.label);
 }
 
 export function getColumnOptions(


### PR DESCRIPTION
Applies sorting to the code paths that produce the options for rendering in our lists. For columns I can just sort all the return statements of `getColumnOptions`, for aggregates I need to sort the values, except the functions because those need to stay at the top.