### PR TITLE
ref(uptime): Improve uptime issues component

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -18,7 +18,7 @@ describe('UptimeAlertDetails', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/?limit=20&project=${project.id}&query=issue.category%3Auptime%20tags%5Buptime_rule%5D%3A1`,
+      url: `/organizations/${organization.slug}/issues/?limit=1&project=${project.id}&query=issue.category%3Auptime%20tags%5Buptime_rule%5D%3A1`,
       body: [],
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
@@ -33,10 +33,13 @@ export function UptimeIssues({project, ruleId}: Props) {
   return (
     <GroupList
       orgSlug={organization.slug}
+      withChart={false}
+      withPagination={false}
+      withColumns={['assignee']}
       queryParams={{
         query,
         project: project.id,
-        limit: 20,
+        limit: 1,
       }}
       renderEmptyMessage={emptyMessage}
     />


### PR DESCRIPTION
- Do not include the chart
 - Do not include pagination as there will only ever be one uptime issue
   per uptime monitor
 - Set the limit to 1, which reduces layout jitter, since we will only
   ever have at most one issue