### PR TITLE
:bug: fix(slack): Don't escape string during assignee dropdown search

### DIFF
--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -39,7 +39,6 @@ class SlackOptionsLoadEndpoint(Endpoint):
     def is_substring(self, string, substring):
         # in case either have special characters, we want to preserve the strings
         # as is, so we escape both before applying re.match
-        string = re.escape(string)
         substring = re.escape(substring)
         return bool(re.match(substring, string, re.I))
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/85530

the bug was that we were regex escaping `string` which represents the actual string we are comparing against (the user's email for example).

if we escape it, it goes from something like `aaa@b.com` to `aaa@b\.com`.

Now, if we try to regex compare it with regex escaped `substring` (user input), when the comparison gets to `.`, it will see `\` in the original string and return False. 

by not escaping the original string, we allow for a natural comparison.

i also verified this locally.