### PR TITLE
fix(grouping): Mark OS frames as non-in-app

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -319,6 +319,9 @@ category:throw ^-group
 # raise() called by abort() should only group by abort()
 [ category:throw ] | category:throw category=internals
 
+# Frames from the OS should never be considered in-app
+category:system -app
+
 # Thread bases such as `main()` are just noise and are called by noise.
 category:threadbase -group v-group
 
@@ -382,6 +385,7 @@ family:native function:*.cold.1 category=indirection
 [ category:runtime ]    | category:system  category=internals
 [ category:runtime ]    | category:runtime category=internals
 [ category:dtor ]       | category:dtor    category=internals
+
 
 # SDK specific rules
 

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.269236+00:00'
+created: '2025-02-25T18:30:54.154107+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "HTTP_THREAD_POOL::_StaticWorkItemCallback"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.400920+00:00'
+created: '2025-02-25T18:30:54.986775+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,13 +33,13 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "-[NSApplication run]"
             frame*
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "-[NSView displayIfNeeded]"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.774733+00:00'
+created: '2025-02-25T18:30:55.282271+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -41,7 +41,7 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "DispatchMessageWorker"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.080358+00:00'
+created: '2025-02-25T18:30:57.547427+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,7 +33,7 @@ contributing variants:
             frame*
               function*
                 "code"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.224165+00:00'
+created: '2025-02-25T18:30:57.622977+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,13 +33,13 @@ contributing variants:
             frame*
               function*
                 "code"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "-[NSApplication run]"
             frame*
               function*
                 "code"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "-[NSView displayIfNeeded]"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.699703+00:00'
+created: '2025-02-25T18:30:58.111612+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "CUseCountedObject<T>::UCDestroy"
             frame*
               function*
                 "destructor'"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.747913+00:00'
+created: '2025-02-25T18:30:58.178292+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,6 +30,6 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.863234+00:00'
+created: '2025-02-25T18:30:58.249951+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "CUseCountedObject<T>::UCDestroy"
             frame*
               function*
                 "destructor'"
-            frame*
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "NOutermost::CDeviceChild::LUCBeginLayerDestruction"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T14:49:11.971747+00:00'
+created: '2025-02-25T18:31:00.963400+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -139,6 +139,6 @@ contributing variants:
             frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "TMulticastDelegateBase<T>::Broadcast<T>"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "tgkill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T14:49:12.266099+00:00'
+created: '2025-02-25T18:31:01.060795+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "21f12614b98d6dd2c5d5303e452b4c6b"
+    hash: "c246c95d4a435b3d601044aebae72a38"
     contributing component: exception
     component:
       app*
@@ -48,9 +48,6 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-              function*
-                "DispatchMessageWorker"
             frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsApplication::AppWndProc"
@@ -149,7 +146,7 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "DispatchMessageWorker"
             frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T20:50:33.309522+00:00'
+created: '2025-02-25T18:31:01.158082+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "a27e168f67ce2d3f12bba36eba67d076"
+    hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
     contributing component: exception
     component:
       app*
@@ -48,9 +48,6 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
-              function*
-                "DispatchMessageWorker"
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsApplication::AppWndProc"
@@ -151,7 +148,7 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame* (marked out of app by stack trace rule (category:system -app))
               function*
                 "DispatchMessageWorker"
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.154516+00:00'
+created: '2025-02-25T18:23:20.086385+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             module*
               "com.android.internal.os.ZygoteInit"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.420112+00:00'
