### PR TITLE
tests(nav-views): Add testing for item content components

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.spec.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.spec.tsx
@@ -1,0 +1,79 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import IssueViewNavEditableTitle from './issueViewNavEditableTitle';
+
+describe('IssueViewNavEditableTitle', () => {
+  const mockOnChange = jest.fn();
+  const mockSetIsEditing = jest.fn();
+  const defaultProps = {
+    label: 'Test Label',
+    onChange: mockOnChange,
+    isEditing: false,
+    isSelected: false,
+    setIsEditing: mockSetIsEditing,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the label correctly', () => {
+    render(<IssueViewNavEditableTitle {...defaultProps} />);
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+  });
+
+  it('enters edit mode on double click', async () => {
+    render(<IssueViewNavEditableTitle {...defaultProps} />);
+    const element = screen.getByText('Test Label');
+    await userEvent.dblClick(element);
+    expect(mockSetIsEditing).toHaveBeenCalledWith(true);
+  });
+
+  it('renders input in edit mode', () => {
+    render(<IssueViewNavEditableTitle {...defaultProps} isEditing />);
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('Test Label');
+  });
+
+  describe('keyboard interactions', () => {
+    it('saves changes on Enter key', async () => {
+      render(<IssueViewNavEditableTitle {...defaultProps} isEditing />);
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.type(input, 'New Label{enter}');
+
+      expect(mockOnChange).toHaveBeenCalledWith('New Label');
+      expect(mockSetIsEditing).toHaveBeenCalledWith(false);
+    });
+
+    it('cancels editing on Escape key', async () => {
+      render(<IssueViewNavEditableTitle {...defaultProps} isEditing />);
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.type(input, 'New Label{escape}');
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(mockSetIsEditing).toHaveBeenCalledWith(false);
+    });
+
+    it('prevents empty values on blur', async () => {
+      render(<IssueViewNavEditableTitle {...defaultProps} isEditing />);
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.tab();
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(mockSetIsEditing).toHaveBeenCalledWith(false);
+    });
+
+    it('trims whitespace on save', async () => {
+      render(<IssueViewNavEditableTitle {...defaultProps} isEditing />);
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.type(input, '  New Label  {enter}');
+
+      expect(mockOnChange).toHaveBeenCalledWith('New Label');
+    });
+  });
+});

