### PR TITLE
ref(quick-start): Add celebration message when 100% tasks completed

### DIFF
--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -598,6 +598,10 @@ export function OnboardingSidebarContent({onClose}: OnboardingSidebarContentProp
     )?.task;
   }, [sortedGettingStartedTasks, sortedBeyondBasicsTasks]);
 
+  const allTasksCompleted = [...gettingStartedTasks, ...beyondBasicsTasks].every(
+    findCompleteTasks
+  );
+
   return (
     <Content>
       <TaskGroup
@@ -625,9 +629,20 @@ export function OnboardingSidebarContent({onClose}: OnboardingSidebarContentProp
           group="beyond_basics"
         />
       )}
+      {allTasksCompleted && (
+        <CompletionCelebrationText>
+          <div>{t('Good job, you’re all done here!')}</div>
+          {t('Now get out of here and write some broken code.')}
+        </CompletionCelebrationText>
+      )}
     </Content>
   );
 }
+
+const CompletionCelebrationText = styled('div')`
+  margin-top: ${space(1.5)};
+  text-align: center;
+`;
 
 const Content = styled('div')`
   padding: ${space(3)};


### PR DESCRIPTION
- Contributes to 2x requirement https://github.com/getsentry/projects/issues/700

an example of how it will look like:
![Screenshot 2025-02-25 at 11 31 28](https://github.com/user-attachments/assets/ee29916e-6792-49e2-a645-4c9c0d72f42d)
