### PR TITLE
fix(ui): Remove white-space: nowrap from OccurrenceSummary

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -230,6 +230,7 @@ const GraphSection = styled('div')`
 `;
 
 const OccurrenceSummarySection = styled(OccurrenceSummary)`
+  white-space: unset;
   grid-area: timeline;
   padding: ${space(1)};
   padding-left: 0;


### PR DESCRIPTION
The problem in question

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/46d0b058-ba41-4752-b769-ed46014b973d" />
