### PR TITLE
ref(dashboards): Rename weird `timeseriesSelection` prop

### DIFF
--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -44,4 +44,4 @@ export type Release = {
 
 export type Aliases = Record<string, string>;
 
-export type TimeseriesSelection = {[key: string]: boolean};
+export type LegendSelection = {[key: string]: boolean};

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidget.tsx
@@ -65,8 +65,8 @@ export function TimeSeriesWidget(props: TimeSeriesWidgetProps) {
           aliases={props.aliases}
           stacked={props.stacked}
           dataCompletenessDelay={props.dataCompletenessDelay}
-          timeseriesSelection={props.timeseriesSelection}
-          onTimeseriesSelectionChange={props.onTimeseriesSelectionChange}
+          legendSelection={props.legendSelection}
+          onLegendSelectionChange={props.onLegendSelectionChange}
         />
       )}
     </WidgetFrame>

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -12,7 +12,7 @@ import type {DateString} from 'sentry/types/core';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 
-import type {Release, TimeSeries, TimeseriesSelection} from '../common/types';
+import type {LegendSelection, Release, TimeSeries} from '../common/types';
 import {shiftTimeserieToNow} from '../timeSeriesWidget/shiftTimeserieToNow';
 
 import {sampleDurationTimeSeries} from './fixtures/sampleDurationTimeSeries';
@@ -265,11 +265,6 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
       },
     });
 
-    const [timeseriesSelection, setTimeseriesSelection] = useState<TimeseriesSelection>({
-      'p50(span.duration)': true,
-      'p99(span.duration)': true,
-    });
-
     const durationTimeSeries1 = toTimeSeriesSelection(
       sampleDurationTimeSeries,
       start,
@@ -295,10 +290,6 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           <TimeSeriesWidgetVisualization
             visualizationType="line"
             timeSeries={[durationTimeSeries1, durationTimeSeries2]}
-            timeseriesSelection={timeseriesSelection}
-            onTimeseriesSelectionChange={newSelection => {
-              setTimeseriesSelection(newSelection);
-            }}
           />
         </MediumWidget>
       </Fragment>
@@ -306,7 +297,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
   });
 
   story('Legends', () => {
-    const [timeSeriesSelection, setTimeSeriesSelection] = useState<TimeseriesSelection>({
+    const [legendSelection, setLegendSelection] = useState<LegendSelection>({
       'p99(span.duration)': false,
     });
 
@@ -319,11 +310,11 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           the charts.
         </p>
         <p>
-          You can control legend selection with the <code>timeseriesSelection</code> prop.
-          By default, all time series are shown. If any time series is set to{' '}
+          You can control legend selection with the <code>legendSelection</code> prop. By
+          default, all time series are shown. If any time series is set to{' '}
           <code>false</code> it will be hidden. The companion{' '}
-          <code>onTimeseriesSelectionChange</code> prop is a callback, it will tell you
-          when the user changes the legend selection by clicking on legend labels.
+          <code>onLegendSelectionChange</code> prop is a callback, it will tell you when
+          the user changes the legend selection by clicking on legend labels.
         </p>
         <p>
           You can also provide aliases for legends to give them a friendlier name. In this
@@ -339,8 +330,8 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
               'p99(span.duration)': 'p99',
               'p50(span.duration)': 'p50',
             }}
-            timeseriesSelection={timeSeriesSelection}
-            onTimeseriesSelectionChange={setTimeSeriesSelection}
+            legendSelection={legendSelection}
+            onLegendSelectionChange={setLegendSelection}
           />
         </MediumWidget>
       </Fragment>

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -31,7 +31,7 @@ import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {useWidgetSyncContext} from '../../contexts/widgetSyncContext';
 import {NO_PLOTTABLE_VALUES, X_GUTTER, Y_GUTTER} from '../common/settings';
-import type {Aliases, Release, TimeSeries, TimeseriesSelection} from '../common/types';
+import type {Aliases, LegendSelection, Release, TimeSeries} from '../common/types';
 
 import {BarChartWidgetSeries} from './seriesConstructors/barChartWidgetSeries';
 import {CompleteAreaChartWidgetSeries} from './seriesConstructors/completeAreaChartWidgetSeries';
@@ -69,9 +69,13 @@ export interface TimeSeriesWidgetVisualizationProps {
    */
   dataCompletenessDelay?: number;
   /**
-   * Callback that returns an updated `timeseriesSelection` after a user manipulations the selection via the legend
+   * A mapping of time series field name to boolean. If the value is `false`, the series is hidden from view
    */
-  onTimeseriesSelectionChange?: (selection: TimeseriesSelection) => void;
+  legendSelection?: LegendSelection;
+  /**
+   * Callback that returns an updated `LegendSelection` after a user manipulations the selection via the legend
+   */
+  onLegendSelectionChange?: (selection: LegendSelection) => void;
   /**
    * Callback that returns an updated ECharts zoom selection. If omitted, the default behavior is to update the URL with updated `start` and `end` query parameters.
    */
@@ -84,10 +88,6 @@ export interface TimeSeriesWidgetVisualizationProps {
    * Only available for `visualizationType="bar"`. If `true`, the bars are stacked
    */
   stacked?: boolean;
-  /**
-   * A mapping of time series field name to boolean. If the value is `false`, the series is hidden from view
-   */
-  timeseriesSelection?: TimeseriesSelection;
 }
 
 export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizationProps) {
@@ -364,12 +364,12 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
                   false
                 );
               },
-              selected: props.timeseriesSelection,
+              selected: props.legendSelection,
             }
           : undefined
       }
       onLegendSelectChanged={event => {
-        props?.onTimeseriesSelectionChange?.(event.selected);
+        props?.onLegendSelectionChange?.(event.selected);
       }}
       tooltip={{
         trigger: 'axis',


### PR DESCRIPTION
- `timeseriesSelection` should be `timeSeriesSelection` for one thing
- `legendSelection` is way clearer what's actually happening
