### PR TITLE
badge: add named export

### DIFF
--- a/static/app/components/core/badge.tsx
+++ b/static/app/components/core/badge.tsx
@@ -50,7 +50,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   type?: BadgeType;
 }
 
-function Badge({children, type = 'default', text, ...props}: BadgeProps) {
+export function Badge({children, type = 'default', text, ...props}: BadgeProps) {
   const badgeColors = useBadgeColors();
 
   return (


### PR DESCRIPTION
Add named export so getsentry can migrate to it and we can remove it.

[getsentry counterpart PR](https://github.com/getsentry/getsentry/pull/16629)