### PR TITLE
ref(ourlogs): Skip endpoint tests until api is migrated

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -19,6 +19,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         }
 
     @pytest.mark.querybuilder
+    @pytest.mark.skip(reason="Changing rpc / snuba api")
     def test_simple(self):
         logs = [
             self.create_ourlog(
@@ -51,6 +52,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["dataset"] == self.dataset
 
     @pytest.mark.querybuilder
+    @pytest.mark.skip(reason="Changing rpc / snuba api")
     def test_timestamp_order(self):
         logs = [
             self.create_ourlog(


### PR DESCRIPTION
### Summary
We're changing the storage for logs, and so querying needs to be updated. We'll unskip these once snuba lands

ref: https://github.com/getsentry/snuba/pull/6903
