### PR TITLE
ref(seer grouping): Small Seer backfill cleanup

### DIFF
--- a/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
+++ b/src/sentry/api/endpoints/project_backfill_similar_issues_embeddings_records.py
@@ -67,7 +67,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecords(ProjectEndpoint):
 
         backfill_seer_grouping_records_for_project.delay(
             current_project_id=project.id,
-            last_processed_group_id_input=last_processed_id,
+            last_processed_group_id=last_processed_id,
             only_delete=only_delete,
             enable_ingestion=enable_ingestion,
             skip_processed_projects=skip_processed_projects,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -363,11 +363,11 @@ def call_next_backfill(
             return
 
         # call the backfill on next project
-        batch_project_id, last_processed_project_index = get_next_project_from_cohort(
+        next_project_id, last_processed_project_index = get_next_project_from_cohort(
             last_processed_project_index, cohort
         )
 
-        if batch_project_id is None and worker_number is None:
+        if next_project_id is None and worker_number is None:
             logger.info(
                 "backfill_seer_grouping_records.project_list_backfill_finished",
                 extra={
@@ -377,7 +377,7 @@ def call_next_backfill(
             )
             # we're at the end of the project list
             return
-        elif batch_project_id is None:
+        elif next_project_id is None:
             logger.info(
                 "backfill_seer_grouping_records.cohort_finished",
                 extra={
@@ -390,7 +390,7 @@ def call_next_backfill(
 
         backfill_seer_grouping_records_for_project.apply_async(
             args=[
-                batch_project_id,
+                next_project_id,
                 None,
                 cohort,
                 last_processed_project_index,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -367,26 +367,29 @@ def call_next_backfill(
             current_project_index_in_cohort, cohort
         )
 
-        if next_project_id is None and worker_number is None:
-            logger.info(
-                "backfill_seer_grouping_records.project_list_backfill_finished",
-                extra={
-                    "cohort": cohort,
-                    "last_processed_project_index": next_project_index_in_cohort,
-                },
-            )
-            # we're at the end of the project list
-            return
-        elif next_project_id is None:
-            logger.info(
-                "backfill_seer_grouping_records.cohort_finished",
-                extra={
-                    "cohort": cohort,
-                    "worker_number": worker_number,
-                },
-            )
-            cohort = None
-            last_processed_project_id = project_id
+        if next_project_id is None:
+            if worker_number is None:
+                logger.info(
+                    "backfill_seer_grouping_records.project_list_backfill_finished",
+                    extra={
+                        "cohort": cohort,
+                        "last_processed_project_index": next_project_index_in_cohort,
+                    },
+                )
+                # we're at the end of the project list
+                return
+
+            else:
+                logger.info(
+                    "backfill_seer_grouping_records.cohort_finished",
+                    extra={
+                        "cohort": cohort,
+                        "worker_number": worker_number,
+                    },
+                )
+                # Set `cohort` to None so the backfill task knows to create the next one
+                cohort = None
+                last_processed_project_id = project_id
 
         backfill_seer_grouping_records_for_project.apply_async(
             args=[

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -50,7 +50,7 @@ def backfill_seer_grouping_records_for_project(
     current_project_id: int | None,
     last_processed_group_id_input: int | None = None,
     cohort: str | list[int] | None = None,
-    last_processed_project_index_input: int | None = None,
+    last_processed_project_index: int | None = None,
     only_delete: bool = False,
     enable_ingestion: bool = False,
     skip_processed_projects: bool = True,
@@ -116,9 +116,7 @@ def backfill_seer_grouping_records_for_project(
         )
         return
 
-    last_processed_project_index = (
-        last_processed_project_index_input if last_processed_project_index_input else 0
-    )
+    last_processed_project_index = last_processed_project_index or 0
     try:
         project = Project.objects.get_from_cache(id=current_project_id)
     except Project.DoesNotExist:
@@ -126,10 +124,9 @@ def backfill_seer_grouping_records_for_project(
             "backfill_seer_grouping_records.project_does_not_exist",
             extra={"project_id": current_project_id, "worker_number": worker_number},
         )
-        assert last_processed_project_index_input is not None
         call_next_backfill(
             project_id=current_project_id,
-            last_processed_project_index=last_processed_project_index_input,
+            last_processed_project_index=last_processed_project_index,
             cohort=cohort,
             only_delete=only_delete,
             enable_ingestion=enable_ingestion,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -363,7 +363,7 @@ def call_next_backfill(
             return
 
         # call the backfill on next project
-        next_project_id, last_processed_project_index = get_next_project_from_cohort(
+        next_project_id, next_project_index_in_cohort = get_next_project_from_cohort(
             last_processed_project_index, cohort
         )
 
@@ -372,7 +372,7 @@ def call_next_backfill(
                 "backfill_seer_grouping_records.project_list_backfill_finished",
                 extra={
                     "cohort": cohort,
-                    "last_processed_project_index": last_processed_project_index,
+                    "last_processed_project_index": next_project_index_in_cohort,
                 },
             )
             # we're at the end of the project list
@@ -393,7 +393,7 @@ def call_next_backfill(
                 next_project_id,
                 None,
                 cohort,
-                last_processed_project_index,
+                next_project_index_in_cohort,
                 only_delete,
                 enable_ingestion,
                 skip_processed_projects,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -243,7 +243,8 @@ def backfill_seer_grouping_records_for_project(
         )
     except EVENT_INFO_EXCEPTIONS:
         metrics.incr("sentry.tasks.backfill_seer_grouping_records.grouping_config_error")
-        nodestore_results, group_hashes_dict = GroupStacktraceData(data=[], stacktrace_list=[]), {}
+        nodestore_results = GroupStacktraceData(data=[], stacktrace_list=[])
+        group_hashes_dict = {}
     except NODESTORE_RETRY_EXCEPTIONS as e:
         extra = {
             "organization_id": project.organization.id,

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 )
 def backfill_seer_grouping_records_for_project(
     current_project_id: int | None,
-    last_processed_group_id_input: int | None = None,
+    last_processed_group_id: int | None = None,
     cohort: str | list[int] | None = None,
     current_project_index_in_cohort: int | None = None,
     only_delete: bool = False,
@@ -110,7 +110,7 @@ def backfill_seer_grouping_records_for_project(
             "backfill_seer_grouping_records.killswitch_enabled",
             extra={
                 "project_id": current_project_id,
-                "last_processed_group_id": last_processed_group_id_input,
+                "last_processed_group_id": last_processed_group_id,
                 "worker_number": worker_number,
             },
         )
@@ -191,7 +191,7 @@ def backfill_seer_grouping_records_for_project(
     # filtering, also capture the last group id in the raw/unfiltered batch, to be used when
     # querying for the next batch.
     (groups_to_backfill_with_no_embedding, batch_end_id) = get_current_batch_groups_from_postgres(
-        project, last_processed_group_id_input, batch_size, worker_number, enable_ingestion
+        project, last_processed_group_id, batch_size, worker_number, enable_ingestion
     )
 
     if len(groups_to_backfill_with_no_embedding) == 0:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -50,7 +50,7 @@ def backfill_seer_grouping_records_for_project(
     current_project_id: int | None,
     last_processed_group_id_input: int | None = None,
     cohort: str | list[int] | None = None,
-    last_processed_project_index: int | None = None,
+    current_project_index_in_cohort: int | None = None,
     only_delete: bool = False,
     enable_ingestion: bool = False,
     skip_processed_projects: bool = True,
@@ -116,7 +116,7 @@ def backfill_seer_grouping_records_for_project(
         )
         return
 
-    last_processed_project_index = last_processed_project_index or 0
+    current_project_index_in_cohort = current_project_index_in_cohort or 0
     try:
         project = Project.objects.get_from_cache(id=current_project_id)
     except Project.DoesNotExist:
@@ -126,7 +126,7 @@ def backfill_seer_grouping_records_for_project(
         )
         call_next_backfill(
             project_id=current_project_id,
-            last_processed_project_index=last_processed_project_index,
+            current_project_index_in_cohort=current_project_index_in_cohort,
             cohort=cohort,
             only_delete=only_delete,
             enable_ingestion=enable_ingestion,
@@ -174,7 +174,7 @@ def backfill_seer_grouping_records_for_project(
     if is_project_processed or is_project_skipped or only_delete or not is_project_seer_eligible:
         call_next_backfill(
             project_id=current_project_id,
-            last_processed_project_index=last_processed_project_index,
+            current_project_index_in_cohort=current_project_index_in_cohort,
             cohort=cohort,
             only_delete=only_delete,
             enable_ingestion=enable_ingestion,
@@ -198,7 +198,7 @@ def backfill_seer_grouping_records_for_project(
         call_next_backfill(
             last_processed_group_id=batch_end_id,
             project_id=current_project_id,
-            last_processed_project_index=last_processed_project_index,
+            current_project_index_in_cohort=current_project_index_in_cohort,
             cohort=cohort,
             enable_ingestion=enable_ingestion,
             skip_processed_projects=skip_processed_projects,
@@ -224,7 +224,7 @@ def backfill_seer_grouping_records_for_project(
         call_next_backfill(
             last_processed_group_id=batch_end_id,
             project_id=current_project_id,
-            last_processed_project_index=last_processed_project_index,
+            current_project_index_in_cohort=current_project_index_in_cohort,
             cohort=cohort,
             enable_ingestion=enable_ingestion,
             skip_processed_projects=skip_processed_projects,
@@ -258,7 +258,7 @@ def backfill_seer_grouping_records_for_project(
         call_next_backfill(
             last_processed_group_id=batch_end_id,
             project_id=current_project_id,
-            last_processed_project_index=last_processed_project_index,
+            current_project_index_in_cohort=current_project_index_in_cohort,
             cohort=cohort,
             enable_ingestion=enable_ingestion,
             skip_processed_projects=skip_processed_projects,
@@ -293,7 +293,7 @@ def backfill_seer_grouping_records_for_project(
             extra={
                 "reason": seer_response.get("reason"),
                 "project_id": current_project_id,
-                "project_index_in_cohort": last_processed_project_index,
+                "project_index_in_cohort": current_project_index_in_cohort,
                 "worker_number": worker_number,
             },
         )
@@ -313,7 +313,7 @@ def backfill_seer_grouping_records_for_project(
     call_next_backfill(
         last_processed_group_id=batch_end_id,
         project_id=current_project_id,
-        last_processed_project_index=last_processed_project_index,
+        current_project_index_in_cohort=current_project_index_in_cohort,
         cohort=cohort,
         enable_ingestion=enable_ingestion,
         skip_processed_projects=skip_processed_projects,
@@ -326,7 +326,7 @@ def backfill_seer_grouping_records_for_project(
 def call_next_backfill(
     *,
     project_id: int,
-    last_processed_project_index: int,
+    current_project_index_in_cohort: int,
     cohort: str | list[int] | None,
     enable_ingestion: bool,
     skip_processed_projects: bool,
@@ -344,7 +344,7 @@ def call_next_backfill(
                 project_id,
                 last_processed_group_id,
                 cohort,
-                last_processed_project_index,
+                current_project_index_in_cohort,
                 only_delete,
                 enable_ingestion,
                 skip_processed_projects,
@@ -364,7 +364,7 @@ def call_next_backfill(
 
         # call the backfill on next project
         next_project_id, next_project_index_in_cohort = get_next_project_from_cohort(
-            last_processed_project_index, cohort
+            current_project_index_in_cohort, cohort
         )
 
         if next_project_id is None and worker_number is None:

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -378,11 +378,8 @@ def get_events_from_nodestore(
             if not stacktrace_string:
                 invalid_event_group_ids.append(group_id)
                 continue
-            primary_hash = event.get_primary_hash()
-            if not primary_hash:
-                invalid_event_group_ids.append(group_id)
-                continue
 
+            primary_hash = event.get_primary_hash()
             exception_type = get_path(event.data, "exception", "values", -1, "type")
             group_data.append(
                 CreateGroupingRecordData(

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -734,8 +734,8 @@ def delete_seer_grouping_records(
         Group.objects.bulk_update(groups_with_seer_metadata, ["data"])
 
 
-def get_next_project_from_cohort(last_processed_project_index, cohort_projects):
-    next_project_index = last_processed_project_index + 1
+def get_next_project_from_cohort(current_project_index, cohort_projects):
+    next_project_index = current_project_index + 1
     if next_project_index >= len(cohort_projects):
         return None, None
 

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -46,7 +46,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=None,
+            last_processed_group_id=None,
             only_delete=False,
             enable_ingestion=False,
             skip_processed_projects=True,
@@ -64,7 +64,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=None,
+            last_processed_group_id=None,
             only_delete=False,
             enable_ingestion=False,
             skip_processed_projects=True,
@@ -85,7 +85,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=8,
+            last_processed_group_id=8,
             only_delete=False,
             enable_ingestion=False,
             skip_processed_projects=True,
@@ -108,7 +108,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=8,
+            last_processed_group_id=8,
             only_delete=True,
             enable_ingestion=False,
             skip_processed_projects=True,
@@ -131,7 +131,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=8,
+            last_processed_group_id=8,
             only_delete=False,
             enable_ingestion=True,
             skip_processed_projects=True,
@@ -154,7 +154,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=8,
+            last_processed_group_id=8,
             only_delete=False,
             enable_ingestion=False,
             # reprocess_backfilled_projects changes the default
@@ -178,7 +178,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
             current_project_id=self.project.id,
-            last_processed_group_id_input=8,
+            last_processed_group_id=8,
             only_delete=False,
             enable_ingestion=False,
             skip_processed_projects=True,

--- a/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
+++ b/tests/sentry/api/endpoints/test_project_backfill_similar_issues_embeddings_records.py
@@ -20,7 +20,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
             },
         )
 
-    def test_post_no_feature_flag(self):
+    def test_no_feature_flag(self):
         response = self.client.post(self.url, data={})
         assert response.status_code == 404, response.content
 
@@ -28,7 +28,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.is_active_superuser",
         return_value=False,
     )
-    def test_post_not_superuser(self, mock_is_active_superuser):
+    def test_not_superuser(self, mock_is_active_superuser):
         response = self.client.post(self.url, data={})
         assert response.status_code == 404, response.content
 
@@ -39,7 +39,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @patch(
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
-    def test_post_success_no_last_processed_id(
+    def test_no_last_processed_id(
         self, mock_backfill_seer_grouping_records, mock_is_active_superuser
     ):
         response = self.client.post(self.url, data={})
@@ -57,9 +57,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
-    def test_post_success_no_last_processed_id_single_org(
-        self, mock_backfill_seer_grouping_records
-    ):
+    def test_no_last_processed_id_single_org(self, mock_backfill_seer_grouping_records):
         response = self.client.post(self.url, data={})
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
@@ -78,9 +76,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @patch(
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
-    def test_post_success_last_processed_id(
-        self, mock_backfill_seer_grouping_records, mock_is_active_superuser
-    ):
+    def test_last_processed_id(self, mock_backfill_seer_grouping_records, mock_is_active_superuser):
         response = self.client.post(self.url, data={"last_processed_id": "8"})
         assert response.status_code == 204, response.content
         mock_backfill_seer_grouping_records.assert_called_with(
@@ -99,9 +95,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @patch(
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
-    def test_post_success_only_delete(
-        self, mock_backfill_seer_grouping_records, mock_is_active_superuser
-    ):
+    def test_only_delete(self, mock_backfill_seer_grouping_records, mock_is_active_superuser):
         response = self.client.post(
             self.url, data={"last_processed_id": "8", "only_delete": "true"}
         )
@@ -122,9 +116,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @patch(
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
-    def test_post_success_enable_ingestion(
-        self, mock_backfill_seer_grouping_records, mock_is_active_superuser
-    ):
+    def test_enable_ingestion(self, mock_backfill_seer_grouping_records, mock_is_active_superuser):
         response = self.client.post(
             self.url, data={"last_processed_id": "8", "enable_ingestion": "true"}
         )
@@ -145,7 +137,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @patch(
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
-    def test_post_success_skip_processed_projects(
+    def test_skip_processed_projects(
         self, mock_backfill_seer_grouping_records, mock_is_active_superuser
     ):
         response = self.client.post(
@@ -169,9 +161,7 @@ class ProjectBackfillSimilarIssuesEmbeddingsRecordsTest(APITestCase):
     @patch(
         "sentry.api.endpoints.project_backfill_similar_issues_embeddings_records.backfill_seer_grouping_records_for_project.delay"
     )
-    def test_post_success_skip_project_ids(
-        self, mock_backfill_seer_grouping_records, mock_is_active_superuser
-    ):
+    def test_skip_project_ids(self, mock_backfill_seer_grouping_records, mock_is_active_superuser):
         response = self.client.post(
             self.url, data={"last_processed_id": "8", "skip_project_ids": [1]}
         )

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -621,7 +621,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=[self.project.id, project2.id],
-                current_project_index_in_cohort=0,
             )
 
         groups = Group.objects.filter(project_id__in=[self.project.id, project2.id])
@@ -641,7 +640,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=99999999999999,
                 cohort=[99999999999999, self.project.id],
-                current_project_index_in_cohort=0,
             )
 
         groups = Group.objects.filter(project_id__in=[99999999999999, self.project.id])
@@ -775,7 +773,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=None,
-                current_project_index_in_cohort=0,
             )
 
         groups = Group.objects.filter(project_id=self.project.id)
@@ -914,7 +911,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=projects,
-                current_project_index_in_cohort=0,
             )
         groups = Group.objects.filter(project_id__in=projects)
         self.assert_groups_metadata_updated(groups)
@@ -925,7 +921,6 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=projects,
-                current_project_index_in_cohort=0,
                 only_delete=True,
             )
 

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -621,7 +621,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=[self.project.id, project2.id],
-                last_processed_project_index=0,
+                current_project_index_in_cohort=0,
             )
 
         groups = Group.objects.filter(project_id__in=[self.project.id, project2.id])
@@ -641,7 +641,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=99999999999999,
                 cohort=[99999999999999, self.project.id],
-                last_processed_project_index=0,
+                current_project_index_in_cohort=0,
             )
 
         groups = Group.objects.filter(project_id__in=[99999999999999, self.project.id])
@@ -775,7 +775,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=None,
-                last_processed_project_index=0,
+                current_project_index_in_cohort=0,
             )
 
         groups = Group.objects.filter(project_id=self.project.id)
@@ -914,7 +914,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=projects,
-                last_processed_project_index=0,
+                current_project_index_in_cohort=0,
             )
         groups = Group.objects.filter(project_id__in=projects)
         self.assert_groups_metadata_updated(groups)
@@ -925,7 +925,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=projects,
-                last_processed_project_index=0,
+                current_project_index_in_cohort=0,
                 only_delete=True,
             )
 
@@ -1111,7 +1111,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         mock_call_next_backfill.assert_called_with(
             last_processed_group_id=group_ids_sorted[-1],
             project_id=self.project.id,
-            last_processed_project_index=0,
+            current_project_index_in_cohort=0,
             cohort=None,
             enable_ingestion=False,
             skip_processed_projects=True,
@@ -1140,7 +1140,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             mock_call_next_backfill.assert_called_with(
                 last_processed_group_id=group_ids_sorted[-1],
                 project_id=self.project.id,
-                last_processed_project_index=0,
+                current_project_index_in_cohort=0,
                 cohort=None,
                 enable_ingestion=False,
                 skip_processed_projects=True,

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -621,7 +621,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=[self.project.id, project2.id],
-                last_processed_project_index_input=0,
+                last_processed_project_index=0,
             )
 
         groups = Group.objects.filter(project_id__in=[self.project.id, project2.id])
@@ -641,7 +641,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=99999999999999,
                 cohort=[99999999999999, self.project.id],
-                last_processed_project_index_input=0,
+                last_processed_project_index=0,
             )
 
         groups = Group.objects.filter(project_id__in=[99999999999999, self.project.id])
@@ -775,7 +775,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=None,
-                last_processed_project_index_input=0,
+                last_processed_project_index=0,
             )
 
         groups = Group.objects.filter(project_id=self.project.id)
@@ -914,7 +914,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=projects,
-                last_processed_project_index_input=0,
+                last_processed_project_index=0,
             )
         groups = Group.objects.filter(project_id__in=projects)
         self.assert_groups_metadata_updated(groups)
@@ -925,7 +925,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             backfill_seer_grouping_records_for_project(
                 current_project_id=self.project.id,
                 cohort=projects,
-                last_processed_project_index_input=0,
+                last_processed_project_index=0,
                 only_delete=True,
             )
 


### PR DESCRIPTION
This includes a number of small changes to our Seer grouping backfill code, pulled from an upcoming PR in order to make it easier to review.

- Stop differentiating between the version of a variable which is passed into a function (`xxxx_input`) and the variable itself (`xxxx`).

- Rename a few variables (most notably `last_processed_project_index`, which has different meanings in different spots) for clarity.

- Reorganize conditionals when finishing a cohort for readability.

- Stop handling case in which primary hash is missing, since the return type of `event.get_primary_hash` has been fixed and now guarantees a value.

- Improve some comments.

- Stop passing redundant `last_processed_project_index` parameter in tests, and simplify test names.