### PR TITLE
ref(issue-views): Delete all PF suffixes, remove pagefilter flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -148,8 +148,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-search-group-attributes-side-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable custom views features in the issue stream
     manager.add("organizations:issue-stream-custom-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable saving page filters to issue views
-    manager.add("organizations:issue-views-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable left nav issue views
     manager.add("organizations:left-nav-issue-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the updated empty state for issues

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -148,6 +148,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-search-group-attributes-side-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable custom views features in the issue stream
     manager.add("organizations:issue-stream-custom-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable saving page filters to issue views
+    manager.add("organizations:issue-views-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable left nav issue views
     manager.add("organizations:left-nav-issue-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the updated empty state for issues

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -34,14 +34,14 @@ import {useDimensionsMultiple} from 'sentry/utils/useDimensionsMultiple';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
-  IssueViewsPFContext,
+  IssueViewsContext,
   TEMPORARY_TAB_KEY,
-} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+} from 'sentry/views/issueList/issueViews/issueViews';
 
 import type {DraggableTabListItemProps} from './item';
 import {Item} from './item';
 
-interface BaseDraggableTabListProps extends DraggableTabListPFProps {
+interface BaseDraggableTabListProps extends DraggableTabListProps {
   items: DraggableTabListItemProps[];
 }
 
@@ -278,7 +278,7 @@ function BaseDraggableTabList({
 }: BaseDraggableTabListProps) {
   const navigate = useNavigate();
   const [hoveringKey, setHoveringKey] = useState<Key | null>(null);
-  const {rootProps, setTabListState} = useContext(IssueViewsPFContext);
+  const {rootProps, setTabListState} = useContext(IssueViewsContext);
   const organization = useOrganization();
   const {
     value,
@@ -403,7 +403,7 @@ function BaseDraggableTabList({
 
 const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
 
-export interface DraggableTabListPFProps
+export interface DraggableTabListProps
   extends AriaTabListOptions<DraggableTabListItemProps>,
     TabListStateOptions<DraggableTabListItemProps> {
   onReorder: (newOrder: Array<Node<DraggableTabListItemProps>>) => void;
@@ -421,11 +421,7 @@ export interface DraggableTabListPFProps
  * To be used as a direct child of the <Tabs /> component. See example usage
  * in tabs.stories.js
  */
-export function DraggableTabListPF({
-  items,
-  onAddView,
-  ...props
-}: DraggableTabListPFProps) {
+export function DraggableTabList({items, onAddView, ...props}: DraggableTabListProps) {
   const collection = useCollection({items, ...props}, collectionFactory);
 
   const parsedItems = useMemo(
@@ -454,7 +450,7 @@ export function DraggableTabListPF({
   );
 }
 
-DraggableTabListPF.Item = Item;
+DraggableTabList.Item = Item;
 
 const TabItemWrap = styled(Reorder.Item, {
   shouldForwardProp: prop => prop !== 'isSelected',

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -10,15 +10,15 @@ import {space} from 'sentry/styles/space';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 
 interface IssueViewNavEllipsisMenuProps {
   baseUrl: string;
   deleteView: () => void;
   duplicateView: () => void;
   setIsEditing: (isEditing: boolean) => void;
-  updateView: (view: IssueViewPF) => void;
-  view: IssueViewPF;
+  updateView: (view: IssueView) => void;
+  view: IssueView;
   sectionRef?: React.RefObject<HTMLDivElement>;
 }
 
@@ -153,7 +153,7 @@ function FeedbackFooter() {
   );
 }
 
-const constructViewLink = (baseUrl: string, view: IssueViewPF) => {
+const constructViewLink = (baseUrl: string, view: IssueView) => {
   return normalizeUrl({
     pathname: `${baseUrl}/views/${view.id}/`,
     query: {

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -21,11 +21,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {normalizeProjectsEnvironments} from 'sentry/views/issueList/issueViewsHeaderPF';
 import type {
-  IssueViewPF,
-  IssueViewPFParams,
-} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+  IssueView,
+  IssueViewParams,
+} from 'sentry/views/issueList/issueViews/issueViews';
+import {normalizeProjectsEnvironments} from 'sentry/views/issueList/issueViewsHeader';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 export interface IssueViewNavItemContentProps {
@@ -44,11 +44,11 @@ export interface IssueViewNavItemContentProps {
   /**
    * A callback function that updates the view with new params.
    */
-  updateView: (updatedView: IssueViewPF) => void;
+  updateView: (updatedView: IssueView) => void;
   /**
    * The issue view to display
    */
-  view: IssueViewPF;
+  view: IssueView;
   /**
    * Ref to the body of the section that contains the reorderable items.
    * This is used as the portal container for the ellipsis menu, and as
@@ -187,10 +187,10 @@ const READABLE_PARAM_MAPPING = {
   timeFilters: t('time range'),
 };
 
-const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewPFParams>) => {
+const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewParams>) => {
   const changedParams = Object.keys(unsavedChanges)
-    .filter(k => unsavedChanges[k as keyof IssueViewPFParams] !== undefined)
-    .map(k => READABLE_PARAM_MAPPING[k as keyof IssueViewPFParams]);
+    .filter(k => unsavedChanges[k as keyof IssueViewParams] !== undefined)
+    .map(k => READABLE_PARAM_MAPPING[k as keyof IssueViewParams]);
 
   return (
     <Fragment>
@@ -204,9 +204,9 @@ const constructUnsavedTooltipTitle = (unsavedChanges: Partial<IssueViewPFParams>
 
 // TODO(msun): Once nuqs supports native array query params, we can use that here and replace this absurd function
 const hasUnsavedChanges = (
-  view: IssueViewPF,
+  view: IssueView,
   queryParams: Location['query']
-): false | Partial<IssueViewPFParams> => {
+): false | Partial<IssueViewParams> => {
   const {
     query: originalQuery,
     querySort: originalSort,
@@ -246,7 +246,7 @@ const hasUnsavedChanges = (
     ? (querySort as IssueSortOptions)
     : undefined;
 
-  const newUnsavedChanges: Partial<IssueViewPFParams> = {
+  const newUnsavedChanges: Partial<IssueViewParams> = {
     query:
       queryQuery !== null &&
       queryQuery !== undefined &&

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -10,14 +10,14 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
-import {generateTempViewId} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
+import {generateTempViewId} from 'sentry/views/issueList/issueViews/issueViews';
 import {useUpdateGroupSearchViews} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViews';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 interface IssueViewNavItemsProps {
   baseUrl: string;
-  loadedViews: IssueViewPF[];
+  loadedViews: IssueView[];
   sectionRef: React.RefObject<HTMLDivElement>;
 }
 
@@ -33,7 +33,7 @@ export function IssueViewNavItems({
 
   const queryParams = location.query;
 
-  const [views, setViews] = useState<IssueViewPF[]>(loadedViews);
+  const [views, setViews] = useState<IssueView[]>(loadedViews);
 
   // If the `viewId` (from `/issues/views/:viewId`) is not found in the views array,
   // then redirect to the "All Issues" page
@@ -106,7 +106,7 @@ export function IssueViewNavItems({
 
   const debounceUpdateViews = useMemo(
     () =>
-      debounce((newTabs: IssueViewPF[]) => {
+      debounce((newTabs: IssueView[]) => {
         if (newTabs) {
           updateViews({
             orgSlug: organization.slug,
@@ -133,7 +133,7 @@ export function IssueViewNavItems({
   );
 
   const handleReorder = useCallback(
-    (newOrder: IssueViewPF[]) => {
+    (newOrder: IssueView[]) => {
       setViews(newOrder);
       debounceUpdateViews(newOrder);
     },
@@ -141,7 +141,7 @@ export function IssueViewNavItems({
   );
 
   const handleUpdateView = useCallback(
-    (view: IssueViewPF, updatedView: IssueViewPF) => {
+    (view: IssueView, updatedView: IssueView) => {
       const newViews = views.map(v => {
         if (v.id === view.id) {
           return updatedView;
@@ -155,7 +155,7 @@ export function IssueViewNavItems({
   );
 
   const handleDeleteView = useCallback(
-    (view: IssueViewPF) => {
+    (view: IssueView) => {
       const newViews = views.filter(v => v.id !== view.id);
       setViews(newViews);
       debounceUpdateViews(newViews);
@@ -170,7 +170,7 @@ export function IssueViewNavItems({
   );
 
   const handleDuplicateView = useCallback(
-    (view: IssueViewPF) => {
+    (view: IssueView) => {
       const idx = views.findIndex(v => v.id === view.id);
       if (idx !== -1) {
         const newViewId = generateTempViewId();
@@ -219,7 +219,7 @@ export function IssueViewNavItems({
   );
 }
 
-export const constructViewLink = (baseUrl: string, view: IssueViewPF) => {
+export const constructViewLink = (baseUrl: string, view: IssueView) => {
   return normalizeUrl({
     pathname: `${baseUrl}/views/${view.id}/`,
     query: {

--- a/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavQueryCount.tsx
@@ -6,7 +6,7 @@ import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
 
 const TAB_MAX_COUNT = 99;
@@ -29,7 +29,7 @@ const constructCountTimeFrame = (
 };
 
 interface IssueViewNavQueryCountProps {
-  view: IssueViewPF;
+  view: IssueView;
 }
 
 export function IssueViewNavQueryCount({view}: IssueViewNavQueryCountProps) {

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -22,15 +22,13 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
-  const hasPageFiltersPersistence = organization.features.includes(
-    'issue-views-page-filter'
-  );
+  const hasIssueViews = organization.features.includes('issue-stream-custom-views');
 
   return (
     <FiltersContainer hasNewLayout={hasNewLayout}>
       <GuideAnchor
         target="issue_views_page_filters_persistence"
-        disabled={!hasPageFiltersPersistence}
+        disabled={!hasIssueViews}
       >
         <StyledPageFilterBar>
           <ProjectPageFilter />

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -16,8 +16,8 @@ function IssueListContainer({children}: Props) {
   return (
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>
       <PageFiltersContainer
-        skipLoadLastUsed={organization.features.includes('issue-views-page-filter')}
-        disablePersistence={organization.features.includes('issue-views-page-filter')}
+        skipLoadLastUsed={organization.features.includes('issue-stream-custom-views')}
+        disablePersistence={organization.features.includes('issue-stream-custom-views')}
       >
         <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
       </PageFiltersContainer>

--- a/static/app/views/issueList/issueViews/editableTabTitle.tsx
+++ b/static/app/views/issueList/issueViews/editableTabTitle.tsx
@@ -6,7 +6,7 @@ import {motion} from 'framer-motion';
 import {GrowingInput} from 'sentry/components/growingInput';
 import {Tooltip} from 'sentry/components/tooltip';
 
-interface EditableTabTitlePFProps {
+interface EditableTabTitleProps {
   isEditing: boolean;
   isSelected: boolean;
   label: string;
@@ -15,14 +15,14 @@ interface EditableTabTitlePFProps {
   disableEditing?: boolean;
 }
 
-function EditableTabTitlePF({
+function EditableTabTitle({
   label,
   onChange,
   isEditing,
   isSelected,
   setIsEditing,
   disableEditing,
-}: EditableTabTitlePFProps) {
+}: EditableTabTitleProps) {
   const [inputValue, setInputValue] = useState(label);
 
   useEffect(() => {
@@ -136,7 +136,7 @@ function EditableTabTitlePF({
   );
 }
 
-export default EditableTabTitlePF;
+export default EditableTabTitle;
 
 const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
   height: 20px;

--- a/static/app/views/issueList/issueViews/issueViewEllipsisMenu.tsx
+++ b/static/app/views/issueList/issueViews/issueViewEllipsisMenu.tsx
@@ -7,17 +7,17 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 
-interface IssueViewEllipsisMenuPFProps {
+interface IssueViewEllipsisMenuProps {
   menuOptions: MenuItemProps[];
   'aria-label'?: string;
   hasUnsavedChanges?: boolean;
 }
 
-export function IssueViewEllipsisMenuPF({
+export function IssueViewEllipsisMenu({
   hasUnsavedChanges = false,
   menuOptions,
   ...props
-}: IssueViewEllipsisMenuPFProps) {
+}: IssueViewEllipsisMenuProps) {
   return (
     <TriggerIconWrap>
       <StyledDropdownMenu

--- a/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/issueList/issueViews/issueViewQueryCount.tsx
@@ -6,7 +6,7 @@ import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
 
 const TAB_MAX_COUNT = 99;
@@ -28,11 +28,11 @@ const constructCountTimeFrame = (
   };
 };
 
-interface IssueViewQueryCountPFProps {
-  view: IssueViewPF;
+interface IssueViewQueryCountProps {
+  view: IssueView;
 }
 
-export function IssueViewQueryCountPF({view}: IssueViewQueryCountPFProps) {
+export function IssueViewQueryCount({view}: IssueViewQueryCountProps) {
   const organization = useOrganization();
   const theme = useTheme();
 

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -7,35 +7,35 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {t} from 'sentry/locale';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import EditableTabTitlePF from 'sentry/views/issueList/issueViewsPF/editableTabTitlePF';
-import {IssueViewEllipsisMenuPF} from 'sentry/views/issueList/issueViewsPF/issueViewEllipsisMenuPF';
-import {IssueViewQueryCountPF} from 'sentry/views/issueList/issueViewsPF/issueViewQueryCountPF';
+import EditableTabTitle from 'sentry/views/issueList/issueViews/editableTabTitle';
+import {IssueViewEllipsisMenu} from 'sentry/views/issueList/issueViews/issueViewEllipsisMenu';
+import {IssueViewQueryCount} from 'sentry/views/issueList/issueViews/issueViewQueryCount';
 import {
   generateTempViewId,
-  type IssueViewPF,
-  IssueViewsPFContext,
+  type IssueView,
+  IssueViewsContext,
   TEMPORARY_TAB_KEY,
-} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+} from 'sentry/views/issueList/issueViews/issueViews';
 
-interface IssueViewPFTabProps {
+interface IssueViewTabProps {
   editingTabKey: string | null;
   initialTabKey: string;
   router: InjectedRouter;
   setEditingTabKey: (key: string | null) => void;
-  view: IssueViewPF;
+  view: IssueView;
 }
 
-export function IssueViewPFTab({
+export function IssueViewTab({
   editingTabKey,
   initialTabKey,
   router,
   setEditingTabKey,
   view,
-}: IssueViewPFTabProps) {
+}: IssueViewTabProps) {
   const navigate = useNavigate();
 
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location?.query ?? {};
-  const {tabListState, state, dispatch} = useContext(IssueViewsPFContext);
+  const {tabListState, state, dispatch} = useContext(IssueViewsContext);
   const {views} = state;
 
   const handleDuplicateView = () => {
@@ -79,7 +79,7 @@ export function IssueViewPFTab({
     }
   };
 
-  const handleDeleteView = (tab: IssueViewPF) => {
+  const handleDeleteView = (tab: IssueView) => {
     dispatch({type: 'DELETE_VIEW', syncViews: true});
     // Including this logic in the dispatch call breaks the tests for some reason
     // so we're doing it here instead
@@ -101,7 +101,7 @@ export function IssueViewPFTab({
     });
   };
 
-  const makeMenuOptions = (tab: IssueViewPF): MenuItemProps[] => {
+  const makeMenuOptions = (tab: IssueView): MenuItemProps[] => {
     if (tab.key === TEMPORARY_TAB_KEY) {
       return makeTempViewMenuOptions({
         onSaveTempView: handleSaveTempView,
@@ -126,7 +126,7 @@ export function IssueViewPFTab({
 
   return (
     <TabContentWrap>
-      <EditableTabTitlePF
+      <EditableTabTitle
         label={view.label}
         isEditing={editingTabKey === view.key}
         setIsEditing={isEditing => setEditingTabKey(isEditing ? view.key : null)}
@@ -139,7 +139,7 @@ export function IssueViewPFTab({
         }
         disableEditing={view.key === TEMPORARY_TAB_KEY}
       />
-      <IssueViewQueryCountPF view={view} />
+      <IssueViewQueryCount view={view} />
       {/* If tablistState isn't initialized, we want to load the elipsis menu
           for the initial tab, that way it won't load in a second later
           and cause the tabs to shift and animate on load. */}
@@ -152,7 +152,7 @@ export function IssueViewPFTab({
           animate={{opacity: 1}}
           transition={{delay: 0.1, duration: 0.1}}
         >
-          <IssueViewEllipsisMenuPF
+          <IssueViewEllipsisMenu
             hasUnsavedChanges={!!view.unsavedChanges}
             menuOptions={makeMenuOptions(view)}
             aria-label={t(`%s Ellipsis Menu`, view.label)}

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -5,7 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
-import IssueViewsPFIssueListHeader from 'sentry/views/issueList/issueViewsHeaderPF';
+import IssueViewsIssueListHeader from 'sentry/views/issueList/issueViewsHeader';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
@@ -127,7 +127,7 @@ describe('IssueViewsHeader', () => {
     });
 
     it('renders all tabs, selects the first one by default, and replaces the query params accordingly', async () => {
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });
@@ -163,7 +163,7 @@ describe('IssueViewsHeader', () => {
 
     it('renders the first tab with the projects from the query params if no other query params are present', async () => {
       render(
-        <IssueViewsPFIssueListHeader {...defaultProps} router={projectsOnlyRouter} />,
+        <IssueViewsIssueListHeader {...defaultProps} router={projectsOnlyRouter} />,
         {
           organization,
           router: projectsOnlyRouter,
@@ -206,7 +206,7 @@ describe('IssueViewsHeader', () => {
         ],
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });
@@ -250,7 +250,7 @@ describe('IssueViewsHeader', () => {
         ],
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
         organization,
         router: queryOnlyRouter,
       });
@@ -282,13 +282,10 @@ describe('IssueViewsHeader', () => {
         }),
       });
 
-      render(
-        <IssueViewsPFIssueListHeader {...defaultProps} router={specificTabRouter} />,
-        {
-          organization,
-          router: specificTabRouter,
-        }
-      );
+      render(<IssueViewsIssueListHeader {...defaultProps} router={specificTabRouter} />, {
+        organization,
+        router: specificTabRouter,
+      });
 
       expect(await screen.findByRole('tab', {name: /Medium Priority/})).toHaveAttribute(
         'aria-selected',
@@ -307,7 +304,7 @@ describe('IssueViewsHeader', () => {
     });
 
     it('initially selects a temporary tab when only a query is present in the url', async () => {
-      render(<IssueViewsPFIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
         organization,
         router: queryOnlyRouter,
       });
@@ -341,13 +338,10 @@ describe('IssueViewsHeader', () => {
           },
         }),
       });
-      render(
-        <IssueViewsPFIssueListHeader {...defaultProps} router={specificTabRouter} />,
-        {
-          organization,
-          router: specificTabRouter,
-        }
-      );
+      render(<IssueViewsIssueListHeader {...defaultProps} router={specificTabRouter} />, {
+        organization,
+        router: specificTabRouter,
+      });
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
       expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
@@ -403,7 +397,7 @@ describe('IssueViewsHeader', () => {
       });
 
       render(
-        <IssueViewsPFIssueListHeader
+        <IssueViewsIssueListHeader
           {...defaultProps}
           router={defaultTabDifferentQueryRouter}
         />,
@@ -440,7 +434,7 @@ describe('IssueViewsHeader', () => {
     });
 
     it('switches tabs when clicked, and updates the query params accordingly', async () => {
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });
@@ -483,7 +477,7 @@ describe('IssueViewsHeader', () => {
       });
 
       render(
-        <IssueViewsPFIssueListHeader
+        <IssueViewsIssueListHeader
           {...defaultProps}
           router={goodViewIdChangedQueryRouter}
         />,
@@ -520,7 +514,7 @@ describe('IssueViewsHeader', () => {
       });
 
       render(
-        <IssueViewsPFIssueListHeader
+        <IssueViewsIssueListHeader
           {...defaultProps}
           router={goodViewIdChangedSortRouter}
         />,
@@ -557,7 +551,7 @@ describe('IssueViewsHeader', () => {
       });
 
       render(
-        <IssueViewsPFIssueListHeader
+        <IssueViewsIssueListHeader
           {...defaultProps}
           router={goodViewIdChangedProjectsRouter}
         />,
@@ -579,7 +573,7 @@ describe('IssueViewsHeader', () => {
       });
 
       render(
-        <IssueViewsPFIssueListHeader
+        <IssueViewsIssueListHeader
           {...defaultProps}
           router={goodViewIdChangedEnvironmentsRouter}
         />,
@@ -601,7 +595,7 @@ describe('IssueViewsHeader', () => {
       });
 
       render(
-        <IssueViewsPFIssueListHeader
+        <IssueViewsIssueListHeader
           {...defaultProps}
           router={goodViewIdChangedTimeFiltersRouter}
         />,
@@ -634,7 +628,7 @@ describe('IssueViewsHeader', () => {
         body: getRequestViews,
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {organization});
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {organization});
 
       await userEvent.click(
         await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
@@ -665,12 +659,9 @@ describe('IssueViewsHeader', () => {
         body: getRequestViews,
       });
 
-      render(
-        <IssueViewsPFIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
-        {
-          organization,
-        }
-      );
+      render(<IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />, {
+        organization,
+      });
 
       await userEvent.click(
         await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
@@ -700,7 +691,7 @@ describe('IssueViewsHeader', () => {
         body: [getRequestViews[0]],
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {organization});
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {organization});
 
       await userEvent.click(
         await screen.findByRole('button', {name: 'High Priority Ellipsis Menu'})
@@ -734,7 +725,7 @@ describe('IssueViewsHeader', () => {
           body: getRequestViews,
         });
 
-        render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+        render(<IssueViewsIssueListHeader {...defaultProps} />, {
           organization,
           router: defaultRouter,
         });
@@ -781,7 +772,7 @@ describe('IssueViewsHeader', () => {
           body: getRequestViews,
         });
 
-        render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+        render(<IssueViewsIssueListHeader {...defaultProps} />, {
           organization,
           router: defaultRouter,
         });
@@ -834,7 +825,7 @@ describe('IssueViewsHeader', () => {
           body: getRequestViews,
         });
 
-        render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+        render(<IssueViewsIssueListHeader {...defaultProps} />, {
           organization,
           router: defaultRouter,
         });
@@ -875,7 +866,7 @@ describe('IssueViewsHeader', () => {
         });
 
         render(
-          <IssueViewsPFIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
+          <IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
           {organization, router: unsavedTabRouter}
         );
 
@@ -915,7 +906,7 @@ describe('IssueViewsHeader', () => {
         });
 
         render(
-          <IssueViewsPFIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
+          <IssueViewsIssueListHeader {...defaultProps} router={unsavedTabRouter} />,
           {organization, router: unsavedTabRouter}
         );
 
@@ -965,7 +956,7 @@ describe('IssueViewsHeader', () => {
         },
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });
@@ -989,7 +980,7 @@ describe('IssueViewsHeader', () => {
         },
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });
@@ -1016,7 +1007,7 @@ describe('IssueViewsHeader', () => {
         },
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });
@@ -1041,7 +1032,7 @@ describe('IssueViewsHeader', () => {
         },
       });
 
-      render(<IssueViewsPFIssueListHeader {...defaultProps} />, {
+      render(<IssueViewsIssueListHeader {...defaultProps} />, {
         organization,
         router: defaultRouter,
       });

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {DraggableTabListPF} from 'sentry/components/draggableTabs/draggableTabListPF';
+import {DraggableTabList} from 'sentry/components/draggableTabs/draggableTabList';
 import type {DraggableTabListItemProps} from 'sentry/components/draggableTabs/item';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -28,19 +28,19 @@ import {
   DEFAULT_ENVIRONMENTS,
   DEFAULT_TIME_FILTERS,
   generateTempViewId,
-  type IssueViewPF,
-  type IssueViewPFParams,
-  IssueViewsPF,
-  IssueViewsPFContext,
+  type IssueView,
+  type IssueViewParams,
+  IssueViews,
+  IssueViewsContext,
   TEMPORARY_TAB_KEY,
-} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
-import {IssueViewPFTab} from 'sentry/views/issueList/issueViewsPF/issueViewTabPF';
+} from 'sentry/views/issueList/issueViews/issueViews';
+import {IssueViewTab} from 'sentry/views/issueList/issueViews/issueViewTab';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 
 import {IssueSortOptions} from './utils';
 
-type IssueViewsPFIssueListHeaderProps = {
+type IssueViewsIssueListHeaderProps = {
   onRealtimeChange: (realtime: boolean) => void;
   realtimeActive: boolean;
   router: InjectedRouter;
@@ -51,12 +51,12 @@ type IssueViewsIssueListHeaderTabsContentProps = {
   router: InjectedRouter;
 };
 
-function IssueViewsPFIssueListHeader({
+function IssueViewsIssueListHeader({
   selectedProjectIds,
   realtimeActive,
   onRealtimeChange,
   router,
-}: IssueViewsPFIssueListHeaderProps) {
+}: IssueViewsIssueListHeaderProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const selectedProjects = projects.filter(({id}) =>
@@ -146,7 +146,7 @@ function IssueViewsPFIssueListHeader({
                 isAllProjects,
               },
               index
-            ): IssueViewPF => {
+            ): IssueView => {
               const tabId = id ?? `default${index.toString()}`;
 
               return {
@@ -180,7 +180,7 @@ function IssueViewsIssueListHeaderTabsContent({
   const location = useLocation();
 
   const {newViewActive, setNewViewActive} = useContext(NewTabContext);
-  const {tabListState, state, dispatch, defaultProject} = useContext(IssueViewsPFContext);
+  const {tabListState, state, dispatch, defaultProject} = useContext(IssueViewsContext);
   const {views, tempView} = state;
 
   const [editingTabKey, setEditingTabKey] = useState<string | null>(null);
@@ -274,7 +274,7 @@ function IssueViewsIssueListHeaderTabsContent({
           ? (sort as IssueSortOptions)
           : undefined;
 
-        const newUnsavedChanges: Partial<IssueViewPFParams> = {
+        const newUnsavedChanges: Partial<IssueViewParams> = {
           query: query === originalQuery ? undefined : query,
           querySort: sort === originalSort ? undefined : issueSortOption,
           projects: isEqual(queryProjects?.sort(), originalProjects.sort())
@@ -455,7 +455,7 @@ function IssueViewsIssueListHeaderTabsContent({
         : views[0]!.key;
 
   return (
-    <DraggableTabListPF
+    <DraggableTabList
       onReorder={(newOrder: Array<Node<DraggableTabListItemProps>>) =>
         dispatch({
           type: 'REORDER_TABS',
@@ -470,7 +470,7 @@ function IssueViewsIssueListHeaderTabsContent({
       hideBorder
     >
       {allTabs.map(view => (
-        <DraggableTabListPF.Item
+        <DraggableTabList.Item
           textValue={view.label}
           key={view.key}
           to={normalizeUrl({
@@ -491,7 +491,7 @@ function IssueViewsIssueListHeaderTabsContent({
           })}
           disabled={view.key === editingTabKey}
         >
-          <IssueViewPFTab
+          <IssueViewTab
             key={view.key}
             view={view}
             initialTabKey={initialTabKey}
@@ -499,13 +499,13 @@ function IssueViewsIssueListHeaderTabsContent({
             editingTabKey={editingTabKey}
             setEditingTabKey={setEditingTabKey}
           />
-        </DraggableTabListPF.Item>
+        </DraggableTabList.Item>
       ))}
-    </DraggableTabListPF>
+    </DraggableTabList>
   );
 }
 
-export default IssueViewsPFIssueListHeader;
+export default IssueViewsIssueListHeader;
 
 /**
  * Normalizes the project and environment query params to arrays of strings and numbers.
@@ -536,7 +536,7 @@ export const normalizeProjectsEnvironments = (
   return {queryEnvs, queryProjects};
 };
 
-const StyledIssueViews = styled(IssueViewsPF)`
+const StyledIssueViews = styled(IssueViews)`
   grid-column: 1 / -1;
 `;
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -49,7 +49,7 @@ import {useParams} from 'sentry/utils/useParams';
 import usePrevious from 'sentry/utils/usePrevious';
 import IssueListTable from 'sentry/views/issueList/issueListTable';
 import {IssuesDataConsentBanner} from 'sentry/views/issueList/issuesDataConsentBanner';
-import IssueViewsPFIssueListHeader from 'sentry/views/issueList/issueViewsHeaderPF';
+import IssueViewsIssueListHeader from 'sentry/views/issueList/issueViewsHeader';
 import LeftNavViewsHeader from 'sentry/views/issueList/leftNavViewsHeader';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
 import SavedIssueSearches from 'sentry/views/issueList/savedIssueSearches';
@@ -1083,7 +1083,7 @@ function IssueListOverview({router}: Props) {
         {!hasLeftNavIssueViews &&
           (organization.features.includes('issue-stream-custom-views') ? (
             <ErrorBoundary message={'Failed to load custom tabs'} mini>
-              <IssueViewsPFIssueListHeader
+              <IssueViewsIssueListHeader
                 router={router}
                 selectedProjectIds={selection.projects}
                 realtimeActive={realtimeActive}

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -6,7 +6,7 @@ import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueViewPF} from 'sentry/views/issueList/issueViewsPF/issueViewsPF';
+import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 
 interface IssuesWrapperProps extends RouteComponentProps {
@@ -64,7 +64,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
                       isAllProjects,
                     },
                     index
-                  ): IssueViewPF => {
+                  ): IssueView => {
                     const tabId = id ?? `default${index.toString()}`;
 
                     return {


### PR DESCRIPTION
This PR gets rid of all of those stupid "PF" suffixes in the components and filenames. Also gets rid of the 'issue-view-page-filter' flag entirely in favor of the 'issue-stream-custom-views' flag. 