### PR TITLE
chore(gh-ent): redirect to optional public_link

### DIFF
--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -252,6 +252,12 @@ class InstallationForm(forms.Form):
         ),
         widget=forms.TextInput(attrs={"placeholder": "our-sentry-app"}),
     )
+    public_link = forms.URLField(
+        label="Public Link",
+        help_text=_('The "public link" for your GitHub enterprise app (optional)'),
+        widget=forms.TextInput(attrs={"placeholder": "https://github.example.com"}),
+        required=False,
+    )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),
         help_text=_(
@@ -478,6 +484,9 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
 
 class GitHubEnterpriseInstallationRedirect(PipelineView):
     def get_app_url(self, installation_data):
+        if installation_data.get("public_link"):
+            return installation_data["public_link"]
+
         url = installation_data.get("url")
         name = installation_data.get("name")
         return f"https://{url}/github-apps/{name}"

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -257,6 +257,7 @@ class InstallationForm(forms.Form):
         help_text=_('The "public link" for your GitHub enterprise app (optional)'),
         widget=forms.TextInput(attrs={"placeholder": "https://github.example.com"}),
         required=False,
+        assume_scheme="https",
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),
@@ -309,6 +310,8 @@ class InstallationConfigView(PipelineView):
             if form.is_valid():
                 form_data = form.cleaned_data
                 form_data["url"] = urlparse(form_data["url"]).netloc
+                if not form_data["public_link"]:
+                    form_data["public_link"] = None
 
                 pipeline.bind_state("installation_data", form_data)
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -253,8 +253,8 @@ class InstallationForm(forms.Form):
         widget=forms.TextInput(attrs={"placeholder": "our-sentry-app"}),
     )
     public_link = forms.URLField(
-        label="Public Link",
-        help_text=_('The "public link" for your GitHub enterprise app (optional)'),
+        label="Public Link (GitHub Enterprise Server only)",
+        help_text=_("The publicly available link for your GitHub App in GitHub Enterprise Server"),
         widget=forms.TextInput(attrs={"placeholder": "https://github.example.com"}),
         required=False,
         assume_scheme="https",

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -185,6 +185,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
                 "id": "2",
                 "name": "test-app",
                 "private_key": "private_key",
+                "public_link": None,
                 "url": "github.example.org",
                 "webhook_secret": "webhook_secret",
                 "verify_ssl": True,

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -27,22 +27,31 @@ from sentry.users.models.identity import Identity, IdentityProvider, IdentitySta
 @control_silo_test
 class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
     provider = GitHubEnterpriseIntegrationProvider
-    config = {
-        "url": "https://github.example.org",
-        "id": 2,
-        "name": "test-app",
-        "client_id": "client_id",
-        "client_secret": "client_secret",
-        "webhook_secret": "webhook_secret",
-        "private_key": "private_key",
-        "verify_ssl": True,
-    }
-    base_url = "https://github.example.org/api/v3"
+
+    def setUp(self):
+        super().setUp()
+        self.config = {
+            "url": "https://github.example.org",
+            "id": 2,
+            "name": "test-app",
+            "client_id": "client_id",
+            "client_secret": "client_secret",
+            "webhook_secret": "webhook_secret",
+            "private_key": "private_key",
+            "verify_ssl": True,
+        }
+        self.base_url = "https://github.example.org/api/v3"
 
     @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token_1")
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def assert_setup_flow(
-        self, get_jwt, _, installation_id="install_id_1", app_id="app_1", user_id="user_id_1"
+        self,
+        get_jwt,
+        _,
+        installation_id="install_id_1",
+        app_id="app_1",
+        user_id="user_id_1",
+        public_link=None,
     ):
         responses.reset()
         resp = self.client.get(self.init_path)
@@ -51,8 +60,11 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         assert resp.status_code == 302
         redirect = urlparse(resp["Location"])
         assert redirect.scheme == "https"
-        assert redirect.netloc == "github.example.org"
-        assert redirect.path == "/github-apps/test-app"
+        if public_link:
+            assert resp["Location"] == public_link
+        else:
+            assert redirect.netloc == "github.example.org"
+            assert redirect.path == "/github-apps/test-app"
 
         # App installation ID is provided, mveo thr
         resp = self.client.get(
@@ -173,6 +185,45 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
                 "id": "2",
                 "name": "test-app",
                 "private_key": "private_key",
+                "url": "github.example.org",
+                "webhook_secret": "webhook_secret",
+                "verify_ssl": True,
+            },
+        }
+        oi = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+        assert oi.config == {}
+
+        idp = IdentityProvider.objects.get(type="github_enterprise")
+        identity = Identity.objects.get(idp=idp, user=self.user, external_id="user_id_1")
+        assert identity.status == IdentityStatus.VALID
+        assert identity.data == {"access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"}
+
+    @responses.activate
+    def test_basic_flow__public_link(self):
+        public_link = "https://github.example.org/github/apps/test-app"
+        self.config["public_link"] = public_link
+        self.assert_setup_flow(public_link=public_link)
+
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        assert integration.external_id == "github.example.org:install_id_1"
+        assert integration.name == "Test Organization"
+        assert integration.metadata == {
+            "access_token": None,
+            "expires_at": None,
+            "icon": "https://github.example.org/avatar.png",
+            "domain_name": "github.example.org/Test-Organization",
+            "account_type": "Organization",
+            "installation_id": "install_id_1",
+            "installation": {
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "id": "2",
+                "name": "test-app",
+                "private_key": "private_key",
+                "public_link": public_link,
                 "url": "github.example.org",
                 "webhook_secret": "webhook_secret",
                 "verify_ssl": True,


### PR DESCRIPTION
We construct a hardcoded redirect link for GH Enterprise to `f"https://{url}/github-apps/{name}"`, but for some GH ent instances this 404s and they should be able to provide their own redirect url.

This is the `Public Link` in the updated screenshot below

<img width="705" alt="Screenshot 2025-02-24 at 13 12 15" src="https://github.com/user-attachments/assets/da23162a-c179-49d9-8d86-5dda638a6b83" />