### PR TITLE
fix(auth): fix page not loading when joining org that requires 2FA

### DIFF
--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -107,6 +107,7 @@ function ExistingMemberAlert() {
 }
 
 function Warning2fa({inviteDetails}: {inviteDetails: InviteDetails}) {
+  const sentryUrl = ConfigStore.get('links').sentryUrl;
   return (
     <Fragment>
       <p data-test-id="2fa-warning">
@@ -116,7 +117,11 @@ function Warning2fa({inviteDetails}: {inviteDetails: InviteDetails}) {
         )}
       </p>
       <Actions>
-        <LinkButton priority="primary" to="/settings/account/security/">
+        <LinkButton
+          external
+          priority="primary"
+          href={`${sentryUrl}/settings/account/security/`}
+        >
           {t('Configure Two-Factor Auth')}
         </LinkButton>
       </Actions>


### PR DESCRIPTION
When users without 2FA configured attempted to join an org that requires 2FA, they would be redirected to the org member user settings page, which wouldn't exist. Fix this to redirect to the org-agnostic user settings page.

Before:

https://github.com/user-attachments/assets/61217382-f131-4301-aba0-e3c9b4b69c94

After:

https://github.com/user-attachments/assets/32f3501d-9a89-4ef9-915d-f2e569b76ecb

