### PR TITLE
ref(dashboards): Move `BigNumberWidget` wrapper into the visualization component

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {defined} from 'sentry/utils';
 import {
   BigNumberWidgetVisualization,
@@ -60,23 +58,16 @@ export function BigNumberWidget(props: BigNumberWidgetProps) {
       revealTooltip={props.revealTooltip}
     >
       {defined(value) && (
-        <BigNumberResizeWrapper>
-          <BigNumberWidgetVisualization
-            value={value}
-            previousPeriodValue={previousPeriodValue}
-            field={field ?? DEFAULT_FIELD}
-            maximumValue={props.maximumValue}
-            preferredPolarity={props.preferredPolarity}
-            meta={props.meta}
-            thresholds={props.thresholds}
-          />
-        </BigNumberResizeWrapper>
+        <BigNumberWidgetVisualization
+          value={value}
+          previousPeriodValue={previousPeriodValue}
+          field={field ?? DEFAULT_FIELD}
+          maximumValue={props.maximumValue}
+          preferredPolarity={props.preferredPolarity}
+          meta={props.meta}
+          thresholds={props.thresholds}
+        />
       )}
     </WidgetFrame>
   );
 }
-
-const BigNumberResizeWrapper = styled('div')`
-  position: relative;
-  flex-grow: 1;
-`;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -140,11 +140,22 @@ export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualization
 
 function Wrapper({children}: any) {
   return (
-    <AutoResizeParent>
-      <AutoSizedText>{children}</AutoSizedText>
-    </AutoResizeParent>
+    <GrowingWrapper>
+      <AutoResizeParent>
+        <AutoSizedText>{children}</AutoSizedText>
+      </AutoResizeParent>
+    </GrowingWrapper>
   );
 }
+
+// Takes up 100% of the parent. If within flex context, grows to fill.
+// Otherwise, takes up 100% horizontally and vertically
+const GrowingWrapper = styled('div')`
+  position: relative;
+  flex-grow: 1;
+  height: 100%;
+  width: 100%;
+`;
 
 const AutoResizeParent = styled('div')`
   position: absolute;


### PR DESCRIPTION
`BigNumberWidgetVisualization` has complicated layout needs, and it needs a few nested wrappers. One of those wrappers was hidden inside `BigNumberWidget`. This is bad for us because we're deprecating that component, and we need to make it easier to use `BigNumberWidgetVisualization` with `Widget`, instead.

This PR moves that last container over, so the visualization can be used mostly standalone. This parallels how the time series visualization works.
