### PR TITLE
analytics(issue-views): Instrument left nav views with analytics

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -7,9 +7,11 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {IconEllipsis, IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 
 interface IssueViewNavEllipsisMenuProps {
@@ -32,6 +34,7 @@ export function IssueViewNavEllipsisMenu({
   baseUrl,
 }: IssueViewNavEllipsisMenuProps) {
   const navigate = useNavigate();
+  const organization = useOrganization();
 
   const handleSaveChanges = () => {
     const updatedView = {
@@ -45,6 +48,11 @@ export function IssueViewNavEllipsisMenu({
     };
     updateView(updatedView);
     navigate(constructViewLink(baseUrl, updatedView));
+
+    trackAnalytics('issue_views.saved_changes', {
+      leftNav: true,
+      organization: organization.slug,
+    });
   };
 
   const handleDiscardChanges = () => {
@@ -54,6 +62,11 @@ export function IssueViewNavEllipsisMenu({
     };
     updateView(updatedView);
     navigate(constructViewLink(baseUrl, updatedView));
+
+    trackAnalytics('issue_views.discarded_changes', {
+      leftNav: true,
+      organization: organization.slug,
+    });
   };
 
   return (

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -16,6 +16,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -105,7 +106,7 @@ export function IssueViewNavItemContent({
   const {startInteraction, endInteraction, isInteractingRef} = useNavContext();
 
   return (
-    <Reorder.Item
+    <StyledReorderItem
       as="div"
       dragConstraints={sectionRef}
       dragElastic={0.03}
@@ -146,9 +147,14 @@ export function IssueViewNavItemContent({
         onPointerDown={e => {
           e.preventDefault();
         }}
-        onPointerUp={e => {
+        onClick={e => {
           if (isInteractingRef.current) {
             e.preventDefault();
+          } else {
+            trackAnalytics('issue_views.switched_views', {
+              leftNav: true,
+              organization: organization.slug,
+            });
           }
         }}
       >
@@ -158,6 +164,10 @@ export function IssueViewNavItemContent({
           isSelected={isActive}
           onChange={value => {
             updateView({...view, label: value});
+            trackAnalytics('issue_views.renamed_view', {
+              leftNav: true,
+              organization: organization.slug,
+            });
           }}
           setIsEditing={setIsEditing}
         />
@@ -175,7 +185,7 @@ export function IssueViewNavItemContent({
           </Tooltip>
         )}
       </StyledSecondaryNavItem>
-    </Reorder.Item>
+    </StyledReorderItem>
   );
 }
 
@@ -280,6 +290,13 @@ const hasUnsavedChanges = (
 
   return newUnsavedChanges;
 };
+
+// Reorder.Item does handle lifting an item being dragged above other items out of the box,
+// but we need to ensure the item is relatively positioned and has a background color for it to work
+const StyledReorderItem = styled(Reorder.Item)`
+  position: relative;
+  background-color: ${p => p.theme.surface200};
+`;
 
 const TrailingItemsWrapper = styled('div')`
   display: flex;

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 
 import {IssueViewNavItemContent} from 'sentry/components/nav/issueViews/issueViewNavItemContent';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -136,8 +137,13 @@ export function IssueViewNavItems({
     (newOrder: IssueView[]) => {
       setViews(newOrder);
       debounceUpdateViews(newOrder);
+
+      trackAnalytics('issue_views.reordered_views', {
+        leftNav: true,
+        organization: organization.slug,
+      });
     },
-    [debounceUpdateViews]
+    [debounceUpdateViews, organization.slug]
   );
 
   const handleUpdateView = useCallback(
@@ -150,8 +156,13 @@ export function IssueViewNavItems({
       });
       debounceUpdateViews(newViews);
       setViews(newViews);
+
+      trackAnalytics('issue_views.updated_view', {
+        leftNav: true,
+        organization: organization.slug,
+      });
     },
-    [debounceUpdateViews, views]
+    [debounceUpdateViews, views, organization.slug]
   );
 
   const handleDeleteView = useCallback(
@@ -165,8 +176,13 @@ export function IssueViewNavItems({
           newViews.length > 0 ? constructViewLink(baseUrl, newViews[0]!) : `${baseUrl}/`;
         navigate(newUrl);
       }
+
+      trackAnalytics('issue_views.deleted_view', {
+        leftNav: true,
+        organization: organization.slug,
+      });
     },
-    [views, debounceUpdateViews, viewId, baseUrl, navigate]
+    [views, debounceUpdateViews, viewId, baseUrl, navigate, organization.slug]
   );
 
   const handleDuplicateView = useCallback(


### PR DESCRIPTION
Instruments the left nav issue views code with analytics. Reuses the same analytics as the old issue views analytics, but adds a `leftNav` param to distinguish between events, and for easier comparison. 