+created: '2025-02-25T18:23:20.317588+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ app:
               "__kernel_rt_sigreturn"
           frame (non app frame)
           frame (marked out of app by stack trace rule (family:native package:/lib/** -app))
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.242928+00:00'
+created: '2025-02-25T18:23:20.792588+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame*
             function*
               "unicorn"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "UIApplicationMain"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.599705+00:00'
+created: '2025-02-25T18:23:27.614953+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app:
           frame (non app frame)
             function*
               "TppWorkpExecuteCallback"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
           frame (non app frame)
@@ -106,7 +106,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "TppWorkpExecuteCallback"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.170967+00:00'
+created: '2025-02-25T18:23:28.399978+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -31,7 +31,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSApplication run]"
           frame (non app frame)
@@ -70,7 +70,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
           frame (non app frame)
@@ -223,7 +223,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSApplication run]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -262,7 +262,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.406993+00:00'
+created: '2025-02-25T18:23:28.724233+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -75,7 +75,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
           frame (non app frame)
@@ -222,7 +222,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.466801+00:00'
+created: '2025-02-25T18:23:31.366709+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -52,7 +52,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
           frame (non app frame)
@@ -207,7 +207,7 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:16.569216+00:00'
+created: '2025-02-25T18:23:31.460972+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -34,7 +34,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSApplication run]"
           frame (non app frame)
@@ -63,7 +63,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
           frame (non app frame)
@@ -217,7 +217,7 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSApplication run]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -246,7 +246,7 @@ system:
           frame*
             function*
               "code"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.088876+00:00'
+created: '2025-02-25T18:23:32.006124+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame (non app frame)
             function*
               "destructor'"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
           frame (non app frame)
@@ -41,13 +41,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame*
             function*
               "destructor'"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.193233+00:00'
+created: '2025-02-25T18:23:32.074562+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame (non app frame)
@@ -36,7 +36,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.289299+00:00'
+created: '2025-02-25T18:23:32.148384+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame (non app frame)
             function*
               "destructor'"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
           frame (non app frame)
@@ -42,13 +42,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame*
             function*
               "destructor'"
-          frame*
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T15:34:53.545940+00:00'
+created: '2025-02-25T18:23:34.633056+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (non app frame)
             function*
               "__NSThread__start__"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T14:49:13.899192+00:00'
+created: '2025-02-25T18:23:34.705180+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
     app*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "__start_thread"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
@@ -75,7 +75,7 @@ app:
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
           frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "tgkill"
         type (ignored because exception is synthetic)
@@ -155,7 +155,7 @@ system:
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
           frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "tgkill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-02-25T14:49:14.216385+00:00'
+created: '2025-02-25T18:23:34.789572+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "21f12614b98d6dd2c5d5303e452b4c6b"
+  hash: "c246c95d4a435b3d601044aebae72a38"
   contributing component: exception
   component:
     app*
@@ -44,10 +44,10 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
@@ -195,7 +195,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-02-20T15:17:59.479604+00:00'
+created: '2025-02-25T18:23:34.874871+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a27e168f67ce2d3f12bba36eba67d076"
+  hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
   contributing component: exception
   component:
     app*
@@ -44,10 +44,10 @@ app:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame (marked out of app by stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
@@ -224,7 +224,7 @@ system:
           frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame* (marked out of app by stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T15:16:52.672918+00:00'
+created: '2025-02-25T18:23:34.962680+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,7 +16,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
             function*
               "__NSThread__start__"
           frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))


### PR DESCRIPTION
In addition to marking frames contributing (or not) using `+/-group` rules, and in-app (or not) using `+/-app` rules, our stacktrace rule system can also tag frames with a category - things like `ui` and `av` (for what you'd expect), `std` (for standard library functions), and `system` (for functions or modules from the os). These categories are then then basis of some of our built-in `+/-group` and `+/-app` rules.

One rule we for some reason don't have is that frames with category `system` should be considered "system" (meaning not in-app) frames. This omission ends up getting somewhat mitigated by rules which reclassify some category `system` frames as category `internal` based on their function names and/or their proximity to frames in other categories (this helps because `internal` frames are marked as non-contributing), but there are cases in which we're still counting category `system` frames as in-app (non-system) frames.

This PR fixes that by adding a `category:system -app` rule to the current grouping config. (Because it won't change the system hashes, this change doesn't require a new grouping config.)