### PR TITLE
feat(nav-headers): Add new navigation's header designs across product

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -25,14 +25,25 @@ export const Page = styled('main')<{withPadding?: boolean}>`
 export const Header = styled('header')<{
   borderStyle?: 'dashed' | 'solid';
   noActionWrap?: boolean;
+  /**
+   * Whether to use the unified header variant. Unified headers have the
+   * same background color as the main content area and no border, thus
+   * "unifying" the two areas.
+   */
+  unified?: boolean;
 }>`
   display: grid;
   grid-template-columns: ${p =>
     !p.noActionWrap ? 'minmax(0, 1fr)' : 'minmax(0, 1fr) auto'};
 
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
-  background-color: transparent;
-  border-bottom: 1px ${p => p.borderStyle ?? 'solid'} ${p => p.theme.border};
+  background-color: ${p => (p.unified ? p.theme.background : 'transparent')};
+
+  ${p =>
+    !p.unified &&
+    `
+      border-bottom: 1px ${p.borderStyle ?? 'solid'} ${p.theme.border};
+    `}
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(2)} ${space(4)} 0 ${space(4)};
@@ -44,7 +55,7 @@ export const Header = styled('header')<{
  * Use HeaderContent to create horizontal regions in the header
  * that contain a heading/breadcrumbs and a button group.
  */
-export const HeaderContent = styled('div')`
+export const HeaderContent = styled('div')<{unified?: boolean}>`
   display: flex;
   flex-direction: column;
   justify-content: normal;
@@ -55,6 +66,12 @@ export const HeaderContent = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     margin-bottom: ${space(1)};
   }
