### PR TITLE
fix(performance): hide default Transaction Summary filters

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
@@ -71,6 +71,12 @@ function StatusBreakdown({eventView, location, organization}: Props) {
             value: parseInt(String(row['count()']), 10),
             onClick: () => {
               const query = new MutableSearch(eventView.query);
+
+              // Strip default filters, as we don't want them to show in the
+              // search bar. See `generateEventView` in
+              // static/app/views/performance/transactionSummary/transactionOverview/index.tsx.
+              query.removeFilter('event.type').removeFilter('transaction');
+
               query
                 .removeFilter('!transaction.status')
                 .setFilterValues('transaction.status', [


### PR DESCRIPTION
The Transaction Summary page applies default filters of `transaction:<selected transaction name>` and `event.type:transaction` to all queries made from it. The `StatusBreakdown` component was exposing these default filters when selecting a status to filter the page on, with `event.type` getting marked as an invalid filter (see #78024). It is actually valid (and necessary), but doesn't make sense for a user to set directly.

Sidestep the issue by no longer exposing the default `transaction` and `event.type` filters when filtering on status from `StatusBreakdown`. This now matches the behaviour of all the other tag breakdown filters, which similarly keep the default filters hidden.

Fixes #78024.