### PR TITLE
feat(insights): Adds a resolve_column_if_exists field alias converter for messaging operation tags

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -61,6 +61,8 @@ SPAN_DESCRIPTION = "span.description"
 SPAN_STATUS = "span.status"
 SPAN_CATEGORY = "span.category"
 REPLAY_ALIAS = "replay"
+MESSAGING_OPERATION_TYPE_ALIAS = "messaging.operation.type"
+MESSAGING_OPERATION_NAME_ALIAS = "messaging.operation.name"
 
 
 class ThresholdDict(TypedDict):

--- a/src/sentry/search/events/datasets/field_aliases.py
+++ b/src/sentry/search/events/datasets/field_aliases.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sentry_sdk
-from snuba_sdk import AliasedExpression, Function
+from snuba_sdk import AliasedExpression, Column, Function
 
 from sentry.discover.models import TeamKeyTransaction
 from sentry.exceptions import IncompatibleMetricsQuery
@@ -165,4 +165,4 @@ def resolve_column_if_exists(builder: BaseQueryBuilder, alias: str) -> SelectTyp
         hasColumn = builder.resolve_tag_key(alias)
         if hasColumn:
             return builder.column(alias)
-    return Function("nullif", ["", ""], alias)
+    return Column("null")

--- a/src/sentry/search/events/datasets/field_aliases.py
+++ b/src/sentry/search/events/datasets/field_aliases.py
@@ -158,3 +158,11 @@ def resolve_replay_alias(builder: BaseQueryBuilder, alias: str) -> SelectType:
         [Function("nullif", [builder.column(column), ""]) for column in columns],
         alias,
     )
+
+
+def resolve_column_if_exists(builder: BaseQueryBuilder, alias: str) -> SelectType:
+    if hasattr(builder, "resolve_tag_key"):
+        hasColumn = builder.resolve_tag_key(alias)
+        if hasColumn:
+            return builder.column(alias)
+    return Function("nullif", ["", ""], alias)

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -62,6 +62,12 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             constants.PROJECT_NAME_ALIAS: lambda alias: field_aliases.resolve_project_slug_alias(
                 self.builder, alias
             ),
+            constants.MESSAGING_OPERATION_TYPE_ALIAS: lambda alias: field_aliases.resolve_column_if_exists(
+                self.builder, alias
+            ),
+            constants.MESSAGING_OPERATION_NAME_ALIAS: lambda alias: field_aliases.resolve_column_if_exists(
+                self.builder, alias
+            ),
         }
 
     def resolve_metric(self, value: str) -> int:

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1901,6 +1901,30 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         assert data == [{"avg_if_process(span.duration)": 10.0}]
 
+    def test_filter_on_messaging_operation(self):
+        self.store_span_metric(
+            10,
+            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
+            timestamp=self.six_min_ago,
+            tags={"span.op": "queue.process"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "avg_if_process(span.duration)",
+                ],
+                "query": "span.op:queue.process OR messaging.operation.type:process OR messaging.operation.name:process",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [{"avg_if_process(span.duration)": 10.0}]
+
     def test_project_mapping(self):
         self.store_span_metric(
             1,
@@ -2377,3 +2401,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_avg_if_process(self):
         super().test_avg_if_process()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_filter_on_messaging_operation(self):
+        super().test_filter_on_messaging_operation()


### PR DESCRIPTION
Adds a `resolve_column_if_exists` resolver that returns null when the requested tag doesn't exist in metrics. Applies this resolver to `messaging.operation.type` and `messaging.operation.name` columns, so that queries don't completely fail when these tags don't exist in span metrics