### PR TITLE
ref(seer grouping): More backfill logging improvements

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -203,7 +203,12 @@ def backfill_seer_grouping_records_for_project(
     # querying for the next batch. If even the unfiltered batch is emtpy, `batch_end_id` will be
     # None, which we'll pass to `call_next_backfill` so it knows to move on to the next project.
     (groups_to_backfill_with_no_embedding, batch_end_id) = get_current_batch_groups_from_postgres(
-        project, last_processed_group_id, batch_size, worker_number, enable_ingestion
+        project,
+        last_processed_group_id,
+        batch_size,
+        worker_number,
+        current_project_index_in_cohort,
+        enable_ingestion,
     )
 
     if len(groups_to_backfill_with_no_embedding) == 0:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -117,6 +117,17 @@ def backfill_seer_grouping_records_for_project(
         return
 
     current_project_index_in_cohort = current_project_index_in_cohort or 0
+
+    if last_processed_group_id is None:
+        logger.info(
+            "backfill_seer_grouping_records.project_start",
+            extra={
+                "project_id": current_project_id,
+                "worker_number": worker_number,
+                "project_index_in_cohort": current_project_index_in_cohort,
+            },
+        )
+
     try:
         project = Project.objects.get_from_cache(id=current_project_id)
     except Project.DoesNotExist:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -234,7 +234,11 @@ def backfill_seer_grouping_records_for_project(
         filtered_snuba_results,
         groups_to_backfill_with_no_embedding_has_snuba_row,
     ) = filter_snuba_results(
-        snuba_results, groups_to_backfill_with_no_embedding, project, worker_number
+        snuba_results,
+        groups_to_backfill_with_no_embedding,
+        project,
+        worker_number,
+        current_project_index_in_cohort,
     )
 
     if len(groups_to_backfill_with_no_embedding_has_snuba_row) == 0:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -326,6 +326,7 @@ def backfill_seer_grouping_records_for_project(
             groups_to_backfill_with_no_embedding_has_snuba_row_and_nodestore_row,
             group_hashes_dict,
             worker_number,
+            current_project_index_in_cohort,
         )
 
     call_next_backfill(

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -112,6 +112,7 @@ def backfill_seer_grouping_records_for_project(
                 "project_id": current_project_id,
                 "last_processed_group_id": last_processed_group_id,
                 "worker_number": worker_number,
+                "project_index_in_cohort": current_project_index_in_cohort,
             },
         )
         return
@@ -133,7 +134,11 @@ def backfill_seer_grouping_records_for_project(
     except Project.DoesNotExist:
         logger.info(
             "backfill_seer_grouping_records.project_does_not_exist",
-            extra={"project_id": current_project_id, "worker_number": worker_number},
+            extra={
+                "project_id": current_project_id,
+                "worker_number": worker_number,
+                "project_index_in_cohort": current_project_index_in_cohort,
+            },
         )
         call_next_backfill(
             project_id=current_project_id,
@@ -161,6 +166,7 @@ def backfill_seer_grouping_records_for_project(
                 "project_already_processed": is_project_processed,
                 "project_manually_skipped": is_project_skipped,
                 "worker_number": worker_number,
+                "project_index_in_cohort": current_project_index_in_cohort,
             },
         )
 
@@ -179,7 +185,11 @@ def backfill_seer_grouping_records_for_project(
         if not is_project_seer_eligible:
             logger.info(
                 "backfill_seer_grouping_records.project_is_not_seer_eligible",
-                extra={"project_id": project.id, "worker_number": worker_number},
+                extra={
+                    "project_id": project.id,
+                    "worker_number": worker_number,
+                    "project_index_in_cohort": current_project_index_in_cohort,
+                },
             )
 
     if is_project_processed or is_project_skipped or only_delete or not is_project_seer_eligible:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -261,6 +261,7 @@ def backfill_seer_grouping_records_for_project(
             filtered_snuba_results,
             groups_to_backfill_with_no_embedding_has_snuba_row,
             worker_number,
+            current_project_index_in_cohort,
         )
     except EVENT_INFO_EXCEPTIONS:
         metrics.incr("sentry.tasks.backfill_seer_grouping_records.grouping_config_error")

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -374,10 +374,7 @@ def call_next_backfill(
             if worker_number is None:
                 logger.info(
                     "backfill_seer_grouping_records.project_list_backfill_finished",
-                    extra={
-                        "cohort": cohort,
-                        "last_processed_project_index": next_project_index_in_cohort,
-                    },
+                    extra={"cohort": cohort},
                 )
                 # we're at the end of the project list
                 return

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -68,7 +68,11 @@ class GroupStacktraceData(TypedDict):
 
 
 def filter_snuba_results(
-    snuba_results, groups_to_backfill_with_no_embedding, project, worker_number
+    snuba_results,
+    groups_to_backfill_with_no_embedding,
+    project,
+    worker_number,
+    project_index_in_cohort,
 ):
     """
     Not all of the groups in `groups_to_backfill_with_no_embedding` are guaranteed to have

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -351,7 +351,11 @@ def _make_snuba_call(project, snuba_requests, referrer, worker_number):
 
 @sentry_sdk.tracing.trace
 def get_events_from_nodestore(
-    project, snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row, worker_number=None
+    project,
+    snuba_results,
+    groups_to_backfill_with_no_embedding_has_snuba_row,
+    worker_number=None,
+    project_index_in_cohort=None,
 ):
     nodestore_events = lookup_group_data_stacktrace_bulk(project, snuba_results, worker_number)
     # If nodestore returns no data

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -87,6 +87,7 @@ def filter_snuba_results(
                 "project_id": project.id,
                 "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding),
                 "worker_number": worker_number,
+                "project_index_in_cohort": project_index_in_cohort,
             },
         )
         return [], []
@@ -111,6 +112,7 @@ def filter_snuba_results(
                     "project_id": project.id,
                     "group_id": group_id,
                     "worker_number": worker_number,
+                    "project_index_in_cohort": project_index_in_cohort,
                 },
             )
     return filtered_snuba_results, groups_to_backfill_with_no_embedding_has_snuba_row
@@ -215,18 +217,27 @@ def get_current_batch_groups_from_postgres(
             "batch_len": len(groups_to_backfill_batch),
             "last_processed_group_id": batch_end_group_id,
             "worker_number": worker_number,
+            "project_index_in_cohort": project_index_in_cohort,
         },
     )
 
     if backfill_batch_raw_length == 0:
         logger.info(
             "backfill_seer_grouping_records.no_more_groups",
-            extra={"project_id": project.id, "worker_number": worker_number},
+            extra={
+                "project_id": project.id,
+                "worker_number": worker_number,
+                "project_index_in_cohort": project_index_in_cohort,
+            },
         )
         if enable_ingestion:
             logger.info(
                 "backfill_seer_grouping_records.enable_ingestion",
-                extra={"project_id": project.id, "worker_number": worker_number},
+                extra={
+                    "project_id": project.id,
+                    "worker_number": worker_number,
+                    "project_index_in_cohort": project_index_in_cohort,
+                },
             )
             project.update_option(PROJECT_BACKFILL_COMPLETED, int(time.time()))
 
@@ -247,6 +258,7 @@ def get_current_batch_groups_from_postgres(
                     len(groups_to_backfill_batch) - len(groups_to_backfill_with_no_embedding)
                 ),
                 "worker_number": worker_number,
+                "project_index_in_cohort": project_index_in_cohort,
             },
         )
     return (
@@ -366,6 +378,7 @@ def get_events_from_nodestore(
                 "project_id": project.id,
                 "group_id_batch": json.dumps(groups_to_backfill_with_no_embedding_has_snuba_row),
                 "worker_number": worker_number,
+                "project_index_in_cohort": project_index_in_cohort,
             },
         )
         return (
@@ -420,6 +433,7 @@ def get_events_from_nodestore(
                 "project_id": project.id,
                 "invalid_group_ids": invalid_event_group_ids,
                 "worker_number": worker_number,
+                "project_index_in_cohort": project_index_in_cohort,
             },
         )
 
@@ -579,6 +593,7 @@ def update_groups(
                         "group_id": group.id,
                         "parent_hash": parent_hash,
                         "worker_number": worker_number,
+                        "project_index_in_cohort": project_index_in_cohort,
                     },
                 )
                 seer_similarity = {}
@@ -596,6 +611,7 @@ def update_groups(
             "project_id": project.id,
             "num_updated": num_updated,
             "worker_number": worker_number,
+            "project_index_in_cohort": project_index_in_cohort,
         },
     )
 

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -527,7 +527,12 @@ def send_group_and_stacktrace_to_seer_multithreaded(
 
 @sentry_sdk.tracing.trace
 def update_groups(
-    project, seer_response, group_id_batch_filtered, group_hashes_dict, worker_number
+    project,
+    seer_response,
+    group_id_batch_filtered,
+    group_hashes_dict,
+    worker_number,
+    project_index_in_cohort,
 ):
     groups_with_neighbor = seer_response["groups_with_neighbor"]
     groups = Group.objects.filter(project_id=project.id, id__in=group_id_batch_filtered)

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -187,7 +187,12 @@ def _make_postgres_call_with_filter(group_id_filter: Q, project_id: int, batch_s
 
 @sentry_sdk.tracing.trace
 def get_current_batch_groups_from_postgres(
-    project, last_processed_group_id, batch_size, worker_number, enable_ingestion: bool = False
+    project,
+    last_processed_group_id,
+    batch_size,
+    worker_number,
+    project_index_in_cohort,
+    enable_ingestion: bool = False,
 ):
     group_id_filter = Q()
     if last_processed_group_id is not None:

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -738,6 +738,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                         "group_id": group.id,
                         "parent_hash": "00000000000000000000000000000000",
                         "worker_number": None,
+                        "project_index_in_cohort": 0,
                     },
                 )
                 mock_seer_deletion_request.delay.assert_called_with(
@@ -793,6 +794,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 },
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
                 "backfill_seer_grouping_records.single_project_backfill_finished",
                 extra={"project_id": self.project.id},
             ),
@@ -807,11 +816,17 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "batch_len": 10,
                     "last_processed_group_id": project_group_ids[batch_size - 1],
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
                 "backfill_seer_grouping_records.bulk_update",
-                extra={"project_id": self.project.id, "num_updated": 10, "worker_number": None},
+                extra={
+                    "project_id": self.project.id,
+                    "num_updated": 10,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
             ),
             call(
                 "backfill_seer_grouping_records.batch",
@@ -820,11 +835,17 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "batch_len": 5,
                     "last_processed_group_id": project_group_ids[-1],
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
                 "backfill_seer_grouping_records.bulk_update",
-                extra={"project_id": self.project.id, "num_updated": 5, "worker_number": None},
+                extra={
+                    "project_id": self.project.id,
+                    "num_updated": 5,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
             ),
             call(
                 "backfill_seer_grouping_records.batch",
@@ -833,11 +854,16 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "batch_len": 0,
                     "last_processed_group_id": None,
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
                 "backfill_seer_grouping_records.no_more_groups",
-                extra={"project_id": self.project.id, "worker_number": None},
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
             ),
         ]
         assert mock_utils_logger.info.call_args_list == expected_utils_call_args_list
@@ -1039,6 +1065,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "project_id": self.project.id,
                     "group_id": group_no_events.id,
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             )
             in mock_logger.info.call_args_list
@@ -1101,6 +1128,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 "project_id": self.project.id,
                 "group_id_batch": json.dumps(group_ids_sorted),
                 "worker_number": None,
+                "project_index_in_cohort": 0,
             },
         )
         mock_call_next_backfill.assert_called_with(
@@ -1189,6 +1217,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 "project_id": self.project.id,
                 "last_processed_group_id": None,
                 "worker_number": None,
+                "project_index_in_cohort": None,
             },
         )
 
@@ -1213,7 +1242,11 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
         mock_logger.info.assert_called_with(
             "backfill_seer_grouping_records.enable_ingestion",
-            extra={"project_id": self.project.id, "worker_number": None},
+            extra={
+                "project_id": self.project.id,
+                "worker_number": None,
+                "project_index_in_cohort": 0,
+            },
         )
         assert self.project.get_option(PROJECT_BACKFILL_COMPLETED) is not None
 
@@ -1258,12 +1291,21 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 },
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
                 "backfill_seer_grouping_records.project_skipped",
                 extra={
                     "project_id": self.project.id,
                     "project_already_processed": True,
                     "project_manually_skipped": None,
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
@@ -1316,6 +1358,18 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 extra={"cohort": cohort, "worker_number": 0},
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": 0,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
+                "backfill_seer_grouping_records.project_start",
+                extra={"project_id": project3.id, "worker_number": 0, "project_index_in_cohort": 1},
+            ),
+            call(
                 "backfill_seer_grouping_records.cohort_finished",
                 extra={"cohort": cohort, "worker_number": 0},
             ),
@@ -1348,12 +1402,21 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 },
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
                 "backfill_seer_grouping_records.project_skipped",
                 extra={
                     "project_id": self.project.id,
                     "project_already_processed": False,
                     "project_manually_skipped": True,
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
@@ -1432,6 +1495,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "batch_len": 0,
                     "last_processed_group_id": group_ids_invalid[0],
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
@@ -1441,6 +1505,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "batch_len": batch_size,
                     "last_processed_group_id": group_ids[0],
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
@@ -1449,6 +1514,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "project_id": project_invalid_batch.id,
                     "num_updated": batch_size,
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
@@ -1458,11 +1524,16 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "batch_len": 0,
                     "last_processed_group_id": None,
                     "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
                 "backfill_seer_grouping_records.no_more_groups",
-                extra={"project_id": project_invalid_batch.id, "worker_number": None},
+                extra={
+                    "project_id": project_invalid_batch.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
             ),
         ]
         assert mock_logger.info.call_args_list == expected_call_args_list
@@ -1523,6 +1594,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 },
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
                 "backfill_seer_grouping_records.seer_failed",
                 extra={
                     "reason": "Gateway Timeout",
@@ -1563,6 +1642,14 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                     "skip_processed_projects": True,
                     "skip_project_ids": None,
                     "worker_number": None,
+                },
+            ),
+            call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": None,
+                    "project_index_in_cohort": 0,
                 },
             ),
             call(
@@ -1649,6 +1736,22 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 extra={"cohort": expected_cohort, "worker_number": worker_number},
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": worker_number,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": project_same_cohort.id,
+                    "worker_number": worker_number,
+                    "project_index_in_cohort": 1,
+                },
+            ),
+            call(
                 "backfill_seer_grouping_records.cohort_finished",
                 extra={"cohort": expected_cohort, "worker_number": worker_number},
             ),
@@ -1731,12 +1834,28 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
                 extra={"cohort": [self.project.id], "worker_number": worker_number},
             ),
             call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": self.project.id,
+                    "worker_number": worker_number,
+                    "project_index_in_cohort": 0,
+                },
+            ),
+            call(
                 "backfill_seer_grouping_records.cohort_finished",
                 extra={"cohort": [self.project.id], "worker_number": worker_number},
             ),
             call(
                 "backfill_seer_grouping_records.cohort_created",
                 extra={"cohort": [project_same_worker.id], "worker_number": worker_number},
+            ),
+            call(
+                "backfill_seer_grouping_records.project_start",
+                extra={
+                    "project_id": project_same_worker.id,
+                    "worker_number": worker_number,
+                    "project_index_in_cohort": 0,
+                },
             ),
             call(
                 "backfill_seer_grouping_records.cohort_finished",


### PR DESCRIPTION
This makes a few more improvements to our logging during backfill.

- Log when starting to process a new project.

- Always include a project's index in its cohort in log data. This is important because when the backfill goes off the rails and gets stuck, one of the symptoms is that it starts creating overlapping cohorts. Knowing where in a cohort a given project falls allows us to differentiate those cohorts. Making this change required passing the data to a number of helper functions, which is why there are a number of signature changes.

- Rather than logging the ids of invalid groups, log how many there are, and a tally of the reasons why they're invalid.