### PR TITLE
feat(billing): Add quotas.backend.on_role_change

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
-from sentry import audit_log, features, ratelimits, roles
+from sentry import audit_log, features, quotas, ratelimits, roles
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -355,7 +355,16 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 )
                 return Response({"detail": message}, status=400)
 
+            previous_role = member.role
             self._change_org_role(member, assigned_org_role)
+
+            # Run any Subscription logic that needs to happen when a role is changed.
+            quotas.backend.on_role_change(
+                organization=organization,
+                organization_member=member,
+                previous_role=previous_role,
+                new_role=assigned_org_role,
+            )
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -16,6 +16,7 @@ from sentry.utils.services import Service
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
+    from sentry.models.organizationmember import OrganizationMember
     from sentry.models.project import Project
     from sentry.models.projectkey import ProjectKey
     from sentry.monitors.models import Monitor
@@ -705,3 +706,22 @@ class Quota(Service):
         Determines if the profile duration outcome should be emitted.
         """
         return True
+
+    def on_role_change(
+        self,
+        organization: Organization,
+        organization_member: OrganizationMember,
+        previous_role: str,
+        new_role: str,
+    ) -> None:
+        """
+        Called when an organization member's role is changed.
+        This is used to run any Subscription logic that needs to happen when a role is changed.
+
+        Args:
+            organization: The organization the member belongs to
+            organization_member: The member whose role is being changed
+            previous_role: The member's role before the change
+            new_role: The member's new role after the change
+        """
+        pass


### PR DESCRIPTION
This adds `quotas.backend.on_role_change` so that we can run any Subscription logic that needs to happen when a role is changed.

This is for https://github.com/getsentry/getsentry/pull/16602.