### PR TITLE
ref(crons): Remove time restriction on uptime issues

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -18,7 +18,7 @@ describe('UptimeAlertDetails', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/?limit=20&project=${project.id}&query=issue.category%3Auptime%20tags%5Buptime_rule%5D%3A1&statsPeriod=14d`,
+      url: `/organizations/${organization.slug}/issues/?limit=20&project=${project.id}&query=issue.category%3Auptime%20tags%5Buptime_rule%5D%3A1`,
       body: [],
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
@@ -5,9 +5,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import {IssueCategory} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {getUtcDateString} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 
 interface Props {
   project: Project;
@@ -16,17 +14,6 @@ interface Props {
 
 export function UptimeIssues({project, ruleId}: Props) {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
-  const {start, end, period} = selection.datetime;
-  const timeProps =
-    start && end
-      ? {
-          start: getUtcDateString(start),
-          end: getUtcDateString(end),
-        }
-      : {
-          statsPeriod: period,
-        };
 
   // TODO(davidenwang): Replace this with an actual query for the specific uptime alert rule
   const query = `issue.category:${IssueCategory.UPTIME} tags[uptime_rule]:${ruleId}`;
@@ -50,7 +37,6 @@ export function UptimeIssues({project, ruleId}: Props) {
         query,
         project: project.id,
         limit: 20,
-        ...timeProps,
       }}
       renderEmptyMessage={emptyMessage}
     />


### PR DESCRIPTION
There will only ever be one issue, so until we have a better component
to use here let's just remove the time-range filter so we always show
that one issue in the table