### PR TITLE
chore(dynamic-sampling): increase timeout for boost_low_volume_projects from 5 to 10 minutes

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -90,8 +90,8 @@ OrgProjectVolumes = tuple[OrganizationId, ProjectId, int, DecisionKeepCount, Dec
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=5 * 60,  # 5 minutes
-    time_limit=5 * 60 + 5,
+    soft_time_limit=10 * 60,  # 5 minutes
+    time_limit=10 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -90,7 +90,7 @@ OrgProjectVolumes = tuple[OrganizationId, ProjectId, int, DecisionKeepCount, Dec
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=10 * 60,  # 5 minutes
+    soft_time_limit=10 * 60,  # 10 minutes
     time_limit=10 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )


### PR DESCRIPTION
- After https://github.com/getsentry/sentry/pull/85443, [we have been seeing some soft timeouts]([SENTRY-3P1Q](https://sentry.sentry.io/issues/6317832466/)), and since we don't want to dilute the logic, we increase the timeout to see if this fixes the problem (as speed is currently not of concern)
