### PR TITLE
feat(ourlogs): Add log ingestion sample rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -536,6 +536,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Ingest only a random fraction of logs sent to relay. Used to roll out ourlogs ingestion.
+#
+# NOTE: Any value below 1.0 will cause customer data to not appear and can break the product. Do not override in production.
+register(
+    "relay.ourlogs-ingestion.sample-rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Extract spans only from a random fraction of transactions.
 #
 # NOTE: Any value below 1.0 will break the product. Do not override in production.

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -21,6 +21,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.metric-bucket-set-encodings",
     "relay.metric-bucket-distribution-encodings",
     "relay.metric-stats.rollout-rate",
+    "relay.ourlogs-ingestion.sample-rate",
     "relay.ourlogs-breadcrumb-extraction.sample-rate",
     "relay.ourlogs-breadcrumb-extraction.max-breadcrumbs-converted",
     "relay.span-extraction.sample-rate",


### PR DESCRIPTION
### Summary
We're moving to sharing the EAP cluster for logs. In order to safely roll out logs onto the existing cluster, we want to be able to control processing into the kafka topics, consumers and storage, one project at a time in production.
