### PR TITLE
feat(insights): Hide LCP and CLS columns from the pageloads sample table when feature flagged

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -534,7 +534,13 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
       {datatype === Datatype.PAGELOADS && (
         <GridEditable
           isLoading={isLoading}
-          columnOrder={PAGELOADS_COLUMN_ORDER}
+          columnOrder={
+            organization.features.includes('performance-vitals-standalone-cls-lcp')
+              ? PAGELOADS_COLUMN_ORDER.filter(
+                  col => !['measurements.cls', 'measurements.lcp'].includes(col.key)
+                )
+              : PAGELOADS_COLUMN_ORDER
+          }
           columnSortBy={[]}
           data={tableData}
           grid={{


### PR DESCRIPTION
Hides the LCP and CLS columns from Web Vitals Pageloads samples table when standalone LCP and CLS spans are feature flagged, because LCP and CLS should appear in the span samples table instead.