### PR TITLE
ref(flags): support sort and provider filter on logs endpoint

### DIFF
--- a/src/sentry/flags/endpoints/logs.py
+++ b/src/sentry/flags/endpoints/logs.py
@@ -76,15 +76,15 @@ class FlagLogIndexRequestSerializer(rest_serializers.Serializer):
 
     # Support camel case since it's used by our response serializer.
     def validate_sort(self, value: str | None) -> str | None:
-        if not value:
+        if value is None:
             return None
 
-        value = camel_to_snake_case(value)
-        if not value.startswith("-") and value not in SORT_FIELDS:
+        value_str: str = camel_to_snake_case(value)  # new var for mypy
+        if not value_str.startswith("-") and value_str not in SORT_FIELDS:
             raise ParseError(detail=f"Invalid sort: {value}")
-        if value.startswith("-") and value[1:] not in SORT_FIELDS:
-            raise ParseError(detail=f"Invalid sort: {value[1:]}")
-        return value
+        if value_str.startswith("-") and value_str[1:] not in SORT_FIELDS:
+            raise ParseError(detail=f"Invalid sort: {value_str[1:]}")
+        return value_str
 
 
 @region_silo_endpoint

--- a/src/sentry/flags/endpoints/logs.py
+++ b/src/sentry/flags/endpoints/logs.py
@@ -57,7 +57,7 @@ class FlagAuditLogModelSerializer(Serializer):
 
 
 class FlagLogIndexRequestSerializer(rest_serializers.Serializer):
-    # start, end handled by get_date_range_from_params
+    # start, end handled separately.
     flag = rest_serializers.ListField(
         child=rest_serializers.CharField(),
         required=False,

--- a/src/sentry/flags/endpoints/logs.py
+++ b/src/sentry/flags/endpoints/logs.py
@@ -69,6 +69,7 @@ class OrganizationFlagLogIndexEndpoint(OrganizationEndpoint):
             queryset = queryset.filter(flag__in=flags)
 
         sort = request.GET.get("sort")
+        # Support camel case since it's used by our response serializer.
         sort = camel_to_snake_case(sort) if isinstance(sort, str) else "created_at"
         if sort:
             queryset = queryset.order_by(sort)

--- a/src/sentry/flags/endpoints/logs.py
+++ b/src/sentry/flags/endpoints/logs.py
@@ -77,9 +77,8 @@ class OrganizationFlagLogIndexEndpoint(OrganizationEndpoint):
             request=request,
             queryset=queryset,
             on_results=lambda x: {
-                "data": serialize(x, request.user, FlagAuditLogModelSerializer()),
+                "data": serialize(x, request.user, FlagAuditLogModelSerializer())
             },
-            # order_by=sort,
             paginator_cls=OffsetPaginator,
         )
 

--- a/src/sentry/flags/endpoints/logs.py
+++ b/src/sentry/flags/endpoints/logs.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Any, TypedDict
 
+from django.core.exceptions import FieldError
+from rest_framework import serializers as rest_serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -14,7 +16,13 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import camel_to_snake_case
 from sentry.api.utils import get_date_range_from_params
-from sentry.flags.models import ActionEnum, CreatedByTypeEnum, FlagAuditLogModel, ProviderEnum
+from sentry.flags.models import (
+    PROVIDER_MAP,
+    ActionEnum,
+    CreatedByTypeEnum,
+    FlagAuditLogModel,
+    ProviderEnum,
+)
 from sentry.models.organization import Organization
 
 
@@ -48,6 +56,26 @@ class FlagAuditLogModelSerializer(Serializer):
         }
 
 
+class FlagLogIndexRequestSerializer(rest_serializers.Serializer):
+    # start, end handled by get_date_range_from_params
+    flag = rest_serializers.ListField(
+        child=rest_serializers.CharField(),
+        required=False,
+    )
+    provider = rest_serializers.ListField(
+        child=rest_serializers.ChoiceField(choices=ProviderEnum.get_names()),
+        required=False,
+    )
+    sort = rest_serializers.CharField(required=False, allow_null=True)
+
+    def validate_provider(self, value: list[str]) -> list[int]:
+        return [PROVIDER_MAP[provider] for provider in value]
+
+    # Support camel case since it's used by our response serializer.
+    def validate_sort(self, value: str | None) -> str | None:
+        return camel_to_snake_case(value) if value else None
+
+
 @region_silo_endpoint
 class OrganizationFlagLogIndexEndpoint(OrganizationEndpoint):
     owner = ApiOwner.FLAG
