### PR TITLE
fix(team-projects): allow team admins to create projects

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -198,7 +198,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                 ).values_list("team__id", flat=True)
             )
             # Only allow project creation if the user is an admin of the team
-            if not (request.access.has_scope("project:admin") and team.id in requester_admin_teams):
+            if team.id not in requester_admin_teams:
                 return Response({"detail": DISABLED_FEATURE_ERROR_STRING}, status=403)
 
         result = serializer.validated_data

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -187,14 +187,6 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        requester_admin_teams = set(
-            OrganizationMemberTeam.objects.filter(
-                organizationmember__user_id=request.user.id,
-                organizationmember__organization=team.organization,
-                role="admin",
-            ).values_list("team__id", flat=True)
-        )
-
         if team.organization.flags.disable_member_project_creation and not (
             request.access.has_scope("org:write")
         ):

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -184,7 +184,7 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         self.create_member(
             user=test_team_admin,
             organization=test_org,
-            role="admin",
+            role="member",
             team_roles=[(test_team, "admin")],
         )
         self.login_as(user=test_team_admin)

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -184,7 +184,7 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         self.create_member(
             user=test_team_admin,
             organization=test_org,
-            role="member",
+            role="admin",
             team_roles=[(test_team, "admin")],
         )
         self.login_as(user=test_team_admin)


### PR DESCRIPTION
even when "Let members create projects" is disabled, we still want organization members to be able to create projects for teams that they are admin of

if member project creation is disabled and the user does not have `org:write`, then we check that the user is a team admin of the team they are creating the project for