### PR TITLE
chore(tests): Disable flaky tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -19,6 +19,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         }
 
     @pytest.mark.querybuilder
+    @pytest.mark.skip(reason="flaky failures around 12:00pm PST")
     def test_simple(self):
         logs = [
             self.create_ourlog(
@@ -51,6 +52,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["dataset"] == self.dataset
 
     @pytest.mark.querybuilder
+    @pytest.mark.skip(reason="flaky failures around 12:00pm PST")
     def test_timestamp_order(self):
         logs = [
             self.create_ourlog(


### PR DESCRIPTION
These failed randomly on an unrelated PR:

```
______________ OrganizationEventsOurLogsEndpointTest.test_simple _______________
tests/snuba/api/endpoints/test_organization_events_ourlogs.py:46: in test_simple
    assert len(data) == 2
E   assert 0 == 2
E    +  where 0 = len([])
__________ OrganizationEventsOurLogsEndpointTest.test_timestamp_order __________
tests/snuba/api/endpoints/test_organization_events_ourlogs.py:79: in test_timestamp_order
    assert len(data) == 2
E   assert 0 == 2
E    +  where 0 = len([])
```
https://github.com/getsentry/sentry/actions/runs/13506981241/job/37738748732?pr=84991

<!-- Describe your PR here. -->