### PR TITLE
tests(grouping): Remove some more fields

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/unreal_assertion_check_fail_android.json
+++ b/tests/sentry/grouping/grouping_inputs/unreal_assertion_check_fail_android.json
@@ -12,8 +12,6 @@
               "symbol": "__start_thread",
               "package": "/system/lib64/libc.so",
               "data": {
-                "orig_in_app": -1,
-                "category": "internals",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -22,15 +20,12 @@
               "symbol": "_ZL15__pthread_startPv",
               "package": "/system/lib64/libc.so",
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               }
             },
             {
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -38,7 +33,6 @@
               "function": "android_main",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -48,7 +42,6 @@
               "symbol": "_Z11AndroidMainP11android_app",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -58,7 +51,6 @@
               "symbol": "_ZN11FEngineLoop4TickEv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -68,7 +60,6 @@
               "symbol": "_ZN11UGameEngine4TickEfb",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -78,7 +69,6 @@
               "symbol": "_ZN6UWorld4TickE10ELevelTickf",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -88,7 +78,6 @@
               "symbol": "_ZN20FLatentActionManager20ProcessLatentActionsEP7UObjectf",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -98,7 +87,6 @@
               "symbol": "_ZN20FLatentActionManager25TickLatentActionForObjectEfR9TMultiMapIiP20FPendingLatentAction20FDefaultSetAllocator27TDefaultMapHashableKeyFuncsIiS2_Lb1EEEP7UObject",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -108,7 +96,6 @@
               "symbol": "_ZN6AActor12ProcessEventEP9UFunctionPv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -118,7 +105,6 @@
               "symbol": "_ZN7UObject12ProcessEventEP9UFunctionPv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -128,7 +114,6 @@
               "symbol": "_ZN9UFunction6InvokeEP7UObjectR6FFramePv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -138,7 +123,6 @@
               "symbol": "_ZN7UObject15ProcessInternalEPS_R6FFramePv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -148,7 +132,6 @@
               "symbol": "_Z26ProcessLocalScriptFunctionP7UObjectR6FFramePv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -158,7 +141,6 @@
               "symbol": "_ZN7UObject20execCallMathFunctionEPS_R6FFramePv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -168,7 +150,6 @@
               "symbol": "_ZN22USentryPlaygroundUtils13execTerminateEP7UObjectR6FFramePv",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -178,7 +159,6 @@
               "symbol": "_ZN22USentryPlaygroundUtils9TerminateE25ESentryAppTerminationType",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -188,7 +168,6 @@
               "symbol": "_ZN6FDebug22CheckVerifyFailedImpl2EPKcS1_iPKDsz",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -198,7 +177,6 @@
               "symbol": "_ZN13FOutputDevice8LogfImplEPKDsz",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -208,7 +186,6 @@
               "symbol": "_ZN24FSentryOutputDeviceError9SerializeEPKDsN13ELogVerbosity4TypeERK5FName",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -218,14 +195,12 @@
               "symbol": "_ZNK22TMulticastDelegateBaseI28FDefaultTSDelegateUserPolicyE9BroadcastI21IBaseDelegateInstanceIFvRK7FStringES0_EJS6_EEEvDpT0_",
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
             {
               "package": "/data/app/io.sentry.unreal.sample-AYKfrnp3OLGXg7fg_lX6dw==/lib/arm64/libUnreal.so",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "missing"
               }
             },
@@ -234,8 +209,6 @@
               "symbol": "tgkill",
               "package": "/system/lib64/libc.so",
               "data": {
-                "orig_in_app": -1,
-                "category": "system",
                 "symbolicator_status": "symbolicated"
               }
             }

