### PR TITLE
ref(grouping): Prevent in-app hints from appearing in system variant

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -229,6 +229,17 @@ class Enhancements:
                     else py_component.hint
                 )
                 py_component.update(contributes=False, hint=hint)
+            elif variant_name == "system":
+                # We don't need hints about marking frames in or out of app in the system stacktrace
+                # because such changes don't actually have an effect there
+                hint = (
+                    rust_component.hint
+                    if rust_component.hint
+                    and not rust_component.hint.startswith("marked in-app")
+                    and not rust_component.hint.startswith("marked out of app")
+                    else py_component.hint
+                )
+                py_component.update(contributes=rust_component.contributes, hint=hint)
             else:
                 py_component.update(
                     contributes=rust_component.contributes, hint=rust_component.hint

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:40:29.945093+00:00'
+created: '2025-02-26T00:31:23.587942+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            frame*
               filename*
                 "/node_modules/express/router.js"
               context-line*
                 "return handler(request);"
-            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            frame*
               filename*
                 "/dogApp/dogpark.js"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:40:30.030946+00:00'
+created: '2025-02-26T00:31:23.724300+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            frame*
               filename*
                 "/node_modules/express/router.js"
               context-line*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:07.009551+00:00'
+created: '2025-02-26T00:31:42.842448+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -291,7 +291,7 @@ contributing variants:
                 "thread.rs"
               function*
                 "std::sys::unix::thread::Thread::new::thread_start"
-            frame* (marked out of app by stack trace rule (family:native function:alloc::* -app))
+            frame*
               filename*
                 "boxed.rs"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:07.213683+00:00'
+created: '2025-02-26T00:31:43.250561+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -43,10 +43,10 @@ contributing variants:
       system*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame*
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame*
               function*
                 "__99+[Something else]_block_invoke_2"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:07.806052+00:00'
+created: '2025-02-26T00:31:44.063306+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -79,7 +79,7 @@ contributing variants:
             frame*
               function*
                 "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame*
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:45:36.771348+00:00'
+created: '2025-02-26T00:31:44.258803+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -46,14 +46,14 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            frame*
               filename*
                 "router.js"
               function*
                 "handleRequest"
               context-line*
                 "return handler(request);"
-            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            frame*
               filename*
                 "dogpark.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:45:36.965256+00:00'
+created: '2025-02-26T00:31:44.368955+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            frame*
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.634816+00:00'
+created: '2025-02-26T00:31:52.297569+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,38 +30,38 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::function<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__value_func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__alloc_func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__functional_base"
               function*
                 "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "type_traits"
               function*
@@ -83,21 +83,21 @@ contributing variants:
             frame*
               function*
                 "_CFBundleDlfcnLoadBundle"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen_internal"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dyld::link"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoader::link"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoader::recursiveRebase"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoaderMachOCompressed::rebase"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.739370+00:00'
+created: '2025-02-26T00:31:52.498115+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_root_queues_init_once"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start_wqthread"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_wqthread"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_worker_thread2"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_root_queue_drain"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_client_callout"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.798172+00:00'
+created: '2025-02-26T00:31:52.584267+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,10 +35,10 @@ contributing variants:
                 "thread.cpp"
               function*
                 "boost::thread::start_thread_noexcept"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "thread_start"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_start"
             frame*
@@ -89,12 +89,12 @@ contributing variants:
             frame*
               function*
                 "gpusGenerateCrashLog.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.857903+00:00'
+created: '2025-02-26T00:31:52.682961+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,10 +30,10 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start_wqthread"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_wqthread"
             frame*
@@ -55,42 +55,42 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "mac"
               function*
                 "std::__1::map<T>::~map"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "map"
               function*
                 "std::__1::map<T>::~map"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__tree"
               function*
                 "std::__1::__tree<T>::~__tree"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__tree"
               function*
                 "std::__1::__tree<T>::destroy"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "memory"
               function*
                 "std::__1::allocator_traits<T>::destroy<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "memory"
               function*
                 "std::__1::allocator_traits<T>::__destroy<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "mac"
               function*
                 "std::__1::pair<T>::~pair"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "utility"
               function*
@@ -98,24 +98,24 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::__1::thread::~thread"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::terminate"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::__terminate"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "default_terminate_handler"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort_message"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.913321+00:00'
+created: '2025-02-26T00:31:52.772840+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,22 +30,22 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_root_queues_init_once"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start_wqthread"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_wqthread"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_worker_thread2"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_root_queue_drain"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_dispatch_client_callout"
             frame*
@@ -67,42 +67,42 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "mac"
               function*
                 "std::__1::map<T>::~map"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "map"
               function*
                 "std::__1::map<T>::~map"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__tree"
               function*
                 "std::__1::__tree<T>::~__tree"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__tree"
               function*
                 "std::__1::__tree<T>::destroy"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "memory"
               function*
                 "std::__1::allocator_traits<T>::destroy<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "memory"
               function*
                 "std::__1::allocator_traits<T>::__destroy<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "mac"
               function*
                 "std::__1::pair<T>::~pair"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "utility"
               function*
@@ -110,24 +110,24 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::terminate"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::__terminate"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "demangling_terminate_handler"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort_message"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:12.963369+00:00'
+created: '2025-02-26T00:31:52.856942+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,15 +33,15 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "thread_start"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_start"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__dynamic_cast"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.079336+00:00'
+created: '2025-02-26T00:31:53.035524+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,38 +30,38 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::function<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__value_func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__alloc_func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__functional_base"
               function*
                 "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "type_traits"
               function*
@@ -74,42 +74,42 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_objc_msgSend_uncached"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "lookUpImpOrForward"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "initializeAndMaybeRelock"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "initializeNonMetaClass"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "CALLING_SOME_+initialize_METHOD"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen_internal"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__report_load"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__report_load.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.146620+00:00'
+created: '2025-02-26T00:31:53.134888+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,38 +30,38 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::function<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__value_func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*
                 "std::__1::__function::__alloc_func<T>::operator()"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "__functional_base"
               function*
                 "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "type_traits"
               function*
@@ -74,57 +74,57 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_objc_msgSend_uncached"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "lookUpImpOrForward"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "initializeAndMaybeRelock"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "initializeNonMetaClass"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "CALLING_SOME_+initialize_METHOD"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen_internal"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dyld::runInitializers"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoader::runInitializers"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoader::processInitializers"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoader::recursiveInitialization"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoaderMachO::doInitialization"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "ImageLoaderMachO::doModInitFunctions"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__report_load"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.211536+00:00'
+created: '2025-02-26T00:31:53.234122+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start"
             frame*
@@ -117,13 +117,13 @@ contributing variants:
             frame*
               function*
                 "gpusGenerateCrashLog.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_sigtramp"
             frame*
@@ -180,9 +180,9 @@ contributing variants:
             frame*
               function*
                 "gpusGenerateCrashLog.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.268866+00:00'
+created: '2025-02-26T00:31:53.320729+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,18 +33,18 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "thread_start"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_start"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_body"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_testcancel"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.394719+00:00'
+created: '2025-02-26T00:31:53.511969+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -61,12 +61,12 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "xtree"
               function*
                 "std::_Tree<T>::insert<T>"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "xtree"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:13.449464+00:00'
+created: '2025-02-26T00:31:53.611363+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -49,17 +49,17 @@ contributing variants:
                 "winmain.cpp"
               function*
                 "wWinMain"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "xstring"
               function*
                 "std::basic_string<T>::{ctor}"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "xstring"
               function*
                 "std::basic_string<T>::assign"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "xstring"
               function*
@@ -67,7 +67,7 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "functional"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:15.233711+00:00'
+created: '2025-02-26T00:31:56.924266+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start"
             frame*
@@ -75,9 +75,9 @@ contributing variants:
             frame*
               function*
                 "gpusGenerateCrashLog.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:15.311600+00:00'
+created: '2025-02-26T00:31:57.046288+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "start"
             frame*
@@ -99,10 +99,10 @@ contributing variants:
             frame*
               function*
                 "gpusGenerateCrashLog.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_sigtramp"
             frame*
@@ -159,9 +159,9 @@ contributing variants:
             frame*
               function*
                 "gpusGenerateCrashLog.cold.1"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "__pthread_kill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:15.913061+00:00'
+created: '2025-02-26T00:31:58.393479+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,18 +33,18 @@ contributing variants:
             frame*
               function*
                 "application_frame"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "malloc_zone_malloc"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "nanov2_malloc"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "nanov2_allocate"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "nanov2_allocate_from_block"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "nanov2_allocate_from_block.cold.1"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:16.830471+00:00'
+created: '2025-02-26T00:32:01.019308+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,19 +33,19 @@ contributing variants:
             frame*
               function*
                 "_main"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start_internal"
             frame*
               function*
                 "___rust_maybe_catch_panic"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::panicking::try::do_call"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start::{{closure}}"
-            frame* (marked in-app by stack trace rule (function:log_demo::* +app))
+            frame*
               function*
                 "log_demo::main"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:17.068712+00:00'
+created: '2025-02-26T00:32:01.483386+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -45,19 +45,19 @@ contributing variants:
             frame*
               function*
                 "_main"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start_internal"
             frame*
               function*
                 "___rust_maybe_catch_panic"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::panicking::try::do_call"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start::{{closure}}"
-            frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+            frame*
               function*
                 "log_demo::main"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:17.116277+00:00'
+created: '2025-02-26T00:32:01.570760+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -45,16 +45,16 @@ contributing variants:
             frame*
               function*
                 "_main"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start_internal"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::panicking::try::do_call"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start::{{closure}}"
-            frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+            frame*
               function*
                 "log_demo::main"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T14:45:37.895921+00:00'
+created: '2025-02-26T00:32:02.120292+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -129,100 +129,100 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_start"
             frame*
               function*
                 "__NSThread__start__"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalFunction::lambda::operator()"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FOutputDevice::LogfImpl"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FGenericPlatformMisc::RaiseException"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-21T22:01:05.773639+00:00'
+created: '2025-02-26T00:32:02.611551+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -127,102 +127,102 @@ contributing variants:
       system*
         threads*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "thread_start"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "_pthread_start"
             frame*
               function*
                 "__NSThread__start__"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalFunction::lambda::operator()"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+            frame*
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:27.523403+00:00'
+created: '2025-02-26T00:32:02.715373+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -285,7 +285,7 @@ contributing variants:
                 "thread.rs"
               function*
                 "std::sys::unix::thread::Thread::new::thread_start"
-            frame* (marked out of app by stack trace rule (family:native function:alloc::* -app))
+            frame*
               filename*
                 "boxed.rs"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.069968+00:00'
+created: '2025-02-26T00:32:03.546142+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -55,7 +55,7 @@ contributing variants:
             frame*
               function*
                 "UIApplicationMain"
-            frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+            frame*
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:46:37.831164+00:00'
+created: '2025-02-26T00:32:03.705182+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -46,14 +46,14 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            frame*
               filename*
                 "router.js"
               function*
                 "handleRequest"
               context-line*
                 "return handler(request);"
-            frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+            frame*
               filename*
                 "dogpark.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:46:37.985114+00:00'
+created: '2025-02-26T00:32:03.784088+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+            frame*
               filename*
                 "router.js"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.326055+00:00'
+created: '2025-02-26T00:32:08.758780+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       system*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
+          frame*
             module*
               "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:34.780688+00:00'
+created: '2025-02-26T00:32:09.949432+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       system*
         stacktrace*
-          frame* (marked out of app by stack trace rule (module:sun.* -app))
+          frame*
             module* (removed codegen marker)
               "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:34.680917+00:00'
+created: '2025-02-26T00:32:09.859524+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
     component:
       system*
         stacktrace*
-          frame* (marked out of app by stack trace rule (module:sun.* -app))
+          frame*
             module* (removed codegen marker)
               "sun.reflect.GeneratedConstructorAccessor<auto>"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:34.874174+00:00'
+created: '2025-02-26T00:32:10.033910+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,12 +29,12 @@ contributing variants:
     component:
       system*
         stacktrace*
-          frame* (marked out of app by stack trace rule (module:sun.* -app))
+          frame*
             module* (removed reflection marker)
               "sun.reflect.GeneratedMethodAccessor"
             function*
               "invoke"
-          frame* (marked out of app by stack trace rule (module:jdk.* -app))
+          frame*
             module* (removed reflection marker)
               "jdk.internal.reflect.GeneratedMethodAccessor"
             function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.015733+00:00'
+created: '2025-02-26T00:32:11.422688+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -44,7 +44,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (path:**/go/pkg/mod/** -app))
+            frame*
               module*
                 "github.com/robfig/cron/v3"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.137154+00:00'
+created: '2025-02-26T00:32:11.512656+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -36,6 +36,6 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:54.154107+00:00'
+created: '2025-02-26T00:32:11.603758+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "HTTP_THREAD_POOL::_StaticWorkItemCallback"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.603142+00:00'
+created: '2025-02-26T00:32:11.817120+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -45,6 +45,6 @@ contributing variants:
             frame*
               function*
                 "gldCreateDevice"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.703004+00:00'
+created: '2025-02-26T00:32:11.909576+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -39,7 +39,7 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "memory"
               function*
@@ -47,6 +47,6 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::terminate"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.803315+00:00'
+created: '2025-02-26T00:32:12.004668+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -39,7 +39,7 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "memory"
               function*
@@ -47,6 +47,6 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::terminate"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.194449+00:00'
+created: '2025-02-26T00:32:12.312636+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -39,9 +39,9 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.308867+00:00'
+created: '2025-02-26T00:32:12.445192+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -39,9 +39,9 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "dlopen"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:54.986775+00:00'
+created: '2025-02-26T00:32:12.566413+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,13 +33,13 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "-[NSApplication run]"
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "-[NSView displayIfNeeded]"
             frame*
@@ -51,6 +51,6 @@ contributing variants:
             frame*
               function*
                 "gpusSubmitDataBuffers"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:55.282271+00:00'
+created: '2025-02-26T00:32:13.559138+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,7 +30,7 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               filename*
                 "xstring"
               function*
@@ -41,7 +41,7 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "DispatchMessageWorker"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.514362+00:00'
+created: '2025-02-26T00:32:17.258843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,18 +30,18 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))
+            frame*
               module*
                 "react-dom@16.13.1/umd/react-dom.production"
               function*
                 "unpkg"
-            frame* (marked out of app by stack trace rule (path:**https://cdnjs.cloudflare.com/** -app))
+            frame*
               function*
                 "cdnjs"
-            frame* (marked out of app by stack trace rule (path:**https://cdn.jsdelivr.net/** -app))
+            frame*
               function*
                 "jsdelivr"
-            frame* (marked out of app by stack trace rule (path:**https://esm.run/** -app))
+            frame*
               function* (trimmed javascript function)
                 "run"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:57.547427+00:00'
+created: '2025-02-26T00:32:19.517204+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,7 +33,7 @@ contributing variants:
             frame*
               function*
                 "code"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
             frame*
@@ -42,6 +42,6 @@ contributing variants:
             frame*
               function*
                 "glTexSubImage2D"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:57.622977+00:00'
+created: '2025-02-26T00:32:19.613014+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,13 +33,13 @@ contributing variants:
             frame*
               function*
                 "code"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "-[NSApplication run]"
             frame*
               function*
                 "code"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "-[NSView displayIfNeeded]"
             frame*
@@ -51,6 +51,6 @@ contributing variants:
             frame*
               function*
                 "gpusSubmitDataBuffers"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "abort"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:58.111612+00:00'
+created: '2025-02-26T00:32:20.717367+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "CUseCountedObject<T>::UCDestroy"
             frame*
               function*
                 "destructor'"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:58.178292+00:00'
+created: '2025-02-26T00:32:20.842525+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,6 +30,6 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:30:58.249951+00:00'
+created: '2025-02-26T00:32:20.975620+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,12 +30,12 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "CUseCountedObject<T>::UCDestroy"
             frame*
               function*
                 "destructor'"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "NOutermost::CDeviceChild::LUCBeginLayerDestruction"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.985200+00:00'
+created: '2025-02-26T00:32:21.509341+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,6 +33,6 @@ contributing variants:
             frame*
               function*
                 "application_frame"
-            frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            frame*
               function*
                 "malloc_zone_malloc"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.286038+00:00'
+created: '2025-02-26T00:32:23.838955+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,16 +33,16 @@ contributing variants:
             frame*
               function*
                 "_main"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start_internal"
             frame*
               function*
                 "___rust_maybe_catch_panic"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::panicking::try::do_call"
-            frame* (marked in-app by stack trace rule (function:log_demo::* +app))
+            frame*
               function*
                 "log_demo::main"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.536839+00:00'
+created: '2025-02-26T00:32:24.290677+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -45,16 +45,16 @@ contributing variants:
             frame*
               function*
                 "_main"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start_internal"
             frame*
               function*
                 "___rust_maybe_catch_panic"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::panicking::try::do_call"
-            frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+            frame*
               function*
                 "log_demo::main"
             frame*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.587959+00:00'
+created: '2025-02-26T00:32:24.398457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -45,13 +45,13 @@ contributing variants:
             frame*
               function*
                 "_main"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::rt::lang_start_internal"
-            frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            frame*
               function*
                 "std::panicking::try::do_call"
-            frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+            frame*
               function*
                 "log_demo::main"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T15:34:51.443176+00:00'
+created: '2025-02-26T00:32:24.945789+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -114,91 +114,91 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FOutputDevice::LogfImpl"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FGenericPlatformMisc::RaiseException"
           type*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:31:00.963400+00:00'
+created: '2025-02-26T00:32:25.041637+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -82,63 +82,63 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "android_main"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "AndroidMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UGameEngine::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UWorld::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FLatentActionManager::ProcessLatentActions"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FLatentActionManager::TickLatentActionForObject"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "AActor::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FOutputDevice::LogfImpl"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "TMulticastDelegateBase<T>::Broadcast<T>"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "tgkill"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:31:01.060795+00:00'
+created: '2025-02-26T00:32:25.147539+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -128,117 +128,117 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "WinMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "DispatchMessageWorker"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               filename*
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FDebug::CheckVerifyFailedImpl2"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FDebug::AssertFailed"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FOutputDevice::LogfImpl"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               filename*
                 "sentryoutputdeviceerror.cpp"
               function*
                 "FSentryOutputDeviceError::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "FWindowsErrorOutputDevice::Serialize"
-            frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+            frame*
               function*
                 "RaiseException"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:31:01.158082+00:00'
+created: '2025-02-26T00:32:25.262374+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -130,96 +130,96 @@ contributing variants:
       system*
         exception*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "WinMain"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "LaunchWindowsStartup"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "GuardedMainWrapper"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FWindowsPlatformApplicationMisc::PumpMessages"
-            frame* (marked out of app by stack trace rule (category:system -app))
+            frame*
               function*
                 "DispatchMessageWorker"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FWindowsApplication::AppWndProc"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FWindowsApplication::ProcessMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FWindowsApplication::DeferMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FWindowsApplication::ProcessDeferredMessage"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "SharedPointerInternals::NewIntrusiveReferenceController<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "TBaseUObjectMethodDelegateInstance<T>::Execute"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "UObject::ProcessInternal"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               function*
                 "UObject::execCallMathFunction"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               filename*
                 "sentryplaygroundutils.gen.cpp"
               function*
                 "USentryPlaygroundUtils::execTerminate"
-            frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+            frame*
               filename*
                 "sentryplaygroundutils.cpp"
               function*

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T15:16:50.984844+00:00'
+created: '2025-02-26T00:32:25.363317+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -115,90 +115,90 @@ contributing variants:
       system*
         threads*
           stacktrace*
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "-[FCocoaGameThread main]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "-[UEAppDelegate runGameThread:]"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "GuardedMain"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FEngineLoop::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::Tick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::TickPlatform"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FMacApplication::ProcessDeferredEvents"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FMacApplication::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FMacApplication::ProcessMouseUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::OnMouseUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::ProcessMouseButtonUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "FSlateApplication::RoutePointerUpEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "SButton::OnMouseButtonUp"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "SButton::ExecuteOnClick"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UButton::SlateHandleClicked"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessEvent"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "ProcessScriptFunction<T>"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "ProcessLocalScriptFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UObject::execLetObj"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UObject::ProcessContextOpcode"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UObject::CallFunction"
-            frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "UFunction::Invoke"
-            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "USentrySubsystem::execCaptureEventWithScope"
-            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "USentrySubsystem::CaptureEventWithScope"
-            frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+            frame*
               function*
                 "SentrySubsystemApple::CaptureEventWithScope"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:35.210768+00:00'
+created: '2025-02-26T00:33:37.643566+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -38,7 +38,7 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame
             function (function name is not used if module or filename are available)
               "__99+[Something else]_block_invoke_2"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:35.261070+00:00'
+created: '2025-02-26T00:33:37.734922+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,7 +46,7 @@ system:
             function (function name is not used if module or filename are available)
               "__kernel_rt_sigreturn"
           frame
-          frame (marked out of app by stack trace rule (family:native package:/lib/** -app))
+          frame
           frame
             function (function name is not used if module or filename are available)
               "kill"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:35.578593+00:00'
+created: '2025-02-26T00:33:38.326987+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -80,13 +80,13 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "-[UIApplication _run]"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_main_queue_drain"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_client_callout"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_block_async_invoke2"
           frame
@@ -107,10 +107,10 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "SentrySetupInteractor.setupSentry"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_lane_barrier_sync_invoke_and_complete"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_client_callout"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:38:38.352402+00:00'
+created: '2025-02-26T00:33:38.518257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -57,7 +57,7 @@ system:
               "return server.serve(port);"
             function (function name is not used if context-line is available)
               "runApp"
-          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+          frame*
             filename*
               "/node_modules/express/router.js"
             context-line*
@@ -71,7 +71,7 @@ system:
               "return withMetrics(handler, metricName, tags);"
             function (function name is not used if context-line is available)
               "recordMetrics"
-          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+          frame*
             filename*
               "/dogApp/dogpark.js"
             context-line*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:38:38.444808+00:00'
+created: '2025-02-26T00:33:38.612276+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -50,7 +50,7 @@ system:
               "return server.serve(port);"
             function (function name is not used if context-line is available)
               "runApp"
-          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+          frame*
             filename*
               "/node_modules/express/router.js"
             context-line*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.231203+00:00'
+created: '2025-02-26T00:33:46.336940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -150,10 +150,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "start"
           frame
@@ -260,22 +260,22 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "_CFBundleDlfcnLoadBundle"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dlopen"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dlopen_internal"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dyld::link"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoader::link"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoader::recursiveRebase"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoaderMachOCompressed::rebase"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.341062+00:00'
+created: '2025-02-26T00:33:46.538012+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -110,22 +110,22 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_worker_thread2"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_root_queue_drain"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_client_callout"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.426366+00:00'
+created: '2025-02-26T00:33:46.620319+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -107,10 +107,10 @@ system:
               "artifacts/boost_source_libraries/1.65.1d/boost_libraries/libs/thread/src/pthread/thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "thread_start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_start"
           frame*
@@ -173,13 +173,13 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.489615+00:00'
+created: '2025-02-26T00:33:46.731373+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -151,16 +151,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame
             function (function name is not used if module or filename are available)
               "start_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame
             function (function name is not used if module or filename are available)
               "stripped_application_code"
@@ -258,28 +258,28 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "std::__1::thread::~thread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "std::terminate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "std::__terminate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "default_terminate_handler"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort_message"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
         type*
           "0x00000000 / 0x00000000"
         value (stacktrace and type take precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.571107+00:00'
+created: '2025-02-26T00:33:46.818271+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -166,22 +166,22 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_worker_thread2"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_root_queue_drain"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_dispatch_client_callout"
           frame
@@ -289,25 +289,25 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "std::terminate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "std::__terminate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "demangling_terminate_handler"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort_message"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.622136+00:00'
+created: '2025-02-26T00:33:46.905819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -73,10 +73,10 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "thread_start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_start"
           frame
@@ -115,7 +115,7 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__dynamic_cast"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.674330+00:00'
+created: '2025-02-26T00:33:46.991043+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -68,9 +68,9 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame
             function (function name is not used if module or filename are available)
               "stripped_application_code"
@@ -107,7 +107,7 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
         type*
           "EXC_BAD_ACCESS / EXC_I386_GPFLT"
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.736624+00:00'
+created: '2025-02-26T00:33:47.082460+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -199,10 +199,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "start"
           frame
@@ -312,19 +312,19 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_objc_msgSend_uncached"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "lookUpImpOrForward"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "initializeAndMaybeRelock"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "initializeNonMetaClass"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "CALLING_SOME_+initialize_METHOD"
           frame
@@ -348,32 +348,32 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dlopen"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dlopen_internal"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame
             function (function name is not used if module or filename are available)
               "__report_load"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__report_load.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.799009+00:00'
+created: '2025-02-26T00:33:47.171772+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -204,7 +204,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start"
           frame
@@ -314,19 +314,19 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_objc_msgSend_uncached"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "lookUpImpOrForward"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "initializeAndMaybeRelock"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "initializeNonMetaClass"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "CALLING_SOME_+initialize_METHOD"
           frame
@@ -350,40 +350,40 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dlopen"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dlopen_internal"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "dyld::runInitializers"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoader::runInitializers"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoader::processInitializers"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoader::recursiveInitialization"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoaderMachO::doInitialization"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "ImageLoaderMachO::doModInitFunctions"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__report_load"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.862292+00:00'
+created: '2025-02-26T00:33:47.256995+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -202,7 +202,7 @@ system:
     system*
       exception*
         stacktrace
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start"
           frame
@@ -304,13 +304,13 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
           frame
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_sigtramp"
           frame
@@ -376,10 +376,10 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:40.908637+00:00'
+created: '2025-02-26T00:33:47.346584+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -55,13 +55,13 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "thread_start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_body"
           frame
@@ -79,7 +79,7 @@ system:
           frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_pthread_testcancel"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:43.591053+00:00'
+created: '2025-02-26T00:33:51.223140+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -165,7 +165,7 @@ system:
     system*
       exception*
         stacktrace
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start"
           frame
@@ -302,10 +302,10 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:43.658967+00:00'
+created: '2025-02-26T00:33:51.317786+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -193,10 +193,10 @@ system:
     system*
       exception*
         stacktrace
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function (function name is not used if module or filename are available)
               "start"
           frame
@@ -288,11 +288,11 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
           frame
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "_sigtramp"
           frame
@@ -358,10 +358,10 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             function (function name is not used if module or filename are available)
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:44.510989+00:00'
+created: '2025-02-26T00:33:52.381880+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -53,27 +53,27 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "application_frame"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "malloc_zone_malloc"
             function (function name is not used if module or filename are available)
               "malloc_zone_malloc"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "nanov2_malloc"
             function (function name is not used if module or filename are available)
               "nanov2_malloc"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "nanov2_allocate"
             function (function name is not used if module or filename are available)
               "nanov2_allocate"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "nanov2_allocate_from_block"
             function (function name is not used if module or filename are available)
               "nanov2_allocate_from_block"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "nanov2_allocate_from_block.cold.1"
             function (function name is not used if module or filename are available)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:45.510365+00:00'
+created: '2025-02-26T00:33:54.200961+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -58,7 +58,7 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "std::rt::lang_start::{{closure}}"
-          frame (marked in-app by stack trace rule (function:log_demo::* +app))
+          frame
             function (function name is not used if module or filename are available)
               "log_demo::main"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:45.777881+00:00'
+created: '2025-02-26T00:33:54.886762+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -58,7 +58,7 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "std::rt::lang_start::{{closure}}"
-          frame (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+          frame
             function (function name is not used if module or filename are available)
               "log_demo::main"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:45.838431+00:00'
+created: '2025-02-26T00:33:55.011758+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -58,7 +58,7 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "std::rt::lang_start::{{closure}}"
-          frame (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+          frame
             function (function name is not used if module or filename are available)
               "log_demo::main"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T14:42:16.935695+00:00'
+created: '2025-02-26T00:33:55.794282+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -182,7 +182,7 @@ system:
     system*
       exception*
         stacktrace
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_pthread_start"
             function (function name is not used if module or filename are available)
@@ -192,152 +192,152 @@ system:
               "__NSThread__start__"
             function (function name is not used if module or filename are available)
               "__NSThread__start__"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "-[FCocoaGameThread main]"
             function (function name is not used if module or filename are available)
               "-[FCocoaGameThread main]"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "-[UEAppDelegate runGameThread:]"
             function (function name is not used if module or filename are available)
               "-[UEAppDelegate runGameThread:]"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_Z11GuardedMainPKDs"
             function (function name is not used if module or filename are available)
               "GuardedMain(char16_t const*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN11FEngineLoop4TickEv"
             function (function name is not used if module or filename are available)
               "FEngineLoop::Tick()"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN17FSlateApplication4TickE14ESlateTickType"
             function (function name is not used if module or filename are available)
               "FSlateApplication::Tick(ESlateTickType)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN17FSlateApplication12TickPlatformEf"
             function (function name is not used if module or filename are available)
               "FSlateApplication::TickPlatform(float)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN15FMacApplication21ProcessDeferredEventsEf"
             function (function name is not used if module or filename are available)
               "FMacApplication::ProcessDeferredEvents(float)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN15FMacApplication12ProcessEventERK17FDeferredMacEvent"
             function (function name is not used if module or filename are available)
               "FMacApplication::ProcessEvent(FDeferredMacEvent const&)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN15FMacApplication19ProcessMouseUpEventERK17FDeferredMacEvent10TSharedPtrI10FMacWindowL7ESPMode1EE"
             function (function name is not used if module or filename are available)
               "FMacApplication::ProcessMouseUpEvent(FDeferredMacEvent const&, TSharedPtr<FMacWindow, (ESPMode)1>)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN17FSlateApplication9OnMouseUpEN13EMouseButtons4TypeEN2UE4Math8TVector2IdEE"
             function (function name is not used if module or filename are available)
               "FSlateApplication::OnMouseUp(EMouseButtons::Type, UE::Math::TVector2<double>)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN17FSlateApplication25ProcessMouseButtonUpEventERK13FPointerEvent"
             function (function name is not used if module or filename are available)
               "FSlateApplication::ProcessMouseButtonUpEvent(FPointerEvent const&)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN17FSlateApplication19RoutePointerUpEventERK11FWidgetPathRK13FPointerEvent"
             function (function name is not used if module or filename are available)
               "FSlateApplication::RoutePointerUpEvent(FWidgetPath const&, FPointerEvent const&)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN7SButton15OnMouseButtonUpERK9FGeometryRK13FPointerEvent"
             function (function name is not used if module or filename are available)
               "SButton::OnMouseButtonUp(FGeometry const&, FPointerEvent const&)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN7SButton14ExecuteOnClickEv"
             function (function name is not used if module or filename are available)
               "SButton::ExecuteOnClick()"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN7UButton18SlateHandleClickedEv"
             function (function name is not used if module or filename are available)
               "UButton::SlateHandleClicked()"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZNK24TMulticastScriptDelegateI26FNotThreadSafeDelegateModeE24ProcessMulticastDelegateI7UObjectEEvPv"
             function (function name is not used if module or filename are available)
               "TMulticastScriptDelegate<FNotThreadSafeDelegateMode>::ProcessMulticastDelegate<UObject>(void*) const"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN7UObject12ProcessEventEP9UFunctionPv"
             function (function name is not used if module or filename are available)
               "UObject::ProcessEvent(UFunction*, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN9UFunction6InvokeEP7UObjectR6FFramePv"
             function (function name is not used if module or filename are available)
               "UFunction::Invoke(UObject*, FFrame&, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_Z26ProcessLocalScriptFunctionP7UObjectR6FFramePv"
             function (function name is not used if module or filename are available)
               "ProcessLocalScriptFunction(UObject*, FFrame&, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_Z20ProcessLocalFunctionP7UObjectP9UFunctionR6FFramePv"
             function (function name is not used if module or filename are available)
               "ProcessLocalFunction(UObject*, UFunction*, FFrame&, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZZ20ProcessLocalFunctionP7UObjectP9UFunctionR6FFramePvENK4$_48clEv"
             function (function name is not used if module or filename are available)
               "ProcessLocalFunction(UObject*, UFunction*, FFrame&, void*)::$_48::operator()() const"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_Z21ProcessScriptFunctionIPFvP7UObjectR6FFramePvEEvS1_P9UFunctionS3_S4_T_"
             function (function name is not used if module or filename are available)
               "ProcessScriptFunction<void (*)(UObject*, FFrame&, void*)>(UObject*, UFunction*, FFrame&, void*, void (*)(UObject*, FFrame&, void*))"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_Z26ProcessLocalScriptFunctionP7UObjectR6FFramePv"
             function (function name is not used if module or filename are available)
               "ProcessLocalScriptFunction(UObject*, FFrame&, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN7UObject20execCallMathFunctionEPS_R6FFramePv"
             function (function name is not used if module or filename are available)
               "UObject::execCallMathFunction(UObject*, FFrame&, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN22USentryPlaygroundUtils13execTerminateEP7UObjectR6FFramePv"
             function (function name is not used if module or filename are available)
               "USentryPlaygroundUtils::execTerminate(UObject*, FFrame&, void*)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN22USentryPlaygroundUtils9TerminateE25ESentryAppTerminationType"
             function (function name is not used if module or filename are available)
               "USentryPlaygroundUtils::Terminate(ESentryAppTerminationType)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN6FDebug22CheckVerifyFailedImpl2EPKcS1_iPKDsz"
             function (function name is not used if module or filename are available)
               "FDebug::CheckVerifyFailedImpl2(char const*, char const*, int, char16_t const*, ...)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN13FOutputDevice8LogfImplEPKDsz"
             function (function name is not used if module or filename are available)
               "FOutputDevice::LogfImpl(char16_t const*, ...)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN24FSentryOutputDeviceError9SerializeEPKDsN13ELogVerbosity4TypeERK5FName"
             function (function name is not used if module or filename are available)
               "FSentryOutputDeviceError::Serialize(char16_t const*, ELogVerbosity::Type, FName const&)"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame
             symbol (symbol is not used if module or filename are available)
               "_ZN20FGenericPlatformMisc14RaiseExceptionEj"
             function (function name is not used if module or filename are available)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.162069+00:00'
+created: '2025-02-26T00:33:16.786208+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -414,7 +414,7 @@ system:
               "thread.rs"
             function*
               "std::sys::unix::thread::Thread::new::thread_start"
-          frame* (marked out of app by stack trace rule (family:native function:alloc::* -app))
+          frame*
             filename*
               "boxed.rs"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.327695+00:00'
+created: '2025-02-26T00:33:17.385619+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,10 +35,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame*
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame*
             function*
               "__99+[Something else]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.373031+00:00'
+created: '2025-02-26T00:33:17.475602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,7 +46,7 @@ system:
             function*
               "__kernel_rt_sigreturn"
           frame
-          frame (marked out of app by stack trace rule (family:native package:/lib/** -app))
+          frame
           frame*
             function*
               "kill"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:46.662151+00:00'
+created: '2025-02-26T00:33:17.988231+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -95,7 +95,7 @@ system:
           frame*
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame*
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:48:30.179389+00:00'
+created: '2025-02-26T00:33:18.156712+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -57,7 +57,7 @@ system:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+          frame*
             filename*
               "router.js"
             function*
@@ -71,7 +71,7 @@ system:
               "recordMetrics"
             context-line*
               "return withMetrics(handler, metricName, tags);"
-          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+          frame*
             filename*
               "dogpark.js"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:48:30.270003+00:00'
+created: '2025-02-26T00:33:18.251634+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -50,7 +50,7 @@ system:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+          frame*
             filename*
               "router.js"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:50.879553+00:00'
+created: '2025-02-26T00:33:26.059305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -150,10 +150,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function*
               "start"
           frame*
@@ -192,32 +192,32 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "type_traits"
             function*
@@ -260,22 +260,22 @@ system:
           frame*
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen_internal"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dyld::link"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoader::link"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoader::recursiveRebase"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoaderMachOCompressed::rebase"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:50.964851+00:00'
+created: '2025-02-26T00:33:26.248394+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -110,22 +110,22 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_root_queues_init_once"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_worker_thread2"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_root_queue_drain"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_client_callout"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.013198+00:00'
+created: '2025-02-26T00:33:26.345486+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -107,10 +107,10 @@ system:
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_start"
           frame*
@@ -173,13 +173,13 @@ system:
           frame*
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.070728+00:00'
+created: '2025-02-26T00:33:26.448766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -151,16 +151,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame*
             function*
               "start_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame*
             function*
               "stripped_application_code"
@@ -189,47 +189,47 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "utility"
             function*
@@ -258,28 +258,28 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::__1::thread::~thread"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::terminate"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::__terminate"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "default_terminate_handler"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort_message"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.137934+00:00'
+created: '2025-02-26T00:33:26.557888+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -166,22 +166,22 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_root_queues_init_once"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_worker_thread2"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_root_queue_drain"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_dispatch_client_callout"
           frame*
@@ -215,52 +215,52 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "utility"
             function*
@@ -289,25 +289,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::terminate"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::__terminate"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "demangling_terminate_handler"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort_message"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.250430+00:00'
+created: '2025-02-26T00:33:26.681256+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -73,10 +73,10 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_start"
           frame*
@@ -115,7 +115,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__dynamic_cast"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.317825+00:00'
+created: '2025-02-26T00:33:26.860588+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -68,9 +68,9 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame*
             function*
               "stripped_application_code"
@@ -107,7 +107,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / EXC_I386_GPFLT"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.391372+00:00'
+created: '2025-02-26T00:33:26.976173+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -199,10 +199,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function*
               "start"
           frame*
@@ -241,32 +241,32 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "type_traits"
             function*
@@ -312,19 +312,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_objc_msgSend_uncached"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "lookUpImpOrForward"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "initializeAndMaybeRelock"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "initializeNonMetaClass"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -348,32 +348,32 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen_internal"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame*
             function*
               "__report_load"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__report_load.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.455554+00:00'
+created: '2025-02-26T00:33:27.091261+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -204,7 +204,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start"
           frame*
@@ -243,32 +243,32 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "type_traits"
             function*
@@ -314,19 +314,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_objc_msgSend_uncached"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "lookUpImpOrForward"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "initializeAndMaybeRelock"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "initializeNonMetaClass"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -350,40 +350,40 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen_internal"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dyld::runInitializers"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoader::runInitializers"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoader::processInitializers"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoader::recursiveInitialization"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoaderMachO::doInitialization"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__report_load"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.514597+00:00'
+created: '2025-02-26T00:33:27.191489+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -202,7 +202,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start"
           frame*
@@ -304,13 +304,13 @@ system:
           frame*
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_sigtramp"
           frame*
@@ -376,10 +376,10 @@ system:
           frame*
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.581742+00:00'
+created: '2025-02-26T00:33:27.274412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -55,13 +55,13 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_body"
           frame*
@@ -79,7 +79,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_testcancel"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.695589+00:00'
+created: '2025-02-26T00:33:27.470796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -176,12 +176,12 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "xtree"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:51.754636+00:00'
+created: '2025-02-26T00:33:27.567589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -176,22 +176,22 @@ system:
               "winmain.cpp"
             function*
               "wWinMain"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "xstring"
             function*
@@ -214,7 +214,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "functional"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.536256+00:00'
+created: '2025-02-26T00:33:32.130082+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -165,7 +165,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start"
           frame*
@@ -302,10 +302,10 @@ system:
           frame*
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:53.648852+00:00'
+created: '2025-02-26T00:33:32.254673+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -193,10 +193,10 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function*
               "start"
           frame*
@@ -288,11 +288,11 @@ system:
           frame*
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_sigtramp"
           frame*
@@ -358,10 +358,10 @@ system:
           frame*
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:54.405751+00:00'
+created: '2025-02-26T00:33:33.475196+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -43,19 +43,19 @@ system:
           frame*
             function*
               "application_frame"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "malloc_zone_malloc"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "nanov2_malloc"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "nanov2_allocate"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "nanov2_allocate_from_block"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "nanov2_allocate_from_block.cold.1"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.687269+00:00'
+created: '2025-02-26T00:33:35.428126+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,19 +46,19 @@ system:
           frame*
             function*
               "_main"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start_internal"
           frame*
             function*
               "___rust_maybe_catch_panic"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::panicking::try::do_call"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by stack trace rule (function:log_demo::* +app))
+          frame*
             function*
               "log_demo::main"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.945374+00:00'
+created: '2025-02-26T00:33:35.922219+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,19 +46,19 @@ system:
           frame*
             function*
               "_main"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start_internal"
           frame*
             function*
               "___rust_maybe_catch_panic"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::panicking::try::do_call"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+          frame*
             function*
               "log_demo::main"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:55.996609+00:00'
+created: '2025-02-26T00:33:36.017223+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,19 +46,19 @@ system:
           frame*
             function*
               "_main"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start_internal"
           frame (ignored by stack trace rule (family:native function:__* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::panicking::try::do_call"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+          frame*
             function*
               "log_demo::main"
           frame (ignored by stack trace rule (family:native function:*::__* -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T14:45:40.841607+00:00'
+created: '2025-02-26T00:33:36.655759+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -118,100 +118,100 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_start"
           frame*
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FOutputDevice::LogfImpl"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FGenericPlatformMisc::RaiseException"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-21T22:01:09.142589+00:00'
+created: '2025-02-26T00:33:37.189690+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -149,106 +149,106 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "_pthread_start"
           frame*
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame (ignored due to recursion)
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame* (marked in-app by stack trace rule (family:native package:/Users/** +app))
+          frame*
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
           frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-20T16:46:32.037299+00:00'
+created: '2025-02-26T00:33:56.367161+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -414,7 +414,7 @@ system:
               "thread.rs"
             function*
               "std::sys::unix::thread::Thread::new::thread_start"
-          frame* (marked out of app by stack trace rule (family:native function:alloc::* -app))
+          frame*
             filename*
               "boxed.rs"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:20.086385+00:00'
+created: '2025-02-26T00:33:56.483613+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -808,14 +808,14 @@ system:
               "zygoteinit.java"
             function*
               "run"
-          frame (marked out of app by stack trace rule (module:java.* -app))
+          frame
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame (marked out of app by stack trace rule (module:java.* -app))
+          frame
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:08.303785+00:00'
+created: '2025-02-26T00:33:56.723299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,10 +35,10 @@ system:
     system (threads of app take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame*
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame*
             function*
               "__99+[Something else]_block_invoke_2"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:20.317588+00:00'
+created: '2025-02-26T00:33:56.816485+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,7 +46,7 @@ system:
             function*
               "__kernel_rt_sigreturn"
           frame
-          frame (marked out of app by stack trace rule (family:native package:/lib/** -app))
+          frame
           frame*
             function*
               "kill"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:20.792588+00:00'
+created: '2025-02-26T00:33:57.364760+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -95,7 +95,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame*
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:49:11.496007+00:00'
+created: '2025-02-26T00:33:57.553210+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -57,7 +57,7 @@ system:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+          frame*
             filename*
               "router.js"
             function*
@@ -71,7 +71,7 @@ system:
               "recordMetrics"
             context-line*
               "return withMetrics(handler, metricName, tags);"
-          frame* (marked in-app by stack trace rule (function:playFetch +app +group))
+          frame*
             filename*
               "dogpark.js"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-01-30T21:49:11.604093+00:00'
+created: '2025-02-26T00:33:57.645767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -50,7 +50,7 @@ system:
               "runApp"
             context-line*
               "return server.serve(port);"
-          frame* (marked out of app by stack trace rule (function:handleRequest -app +group))
+          frame*
             filename*
               "router.js"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.149862+00:00'
+created: '2025-02-26T00:34:02.567005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -23,7 +23,7 @@ system:
   component:
     system*
       stacktrace*
-        frame* (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
+        frame*
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.864856+00:00'
+created: '2025-02-26T00:34:03.980784+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ system:
   component:
     system*
       stacktrace*
-        frame* (marked out of app by stack trace rule (module:sun.* -app))
+        frame*
           module* (removed codegen marker)
             "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.811786+00:00'
+created: '2025-02-26T00:34:03.878371+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ system:
   component:
     system*
       stacktrace*
-        frame* (marked out of app by stack trace rule (module:sun.* -app))
+        frame*
           module* (removed codegen marker)
             "sun.reflect.GeneratedConstructorAccessor<auto>"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.920891+00:00'
+created: '2025-02-26T00:34:04.071130+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,12 +26,12 @@ system:
   component:
     system*
       stacktrace*
-        frame* (marked out of app by stack trace rule (module:sun.* -app))
+        frame*
           module* (removed reflection marker)
             "sun.reflect.GeneratedMethodAccessor"
           function*
             "invoke"
-        frame* (marked out of app by stack trace rule (module:jdk.* -app))
+        frame*
           module* (removed reflection marker)
             "jdk.internal.reflect.GeneratedMethodAccessor"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.485235+00:00'
+created: '2025-02-26T00:34:05.247773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,7 +36,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (path:**/go/pkg/mod/** -app))
+          frame*
             module*
               "github.com/robfig/cron/v3"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.544732+00:00'
+created: '2025-02-26T00:34:05.380716+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -153,7 +153,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function*
               "start"
           frame*
@@ -260,7 +260,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:27.614953+00:00'
+created: '2025-02-26T00:34:05.494750+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -106,7 +106,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "TppWorkpExecuteCallback"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.714453+00:00'
+created: '2025-02-26T00:34:05.707221+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -173,7 +173,7 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame (ignored by stack trace rule (category:throw ^-group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.776238+00:00'
+created: '2025-02-26T00:34:05.871975+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -151,16 +151,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame*
             function*
               "stripped_application_code"
@@ -204,7 +204,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "__tree"
             function*
@@ -214,7 +214,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "memory"
             function*
@@ -261,7 +261,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::thread::~thread"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::terminate"
           frame (ignored by stack trace rule (category:throw ^-group))
@@ -279,7 +279,7 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.841587+00:00'
+created: '2025-02-26T00:34:06.011222+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -230,7 +230,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "__tree"
             function*
@@ -240,12 +240,12 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "memory"
             function*
@@ -289,7 +289,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::terminate"
           frame (ignored by stack trace rule (category:throw ^-group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.962182+00:00'
+created: '2025-02-26T00:34:06.203034+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -68,9 +68,9 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame*
             function*
               "stripped_application_code"
@@ -107,7 +107,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / EXC_I386_GPFLT"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.048020+00:00'
+created: '2025-02-26T00:34:06.338424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -202,7 +202,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function*
               "start"
           frame*
@@ -348,26 +348,26 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "dlopen_internal"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
+          frame (ignored due to recursion)
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__report_load"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "__report_load.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame (ignored by stack trace rule (category:throw ^-group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.110450+00:00'
+created: '2025-02-26T00:34:06.460061+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -350,7 +350,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "dlopen"
           frame (ignored by stack trace rule (category:internals -group))
@@ -377,7 +377,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__report_load"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame (ignored by stack trace rule (category:throw ^-group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:28.399978+00:00'
+created: '2025-02-26T00:34:06.608710+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -223,7 +223,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "-[NSApplication run]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -262,7 +262,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "-[NSView displayIfNeeded]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -304,7 +304,7 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame (ignored by stack trace rule (category:throw ^-group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:28.724233+00:00'
+created: '2025-02-26T00:34:07.049436+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -176,7 +176,7 @@ system:
               "winmain.cpp"
             function*
               "wWinMain"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             filename*
               "xstring"
             function*
@@ -186,7 +186,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored due to recursion)
             filename*
               "xstring"
             function*
@@ -222,7 +222,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "DispatchMessageWorker"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.009899+00:00'
+created: '2025-02-26T00:34:08.057415+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -415,28 +415,28 @@ system:
     system*
       exception*
         stacktrace*
-          frame (marked out of app by stack trace rule (module:java.* -app))
+          frame
             module*
               "java.lang.Thread"
             filename (module takes precedence)
               "thread.java"
             function*
               "run"
-          frame (marked out of app by stack trace rule (module:org.apache.* -app))
+          frame
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
             filename (module takes precedence)
               "taskthread.java"
             function*
               "run"
-          frame (marked out of app by stack trace rule (module:java.* -app))
+          frame
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
             filename (module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
-          frame (marked out of app by stack trace rule (module:java.* -app))
+          frame
             module*
               "java.util.concurrent.ThreadPoolExecutor"
             filename (module takes precedence)
@@ -765,7 +765,7 @@ system:
               "invocablehandlermethod.java"
             function*
               "doInvoke"
-          frame (marked out of app by stack trace rule (module:java.* -app))
+          frame
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:15.532309+00:00'
+created: '2025-02-26T00:34:09.069606+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,24 +44,24 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))
+          frame*
             module*
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
               "unpkg"
-          frame* (marked out of app by stack trace rule (path:**https://cdnjs.cloudflare.com/** -app))
+          frame*
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
               "cdnjs"
-          frame* (marked out of app by stack trace rule (path:**https://cdn.jsdelivr.net/** -app))
+          frame*
             filename (ignored because frame points to a URL)
               "jquery.min.js"
             function*
               "jsdelivr"
-          frame* (marked out of app by stack trace rule (path:**https://esm.run/** -app))
+          frame*
             filename (ignored because frame points to a URL)
               "d3@7.6.1"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:31.366709+00:00'
+created: '2025-02-26T00:34:10.510211+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -207,7 +207,7 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -302,7 +302,7 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame (ignored by stack trace rule (category:throw ^-group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:31.460972+00:00'
+created: '2025-02-26T00:34:10.612905+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -196,7 +196,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored due to recursion)
             function*
               "start"
           frame*
@@ -217,7 +217,7 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "-[NSApplication run]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -246,7 +246,7 @@ system:
           frame*
             function*
               "code"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "-[NSView displayIfNeeded]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -288,7 +288,7 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "abort"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:32.006124+00:00'
+created: '2025-02-26T00:34:11.326908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -41,13 +41,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame*
             function*
               "destructor'"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:32.074562+00:00'
+created: '2025-02-26T00:34:11.440700+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,7 +36,7 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:32.148384+00:00'
+created: '2025-02-26T00:34:11.534819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -42,13 +42,13 @@ system:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "CUseCountedObject<T>::UCDestroy"
           frame*
             function*
               "destructor'"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:17.403904+00:00'
+created: '2025-02-26T00:34:11.713029+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -43,7 +43,7 @@ system:
           frame*
             function*
               "application_frame"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame*
             function*
               "malloc_zone_malloc"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.445492+00:00'
+created: '2025-02-26T00:34:14.852322+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,19 +46,19 @@ system:
           frame*
             function*
               "_main"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start_internal"
           frame*
             function*
               "___rust_maybe_catch_panic"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::panicking::try::do_call"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by stack trace rule (function:log_demo::* +app))
+          frame*
             function*
               "log_demo::main"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.740583+00:00'
+created: '2025-02-26T00:34:15.407981+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,19 +46,19 @@ system:
           frame*
             function*
               "_main"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start_internal"
           frame*
             function*
               "___rust_maybe_catch_panic"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::panicking::try::do_call"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+          frame*
             function*
               "log_demo::main"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.788584+00:00'
+created: '2025-02-26T00:34:15.546061+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,19 +46,19 @@ system:
           frame*
             function*
               "_main"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::rt::lang_start_internal"
           frame (ignored by stack trace rule (family:native function:__* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame*
             function*
               "std::panicking::try::do_call"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
-          frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+          frame*
             function*
               "log_demo::main"
           frame (ignored by stack trace rule (family:native function:*::__* -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:34.633056+00:00'
+created: '2025-02-26T00:34:16.189781+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -124,94 +124,94 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FOutputDevice::LogfImpl"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FGenericPlatformMisc::RaiseException"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:34.705180+00:00'
+created: '2025-02-26T00:34:16.297561+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -96,66 +96,66 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
-          frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame
+          frame*
             function*
               "android_main"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "AndroidMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UGameEngine::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UWorld::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FLatentActionManager::ProcessLatentActions"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FLatentActionManager::TickLatentActionForObject"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "AActor::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FOutputDevice::LogfImpl"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "TMulticastDelegateBase<T>::Broadcast<T>"
-          frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame
+          frame*
             function*
               "tgkill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:34.789572+00:00'
+created: '2025-02-26T00:34:16.413488+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -177,127 +177,127 @@ system:
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "WinMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "DispatchMessageWorker"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             filename*
               "sentryplaygroundutils.cpp"
             function*
               "USentryPlaygroundUtils::Terminate"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FDebug::CheckVerifyFailedImpl2"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FDebug::AssertFailed"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FOutputDevice::LogfImpl"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             filename*
               "sentryoutputdeviceerror.cpp"
             function*
               "FSentryOutputDeviceError::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "FWindowsErrorOutputDevice::Serialize"
-          frame* (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame*
             function*
               "RaiseException"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:34.874871+00:00'
+created: '2025-02-26T00:34:16.527674+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -206,105 +206,105 @@ system:
               "exe_common.inl"
             function*
               "invoke_main"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "WinMain"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "LaunchWindowsStartup"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "GuardedMainWrapper"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FWindowsPlatformApplicationMisc::PumpMessages"
-          frame* (marked out of app by stack trace rule (category:system -app))
+          frame*
             function*
               "DispatchMessageWorker"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FWindowsApplication::AppWndProc"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FWindowsApplication::ProcessMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FWindowsApplication::DeferMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FWindowsApplication::ProcessDeferredMessage"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "SharedPointerInternals::NewIntrusiveReferenceController<T>"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TArray<T>::Remove'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "TBaseUObjectMethodDelegateInstance<T>::Execute"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "UObject::ProcessInternal"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "`TThreadSingleton<T>::Get'::`2'::<T>::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             function*
               "UObject::execCallMathFunction"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             filename*
               "sentryplaygroundutils.gen.cpp"
             function*
               "USentryPlaygroundUtils::execTerminate"
-          frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app))
+          frame*
             filename*
               "sentryplaygroundutils.cpp"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-25T18:23:34.962680+00:00'
+created: '2025-02-26T00:34:16.642847+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -158,97 +158,97 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "-[FCocoaGameThread main]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "-[UEAppDelegate runGameThread:]"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "GuardedMain"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FEngineLoop::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::Tick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::TickPlatform"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FMacApplication::ProcessDeferredEvents"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FMacApplication::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FMacApplication::ProcessMouseUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::OnMouseUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::ProcessMouseButtonUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "FSlateApplication::RoutePointerUpEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "SButton::OnMouseButtonUp"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "SButton::ExecuteOnClick"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UButton::SlateHandleClicked"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "TMulticastScriptDelegate<T>::ProcessMulticastDelegate<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessEvent"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalFunction"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "ProcessLocalFunction::lambda::operator()"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "ProcessScriptFunction<T>"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "ProcessLocalScriptFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UObject::execLetObj"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UObject::ProcessContextOpcode"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UObject::CallFunction"
-          frame* (marked in-app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "UFunction::Invoke"
-          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "USentrySubsystem::execCaptureEventWithScope"
-          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (ignored due to recursion)
             function*
               "USentrySubsystem::CaptureEventWithScope"
-          frame* (marked out of app by stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame*
             function*
               "SentrySubsystemApple::CaptureEventWithScope"
           frame (ignored by stack trace rule (family:native function:?[[]Sentry* -app -group))


### PR DESCRIPTION
In the system variant, whether or not a frame is in-app doesn't have any effect on whether or not the frame is used for grouping. Even so, we include "marked in-app by rule xxx" and "marked out of app by rule xxx" hints on those frames. This is at minimum superfluous, and at worst means that we overwrite more useful hints (such as a frame being ignored because of recursion). This PR therefore prevents in-app hints from being applied to frames in the system variant.

Note that to test this, I ended up combining the `test_uses_results_from_rust_enhancers_simple` and `test_always_marks_app_variant_system_frames_non_contributing` tests into one since a) there is no simple case anymore, and b) it was easier to make sure I was covering all of the different combos of frame types and `contributes`/`in_app` values if I had them all in one spot.