### PR TITLE
fix(left-nav-views): Fix z-index on drag, improve dragging/navigate response

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
 import {GrowingInput} from 'sentry/components/growingInput';
+import {useNavContext} from 'sentry/components/nav/context';
 import {Tooltip} from 'sentry/components/tooltip';
 
 interface IssueViewNavEditableTitleProps {
@@ -27,6 +28,7 @@ function IssueViewNavEditableTitle({
     setInputValue(label);
   }, [label]);
 
+  const {isInteractingRef} = useNavContext();
   const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const isEmpty = !inputValue.trim();
@@ -84,7 +86,12 @@ function IssueViewNavEditableTitle({
   };
 
   return (
-    <Tooltip title={label} disabled={isEditing} showOnlyOnOverflow skipWrapper>
+    <Tooltip
+      title={label}
+      disabled={isEditing || !!isInteractingRef.current}
+      showOnlyOnOverflow
+      skipWrapper
+    >
       <motion.div layout="position" transition={{duration: 0.2}}>
         {isEditing ? (
           <StyledGrowingInput

--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
 import {GrowingInput} from 'sentry/components/growingInput';
-import {useNavContext} from 'sentry/components/nav/context';
 import {Tooltip} from 'sentry/components/tooltip';
 
 interface IssueViewNavEditableTitleProps {
+  isDragging: boolean;
   isEditing: boolean;
   isSelected: boolean;
   label: string;
@@ -21,6 +21,7 @@ function IssueViewNavEditableTitle({
   isEditing,
   isSelected,
   setIsEditing,
+  isDragging,
 }: IssueViewNavEditableTitleProps) {
   const [inputValue, setInputValue] = useState(label);
 
@@ -28,7 +29,6 @@ function IssueViewNavEditableTitle({
     setInputValue(label);
   }, [label]);
 
-  const {isInteractingRef} = useNavContext();
   const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const isEmpty = !inputValue.trim();
@@ -88,7 +88,7 @@ function IssueViewNavEditableTitle({
   return (
     <Tooltip
       title={label}
-      disabled={isEditing || !!isInteractingRef.current}
+      disabled={isEditing || isDragging}
       showOnlyOnOverflow
       skipWrapper
     >

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -105,7 +105,7 @@ export function IssueViewNavItemContent({
   const {startInteraction, endInteraction, isInteractingRef} = useNavContext();
 
   return (
-    <Reorder.Item
+    <StyledReorderItem
       as="div"
       dragConstraints={sectionRef}
       dragElastic={0.03}
@@ -175,7 +175,7 @@ export function IssueViewNavItemContent({
           </Tooltip>
         )}
       </StyledSecondaryNavItem>
-    </Reorder.Item>
+    </StyledReorderItem>
   );
 }
 
@@ -280,6 +280,13 @@ const hasUnsavedChanges = (
 
   return newUnsavedChanges;
 };
+
+// framer-motion's reorder item handles putting the dragging item in front of other items out of the box
+// but we need to make sure the item is relatively positioned and has a background color for it to work
+const StyledReorderItem = styled(Reorder.Item)`
+  position: relative;
+  background-color: ${p => p.theme.surface200};
+`;
 
 const TrailingItemsWrapper = styled('div')`
   display: flex;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -71,6 +71,7 @@ export function IssueViewNavItemContent({
 
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const [isEditing, setIsEditing] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
 
   const {projects} = useProjects();
 
@@ -115,9 +116,11 @@ export function IssueViewNavItemContent({
         cursor: 'grabbing',
       }}
       onDragStart={() => {
+        setIsDragging(true);
         startInteraction();
       }}
       onDragEnd={() => {
+        setIsDragging(false);
         endInteraction();
       }}
     >
@@ -160,6 +163,7 @@ export function IssueViewNavItemContent({
             updateView({...view, label: value});
           }}
           setIsEditing={setIsEditing}
+          isDragging={isDragging}
         />
         {view.unsavedChanges && (
           <Tooltip

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -281,8 +281,8 @@ const hasUnsavedChanges = (
   return newUnsavedChanges;
 };
 
-// framer-motion's reorder item handles putting the dragging item in front of other items out of the box
-// but we need to make sure the item is relatively positioned and has a background color for it to work
+// Reorder.Item does handle lifting an item being dragged above other items out of the box,
+// but we need to ensure the item is relatively positioned and has a background color for it to work
 const StyledReorderItem = styled(Reorder.Item)`
   position: relative;
   background-color: ${p => p.theme.surface200};

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -146,7 +146,7 @@ export function IssueViewNavItemContent({
         onPointerDown={e => {
           e.preventDefault();
         }}
-        onPointerUp={e => {
+        onClick={e => {
           if (isInteractingRef.current) {
             e.preventDefault();
           }


### PR DESCRIPTION
This PR makes three subtle, but important improvements for views: 

1. The item being dragged appears over other items 
2. The item label tooltip is disabled on dragging 
3. Stops accidental selection after dragging 

Before: 

https://github.com/user-attachments/assets/5deedd07-ae0c-46be-9ac1-6b5e183f6160

After:

https://github.com/user-attachments/assets/09196cbe-33b2-4604-91bf-7be3acd1e5c0