### PR TITLE
ref(aci): skip disabled workflows in process_workflows

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -127,7 +127,9 @@ def process_workflows(job: WorkflowJob) -> set[Workflow]:
         return set()
 
     # Get the workflows, evaluate the when_condition_group, finally evaluate the actions for workflows that are triggered
-    workflows = set(Workflow.objects.filter(detectorworkflow__detector_id=detector.id).distinct())
+    workflows = set(
+        Workflow.objects.filter(detectorworkflow__detector_id=detector.id, enabled=True).distinct()
+    )
 
     if workflows:
         metrics.incr(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -60,6 +60,25 @@ class TestProcessWorkflows(BaseWorkflowTest):
             }
         )
 
+    def test_skips_disabled_workflows(self):
+        workflow_triggers = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=workflow_triggers,
+            type=Condition.EVENT_SEEN_COUNT,
+            comparison=1,
+            condition_result=True,
+        )
+        workflow = self.create_workflow(
+            name="disabled_workflow", when_condition_group=workflow_triggers, enabled=False
+        )
+        self.create_detector_workflow(
+            detector=self.error_detector,
+            workflow=workflow,
+        )
+
+        triggered_workflows = process_workflows(self.job)
+        assert triggered_workflows == {self.error_workflow}
+
     def test_error_event(self):
         triggered_workflows = process_workflows(self.job)
         assert triggered_workflows == {self.error_workflow}


### PR DESCRIPTION
We should skip processing workflows that have `enabled=False`.