### PR TITLE
feat(releases): add release health table to mobile insights

### DIFF
--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -20,6 +20,7 @@ export default function useOrganizationReleases() {
           ...locationWithoutWidth.query,
           adoptionStages: 1,
           health: 1,
+          per_page: 25,
         },
       },
     ],

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import React from 'react';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
@@ -46,15 +46,13 @@ export function SessionsOverview() {
                 <CrashFreeSessionChart />
               </ModuleLayout.Half>
             ) : (
-              <Fragment>
-                <ModuleLayout.Third>
-                  <ErrorFreeSessionsChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Full>
-                  <ReleaseHealth />
-                </ModuleLayout.Full>
-              </Fragment>
+              <ModuleLayout.Third>
+                <ErrorFreeSessionsChart />
+              </ModuleLayout.Third>
             )}
+            <ModuleLayout.Full>
+              <ReleaseHealth />
+            </ModuleLayout.Full>
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>


### PR DESCRIPTION
add the release health table to mobile (no modifications needed) and also limit the number per page so the table is shorter

relates to https://github.com/getsentry/sentry/issues/84877

<img width="707" alt="SCR-20250221-mkhv" src="https://github.com/user-attachments/assets/e545b7f1-5ac2-4167-8332-19d35b06f4a2" />
