### PR TITLE
alertlink: refactor to use composition

### DIFF
--- a/static/app/components/core/alert.stories.tsx
+++ b/static/app/components/core/alert.stories.tsx
@@ -83,6 +83,23 @@ export default storyBook('Alert', (story, APIReference) => {
     );
   });
 
+  story('Without icon and custom trailing items', () => {
+    return (
+      <Fragment>
+        <p>
+          The <JSXProperty name="showIcon" value /> and{' '}
+          <JSXProperty name="trailingItems" value /> props can be used to customize the
+          alert.
+        </p>
+        <Alert.Container>
+          <Alert type="info" showIcon={false} trailingItems={<IconStar />}>
+            This alert has no icon and a custom trailing item.
+          </Alert>
+        </Alert.Container>
+      </Fragment>
+    );
+  });
+
   story('Dismissible Alerts', () => {
     const LOCAL_STORAGE_KEY = 'alert-stories-banner-dismissed';
     const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});

--- a/static/app/components/core/alert.tsx
+++ b/static/app/components/core/alert.tsx
@@ -286,7 +286,9 @@ function AlertIcon({type}: {type: AlertProps['type']}): React.ReactNode {
   return null;
 }
 
-// Spaces items within the container evenly.
+/**
+ * Manages margins of Alert components
+ */
 const Container = styled('div')`
   > div {
     margin-bottom: ${space(2)};

--- a/static/app/components/core/alertLink.spec.tsx
+++ b/static/app/components/core/alertLink.spec.tsx
@@ -1,22 +1,76 @@
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import AlertLink from 'sentry/components/core/alertLink';
-import {IconMail} from 'sentry/icons';
+import {AlertLink} from 'sentry/components/core/alertLink';
 
-describe('AlertLink', function () {
-  it('renders', function () {
+describe('AlertLink', () => {
+  it('renders internal link pointing to the correct path', () => {
     render(
-      <AlertLink to="/settings/accounts/notifications">
-        This is an external link button
+      <AlertLink type="info" to="/settings/accounts/notifications">
+        This is an internal link button
       </AlertLink>
     );
+
+    expect(
+      screen.getByRole('link', {name: 'This is an internal link button'})
+    ).toHaveAttribute('href', '/settings/accounts/notifications');
   });
 
-  it('renders with icon', function () {
+  it('link has rel="noopener noreferrer" and target="_blank" when openInNewTab is true', () => {
     render(
-      <AlertLink to="/settings/accounts/notifications" icon={<IconMail />}>
+      <AlertLink type="info" href="https://example.com" openInNewTab>
         This is an external link button
       </AlertLink>
     );
+
+    const link = screen.getByRole('link', {
+      name: 'This is an external link button',
+    });
+
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+
+  it('does not have rel="noopener noreferrer" and target="_blank" when openInNewTab is not set', () => {
+    render(
+      <AlertLink type="info" href="https://example.com" openInNewTab={false}>
+        This is an external link button
+      </AlertLink>
+    );
+
+    const link = screen.getByRole('link', {
+      name: 'This is an external link button',
+    });
+
+    expect(link).not.toHaveAttribute('target', '_blank');
+    expect(link).not.toHaveAttribute('rel', 'noreferrer noopener');
+  });
+
+  it('fires onClick when clicked', async () => {
+    const onClick = jest.fn();
+
+    render(
+      <AlertLink type="info" onClick={onClick}>
+        This is an external link button
+      </AlertLink>
+    );
+
+    await userEvent.click(
+      screen.getByRole('link', {name: 'This is an external link button'})
+    );
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders a custom trailing item', () => {
+    render(
+      <AlertLink
+        type="info"
+        to="/settings/accounts/notifications"
+        trailingItems={'custom trailing item'}
+      >
+        This is an external link button
+      </AlertLink>
+    );
+
+    expect(screen.getByText('custom trailing item')).toBeInTheDocument();
   });
 });

--- a/static/app/components/core/alertLink.stories.tsx
+++ b/static/app/components/core/alertLink.stories.tsx
@@ -1,160 +1,118 @@
-import {Fragment, useState} from 'react';
+import {Fragment} from 'react';
 
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink, type AlertLinkProps} from 'sentry/components/core/alertLink';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
-import {IconSentry} from 'sentry/icons';
+import {IconMail} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook('AlertLink', story => {
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import types from '!!type-loader!sentry/components/core/alertLink';
+
+const DUMMY_LINK = '/stories';
+
+const ALERT_LINK_VARIANTS: Array<AlertLinkProps['type']> = [
+  'info',
+  'warning',
+  'success',
+  'error',
+  'muted',
+];
+
+export default storyBook('AlertLink', (story, APIReference) => {
+  APIReference(types.AlertLink);
   story('Default', () => {
     return (
       <Fragment>
         <p>
-          The <JSXNode name="AlertLink" /> component is a highlighted banner that links to
-          some other page (or component). Depending on the{' '}
-          <JSXProperty name="priority" value /> prop specified, it can be used as a
-          success alert, an error or warning alert, and for various other use cases.
+          The <JSXNode name="AlertLink" /> component is a type of <JSXNode name="Alert" />
+          . The primary use case is when you want the entire alert to be a link.
         </p>
         <p>
           The default <JSXNode name="AlertLink" /> looks like this:
         </p>
-        <AlertLink href="https://sentry.io/welcome">
+        {ALERT_LINK_VARIANTS.map(variant => (
+          <AlertLink key={variant} type={variant} to={DUMMY_LINK}>
+            Clicking this link will not open in a new tab!
+          </AlertLink>
+        ))}
+      </Fragment>
+    );
+  });
+
+  story('Internal, External, and Manual Links', () => {
+    return (
+      <Fragment>
+        <p>
+          The <JSXNode name="AlertLink" /> component can be used as an external link, an
+          internal link, or a manual link (by specifying a{' '}
+          <JSXProperty name="onClick" value /> prop). Currently, only the{' '}
+          <JSXNode name="ExternalLink" /> component supports the{' '}
+          <JSXProperty name="openInNewTab" value /> prop - this prop is not supported for
+          internal or manual links.{' '}
+        </p>
+
+        <p>
+          AlertLink as an external link using{' '}
+          <JSXProperty name="href" value={`https://santry.io${DUMMY_LINK}`} />
+          and <JSXProperty name="openInNewTab" value />:
+        </p>
+        <AlertLink type="info" href={`https://santry.io/${DUMMY_LINK}`} openInNewTab>
+          Info Link
+        </AlertLink>
+        <p>
+          AlertLink as an internal link using <JSXProperty name="to" value={DUMMY_LINK} />
+          :
+        </p>
+        <AlertLink type="info" to={DUMMY_LINK}>
+          Info Link
+        </AlertLink>
+        <p>
+          AlertLink as a manual link using{' '}
+          <JSXProperty name="onClick" value={`() => window.alert('Clicked!')`} />:
+        </p>
+        {/* eslint-disable-next-line */}
+        <AlertLink type="info" onClick={() => window.alert('Clicked!')}>
+          Info Link
+        </AlertLink>
+      </Fragment>
+    );
+  });
+  story('With Custom Icon', () => {
+    return (
+      <Fragment>
+        <p>
+          The <JSXNode name="AlertLink" /> component can also be used with a custom icon.
+          The icon can be overriden by passing a{' '}
+          <JSXProperty name="trailingItems" value={'<IconMail />'} /> prop.
+        </p>
+        <AlertLink type="info" to={DUMMY_LINK} trailingItems={<IconMail />}>
           Clicking this link will not open in a new tab!
         </AlertLink>
-        <p>
-          The default props are <JSXProperty name="size" value="normal" />,{' '}
-          <JSXProperty name="priority" value="warning" />,{' '}
-          <JSXProperty name="withoutMarginBottom" value="false" />, and{' '}
-          <JSXProperty name="openInNewTab" value="false" />.
-        </p>
-        <p>
-          This alert below has <JSXProperty name="openInNewTab" value="true" />:
-        </p>
-        <AlertLink href="https://sentry.io/welcome" openInNewTab>
-          Clicking this link WILL open in a new tab!
-        </AlertLink>
       </Fragment>
     );
   });
 
