### PR TITLE
fix(rpc): Handle aggregates with shortforms

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -916,7 +916,7 @@ class SearchVisitor(NodeVisitor):
         try:
             # Even if the search value matches duration format, only act as
             # duration for certain columns
-            result_type = self.builder.get_function_result_type(search_key.name)
+            result_type = self.get_function_result_type(search_key.name)
 
             if result_type == "duration" or result_type in DURATION_UNITS:
                 aggregate_value = parse_duration(*search_value)
@@ -957,7 +957,7 @@ class SearchVisitor(NodeVisitor):
         try:
             # Even if the search value matches percentage format, only act as
             # percentage for certain columns
-            result_type = self.builder.get_function_result_type(search_key.name)
+            result_type = self.get_function_result_type(search_key.name)
             if result_type == "percentage":
                 aggregate_value = parse_percentage(search_value)
         except ValueError:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2544,3 +2544,55 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     @pytest.mark.skip(reason="user display alias not migrated over")
     def test_user_display(self):
         super().test_user_display()
+
+    def test_aggregate_filter(self):
+        self._test_aggregate_filter(
+            [
+                "count():2",
+                "count():>1",
+                "avg(measurements.lcp):>3000",
+                "avg(measurements.lcp):>3s",
+                "avg(span.duration):>3s",
+                "count():>1 avg(measurements.lcp):>3000",
+                "count():>1 AND avg(measurements.lcp):>3000",
+                "count():>1 OR avg(measurements.lcp):>3000",
+            ]
+        )
+
+    def test_shortform_aggregate_filtering(self):
+        spans = [
+            self.create_span(
+                {"description": "bar", "sentry_tags": {"status": "invalid_argument"}},
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "foo", "sentry_tags": {"status": "success"}},
+                start_ts=self.ten_mins_ago,
+            ),
+        ]
+        self.store_spans(spans, is_eap=self.is_eap)
+        response = self.do_request(
+            {
+                "field": ["avg(span.duration)", "description"],
+                "query": "avg(span.duration):>0.5s",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {
+                "avg(span.duration)": 1000.0,
+                "description": "bar",
+            },
+            {
+                "avg(span.duration)": 1000.0,
+                "description": "foo",
+            },
+        ]
+        assert meta["dataset"] == self.dataset

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2545,21 +2545,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     def test_user_display(self):
         super().test_user_display()
 
-    def test_aggregate_filter(self):
-        self._test_aggregate_filter(
-            [
-                "count():2",
-                "count():>1",
-                "avg(measurements.lcp):>3000",
-                "avg(measurements.lcp):>3s",
-                "avg(span.duration):>3s",
-                "count():>1 avg(measurements.lcp):>3000",
-                "count():>1 AND avg(measurements.lcp):>3000",
-                "count():>1 OR avg(measurements.lcp):>3000",
-            ]
-        )
-
-    def test_shortform_aggregate_filtering(self):
+    def test_unit_aggregate_filtering(self):
         spans = [
             self.create_span(
                 {"description": "bar", "sentry_tags": {"status": "invalid_argument"}},


### PR DESCRIPTION
- the spans rpc call was failing on queries with a shortform in it like `s` for seconds
  - This was because the event_search was still calling `self.builder` instead of the resolved `get_function_result_type` by accident