### PR TITLE
fix(issue-views): Fix copy pasting links not working 

### DIFF
--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -217,41 +217,40 @@ function IssueViewsIssueListHeaderTabsContent({
         environments,
         timeFilters,
       } = views[0]!;
-      if (queryProjects || queryTimeFilters) {
-        navigate(
-          normalizeUrl({
-            ...location,
-            query: {
-              ...router.location.query,
-              viewId: id,
-              query: query ?? viewQuery,
-              sort: sort ?? querySort,
-              project: queryProjects ?? projects,
-              environment: queryEnvs ?? environments,
-              ...normalizeDateTimeParams(queryTimeFilters ?? timeFilters),
-            },
-          }),
-          {replace: true}
-        );
-        tabListState?.setSelectedKey(views[0]!.key);
-        return;
-      }
       if (!query && !sort) {
-        navigate(
-          normalizeUrl({
-            ...location,
-            query: {
-              ...router.location.query,
-              viewId: id,
-              query: viewQuery,
-              sort: querySort,
-              project: projects,
-              environment: environments,
-              ...normalizeDateTimeParams(timeFilters),
-            },
-          }),
-          {replace: true}
-        );
+        if (queryProjects || queryTimeFilters) {
+          navigate(
+            normalizeUrl({
+              ...location,
+              query: {
+                ...router.location.query,
+                viewId: id,
+                query: query ?? viewQuery,
+                sort: sort ?? querySort,
+                project: queryProjects ?? projects,
+                environment: queryEnvs ?? environments,
+                ...normalizeDateTimeParams(queryTimeFilters ?? timeFilters),
+              },
+            }),
+            {replace: true}
+          );
+        } else {
+          navigate(
+            normalizeUrl({
+              ...location,
+              query: {
+                ...router.location.query,
+                viewId: id,
+                query: viewQuery,
+                sort: querySort,
+                project: projects,
+                environment: environments,
+                ...normalizeDateTimeParams(timeFilters),
+              },
+            }),
+            {replace: true}
+          );
+        }
         tabListState?.setSelectedKey(views[0]!.key);
         return;
       }


### PR DESCRIPTION
Fixes a bug where copy pasting a link with time filters or projects and a query in the url would incorrectly redirect to the first tab, rather than a temporary tab. 

New behavior: 

* Just projects -> first tab with project filter updated
* Just time filters -> first tab with time filters updated
* Just Projects & timefilters -> first tab with projects & time filters updated
* Query & projects -> temp tab 
* Query & time filters -> temp tab 
* Query & time filters & projects -> temp tab 