### PR TITLE
feat(nav): Add banner to draw attention to UI toggle

### DIFF
--- a/static/app/components/nav/optInBanner.tsx
+++ b/static/app/components/nav/optInBanner.tsx
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import Panel from 'sentry/components/panels/panel';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
+
+import {useNavPrompts} from './useNavPrompts';
+
+type Props = {collapsed: boolean; organization: Organization};
+
+export function OptInBanner({collapsed, organization}: Props) {
+  const config = useLegacyStore(ConfigStore);
+  const {mutate: mutateUserOptions} = useMutateUserOptions();
+  const isDarkMode = config.theme === 'dark';
+
+  const {shouldShowSidebarBanner, onDismissSidebarBanner} = useNavPrompts({
+    collapsed,
+    organization,
+  });
+
+  if (!shouldShowSidebarBanner || !organization) {
+    return null;
+  }
+
+  return (
+    <TranslucentBackgroundPanel isDarkMode={isDarkMode}>
+      <Title>{t('✨ Try New Navigation')}</Title>
+      <Description>
+        {t("We've redesigned our sidebar to make it easier to navigate Sentry.")}
+      </Description>
+      <OptInButton
+        priority="primary"
+        size="xs"
+        analyticsEventKey="navigation.banner_opt_in_stacked_navigation_clicked"
+        analyticsEventName="Navigation: Stacked Navigation Banner Opt In Clicked"
+        onClick={() => mutateUserOptions({prefersStackedNavigation: true})}
+      >
+        {t('Try now')}
+      </OptInButton>
+      <DismissButton
+        icon={<IconClose />}
+        aria-label={t('Dismiss')}
+        onClick={onDismissSidebarBanner}
+        size="xs"
+        borderless
+        analyticsEventKey="navigation.banner_dismiss_stacked_navigation"
+        analyticsEventName="Navigation: Stacked Navigation Banner Dismissed"
+      />
+    </TranslucentBackgroundPanel>
+  );
+}
+
+const TranslucentBackgroundPanel = styled(Panel)<{isDarkMode: boolean}>`
+  position: relative;
+  background: rgba(245, 243, 247, ${p => (p.isDarkMode ? 0.05 : 0.1)});
+  border: 1px solid rgba(245, 243, 247, ${p => (p.isDarkMode ? 0.1 : 0.15)});
+  padding: ${space(1)};
+  color: ${p => (p.isDarkMode ? p.theme.textColor : '#ebe6ef')};
+
+  margin-bottom: ${space(1)};
+`;
+
+const Title = styled('p')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin: 0;
+`;
+
+const Description = styled('p')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin: ${space(0.5)} 0;
+`;
+
+const OptInButton = styled(Button)`
+  margin: 0 auto;
+  width: 100%;
+`;
+
+const DismissButton = styled(Button)`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  color: currentColor;
+
+  &:hover {
+    color: currentColor;
+  }
+`;

--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -26,6 +26,7 @@ import {
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -167,6 +168,12 @@ export function PrimaryNavigationItems() {
                   label: t('Switch to old navigation'),
                   onAction() {
                     mutateUserOptions({prefersStackedNavigation: false});
+                    trackAnalytics(
+                      'navigation.help_menu_opt_out_stacked_navigation_clicked',
+                      {
+                        organization,
+                      }
+                    );
                   },
                 },
               ],

--- a/static/app/components/nav/useNavPrompts.tsx
+++ b/static/app/components/nav/useNavPrompts.tsx
@@ -1,0 +1,49 @@
+import {usePrompt} from 'sentry/actionCreators/prompts';
+import type {Organization} from 'sentry/types/organization';
+
+export function useNavPrompts({
+  collapsed,
+  organization,
+}: {
+  collapsed: boolean;
+  organization: Organization | null;
+}) {
+  const hasNavigationV2 = organization?.features.includes('navigation-sidebar-v2');
+
+  const {
+    isPromptDismissed: isSidebarPromptDismissed,
+    dismissPrompt: dismissSidebarPrompt,
+  } = usePrompt({
+    feature: 'stacked_navigation_banner',
+    organization,
+    options: {enabled: hasNavigationV2},
+  });
+
+  const {
+    isPromptDismissed: isDropdownPromptDismissed,
+    dismissPrompt: dismissDropdownPrompt,
+  } = usePrompt({
+    feature: 'stacked_navigation_help_menu',
+    organization,
+    options: {enabled: hasNavigationV2},
+  });
+
+  return {
+    shouldShowSidebarBanner:
+      hasNavigationV2 && !collapsed && isSidebarPromptDismissed === false,
+    shouldShowHelpMenuDot:
+      hasNavigationV2 &&
+      isDropdownPromptDismissed === false &&
+      (collapsed || isSidebarPromptDismissed),
+    onOpenHelpMenu: () => {
+      if (
+        hasNavigationV2 &&
+        isSidebarPromptDismissed === true &&
+        isDropdownPromptDismissed === false
+      ) {
+        dismissDropdownPrompt();
+      }
+    },
+    onDismissSidebarBanner: dismissSidebarPrompt,
+  };
+}

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -45,7 +45,11 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
               id="help"
             />
             {shouldShowHelpMenuDot && (
-              <IndicatorDot orientation={orientation} collapsed={collapsed} />
+              <IndicatorDot
+                orientation={orientation}
+                collapsed={collapsed}
+                data-test-id="help-menu-dot"
+              />
             )}
           </HelpActor>
 

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -3,11 +3,13 @@ import styled from '@emotion/styled';
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 import DeprecatedDropdownMenu from 'sentry/components/deprecatedDropdownMenu';
 import Hook from 'sentry/components/hook';
