### PR TITLE
fix(symbolication): Mark NuGet as "requires checksum"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2739,7 +2739,11 @@ SENTRY_BUILTIN_SOURCES = {
         "id": "sentry:nuget",
         "name": "NuGet.org",
         "layout": {"type": "symstore"},
-        "filters": {"filetypes": ["portablepdb"]},
+        # We mark this source as "requires checksum" so that downloads of
+        # portable PDB fies that don't have a debug checksum won't even be
+        # attempted. Such downloads always fail with a 403 error. See
+        # https://github.com/getsentry/team-ingest/issues/643.
+        "filters": {"filetypes": ["portablepdb"], "requires_checksum": True},
         "url": "https://symbols.nuget.org/download/symbols/",
         "is_public": True,
     },


### PR DESCRIPTION
This adds the requires_checksum flag, introduced in Symbolicator in https://github.com/getsentry/symbolicator/pull/1628, to the NuGet symbol source. This should severely curtail the number of permission errors we get from NuGet (by not even attempting downloads that would fail). See https://github.com/getsentry/team-ingest/issues/643 for the tracking issue.