### PR TITLE
ref(theme): Darken `surface200`

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -567,7 +567,7 @@ const lightColors: Colors = {
   lightModeWhite: '#FFFFFF',
 
   surface100: '#F5F3F7',
-  surface200: '#FAF9FB',
+  surface200: '#F7F6F9',
   surface300: '#FFFFFF',
   surface400: '#FFFFFF',
 


### PR DESCRIPTION
Make `surface200` (`backgroundSecondary`) one stop darker to provide better contrast against `gray300` (`background`), which will make stacking levels more apparent.

The [recently updated `gray300`](https://github.com/getsentry/sentry/pull/85671) has been tested against this new value, with a 5.14 contrast ratio.

**Before —**
<img width="450" alt="Screenshot 2025-02-21 at 11 37 47 AM" src="https://github.com/user-attachments/assets/7c69d26f-b0a3-44e4-a469-216673b2f0c8" />

**After —**
<img width="450" alt="Screenshot 2025-02-21 at 11 37 26 AM" src="https://github.com/user-attachments/assets/a301d2a8-f7ef-43f5-9768-864875eab8b5" />
