### PR TITLE
feat(explore): Adding quota exceeded banner

### DIFF
--- a/static/app/components/core/alert.tsx
+++ b/static/app/components/core/alert.tsx
@@ -167,6 +167,7 @@ const AlertPanel = styled('div')<
     minmax(0, 1fr)
     ${p => defined(p.trailingItems) && 'max-content'}
     ${p => defined(p.expand) && 'max-content'};
+  align-items: center;
   gap: ${space(1)};
   color: ${p => p.alertColors.color};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/explore/spans/quotaAlert.spec.tsx
+++ b/static/app/views/explore/spans/quotaAlert.spec.tsx
@@ -1,0 +1,112 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+import {QuotaExceededAlert} from './quotaAlert';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/usePageFilters');
+
+describe('Renders QuotaExceededAlert correctly', function () {
+  const {organization} = initializeOrg();
+
+  beforeEach(function () {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-12-14'));
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '7d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [2],
+      },
+    });
+
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {statsPeriod: '7d'},
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+  });
+
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders alert when quota is exceeded', async function () {
+    // Mock performance usage stats endpoint
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/stats_v2/`,
+      method: 'GET',
+      body: {
+        groups: [
+          {
+            by: {
+              reason: 'span_usage_exceeded',
+            },
+            totals: {
+              'sum(quantity)': 1000,
+            },
+          },
+        ],
+      },
+    });
+
+    // Mock subscription details endpoint
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: {
+        renewalDate: '2024-12-31',
+        onDemandBudgets: {
+          enabled: true,
+        },
+        planTier: 'am1',
+        categories: {
+          spans: {
+            usageExceeded: true,
+          },
+        },
+      },
+    });
+
+    render(<QuotaExceededAlert />, {
+      organization,
+    });
+
+    expect(await screen.findByText(/You[''\u2019]ve exceeded your/i)).toBeInTheDocument();
+
+    const onDemandTexts = screen.getAllByText(/on-demand budget/i);
+    expect(onDemandTexts).toHaveLength(2);
+
+    expect(
+      screen.getByText(
+        /during this date range and results will be skewed. We can’t collect more spans until/
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Dec 30, 2024/)).toBeInTheDocument();
+    expect(screen.getByText(/or adjust your date range prior to/)).toBeInTheDocument();
+    expect(screen.getByText(/Dec 06, 2024/)).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {name: /increase your on-demand budget/})
+    ).toHaveAttribute(
+      'href',
+      '/settings/billing/checkout/?referrer=trace-view&skipBundles=true'
+    );
+  });
+});

--- a/static/app/views/explore/spans/quotaAlert.tsx
+++ b/static/app/views/explore/spans/quotaAlert.tsx
@@ -1,0 +1,146 @@
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/core/alert';
+import Link from 'sentry/components/links/link';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {usePerformanceSubscriptionDetails} from 'sentry/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails';
+import {usePerformanceUsageStats} from 'sentry/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceUsageStats';
+
+function dateFormatter(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  });
+}
+
+// Returns the beggining of statsPeriod fomatted like "Jan 1, 2022"
+// or absolute date range formatted like "Jan 1, 2022 - Jan 2, 2022"
+function getFormattedDateTime({
+  statsPeriod,
+  start,
+  end,
+}: {
+  end: string | undefined;
+  start: string | undefined;
+  statsPeriod: string | null | undefined;
+}): string | null {
+  if (statsPeriod) {
+    const periodToHours = parsePeriodToHours(statsPeriod);
+    const periodStartDate = new Date(Date.now() - periodToHours * 60 * 60 * 1000);
+    return dateFormatter(periodStartDate);
+  }
+
+  if (start && end) {
+    return `${dateFormatter(new Date(start))} - ${dateFormatter(new Date(end))}`;
+  }
+
+  return null;
+}
+
+function useQuotaExceededAlertMessage() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {start, end, statsPeriod} = normalizeDateTimeParams(location.query);
+
+  const {data: performanceUsageStats} = usePerformanceUsageStats({
+    organization,
+    dateRange: statsPeriod ? {statsPeriod} : {start, end},
+    projectIds: selection.projects,
+  });
+
+  // Check if events were dropped due to exceeding the transaction/spans quota
+  const droppedEventsCount = performanceUsageStats?.totals['sum(quantity)'] || 0;
+
+  const {
+    data: {hasExceededPerformanceUsageLimit, subscription},
+  } = usePerformanceSubscriptionDetails();
+
+  if (droppedEventsCount === 0 || !hasExceededPerformanceUsageLimit || !subscription) {
+    return null;
+  }
+
+  const budgetType = subscription?.onDemandBudgets?.enabled
+    ? ['am1', 'am2'].includes(subscription.planTier)
+      ? t('on-demand budget')
+      : t('pay-as-you-go budget')
+    : t('reserved volumes');
+  const formattedDateRange: string | null = getFormattedDateTime({
+    statsPeriod,
+    start,
+    end,
+  });
+  const billingPageLink = (
+    <Link
+      to={{
+        pathname: `/settings/billing/checkout/?referrer=trace-view`,
+        query: {
+          skipBundles: true,
+        },
+      }}
+    >
+      {tct('increase your [budgetType]', {budgetType})}
+    </Link>
+  );
+
+  const subscriptionRenewalDate = dateFormatter(new Date(subscription.renewalDate));
+
+  if (!formattedDateRange) {
+    return tct(
+      'You’ve exceeded your [budgetType] during this date range and results will be skewed. We can’t collect more spans until [subscriptionRenewalDate]. If you need more, [billingPageLink]',
+      {
+        subscriptionRenewalDate,
+        billingPageLink,
+        budgetType,
+      }
+    );
+  }
+
+  return tct(
+    'You’ve exceeded your [budgetType] during this date range and results will be skewed. We can’t collect more spans until [subscriptionRenewalDate]. [rest]',
+    {
+      budgetType,
+      subscriptionRenewalDate,
+      rest: statsPeriod
+        ? tct(
+            'If you need more, [billingPageLink] or adjust your date range prior to [formattedDateRange].',
+            {
+              billingPageLink,
+              formattedDateRange,
+            }
+          )
+        : tct(
+            'If you need more, [billingPageLink] or adjust your date range before or after [formattedDateRange].',
+            {
+              billingPageLink,
+              formattedDateRange,
+            }
+          ),
+    }
+  );
+}
+
+export function QuotaExceededAlert() {
+  const message = useQuotaExceededAlertMessage();
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <StyledAlert type="warning" showIcon>
+      {message}
+    </StyledAlert>
+  );
+}
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(2)};
+`;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -57,6 +57,8 @@ import {
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {Onboarding} from 'sentry/views/performance/onboarding';
 
+import {QuotaExceededAlert} from './quotaAlert';
+
 export type SpanTabProps = {
   defaultPeriod: DefaultPeriod;
   maxPickableDays: MaxPickableDays;
@@ -145,6 +147,15 @@ export function SpansTabContentImpl({
     timeseriesResult,
   });
 
+  const resultsLength =
+    {
+      aggregate: aggregatesTableResult.result.data?.length,
+      samples: spansTableResult.result.data?.length,
+      traces: tracesTableResult.result.data?.data?.length,
+    }[queryType] ?? 0;
+
+  const hasResults = !!resultsLength;
+
   return (
     <Body withToolbar={expanded}>
       <TopSection>
@@ -199,6 +210,7 @@ export function SpansTabContentImpl({
         <ExploreToolbar width={300} extras={toolbarExtras} />
       </SideSection>
       <section>
+        {!hasResults && <QuotaExceededAlert />}
         <MainContent>
           <ExploreCharts
             canUsePreviousResults={canUsePreviousResults}

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
@@ -24,6 +24,9 @@ import {TraceWarningComponents} from './styles';
 import {usePerformanceSubscriptionDetails} from './usePerformanceSubscriptionDetails';
 import {usePerformanceUsageStats} from './usePerformanceUsageStats';
 
+// 1 hour in milliseconds
+const ONE_HOUR = 60 * 60 * 1000;
+
 type ErrorOnlyWarningsProps = {
   organization: Organization;
   traceSlug: string | undefined;
@@ -130,9 +133,20 @@ function PerformanceSetupBanner({
 }
 
 function PerformanceQuotaExceededWarning(props: ErrorOnlyWarningsProps) {
+  const traceNode = props.tree.root.children[0];
+  const traceStartDate = new Date(traceNode?.space?.[0]!);
+  const traceEndDate = new Date(traceNode?.space?.[0]! + traceNode?.space?.[1]!);
+
+  // Add 1 hour buffer to the trace start and end date.
+  const start = traceNode
+    ? new Date(traceStartDate.getTime() - ONE_HOUR).toISOString()
+    : '';
+  const end = traceNode ? new Date(traceEndDate.getTime() + ONE_HOUR).toISOString() : '';
+
   const {data: performanceUsageStats} = usePerformanceUsageStats({
     organization: props.organization,
-    tree: props.tree,
+    dateRange: {start, end},
+    projectIds: Array.from(props.tree.projects.keys()),
   });
 
   const {

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails.tsx
@@ -19,6 +19,7 @@ type Subscription = {
     billingInterval: 'monthly' | 'annual';
   };
   planTier: string;
+  renewalDate: string;
   onDemandBudgets?: {
     enabled: boolean;
   };

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceUsageStats.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceUsageStats.tsx
@@ -1,10 +1,6 @@
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
-
-import type {TraceTree} from '../traceModels/traceTree';
-
-// 1 hour in milliseconds
-const ONE_HOUR = 60 * 60 * 1000;
 
 export type PerformanceStatsGroup = {
   by: {
@@ -19,43 +15,45 @@ type PartialUsageStats = {
   groups: PerformanceStatsGroup[];
 };
 
+type DateRange =
+  | {
+      end: string | undefined;
+      start: string | undefined;
+    }
+  | {
+      statsPeriod: string | null | undefined;
+    };
+
 export function usePerformanceUsageStats({
   organization,
-  tree,
+  dateRange,
+  projectIds,
 }: {
+  dateRange: DateRange;
   organization: Organization;
-  tree: TraceTree;
+  projectIds: number[] | undefined;
 }) {
-  const traceNode = tree.root.children[0];
-
-  const traceStartDate = new Date(traceNode?.space?.[0]!);
-  const traceEndDate = new Date(traceNode?.space?.[0]! + traceNode?.space?.[1]!);
-
-  // Add 1 hour buffer to the trace start and end date.
-  const start = traceNode
-    ? new Date(traceStartDate.getTime() - ONE_HOUR).toISOString()
-    : '';
-  const end = traceNode ? new Date(traceEndDate.getTime() + ONE_HOUR).toISOString() : '';
-
+  const statsPeriod = 'statsPeriod' in dateRange ? dateRange.statsPeriod : undefined;
+  const {start, end} = 'start' in dateRange ? dateRange : {};
   const pathname = `/organizations/${organization.slug}/stats_v2/`;
 
   const endpointOptions = {
     query: {
       start,
       end,
+      statsPeriod,
       interval: '1h',
       groupBy: ['outcome', 'reason'],
       field: 'sum(quantity)',
       utc: true,
       category: 'transaction_indexed',
-      project: Array.from(tree.projects.keys()),
+      project: projectIds ?? ALL_ACCESS_PROJECTS,
       referrer: 'trace-view-warnings',
     },
   };
 
   const results = useApiQuery<PartialUsageStats>([pathname, endpointOptions], {
     staleTime: Infinity,
-    enabled: !!traceNode,
   });
 
   return {


### PR DESCRIPTION
Banner to be rendered when there is `no data` in explore and we detect that `events were dropped due to quota being exceeded`, within the selected date range:
<img width="1289" alt="Screenshot 2025-02-24 at 3 52 17 PM" src="https://github.com/user-attachments/assets/cd24f7d4-bd81-4ee6-b819-e8f0d6bcada4" />

Added tests