### PR TITLE
fix(insights): prioritize data load/error over empty series

### DIFF
--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -57,18 +57,6 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
 
   const Title = <Widget.WidgetTitle title={props.title} />;
 
-  // TODO: Instead of using `ChartContainer`, enforce the height from the parent layout
-  if (visualizationProps.timeSeries.length === 0) {
-    return (
-      <ChartContainer>
-        <Widget
-          Title={Title}
-          Visualization={<Widget.WidgetError error={MISSING_DATA_MESSAGE} />}
-        />
-      </ChartContainer>
-    );
-  }
-
   if (props.isLoading) {
     return (
       <ChartContainer>
@@ -86,6 +74,18 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
         <Widget
           Title={Title}
           Visualization={<Widget.WidgetError error={props.error} />}
+        />
+      </ChartContainer>
+    );
+  }
+
+  // TODO: Instead of using `ChartContainer`, enforce the height from the parent layout
+  if (visualizationProps.timeSeries.length === 0) {
+    return (
+      <ChartContainer>
+        <Widget
+          Title={Title}
+          Visualization={<Widget.WidgetError error={MISSING_DATA_MESSAGE} />}
         />
       </ChartContainer>
     );


### PR DESCRIPTION
i noticed that the charts were loading an empty state before there was data readily available instead of the loading indicator; it appears we were not prioritizing checking the loading/error state over the empty series. i simply reordered the code so that we check for loading/error first

before:

https://github.com/user-attachments/assets/758f4012-b1b4-4652-a8e6-ba2e01bbbfc3

after:

https://github.com/user-attachments/assets/edc69449-bddd-4611-8a67-8bed9edfb48f

