### PR TITLE
fix(replays): Emit click events in separated compute path

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import time
 import zlib
 from datetime import datetime, timezone
 from typing import Any, TypedDict, cast
@@ -27,6 +28,7 @@ from sentry.replays.usecases.ingest.dom_index import ReplayActionsEvent, emit_re
 from sentry.replays.usecases.ingest.dom_index import log_canvas_size as log_canvas_size_old
 from sentry.replays.usecases.ingest.dom_index import parse_replay_actions
 from sentry.replays.usecases.ingest.event_logger import (
+    emit_click_events,
     emit_request_response_metrics,
     log_canvas_size,
     log_mutation_events,
@@ -389,8 +391,12 @@ def emit_replay_events(
     org_id: int,
     project: Project,
     replay_id: str,
+    retention_days: int,
     replay_event: dict[str, Any] | None,
 ) -> None:
+    emit_click_events(
+        event_meta.click_events, project.id, replay_id, retention_days, start_time=time.time()
+    )
     emit_request_response_metrics(event_meta)
     log_canvas_size(event_meta, org_id, project.id, replay_id)
     log_mutation_events(event_meta, project.id, replay_id)

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -271,6 +271,7 @@ def recording_post_processor(
                 message.org_id,
                 project,
                 message.replay_id,
+                message.retention_days,
                 replay_event,
             )
         else:

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -7,7 +7,9 @@ from sentry.models.project import Project
 from sentry.replays.usecases.ingest.dom_index import (
     ReplayActionsEvent,
     ReplayActionsEventPayload,
+    ReplayActionsEventPayloadClick,
     _initialize_publisher,
+    encode_as_uuid,
 )
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
 from sentry.replays.usecases.ingest.issue_creation import (
@@ -26,18 +28,18 @@ def emit_click_events(
     retention_days: int,
     start_time: float,
 ) -> None:
-    clicks = [
+    clicks: list[ReplayActionsEventPayloadClick] = [
         {
             "alt": click.alt,
             "aria_label": click.aria_label,
             "class": click.classes,
             "component_name": click.component_name,
+            "event_hash": encode_as_uuid(f"{replay_id}{click.timestamp}{click.node_id}"),
             "id": click.id,
             "is_dead": click.is_dead,
             "is_rage": click.is_rage,
             "node_id": click.node_id,
             "role": click.role,
-            "selector": click.selector,
             "tag": click.tag,
             "testid": click.testid,
             "text": click.text,


### PR DESCRIPTION
We weren't emitting click events in the new segmented path.