### PR TITLE
spike(sentry apps): Spike out what context manager usage will look for ext. requests

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -1,0 +1,57 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.integrations.utils.metrics import EventLifecycleMetric
+from sentry.sentry_apps.models.sentry_app import SentryApp
+from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
+
+
+class SentryAppInteractionType(StrEnum):
+    """Actions that Sentry Apps can do"""
+
+    # Webhook actions
+    PREPARE_EVENT_WEBHOOK = "prepare_event_webhook"
+    SEND_EVENT_WEBHOOK = "send_event_webhook"
+    SEND_WEBHOOK = "send_webhook"
+
+    # External Requests actions
+    SELECT_REQUESTER = "select_requester"
+
+
+@dataclass
+class SentryAppInteractionEvent(EventLifecycleMetric):
+    """An event under the Sentry App umbrella"""
+
+    operation_type: SentryAppInteractionType
+    sentry_app: SentryApp | RpcSentryApp | None = None
+    sentry_app_installation: SentryAppInstallation | RpcSentryAppInstallation | None = None
+    region: str | None = None
+
+    def get_sentry_app_name(self) -> str:
+        return self.sentry_app.slug if self.sentry_app else ""
+
+    def get_sentry_app_installation(self) -> str:
+        return self.sentry_app_installation.uuid if self.sentry_app_installation else ""
+
+    def get_region(self) -> str:
+        return self.region or ""
+
+    def get_metric_key(self, outcome: EventLifecycleOutcome) -> str:
+        tokens = ("sentry_app", str(outcome))
+        return ".".join(tokens)
+
+    def get_metric_tags(self) -> Mapping[str, str]:
+        return {
+            "operation_type": self.operation_type,
+            "region": self.get_region(),
+        }
+
+    def get_extras(self) -> Mapping[str, Any]:
+        return {
+            "sentry_app": self.get_sentry_app_name(),
+            "installation_uuid": self.get_sentry_app_installation(),
+        }


### PR DESCRIPTION
Using `SelectRequester` as the example here:

Context: `SelectRequester` is one our most used dataclasses as it queries the 3p integrator to get the 'options' they want us to display for the '[Select](https://docs.sentry.io/organization/integrations/integration-platform/ui-components/formfield/#select)' input/dropdown field. Here we're just wrapping the .run()/driver function in the context manager. We add halts for the failures as the errors are usually from the 3p giving us a bad URL or incorrect format.