### PR TITLE
fix(dynamic alerts): Check that aggregation value is a float

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -27,6 +27,14 @@ SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
 )
 
 
+def is_number(aggregation_value: int | float) -> bool:
+    return (
+        True
+        if isinstance(aggregation_value, int) or isinstance(aggregation_value, float)
+        else False
+    )
+
+
 def get_anomaly_data_from_seer(
     alert_rule: AlertRule,
     subscription: QuerySubscription,
@@ -40,7 +48,7 @@ def get_anomaly_data_from_seer(
         "project_id": subscription.project_id,
         "alert_rule_id": alert_rule.id,
     }
-    if not snuba_query or not isinstance(aggregation_value, float):
+    if not snuba_query or not is_number(aggregation_value):
         extra_data["aggregation_value"] = aggregation_value
         logger.info("Aggregation value not integer or snuba query is empty", extra=extra_data)
         return None

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -27,7 +27,7 @@ SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
 )
 
 
-def is_number(aggregation_value: int | float) -> bool:
+def is_number(aggregation_value: int | float | None) -> bool:
     return (
         True
         if isinstance(aggregation_value, int) or isinstance(aggregation_value, float)

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -27,14 +27,6 @@ SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
 )
 
 
-def is_number(aggregation_value: int | float | None) -> bool:
-    return (
-        True
-        if isinstance(aggregation_value, int) or isinstance(aggregation_value, float)
-        else False
-    )
-
-
 def get_anomaly_data_from_seer(
     alert_rule: AlertRule,
     subscription: QuerySubscription,
@@ -48,9 +40,9 @@ def get_anomaly_data_from_seer(
         "project_id": subscription.project_id,
         "alert_rule_id": alert_rule.id,
     }
-    if not snuba_query or not is_number(aggregation_value):
+    if not snuba_query or not isinstance(aggregation_value, (int, float)):
         extra_data["aggregation_value"] = aggregation_value
-        logger.info("Aggregation value not integer or snuba query is empty", extra=extra_data)
+        logger.warning("Aggregation value not integer or snuba query is empty", extra=extra_data)
         return None
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -40,9 +40,9 @@ def get_anomaly_data_from_seer(
         "project_id": subscription.project_id,
         "alert_rule_id": alert_rule.id,
     }
-    if not snuba_query or aggregation_value in {None, "NULL_VALUE"}:
+    if not snuba_query or not isinstance(aggregation_value, float):
         extra_data["aggregation_value"] = aggregation_value
-        logger.info("Aggregation value or snuba query is empty", extra=extra_data)
+        logger.info("Aggregation value not integer or snuba query is empty", extra=extra_data)
         return None
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -711,7 +711,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             "aggregation_value": "NULL_VALUE",
         }
         assert result is None
-        mock_logger.info.assert_called_with(
+        mock_logger.warning.assert_called_with(
             "Aggregation value not integer or snuba query is empty",
             extra=logger_extra,
         )

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -712,7 +712,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         }
         assert result is None
         mock_logger.info.assert_called_with(
-            "Aggregation value or snuba query is empty",
+            "Aggregation value not integer or snuba query is empty",
             extra=logger_extra,
         )
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/85074 to check that `aggregation_value` is a float before sending it to Seer. We haven't been able to determine exactly what strange value we're getting (it just says null/"NULL_VALUE" in GCP) but this will at least prevent the wrong data from being sent to Seer.