### PR TITLE
ref(metric alerts): Update typing to make metric_value not None take 2

### DIFF
--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -18,7 +18,7 @@ class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
         alert_rule: AlertRule,
         incident: Incident,
         new_status: IncidentStatus,
-        metric_value: float | None = None,
+        metric_value: float,
         chart_url: str | None = None,
     ) -> None:
         self.alert_rule = alert_rule

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -117,7 +117,8 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
 def incident_attachment_info(
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float,
+    # WIP(iamrajjoshi): This should shouldn't be None, but it sometimes is. Working on figuring out why.
+    metric_value: float | None,
     notification_uuid=None,
     referrer="metric_alert",
 ) -> AttachmentInfo:
@@ -127,8 +128,8 @@ def incident_attachment_info(
         sentry_sdk.capture_message(
             "Metric value is None when building incident attachment info",
             level="warning",
-            extra={"incident_id": incident.id, "alert_rule_id": alert_rule.id},
         )
+        metric_value = get_metric_count_from_incident(incident)
 
     status = INCIDENT_STATUS[new_status]
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -116,16 +116,13 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
 def incident_attachment_info(
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value=None,
+    metric_value: float,
     notification_uuid=None,
     referrer="metric_alert",
 ) -> AttachmentInfo:
     alert_rule = incident.alert_rule
 
     status = INCIDENT_STATUS[new_status]
-
-    if metric_value is None:
-        metric_value = get_metric_count_from_incident(incident)
 
     text = get_incident_status_text(alert_rule, metric_value)
     if features.has(
@@ -164,7 +161,7 @@ def incident_attachment_info(
     )
 
 
-def metric_alert_attachment_info(
+def metric_alert_unfurl_attachment_info(
     alert_rule: AlertRule,
     selected_incident: Incident | None = None,
     new_status: IncidentStatus | None = None,

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -118,7 +118,7 @@ def incident_attachment_info(
     incident: Incident,
     new_status: IncidentStatus,
     # WIP(iamrajjoshi): This should shouldn't be None, but it sometimes is. Working on figuring out why.
-    metric_value: float | None,
+    metric_value: float | None = None,
     notification_uuid=None,
     referrer="metric_alert",
 ) -> AttachmentInfo:

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import TypedDict
 from urllib import parse
 
+import sentry_sdk
 from django.db.models import Max
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -121,6 +122,13 @@ def incident_attachment_info(
     referrer="metric_alert",
 ) -> AttachmentInfo:
     alert_rule = incident.alert_rule
+
+    if metric_value is None:
+        sentry_sdk.capture_message(
+            "Metric value is None when building incident attachment info",
+            level="warning",
+            extra={"incident_id": incident.id, "alert_rule_id": alert_rule.id},
+        )
 
     status = INCIDENT_STATUS[new_status]
 

--- a/src/sentry/integrations/msteams/card_builder/incident_attachment.py
+++ b/src/sentry/integrations/msteams/card_builder/incident_attachment.py
@@ -15,7 +15,7 @@ from sentry.integrations.msteams.card_builder.block import (
 def build_incident_attachment(
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float,
     notification_uuid: str | None = None,
 ) -> AdaptiveCard:
     data = incident_attachment_info(

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -101,7 +101,7 @@ def get_channel_id(organization: Organization, integration_id: int, name: str) -
 def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
-    metric_value: float | None,
+    metric_value: float,
     new_status: IncidentStatus,
     notification_uuid: str | None = None,
 ) -> bool:

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -20,7 +20,7 @@ OPSGENIE_CUSTOM_PRIORITIES = {"P1", "P2", "P3", "P4", "P5"}
 def build_incident_attachment(
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float,
     notification_uuid: str | None = None,
 ) -> dict[str, Any]:
     data = incident_attachment_info(

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -91,7 +91,7 @@ def build_incident_attachment(
     incident,
     integration_key,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float,
     notfication_uuid: str | None = None,
 ) -> dict[str, Any]:
     data = incident_attachment_info(

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -364,7 +364,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         new_status: int,
         incident_attachment_json: str,
         organization_id: int,
-        metric_value: str | None = None,
+        metric_value: float,
         notification_uuid: str | None = None,
     ) -> bool:
         try:

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -228,7 +228,7 @@ class IntegrationService(RpcService):
         new_status: int,
         incident_attachment_json: str,
         organization_id: int,
-        metric_value: str | None = None,
+        metric_value: float,
         notification_uuid: str | None = None,
     ) -> bool:
         pass

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -24,7 +24,7 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
         self,
         incident: Incident,
         new_status: IncidentStatus,
-        metric_value: float | None = None,
+        metric_value: float,
         chart_url: str | None = None,
         notification_uuid: str | None = None,
     ) -> None:

--- a/src/sentry/integrations/slack/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/slack/message_builder/metric_alerts.py
@@ -1,6 +1,6 @@
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.integrations.metric_alerts import metric_alert_attachment_info
+from sentry.integrations.metric_alerts import metric_alert_unfurl_attachment_info
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.types import (
     INCIDENT_COLOR_MAPPING,
@@ -36,7 +36,7 @@ class SlackMetricAlertMessageBuilder(BlockSlackMessageBuilder):
         self.chart_url = chart_url
 
     def build(self) -> SlackBody:
-        data = metric_alert_attachment_info(
+        data = metric_alert_unfurl_attachment_info(
             self.alert_rule, self.incident, self.new_status, self.metric_value
         )
 

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -31,7 +31,7 @@ PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS = ["PagerDuty", "Slack", "Opsgenie"]
 def build_incident_attachment(
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float,
     notification_uuid: str | None = None,
 ) -> dict[str, str]:
     from sentry.api.serializers.rest_framework.base import (
@@ -54,7 +54,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     new_status: IncidentStatus,
-    metric_value: float | None = None,
+    metric_value: float,
     notification_uuid: str | None = None,
 ) -> bool:
     """
@@ -62,7 +62,7 @@ def send_incident_alert_notification(
     :param action: The triggered `AlertRuleTriggerAction`.
     :param incident: The `Incident` for which to build a payload.
     :param metric_value: The value of the metric that triggered this alert to
-    fire. If not provided we'll attempt to calculate this ourselves.
+    fire.
     :return:
     """
     organization = serialize_rpc_organization(incident.organization)

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -57,6 +57,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule=self.alert_rule,
             incident=incident,
             new_status=IncidentStatus.CLOSED,
+            metric_value=0,
         ).build(notification_uuid=uuid) == {
             "content": "",
             "embeds": [
@@ -94,6 +95,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule=self.alert_rule,
             incident=incident,
             new_status=IncidentStatus.CRITICAL,
+            metric_value=0,
         ).build(notification_uuid=uuid) == {
             "content": "",
             "embeds": [
@@ -171,6 +173,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule=self.alert_rule,
             incident=incident,
             new_status=new_status,
+            metric_value=0,
             chart_url="chart_url",
         ).build(notification_uuid=uuid) == {
             "content": "",
@@ -210,6 +213,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule=self.alert_rule,
             incident=incident,
             new_status=IncidentStatus.CRITICAL,
+            metric_value=0,
         ).build() == {
             "content": "",
             "embeds": [
@@ -259,6 +263,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule=alert_rule,
             incident=incident,
             new_status=IncidentStatus.CRITICAL,
+            metric_value=0,
         ).build(notification_uuid=uuid) == {
             "content": "",
             "embeds": [

--- a/tests/sentry/integrations/services/test_integration.py
+++ b/tests/sentry/integrations/services/test_integration.py
@@ -332,6 +332,7 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
             action_id=1,
             incident_id=1,
             new_status=0,
+            metric_value=100,
             organization_id=self.organization.id,
             incident_attachment_json="{}",
         )

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -804,7 +804,9 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
-        assert SlackIncidentsMessageBuilder(incident, IncidentStatus.CRITICAL).build() == {
+        assert SlackIncidentsMessageBuilder(
+            incident, IncidentStatus.CRITICAL, metric_value=0
+        ).build() == {
             "blocks": [
                 {
                     "type": "section",
@@ -868,7 +870,9 @@ class BuildIncidentAttachmentTest(TestCase):
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
-        assert SlackIncidentsMessageBuilder(incident, IncidentStatus.CLOSED).build() == {
+        assert SlackIncidentsMessageBuilder(
+            incident, IncidentStatus.CLOSED, metric_value=0
+        ).build() == {
             "blocks": [
                 {
                     "type": "section",
@@ -941,7 +945,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
-            incident, IncidentStatus.CLOSED, chart_url="chart-url"
+            incident, IncidentStatus.CLOSED, metric_value=0, chart_url="chart-url"
         ).build() == {
             "blocks": [
                 {
@@ -989,7 +993,9 @@ class BuildIncidentAttachmentTest(TestCase):
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={detection_type}"
         )
-        assert SlackIncidentsMessageBuilder(incident, IncidentStatus.CRITICAL).build() == {
+        assert SlackIncidentsMessageBuilder(
+            incident, IncidentStatus.CRITICAL, metric_value=0
+        ).build() == {
             "blocks": [
                 {
                     "type": "section",

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -85,7 +85,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         incident_trigger.update(date_modified=now)
 
         # Test the trigger "firing"
-        data = incident_attachment_info(incident, IncidentStatus.CRITICAL)
+        data = incident_attachment_info(incident, IncidentStatus.CRITICAL, metric_value=4)
         assert data["title"] == "Critical: {}".format(
             alert_rule.name
         )  # Pulls from trigger, not incident
@@ -102,7 +102,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         )
 
         # Test the trigger "resolving"
-        data = incident_attachment_info(incident, IncidentStatus.CLOSED)
+        data = incident_attachment_info(incident, IncidentStatus.CLOSED, metric_value=4)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "4 events in the last 10 minutes"
@@ -117,7 +117,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         )
 
         # No trigger passed, uses incident as fallback
-        data = incident_attachment_info(incident, IncidentStatus.CLOSED)
+        data = incident_attachment_info(incident, IncidentStatus.CLOSED, metric_value=4)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "4 events in the last 10 minutes"
@@ -202,7 +202,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
-        metric_value = "123.12"
+        metric_value = 123.12
         data = incident_attachment_info(incident, IncidentStatus.CRITICAL, metric_value)
         assert (
             data["text"]
@@ -280,7 +280,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
 
     def test_with_incident_trigger_sessions_resolve(self):
         self.create_incident_and_related_objects()
-        data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
+        data = incident_attachment_info(self.incident, IncidentStatus.CLOSED, metric_value=100.0)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "100.0% sessions crash free rate in the last hour"
@@ -304,7 +304,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
 
     def test_with_incident_trigger_users_resolve(self):
         self.create_incident_and_related_objects(field="users")
-        data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
+        data = incident_attachment_info(self.incident, IncidentStatus.CLOSED, metric_value=100.0)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "100.0% users crash free rate in the last hour"
@@ -316,7 +316,9 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
 
     def test_with_daily_incident_trigger_users_resolve(self):
         self.create_daily_incident_and_related_objects(field="users")
-        data = incident_attachment_info(self.daily_incident, IncidentStatus.CLOSED)
+        data = incident_attachment_info(
+            self.daily_incident, IncidentStatus.CLOSED, metric_value=100.0
+        )
         assert data["title"] == f"Resolved: {self.daily_alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "100.0% users crash free rate in the last day"
@@ -345,11 +347,11 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, BaseMetricsTestCase
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
-        data = incident_attachment_info(incident, IncidentStatus.CRITICAL)
+        data = incident_attachment_info(incident, IncidentStatus.CRITICAL, 0)
 
         assert data["title"] == f"Critical: {alert_rule.name}"
         assert data["status"] == "Critical"
-        assert data["text"] == "No sessions crash free rate in the last hour"
+        assert data["text"] == "0% sessions crash free rate in the last hour"
 
 
 @freeze_time(MOCK_NOW)


### PR DESCRIPTION
take 2 of https://github.com/getsentry/sentry/pull/85508.

i reverted the last pr because i found that `metric_value` is None in certain cases, i am still not sure why. this time i just add the capture message to get additional context  but we still make the function call to get the metric count.