+import {useNavPrompts} from 'sentry/components/nav/useNavPrompts';
 import SidebarItem from 'sentry/components/sidebar/sidebarItem';
 import {IconQuestion} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 
 import SidebarDropdownMenu from './sidebarDropdownMenu.styled';
@@ -22,10 +24,14 @@ type Props = Pick<
 };
 
 function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
+  const {shouldShowHelpMenuDot, onOpenHelpMenu} = useNavPrompts({
+    collapsed,
+    organization,
+  });
   const {mutate: mutateUserOptions} = useMutateUserOptions();
 
   return (
-    <DeprecatedDropdownMenu>
+    <DeprecatedDropdownMenu onOpen={onOpenHelpMenu}>
       {({isOpen, getActorProps, getMenuProps}) => (
         <HelpRoot>
           <HelpActor {...getActorProps({onClick: hidePanel})}>
@@ -38,6 +44,9 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
               label={t('Help')}
               id="help"
             />
+            {shouldShowHelpMenuDot && (
+              <IndicatorDot orientation={orientation} collapsed={collapsed} />
+            )}
           </HelpActor>
 
           {isOpen && (
@@ -57,9 +66,17 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
               <Hook name="sidebar:help-menu" organization={organization} />
               {organization?.features?.includes('navigation-sidebar-v2') && (
                 <SidebarMenuItem
-                  onClick={() => mutateUserOptions({prefersStackedNavigation: true})}
+                  onClick={() => {
+                    mutateUserOptions({prefersStackedNavigation: true});
+                    trackAnalytics(
+                      'navigation.help_menu_opt_in_stacked_navigation_clicked',
+                      {
+                        organization,
+                      }
+                    );
+                  }}
                 >
-                  {t('Try new navigation')}
+                  {t('Try new navigation ✨')}
                 </SidebarMenuItem>
               )}
             </HelpMenu>
@@ -86,4 +103,19 @@ const HelpMenu = styled('div', {shouldForwardProp: p => p !== 'orientation'})<{
 }>`
   ${SidebarDropdownMenu};
   ${p => (p.orientation === 'left' ? 'bottom: 100%' : `top: ${space(4)}; right: 0px;`)}
+`;
+
+const IndicatorDot = styled('div')<{
+  collapsed: Props['collapsed'];
+  orientation: Props['orientation'];
+}>`
+  position: absolute;
+  top: ${p => (p.orientation === 'left' && !p.collapsed ? '50%' : 0)};
+  right: ${p => (p.orientation === 'left' && !p.collapsed ? space(1) : 0)};
+  width: 11px;
+  height: 11px;
+  transform: ${p =>
+    p.orientation === 'left' && !p.collapsed ? 'translate(-50%, -50%)' : 'none'};
+  border-radius: 50%;
+  background-color: ${p => p.theme.red300};
 `;

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -9,6 +9,7 @@ import {Chevron} from 'sentry/components/chevron';
 import FeatureFlagOnboardingSidebar from 'sentry/components/events/featureFlags/featureFlagOnboardingSidebar';
 import FeedbackOnboardingSidebar from 'sentry/components/feedback/feedbackOnboarding/sidebar';
 import Hook from 'sentry/components/hook';
+import {OptInBanner} from 'sentry/components/nav/optInBanner';
 import PerformanceOnboardingSidebar from 'sentry/components/performanceOnboarding/sidebar';
 import ReplaysOnboardingSidebar from 'sentry/components/replaysOnboarding/sidebar';
 import {
@@ -568,6 +569,10 @@ function Sidebar() {
             </SidebarSection>
 
             <SidebarSection centeredItems={horizontal}>
+              <OptInBanner
+                collapsed={collapsed || horizontal}
+                organization={organization}
+              />
               {HookStore.get('sidebar:bottom-items').length > 0 &&
                 HookStore.get('sidebar:bottom-items')[0]!({
                   orientation,

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -13,6 +13,7 @@ import {
   featureFlagEventMap,
   type FeatureFlagEventParameters,
 } from 'sentry/utils/analytics/featureFlagAnalyticsEvents';
+import {navigationAnalyticsEventMap} from 'sentry/utils/analytics/navigationAnalyticsEvents';
 import {
   quickStartEventMap,
   type QuickStartEventParameters,
@@ -131,6 +132,7 @@ const allEventMap: Record<string, string | null> = {
   ...signupEventMap,
   ...statsEventMap,
   ...quickStartEventMap,
+  ...navigationAnalyticsEventMap,
 };
 
 /**

--- a/static/app/utils/analytics/navigationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/navigationAnalyticsEvents.tsx
@@ -1,0 +1,13 @@
+export type NavigationEventParameters = {
+  'navigation.help_menu_opt_in_stacked_navigation_clicked': Record<string, unknown>;
+  'navigation.help_menu_opt_out_stacked_navigation_clicked': Record<string, unknown>;
+};
+
+export type NavigationEventKey = keyof NavigationEventParameters;
+
+export const navigationAnalyticsEventMap: Record<NavigationEventKey, string | null> = {
+  'navigation.help_menu_opt_in_stacked_navigation_clicked':
+    'Navigation: Help Menu Opt In To Stacked Navigation Clicked',
+  'navigation.help_menu_opt_out_stacked_navigation_clicked':
+    'Navigation: Help Menu Opt Out Of Stacked Navigation Clicked',
+};


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/84018

To call attention to the new UI toggle, adds a banner at the bottom of the old nav UI. When dismissed, it places a dot on the help menu to hint at the user that they can still toggle from there.

https://github.com/user-attachments/assets/4a4d6673-cea8-497f-907f-6dd3d2370576

