### PR TITLE
fix(seer grouping): Save grouphash metadata before adding seer results

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -398,6 +398,16 @@ def maybe_check_seer_for_matching_grouphash(
         # Update the relevant GroupHash with Seer results
         gh_metadata = grouphash_sent.metadata
         if gh_metadata:
+
+            # TODO: This should never be true (anything created with `objects.create` should have an
+            # id), but it seems in some cases to happen anyway. This is an attempt to mitigate the
+            # problem.
+            metadata_id: Any = (
+                gh_metadata.id
+            )  # Even mypy knows this should never happen, hence the need for the Any
+            if metadata_id is None:
+                gh_metadata.save()
+
             gh_metadata.update(
                 # Technically the time of the metadata record creation and the time of the Seer
                 # request will be some milliseconds apart, but a) the difference isn't meaningful

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -406,11 +406,29 @@ def maybe_check_seer_for_matching_grouphash(
                 gh_metadata.id
             )  # Even mypy knows this should never happen, hence the need for the Any
             if metadata_id is None:
+                logger.info(
+                    "grouphash_metadata.none_id",
+                    extra={
+                        "event_id": event.event_id,
+                        "grouphash": str(event_grouphash),
+                        "grouphash_metadata": str(gh_metadata),
+                        "project": str(event.project),
+                    },
+                )
                 gh_metadata.save()
 
                 # If that didn't work, log it and bail
                 metadata_id = gh_metadata.id
                 if metadata_id is None:
+                    logger.error(
+                        "grouphash_metadata.none_id_fix_failed",
+                        extra={
+                            "event_id": event.event_id,
+                            "grouphash": str(event_grouphash),
+                            "grouphash_metadata": str(gh_metadata),
+                            "project": str(event.project),
+                        },
+                    )
                     return seer_matched_grouphash
 
             gh_metadata.update(

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -408,6 +408,11 @@ def maybe_check_seer_for_matching_grouphash(
             if metadata_id is None:
                 gh_metadata.save()
 
+                # If that didn't work, log it and bail
+                metadata_id = gh_metadata.id
+                if metadata_id is None:
+                    return seer_matched_grouphash
+
             gh_metadata.update(
                 # Technically the time of the metadata record creation and the time of the Seer
                 # request will be some milliseconds apart, but a) the difference isn't meaningful


### PR DESCRIPTION
Once we turned on the grouphash metadata backfill for existing grouphashes, a weird thing started sometimes happening with new grouphashes: when we went to update their metadata with Seer results, we got a `Cannot update an instance that has not yet been created` error. The breadcrumbs show us querying for the metadata record (the instance in question), and presumably we find it, since we then test whether the result is truthy and only proceed if it is. Indeed, in the stack locals of the error, we can see that there's a metadata object there. 

One odd thing we noticed is that the metadata object retrieved has an id of `None`, as if it only exists in memory and hasn't yet been saved to the database. That shouldn't be possible, since it's created with `objects.create`, which should immediately save the record, but perhaps creation is buffered and we're running into a race condition? To test that hypothesis, this PR forces the object to be saved in cases where the id is `None`. It also bails before the problematic `update` call if that save doesn't fix the problem, so ingestion can proceed without errors. Finally, it adds logging so we can see both how often it happens and whether the fix works.