### PR TITLE
fix(Jira): Automatically truncates issue title when it's too long

### DIFF
--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -88,7 +88,10 @@ def transform_fields(
     transformed_data = {}
 
     # Special handling for fields that don't map cleanly to the transformer logic
-    data["summary"] = data.get("title")
+    # Also, we need to truncate the title field to prevent Jira from erroring
+    # when it's too long.
+    title = data.get("title")
+    data["summary"] = title[:255] if title else None
     if labels := data.get("labels"):
         data["labels"] = [label.strip() for label in labels.split(",") if label.strip()]
 

--- a/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
+++ b/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
@@ -194,3 +194,15 @@ class TestDataTransformer(TestCase):
         )
 
         assert transformed_data == {"fixVersion": {"id": 0}}
+
+    def test_title_field(self):
+        field = self.create_standard_field(name="summary", schema_type=JiraSchemaTypes.string)
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"title": "a" * 512}
+        )
+        assert transformed_data == {"summary": "a" * 255}
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"title": "Test Title"}
+        )
+        assert transformed_data == {"summary": "Test Title"}


### PR DESCRIPTION
<!-- Describe your PR here. -->
Addresses #55524

Auto-truncates issue titles to 255 characters, as Jira will error if the summary exceeds this length.
Implementing this only for Jira for now, but will expand this to cover other integrations in the future if they're affected.

