### PR TITLE
chore(insights-terminology): update latency to duration

### DIFF
--- a/static/app/views/insights/common/components/chartPanel.spec.tsx
+++ b/static/app/views/insights/common/components/chartPanel.spec.tsx
@@ -9,11 +9,11 @@ describe('chartPanel', function () {
   });
   it('should render', function () {
     render(
-      <ChartPanel title="Avg Latency">
+      <ChartPanel title="Average Duration">
         <div />
       </ChartPanel>,
       {organization}
     );
-    expect(screen.getByText('Avg Latency')).toBeInTheDocument();
+    expect(screen.getByText('Average Duration')).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.spec.tsx
@@ -24,7 +24,7 @@ describe('latencyChart', () => {
       <LatencyChart destination="events" referrer={Referrer.QUEUES_SUMMARY_CHARTS} />,
       {organization}
     );
-    screen.getByText('Avg Latency');
+    screen.getByText('Average Duration');
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({

--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -23,7 +23,7 @@ export function LatencyChart({error, destination, referrer}: Props) {
 
   return (
     <InsightsAreaChartWidget
-      title={t('Avg Latency')}
+      title={t('Average Duration')}
       series={[
         data['avg(messaging.message.receive.latency)'],
         data['avg(span.duration)'],

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -77,7 +77,7 @@ describe('destinationSummaryPage', () => {
     render(<PageWithProviders />, {organization});
     await screen.findByRole('table', {name: 'Transactions'});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
-    screen.getByText('Avg Latency');
+    screen.getByText('Average Duration');
     screen.getByText('Published vs Processed');
     expect(eventsStatsMock).toHaveBeenCalled();
     expect(eventsMock).toHaveBeenCalled();

--- a/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
@@ -79,7 +79,7 @@ describe('queuesLandingPage', () => {
     render(<QueuesLandingPage />, {organization});
     await screen.findByRole('table', {name: 'Queues'});
     screen.getByPlaceholderText('Search for more destinations');
-    screen.getByText('Avg Latency');
+    screen.getByText('Average Duration');
     screen.getByText('Published vs Processed');
     expect(eventsStatsMock).toHaveBeenCalled();
     expect(eventsMock).toHaveBeenCalled();


### PR DESCRIPTION
We do not use latency anywhere in the app - we specifically use duration. This means that when a user searches for P50 or P75, the option will be span.duration. Columns in the table are also reflected as duration. Widgets in every module are also reflected as duration. See Queries and API for examples:
![Screenshot 2025-02-22 at 2 08 17 PM](https://github.com/user-attachments/assets/5a705fd7-a742-4759-9c68-a1d5b7d0edba)

**Before:**
![Screenshot 2025-02-22 at 2 08 00 PM](https://github.com/user-attachments/assets/115ef899-c58a-406b-a488-5b2e4dc86d4f)

**After:**
![Screenshot 2025-02-22 at 2 06 53 PM](https://github.com/user-attachments/assets/4ae671c1-c2fd-4486-a166-6f71c1bd1044)