### PR TITLE
feat(autofix): Pass readability down in repositories list

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -455,25 +455,26 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         repo_code_mappings[mapping.repository.external_id] = mapping
 
             for repo_external_id, repo_state in autofix_codebase_state.items():
-                mapping = repo_code_mappings.get(repo_external_id, None)
+                if repo_external_id:
+                    mapping = repo_code_mappings.get(repo_external_id, None)
 
-                if not mapping:
-                    continue
+                    if not mapping:
+                        continue
 
-                mapping_repo: Repository = mapping.repository
+                    mapping_repo: Repository = mapping.repository
 
-                repositories.append(
-                    {
-                        "integration_id": mapping_repo.integration_id,
-                        "url": mapping_repo.url,
-                        "external_id": repo_external_id,
-                        "name": mapping_repo.name,
-                        "provider": mapping_repo.provider,
-                        "default_branch": mapping.default_branch,
-                        "is_readable": repo_state.get("is_readable", False),
-                        "is_writeable": repo_state.get("is_writeable", False),
-                    }
-                )
+                    repositories.append(
+                        {
+                            "integration_id": mapping_repo.integration_id,
+                            "url": mapping_repo.url,
+                            "external_id": repo_external_id,
+                            "name": mapping_repo.name,
+                            "provider": mapping_repo.provider,
+                            "default_branch": mapping.default_branch,
+                            "is_readable": repo_state.get("is_readable", False),
+                            "is_writeable": repo_state.get("is_writeable", False),
+                        }
+                    )
 
             response_state["repositories"] = repositories
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -470,7 +470,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         "provider": mapping_repo.provider,
                         "default_branch": mapping.default_branch,
                         "is_readable": repo_state.get("is_readable", False),
-                        "is_writable": repo_state.get("is_writable", False),
+                        "is_writeable": repo_state.get("is_writeable", False),
                     }
                 )
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -451,7 +451,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
             if project:
                 code_mappings = get_sorted_code_mapping_configs(project=project)
                 for mapping in code_mappings:
-                    repo_code_mappings[mapping.repository.external_id] = mapping
+                    if mapping.repository.external_id:
+                        repo_code_mappings[mapping.repository.external_id] = mapping
 
             for repo_external_id, repo_state in autofix_codebase_state.items():
                 mapping = repo_code_mappings.get(repo_external_id, None)

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -455,26 +455,27 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         repo_code_mappings[mapping.repository.external_id] = mapping
 
             for repo_external_id, repo_state in autofix_codebase_state.items():
-                if repo_external_id:
-                    mapping = repo_code_mappings.get(repo_external_id, None)
+                mapping: RepositoryProjectPathConfig | None = repo_code_mappings.get(
+                    repo_external_id, None
+                )
 
-                    if not mapping:
-                        continue
+                if not mapping:
+                    continue
 
-                    mapping_repo: Repository = mapping.repository
+                mapping_repo: Repository = mapping.repository
 
-                    repositories.append(
-                        {
-                            "integration_id": mapping_repo.integration_id,
-                            "url": mapping_repo.url,
-                            "external_id": repo_external_id,
-                            "name": mapping_repo.name,
-                            "provider": mapping_repo.provider,
-                            "default_branch": mapping.default_branch,
-                            "is_readable": repo_state.get("is_readable", False),
-                            "is_writeable": repo_state.get("is_writeable", False),
-                        }
-                    )
+                repositories.append(
+                    {
+                        "integration_id": mapping_repo.integration_id,
+                        "url": mapping_repo.url,
+                        "external_id": repo_external_id,
+                        "name": mapping_repo.name,
+                        "provider": mapping_repo.provider,
+                        "default_branch": mapping.default_branch,
+                        "is_readable": repo_state.get("is_readable", False),
+                        "is_writeable": repo_state.get("is_writeable", False),
+                    }
+                )
 
             response_state["repositories"] = repositories
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -472,8 +472,8 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         "name": mapping_repo.name,
                         "provider": mapping_repo.provider,
                         "default_branch": retrieved_mapping.default_branch,
-                        "is_readable": repo_state.get("is_readable", False),
-                        "is_writeable": repo_state.get("is_writeable", False),
+                        "is_readable": repo_state.get("is_readable", None),
+                        "is_writeable": repo_state.get("is_writeable", None),
                     }
                 )
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -455,14 +455,14 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         repo_code_mappings[mapping.repository.external_id] = mapping
 
             for repo_external_id, repo_state in autofix_codebase_state.items():
-                mapping: RepositoryProjectPathConfig | None = repo_code_mappings.get(
+                retrieved_mapping: RepositoryProjectPathConfig | None = repo_code_mappings.get(
                     repo_external_id, None
                 )
 
-                if not mapping:
+                if not retrieved_mapping:
                     continue
 
-                mapping_repo: Repository = mapping.repository
+                mapping_repo: Repository = retrieved_mapping.repository
 
                 repositories.append(
                     {

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -471,7 +471,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
                         "external_id": repo_external_id,
                         "name": mapping_repo.name,
                         "provider": mapping_repo.provider,
-                        "default_branch": mapping.default_branch,
+                        "default_branch": retrieved_mapping.default_branch,
                         "is_readable": repo_state.get("is_readable", False),
                         "is_writeable": repo_state.get("is_writeable", False),
                     }

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -32,12 +32,26 @@ class AutofixStatus(str, enum.Enum):
     WAITING_FOR_USER_RESPONSE = "WAITING_FOR_USER_RESPONSE"
 
 
+class FileChange(BaseModel):
+    path: str
+    content: str | None = None
+    is_deleted: bool = False
+
+
+class CodebaseState(BaseModel):
+    repo_external_id: str | None = None
+    file_changes: list[FileChange] = []
+    is_readable: bool = False
+    is_writeable: bool = False
+
+
 class AutofixState(BaseModel):
     run_id: int
     request: AutofixRequest
     updated_at: datetime.datetime
     status: AutofixStatus
     actor_ids: list[str] | None = None
+    codebases: dict[str, CodebaseState] = {}
 
     class Config:
         extra = "allow"

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -41,8 +41,8 @@ class FileChange(BaseModel):
 class CodebaseState(BaseModel):
     repo_external_id: str | None = None
     file_changes: list[FileChange] = []
-    is_readable: bool = False
-    is_writeable: bool = False
+    is_readable: bool | None = None
+    is_writeable: bool | None = None
 
 
 class AutofixState(BaseModel):

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -153,8 +153,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is not None
         assert len(response.data["autofix"]["repositories"]) == 2
 
+        repositories = sorted(
+            response.data["autofix"]["repositories"], key=lambda x: x["integration_id"]
+        )
+
         # Check first repo
-        repo = response.data["autofix"]["repositories"][0]
+        repo = repositories[0]
         assert repo["default_branch"] == "main"
         assert repo["name"] == "repo1"
         assert repo["provider"] == "github"
@@ -165,7 +169,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert repo["is_writeable"] is True
 
         # Check second repo
-        repo = response.data["autofix"]["repositories"][1]
+        repo = repositories[1]
         assert repo["default_branch"] == "master"
         assert repo["name"] == "repo2"
         assert repo["provider"] == "gitlab"


### PR DESCRIPTION
Passes repo readibility stuff down, and also maps the codebases from the state instead.

This will not affect any existing runs but should be deployed before frontend does.
