### PR TITLE
fix(nav): Better collapsed nav interactions

### DIFF
--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -6,7 +6,13 @@ jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: jest.fn(),
 }));
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import Nav from 'sentry/components/nav';
 import {NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY} from 'sentry/components/nav/constants';
@@ -174,10 +180,12 @@ describe('Nav', function () {
         await userEvent.unhover(
           screen.getByRole('navigation', {name: 'Primary Navigation'})
         );
-        expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-          'data-visible',
-          'false'
-        );
+        await waitFor(() => {
+          expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
+            'data-visible',
+            'false'
+          );
+        });
       });
     });
   });

--- a/static/app/components/nav/index.tsx
+++ b/static/app/components/nav/index.tsx
@@ -1,94 +1,16 @@
-import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {useInteractOutside} from '@react-aria/interactions';
 
 import {useNavContext} from 'sentry/components/nav/context';
 import MobileTopbar from 'sentry/components/nav/mobileTopbar';
 import {Sidebar} from 'sentry/components/nav/sidebar';
 import {NavLayout} from 'sentry/components/nav/types';
 
-function useHoverWithin({isDisabled}: {isDisabled?: boolean}) {
-  const [isHovered, setIsHovered] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  // Resets hover state if nav is disabled
-  // Without this the menu will pop back open when collapsing
-  if (isDisabled && isHovered) {
-    setIsHovered(false);
-  }
-
-  // Sets up event listeners for opening/closing the nav
-  // Mouse in -> open
-  // Mouse out -> close
-  // Focus on elements within nav -> open
-  // Focus on elements outside nav -> close
-  // Escape -> close
-  useEffect(() => {
-    const element = ref.current;
-    if (!element || isDisabled) {
-      return () => {};
-    }
-
-    const handleMouseEnter = () => setIsHovered(true);
-    const handleMouseLeave = () => {
-      if (!ref.current?.contains(document.activeElement as Node)) {
-        setIsHovered(false);
-      }
-    };
-
-    element.addEventListener('mouseenter', handleMouseEnter);
-    element.addEventListener('mouseleave', handleMouseLeave);
-
-    const handleFocus = (e: FocusEvent) => {
-      if (ref.current?.contains(e.target as Node)) {
-        setIsHovered(true);
-      } else {
-        setIsHovered(false);
-      }
-    };
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsHovered(false);
-      }
-    };
-
-    document.addEventListener('focusin', handleFocus);
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      element.removeEventListener('mouseenter', handleMouseEnter);
-      element.removeEventListener('mouseleave', handleMouseLeave);
-      document.removeEventListener('focusin', handleFocus);
-    };
-  }, [isDisabled]);
-
-  // Handles clicks outside the nav container
-  // Most of the the nav will already be closed by mouse or focus events,
-  // but this will catch instances where clicks on non-focusable elements
-  useInteractOutside({
-    ref,
-    onInteractOutside: () => setIsHovered(false),
-    isDisabled,
-  });
-
-  return {ref, isHovered};
-}
-
 function Nav() {
-  const {layout, isCollapsed} = useNavContext();
-
-  const {isHovered, ref} = useHoverWithin({
-    isDisabled: layout !== NavLayout.SIDEBAR || !isCollapsed,
-  });
+  const {layout, navParentRef} = useNavContext();
 
   return (
-    <NavContainer ref={ref}>
-      {layout === NavLayout.SIDEBAR ? (
-        <Sidebar isHovered={isHovered} />
-      ) : (
-        <MobileTopbar />
-      )}
+    <NavContainer ref={navParentRef}>
+      {layout === NavLayout.SIDEBAR ? <Sidebar /> : <MobileTopbar />}
     </NavContainer>
   );
 }

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -102,7 +102,7 @@ export function IssueViewNavItemContent({
     .map(p => p.platform)
     .filter(defined);
 
-  const {isInteracting, setisInteracting} = useNavContext();
+  const {startInteraction, endInteraction, isInteractingRef} = useNavContext();
 
   return (
     <Reorder.Item
@@ -115,10 +115,10 @@ export function IssueViewNavItemContent({
         cursor: 'grabbing',
       }}
       onDragStart={() => {
-        setisInteracting(true);
+        startInteraction();
       }}
       onDragEnd={() => {
-        setisInteracting(false);
+        endInteraction();
       }}
     >
       <StyledSecondaryNavItem
@@ -147,7 +147,7 @@ export function IssueViewNavItemContent({
           e.preventDefault();
         }}
         onPointerUp={e => {
-          if (isInteracting) {
+          if (isInteractingRef.current) {
             e.preventDefault();
           }
         }}

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -9,15 +9,13 @@ import {
 import {useNavContext} from 'sentry/components/nav/context';
 import {PrimaryNavigationItems} from 'sentry/components/nav/primary/index';
 import {SecondarySidebar} from 'sentry/components/nav/secondarySidebar';
+import {useCollapsedNav} from 'sentry/components/nav/useCollapsedNav';
 import SidebarDropdown from 'sentry/components/sidebar/sidebarDropdown';
 import {space} from 'sentry/styles/space';
 
-type SidebarProps = {
-  isHovered: boolean;
-};
-
-export function Sidebar({isHovered}: SidebarProps) {
-  const {isCollapsed, isInteracting} = useNavContext();
+export function Sidebar() {
+  const {isCollapsed} = useNavContext();
+  const {isOpen} = useCollapsedNav();
 
   return (
     <Fragment>
@@ -32,14 +30,14 @@ export function Sidebar({isHovered}: SidebarProps) {
       {isCollapsed ? (
         <CollapsedSecondaryWrapper
           initial="hidden"
-          animate={isHovered || isInteracting ? 'visible' : 'hidden'}
+          animate={isOpen ? 'visible' : 'hidden'}
           variants={{
             visible: {x: 0},
             hidden: {x: -SECONDARY_SIDEBAR_WIDTH - 10},
           }}
-          transition={{duration: 0.3}}
+          transition={{duration: 0.15, ease: 'easeOut'}}
           data-test-id="collapsed-secondary-sidebar"
-          data-visible={isHovered || isInteracting}
+          data-visible={isOpen}
         >
           <SecondarySidebar />
         </CollapsedSecondaryWrapper>
@@ -63,6 +61,7 @@ const CollapsedSecondaryWrapper = styled(motion.div)`
   top: 0;
   left: ${PRIMARY_SIDEBAR_WIDTH}px;
   height: 100%;
+  box-shadow: ${p => p.theme.dropShadowHeavy};
 `;
 
 const SidebarHeader = styled('header')`

--- a/static/app/components/nav/useCollapsedNav.tsx
+++ b/static/app/components/nav/useCollapsedNav.tsx
@@ -1,0 +1,138 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {useInteractOutside} from '@react-aria/interactions';
+
+import {useNavContext} from 'sentry/components/nav/context';
+
+// Slightly delay closing the nav to prevent accidental dismissal
+const CLOSE_DELAY = 300;
+
+/**
+ * Handles logic for deciding when the collpased nav should be visible.
+ *
+ * Mouse in -> open
+ * Mouse out -> close
+ * Keyboard focus on elements within nav -> open
+ * Menu open within nav -> open
+ * Other interactions (such as dragging) -> open
+ * Interaction outside nav -> close
+ * Escape -> close
+ */
+export function useCollapsedNav() {
+  const {navParentRef, isCollapsed, isInteractingRef, endInteraction} = useNavContext();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const isHoveredRef = useRef(false);
+
+  const closeNav = useCallback(() => {
+    isHoveredRef.current = false;
+    endInteraction();
+    setIsOpen(false);
+  }, [endInteraction]);
+
+  const shouldNavStayOpen = useCallback(() => {
+    const hasKeyboardFocus = navParentRef.current?.querySelector(':focus-visible');
+    const hasOpenMenu = navParentRef.current?.querySelector('[aria-expanded="true"]');
+
+    return (
+      isHoveredRef.current || isInteractingRef.current || hasKeyboardFocus || hasOpenMenu
+    );
+  }, [isInteractingRef, navParentRef]);
+
+  const tryCloseNav = useCallback(() => {
+    if (shouldNavStayOpen()) {
+      return;
+    }
+
+    closeNav();
+  }, [closeNav, shouldNavStayOpen]);
+
+  // Resets hover state if nav is disabled
+  // Without this the menu will pop back open when collapsing
+  if (!isCollapsed && isOpen) {
+    closeNav();
+  }
+
+  // Sets up event listeners hover and focus changes
+  useEffect(() => {
+    const element = navParentRef.current;
+    if (!element || !isCollapsed || !navParentRef.current) {
+      return () => {};
+    }
+
+    const navParentEl = navParentRef.current;
+    let closeTimer: NodeJS.Timeout;
+
+    const hoverIn = () => {
+      clearTimeout(closeTimer);
+      isHoveredRef.current = true;
+      setIsOpen(true);
+    };
+
+    const hoverOut = () => {
+      isHoveredRef.current = false;
+
+      closeTimer = setTimeout(() => {
+        tryCloseNav();
+      }, CLOSE_DELAY);
+    };
+
+    const handleMouseEnter = () => {
+      hoverIn();
+    };
+
+    const handleMouseLeave = () => {
+      hoverOut();
+    };
+
+    element.addEventListener('mouseenter', handleMouseEnter);
+    element.addEventListener('mouseleave', handleMouseLeave);
+
+    const handleFocusIn = () => {
+      hoverIn();
+    };
+
+    const handleFocusOut = () => {
+      tryCloseNav();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeNav();
+      }
+    };
+
+    navParentEl.addEventListener('focusin', handleFocusIn);
+    navParentEl.addEventListener('focusout', handleFocusOut);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      element.removeEventListener('mouseenter', handleMouseEnter);
+      element.removeEventListener('mouseleave', handleMouseLeave);
+      navParentEl.removeEventListener('focusin', handleFocusIn);
+      navParentEl.removeEventListener('focusout', handleFocusOut);
+      document.removeEventListener('keydown', handleKeyDown);
+      clearTimeout(closeTimer);
+    };
+  }, [
+    closeNav,
+    endInteraction,
+    isCollapsed,
+    isInteractingRef,
+    navParentRef,
+    shouldNavStayOpen,
+    tryCloseNav,
+  ]);
+
+  // Handles clicks outside the nav container
+  // Most of the the nav will already be closed by mouse or focus events,
+  // but this will catch instances where clicks on non-focusable elements
+  useInteractOutside({
+    ref: navParentRef,
+    onInteractOutside: () => {
+      closeNav();
+    },
+    isDisabled: !isCollapsed,
+  });
+
+  return {isOpen};
+}

--- a/static/app/components/nav/useCollapsedNav.tsx
+++ b/static/app/components/nav/useCollapsedNav.tsx
@@ -4,7 +4,7 @@ import {useInteractOutside} from '@react-aria/interactions';
 import {useNavContext} from 'sentry/components/nav/context';
 
 // Slightly delay closing the nav to prevent accidental dismissal
-const CLOSE_DELAY = 300;
+const CLOSE_DELAY = 200;
 
 /**
  * Handles logic for deciding when the collpased nav should be visible.

--- a/static/app/components/nav/useCollapsedNav.tsx
+++ b/static/app/components/nav/useCollapsedNav.tsx
@@ -87,8 +87,11 @@ export function useCollapsedNav() {
     element.addEventListener('mouseenter', handleMouseEnter);
     element.addEventListener('mouseleave', handleMouseLeave);
 
-    const handleFocusIn = () => {
-      hoverIn();
+    const handleFocusIn = (e: FocusEvent) => {
+      if (e.target instanceof HTMLElement && e.target.matches(':focus-visible')) {
+        clearTimeout(closeTimer);
+        setIsOpen(true);
+      }
     };
 
     const handleFocusOut = () => {

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -235,3 +235,24 @@ Object.defineProperty(global.self, 'crypto', {
     subtle: webcrypto.subtle,
   },
 });
+
+// Using `:focus-visible` in `querySelector` or `matches` will throw an error in JSDOM.
+// See https://github.com/jsdom/jsdom/issues/3055
+// eslint-disable-next-line testing-library/no-node-access
+const originalQuerySelector = HTMLElement.prototype.querySelector;
+const originalMatches = HTMLElement.prototype.matches;
+// eslint-disable-next-line testing-library/no-node-access
+HTMLElement.prototype.querySelector = function (selectors: string) {
+  if (selectors === ':focus-visible') {
+    return null;
+  }
+
+  return originalQuerySelector.call(this, selectors);
+};
+HTMLElement.prototype.matches = function (selectors: string) {
+  if (selectors === ':focus-visible') {
+    return false;
+  }
+
+  return originalMatches.call(this, selectors);
+};


### PR DESCRIPTION
Some improvements to showing/hiding the collapsed nav:

- Quicker animation
- Adds slight delay before closing when moving cursor out of menu
- Fixes issue where using the nav would keep it open (because it retained focus, but now I'm checking for `focus-visible` instead)
- Some refactoring (move hook into its own file, integrate `isInteracting`)