### PR TITLE
feat(dashboards): Add story for bar stacking in `TimeSeriesWidgetVisualization`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -205,6 +205,23 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           <code>stacked</code> prop. Area charts are always stacked. Line charts are never
           stacked.
         </p>
+
+        <SideBySide>
+          <MediumWidget>
+            <TimeSeriesWidgetVisualization
+              visualizationType="bar"
+              timeSeries={[sampleDurationTimeSeries, sampleDurationTimeSeries2]}
+            />
+          </MediumWidget>
+          <MediumWidget>
+            <TimeSeriesWidgetVisualization
+              visualizationType="bar"
+              timeSeries={[sampleDurationTimeSeries, sampleDurationTimeSeries2]}
+              stacked
+            />
+          </MediumWidget>
+          <SmallWidget />
+        </SideBySide>
       </Fragment>
     );
   });


### PR DESCRIPTION
Useful for testing, otherwise people just have to imagine this in their
heads?

**e.g.,**
<img width="947" alt="Screenshot 2025-02-24 at 3 13 22 PM" src="https://github.com/user-attachments/assets/42cd019d-1fa4-453e-85cd-7dd1ad9b9383" />
