### PR TITLE
fix(onboarding): Avoid adding `--saas` wizard arg on self-hosted

### DIFF
--- a/static/app/gettingStartedDocs/javascript/nuxt.tsx
+++ b/static/app/gettingStartedDocs/javascript/nuxt.tsx
@@ -32,7 +32,7 @@ import {t, tct, tctCode} from 'sentry/locale';
 type Params = DocsParams;
 
 const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '--saas' : '--saas';
+  const urlParam = isSelfHosted ? '' : '--saas';
 
   return [
     {


### PR DESCRIPTION
Looks like for Nuxt, we always added `--saas` to the wizard command snippet, even in self-hosted sentry installs. This PR ensures we only add it when on SaaS 

h/t @romtsn for reporting