### PR TITLE
chore(ACI): Add audit log entries for detectors and workflows

### DIFF
--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -630,3 +630,11 @@ default_manager.add(
         template="created project {slug} via {origin}",
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=1155,
+        name="DETECTOR_CREATE",
+        api_name="detector.create",
+        template="created detector {name}",
+    )
+)

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -586,6 +586,30 @@ default_manager.add(
         template="removed detector {name}",
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=213,
+        name="WORFKLOW_ADD",
+        api_name="workflow.add",
+        template="added workflow {name}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
+        event_id=214,
+        name="WORFKLOW_EDIT",
+        api_name="workflow.edit",
+        template="edited workflow {name}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
+        event_id=215,
+        name="WORFKLOW_REMOVE",
+        api_name="workflow.remove",
+        template="removed workflow {name}",
+    )
+)
 
 default_manager.add(
     AuditLogEvent(

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -565,25 +565,25 @@ default_manager.add(
 default_manager.add(
     AuditLogEvent(
         event_id=210,
-        name="WORKFLOW_ENGINE_DETECTOR_ADD",
-        api_name="workflow_engine_detector.add",
-        template="added workflow engine detector {name}",
+        name="DETECTOR_ADD",
+        api_name="detector.add",
+        template="added detector {name}",
     )
 )
 default_manager.add(
     AuditLogEvent(
         event_id=211,
-        name="WORKFLOW_ENGINE_DETECTOR_EDIT",
-        api_name="workflow_engine_detector.edit",
-        template="edited workflow engine detector {name}",
+        name="DETECTOR_EDIT",
+        api_name="detector.edit",
+        template="edited detector {name}",
     )
 )
 default_manager.add(
     AuditLogEvent(
         event_id=212,
-        name="WORKFLOW_ENGINE_DETECTOR_REMOVE",
-        api_name="workflow_engine_detector.remove",
-        template="removed workflow engine detector {name}",
+        name="DETECTOR_REMOVE",
+        api_name="detector.remove",
+        template="removed detector {name}",
     )
 )
 
@@ -628,13 +628,5 @@ default_manager.add(
         name="PROJECT_ADD_WITH_ORIGIN",
         api_name="project.create-with-origin",
         template="created project {slug} via {origin}",
-    )
-)
-default_manager.add(
-    AuditLogEvent(
-        event_id=1155,
-        name="DETECTOR_CREATE",
-        api_name="detector.create",
-        template="created detector {name}",
     )
 )

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -81,9 +81,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 request=self.context["request"],
                 organization=self.context["organization"],
                 target_object=detector.id,
-                event=audit_log.get_event_id(
-                    "UPTIME_MONITOR_ADD"
-                ),  # TODO this is the wrong event type
+                event=audit_log.get_event_id("DETECTOR_CREATE"),
                 data=detector.get_audit_log_data(),
             )
         return detector

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -81,7 +81,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 request=self.context["request"],
                 organization=self.context["organization"],
                 target_object=detector.id,
-                event=audit_log.get_event_id("DETECTOR_CREATE"),
+                event=audit_log.get_event_id("DETECTOR_ADD"),
                 data=detector.get_audit_log_data(),
             )
         return detector

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -65,7 +65,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
                 request=self.context["request"],
                 organization=self.context["organization"],
                 target_object=detector.id,
-                event=audit_log.get_event_id("WORKFLOW_ENGINE_DETECTOR_ADD"),
+                event=audit_log.get_event_id("DETECTOR_ADD"),
                 data=detector.get_audit_log_data(),
             )
         return detector

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -106,8 +106,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return group_type.detector_handler(self)
 
     def get_audit_log_data(self) -> dict[str, Any]:
-        # TODO: Create proper audit log data for the detector, group and conditions
-        return {}
+        return {"name": self.name}
 
     def get_option(
         self, key: str, default: Any | None = None, validate: Callable[[object], bool] | None = None

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -70,6 +70,9 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             )
         ]
 
+    def get_audit_log_data(self) -> dict[str, Any]:
+        return {"name": self.name}
+
     def evaluate_trigger_conditions(self, job: WorkflowJob) -> tuple[bool, list[DataCondition]]:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -51,7 +51,7 @@ class TestErrorDetectorValidator(TestCase):
             request=self.context["request"],
             organization=self.project.organization,
             target_object=detector.id,
-            event=audit_log.get_event_id("WORKFLOW_ENGINE_DETECTOR_ADD"),
+            event=audit_log.get_event_id("DETECTOR_ADD"),
             data=detector.get_audit_log_data(),
         )
 

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -262,7 +262,7 @@ class DetectorValidatorTest(BaseValidatorTest):
             request=self.context["request"],
             organization=self.project.organization,
             target_object=detector.id,
-            event=audit_log.get_event_id("DETECTOR_CREATE"),
+            event=audit_log.get_event_id("DETECTOR_ADD"),
             data=detector.get_audit_log_data(),
         )
 
@@ -381,7 +381,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             request=self.context["request"],
             organization=self.project.organization,
             target_object=detector.id,
-            event=audit_log.get_event_id("DETECTOR_CREATE"),
+            event=audit_log.get_event_id("DETECTOR_ADD"),
             data=detector.get_audit_log_data(),
         )
 

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -262,7 +262,7 @@ class DetectorValidatorTest(BaseValidatorTest):
             request=self.context["request"],
             organization=self.project.organization,
             target_object=detector.id,
-            event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
+            event=audit_log.get_event_id("DETECTOR_CREATE"),
             data=detector.get_audit_log_data(),
         )
 
@@ -381,7 +381,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             request=self.context["request"],
             organization=self.project.organization,
             target_object=detector.id,
-            event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
+            event=audit_log.get_event_id("DETECTOR_CREATE"),
             data=detector.get_audit_log_data(),
         )
 


### PR DESCRIPTION
Edit the audit log entry names for detectors, call them where appropriate, and add audit log entry types for workflows. We don't have the workflow endpoints yet to be able to call them yet, but at least they're there for when we build them.