### PR TITLE
Add tabs for alternative install methods (brew, npx, .exe)

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -17,6 +17,7 @@ import {
 import {feedbackOnboardingCrashApiJava} from 'sentry/gettingStartedDocs/java/java';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
 export enum InstallationMode {
   AUTO = 'auto',
@@ -58,11 +59,6 @@ plugins {
     '3.12.0'
   )}"
 }`;
-
-const getAutoInstallSnippet = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-  return `brew install getsentry/tools/sentry-wizard && sentry-wizard -i android ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
-};
 
 const getConfigurationSnippet = (params: Params) => `
 <application>
@@ -137,8 +133,10 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                language: 'bash',
-                code: getAutoInstallSnippet(params),
+                code: getWizardInstallSnippet({
+                  platform: 'android',
+                  params,
+                }),
               },
               {
                 description: (
@@ -178,14 +176,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                       </ListItem>
                     </List>
                   </Fragment>
-                ),
-                additionalInfo: tct(
-                  'Alternatively, you can also [manualSetupLink:set up the SDK manually].',
-                  {
-                    manualSetupLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/android/manual-setup/" />
-                    ),
-                  }
                 ),
               },
             ],

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -15,6 +15,7 @@ import {
 import {appleFeedbackOnboarding} from 'sentry/gettingStartedDocs/apple/macos';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
 export enum InstallationMode {
   AUTO = 'auto',
@@ -46,11 +47,6 @@ type Params = DocsParams<PlatformOptions>;
 
 const isAutoInstall = (params: Params) =>
   params.platformOptions.installationMode === InstallationMode.AUTO;
-
-const getAutoInstallSnippet = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-  return `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
-};
 
 const getManualInstallSnippet = (params: Params) => `
 .package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
@@ -222,8 +218,10 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                language: 'bash',
-                code: getAutoInstallSnippet(params),
+                code: getWizardInstallSnippet({
+                  platform: 'ios',
+                  params,
+                }),
               },
             ],
           },
@@ -268,8 +266,8 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ? [
           {
             type: StepType.CONFIGURE,
-            description: t(
-              'The Sentry wizard will automatically patch your application:'
+            description: (
+              <p>{t('The Sentry wizard will automatically patch your application:')}</p>
             ),
             configurations: [
               {
@@ -308,15 +306,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                       )}
                     </ListItem>
                   </List>
-                ),
-                additionalInfo: tct(
-                  'Alternatively, you can also [manualSetupLink:set up the SDK manually].',
-                  {
-                    manualSetupLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/manual-setup/" />
-                    ),
-                    stepsBelow: <strong />,
-                  }
                 ),
               },
             ],

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -18,6 +18,7 @@ import {
 import {feedbackOnboardingCrashApiDart} from 'sentry/gettingStartedDocs/dart/dart';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
 
 export enum InstallationMode {
   AUTO = 'auto',
@@ -49,11 +50,6 @@ type Params = DocsParams<PlatformOptions>;
 
 const isAutoInstall = (params: Params) =>
   params.platformOptions?.installationMode === InstallationMode.AUTO;
-
-const getInstallSnippet = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-  return `brew install getsentry/tools/sentry-wizard && sentry-wizard -i flutter ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
-};
 
 const getManualInstallSnippet = (params: Params) => {
   const version = getPackageVersion(params, 'sentry.dart.flutter', '8.13.2');
@@ -174,8 +170,10 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                language: 'bash',
-                code: getInstallSnippet(params),
+                code: getWizardInstallSnippet({
+                  platform: 'flutter',
+                  params,
+                }),
               },
               {
                 description: (
@@ -207,14 +205,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                       </ListItem>
                     </List>
                   </Fragment>
-                ),
-                additionalInfo: tct(
-                  'Alternatively, you can also [manualSetupLink:set up the SDK manually].',
-                  {
-                    manualSetupLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/flutter/" />
-                    ),
-                  }
                 ),
               },
             ],
@@ -387,7 +377,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               label: 'YAML',
               value: 'yaml',
               language: 'yaml',
-              code: getInstallSnippet(params),
+              code: getManualInstallSnippet(params),
             },
           ],
         },

