### PR TITLE
feat(assemble): Add ownership check for file blobs

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -96,7 +96,12 @@ def assemble_file(task, org_or_project, name, checksum, chunks, file_type) -> As
         organization = org_or_project
 
     # Load all FileBlobs from db since we can be sure here we already own all chunks need to build the file.
-    file_blobs = FileBlob.objects.filter(checksum__in=chunks).values_list("id", "checksum", "size")
+    #
+    # To guarantee that the blobs are owned by the org which is building this file, we check the ownership when checking
+    # the blobs.
+    file_blobs = FileBlob.objects.filter(
+        checksum__in=chunks, fileblobowner__organization_id=organization.id
+    ).values_list("id", "checksum", "size")
 
     # Reject all files that exceed the maximum allowed size for this organization.
     file_size = sum(size for _, _, size in file_blobs if size is not None)

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -211,7 +211,7 @@ class DifAssembleEndpoint(APITestCase):
 
     def test_dif_response(self):
         sym_file = self.load_fixture("crash.sym")
-        blob1 = FileBlob.from_file(ContentFile(sym_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(sym_file), self.organization)
         total_checksum = sha1(sym_file).hexdigest()
         chunks = [blob1.checksum]
 
@@ -234,7 +234,7 @@ class DifAssembleEndpoint(APITestCase):
 
     def test_dif_error_response(self):
         sym_file = b"fail"
-        blob1 = FileBlob.from_file(ContentFile(sym_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(sym_file), self.organization)
         total_checksum = sha1(sym_file).hexdigest()
         chunks = [blob1.checksum]
 

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -62,7 +62,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
         )
         total_checksum = sha1(bundle_file).hexdigest()
 
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob1)
 
         response = self.client.post(
@@ -92,7 +92,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
             org=self.organization.slug, release=self.release.version
         )
         total_checksum = sha1(bundle_file).hexdigest()
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
 
         assemble_artifacts(
             org_id=self.organization.id,
@@ -116,7 +116,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
     def test_dif_error_response(self):
         bundle_file = b"invalid"
         total_checksum = sha1(bundle_file).hexdigest()
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
 
         assemble_artifacts(
             org_id=self.organization.id,
@@ -144,7 +144,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
         )
         total_checksum = sha1(bundle_file).hexdigest()
 
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob1)
 
         response = self.client.post(

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -58,7 +58,7 @@ def make_compressed_zip_file(files):
 
 
 def upload_bundle(bundle_file, project, release=None, dist=None, upload_as_artifact_bundle=True):
-    blob1 = FileBlob.from_file(ContentFile(bundle_file))
+    blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), project.organization)
     total_checksum = sha1(bundle_file).hexdigest()
 
     return assemble_artifacts(

--- a/tests/sentry/debug_files/test_artifact_bundles.py
+++ b/tests/sentry/debug_files/test_artifact_bundles.py
@@ -40,7 +40,7 @@ def make_compressed_zip_file(files):
 
 
 def upload_bundle(bundle_file, project, release=None, dist=None):
-    blob1 = FileBlob.from_file(ContentFile(bundle_file))
+    blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), project.organization)
     total_checksum = sha1(bundle_file).hexdigest()
 
     return assemble_artifacts(

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -61,9 +61,9 @@ class AssembleDifTest(BaseAssembleTest):
         total_checksum = sha1(content2 + content1 + content3).hexdigest()
 
         # The order here is on purpose because we check for the order of checksums
-        blob1 = FileBlob.from_file(fileobj1)
-        blob3 = FileBlob.from_file(fileobj3)
-        blob2 = FileBlob.from_file(fileobj2)
+        blob1 = FileBlob.from_file_with_organization(fileobj1, self.organization)
+        blob3 = FileBlob.from_file_with_organization(fileobj3, self.organization)
+        blob2 = FileBlob.from_file_with_organization(fileobj2, self.organization)
 
         chunks = [blob2.checksum, blob1.checksum, blob3.checksum]
 
@@ -76,7 +76,7 @@ class AssembleDifTest(BaseAssembleTest):
 
     def test_dif(self):
         sym_file = self.load_fixture("crash.sym")
-        blob1 = FileBlob.from_file(ContentFile(sym_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(sym_file), self.organization)
         total_checksum = sha1(sym_file).hexdigest()
 
         assemble_dif(
@@ -186,7 +186,7 @@ class AssembleDifTest(BaseAssembleTest):
 
     def test_assemble_debug_id_override(self):
         sym_file = self.load_fixture("crash.sym")
-        blob1 = FileBlob.from_file(ContentFile(sym_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(sym_file), self.organization)
         total_checksum = sha1(sym_file).hexdigest()
 
         assemble_dif(
@@ -213,7 +213,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         expected_source_file_types = [SourceFileType.MINIFIED_SOURCE, SourceFileType.SOURCE_MAP]
@@ -290,7 +290,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         assemble_artifacts(
@@ -313,7 +313,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         assemble_artifacts(
@@ -333,7 +333,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = "a" * 40
 
         assemble_artifacts(
@@ -353,7 +353,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_duplicated_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         expected_debug_ids = ["eb6e60f1-65ff-4f6f-adff-f1bbeded627b"]
 
@@ -378,7 +378,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
         debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
@@ -428,7 +428,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
         debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
@@ -460,7 +460,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
         debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
@@ -503,7 +503,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
         debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
@@ -540,7 +540,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
         debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
@@ -577,7 +577,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
         # debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
@@ -629,7 +629,9 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file_1 = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1_1 = FileBlob.from_file(ContentFile(bundle_file_1))
+        blob1_1 = FileBlob.from_file_with_organization(
+            ContentFile(bundle_file_1), self.organization
+        )
         total_checksum_1 = sha1(bundle_file_1).hexdigest()
 
         # We try to upload the first bundle.
@@ -649,7 +651,9 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file_2 = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle", project=self.project.id
         )
-        blob1_2 = FileBlob.from_file(ContentFile(bundle_file_2))
+        blob1_2 = FileBlob.from_file_with_organization(
+            ContentFile(bundle_file_2), self.organization
+        )
         total_checksum_2 = sha1(bundle_file_2).hexdigest()
 
         # We try to upload the first bundle.
@@ -669,7 +673,9 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file_3 = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_duplicated_debug_ids", project=self.project.id
         )
-        blob1_3 = FileBlob.from_file(ContentFile(bundle_file_3))
+        blob1_3 = FileBlob.from_file_with_organization(
+            ContentFile(bundle_file_3), self.organization
+        )
         total_checksum_3 = sha1(bundle_file_3).hexdigest()
 
         # We try to upload the first bundle.
@@ -695,7 +701,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             org=self.organization.slug, release=self.release.version
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         for min_files in (10, 1):
@@ -746,7 +752,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
 
     def test_artifacts_invalid_org(self):
         bundle_file = self.create_artifact_bundle_zip(org="invalid", release=self.release.version)
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         assemble_artifacts(
@@ -764,7 +770,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
 
     def test_artifacts_invalid_release(self):
         bundle_file = self.create_artifact_bundle_zip(org=self.organization.slug, release="invalid")
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         assemble_artifacts(
@@ -782,7 +788,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
 
     def test_artifacts_invalid_zip(self):
         bundle_file = b""
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         assemble_artifacts(
@@ -803,7 +809,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
         bundle_file = self.create_artifact_bundle_zip(
             org=self.organization.slug, release=self.release.version
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
 
         with self.options(
@@ -854,7 +860,7 @@ class ArtifactBundleIndexingTest(TestCase):
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id
         )
-        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
         total_checksum = sha1(bundle_file).hexdigest()
         rv = assemble_file(
             task=AssembleTask.ARTIFACT_BUNDLE,


### PR DESCRIPTION
This PR adds ownership check of blobs before building a file for a sourcemap or debug file.