### PR TITLE
feat(releases): add dropdown to filter release tables and update table styling

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -64,6 +64,7 @@ import {
   SpanOperationBreakdownFilter,
   stringToFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
+import {ADOPTION_STAGE_LABELS} from 'sentry/views/releases/utils';
 
 import {decodeScalar} from '../queryString';
 
@@ -705,18 +706,16 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   adoption_stage: {
     sortField: 'adoption_stage',
-    renderFunc: data =>
-      data.adoption_stage ? (
-        data.adoption_stage === 'low_adoption' ? (
-          <Tag type="error">{t('Low Adoption')}</Tag>
-        ) : data.adoption_stage === 'replaced' ? (
-          <Tag type="warning">{t('Replaced')}</Tag>
-        ) : (
-          <Tag type="success">{t('Adopted')}</Tag>
-        )
+    renderFunc: data => {
+      const label = ADOPTION_STAGE_LABELS[data.adoption_stage];
+      return data.adoption_stage && label ? (
+        <Tooltip title={label.tooltipTitle} isHoverable>
+          <Tag type={label.type}>{label.name}</Tag>
+        </Tooltip>
       ) : (
         <Container>{emptyValue}</Container>
-      ),
+      );
+    },
   },
   release: {
     sortField: 'release',

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 import partial from 'lodash/partial';
 
+import Tag from 'sentry/components/badge/tag';
 import {Button} from 'sentry/components/button';
 import Count from 'sentry/components/count';
 import {deviceNameMapper} from 'sentry/components/deviceName';
@@ -366,6 +367,7 @@ type SpecialField = {
 };
 
 type SpecialFields = {
+  adoption_stage: SpecialField;
   'apdex()': SpecialField;
   attachments: SpecialField;
   'count_unique(user)': SpecialField;
@@ -700,6 +702,21 @@ const SPECIAL_FIELDS: SpecialFields = {
 
       return <Container>{emptyValue}</Container>;
     },
+  },
+  adoption_stage: {
+    sortField: 'adoption_stage',
+    renderFunc: data =>
+      data.adoption_stage ? (
+        data.adoption_stage === 'low_adoption' ? (
+          <Tag type="error">{t('Low Adoption')}</Tag>
+        ) : data.adoption_stage === 'replaced' ? (
+          <Tag type="warning">{t('Replaced')}</Tag>
+        ) : (
+          <Tag type="success">{t('Adopted')}</Tag>
+        )
+      ) : (
+        <Container>{emptyValue}</Container>
+      ),
   },
   release: {
     sortField: 'release',

--- a/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
+++ b/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
@@ -1,0 +1,68 @@
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+export default function FilterReleaseDropdown({
+  filters,
+  setFilters,
+}: {
+  filters: string[];
+  setFilters: (filters: string[]) => void;
+}) {
+  const {
+    selection: {environments},
+  } = usePageFilters();
+
+  const finalized = ['Not Finalized', 'Finalized'];
+  const status = ['Active', 'Archived'];
+  const stage = ['Adopted', 'Replaced', 'Low Adoption'];
+
+  const arrayToOptions = (array: string[]) =>
+    array.map(item => ({
+      value: item,
+      label: item,
+    }));
+
+  const handleValueChange = (newValues: any) => {
+    setFilters(newValues.map((value: any) => value.value));
+  };
+
+  const isDisabled = environments.length !== 1;
+
+  const options = [
+    {
+      key: 'finalized',
+      label: t('Finalized'),
+      options: arrayToOptions(finalized),
+    },
+    {
+      key: 'status',
+      label: t('Status'),
+      options: arrayToOptions(status),
+    },
+    {
+      key: 'stage',
+      label: t('Stage'),
+      options: arrayToOptions(stage),
+      disabled: isDisabled,
+      tooltipOptions: {position: 'left'},
+      tooltip: isDisabled
+        ? t('Please select a single environment to filter by stage')
+        : undefined,
+    },
+  ];
+
+  return (
+    <CompactSelect
+      position="right"
+      triggerProps={{
+        prefix: t('Filter'),
+      }}
+      value={filters}
+      onChange={handleValueChange}
+      options={options}
+      multiple
+      clearable
+    />
+  );
+}

--- a/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
+++ b/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
@@ -13,14 +13,23 @@ export default function FilterReleaseDropdown({
     selection: {environments},
   } = usePageFilters();
 
-  const finalized = ['Not Finalized', 'Finalized'];
-  const status = ['Active', 'Archived'];
-  const stage = ['Adopted', 'Replaced', 'Low Adoption'];
+  const finalizedOptions = ['Not Finalized', 'Finalized'];
+  const statusOptions = ['Active', 'Archived'];
+  const stageOptions = ['Adopted', 'Replaced', 'Low Adoption'];
 
-  const arrayToOptions = (array: string[]) =>
+  const arrayToOptions = ({
+    array,
+    showTooltip,
+    tooltip,
+  }: {
+    array: string[];
+    showTooltip?: boolean;
+    tooltip?: string;
+  }) =>
     array.map(item => ({
       value: item,
       label: item,
+      tooltip: showTooltip ? tooltip : undefined,
     }));
 
   const handleValueChange = (newValues: any) => {
@@ -33,22 +42,22 @@ export default function FilterReleaseDropdown({
     {
       key: 'finalized',
       label: t('Finalized'),
-      options: arrayToOptions(finalized),
+      options: arrayToOptions({array: finalizedOptions}),
     },
     {
       key: 'status',
       label: t('Status'),
-      options: arrayToOptions(status),
+      options: arrayToOptions({array: statusOptions}),
     },
     {
       key: 'stage',
       label: t('Stage'),
-      options: arrayToOptions(stage),
+      options: arrayToOptions({
+        array: stageOptions,
+        showTooltip: isDisabled,
+        tooltip: t('Please select a single environment to filter by stage'),
+      }),
       disabled: isDisabled,
-      tooltipOptions: {position: 'left'},
-      tooltip: isDisabled
-        ? t('Please select a single environment to filter by stage')
-        : undefined,
     },
   ];
 

--- a/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
+++ b/static/app/views/insights/sessions/components/filterReleaseDropdown.tsx
@@ -1,4 +1,4 @@
-import {CompactSelect} from 'sentry/components/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -13,9 +13,9 @@ export default function FilterReleaseDropdown({
     selection: {environments},
   } = usePageFilters();
 
-  const finalizedOptions = ['Not Finalized', 'Finalized'];
-  const statusOptions = ['Active', 'Archived'];
-  const stageOptions = ['Adopted', 'Replaced', 'Low Adoption'];
+  const finalizedOptions = [t('Not Finalized'), t('Finalized')];
+  const statusOptions = [t('Active'), t('Archived')];
+  const stageOptions = [t('Adopted'), t('Replaced'), t('Low Adoption')];
 
   const arrayToOptions = ({
     array,
@@ -32,8 +32,8 @@ export default function FilterReleaseDropdown({
       tooltip: showTooltip ? tooltip : undefined,
     }));
 
-  const handleValueChange = (newValues: any) => {
-    setFilters(newValues.map((value: any) => value.value));
+  const handleValueChange = (newValues: Array<SelectOption<string>>) => {
+    setFilters(newValues.map((value: SelectOption<string>) => value.value));
   };
 
   const isDisabled = environments.length !== 1;

--- a/static/app/views/insights/sessions/components/tables/releaseAdoption.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseAdoption.tsx
@@ -27,7 +27,7 @@ export default function ReleaseAdoption({filters}: {filters: string[]}) {
           fields: {
             release: 'string',
             date: 'date',
-            stage: 'string',
+            adoption_stage: 'string',
             lifespan: 'duration',
             adoption: 'percentage',
           },

--- a/static/app/views/insights/sessions/components/tables/releaseAdoption.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseAdoption.tsx
@@ -7,8 +7,11 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import ReleaseAdoptionTable from 'sentry/views/insights/sessions/components/tables/releaseAdoptionTable';
 import useOrganizationReleases from 'sentry/views/insights/sessions/queries/useOrganizationReleases';
 
-export default function ReleaseAdoption() {
-  const {releaseData, isLoading, isError, pageLinks} = useOrganizationReleases();
+export default function ReleaseAdoption({filters}: {filters: string[]}) {
+  const {releaseData, isLoading, isError, pageLinks} = useOrganizationReleases({
+    tableType: 'adoption',
+    filters,
+  });
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -39,7 +42,7 @@ export default function ReleaseAdoption() {
         onCursor={(cursor, path, searchQuery) => {
           navigate({
             pathname: path,
-            query: {...searchQuery, cursor},
+            query: {...searchQuery, cursor_adoption_table: cursor},
           });
         }}
       />

--- a/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
@@ -87,7 +87,7 @@ export default function ReleaseAdoptionTable({
             />
           </CellWrapper>
         ) : (
-          // the bottom lifespan for each project the table is rendered as '--' since there's nothing previous to compare it to
+          // the last lifespan in the table is rendered as '--' since there's nothing previous to compare it to
           '--'
         );
       }

--- a/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
@@ -16,11 +16,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type ReleaseAdoptionItem = {
   adoption: number;
+  adoption_stage: string;
   date: string;
   lifespan: number | undefined;
   project_id: number;
   release: string;
-  stage: string;
 };
 
 interface Props {
@@ -38,7 +38,7 @@ const BASE_COLUMNS: Array<GridColumnOrder<keyof ReleaseAdoptionItem>> = [
   {key: 'date', name: 'date created'},
   {key: 'lifespan', name: 'lifespan'},
   {key: 'adoption', name: 'adoption'},
-  {key: 'stage', name: 'stage'},
+  {key: 'adoption_stage', name: 'stage'},
 ];
 
 export default function ReleaseAdoptionTable({

--- a/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
@@ -87,7 +87,7 @@ export default function ReleaseAdoptionTable({
             />
           </CellWrapper>
         ) : (
-          // the last lifespan in the table is rendered as '--' since there's nothing previous to compare it to
+          // the bottom lifespan for each project the table is rendered as '--' since there's nothing previous to compare it to
           '--'
         );
       }

--- a/static/app/views/insights/sessions/components/tables/releaseHealth.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealth.tsx
@@ -27,7 +27,7 @@ export default function ReleaseHealth({filters}: {filters: string[]}) {
           fields: {
             release: 'string',
             date: 'date',
-            stage: 'string',
+            adoption_stage: 'string',
             crash_free_sessions: 'percentage',
             sessions: 'integer',
             error_count: 'integer',

--- a/static/app/views/insights/sessions/components/tables/releaseHealth.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealth.tsx
@@ -7,8 +7,11 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import ReleaseHealthTable from 'sentry/views/insights/sessions/components/tables/releaseHealthTable';
 import useOrganizationReleases from 'sentry/views/insights/sessions/queries/useOrganizationReleases';
 
-export default function ReleaseHealth() {
-  const {releaseData, isLoading, isError, pageLinks} = useOrganizationReleases();
+export default function ReleaseHealth({filters}: {filters: string[]}) {
+  const {releaseData, isLoading, isError, pageLinks} = useOrganizationReleases({
+    tableType: 'health',
+    filters,
+  });
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -39,7 +42,7 @@ export default function ReleaseHealth() {
         onCursor={(cursor, path, searchQuery) => {
           navigate({
             pathname: path,
-            query: {...searchQuery, cursor},
+            query: {...searchQuery, cursor_health_table: cursor},
           });
         }}
       />

--- a/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
@@ -18,13 +18,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getReleaseNewIssuesUrl} from 'sentry/views/releases/utils';
 
 type ReleaseHealthItem = {
+  adoption_stage: string;
   crash_free_sessions: number;
   date: string;
   error_count: number;
   project_id: number;
   release: string;
   sessions: number;
-  stage: string;
 };
 
 interface Props {
@@ -40,7 +40,7 @@ type Column = GridColumnHeader<keyof ReleaseHealthItem>;
 const BASE_COLUMNS: Array<GridColumnOrder<keyof ReleaseHealthItem>> = [
   {key: 'release', name: 'version'},
   {key: 'date', name: 'date created'},
-  {key: 'stage', name: 'stage'},
+  {key: 'adoption_stage', name: 'stage'},
   {key: 'crash_free_sessions', name: 'crash free rate'},
   {key: 'sessions', name: 'total sessions'},
   {key: 'error_count', name: 'new issues'},

--- a/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
@@ -87,7 +87,7 @@ export default function ReleaseHealthTable({
       }
 
       if (column.key === 'error_count') {
-        return (
+        return (value as number) > 0 ? (
           <Tooltip title={t('Open in Issues')} position="auto-start">
             <GlobalSelectionLink
               to={getReleaseNewIssuesUrl(
@@ -99,6 +99,8 @@ export default function ReleaseHealthTable({
               <Count value={value} />
             </GlobalSelectionLink>
           </Tooltip>
+        ) : (
+          <Count value={value} />
         );
       }
       if (!meta?.fields) {

--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -15,6 +15,8 @@ export default function useCrashFreeSessions() {
       ...location.query,
       width_health_table: undefined,
       width_adoption_table: undefined,
+      cursor_health_table: undefined,
+      cursor_adoption_table: undefined,
     },
   };
 

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -13,6 +13,8 @@ export default function useErrorFreeSessions() {
       ...location.query,
       width_health_table: undefined,
       width_adoption_table: undefined,
+      cursor_health_table: undefined,
+      cursor_adoption_table: undefined,
     },
   };
 

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -102,12 +102,16 @@ export default function useOrganizationReleases({
           })
           .map((release, index, releases) => {
             const projSlug = release.projects[0]?.slug;
+            const projectId = release.projects[0]?.id ?? 0;
 
             const currentDate = new Date(release.dateCreated);
-            const previousDate =
-              index < releases.length - 1
-                ? new Date(releases[index + 1]?.dateCreated ?? 0)
-                : null;
+            // Find the previous release with the same project ID
+            const previousRelease = releases
+              .slice(index + 1)
+              .find(r => r.projects[0]?.id === projectId);
+            const previousDate = previousRelease
+              ? new Date(previousRelease.dateCreated)
+              : null;
 
             const lifespan = previousDate
               ? Math.floor(currentDate.getTime() - previousDate.getTime())

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -116,7 +116,9 @@ export default function useOrganizationReleases({
             return {
               release: release.shortVersion ?? release.version,
               date: release.dateCreated,
-              stage: projSlug ? release.adoptionStages?.[projSlug]?.stage ?? '' : '',
+              adoption_stage: projSlug
+                ? release.adoptionStages?.[projSlug]?.stage ?? ''
+                : '',
               crash_free_sessions:
                 release.projects[0]?.healthData?.crashFreeSessions ?? 0,
               sessions: release.projects[0]?.healthData?.totalSessions ?? 0,

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -102,16 +102,12 @@ export default function useOrganizationReleases({
           })
           .map((release, index, releases) => {
             const projSlug = release.projects[0]?.slug;
-            const projectId = release.projects[0]?.id ?? 0;
-
             const currentDate = new Date(release.dateCreated);
-            // Find the previous release with the same project ID
-            const previousRelease = releases
-              .slice(index + 1)
-              .find(r => r.projects[0]?.id === projectId);
-            const previousDate = previousRelease
-              ? new Date(previousRelease.dateCreated)
-              : null;
+
+            const previousDate =
+              index < releases.length - 1
+                ? new Date(releases[index + 1]?.dateCreated ?? 0)
+                : null;
 
             const lifespan = previousDate
               ? Math.floor(currentDate.getTime() - previousDate.getTime())

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -1,9 +1,16 @@
 import type {Release} from 'sentry/types/release';
+import {FieldKey} from 'sentry/utils/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function useOrganizationReleases() {
+export default function useOrganizationReleases({
+  tableType,
+  filters,
+}: {
+  filters: string[];
+  tableType: 'health' | 'adoption';
+}) {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -13,18 +20,66 @@ export default function useOrganizationReleases() {
       ...location.query,
       width_health_table: undefined,
       width_adoption_table: undefined,
+      cursor_health_table: undefined,
+      cursor_adoption_table: undefined,
     },
   };
+
+  let finalized;
+  const hasFinalized = filters.includes('Finalized');
+  const hasNotFinalized = filters.includes('Not Finalized');
+
+  if (hasFinalized && !hasNotFinalized) {
+    finalized = 'finalized';
+  } else if (!hasFinalized && hasNotFinalized) {
+    finalized = 'not finalized';
+  } else {
+    // if both or neither are selected, it's the same as not selecting any
+    finalized = undefined;
+  }
+
+  let status;
+  const hasActive = filters.includes('Active');
+  const hasArchived = filters.includes('Archived');
+
+  if (hasActive && !hasArchived) {
+    status = 'open';
+  } else if (!hasActive && hasArchived) {
+    status = 'archived';
+  } else {
+    // if both or neither are selected, it's the same as not selecting any
+    status = undefined;
+  }
+
+  const stages: string[] = [];
+  if (filters.includes('Adopted')) {
+    stages.push('adopted');
+  }
+  if (filters.includes('Replaced')) {
+    stages.push('replaced');
+  }
+  if (filters.includes('Low Adoption')) {
+    stages.push('low_adoption');
+  }
+  const stage = stages.length
+    ? `${FieldKey.RELEASE_STAGE}:[${stages.join(',')}]`
+    : undefined;
 
   const {data, isError, isPending, getResponseHeader} = useApiQuery<Release[]>(
     [
       `/organizations/${organization.slug}/releases/`,
       {
         query: {
+          query: stage,
           ...locationWithoutWidth.query,
           adoptionStages: 1,
           health: 1,
           per_page: 10,
+          cursor:
+            tableType === 'health'
+              ? location.query.cursor_health_table
+              : location.query.cursor_adoption_table,
+          status,
         },
       },
     ],
@@ -34,31 +89,43 @@ export default function useOrganizationReleases() {
   const releaseData =
     isPending || !data
       ? []
-      : data.map((release, index, releases) => {
-          const projSlug = release.projects[0]?.slug;
+      : data
+          // need to filter since the endpoint does not support querying by finalized status
+          .filter(release => {
+            if (finalized === 'finalized') {
+              return !!release.dateReleased;
+            }
+            if (finalized === 'not finalized') {
+              return !release.dateReleased;
+            }
+            return true;
+          })
+          .map((release, index, releases) => {
+            const projSlug = release.projects[0]?.slug;
 
-          const currentDate = new Date(release.dateCreated);
-          const previousDate =
-            index < releases.length - 1
-              ? new Date(releases[index + 1]?.dateCreated ?? 0)
-              : null;
+            const currentDate = new Date(release.dateCreated);
+            const previousDate =
+              index < releases.length - 1
+                ? new Date(releases[index + 1]?.dateCreated ?? 0)
+                : null;
 
-          const lifespan = previousDate
-            ? Math.floor(currentDate.getTime() - previousDate.getTime())
-            : undefined;
+            const lifespan = previousDate
+              ? Math.floor(currentDate.getTime() - previousDate.getTime())
+              : undefined;
 
-          return {
-            release: release.shortVersion ?? release.version,
-            date: release.dateCreated,
-            stage: projSlug ? release.adoptionStages?.[projSlug]?.stage ?? '' : '',
-            crash_free_sessions: release.projects[0]?.healthData?.crashFreeSessions ?? 0,
-            sessions: release.projects[0]?.healthData?.totalSessions ?? 0,
-            error_count: release.projects[0]?.newGroups ?? 0,
-            project_id: release.projects[0]?.id ?? 0,
-            adoption: release.projects[0]?.healthData?.adoption ?? 0,
-            lifespan,
-          };
-        });
+            return {
+              release: release.shortVersion ?? release.version,
+              date: release.dateCreated,
+              stage: projSlug ? release.adoptionStages?.[projSlug]?.stage ?? '' : '',
+              crash_free_sessions:
+                release.projects[0]?.healthData?.crashFreeSessions ?? 0,
+              sessions: release.projects[0]?.healthData?.totalSessions ?? 0,
+              error_count: release.projects[0]?.newGroups ?? 0,
+              project_id: release.projects[0]?.id ?? 0,
+              adoption: release.projects[0]?.healthData?.adoption ?? 0,
+              lifespan,
+            };
+          });
 
   return {
     releaseData,

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -51,16 +51,16 @@ export default function useOrganizationReleases({
     status = undefined;
   }
 
-  const stages: string[] = [];
-  if (filters.includes('Adopted')) {
-    stages.push('adopted');
-  }
-  if (filters.includes('Replaced')) {
-    stages.push('replaced');
-  }
-  if (filters.includes('Low Adoption')) {
-    stages.push('low_adoption');
-  }
+  const stageMap = {
+    Adopted: 'adopted',
+    Replaced: 'replaced',
+    'Low Adoption': 'low_adoption',
+  };
+
+  const stages = Object.entries(stageMap)
+    .filter(([filter]) => filters.includes(filter))
+    .map(([, value]) => value);
+
   const stage = stages.length
     ? `${FieldKey.RELEASE_STAGE}:[${stages.join(',')}]`
     : undefined;

--- a/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionProjectTotal.tsx
@@ -13,6 +13,8 @@ export default function useSessionProjectTotal() {
       ...location.query,
       width_health_table: undefined,
       width_adoption_table: undefined,
+      cursor_health_table: undefined,
+      cursor_adoption_table: undefined,
     },
   };
 

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,7 +1,10 @@
 import React, {useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {IconInfo} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
@@ -47,6 +50,11 @@ export function SessionsOverview() {
                     setFilters(['']);
                   }}
                 />
+                <Alert type="info" icon={<IconInfo />} showIcon>
+                  {t(
+                    `This page is a temporary spot to put experimental release charts and tables currently in development. We will move things around eventually, but for now, it's a spot where we can put everything and get quick feedback.`
+                  )}
+                </Alert>
               </ToolRibbon>
             </ModuleLayout.Full>
             {view === MOBILE_LANDING_SUB_PATH ? (

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, {useState} from 'react';
+import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {space} from 'sentry/styles/space';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -15,6 +17,7 @@ import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settin
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import CrashFreeSessionChart from 'sentry/views/insights/sessions/charts/crashFreeSessionChart';
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
+import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/filterReleaseDropdown';
 import ReleaseAdoption from 'sentry/views/insights/sessions/components/tables/releaseAdoption';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -25,6 +28,7 @@ export function SessionsOverview() {
   };
 
   const {view} = useDomainViewFilters();
+  const [filters, setFilters] = useState<string[]>(['']);
 
   return (
     <React.Fragment>
@@ -39,6 +43,9 @@ export function SessionsOverview() {
                 <ModulePageFilterBar
                   moduleName={ModuleName.SESSIONS}
                   extraFilters={<SubregionSelector />}
+                  onProjectChange={() => {
+                    setFilters(['']);
+                  }}
                 />
               </ToolRibbon>
             </ModuleLayout.Full>
@@ -52,8 +59,11 @@ export function SessionsOverview() {
               </ModuleLayout.Third>
             )}
             <ModuleLayout.Full>
-              <ReleaseAdoption />
-              <ReleaseHealth />
+              <FilterWrapper>
+                <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
+              </FilterWrapper>
+              <ReleaseAdoption filters={filters} />
+              <ReleaseHealth filters={filters} />
             </ModuleLayout.Full>
           </ModuleLayout.Layout>
         </Layout.Main>
@@ -74,3 +84,8 @@ function PageWithProviders() {
 }
 
 export default PageWithProviders;
+
+const FilterWrapper = styled('div')`
+  display: flex;
+  margin: ${space(2)} 0;
+`;

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
@@ -57,22 +57,25 @@ export function SessionsOverview() {
                 </Alert>
               </ToolRibbon>
             </ModuleLayout.Full>
-            {view === MOBILE_LANDING_SUB_PATH ? (
-              <ModuleLayout.Half>
-                <CrashFreeSessionChart />
-              </ModuleLayout.Half>
-            ) : (
+            {view === MOBILE_LANDING_SUB_PATH && (
+              <Fragment>
+                <ModuleLayout.Half>
+                  <CrashFreeSessionChart />
+                </ModuleLayout.Half>
+                <ModuleLayout.Full>
+                  <FilterWrapper>
+                    <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
+                  </FilterWrapper>
+                  <ReleaseAdoption filters={filters} />
+                  <ReleaseHealth filters={filters} />
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+            {view === FRONTEND_LANDING_SUB_PATH && (
               <ModuleLayout.Third>
                 <ErrorFreeSessionsChart />
               </ModuleLayout.Third>
             )}
-            <ModuleLayout.Full>
-              <FilterWrapper>
-                <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
-              </FilterWrapper>
-              <ReleaseAdoption filters={filters} />
-              <ReleaseHealth filters={filters} />
-            </ModuleLayout.Full>
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/84877

### ♻️ refactor chart/table placement
frontend: error session chart
mobile: error session chart by release & both tables
backend: nothing

### ✨ adds a dropdown to filter the release tables on insights pages (this filters both tables)
note: stage is disabled if 1+ env selected

<img width="352" alt="SCR-20250224-oazu" src="https://github.com/user-attachments/assets/4c5cd6c5-2fdc-4f70-bf37-e7f896ce6911" /><img width="288" alt="SCR-20250225-kupb" src="https://github.com/user-attachments/assets/17fd6035-7a7e-44d0-a14f-9ef5ea96f6b1" />



#### finalized
```
finalized = release.dateReleased exists
not finalized = !release.dateReleased exists
```

#### status
```
query: {
   status: 'active'
}
```

or 

``` 
query: {
   status: 'open'
}
```

#### stage
```
query: {
   query : {
      release: [low_adoption,replaced]
   }
}
```

### 🐛 also fixes a bug: pagination was affecting both tables at once

### 💄 adds styling to the adoption column:
<img width="838" alt="SCR-20250224-ooel" src="https://github.com/user-attachments/assets/150928b6-021e-4910-b699-267919edd60c" />
<img width="1118" alt="SCR-20250224-oobq" src="https://github.com/user-attachments/assets/a2ca87e9-1146-4a83-b357-81c98d823f99" />

### ✨ adds an alert to the page to clarify its purpose

<img width="1170" alt="SCR-20250225-kcux" src="https://github.com/user-attachments/assets/ae84db13-46fb-4fab-8a90-77025b3d6137" />