--- a/tests/sentry/grouping/grouping_inputs/unreal_assertion_check_fail_on_windows.json
+++ b/tests/sentry/grouping/grouping_inputs/unreal_assertion_check_fail_on_windows.json
@@ -12,8 +12,6 @@
               "symbol": "RtlUserThreadStart",
               "package": "C:\\Windows\\SYSTEM32\\ntdll.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -23,8 +21,6 @@
               "symbol": "BaseThreadInitThunk",
               "package": "C:\\Windows\\System32\\KERNEL32.DLL",
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -37,7 +33,7 @@
               "filename": "exe_common.inl",
               "abs_path": "D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl",
               "lineno": 288,
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -49,8 +45,6 @@
               "abs_path": "D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl",
               "lineno": 102,
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -59,7 +53,7 @@
               "function": "WinMain",
               "symbol": "WinMain",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -67,7 +61,7 @@
               "raw_function": "LaunchWindowsStartup(HINSTANCE__*, HINSTANCE__*, char*, int, wchar_t const*)",
               "symbol": "?LaunchWindowsStartup@@YAHPEAUHINSTANCE__@@0PEADHPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -75,7 +69,7 @@
               "raw_function": "GuardedMainWrapper(wchar_t const*)",
               "symbol": "?GuardedMainWrapper@@YAHPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -83,7 +77,7 @@
               "raw_function": "GuardedMain(wchar_t const*)",
               "symbol": "?GuardedMain@@YAHPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -91,7 +85,7 @@
               "raw_function": "FEngineLoop::Tick(void)",
               "symbol": "?Tick@FEngineLoop@@UEAAXXZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -99,7 +93,7 @@
               "raw_function": "FWindowsPlatformApplicationMisc::PumpMessages(bool)",
               "symbol": "?PumpMessages@FWindowsPlatformApplicationMisc@@SAX_N@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -107,8 +101,6 @@
               "symbol": "DispatchMessageWorker",
               "package": "C:\\Windows\\System32\\USER32.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "system",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -119,8 +111,6 @@
               "symbol": "?UserCallWinProcCheckWow@@YA_JPEAU_ACTIVATION_CONTEXT@@P6A_JPEAUtagWND@@I_K_J@ZPEAUHWND__@@W4_WM_VALUE@@23PEAXH@Z",
               "package": "C:\\Windows\\System32\\USER32.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "internals",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -130,7 +120,7 @@
               "raw_function": "FWindowsApplication::AppWndProc(HWND__*, unsigned int, uint64_t, int64_t)",
               "symbol": "?AppWndProc@FWindowsApplication@@KA_JPEAUHWND__@@I_K_J@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -138,7 +128,7 @@
               "raw_function": "FWindowsApplication::ProcessMessage(HWND__*, unsigned int, uint64_t, int64_t)",
               "symbol": "?ProcessMessage@FWindowsApplication@@IEAAHPEAUHWND__@@I_K_J@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -146,7 +136,7 @@
               "raw_function": "FWindowsApplication::DeferMessage(TSharedPtr<FWindowsWindow, 1>&, HWND__*, unsigned int, uint64_t, int64_t, int, int, unsigned int)",
               "symbol": "?DeferMessage@FWindowsApplication@@AEAAXAEAV?$TSharedPtr@VFWindowsWindow@@$00@@PEAUHWND__@@I_K_JHHI@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -154,7 +144,7 @@
               "raw_function": "FWindowsApplication::ProcessDeferredMessage(FDeferredWindowsMessage const&)",
               "symbol": "?ProcessDeferredMessage@FWindowsApplication@@IEAAHAEBUFDeferredWindowsMessage@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -162,7 +152,7 @@
               "raw_function": "FSlateApplication::OnMouseUp(EMouseButtons::Type, UE::Math::TVector2<double>)",
               "symbol": "?OnMouseUp@FSlateApplication@@UEAA_NW4Type@EMouseButtons@@U?$TVector2@N@Math@UE@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -170,7 +160,7 @@
               "raw_function": "FSlateApplication::ProcessMouseButtonUpEvent(FPointerEvent const&)",
               "symbol": "?ProcessMouseButtonUpEvent@FSlateApplication@@QEAA_NAEBUFPointerEvent@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -178,7 +168,7 @@
               "raw_function": "FSlateApplication::RoutePointerUpEvent(FWidgetPath const&, FPointerEvent const&)",
               "symbol": "?RoutePointerUpEvent@FSlateApplication@@QEAA?AVFReply@@AEBVFWidgetPath@@AEBUFPointerEvent@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -186,7 +176,7 @@
               "raw_function": "SharedPointerInternals::NewIntrusiveReferenceController<1, SWindowTitleBar>(void)",
               "symbol": "??$NewIntrusiveReferenceController@$00VSWindowTitleBar@@$$V@SharedPointerInternals@@YAPEAV?$TIntrusiveReferenceController@VSWindowTitleBar@@$00@0@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -195,8 +185,6 @@
               "symbol": "??R<lambda_1>@?1??Remove@?$TArray@V?$TWeakPtr@VTAnimatedAttributeBase@@$00@@V?$TSizedDefaultAllocator@$0CA@@@@@QEAAHAEBV?$TWeakPtr@VTAnimatedAttributeBase@@$00@@@Z@QEBA@AEAV3@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
