### PR TITLE
chore(uptime): Cache query to fetch project subscriptions in result consumer

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -32,6 +32,7 @@ from sentry.uptime.models import (
     UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
+    get_project_subscriptions_for_uptime_subscription,
     get_top_hosting_provider_names,
 )
 from sentry.uptime.subscriptions.regions import get_active_region_configs
@@ -205,11 +206,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
 
         self.check_and_update_regions(subscription, result)
 
-        project_subscriptions = list(
-            subscription.projectuptimesubscription_set.select_related(
-                "project", "project__organization"
-            ).all()
-        )
+        project_subscriptions = get_project_subscriptions_for_uptime_subscription(subscription.id)
 
         cluster = _get_cluster()
         last_updates: list[str | None] = cluster.mget(

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -259,5 +259,20 @@ def get_top_hosting_provider_names(limit: int) -> set[str]:
     )
 
 
+@cache_func_for_models(
+    [(ProjectUptimeSubscription, lambda project_sub: (project_sub.uptime_subscription_id,))],
+    recalculate=False,
+    cache_ttl=timedelta(hours=4),
+)
+def get_project_subscriptions_for_uptime_subscription(
+    uptime_subscription_id: int,
+) -> list[ProjectUptimeSubscription]:
+    return list(
+        ProjectUptimeSubscription.objects.filter(
+            uptime_subscription_id=uptime_subscription_id
+        ).select_related("project", "project__organization")
+    )
+
+
 class UptimeRegionScheduleMode(enum.StrEnum):
     ROUND_ROBIN = REGIONSCHEDULEMODE_ROUND_ROBIN


### PR DESCRIPTION
We fetch this every minute for most subscriptions. Adding a cache here, since these change infrequently.

<!-- Describe your PR here. -->