@@ -58,21 +86,34 @@ class OrganizationFlagLogIndexEndpoint(OrganizationEndpoint):
         if start is None or end is None:
             raise ParseError(detail="Invalid date range")
 
+        validator = FlagLogIndexRequestSerializer(
+            data={
+                **request.GET.dict(),
+                "flag": request.GET.getlist("flag"),
+                "provider": request.GET.getlist("provider"),
+            }
+        )
+        if not validator.is_valid():
+            raise ParseError(detail=validator.errors)
+        query_params = validator.validated_data
+
         queryset = FlagAuditLogModel.objects.filter(
             created_at__gte=start,
             created_at__lt=end,
             organization_id=organization.id,
         )
 
-        flags = request.GET.getlist("flag")
-        if flags:
+        if flags := query_params.get("flag"):
             queryset = queryset.filter(flag__in=flags)
 
-        sort = request.GET.get("sort")
-        # Support camel case since it's used by our response serializer.
-        sort = camel_to_snake_case(sort) if isinstance(sort, str) else "created_at"
-        if sort:
-            queryset = queryset.order_by(sort)
+        if providers := query_params.get("provider"):
+            queryset = queryset.filter(provider__in=providers)
+
+        if sort := query_params.get("sort"):
+            try:
+                queryset = queryset.order_by(sort)
+            except FieldError:
+                raise ParseError(detail=f"Invalid sort: {sort}")
 
         return self.paginate(
             request=request,

--- a/src/sentry/flags/endpoints/secrets.py
+++ b/src/sentry/flags/endpoints/secrets.py
@@ -17,7 +17,7 @@ from sentry.api.bases.organization import (
 )
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.flags.models import FlagWebHookSigningSecretModel, ProviderEnum
+from sentry.flags.models import FlagWebHookSigningSecretModel
 from sentry.models.organization import Organization
 
 
@@ -42,7 +42,9 @@ class FlagWebhookSigningSecretSerializer(Serializer):
 
 
 class FlagWebhookSigningSecretValidator(serializers.Serializer):
-    provider = serializers.ChoiceField(choices=ProviderEnum.get_names(), required=True)
+    provider = serializers.ChoiceField(
+        choices=["launchdarkly", "generic", "unleash", "statsig"], required=True
+    )
     secret = serializers.CharField(required=True)
 
     def validate_secret(self, value):

--- a/src/sentry/flags/endpoints/secrets.py
+++ b/src/sentry/flags/endpoints/secrets.py
@@ -17,7 +17,7 @@ from sentry.api.bases.organization import (
 )
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.flags.models import FlagWebHookSigningSecretModel
+from sentry.flags.models import FlagWebHookSigningSecretModel, ProviderEnum
 from sentry.models.organization import Organization
 
 
@@ -42,9 +42,7 @@ class FlagWebhookSigningSecretSerializer(Serializer):
 
 
 class FlagWebhookSigningSecretValidator(serializers.Serializer):
-    provider = serializers.ChoiceField(
-        choices=["launchdarkly", "generic", "unleash", "statsig"], required=True
-    )
+    provider = serializers.ChoiceField(choices=ProviderEnum.get_names(), required=True)
     secret = serializers.CharField(required=True)
 
     def validate_secret(self, value):

--- a/src/sentry/flags/models.py
+++ b/src/sentry/flags/models.py
@@ -63,7 +63,7 @@ class ProviderEnum(Enum):
     STATSIG = 4
 
     @classmethod
-    def to_string(cls, integer):
+    def to_string(cls, integer) -> str:
         if integer == 0:
             return "generic"
         if integer == 1:
@@ -75,6 +75,10 @@ class ProviderEnum(Enum):
         if integer == 4:
             return "statsig"
         raise ValueError
+
+    @classmethod
+    def get_names(cls) -> list[str]:
+        return [cls.to_string(e.value) for e in cls]
 
 
 PROVIDER_MAP = {

--- a/tests/sentry/flags/endpoints/test_logs.py
+++ b/tests/sentry/flags/endpoints/test_logs.py
@@ -212,6 +212,19 @@ class OrganizationFlagLogIndexEndpointTestCase(APITestCase):
             assert response.json()["data"][0]["flag"] == "goodbye"
             assert response.json()["data"][1]["flag"] == "hello"
 
+            # Camel case
+            response = self.client.get(self.url + "?sort=createdAt")
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 2
+            assert response.json()["data"][0]["flag"] == "hello"
+            assert response.json()["data"][1]["flag"] == "goodbye"
+
+            response = self.client.get(self.url + "?sort=-createdAt")
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 2
+            assert response.json()["data"][0]["flag"] == "goodbye"
+            assert response.json()["data"][1]["flag"] == "hello"
+
     def test_get_sort_default(self):
         FlagAuditLogModel(
             action=0,
@@ -239,40 +252,6 @@ class OrganizationFlagLogIndexEndpointTestCase(APITestCase):
             assert len(response.json()["data"]) == 2
             assert response.json()["data"][0]["tags"].get("commit_sha") == "123"
             assert response.json()["data"][1]["tags"].get("commit_sha") is None
-
-    def test_get_sort_camel_case(self):
-        FlagAuditLogModel(
-            action=0,
-            created_at=datetime.now(timezone.utc) - timedelta(days=1),
-            created_by="a@b.com",
-            created_by_type=0,
-            flag="hello",
-            organization_id=self.organization.id,
-            tags={"commit_sha": "123"},
-        ).save()
-
-        FlagAuditLogModel(
-            action=1,
-            created_at=datetime.now(timezone.utc),
-            created_by="a@b.com",
-            created_by_type=0,
-            flag="goodbye",
-            organization_id=self.organization.id,
-            tags={},
-        ).save()
-
-        with self.feature(self.features):
-            response = self.client.get(self.url + "?sort=created_at")
-            assert response.status_code == 200
-            assert len(response.json()["data"]) == 2
-            assert response.json()["data"][0]["flag"] == "hello"
-            assert response.json()["data"][1]["flag"] == "goodbye"
-
-            response = self.client.get(self.url + "?sort=-created_at")
-            assert response.status_code == 200
-            assert len(response.json()["data"]) == 2
-            assert response.json()["data"][0]["flag"] == "goodbye"
-            assert response.json()["data"][1]["flag"] == "hello"
 
     def test_get_paginate(self):
         FlagAuditLogModel(

--- a/tests/sentry/flags/endpoints/test_logs.py
+++ b/tests/sentry/flags/endpoints/test_logs.py
@@ -179,6 +179,12 @@ class OrganizationFlagLogIndexEndpointTestCase(APITestCase):
             assert result["data"][0]["flag"] == "hello"
             assert result["data"][1]["flag"] == "world"
 
+            response = self.client.get(self.url + "?provider=unknown")
+            assert response.status_code == 200
+            result = response.json()
+            assert len(result["data"]) == 1
+            assert result["data"][0]["flag"] == "goodbye"
+
             # Invalid provider
             response = self.client.get(self.url + "?provider=blahblah")
             assert response.status_code == 400

--- a/tests/sentry/flags/endpoints/test_logs.py
+++ b/tests/sentry/flags/endpoints/test_logs.py
@@ -225,7 +225,7 @@ class OrganizationFlagLogIndexEndpointTestCase(APITestCase):
             assert response.json()["data"][0]["flag"] == "goodbye"
             assert response.json()["data"][1]["flag"] == "hello"
 
-    def test_get_sort_default(self):
+    def test_get_sort_default_created_at(self):
         FlagAuditLogModel(
             action=0,
             created_at=datetime.now(timezone.utc) - timedelta(days=1),


### PR DESCRIPTION
We need this for https://github.com/getsentry/sentry/issues/85219, to get the most recent X logs in reverse order.
Pagination test is added as an example of how to paginate - from the frontend this will mostly be handled by [pagination.tsx](https://github.com/getsentry/sentry/blob/02165b360d750a982126afedccb6c3faac9cf49c/static/app/components/pagination.tsx#L1-L108)