### PR TITLE
fix(ui): Hide overflow for checkInTimeline

### DIFF
--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -141,6 +141,8 @@ export function MockCheckInTimeline<Status extends string>({
 const TimelineContainer = styled('div')`
   position: relative;
   height: 14px;
+  width: 100%;
+  overflow: hidden;
 `;
 
 const JobTick = styled('div')<{
@@ -148,10 +150,8 @@ const JobTick = styled('div')<{
   roundedRight: boolean;
 }>`
   position: absolute;
-  top: calc(50% + 1px);
   width: 4px;
   height: 14px;
-  transform: translateY(-50%);
   opacity: 0.7;
 
   ${p =>

--- a/static/app/views/monitors/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/overviewRow.tsx
@@ -397,14 +397,14 @@ const TimelineContainer = styled('div')`
 
 const TimelineEnvOuterContainer = styled('div')`
   position: relative;
+  display: flex;
+  align-items: center;
   height: calc(${p => p.theme.fontSizeLarge} * ${p => p.theme.text.lineHeightHeading});
   opacity: var(--disabled-opacity);
 `;
 
 const TimelineEnvContainer = styled('div')`
-  position: absolute;
-  inset: 0;
+  width: 100%;
   opacity: 0;
   animation: ${fadeIn} 1.5s ease-out forwards;
-  contain: content;
 `;


### PR DESCRIPTION
When you resize your window the timeline may overflow out of it's
container. We fix this with a overflow: hidden on the timeline itself