### PR TITLE
ref(nav): Adjust margins for secondary nav items, body, and issue view items

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -284,8 +284,7 @@ const hasUnsavedChanges = (
 const TrailingItemsWrapper = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(0.5)};
-  margin-right: ${space(0.5)};
+  margin-right: ${space(0.25)};
 `;
 
 const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
@@ -323,7 +322,7 @@ const UnsavedChangesIndicator = styled('div')<{isActive: boolean}>`
 
   border-radius: 50%;
   background: ${p => p.theme.purple400};
-  border: solid 2px ${p => p.theme.background};
+  border: solid 2px ${p => p.theme.surface200};
   position: absolute;
   width: 12px;
   height: 12px;

--- a/static/app/components/nav/issueViews/issueViewProjectIcons.tsx
+++ b/static/app/components/nav/issueViews/issueViewProjectIcons.tsx
@@ -45,7 +45,7 @@ const IconWrap = styled('div')`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-right: ${space(1)};
+  margin-right: ${space(0.75)};
 `;
 
 const IconContainer = styled('div')`
@@ -58,7 +58,7 @@ const IconContainer = styled('div')`
 const BorderOverlay = styled('div')`
   position: absolute;
   inset: 0;
-  border: 1px solid ${p => p.theme.translucentGray200};
+  border: 1px solid ${p => p.theme.translucentGray100};
   border-radius: 3px;
   pointer-events: none;
   z-index: 1;

--- a/static/app/components/nav/secondary.tsx
+++ b/static/app/components/nav/secondary.tsx
@@ -146,7 +146,7 @@ const Header = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.subText};
-  padding: 0 ${space(1)} 0 ${space(3)};
+  padding: 0 ${space(1)} 0 ${space(2)};
   height: 44px;
   border-bottom: 1px solid ${p => p.theme.innerBorder};
 
@@ -177,7 +177,7 @@ const Section = styled('div')`
 const SectionTitle = styled('div')<{layout: NavLayout}>`
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.subText};
-  padding: 0 ${space(1.5)};
+  padding: 0 ${space(1)};
   margin: ${space(2)} 0 ${space(0.5)} 0;
 
   ${p =>
@@ -199,7 +199,7 @@ const SectionSeparator = styled('hr')`
 const Item = styled(Link)<{layout: NavLayout}>`
   position: relative;
   display: flex;
-  padding: 4px ${space(1.5)};
+  padding: 4px ${space(1)};
   height: 34px;
   align-items: center;
   color: ${p => p.theme.textColor};
@@ -244,7 +244,7 @@ const ItemText = styled('span')`
 `;
 
 const Footer = styled('div')<{layout: NavLayout}>`
-  padding: ${space(1)} ${space(1.5)};
+  padding: ${space(1)} ${space(1)};
   border-top: 1px solid ${p => p.theme.innerBorder};
 
   ${p =>


### PR DESCRIPTION
Slightly reduces margins for all components in the left nav and within issue views. This should give more room for the labels without looking too cramped. 
(Approved by Vu)

Before:

![image](https://github.com/user-attachments/assets/6a07802b-3b4b-4be0-8eb9-3c6d1b58d9e2)


After:

![image](https://github.com/user-attachments/assets/09b26d35-422b-4cf9-83d7-97a18406b094)