-                "category": "indirection",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -206,7 +194,7 @@
               "raw_function": "SButton::OnMouseButtonUp(FGeometry const&, FPointerEvent const&)",
               "symbol": "?OnMouseButtonUp@SButton@@UEAA?AVFReply@@AEBUFGeometry@@AEBUFPointerEvent@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -214,7 +202,7 @@
               "raw_function": "SButton::ExecuteOnClick(void)",
               "symbol": "?ExecuteOnClick@SButton@@IEAA?AVFReply@@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -222,7 +210,7 @@
               "raw_function": "TBaseUObjectMethodDelegateInstance<0, UButton, FReply (void), FDefaultDelegateUserPolicy>::Execute(void) const",
               "symbol": "?Execute@?$TBaseUObjectMethodDelegateInstance@$0A@VUButton@@$$A6A?AVFReply@@XZUFDefaultDelegateUserPolicy@@$$V@@UEBA?AVFReply@@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -230,7 +218,7 @@
               "raw_function": "UButton::SlateHandleClicked(void)",
               "symbol": "?SlateHandleClicked@UButton@@IEAA?AVFReply@@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -238,7 +226,7 @@
               "raw_function": "TMulticastScriptDelegate<FNotThreadSafeDelegateMode>::ProcessMulticastDelegate<UObject>(void*) const",
               "symbol": "??$ProcessMulticastDelegate@VUObject@@@?$TMulticastScriptDelegate@UFNotThreadSafeDelegateMode@@@@QEBAXPEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -246,7 +234,7 @@
               "raw_function": "UObject::ProcessEvent(UFunction*, void*)",
               "symbol": "?ProcessEvent@UObject@@UEAAXPEAVUFunction@@PEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -254,7 +242,7 @@
               "raw_function": "UFunction::Invoke(UObject*, FFrame&, void* const)",
               "symbol": "?Invoke@UFunction@@QEAAXPEAVUObject@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -262,7 +250,7 @@
               "raw_function": "UObject::ProcessInternal(UObject*, FFrame&, void* const)",
               "symbol": "?ProcessInternal@UObject@@SAXPEAV1@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -270,7 +258,7 @@
               "raw_function": "ProcessLocalScriptFunction(UObject*, FFrame&, void* const)",
               "symbol": "?ProcessLocalScriptFunction@@YAXPEAVUObject@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -278,7 +266,7 @@
               "raw_function": "ProcessLocalFunction(UObject*, UFunction*, FFrame&, void* const)",
               "symbol": "?ProcessLocalFunction@@YAXPEAVUObject@@PEAVUFunction@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -287,8 +275,6 @@
               "symbol": "??R<lambda_1>@?1??Get@?$TThreadSingleton@UFDeferredScriptTracker@@@@SAAEAUFDeferredScriptTracker@@XZ@QEBA@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
