### PR TITLE
fix(ui): Keep cursor in checkInTimeline navigations

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -183,7 +183,8 @@ export function GridLineOverlay({
           start: dateFromPosition(startX).startOf('minute').toDate(),
           end: dateFromPosition(endX).add(1, 'minute').startOf('minute').toDate(),
         },
-        router
+        router,
+        {keepCursor: true}
       ),
     [dateFromPosition, router]
   );

--- a/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
+++ b/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
@@ -49,7 +49,9 @@ export function useDateNavigation(): DateNavigation {
     );
     const nextSince = moment(nextUntil).subtract(windowMs, 'milliseconds');
 
-    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, router);
+    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, router, {
+      keepCursor: true,
+    });
   }, [until, windowMs, nowRef, router]);
 
   return {


### PR DESCRIPTION
Avoids resetting the pagination cursor when navigating