+
+  ${p =>
+    p.unified &&
+    `
+      margin-bottom: 0;
+    `}
 `;
 
 /**

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -15,6 +15,7 @@ import {Alert} from 'sentry/components/core/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import Pagination from 'sentry/components/pagination';
@@ -90,6 +91,7 @@ function ManageDashboards() {
   const location = useLocation();
   const api = useApi();
   const dashboardGridRef = useRef<HTMLDivElement>(null);
+  const prefersStackedNav = usePrefersStackedNav();
 
   const [showTemplates, setShowTemplatesLocal] = useLocalStorageState(
     SHOW_TEMPLATES_KEY,
@@ -428,8 +430,8 @@ function ManageDashboards() {
           ) : (
             <Layout.Page>
               <NoProjectMessage organization={organization}>
-                <Layout.Header>
-                  <Layout.HeaderContent>
+                <Layout.Header unified={prefersStackedNav}>
+                  <Layout.HeaderContent unified={prefersStackedNav}>
                     <Layout.Title>
                       {t('Dashboards')}
                       <PageHeadingQuestionTooltip

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -6,6 +6,7 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -20,6 +21,7 @@ export function ExploreContent() {
   const organization = useOrganization();
   const {defaultPeriod, maxPickableDays, relativeOptions} =
     limitMaxPickableDays(organization);
+  const prefersStackedNav = usePrefersStackedNav();
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -37,8 +39,8 @@ export function ExploreContent() {
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
       <PageFiltersContainer maxPickableDays={maxPickableDays}>
         <Layout.Page>
-          <Layout.Header>
-            <Layout.HeaderContent>
+          <Layout.Header unified={prefersStackedNav}>
+            <Layout.HeaderContent unified={prefersStackedNav}>
               <Layout.Title>
                 {t('Traces')}
                 <PageHeadingQuestionTooltip

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -17,6 +17,7 @@ import {FeedbackQueryKeys} from 'sentry/components/feedback/useFeedbackQueryKeys
 import useRedirectToFeedbackFromEvent from 'sentry/components/feedback/useRedirectToFeedbackFromEvent';
 import FullViewport from 'sentry/components/layouts/fullViewport';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -42,6 +43,7 @@ export default function FeedbackListPage() {
 
   const pageFilters = usePageFilters();
   const projects = useProjects();
+  const prefersStackedNav = usePrefersStackedNav();
 
   const selectedProjects = projects.projects.filter(p =>
     pageFilters.selection.projects.includes(Number(p.id))
@@ -53,13 +55,12 @@ export default function FeedbackListPage() {
   );
 
   const showWidgetBanner = showWhatsNewBanner && oneIsWidgetEligible;
-
   return (
     <SentryDocumentTitle title={t('User Feedback')} orgSlug={organization.slug}>
       <FullViewport>
         <FeedbackQueryKeys organization={organization}>
-          <Layout.Header>
-            <Layout.HeaderContent>
+          <Layout.Header unified={prefersStackedNav}>
+            <Layout.HeaderContent unified={prefersStackedNav}>
               <Layout.Title>
                 {t('User Feedback')}
                 <PageHeadingQuestionTooltip

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -17,6 +18,7 @@ function LeftNavViewsHeader({selectedProjectIds}: LeftNavViewsHeaderProps) {
   const {projects} = useProjects();
   const organization = useOrganization();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
+  const prefersStackedNav = usePrefersStackedNav();
 
   const selectedProjects = projects.filter(({id}) =>
     selectedProjectIds.includes(Number(id))
@@ -29,26 +31,17 @@ function LeftNavViewsHeader({selectedProjectIds}: LeftNavViewsHeaderProps) {
   const viewTitle = groupSearchViews?.find(v => v.id === viewId)?.name;
 
   return (
-    <StyledHeader noActionWrap>
-      <StyledHeaderContent>
+    <Layout.Header noActionWrap unified={prefersStackedNav}>
+      <Layout.HeaderContent unified={prefersStackedNav}>
         <Layout.Title>{viewTitle ?? t('Issues')}</Layout.Title>
-      </StyledHeaderContent>
+      </Layout.HeaderContent>
       <Layout.HeaderActions />
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-    </StyledHeader>
+    </Layout.Header>
   );
 }
 
 export default LeftNavViewsHeader;
-
-const StyledHeader = styled(Layout.Header)`
-  background-color: ${p => p.theme.background};
-  border: 0;
-`;
-
-const StyledHeaderContent = styled(Layout.HeaderContent)`
-  margin-bottom: 0;
-`;
 
 const StyledGlobalEventProcessingAlert = styled(GlobalEventProcessingAlert)`
   grid-column: 1/-1;

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -7,6 +7,7 @@ import {Alert} from 'sentry/components/core/alert';
 import type {SmartSearchBarProps} from 'sentry/components/deprecatedSmartSearchBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -328,9 +329,11 @@ function ProfilingOnboardingCTA() {
 }
 
 function ProfilingContentPageHeader() {
+  const prefersStackedNav = usePrefersStackedNav();
+
   return (
-    <StyledLayoutHeader>
-      <StyledHeaderContent>
+    <StyledLayoutHeader unified={prefersStackedNav}>
+      <StyledHeaderContent unified={prefersStackedNav}>
         <Layout.Title>
           {t('Profiling')}
           <PageHeadingQuestionTooltip

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -16,6 +16,7 @@ import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingA
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import MissingProjectMembership from 'sentry/components/projects/missingProjectMembership';
@@ -74,6 +75,7 @@ export default function ProjectDetail({router, location, organization}: Props) {
     organization.slug,
     false
   );
+  const prefersStackedNav = usePrefersStackedNav();
 
   const visibleCharts = useMemo(() => {
     if (hasTransactions || hasSessions) {
@@ -151,8 +153,8 @@ export default function ProjectDetail({router, location, organization}: Props) {
       >
         <Layout.Page>
           <NoProjectMessage organization={organization}>
-            <Layout.Header>
-              <Layout.HeaderContent>
+            <Layout.Header unified={prefersStackedNav}>
+              <Layout.HeaderContent unified={prefersStackedNav}>
                 <Breadcrumbs
                   crumbs={[
                     {

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -10,6 +10,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {canCreateProject} from 'sentry/components/projects/canCreateProject';
@@ -83,6 +84,8 @@ function Dashboard() {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
+  const prefersStackedNav = usePrefersStackedNav();
+
   useEffect(() => {
     return function cleanup() {
       ProjectsStatsStore.reset();
@@ -167,8 +170,8 @@ function Dashboard() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Projects Dashboard')} orgSlug={organization.slug} />
-      <Layout.Header>
-        <Layout.HeaderContent>
+      <Layout.Header unified={prefersStackedNav}>
+        <Layout.HeaderContent unified={prefersStackedNav}>
           <Layout.Title>
             {t('Projects')}
             <PageHeadingQuestionTooltip

--- a/static/app/views/releases/components/header.tsx
+++ b/static/app/views/releases/components/header.tsx
@@ -1,11 +1,14 @@
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t} from 'sentry/locale';
 
 function Header() {
+  const prefersStackedNav = usePrefersStackedNav();
+
   return (
-    <Layout.Header noActionWrap>
-      <Layout.HeaderContent>
+    <Layout.Header noActionWrap unified={prefersStackedNav}>
+      <Layout.HeaderContent unified={prefersStackedNav}>
         <Layout.Title>
           {t('Releases')}
           <PageHeadingQuestionTooltip


### PR DESCRIPTION
Adds the "unified" (open to better naming suggestions) header variant and makes all pages without tabs use this variant. 

This is gated under the prefersNewNavigation user option. 

Full list of affected areas:
* Issues `/issues`
* User Feedback `issues/feedback`
* Traces `/explore/traces`
* Profiling `/explore/profiling`
* Releases `/explore/releases` 
* Dashboards `/dashboards`
* All Projects `/insight/projects`


(all routes reflect new navigation routing) 