-                "category": "indirection",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "cfi"
@@ -298,7 +284,7 @@
               "raw_function": "ProcessScriptFunction<void (*)(UObject*, FFrame&, void*)>(UObject*, UFunction*, FFrame&, void* const, void (*)(UObject*, FFrame&, void*))",
               "symbol": "??$ProcessScriptFunction@P6AXPEAVUObject@@AEAUFFrame@@PEAX@Z@@YAXPEAVUObject@@PEAVUFunction@@AEAUFFrame@@QEAXP6AX02PEAX@Z@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -306,7 +292,7 @@
               "raw_function": "ProcessLocalScriptFunction(UObject*, FFrame&, void* const)",
               "symbol": "?ProcessLocalScriptFunction@@YAXPEAVUObject@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -314,7 +300,7 @@
               "raw_function": "UObject::execCallMathFunction(UObject*, FFrame&, void* const)",
               "symbol": "?execCallMathFunction@UObject@@SAXPEAV1@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -326,7 +312,7 @@
               "abs_path": "D:\\projects\\sentry-unreal\\sample\\Intermediate\\Build\\Win64\\UnrealGame\\Inc\\SentryPlayground\\UHT\\SentryPlaygroundUtils.gen.cpp",
               "lineno": 127,
               "context_line": "\tUSentryPlaygroundUtils::Terminate(ESentryAppTerminationType(Z_Param_Type));",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -338,7 +324,7 @@
               "abs_path": "D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp",
               "lineno": 34,
               "context_line": "\t\t\t\tcheck(assertPtr != nullptr);",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -346,7 +332,7 @@
               "raw_function": "FDebug::CheckVerifyFailedImpl2(char const*, char const*, int, wchar_t const*, ...)",
               "symbol": "?CheckVerifyFailedImpl2@FDebug@@SA_NPEBD0HPEB_WZZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -354,7 +340,7 @@
               "raw_function": "FDebug::AssertFailed(char const*, char const*, int, wchar_t const*, ...)",
               "symbol": "?AssertFailed@FDebug@@SAXPEBD0HPEB_WZZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -362,7 +348,7 @@
               "raw_function": "FOutputDevice::LogfImpl(wchar_t const*, ...)",
               "symbol": "?LogfImpl@FOutputDevice@@AEAAXPEB_WZZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -374,7 +360,7 @@
               "abs_path": "D:\\projects\\sentry-unreal\\sample\\Plugins\\sentry\\Source\\Sentry\\Private\\SentryOutputDeviceError.cpp",
               "lineno": 22,
               "context_line": "\tParentDevice->Serialize(V, Verbosity, Category);",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -382,7 +368,7 @@
               "raw_function": "FWindowsErrorOutputDevice::Serialize(wchar_t const*, ELogVerbosity::Type, FName const&)",
               "symbol": "?Serialize@FWindowsErrorOutputDevice@@UEAAXPEB_WW4Type@ELogVerbosity@@AEBVFName@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
-              "data": {"orig_in_app": -1, "symbolicator_status": "symbolicated"},
+              "data": {"symbolicator_status": "symbolicated"},
               "trust": "cfi"
             },
             {
@@ -390,8 +376,6 @@
               "symbol": "RaiseException",
               "package": "C:\\Windows\\System32\\KERNELBASE.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "throw",
                 "symbolicator_status": "symbolicated"
               },
               "trust": "context"

