### PR TITLE
fix(widget-builder): Change `field (no aggregate)` to `field`

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -248,7 +248,7 @@ describe('Visualize', () => {
       await screen.findByRole('button', {name: 'Column Selection'})
     ).toHaveTextContent('transaction.duration');
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
-      'field (no aggregate)'
+      'field'
     );
   });
 
@@ -272,7 +272,7 @@ describe('Visualize', () => {
     );
 
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
-    await userEvent.click(screen.getByRole('option', {name: 'field (no aggregate)'}));
+    await userEvent.click(screen.getByRole('option', {name: 'field'}));
 
     // The column selection is automatically opened for aggregates
     await userEvent.click(screen.getByRole('option', {name: 'transaction.duration'}));
@@ -281,7 +281,7 @@ describe('Visualize', () => {
       'transaction.duration'
     );
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
-      'field (no aggregate)'
+      'field'
     );
   });
 
@@ -629,11 +629,9 @@ describe('Visualize', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
 
-    // Being unable to choose "field (no aggregate)" in the aggregate selection means that the
+    // Being unable to choose "field" in the aggregate selection means that the
     // individual field is not allowed, i.e. only aggregates appear.
-    expect(
-      screen.queryByRole('option', {name: 'field (no aggregate)'})
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'field'})).not.toBeInTheDocument();
   });
 
   it('updates only the selected field', async () => {
@@ -1035,7 +1033,7 @@ describe('Visualize', () => {
 
     // Component automatically populates the selection as a column
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
-      'field (no aggregate)'
+      'field'
     );
     expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
       'message'

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -59,8 +59,8 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 export const NONE = 'none';
 
 export const NONE_AGGREGATE = {
-  textValue: t('field (no aggregate)'),
-  label: tct('[emphasis:field (no aggregate)]', {
+  textValue: t('field'),
+  label: tct('[emphasis:field]', {
     emphasis: <em />,
   }),
   value: NONE,


### PR DESCRIPTION
Made this fix as discussed in [this thread](https://sentry.slack.com/archives/C01MYDW8Y7K/p1740407668997609?thread_ts=1740384005.567329&cid=C01MYDW8Y7K)
 
<img width="424" alt="image" src="https://github.com/user-attachments/assets/029da500-b0b4-4d8a-b133-b19cb879f612" />

