### PR TITLE
feat(taskworker): Set multiprocessing queue size to 1

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -284,11 +284,6 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 )
 @click.option("--concurrency", help="Number of child worker processes to create.", default=1)
 @click.option(
-    "--prefetch-multiplier",
-    help="How many tasks to keep in the child worker queue and results queue. Multiplied by --concurrency",
-    default=1.0,
-)
-@click.option(
     "--namespace", help="The dedicated task namespace that taskworker operates on", default=None
 )
 @log_options()
@@ -309,7 +304,6 @@ def run_taskworker(
     max_task_count: int,
     namespace: str | None,
     concurrency: int,
-    prefetch_multiplier: float,
     **options: Any,
 ) -> None:
     """
@@ -324,7 +318,6 @@ def run_taskworker(
             max_task_count=max_task_count,
             namespace=namespace,
             concurrency=concurrency,
-            prefetch_multiplier=prefetch_multiplier,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/taskworker/constants.py
+++ b/src/sentry/taskworker/constants.py
@@ -1,4 +1,4 @@
-DEFAULT_PROCESSING_DEADLINE = 5
+DEFAULT_PROCESSING_DEADLINE = 10
 """
 The fallback/default processing_deadline that tasks
 will use if neither the TaskNamespace or Task define a deadline

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -238,7 +238,6 @@ class TaskWorker:
         max_task_count: int | None = None,
         namespace: str | None = None,
         concurrency: int = 1,
-        prefetch_multiplier: float = 1.0,
         **options: dict[str, Any],
     ) -> None:
         self.options = options
@@ -248,13 +247,8 @@ class TaskWorker:
         self._namespace = namespace
         self._concurrency = concurrency
         self.client = TaskworkerClient(rpc_host, num_brokers)
-        queuesize = int(concurrency * prefetch_multiplier)
-        self._child_tasks: multiprocessing.Queue[TaskActivation] = mp_context.Queue(
-            maxsize=queuesize
-        )
-        self._processed_tasks: multiprocessing.Queue[ProcessingResult] = mp_context.Queue(
-            maxsize=queuesize
-        )
+        self._child_tasks: multiprocessing.Queue[TaskActivation] = mp_context.Queue(maxsize=1)
+        self._processed_tasks: multiprocessing.Queue[ProcessingResult] = mp_context.Queue(maxsize=1)
         self._children: list[ForkProcess] = []
         self._shutdown_event = mp_context.Event()
         self.backoff_sleep_seconds = 0

--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -249,7 +249,7 @@ def test_registry_create_namespace_simple() -> None:
     ns = registry.create_namespace(name="tests")
     assert ns.default_retry is None
     assert ns.default_expires is None
-    assert ns.default_processing_deadline_duration == 5
+    assert ns.default_processing_deadline_duration == 10
     assert ns.name == "tests"
     assert ns.topic == Topic.TASK_WORKER
 


### PR DESCRIPTION
Since queue size = 1 yields the optimal task execution duration and throughput in our sandbox test, I think we can remove this tuning parameter and reduce the number of knobs a taskbroker on-call needs to maintain. This PR also bumps the default deadline duration to 10s.