--- a/static/app/utils/gettingStartedDocs/mobileWizard.ts
+++ b/static/app/utils/gettingStartedDocs/mobileWizard.ts
@@ -1,4 +1,5 @@
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
 export function getWizardInstallSnippet({
   platform,
@@ -9,19 +10,67 @@ export function getWizardInstallSnippet({
 }) {
   const {isSelfHosted, organization, projectSlug} = params;
   const urlParam = isSelfHosted ? '' : '--saas';
+  const platformWithFlags = `${platform} ${urlParam} --org ${organization.slug} --project ${projectSlug}`;
+
+  // Get version from registry if available, or use fallback
+  const version = getPackageVersion(params, 'sentry.wizard', '4.0.1');
 
   return [
     {
       label: 'brew',
       value: 'brew',
       language: 'bash',
-      code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ${platform} ${urlParam} --org ${organization.slug} --project ${projectSlug}`,
+      code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ${platformWithFlags}`,
     },
     {
       label: 'npx',
       value: 'npx',
       language: 'bash',
-      code: `npx @sentry/wizard@latest -i ${platform} ${urlParam} --org ${organization.slug} --project ${projectSlug}`,
+      code: `npx @sentry/wizard@latest -i ${platformWithFlags}`,
+    },
+    {
+      label: 'macOS (Intel/x64)',
+      value: 'macos-x64',
+      language: 'bash',
+      code: `downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v${version}/sentry-wizard-darwin-x64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i ${platformWithFlags}`,
+    },
+    {
+      label: 'macOS (Apple Silicon/arm64)',
+      value: 'macos-arm64',
+      language: 'bash',
+      code: `downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v${version}/sentry-wizard-darwin-arm64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i ${platformWithFlags}`,
+    },
+    {
+      label: 'Linux (x64)',
+      value: 'linux-x64',
+      language: 'bash',
+      code: `downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v${version}/sentry-wizard-linux-x64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i ${platformWithFlags}`,
+    },
+    {
+      label: 'Linux (arm64)',
+      value: 'linux-arm64',
+      language: 'bash',
+      code: `downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v${version}/sentry-wizard-linux-arm64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i ${platformWithFlags}`,
+    },
+    {
+      label: 'Windows',
+      value: 'windows',
+      language: 'powershell',
+      code: `$downloadUrl = "https://github.com/getsentry/sentry-wizard/releases/download/v${version}/sentry-wizard-win-x64.exe"
+Invoke-WebRequest $downloadUrl -OutFile sentry-wizard.exe
+./sentry-wizard.exe -i ${platformWithFlags}`,
     },
   ];
 }

--- a/static/app/utils/gettingStartedDocs/mobileWizard.ts
+++ b/static/app/utils/gettingStartedDocs/mobileWizard.ts
@@ -1,0 +1,27 @@
+import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+export function getWizardInstallSnippet({
+  platform,
+  params,
+}: {
+  params: DocsParams;
+  platform: 'ios' | 'android' | 'flutter' | 'reactNative';
+}) {
+  const {isSelfHosted, organization, projectSlug} = params;
+  const urlParam = isSelfHosted ? '' : '--saas';
+
+  return [
+    {
+      label: 'brew',
+      value: 'brew',
+      language: 'bash',
+      code: `brew install getsentry/tools/sentry-wizard && sentry-wizard -i ${platform} ${urlParam} --org ${organization.slug} --project ${projectSlug}`,
+    },
+    {
+      label: 'npx',
+      value: 'npx',
+      language: 'bash',
+      code: `npx @sentry/wizard@latest -i ${platform} ${urlParam} --org ${organization.slug} --project ${projectSlug}`,
+    },
+  ];
+}


### PR DESCRIPTION
Brew is only natively available on mac, and while npx is maybe "foreign" to some mobile devs also on windows. There is still the manual flow option available

- with the 4.0.0 major of the sentry-wizard we started publishing executable binaries of the wizard which can be run on different OSs should users want them, we made them available in the UI for Android, Flutter and iOS.

also removing the link to set up manually since all these guides have manual set up in product already

Added for Android, iOS, and flutter. I will add to react-native after/with this https://github.com/getsentry/sentry/pull/85743

<img width="835" alt="image" src="https://github.com/user-attachments/assets/be987bbb-0105-45b1-ab26-0df3a4e51ce1" />

