### PR TITLE
ref(grouping): Improve hint for ignored threads component

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -781,15 +781,13 @@ def chained_exception_variant_processor(
 def threads(
     interface: Threads, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    thread_variants = _filtered_threads(
-        [thread for thread in interface.values if thread.get("crashed")], event, context, meta
-    )
+    crashed_threads = [thread for thread in interface.values if thread.get("crashed")]
+    thread_variants = _filtered_threads(crashed_threads, event, context, meta)
     if thread_variants is not None:
         return thread_variants
 
-    thread_variants = _filtered_threads(
-        [thread for thread in interface.values if thread.get("current")], event, context, meta
-    )
+    current_threads = [thread for thread in interface.values if thread.get("current")]
+    thread_variants = _filtered_threads(current_threads, event, context, meta)
     if thread_variants is not None:
         return thread_variants
 
@@ -801,9 +799,10 @@ def threads(
         "app": ThreadsGroupingComponent(
             contributes=False,
             hint=(
-                "ignored because does not contain exactly one crashing, "
-                "one current or just one thread, instead contains %s threads"
-                % len(interface.values)
+                "ignored because it contains neither a single thread nor multiple threads with "
+                "exactly one crashing or current thread; instead contains %s crashing, %s current, "
+                "and %s total threads"
+                % (len(crashed_threads), len(current_threads), len(interface.values))
             ),
         )
     }

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:56.208300+00:00'
+created: '2025-02-25T04:22:23.168919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   contributing component: null
   component:
     app
-      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
+      threads (ignored because it contains neither a single thread nor multiple threads with exactly one crashing or current thread; instead contains 0 crashing, 2 current, and 2 total threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:19.169758+00:00'
+created: '2025-02-25T04:21:43.518732+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   contributing component: null
   component:
     app
-      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
+      threads (ignored because it contains neither a single thread nor multiple threads with exactly one crashing or current thread; instead contains 0 crashing, 2 current, and 2 total threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"


### PR DESCRIPTION
This is a small refactor in order to express the hint for ignoring `threads` more clearly/less awkwardly.