### PR TITLE
ref: replace self.redirect with HttpResponseRedirect directly

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qsl, urlencode
 
 import orjson
 from django.http import HttpRequest, HttpResponse
+from django.http.response import HttpResponseRedirect
 from django.urls import reverse
 
 from sentry.auth.exceptions import IdentityNotValid
@@ -65,7 +66,7 @@ class OAuth2Login(AuthView):
         if request.subdomain:
             helper.bind_state("subdomain", request.subdomain)
 
-        return self.redirect(authorization_url)
+        return HttpResponseRedirect(authorization_url)
 
 
 class OAuth2Callback(AuthView):

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.contrib.auth import logout
 from django.http import HttpResponse, HttpResponseServerError
 from django.http.request import HttpRequest
+from django.http.response import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
@@ -72,7 +73,7 @@ class SAML2LoginView(AuthView):
         saml_config = build_saml_config(provider.config, helper.organization.slug)
         auth = build_auth(request, saml_config)
 
-        return self.redirect(auth.login())
+        return HttpResponseRedirect(auth.login())
 
 
 # With SAML, the SSO request can be initiated by both the Service Provider


### PR DESCRIPTION
I'm divorcing the AuthView / PipelineView inheritance hierarchy from django's views so that we can have a particular `dispatch` signature -- this removes calls to `.redirect(...)` and replaces it with the response type directly

<!-- Describe your PR here. -->