### PR TITLE
ref: use the normal logger instead of borrowing another's

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -147,7 +147,7 @@ class OAuth2Provider(Provider):
         formatted_error = f"HTTP {req.status_code} ({error_name}): {error_description}"
 
         if req.status_code == 401:
-            self.logger.info(
+            logger.info(
                 "identity.oauth.refresh.identity-not-valid-error",
                 extra={
                     "error_name": error_name,
@@ -162,7 +162,7 @@ class OAuth2Provider(Provider):
             # this may not be common, but at the very least Google will return
             # an invalid grant when a user is suspended
             if error_name == "invalid_grant":
-                self.logger.info(
+                logger.info(
                     "identity.oauth.refresh.identity-not-valid-error",
                     extra={
                         "error_name": error_name,
@@ -174,7 +174,7 @@ class OAuth2Provider(Provider):
                 raise IdentityNotValid(formatted_error)
 
         if req.status_code != 200:
-            self.logger.info(
+            logger.info(
                 "identity.oauth.refresh.api-error",
                 extra={
                     "error_name": error_name,
@@ -353,14 +353,14 @@ class OAuth2CallbackView(PipelineView):
             code = request.GET.get("code")
 
             if error:
-                pipeline.logger.info("identity.token-exchange-error", extra={"error": error})
+                logger.info("identity.token-exchange-error", extra={"error": error})
                 lifecycle.record_failure(
                     "token_exchange_error", extra={"failure_info": ERR_INVALID_STATE}
                 )
                 return pipeline.error(f"{ERR_INVALID_STATE}\nError: {error}")
 
             if state != pipeline.fetch_state("state"):
-                pipeline.logger.info(
+                logger.info(
                     "identity.token-exchange-error",
                     extra={
                         "error": "invalid_state",
@@ -383,7 +383,7 @@ class OAuth2CallbackView(PipelineView):
             return pipeline.error(data["error_description"])
 
         if "error" in data:
-            pipeline.logger.info("identity.token-exchange-error", extra={"error": data["error"]})
+            logger.info("identity.token-exchange-error", extra={"error": data["error"]})
             return pipeline.error(f"{ERR_TOKEN_RETRIEVAL}\nError: {data['error']}")
 
         # we can either expect the API to be implicit and say "im looking for

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -21,12 +19,8 @@ from . import default_manager
 
 IDENTITY_LINKED = _("Your {identity_provider} account has been associated with your Sentry account")
 
-logger = logging.getLogger("sentry.identity")
-
 
 class IdentityProviderPipeline(Pipeline):
-    logger = logger
-
     pipeline_name = "identity_provider"
     provider_manager = default_manager
     provider_model_cls = IdentityProvider


### PR DESCRIPTION
`Pipeline` doesn't generically have a `logger` -- using a logger in the normal way works just the same here

<!-- Describe your PR here. -->