### PR TITLE
spike(sentry apps): drag out webhook spike to own PR

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -1,0 +1,55 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.integrations.utils.metrics import EventLifecycleMetric
+from sentry.sentry_apps.components import RpcSentryAppInstallation
+from sentry.sentry_apps.models.sentry_app import SentryApp
+from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryApp
+
+
+class SentryAppInteractionType(StrEnum):
+    """Actions that Sentry Apps can do"""
+
+    # Webhook actions
+    PREPARE_EVENT_WEBHOOK = "prepare_event_webhook"
+    SEND_EVENT_WEBHOOK = "send_event_webhook"
+    SEND_WEBHOOK = "send_webhook"
+
+    # External Requests actions
+    SELECT_REQUESTER = "select_requester"
+
+
+@dataclass
+class SentryAppInteractionEvent(EventLifecycleMetric):
+    """An event under the Sentry App umbrella"""
+
+    operation_type: SentryAppInteractionType
+    sentry_app: SentryApp | RpcSentryApp | None = None
+    sentry_app_installation: SentryAppInstallation | RpcSentryAppInstallation | None = None
+    region: str | None = None
+
+    def get_sentry_app_name(self) -> str:
+        return self.sentry_app.slug if self.sentry_app else ""
+
+    def get_region(self) -> str:
+        return self.region or ""
+
+    def get_metric_key(self, outcome: EventLifecycleOutcome) -> str:
+        tokens = ("sentry_app", str(outcome))
+        return ".".join(tokens)
+
+    def get_metric_tags(self) -> Mapping[str, str]:
+        return {
+            "operation_type": self.operation_type,
+            "region": self.get_region(),
+        }
+
+    def get_extras(self) -> Mapping[str, Any]:
+        return {
+            "sentry_app": self.get_sentry_app_name(),
+            "installation_uuid": (self.org_integration.id if self.org_integration else None),
+        }

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -5,10 +5,9 @@ from typing import Any
 
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.utils.metrics import EventLifecycleMetric
-from sentry.sentry_apps.components import RpcSentryAppInstallation
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.sentry_apps.services.app.model import RpcSentryApp
+from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
 
 
 class SentryAppInteractionType(StrEnum):
@@ -35,6 +34,9 @@ class SentryAppInteractionEvent(EventLifecycleMetric):
     def get_sentry_app_name(self) -> str:
         return self.sentry_app.slug if self.sentry_app else ""
 
+    def get_sentry_app_installation(self) -> str:
+        return self.sentry_app_installation.uuid if self.sentry_app_installation else ""
+
     def get_region(self) -> str:
         return self.region or ""
 
@@ -51,5 +53,5 @@ class SentryAppInteractionEvent(EventLifecycleMetric):
     def get_extras(self) -> Mapping[str, Any]:
         return {
             "sentry_app": self.get_sentry_app_name(),
-            "installation_uuid": (self.org_integration.id if self.org_integration else None),
+            "installation_uuid": self.get_sentry_app_installation(),
         }


### PR DESCRIPTION
Last PR was getting big so dragging webhook spike to here (Also had most questions/concerns on the webhooks)

CONTEXT:
[`process_resource_change_bound`](https://github.com/getsentry/sentry/pull/85707/files#diff-b5fc1664529df00a2660afe503420f76540827b1292aa857a147c2229122ef04R210) is the task called by post_process to send out `issue.created` & `error.created` (error) webhooks. For this task, anything that logged & returned or abruptly stopped the task was recorded as a failure. After creating the webhook body, we call [`send_resource_change_webhook`](https://github.com/getsentry/sentry/pull/85707/files#diff-b5fc1664529df00a2660afe503420f76540827b1292aa857a147c2229122ef04R462) to send the webhook to the appropriate Sentry App, (this is because we may have many Sentry Apps that are subscribed to error webhooks for 1 organization). 

In `send_resource_change_webhook` we get the `SentryAppInstallation` and then call [`send_webhooks`](https://github.com/getsentry/sentry/pull/85707/files#diff-b5fc1664529df00a2660afe503420f76540827b1292aa857a147c2229122ef04R477) which gets what webhook URLs we need to send to. Creates the request payload and then we call [`send_and_save_webhook_request`](https://github.com/getsentry/sentry/pull/85707/files#diff-bdce15d8f1cdcc2358084992bd1da1ccd87b91474eeda778c7247089b8d3da65R116) which actually sends the webhook to the 3p.

Since I wanted to divide up the metric for processing/generating the webhook and the actual sending of the webhook, I added a new context manager to the `send_resource_change_webhook` task too (though they're separate tasks so I don't know if there was another way to connect the two context managers otherwise?), more on this below.

QUESTIONS
Also is there a way to connect context managers to each other without re declaring the context manager completely? Or is that a no - no ? The reason is because for tracking if a webhook (for `send_resource_change_webhook`) was sent correctly there was two methods I was going between 🤷‍♀️ 

1. Declare the the context manager in [`send_resource_change_webhook`](https://github.com/getsentry/sentry/pull/85707/files#diff-b5fc1664529df00a2660afe503420f76540827b1292aa857a147c2229122ef04R465-R468) and then raise errors in the 'helper' methods for the context manager to catch. This approach would lead to some issues of redundant logging since Idk if I can attach the variables/'extras' from, [send_and_save_webhook_requests](https://github.com/getsentry/sentry/pull/85707/files#diff-bdce15d8f1cdcc2358084992bd1da1ccd87b91474eeda778c7247089b8d3da65R116) to what  I want to the context manager (?) <- is there a way to do this?

2. Have separate, more 'general' context managers that track general webhook sending. Which can be seen in the PR for [`send_and_save_webhook_request`](https://github.com/getsentry/sentry/pull/85707/files#diff-bdce15d8f1cdcc2358084992bd1da1ccd87b91474eeda778c7247089b8d3da65R131-R135). This will definitely lead to cascading fails though since if the event `SEND_WEBHOOK` fails then `SEND_EVENT_WEBHOOK` will definitely fail. This also has an issue where context/logs are not grouped by failure, i.e I want all the extras added in the `send_and_save_webhook_request` context manager to also be in the context manager declared in `send_webhooks`, do we already do this? If so can I achieve this single log end state without declaring two context managers?
