### PR TITLE
chore(ACI): Metric alert detector nits

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 from sentry import features
+from sentry.incidents.metric_alert_detector import MetricAlertsDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
@@ -13,9 +14,6 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.endpoints.validators.metric_alert_detector import (
-    MetricAlertsDetectorValidator,
-)
 from sentry.workflow_engine.handlers.detector import StatefulDetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey

--- a/src/sentry/incidents/metric_alert_detector.py
+++ b/src/sentry/incidents/metric_alert_detector.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, TypedDict
+from typing import Any
 
 from rest_framework import serializers
 
@@ -13,26 +13,11 @@ from sentry.workflow_engine.endpoints.validators.base import (
 )
 from sentry.workflow_engine.models import DataConditionGroup, DataSource, Detector
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
-from sentry.workflow_engine.types import DetectorPriorityLevel
-
-
-class DataConditionType(TypedDict):
-    id: int | None
-    comparison: int
-    type: Condition
-    condition_result: DetectorPriorityLevel
-    condition_group_id: int
-
-
-class DataSourceType(TypedDict):
-    query_type: int
-    dataset: str
-    query: str
-    aggregate: str
-    time_window: float
-    resolution: float
-    environment: str
-    event_types: list[SnubaQueryEventType]
+from sentry.workflow_engine.types import (
+    DataConditionType,
+    DetectorPriorityLevel,
+    SnubaQueryDataSourceType,
+)
 
 
 class MetricAlertComparisonConditionValidator(NumericComparisonConditionValidator):
@@ -100,7 +85,7 @@ class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
                 )
         return data_condition_group
 
-    def update_data_source(self, instance: Detector, data_source: DataSourceType):
+    def update_data_source(self, instance: Detector, data_source: SnubaQueryDataSourceType):
         try:
             source_instance = DataSource.objects.get(detector=instance)
         except DataSource.DoesNotExist:
@@ -138,7 +123,7 @@ class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
         if data_conditions:
             self.update_data_conditions(instance, data_conditions)
 
-        data_source: DataSourceType = validated_data.pop("data_source")
+        data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
         if data_source:
             self.update_data_source(instance, data_source)
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -9,7 +9,9 @@ if TYPE_CHECKING:
     from sentry.deletions.base import ModelRelation
     from sentry.eventstore.models import GroupEvent
     from sentry.eventstream.base import GroupState
+    from sentry.snuba.models import SnubaQueryEventType
     from sentry.workflow_engine.models import Action, Detector, Workflow
+    from sentry.workflow_engine.models.data_condition import Condition
 
 T = TypeVar("T")
 
@@ -71,3 +73,22 @@ class DataConditionHandler(Generic[T]):
     @staticmethod
     def evaluate_value(value: T, comparison: Any) -> DataConditionResult:
         raise NotImplementedError
+
+
+class DataConditionType(TypedDict):
+    id: int | None
+    comparison: int
+    type: Condition
+    condition_result: DetectorPriorityLevel
+    condition_group_id: int
+
+
+class SnubaQueryDataSourceType(TypedDict):
+    query_type: int
+    dataset: str
+    query: str
+    aggregate: str
+    time_window: float
+    resolution: float
+    environment: str
+    event_types: list[SnubaQueryEventType]

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_details.py
@@ -92,39 +92,6 @@ class ProjectDetectorDetailsGetTest(ProjectDetectorDetailsBaseTest):
 
 
 @region_silo_test
-class ProjectDetectorIndexDeleteTest(ProjectDetectorDetailsBaseTest):
-    method = "DELETE"
-
-    def test_simple(self):
-        with outbox_runner():
-            self.get_success_response(self.organization.slug, self.project.slug, self.detector.id)
-
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="Detector", object_id=self.detector.id
-        ).exists()
-
-    def test_error_group_type(self):
-        """
-        Test that we do not delete the required error detector
-        """
-        data_condition_group = self.create_data_condition_group()
-        error_detector = self.create_detector(
-            project_id=self.project.id,
-            name="Error Detector",
-            type=ErrorGroupType.slug,
-            workflow_condition_group=data_condition_group,
-        )
-        with outbox_runner():
-            self.get_error_response(
-                self.organization.slug, self.project.slug, error_detector.id, status_code=403
-            )
-
-        assert not RegionScheduledDeletion.objects.filter(
-            model_name="Detector", object_id=error_detector.id
-        ).exists()
-
-
-@region_silo_test
 class ProjectDetectorDetailsPutTest(ProjectDetectorDetailsBaseTest):
     method = "PUT"
 
@@ -258,3 +225,36 @@ class ProjectDetectorDetailsPutTest(ProjectDetectorDetailsBaseTest):
                 **data,
                 status_code=400,
             )
+
+
+@region_silo_test
+class ProjectDetectorIndexDeleteTest(ProjectDetectorDetailsBaseTest):
+    method = "DELETE"
+
+    def test_simple(self):
+        with outbox_runner():
+            self.get_success_response(self.organization.slug, self.project.slug, self.detector.id)
+
+        assert RegionScheduledDeletion.objects.filter(
+            model_name="Detector", object_id=self.detector.id
+        ).exists()
+
+    def test_error_group_type(self):
+        """
+        Test that we do not delete the required error detector
+        """
+        data_condition_group = self.create_data_condition_group()
+        error_detector = self.create_detector(
+            project_id=self.project.id,
+            name="Error Detector",
+            type=ErrorGroupType.slug,
+            workflow_condition_group=data_condition_group,
+        )
+        with outbox_runner():
+            self.get_error_response(
+                self.organization.slug, self.project.slug, error_detector.id, status_code=403
+            )
+
+        assert not RegionScheduledDeletion.objects.filter(
+            model_name="Detector", object_id=error_detector.id
+        ).exists()

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -8,6 +8,10 @@ from sentry import audit_log
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model
 from sentry.incidents.grouptype import MetricAlertFire
+from sentry.incidents.metric_alert_detector import (
+    MetricAlertComparisonConditionValidator,
+    MetricAlertsDetectorValidator,
+)
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.issues import grouptype
@@ -28,10 +32,6 @@ from sentry.workflow_engine.endpoints.validators.base import (
     BaseDetectorTypeValidator,
     DataSourceCreator,
     NumericComparisonConditionValidator,
-)
-from sentry.workflow_engine.endpoints.validators.metric_alert_detector import (
-    MetricAlertComparisonConditionValidator,
-    MetricAlertsDetectorValidator,
 )
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource
 from sentry.workflow_engine.models.data_condition import Condition


### PR DESCRIPTION
Small nitty updates from https://github.com/getsentry/sentry/pull/84098/

* Moves the `MetricAlertsDetectorValidator` to the `/incidents` directory
* Moves the delete endpoint tests to the bottom of the file
* Renames the `DataSourceType` to `SnubaQueryDataSourceType`
* Moves `SnubaQueryDataSourceType` and `DataConditionType` to `workflow_engine/types.py`