### PR TITLE
feat(demo-mode): ban `IsAuthenticated` import

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAuthenticated
+from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAuthenticated  # noqa: S012
 from rest_framework.request import Request
 
 from sentry.api.exceptions import (
@@ -328,6 +328,10 @@ class DemoSafePermission(SentryPermission):
 
 
 class SentryIsAuthenticated(IsAuthenticated):
+    """
+    Used to deny access for demo users in both view and object permission checks.
+    """
+
     def has_permission(self, request: Request, view: object) -> bool:
         if demo_mode.is_demo_user(request.user):
             return False

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -213,3 +213,14 @@ class Test(ApiTestCase):
         "t.py:19:27: S011 Use override_options(...) instead to ensure proper cleanup",
     ]
     assert _run(src, filename="tests/test_example.py") == expected
+
+
+def test_S012():
+    src = """\
+from rest_framework.permissions import BasePermission, IsAuthenticated, SAFE_METHODS
+"""
+
+    expected = [
+        "t.py:1:0: S012 Use ``from sentry.api.permissions import SentryIsAuthenticated`` instead"
+    ]
+    assert _run(src, filename="tests/test_example.py") == expected

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -33,6 +33,8 @@ S010_msg = "S010 Except handler does nothing and should be removed"
 
 S011_msg = "S011 Use override_options(...) instead to ensure proper cleanup"
 
+S012_msg = "S012 Use ``from sentry.api.permissions import SentryIsAuthenticated`` instead"
+
 
 class SentryVisitor(ast.NodeVisitor):
     def __init__(self, filename: str) -> None:
@@ -64,6 +66,10 @@ class SentryVisitor(ast.NodeVisitor):
                 and "sentry.testutils" in node.module
             ):
                 self.errors.append((node.lineno, node.col_offset, S007_msg))
+            elif node.module == "rest_framework.permissions" and any(
+                x.name == "IsAuthenticated" for x in node.names
+            ):
+                self.errors.append((node.lineno, node.col_offset, S012_msg))
 
         self.generic_visit(node)
 

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -33,6 +33,7 @@ S010_msg = "S010 Except handler does nothing and should be removed"
 
 S011_msg = "S011 Use override_options(...) instead to ensure proper cleanup"
 
+# SentryIsAuthenticated extends from IsAuthenticated and provides additional checks for demo users
 S012_msg = "S012 Use ``from sentry.api.permissions import SentryIsAuthenticated`` instead"
 
 


### PR DESCRIPTION
- Closes https://github.com/getsentry/projects/issues/655
- Follow up of #79665 
- Forces use of `sentry.api.permissions.SentryIsAuthenticated` which performs demo mode related checks instead of `rest_framework.permissions.IsAuthenticated` 