### PR TITLE
fix(widget-builder): Change ondemand icon colour to yellow

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -258,6 +258,11 @@ export function WidgetOnDemandQueryWarning(props: {
         'We don’t routinely collect metrics from this property. However, we’ll do so [strong:once this widget has been saved.]',
         {strong: <strong />}
       )}
+      color={
+        organization.features.includes('dashboards-widget-builder-redesign')
+          ? 'yellow300'
+          : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
Feature flagged so it only shows on the new redesign. Makes it a bit clearer there's something to hover for more info here.

![Screenshot 2025-02-25 at 11 59 12 AM](https://github.com/user-attachments/assets/d14ae32e-c07c-4d9f-9148-65d057baf34a)