--- a/static/app/components/nav/issueViews/issueViewNavEditableTitle.spec.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEditableTitle.spec.tsx
@@ -11,6 +11,7 @@ describe('IssueViewNavEditableTitle', () => {
     isEditing: false,
     isSelected: false,
     setIsEditing: mockSetIsEditing,
+    isDragging: false,
   };
 
   beforeEach(() => {

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.spec.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.spec.tsx
@@ -1,0 +1,112 @@
+import styled from '@emotion/styled';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+import {IssueViewNavEllipsisMenu} from './issueViewNavEllipsisMenu';
+
+describe('StyledIssueViewNavEllipsisMenu', () => {
+  const mockView = {
+    id: '123',
+    name: 'Test View',
+    query: 'is:unresolved',
+    querySort: IssueSortOptions.DATE,
+    projects: [1],
+    environments: ['prod'],
+    timeFilters: {
+      start: '7d',
+      end: null,
+      period: '7d',
+      utc: null,
+    },
+    isCommitted: true,
+    key: 'test-view',
+    label: 'Test View',
+  };
+
+  const defaultProps = {
+    baseUrl: '/organizations/sentry/issues',
+    deleteView: jest.fn(),
+    duplicateView: jest.fn(),
+    setIsEditing: jest.fn(),
+    updateView: jest.fn(),
+    view: mockView,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders ellipsis menu trigger', () => {
+    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('shows menu items when clicked', async () => {
+    const user = userEvent.setup();
+    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Rename')).toBeInTheDocument();
+    expect(screen.getByText('Duplicate')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('handles rename action', async () => {
+    const user = userEvent.setup();
+    const setIsEditing = jest.fn();
+    render(
+      <StyledIssueViewNavEllipsisMenu {...defaultProps} setIsEditing={setIsEditing} />
+    );
+
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText('Rename'));
+
+    expect(setIsEditing).toHaveBeenCalledWith(true);
+  });
+
+  it('shows save and discard options when there are unsaved changes', async () => {
+    const user = userEvent.setup();
+    const viewWithChanges = {
+      ...mockView,
+      unsavedChanges: {
+        query: 'is:resolved',
+      },
+    };
+
+    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} view={viewWithChanges} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Save Changes')).toBeInTheDocument();
+    expect(screen.getByText('Discard Changes')).toBeInTheDocument();
+  });
+
+  it('handles keyboard interactions correctly', async () => {
+    const user = userEvent.setup();
+    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} />);
+
+    const trigger = screen.getByRole('button');
+
+    await user.tab();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('Rename')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(screen.queryByText('Rename')).not.toBeInTheDocument();
+    });
+  });
+});
+
+/**
+ * By default, the ellipsis menu is hidden (display:none),
+ * so we need to force it to be visible for testing purposes.
+ */
+const StyledIssueViewNavEllipsisMenu = styled(IssueViewNavEllipsisMenu)`
+  display: flex;
+`;

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.spec.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.spec.tsx
@@ -1,12 +1,10 @@
-import styled from '@emotion/styled';
-
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 import {IssueViewNavEllipsisMenu} from './issueViewNavEllipsisMenu';
 
-describe('StyledIssueViewNavEllipsisMenu', () => {
+describe('IssueViewNavEllipsisMenu', () => {
   const mockView = {
     id: '123',
     name: 'Test View',
@@ -39,13 +37,13 @@ describe('StyledIssueViewNavEllipsisMenu', () => {
   });
 
   it('renders ellipsis menu trigger', () => {
-    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} />);
+    render(<IssueViewNavEllipsisMenu {...defaultProps} />);
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('shows menu items when clicked', async () => {
     const user = userEvent.setup();
-    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} />);
+    render(<IssueViewNavEllipsisMenu {...defaultProps} />);
 
     await user.click(screen.getByRole('button'));
 
@@ -57,9 +55,7 @@ describe('StyledIssueViewNavEllipsisMenu', () => {
   it('handles rename action', async () => {
     const user = userEvent.setup();
     const setIsEditing = jest.fn();
-    render(
-      <StyledIssueViewNavEllipsisMenu {...defaultProps} setIsEditing={setIsEditing} />
-    );
+    render(<IssueViewNavEllipsisMenu {...defaultProps} setIsEditing={setIsEditing} />);
 
     await user.click(screen.getByRole('button'));
     await user.click(screen.getByText('Rename'));
@@ -76,7 +72,7 @@ describe('StyledIssueViewNavEllipsisMenu', () => {
       },
     };
 
-    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} view={viewWithChanges} />);
+    render(<IssueViewNavEllipsisMenu {...defaultProps} view={viewWithChanges} />);
 
     await user.click(screen.getByRole('button'));
 
@@ -86,7 +82,7 @@ describe('StyledIssueViewNavEllipsisMenu', () => {
 
   it('handles keyboard interactions correctly', async () => {
     const user = userEvent.setup();
-    render(<StyledIssueViewNavEllipsisMenu {...defaultProps} />);
+    render(<IssueViewNavEllipsisMenu {...defaultProps} />);
 
     const trigger = screen.getByRole('button');
 
@@ -102,11 +98,3 @@ describe('StyledIssueViewNavEllipsisMenu', () => {
     });
   });
 });
-
-/**
- * By default, the ellipsis menu is hidden (display:none),
- * so we need to force it to be visible for testing purposes.
- */
-const StyledIssueViewNavEllipsisMenu = styled(IssueViewNavEllipsisMenu)`
-  display: flex;
-`;

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -85,6 +85,7 @@ export function IssueViewNavEllipsisMenu({
             e.preventDefault();
             e.currentTarget.click();
           }}
+          size="zero"
         >
           <InteractionStateLayer />
           <IconEllipsis compact color="gray500" />
@@ -181,7 +182,8 @@ const constructViewLink = (baseUrl: string, view: IssueView) => {
   });
 };
 
-const TriggerWrapper = styled('div')`
+const TriggerWrapper = styled(Button)`
+  display: none;
   position: relative;
   width: 24px;
   height: 20px;
@@ -192,7 +194,6 @@ const TriggerWrapper = styled('div')`
   padding: 0;
   background-color: inherit;
   opacity: inherit;
-  display: none;
 `;
 
 const SectionedOverlayFooter = styled('div')`

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -183,7 +183,7 @@ const constructViewLink = (baseUrl: string, view: IssueView) => {
 };
 
 const TriggerWrapper = styled(Button)`
-  display: none;
+  display: flex;
   position: relative;
   width: 24px;
   height: 20px;

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -312,21 +312,24 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
   position: relative;
   padding-right: ${space(0.5)};
 
-  :hover {
+  /* Hide the ellipsis menu if not hovered, or if it's not expanded  */
+  :not(:hover):not(:has([data-ellipsis-menu-trigger][aria-expanded='true'])) {
     [data-ellipsis-menu-trigger] {
-      display: flex;
-    }
-    [data-issue-view-query-count] {
-      display: none;
+      ${p => p.theme.visuallyHidden}
     }
   }
 
-  [data-ellipsis-menu-trigger][aria-expanded='true'] {
-    display: flex;
+  /* Hide the query count if the ellipsis menu is not expanded */
+  :hover {
+    [data-issue-view-query-count] {
+      ${p => p.theme.visuallyHidden}
+    }
   }
+
+  /* Hide the query count if the ellipsis menu is expanded */
   &:has([data-ellipsis-menu-trigger][aria-expanded='true'])
     [data-issue-view-query-count] {
-    display: none;
+    ${p => p.theme.visuallyHidden}
   }
 `;
 

--- a/static/app/components/nav/issueViews/issueViewNavQueryCount.spec.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavQueryCount.spec.tsx
@@ -1,0 +1,56 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+describe('IssueViewNavQueryCount', () => {
+  const mockView = {
+    id: '1',
+    name: 'Test View',
+    query: 'is:unresolved',
+    querySort: IssueSortOptions.DATE,
+    environments: ['37'],
+    projects: [73],
+    timeFilters: {
+      period: '1d',
+      start: null,
+      end: null,
+      utc: null,
+    },
+    isCommitted: true,
+    key: 'test-view',
+    label: 'Test View',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('should render the precise query count if its under 100', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-count/',
+      method: 'GET',
+      body: {
+        'is:unresolved': 71,
+      },
+    });
+
+    render(<IssueViewNavQueryCount view={mockView} />);
+
+    expect(await screen.findByText('71')).toBeInTheDocument();
+  });
+
+  it('should render the "99+" if the count is over 100', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-count/',
+      method: 'GET',
+      body: {
+        'is:unresolved': 101,
+      },
+    });
+
+    render(<IssueViewNavQueryCount view={mockView} />);
+
+    expect(await screen.findByText('99+')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds testing for three of the components that are used in views: 

1. `<IssueViewNavEditableTitle/>`: The tab label component 
2. `<IssueViewNavEllipsisMenu/>`: The tab's ellipsis menu component 
3. `<IssueViewNavQueryCount/>`: The tab's query count indicator 

We still need testing for the high level routing behavior, but that's a bit more complex and should be in its own PR