--- a/tests/sentry/grouping/grouping_inputs/unreal_ensure_check_fail_on_windows.json
+++ b/tests/sentry/grouping/grouping_inputs/unreal_ensure_check_fail_on_windows.json
@@ -12,8 +12,6 @@
               "symbol": "RtlUserThreadStart",
               "package": "C:\\Windows\\SYSTEM32\\ntdll.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -22,8 +20,6 @@
               "symbol": "BaseThreadInitThunk",
               "package": "C:\\Windows\\System32\\KERNEL32.DLL",
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -36,7 +32,6 @@
               "abs_path": "D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl",
               "lineno": 288,
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -49,8 +44,6 @@
               "abs_path": "D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl",
               "lineno": 102,
               "data": {
-                "orig_in_app": -1,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -59,7 +52,6 @@
               "symbol": "WinMain",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -69,7 +61,6 @@
               "symbol": "?LaunchWindowsStartup@@YAHPEAUHINSTANCE__@@0PEADHPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -79,7 +70,6 @@
               "symbol": "?GuardedMainWrapper@@YAHPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -89,7 +79,6 @@
               "symbol": "?GuardedMain@@YAHPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -99,7 +88,6 @@
               "symbol": "?Tick@FEngineLoop@@UEAAXXZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -109,7 +97,6 @@
               "symbol": "?PumpMessages@FWindowsPlatformApplicationMisc@@SAX_N@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -118,8 +105,6 @@
               "symbol": "DispatchMessageWorker",
               "package": "C:\\Windows\\System32\\USER32.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "system",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -129,8 +114,6 @@
               "symbol": "?UserCallWinProcCheckWow@@YA_JPEAU_ACTIVATION_CONTEXT@@P6A_JPEAUtagWND@@I_K_J@ZPEAUHWND__@@W4_WM_VALUE@@23PEAXH@Z",
               "package": "C:\\Windows\\System32\\USER32.dll",
               "data": {
-                "orig_in_app": -1,
-                "category": "internals",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -140,7 +123,6 @@
               "symbol": "?AppWndProc@FWindowsApplication@@KA_JPEAUHWND__@@I_K_J@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -150,7 +132,6 @@
               "symbol": "?ProcessMessage@FWindowsApplication@@IEAAHPEAUHWND__@@I_K_J@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -160,7 +141,6 @@
               "symbol": "?DeferMessage@FWindowsApplication@@AEAAXAEAV?$TSharedPtr@VFWindowsWindow@@$00@@PEAUHWND__@@I_K_JHHI@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -170,7 +150,6 @@
               "symbol": "?ProcessDeferredMessage@FWindowsApplication@@IEAAHAEBUFDeferredWindowsMessage@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -180,7 +159,6 @@
               "symbol": "?OnMouseUp@FSlateApplication@@UEAA_NW4Type@EMouseButtons@@U?$TVector2@N@Math@UE@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -190,7 +168,6 @@
               "symbol": "?ProcessMouseButtonUpEvent@FSlateApplication@@QEAA_NAEBUFPointerEvent@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -200,7 +177,6 @@
               "symbol": "?RoutePointerUpEvent@FSlateApplication@@QEAA?AVFReply@@AEBVFWidgetPath@@AEBUFPointerEvent@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -210,7 +186,6 @@
               "symbol": "??$NewIntrusiveReferenceController@$00VSWindowTitleBar@@$$V@SharedPointerInternals@@YAPEAV?$TIntrusiveReferenceController@VSWindowTitleBar@@$00@0@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -220,8 +195,6 @@
               "symbol": "??R<lambda_1>@?1??Remove@?$TArray@V?$TWeakPtr@VTAnimatedAttributeBase@@$00@@V?$TSizedDefaultAllocator@$0CA@@@@@QEAAHAEBV?$TWeakPtr@VTAnimatedAttributeBase@@$00@@@Z@QEBA@AEAV3@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
-                "category": "indirection",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -231,7 +204,6 @@
               "symbol": "?OnMouseButtonUp@SButton@@UEAA?AVFReply@@AEBUFGeometry@@AEBUFPointerEvent@@@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -241,7 +213,6 @@
               "symbol": "?ExecuteOnClick@SButton@@IEAA?AVFReply@@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -251,7 +222,6 @@
               "symbol": "?Execute@?$TBaseUObjectMethodDelegateInstance@$0A@VUButton@@$$A6A?AVFReply@@XZUFDefaultDelegateUserPolicy@@$$V@@UEBA?AVFReply@@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -261,7 +231,6 @@
               "symbol": "?SlateHandleClicked@UButton@@IEAA?AVFReply@@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -271,7 +240,6 @@
               "symbol": "??$ProcessMulticastDelegate@VUObject@@@?$TMulticastScriptDelegate@UFNotThreadSafeDelegateMode@@@@QEBAXPEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -281,7 +249,6 @@
               "symbol": "?ProcessEvent@UObject@@UEAAXPEAVUFunction@@PEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -291,7 +258,6 @@
               "symbol": "?Invoke@UFunction@@QEAAXPEAVUObject@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -301,7 +267,6 @@
               "symbol": "?ProcessInternal@UObject@@SAXPEAV1@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -311,7 +276,6 @@
               "symbol": "?ProcessLocalScriptFunction@@YAXPEAVUObject@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -321,7 +285,6 @@
               "symbol": "?ProcessLocalFunction@@YAXPEAVUObject@@PEAVUFunction@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -331,8 +294,6 @@
               "symbol": "??R<lambda_1>@?1??Get@?$TThreadSingleton@UFDeferredScriptTracker@@@@SAAEAUFDeferredScriptTracker@@XZ@QEBA@XZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
-                "category": "indirection",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -342,7 +303,6 @@
               "symbol": "??$ProcessScriptFunction@P6AXPEAVUObject@@AEAUFFrame@@PEAX@Z@@YAXPEAVUObject@@PEAVUFunction@@AEAUFFrame@@QEAXP6AX02PEAX@Z@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -352,7 +312,6 @@
               "symbol": "?ProcessLocalScriptFunction@@YAXPEAVUObject@@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -362,7 +321,6 @@
               "symbol": "?execCallMathFunction@UObject@@SAXPEAV1@AEAUFFrame@@QEAX@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -376,7 +334,6 @@
               "lineno": 127,
               "context_line": "\tUSentryPlaygroundUtils::Terminate(ESentryAppTerminationType(Z_Param_Type));",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -390,7 +347,6 @@
               "lineno": 40,
               "context_line": "\t\t\t\tensure(ensurePtr != nullptr);",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -400,7 +356,6 @@
               "symbol": "?ExecCheckImplInternal@Private@Assert@UE@@YA_NAEAU?$atomic@_N@std@@_NPEBDH2@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -410,7 +365,6 @@
               "symbol": "?CheckVerifyImpl@@YA_NAEAU?$atomic@_N@std@@_NPEBDHPEAX2PEB_WPEAD@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -420,7 +374,6 @@
               "symbol": "?OptionallyLogFormattedEnsureMessageReturningFalseImpl@FDebug@@CA_N_NPEBD1HPEAXPEB_WPEAD@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -430,7 +383,6 @@
               "symbol": "?EnsureFailed@FDebug@@SAXPEBD0HPEAXPEB_W@Z",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -440,7 +392,6 @@
               "symbol": "?Broadcast@?$TMulticastDelegate@$$A6AXXZUFDefaultDelegateUserPolicy@@@@QEBAXXZ",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -454,7 +405,6 @@
               "lineno": 870,
               "context_line": "\t\t(void)this->Payload.ApplyAfter(Functor, Forward<ParamTypes>(Params)...);",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -468,7 +418,6 @@
               "lineno": 317,
               "context_line": "\t\ttemplate <typename FuncType, typename... ArgTypes> decltype(auto) ApplyAfter(FuncType&& Func, ArgTypes&&... Args) const         &  { retur {snip}",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -482,7 +431,6 @@
               "lineno": 47,
               "context_line": "\treturn Forward<FuncType>(Func)(Forward<ArgTypes>(Args)...);",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -496,8 +444,6 @@
               "lineno": 151,
               "context_line": "\t\tSubsystemNativeImpl->CaptureEnsure(TEXT(\"Ensure failed\"), EnsureMessage.TrimStartAndEnd());",
               "data": {
-                "orig_in_app": -1,
-                "category": "indirection",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -511,7 +457,6 @@
               "lineno": 439,
               "context_line": "\tsentry_value_set_stacktrace(exceptionEvent, nullptr, 0);",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -520,7 +465,6 @@
               "symbol": "sentry_value_set_stacktrace",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -529,7 +473,6 @@
               "symbol": "sentry_value_new_stacktrace",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -538,7 +481,6 @@
               "symbol": "sentry_unwind_stack_from_ucontext",
               "package": "C:\\Users\\foo\\Desktop\\Windows\\SentryPlayground\\Binaries\\Win64\\SentryPlayground.exe",
               "data": {
-                "orig_in_app": -1,
                 "symbolicator_status": "symbolicated"
               }
             }

--- a/tests/sentry/grouping/grouping_inputs/unreal_event_capture_mac.json
+++ b/tests/sentry/grouping/grouping_inputs/unreal_event_capture_mac.json
@@ -12,8 +12,6 @@
               "symbol": "thread_start",
               "package": "/usr/lib/system/libsystem_pthread.dylib",
               "data": {
-                "orig_in_app": 0,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -22,8 +20,6 @@
               "symbol": "_pthread_start",
               "package": "/usr/lib/system/libsystem_pthread.dylib",
               "data": {
-                "orig_in_app": 0,
-                "category": "threadbase",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -32,8 +28,6 @@
               "symbol": "__NSThread__start__",
               "package": "/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation",
               "data": {
-                "orig_in_app": 0,
-                "category": "internals",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -221,7 +215,6 @@
               "symbol": "_ZZ20ProcessLocalFunctionP7UObjectP9UFunctionR6FFramePvENK4$_48clEv",
               "package": "/Users/foo/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground",
               "data": {
-                "category": "indirection",
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -285,7 +278,6 @@
               "symbol": "_ZN16USentrySubsystem25execCaptureEventWithScopeEP7UObjectR6FFramePv",
               "package": "/Users/foo/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground",
               "data": {
-                "orig_in_app": 1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -295,7 +287,6 @@
               "symbol": "_ZN16USentrySubsystem21CaptureEventWithScopeEP12USentryEventRK23FConfigureScopeDelegate",
               "package": "/Users/foo/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground",
               "data": {
-                "orig_in_app": 1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -305,7 +296,6 @@
               "symbol": "_ZN16USentrySubsystem21CaptureEventWithScopeEP12USentryEventRK9TDelegateIFvP12USentryScopeE26FDefaultDelegateUserPolicyE",
               "package": "/Users/foo/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground",
               "data": {
-                "orig_in_app": 1,
                 "symbolicator_status": "symbolicated"
               }
             },
@@ -315,7 +305,6 @@
               "symbol": "_ZN20SentrySubsystemApple21CaptureEventWithScopeE10TSharedPtrI12ISentryEventL7ESPMode1EERK9TDelegateIFvS0_I12ISentryScopeLS2_1EEE26FDefaultDelegateUserPolicyE",
               "package": "/Users/foo/Desktop/Mac/SentryPlayground.app/Contents/MacOS/SentryPlayground",
               "data": {
-                "orig_in_app": 1,
                 "symbolicator_status": "symbolicated"
               }
             },

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:23:51.119285+00:00'
+created: '2025-02-21T22:01:05.773639+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -111,13 +111,13 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"
   system*
@@ -127,10 +127,10 @@ contributing variants:
       system*
         threads*
           stacktrace*
-            frame*
+            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
               function*
                 "thread_start"
-            frame*
+            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
               function*
                 "_pthread_start"
             frame*
@@ -217,12 +217,12 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-20T15:17:58.268855+00:00'
+created: '2025-02-21T22:01:09.035981+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -108,12 +108,12 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "UFunction::Invoke"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame*
+            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:25:03.445606+00:00'
+created: '2025-02-21T22:01:09.142589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,10 +10,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)
@@ -100,16 +100,16 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
           frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
@@ -149,10 +149,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame*
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame*
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame*
@@ -239,16 +239,16 @@ system:
           frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
           frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-20T15:17:59.790275+00:00'
+created: '2025-02-21T22:01:10.565897+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,10 +10,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (ignored by stack trace rule (category:internals -group))
@@ -100,16 +100,16 @@ app:
           frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
           frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app -group))
@@ -239,16 +239,16 @@ system:
           frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "UFunction::Invoke"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (ignored due to recursion)
+          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame*
+          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
           frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))


### PR DESCRIPTION
There are more unnecessary fields in the JSON inputs.
Even though the snapshots change, the hashes do not change, thus, the grouping stays unaffected.