-  story('priority', () => {
+  story('AlertLink.Container', () => {
     return (
       <Fragment>
         <p>
-          The <JSXProperty name="priority" value /> prop specifies the alert category, and
-          changes the color of the alert.
+          The <JSXNode name="AlertLink.Container" /> component is a container for one or
+          multiple <JSXNode name="AlertLink" /> components. It manages margins between the
+          links.
         </p>
-        <AlertLink priority="error">
-          This is an error alert. Something went wrong.
-        </AlertLink>
-        <AlertLink priority="info">Info alert. Put some exciting info here.</AlertLink>
-        <AlertLink priority="muted">Muted alerts look like this.</AlertLink>
-        <AlertLink priority="success">Success alert. Yay!</AlertLink>
-        <AlertLink priority="warning">
-          Warning alert. Something is about to go wrong, probably.
-        </AlertLink>
-      </Fragment>
-    );
-  });
-
-  story('icon', () => {
-    return (
-      <Fragment>
-        <p>
-          The <JSXProperty name="icon" value /> prop can be specified if you want to add
-          an icon to the alert. Just directly pass in the icon, like{' '}
-          <JSXNode name="IconSentry" /> for example, to the prop.
-        </p>
-        <AlertLink priority="warning" icon={<IconSentry />}>
-          Read the docs.
-        </AlertLink>
-      </Fragment>
-    );
-  });
-
-  story('system', () => {
-    return (
-      <Fragment>
-        <p>
-          The <JSXProperty name="system" value /> prop is a boolean that's{' '}
-          <code>false</code> by default.
-        </p>
-        <AlertLink>The default style.</AlertLink>
-        <AlertLink system>This is in the system style.</AlertLink>
-      </Fragment>
-    );
-  });
-
-  story('withoutMarginBottom', () => {
-    return (
-      <Fragment>
-        <p>
-          The <JSXProperty name="withoutMarginBottom" value /> prop is a boolean that's{' '}
-          <code>false</code> by default.
-        </p>
-        <AlertLink withoutMarginBottom>This one has no bottom margin.</AlertLink>
-        <AlertLink>This one has bottom margin by default.</AlertLink>
-        <AlertLink withoutMarginBottom>This one has no margin bottom.</AlertLink>
-      </Fragment>
-    );
-  });
-
-  story('size', () => {
-    return (
-      <Fragment>
-        <p>
-          The <JSXProperty name="size" value /> prop can be either <code>"small"</code> or{' '}
-          <code>"normal"</code>.{' '}
-        </p>
-        <AlertLink priority="info" size="normal">
-          Normal
-        </AlertLink>
-        <AlertLink priority="info" size="small">
-          Small
-        </AlertLink>
-      </Fragment>
-    );
-  });
-
-  story('to vs href vs onClick', () => {
-    const [count, setCount] = useState(0);
-    return (
-      <Fragment>
-        <p>
-          There are three ways to specify what should happen when the{' '}
-          <JSXNode name="AlertLink" /> is clicked.{' '}
-        </p>
-        <p>
-          The <JSXProperty name="to" value /> prop should be used for internal links.
-          Note: links specified with this prop will never open in a new tab, even if you
-          set
-          <JSXProperty name="openInNewTab" value="true" /> .
-        </p>
-        <AlertLink
-          priority="info"
-          size="normal"
-          to="/stories/?name=app/components/badge.stories.tsx"
-        >
-          View the badge story page
-        </AlertLink>
-        <p>
-          The <JSXProperty name="href" value /> prop should be used for external links.
-        </p>
-        <AlertLink
-          priority="info"
-          size="normal"
-          href="https://sentry.io/for/session-replay/"
-          openInNewTab
-        >
-          Learn more about Session Replay
-        </AlertLink>
-        <p>
-          Lastly, you can get creative with the <JSXProperty name="onClick" value /> prop.
-        </p>
-        <AlertLink priority="info" size="normal" onClick={() => setCount(count + 1)}>
-          You clicked this {count} times.
-        </AlertLink>
+        <AlertLink.Container>
+          <AlertLink type="info" to={DUMMY_LINK}>
+            Multiple AlertLinks
+          </AlertLink>
+          <AlertLink type="info" href={DUMMY_LINK} openInNewTab={false}>
+            Are nicely spaced out
+          </AlertLink>
+          {/* eslint-disable-next-line */}
+          <AlertLink type="info" onClick={() => window.alert('Clicked!')}>
+            ... all of them
+          </AlertLink>
+        </AlertLink.Container>
       </Fragment>
     );
   });

--- a/static/app/components/core/alertLink.stories.tsx
+++ b/static/app/components/core/alertLink.stories.tsx
@@ -31,11 +31,13 @@ export default storyBook('AlertLink', (story, APIReference) => {
         <p>
           The default <JSXNode name="AlertLink" /> looks like this:
         </p>
-        {ALERT_LINK_VARIANTS.map(variant => (
-          <AlertLink key={variant} type={variant} to={DUMMY_LINK}>
-            Clicking this link will not open in a new tab!
-          </AlertLink>
-        ))}
+        <AlertLink.Container>
+          {ALERT_LINK_VARIANTS.map(variant => (
+            <AlertLink key={variant} type={variant} to={DUMMY_LINK}>
+              Clicking this link will not open in a new tab!
+            </AlertLink>
+          ))}
+        </AlertLink.Container>
       </Fragment>
     );
   });

--- a/static/app/components/core/alertLink.tsx
+++ b/static/app/components/core/alertLink.tsx
@@ -11,13 +11,13 @@ import {space} from 'sentry/styles/space';
 interface BaseAlertLinkProps
   extends Pick<AlertProps, 'system' | 'children' | 'trailingItems'> {
   /**
+   * @deprecated use trailingItems instead
+   */
+  icon?: React.ReactNode;
+  /**
    * @deprecated Use `type` instead.
    */
   priority?: AlertProps['type'];
-  /**
-   * @deprecated use trailingItems instead
-   */
-  trailingItems?: React.ReactNode;
   type?: AlertProps['type'];
 }
 
@@ -54,9 +54,9 @@ export type AlertLinkProps =
 
 export function AlertLink(props: AlertLinkProps): React.ReactNode {
   const alertProps: AlertProps = {
-    type: props.type ?? props.priority ?? 'info',
+    type: props.priority ?? props.type ?? 'info',
     system: props.system,
-    trailingItems: props.trailingItems ?? <IconChevron direction="right" />,
+    trailingItems: props.icon ?? props.trailingItems ?? <IconChevron direction="right" />,
   };
 
   // @TODO(jonasbadalic): we should check for empty href and report to sentry

--- a/static/app/components/core/alertLink.tsx
+++ b/static/app/components/core/alertLink.tsx
@@ -9,7 +9,17 @@ import {IconChevron} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 
 interface BaseAlertLinkProps
-  extends Pick<AlertProps, 'type' | 'system' | 'children' | 'trailingItems'> {}
+  extends Pick<AlertProps, 'system' | 'children' | 'trailingItems'> {
+  /**
+   * @deprecated Use `type` instead.
+   */
+  priority?: AlertProps['type'];
+  /**
+   * @deprecated use trailingItems instead
+   */
+  trailingItems?: React.ReactNode;
+  type?: AlertProps['type'];
+}
 
 interface ExternalAlertLinkProps extends BaseAlertLinkProps {
   href: string;
@@ -44,7 +54,7 @@ export type AlertLinkProps =
 
 export function AlertLink(props: AlertLinkProps): React.ReactNode {
   const alertProps: AlertProps = {
-    type: props.type,
+    type: props.type ?? props.priority ?? 'info',
     system: props.system,
     trailingItems: props.trailingItems ?? <IconChevron direction="right" />,
   };
@@ -54,7 +64,7 @@ export function AlertLink(props: AlertLinkProps): React.ReactNode {
     // @TODO(jonasbadalic): Should we validate that the href is a valid URL?
     return (
       <ExternalLinkWithTextDecoration
-        type={props.type}
+        type={alertProps.type}
         href={props.href}
         openInNewTab={props.openInNewTab}
       >
@@ -69,7 +79,7 @@ export function AlertLink(props: AlertLinkProps): React.ReactNode {
       // causes the link to render a path to / which probably means that even though a manual link is specified,
       // the user might still be redirected to a path that they dont want to be redirected to?. Should this
       // be a button in this case?
-      <LinkWithTextDecoration type={props.type} to="" onClick={props.onClick}>
+      <LinkWithTextDecoration type={alertProps.type} to="" onClick={props.onClick}>
         <Alert {...alertProps}>{props.children}</Alert>
       </LinkWithTextDecoration>
     );
@@ -77,7 +87,7 @@ export function AlertLink(props: AlertLinkProps): React.ReactNode {
 
   // @TODO(jonasbadalic): we should check for empty to value and report to sentry
   return (
-    <LinkWithTextDecoration type={props.type} to={props.to}>
+    <LinkWithTextDecoration type={alertProps.type} to={props.to}>
       <Alert {...alertProps}>{props.children}</Alert>
     </LinkWithTextDecoration>
   );

--- a/static/app/components/core/alertLink.tsx
+++ b/static/app/components/core/alertLink.tsx
@@ -1,133 +1,124 @@
+import type React from 'react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
-import omit from 'lodash/omit';
 
+import {Alert, type AlertProps} from 'sentry/components/core/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {IconChevron} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 
-type Size = 'small' | 'normal';
-type Priority = 'info' | 'warning' | 'success' | 'error' | 'muted';
+interface BaseAlertLinkProps
+  extends Pick<AlertProps, 'type' | 'system' | 'children' | 'trailingItems'> {}
 
-type LinkProps = React.ComponentPropsWithoutRef<typeof Link>;
-
-type OtherProps = {
-  children?: React.ReactNode;
-  ['data-test-id']?: string;
-  icon?: string | React.ReactNode;
-  onClick?: (e: React.MouseEvent) => void;
-};
-
-type DefaultProps = {
+interface ExternalAlertLinkProps extends BaseAlertLinkProps {
+  href: string;
+  // @TODO(jonasbadalic): type definition used ot indicated this prop for all types, but it never actually worked for anything except external links
+  // @TODO(jonasbadalic): this type should not be optional because it has a default initializer inside ExternalLink!!
   openInNewTab: boolean;
-  priority: Priority;
-  size: Size;
-  withoutMarginBottom: boolean;
-  href?: string;
-  system?: boolean;
-};
+  onClick?: never;
+  // Disable other props that are not applicable for this type
+  to?: never;
+}
 
-type Props = OtherProps & Partial<DefaultProps> & Partial<Pick<LinkProps, 'to'>>;
+interface InternalAlertLinkProps extends BaseAlertLinkProps {
+  to: string;
+  // Disable other props that are not applicable for this type
+  href?: never;
+  onClick?: never;
+  openInNewTab?: never;
+}
 
-type StyledLinkProps = DefaultProps &
-  Partial<Pick<LinkProps, 'to'>> &
-  Omit<LinkProps, 'to' | 'size'>;
+interface ManualAlertLinkProps extends BaseAlertLinkProps {
+  onClick: React.MouseEventHandler<HTMLAnchorElement>;
+  // Disable other props that are not applicable for this type
+  href?: never;
+  openInNewTab?: never;
+  to?: never;
+}
 
-export function AlertLink({
-  size = 'normal',
-  priority = 'warning',
-  icon,
-  children,
-  onClick,
-  system = false,
-  withoutMarginBottom = false,
-  openInNewTab = false,
-  to,
-  href,
-  ['data-test-id']: dataTestId,
-}: Props) {
+export type AlertLinkProps =
+  | ExternalAlertLinkProps
+  | InternalAlertLinkProps
+  | ManualAlertLinkProps;
+
+export function AlertLink(props: AlertLinkProps): React.ReactNode {
+  const alertProps: AlertProps = {
+    type: props.type,
+    system: props.system,
+    trailingItems: props.trailingItems ?? <IconChevron direction="right" />,
+  };
+
+  // @TODO(jonasbadalic): we should check for empty href and report to sentry
+  if ('href' in props) {
+    // @TODO(jonasbadalic): Should we validate that the href is a valid URL?
+    return (
+      <ExternalLinkWithTextDecoration
+        type={props.type}
+        href={props.href}
+        openInNewTab={props.openInNewTab}
+      >
+        <Alert {...alertProps}>{props.children}</Alert>
+      </ExternalLinkWithTextDecoration>
+    );
+  }
+
+  if ('onClick' in props) {
+    return (
+      // @TODO(jonasbadalic): fix this hacky way of making the link work. It seems that doing this
+      // causes the link to render a path to / which probably means that even though a manual link is specified,
+      // the user might still be redirected to a path that they dont want to be redirected to?. Should this
+      // be a button in this case?
+      <LinkWithTextDecoration type={props.type} to="" onClick={props.onClick}>
+        <Alert {...alertProps}>{props.children}</Alert>
+      </LinkWithTextDecoration>
+    );
+  }
+
+  // @TODO(jonasbadalic): we should check for empty to value and report to sentry
   return (
-    <StyledLink
-      data-test-id={dataTestId}
-      to={to}
-      href={href}
-      onClick={onClick}
-      size={size}
-      priority={priority}
-      system={system}
-      withoutMarginBottom={withoutMarginBottom}
-      openInNewTab={openInNewTab}
-    >
-      {icon && <IconWrapper>{icon}</IconWrapper>}
-      <AlertLinkText>{children}</AlertLinkText>
-      <IconLink>
-        <IconChevron direction="right" />
-      </IconLink>
-    </StyledLink>
+    <LinkWithTextDecoration type={props.type} to={props.to}>
+      <Alert {...alertProps}>{props.children}</Alert>
+    </LinkWithTextDecoration>
   );
 }
 
-export default AlertLink;
+// @TODO(jonasbadalic): the styles here are duplicated...
+const ExternalLinkWithTextDecoration = styled(ExternalLink)<{
+  type: AlertProps['type'];
+}>`
+  display: block;
+  ${p => textDecorationStyles({type: p.type, theme: p.theme})}
+`;
 
-const StyledLink = styled(
-  ({openInNewTab, to, href, system: _, ...props}: StyledLinkProps) => {
-    const linkProps = omit(props, ['withoutMarginBottom', 'priority', 'size']);
-    if (href) {
-      return <ExternalLink {...linkProps} href={href} openInNewTab={openInNewTab} />;
-    }
+const LinkWithTextDecoration = styled(Link)<{type: AlertProps['type']}>`
+  display: block;
+  ${p => textDecorationStyles({type: p.type, theme: p.theme})}
+`;
 
-    return <Link {...linkProps} to={to || ''} />;
-  }
-)`
-  display: flex;
-  align-items: center;
-  background-color: ${p => p.theme.alert[p.priority].backgroundLight};
-  color: ${p => p.theme.alert[p.priority].color};
-  font-size: ${p => p.theme.fontSizeMedium};
-  text-decoration-color: ${p => p.theme.alert[p.priority].border};
-  text-decoration-style: solid;
-  text-decoration-line: underline;
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.06em;
-  border: 1px solid ${p => p.theme.alert[p.priority].border};
-  padding: ${p => (p.size === 'small' ? `${space(1)} ${space(1.5)}` : space(2))};
-  margin-bottom: ${p => (p.withoutMarginBottom ? 0 : space(3))};
-  border-radius: 0.25em;
-  transition: 0.2s border-color;
-
-  &:hover {
-    color: ${p => p.theme.alert[p.priority].color};
-    text-decoration-color: ${p => p.theme.alert[p.priority].color};
+function textDecorationStyles({type, theme}: {theme: Theme; type: AlertProps['type']}) {
+  return css`
+    text-decoration-color: ${theme.alert[type].border};
     text-decoration-style: solid;
     text-decoration-line: underline;
+    /* @TODO(jonasbadalic): can/should we standardize this transition? */
+    transition: 0.2s border-color;
+
+    &:hover {
+      text-decoration-color: ${theme.alert[type].color};
+      text-decoration-style: solid;
+      text-decoration-line: underline;
+    }
+  `;
+}
+
+/**
+ * Manages margins of AlertLink components
+ */
+const Container = styled('div')`
+  > a {
+    margin-bottom: ${space(2)};
   }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: ${p => p.theme.alert[p.priority].border} 0 0 0 2px;
-  }
-
-  ${p =>
-    p.system &&
-    `
-      border-width: 0 0 1px 0;
-      border-radius: 0;
-    `}
 `;
 
-const IconWrapper = styled('span')`
-  display: flex;
-  height: calc(${p => p.theme.fontSizeMedium} * ${p => p.theme.text.lineHeightBody});
-  margin-right: ${space(1)};
-  align-items: center;
-`;
-
-const IconLink = styled(IconWrapper)`
-  margin-right: 0;
-  margin-left: ${space(1)};
-`;
-
-const AlertLinkText = styled('div')`
-  line-height: ${p => p.theme.text.lineHeightBody};
-  flex-grow: 1;
-`;
+AlertLink.Container = Container;

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/reprocessAlert.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/reprocessAlert.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState} from 'react';
 
 import type {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
@@ -59,12 +59,7 @@ function ReprocessAlert({onReprocessEvent, api, orgSlug, projSlug, eventId}: Pro
 
   if (reprocessable) {
     return (
-      <AlertLink
-        priority="warning"
-        size="small"
-        onClick={onReprocessEvent}
-        withoutMarginBottom
-      >
+      <AlertLink type="warning" onClick={onReprocessEvent}>
         {t(
           'You’ve uploaded new debug files. Reprocess events in this issue to view a better stack trace'
         )}

--- a/static/app/components/feedback/feedbackItem/issueTrackingSection.tsx
+++ b/static/app/components/feedback/feedbackItem/issueTrackingSection.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueActions from 'sentry/components/group/externalIssuesList/externalIssueActions';
 import type {
@@ -77,13 +77,13 @@ export default function IssueTrackingSection({group, event, project}: Props) {
       ))}
     </Fragment>
   ) : (
-    <AlertLink
-      priority="muted"
-      size="small"
-      to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
-      withoutMarginBottom
-    >
-      {t('Track this issue in Jira, GitHub, etc.')}
-    </AlertLink>
+    <AlertLink.Container>
+      <AlertLink
+        type="muted"
+        to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
+      >
+        {t('Track this issue in Jira, GitHub, etc.')}
+      </AlertLink>
+    </AlertLink.Container>
   );
 }

--- a/static/app/components/group/externalIssuesList/index.tsx
+++ b/static/app/components/group/externalIssuesList/index.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueActions from 'sentry/components/group/externalIssuesList/externalIssueActions';
 import type {
@@ -76,13 +76,14 @@ export default function ExternalIssueList({group, event, project}: Props) {
             <Fragment key={key}>{renderers[type](props)}</Fragment>
           ))
         ) : (
-          <AlertLink
-            priority="muted"
-            size="small"
-            to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
-          >
-            {t('Track this issue in Jira, GitHub, etc.')}
-          </AlertLink>
+          <AlertLink.Container>
+            <AlertLink
+              type="muted"
+              to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
+            >
+              {t('Track this issue in Jira, GitHub, etc.')}
+            </AlertLink>
+          </AlertLink.Container>
         )}
       </SidebarSection.Content>
     </SidebarSection.Wrap>

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -2,7 +2,7 @@ import {Fragment, memo} from 'react';
 import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import GroupReleaseChart from 'sentry/components/group/releaseChart';
 import SeenInfo from 'sentry/components/group/seenInfo';
 import Placeholder from 'sentry/components/placeholder';
@@ -165,9 +165,11 @@ function GroupReleaseStats({
             <SidebarSection.Wrap>
               <SidebarSection.Title>{t('Releases')}</SidebarSection.Title>
               <SidebarSection.Content>
-                <AlertLink priority="muted" size="small" to={releaseTrackingUrl}>
-                  {t('See which release caused this issue ')}
-                </AlertLink>
+                <AlertLink.Container>
+                  <AlertLink type="muted" to={releaseTrackingUrl}>
+                    {t('See which release caused this issue ')}
+                  </AlertLink>
+                </AlertLink.Container>
               </SidebarSection.Content>
             </SidebarSection.Wrap>
           ) : null}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -20,7 +20,7 @@ import {Button} from 'sentry/components/button';
 import Checkbox from 'sentry/components/checkbox';
 import Confirm from 'sentry/components/confirm';
 import {Alert} from 'sentry/components/core/alert';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
@@ -913,23 +913,25 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
 
     // We want this to open in a new tab to not lose the current state of the rule editor
     return (
-      <AlertLink
-        openInNewTab
-        priority="error"
-        icon={<IconNot color="red300" />}
-        href={makeAlertsPathname({
-          path: `/rules/${project.slug}/${duplicateRuleId}/details/`,
-          organization,
-        })}
-      >
-        {tct(
-          'This rule fully duplicates "[alertName]" in the project [projectName] and cannot be saved.',
-          {
-            alertName: duplicateName,
-            projectName: project.name,
-          }
-        )}
-      </AlertLink>
+      <AlertLink.Container>
+        <AlertLink
+          openInNewTab
+          type="error"
+          trailingItems={<IconNot color="red300" />}
+          href={makeAlertsPathname({
+            path: `/rules/${project.slug}/${duplicateRuleId}/details/`,
+            organization,
+          })}
+        >
+          {tct(
+            'This rule fully duplicates "[alertName]" in the project [projectName] and cannot be saved.',
+            {
+              alertName: duplicateName,
+              projectName: project.name,
+            }
+          )}
+        </AlertLink>
+      </AlertLink.Container>
     );
   }
 

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueList.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, type ButtonProps, LinkButton} from 'sentry/components/button';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -185,10 +185,8 @@ export function ExternalIssueList({group, event, project}: ExternalIssueListProp
         </Fragment>
       ) : (
         <AlertLink
-          priority="muted"
-          size="small"
+          type="muted"
           to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
-          withoutMarginBottom
         >
           {t('Track this issue in Jira, GitHub, etc.')}
         </AlertLink>

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
 import {Alert} from 'sentry/components/core/alert';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
@@ -494,12 +494,11 @@ function MonitorForm({
         <InputGroup>
           {monitor?.config.alert_rule_id && (
             <AlertLink
-              priority="muted"
+              type="muted"
               to={makeAlertsPathname({
                 path: `/rules/${monitor.project.slug}/${monitor.config.alert_rule_id}/`,
                 organization,
               })}
-              withoutMarginBottom
             >
               {t('Customize this monitors notification configuration in Alerts')}
             </AlertLink>

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -6,7 +6,7 @@ import type {RequestOptions} from 'sentry/api';
 import Tag from 'sentry/components/badge/tag';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import type {FormProps} from 'sentry/components/forms/form';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -68,9 +68,15 @@ function AccountEmails() {
         <JsonForm forms={accountEmailsFields} />
       </Form>
 
-      <AlertLink to="/settings/account/notifications" icon={<IconStack />}>
-        {t('Want to change how many emails you get? Use the notifications panel.')}
-      </AlertLink>
+      <AlertLink.Container>
+        <AlertLink
+          to="/settings/account/notifications"
+          trailingItems={<IconStack />}
+          type="info"
+        >
+          {t('Want to change how many emails you get? Use the notifications panel.')}
+        </AlertLink>
+      </AlertLink.Container>
     </Fragment>
   );
 }

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject} from 'sentry/components/forms/types';
@@ -124,9 +124,11 @@ function NotificationSettings({organizations}: NotificationSettingsProps) {
           </Form>
         )}
       </BottomFormWrapper>
-      <AlertLink to="/settings/account/emails" icon={<IconMail />}>
-        {t('Looking to add or remove an email address? Use the emails panel.')}
-      </AlertLink>
+      <AlertLink.Container>
+        <AlertLink type="info" to="/settings/account/emails" trailingItems={<IconMail />}>
+          {t('Looking to add or remove an email address? Use the emails panel.')}
+        </AlertLink>
+      </AlertLink.Container>
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -3,7 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import LinkWithConfirmation from 'sentry/components/links/linkWithConfirmation';
@@ -73,15 +73,16 @@ function OrganizationApiKeysList({
         )}
       </TextBlock>
 
-      <AlertLink to="/settings/account/api/auth-tokens/" priority="info">
-        {tct(
-          'Until Sentry supports OAuth, you might want to switch to using [tokens:User Auth Tokens] instead.',
-          {
-            tokens: <u />,
-          }
-        )}
-      </AlertLink>
-
+      <AlertLink.Container>
+        <AlertLink to="/settings/account/api/auth-tokens/" type="info">
+          {tct(
+            'Until Sentry supports OAuth, you might want to switch to using [tokens:User Auth Tokens] instead.',
+            {
+              tokens: <u />,
+            }
+          )}
+        </AlertLink>
+      </AlertLink.Container>
       <PanelTable
         isLoading={loading}
         isEmpty={!hasKeys}

--- a/static/app/views/settings/organizationRepositories/organizationRepositories.tsx
+++ b/static/app/views/settings/organizationRepositories/organizationRepositories.tsx
@@ -1,5 +1,5 @@
 import {LinkButton} from 'sentry/components/button';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
@@ -25,11 +25,13 @@ function OrganizationRepositories({itemList, onRepositoryChange, organization}: 
   return (
     <div>
       <SettingsPageHeader title={t('Repositories')} />
-      <AlertLink to={`/settings/${organization.slug}/integrations/`}>
-        {t(
-          'Want to add a repository to start tracking commits? Install or configure your version control integration here.'
-        )}
-      </AlertLink>
+      <AlertLink.Container>
+        <AlertLink type="info" to={`/settings/${organization.slug}/integrations/`}>
+          {t(
+            'Want to add a repository to start tracking commits? Install or configure your version control integration here.'
+          )}
+        </AlertLink>
+      </AlertLink.Container>
       {!hasItemList && (
         <div className="m-b-2">
           <TextBlock>

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import {LinkButton} from 'sentry/components/button';
-import AlertLink from 'sentry/components/core/alertLink';
+import {AlertLink} from 'sentry/components/core/alertLink';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import LoadingError from 'sentry/components/loadingError';
@@ -121,11 +121,17 @@ function ProjectAlertSettings({canEditRule, params}: ProjectAlertSettingsProps) 
         }
       />
       <ProjectPermissionAlert project={project} />
-      <AlertLink to="/settings/account/notifications/" icon={<IconMail />}>
-        {t(
-          'Looking to fine-tune your personal notification preferences? Visit your Account Settings'
-        )}
-      </AlertLink>
+      <AlertLink.Container>
+        <AlertLink
+          to="/settings/account/notifications/"
+          trailingItems={<IconMail />}
+          type="info"
+        >
+          {t(
+            'Looking to fine-tune your personal notification preferences? Visit your Account Settings'
+          )}
+        </AlertLink>
+      </AlertLink.Container>
 
       {isProjectLoading || isPluginListLoading ? (
         <LoadingIndicator />


### PR DESCRIPTION
Refactor AlertLink to use the actual alert component and improve types. There are quite a few gotchas with this component and its types, and I expect there to be some unwanted behavior out there. This PR highlights all of those issues (see the number of todo comments) and addresses some.

Before:
![CleanShot 2025-02-21 at 17 42 11@2x](https://github.com/user-attachments/assets/8dc52ab1-bcaf-4c03-8961-ce84099714ab)

After
![CleanShot 2025-02-21 at 17 42 18@2x](https://github.com/user-attachments/assets/335d7eb0-57b8-4159-9326-c01ac583243d)

Some, but not all issues include:
- To wide of a prop definition - you could pass `to`, `href` and `onClick` at the same time, not really knowing which one is used?
- Unless explicitly set to false, openInNewTab prop would result in the link always being open in a new tab due to the default initializer inside 
- Visual discrepancy from the actual alert component
- Default margin being set and overriden in some cases. This has been updated to leverage a known pattern that @michellewzhang introduced for the Alert component
- Lack of tests - we now test for the some basic scenarios
- if only `onClick` is set, then a default value of `to='/'` is set, meaning event propagation likely has to be handled inside the onClick handler, else the navigation will still fire.
