### PR TITLE
feat(uptime): Skip results from shadow regions in the result consumer

### DIFF
--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -263,6 +263,7 @@ def get_top_hosting_provider_names(limit: int) -> set[str]:
         )
     )
 
+
 @cache_func_for_models(
     [(ProjectUptimeSubscription, lambda project_sub: (project_sub.uptime_subscription_id,))],
     recalculate=False,

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -263,7 +263,6 @@ def get_top_hosting_provider_names(limit: int) -> set[str]:
         )
     )
 
-
 @cache_func_for_models(
     [(ProjectUptimeSubscription, lambda project_sub: (project_sub.uptime_subscription_id,))],
     recalculate=False,
@@ -276,6 +275,18 @@ def get_project_subscriptions_for_uptime_subscription(
         ProjectUptimeSubscription.objects.filter(
             uptime_subscription_id=uptime_subscription_id
         ).select_related("project", "project__organization")
+    )
+
+
+@cache_func_for_models(
+    [(UptimeSubscriptionRegion, lambda region: (region.uptime_subscription_id,))],
+    recalculate=False,
+)
+def get_regions_for_uptime_subscription(
+    uptime_subscription_id: int,
+) -> list[UptimeSubscriptionRegion]:
+    return list(
+        UptimeSubscriptionRegion.objects.filter(uptime_subscription_id=uptime_subscription_id)
     )
 
 


### PR DESCRIPTION
When we receive a result, we check the subscriptions regions and see if they're in shadow mode. If so, drop the result and log a stat.