### PR TITLE
storybook: provide story primitives via story callback

### DIFF
--- a/static/app/components/badge/featureBadge.stories.tsx
+++ b/static/app/components/badge/featureBadge.stories.tsx
@@ -3,20 +3,19 @@ import {Fragment} from 'react';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('FeatureBadge', story => {
-  story('Types', () => (
-    <SideBySide>
+export default StoryBook('FeatureBadge', Story => {
+  Story('Types', () => (
+    <Story.SideBySide>
       <FeatureBadge type="alpha" />
       <FeatureBadge type="beta" />
       <FeatureBadge type="new" />
       <FeatureBadge type="experimental" />
-    </SideBySide>
+    </Story.SideBySide>
   ));
 
-  story('Custom tooltip props', () => (
+  Story('Custom tooltip props', () => (
     <Fragment>
       <FeatureBadge type="new" title="The tooltip title can be custom too" />
       <FeatureBadge
@@ -28,7 +27,7 @@ export default storyBook('FeatureBadge', story => {
     </Fragment>
   ));
 
-  story('variant', () => (
+  Story('variant', () => (
     <Fragment>
       <p>
         When using an indicator you might want to position it manually using{' '}

--- a/static/app/components/badge/groupPriority.stories.tsx
+++ b/static/app/components/badge/groupPriority.stories.tsx
@@ -4,24 +4,23 @@ import {
   GroupPriorityBadge,
   GroupPriorityDropdown,
 } from 'sentry/components/badge/groupPriority';
-import SideBySide from 'sentry/components/stories/sideBySide';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {PriorityLevel} from 'sentry/types/group';
 
 const PRIORITIES = [PriorityLevel.HIGH, PriorityLevel.MEDIUM, PriorityLevel.LOW];
 
-export const Badge = storyBook('GroupPriorityBadge', story => {
-  story('Default', () => (
-    <SideBySide>
+export const Badge = StoryBook('GroupPriorityBadge', Story => {
+  Story('Default', () => (
+    <Story.SideBySide>
       {PRIORITIES.map(priority => (
         <GroupPriorityBadge key={priority} priority={priority} />
       ))}
-    </SideBySide>
+    </Story.SideBySide>
   ));
 });
 
-export const Dropdown = storyBook('GroupPriorityDropdown', story => {
-  story('Default', () => {
+export const Dropdown = StoryBook('GroupPriorityDropdown', Story => {
+  Story('Default', () => {
     const [value, setValue] = useState(PriorityLevel.MEDIUM);
 
     return (

--- a/static/app/components/button.stories.tsx
+++ b/static/app/components/button.stories.tsx
@@ -5,19 +5,19 @@ import {Button} from 'sentry/components/button';
 import type {PropMatrix} from 'sentry/components/stories/matrix';
 import Matrix from 'sentry/components/stories/matrix';
 import {IconDelete} from 'sentry/icons';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/button';
 
-export default storyBook('Button', (story, APIReference) => {
-  APIReference(types.Button);
+export default StoryBook('Button', Story => {
+  Story.APIReference(types.Button);
 
-  story('Default', () => {
+  Story('Default', () => {
     return <Button>Default Button</Button>;
   });
 
-  story('onClick', () => {
+  Story('onClick', () => {
     const [clickCount, setClickCount] = useState(0);
     return (
       <Fragment>
@@ -39,7 +39,7 @@ export default storyBook('Button', (story, APIReference) => {
     title: [undefined, 'Delete this'],
     translucentBorder: [false, true],
   };
-  story('Props', () => (
+  Story('Props', () => (
     <div>
       <Matrix<ButtonProps>
         render={Button}

--- a/static/app/components/clippedBox.stories.tsx
+++ b/static/app/components/clippedBox.stories.tsx
@@ -7,13 +7,12 @@ import ClippedBox from 'sentry/components/clippedBox';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook('ClippedBox', story => {
-  story('Default', () => (
+export default StoryBook('ClippedBox', Story => {
+  Story('Default', () => (
     <Fragment>
       <p>
         By default <JSXNode name="ClippedBox" /> is just a container. Add{' '}
@@ -45,7 +44,7 @@ export default storyBook('ClippedBox', story => {
     pointer-events: none;
   `;
 
-  story('Title', () => (
+  Story('Title', () => (
     <SizingWindow>
       <ClippedBox title="This is the title">
         <img src={onboardingFrameworkSelectionJavascript} height={300} />
@@ -53,7 +52,7 @@ export default storyBook('ClippedBox', story => {
     </SizingWindow>
   ));
 
-  story('Custom Button & Fade', () => (
+  Story('Custom Button & Fade', () => (
     <Matrix
       render={ClippedBox}
       propMatrix={{
@@ -72,7 +71,7 @@ export default storyBook('ClippedBox', story => {
     />
   ));
 
-  story('Callbacks', () => {
+  Story('Callbacks', () => {
     return (
       <Fragment>
         <p>
@@ -80,7 +79,7 @@ export default storyBook('ClippedBox', story => {
           <JSXProperty name="onSetRenderedHeight" value={Function} />&{' '}
           <JSXProperty name="onReveal" value={Function} />.
         </p>
-        <SideBySide>
+        <Story.SideBySide>
           {[50, 100, 150].map(imgHeight => {
             const [isRevealed, setIsRevealed] = useState(false);
             const [renderedHeight, setRenderedHeight] = useState<number | undefined>(
@@ -110,7 +109,7 @@ export default storyBook('ClippedBox', story => {
               </div>
             );
           })}
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });

--- a/static/app/components/collapsePanel.stories.tsx
+++ b/static/app/components/collapsePanel.stories.tsx
@@ -4,12 +4,11 @@ import CollapsePanel from 'sentry/components/collapsePanel';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('CollapsePanel', story => {
-  story('Basics', () => (
+export default StoryBook('CollapsePanel', Story => {
+  Story('Basics', () => (
     <Fragment>
       <p>
         The <JSXNode name="CollapsePanel" /> expanded state will be set based on whether{' '}
@@ -32,13 +31,13 @@ export default storyBook('CollapsePanel', story => {
     </Fragment>
   ));
 
-  story('Bugs', () => (
+  Story('Bugs', () => (
     <Fragment>
       <p>
         Starting with items less than or equal to the <var>collapseCount</var> will return
         an incorrect <var>isExpanded</var> value.
       </p>
-      <SideBySide>
+      <Story.SideBySide>
         {[6, 5, 4].map(items => (
           <Fragment key={items}>
             <JSXNode name="CollapsePanel" props={{items, collapseCount: 5}} />
@@ -54,11 +53,11 @@ export default storyBook('CollapsePanel', story => {
             </SizingWindow>
           </Fragment>
         ))}
-      </SideBySide>
+      </Story.SideBySide>
     </Fragment>
   ));
 
-  story('Rendering a list', () => {
+  Story('Rendering a list', () => {
     const allItems = ['one', 'two', 'three', 'four', 'five'];
     const collapseCount = 3; // Show 3 items to start
     return (
@@ -88,7 +87,7 @@ export default storyBook('CollapsePanel', story => {
     );
   });
 
-  story('Props', () => (
+  Story('Props', () => (
     <Matrix
       render={CollapsePanel}
       propMatrix={{

--- a/static/app/components/collapsible.stories.tsx
+++ b/static/app/components/collapsible.stories.tsx
@@ -4,12 +4,11 @@ import {Button} from 'sentry/components/button';
 import Collapsible from 'sentry/components/collapsible';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('Collapsible', story => {
-  story('Default', () => (
+export default StoryBook('Collapsible', Story => {
+  Story('Default', () => (
     <Fragment>
       <p>
         After passing in a list of children, <JSXNode name="Collapsible" /> will truncate
@@ -28,13 +27,13 @@ export default storyBook('Collapsible', story => {
     </Fragment>
   ));
 
-  story('Bugs', () => (
+  Story('Bugs', () => (
     <Fragment>
       <p>
         It's possible to use <JSXNode name="ul" /> or <JSXNode name="ol" />, but beware
         that the button will appear inside the list as well.
       </p>
-      <SideBySide>
+      <Story.SideBySide>
         <ol>
           <Collapsible maxVisibleItems={2}>
             <li>Item 1</li>
@@ -49,11 +48,11 @@ export default storyBook('Collapsible', story => {
             <li>Item 3</li>
           </Collapsible>
         </ul>
-      </SideBySide>
+      </Story.SideBySide>
     </Fragment>
   ));
 
-  story('maxVisibleItems', () => {
+  Story('maxVisibleItems', () => {
     const allItems = ['one', 'two', 'three', 'four', 'five'].map(i => (
       <div key={i}>Item {i}</div>
     ));
@@ -64,7 +63,7 @@ export default storyBook('Collapsible', story => {
           <JSXProperty name="maxVisibleItems" value={Number} /> will show/hide and
           pluralize the button label as needed.
         </p>
-        <SideBySide>
+        <Story.SideBySide>
           {[3, 4, 5, 6].map(maxVisibleItems => (
             <div key={maxVisibleItems}>
               <p>
@@ -75,12 +74,12 @@ export default storyBook('Collapsible', story => {
               </SizingWindow>
             </div>
           ))}
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Custom Buttons', () => (
+  Story('Custom Buttons', () => (
     <Fragment>
       <p>
         You can set custom <JSXProperty name="collapseButton" value={Function} /> &{' '}

--- a/static/app/components/confirm.stories.tsx
+++ b/static/app/components/confirm.stories.tsx
@@ -7,12 +7,11 @@ import Link from 'sentry/components/links/link';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
-export default storyBook('Confirm', story => {
-  story('Triggers', () => {
+export default StoryBook('Confirm', Story => {
+  Story('Triggers', () => {
     const [state, setState] = useState('empty');
 
     return (
@@ -25,7 +24,7 @@ export default storyBook('Confirm', story => {
           It's recommended to call <code>openConfirmModal()</code>.
         </p>
         <p>Current state is: {state}.</p>
-        <SideBySide>
+        <Story.SideBySide>
           <Button
             onClick={() =>
               openConfirmModal({
@@ -48,19 +47,19 @@ export default storyBook('Confirm', story => {
               Button is wrapped with <JSXNode name="Confirm" />
             </Button>
           </Confirm>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Labels', () => (
+  Story('Labels', () => (
     <Fragment>
       <p>
         You must implement at least <JSXProperty name="message" value={String} />, but
         have the option of implementing{' '}
         <JSXProperty name="renderMessage" value={Function} /> instead.
       </p>
-      <SideBySide>
+      <Story.SideBySide>
         <Button
           onClick={() =>
             openConfirmModal({
@@ -101,11 +100,11 @@ export default storyBook('Confirm', story => {
         >
           With ReactNode Labels
         </Button>
-      </SideBySide>
+      </Story.SideBySide>
     </Fragment>
   ));
 
-  story('Callbacks & bypass={true}', () => {
+  Story('Callbacks & bypass={true}', () => {
     const [callbacks, setCallbacks] = useState<string[]>([]);
     return (
       <Fragment>
@@ -115,7 +114,7 @@ export default storyBook('Confirm', story => {
           selected in a bulk-change operation, and directly run the{' '}
           <JSXProperty name="onConfirm" value={Function} /> callback.
         </p>
-        <SideBySide>
+        <Story.SideBySide>
           <Button
             onClick={() =>
               openConfirmModal({
@@ -144,7 +143,7 @@ export default storyBook('Confirm', story => {
           >
             With callbacks (bypass = true)
           </Button>
-        </SideBySide>
+        </Story.SideBySide>
         <p>
           <label>
             Callback debugger:
@@ -158,7 +157,7 @@ export default storyBook('Confirm', story => {
     );
   });
 
-  story('<Confirm> child render func', () => (
+  Story('<Confirm> child render func', () => (
     <Fragment>
       <p>
         Here's an example where <JSXProperty name="children" value={Function} /> is a
@@ -168,7 +167,7 @@ export default storyBook('Confirm', story => {
     </Fragment>
   ));
 
-  story('<Confirm> specific props', () => {
+  Story('<Confirm> specific props', () => {
     const [clicks, setClicks] = useState(0);
 
     return (

--- a/static/app/components/core/alert/alertLink.stories.tsx
+++ b/static/app/components/core/alert/alertLink.stories.tsx
@@ -4,7 +4,7 @@ import {AlertLink, type AlertLinkProps} from 'sentry/components/core/alert/alert
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import {IconMail} from 'sentry/icons';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/alert/alertLink';
@@ -19,9 +19,9 @@ const ALERT_LINK_VARIANTS: Array<AlertLinkProps['type']> = [
   'muted',
 ];
 
-export default storyBook('AlertLink', (story, APIReference) => {
-  APIReference(types.AlertLink);
-  story('Default', () => {
+export default StoryBook('AlertLink', Story => {
+  Story.APIReference(types.AlertLink);
+  Story('Default', () => {
     return (
       <Fragment>
         <p>
@@ -42,7 +42,7 @@ export default storyBook('AlertLink', (story, APIReference) => {
     );
   });
 
-  story('Internal, External, and Manual Links', () => {
+  Story('Internal, External, and Manual Links', () => {
     return (
       <Fragment>
         <p>
@@ -80,7 +80,7 @@ export default storyBook('AlertLink', (story, APIReference) => {
       </Fragment>
     );
   });
-  story('With Custom Icon', () => {
+  Story('With Custom Icon', () => {
     return (
       <Fragment>
         <p>
@@ -95,7 +95,7 @@ export default storyBook('AlertLink', (story, APIReference) => {
     );
   });
 
-  story('AlertLink.Container', () => {
+  Story('AlertLink.Container', () => {
     return (
       <Fragment>
         <p>

--- a/static/app/components/core/alert/index.stories.tsx
+++ b/static/app/components/core/alert/index.stories.tsx
@@ -5,7 +5,7 @@ import {Alert, type AlertProps} from 'sentry/components/core/alert';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import {IconClose, IconSentry, IconStar} from 'sentry/icons';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -23,9 +23,9 @@ const RECOMMENDED_USAGE: Partial<AlertProps> = {
   showIcon: true,
 };
 
-export default storyBook('Alert', (story, APIReference) => {
-  APIReference(types.Alert);
-  story('Default', () => {
+export default StoryBook('Alert', Story => {
+  Story.APIReference(types.Alert);
+  Story('Default', () => {
     return (
       <Fragment>
         <p>
@@ -48,7 +48,7 @@ export default storyBook('Alert', (story, APIReference) => {
     );
   });
 
-  story('System', () => {
+  Story('System', () => {
     return (
       <Fragment>
         <p>System alerts are used for important messages that are not dismissible.</p>
@@ -63,7 +63,7 @@ export default storyBook('Alert', (story, APIReference) => {
     );
   });
 
-  story('Expandable Alerts', () => {
+  Story('Expandable Alerts', () => {
     return (
       <Fragment>
         <p>
@@ -83,7 +83,7 @@ export default storyBook('Alert', (story, APIReference) => {
     );
   });
 
-  story('Without icon and custom trailing items', () => {
+  Story('Without icon and custom trailing items', () => {
     return (
       <Fragment>
         <p>
@@ -100,7 +100,7 @@ export default storyBook('Alert', (story, APIReference) => {
     );
   });
 
-  story('Dismissible Alerts', () => {
+  Story('Dismissible Alerts', () => {
     const LOCAL_STORAGE_KEY = 'alert-stories-banner-dismissed';
     const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
     const [stateDismissed, setStateDismissed] = useState(false);
@@ -159,7 +159,7 @@ export default storyBook('Alert', (story, APIReference) => {
     );
   });
 
-  story('Alert.Container', () => {
+  Story('Alert.Container', () => {
     return (
       <Fragment>
         <p>

--- a/static/app/components/core/badge/index.stories.tsx
+++ b/static/app/components/core/badge/index.stories.tsx
@@ -1,19 +1,19 @@
 import Badge from 'sentry/components/core/badge';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SideBySide from 'sentry/components/stories/sideBySide';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('Badge', story => {
-  story('Default', () => (
-    <SideBySide>
+export default StoryBook('Badge', Story => {
+  Story('Default', () => (
+    <Story.SideBySide>
       <Badge text="Text Prop" />
       <Badge>
         Using <JSXProperty name="children" value="" />
       </Badge>
-    </SideBySide>
+    </Story.SideBySide>
   ));
 
-  story('Type', () => (
+  Story('Type', () => (
     <SideBySide>
       <Badge type="default">Default</Badge>
       <Badge type="alpha">Alpha</Badge>

--- a/static/app/components/core/input.stories.tsx
+++ b/static/app/components/core/input.stories.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
 import {Input} from './input';
@@ -10,10 +10,10 @@ import {Input} from './input';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/input';
 
-export default storyBook('Input', (story, APIReference) => {
-  APIReference(types.Input);
+export default StoryBook('Input', Story => {
+  Story.APIReference(types.Input);
 
-  story('Sizes', () => {
+  Story('Sizes', () => {
     return (
       <Fragment>
         <p>
@@ -34,7 +34,7 @@ export default storyBook('Input', (story, APIReference) => {
     );
   });
 
-  story('Locked', () => {
+  Story('Locked', () => {
     return (
       <Fragment>
         <p>

--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -7,9 +7,8 @@ import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedCo
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import {backend, frontend} from 'sentry/data/platformCategories';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {useLocation} from 'sentry/utils/useLocation';
 
 interface ExampleDataItem {
@@ -17,7 +16,7 @@ interface ExampleDataItem {
   name: string;
 }
 
-export default storyBook('GridEditable', story => {
+export default StoryBook('GridEditable', Story => {
   const columns: Array<GridColumnOrder<keyof ExampleDataItem>> = [
     {key: 'category', name: 'Platform Category'},
     {key: 'name', name: 'Platform Name'},
@@ -28,7 +27,7 @@ export default storyBook('GridEditable', story => {
     ...backend.slice(0, 3).map(name => ({name, category: 'backend' as const})),
   ];
 
-  story('Minimal', () => {
+  Story('Minimal', () => {
     return <GridEditable data={[]} columnOrder={columns} columnSortBy={[]} grid={{}} />;
   });
 
@@ -53,7 +52,7 @@ export default storyBook('GridEditable', story => {
         dataRow[column.key]
       : JSON.stringify({column, dataRow, rowIndex, columnIndex});
 
-  story('Basic', () => {
+  Story('Basic', () => {
     return (
       <Fragment>
         <p>
@@ -73,8 +72,8 @@ export default storyBook('GridEditable', story => {
     );
   });
 
-  story('Props', () => (
-    <SideBySide>
+  Story('Props', () => (
+    <Story.SideBySide>
       <div>
         <p>
           <JSXNode name="GridEditable" props={{error: String}} />
@@ -99,10 +98,10 @@ export default storyBook('GridEditable', story => {
           grid={{}}
         />
       </div>
-    </SideBySide>
+    </Story.SideBySide>
   ));
 
-  story('Row Mouse Events', () => {
+  Story('Row Mouse Events', () => {
     const [activeRowKey, setActiveRowKey] = useState<number | undefined>(undefined);
     const activeRow = activeRowKey !== undefined ? data[activeRowKey] : undefined;
 
@@ -158,7 +157,7 @@ export default storyBook('GridEditable', story => {
     };
   }
 
-  story('Column Resize', () => {
+  Story('Column Resize', () => {
     const statefulColumnResize = useStatefulColumnWidths();
 
     const location = useLocation();
@@ -174,7 +173,7 @@ export default storyBook('GridEditable', story => {
           You can keep track of the column widths by implementing the{' '}
           <JSXProperty name="onResizeColumn" value={Function} /> callback.
         </p>
-        <SideBySide>
+        <Story.SideBySide>
           <div>
             <p>In this example we are saving the column widths to state.</p>
             <GridEditable
@@ -204,12 +203,12 @@ export default storyBook('GridEditable', story => {
               }}
             />
           </div>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Fixed Height', () => (
+  Story('Fixed Height', () => (
     <GridEditable
       data={data}
       columnOrder={columns}
@@ -223,7 +222,7 @@ export default storyBook('GridEditable', story => {
     />
   ));
 
-  story('Header Augmentations', () => (
+  Story('Header Augmentations', () => (
     <Matrix
       render={GridEditable}
       propMatrix={{

--- a/static/app/components/replays/player/replayCurrentTime.stories.tsx
+++ b/static/app/components/replays/player/replayCurrentTime.stories.tsx
@@ -5,14 +5,13 @@ import ReplayCurrentTime from 'sentry/components/replays/player/replayCurrentTim
 import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
 import ReplayPlayPauseButton from 'sentry/components/replays/player/replayPlayPauseButton';
-import SideBySide from 'sentry/components/stories/sideBySide';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('ReplayCurrentTime', story => {
-  story('Default', () => {
+export default StoryBook('ReplayCurrentTime', Story => {
+  Story('Default', () => {
     function Example() {
       return (
-        <SideBySide>
+        <Story.SideBySide>
           <ReplayPlayPauseButton />
           <ReplayCurrentTime />
           <NegativeSpaceContainer style={{height: 300}}>
@@ -20,7 +19,7 @@ export default storyBook('ReplayCurrentTime', story => {
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>
-        </SideBySide>
+        </Story.SideBySide>
       );
     }
     return (
@@ -30,10 +29,10 @@ export default storyBook('ReplayCurrentTime', story => {
     );
   });
 
-  story('Jumping to different times', () => {
+  Story('Jumping to different times', () => {
     function Example() {
       return (
-        <SideBySide>
+        <Story.SideBySide>
           <ReplayPlayPauseButton />
           <ReplayCurrentTime />
           <JumpToOffsetButtonBar intervals={['0m', '1m', '12m']} />
@@ -43,7 +42,7 @@ export default storyBook('ReplayCurrentTime', story => {
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>
-        </SideBySide>
+        </Story.SideBySide>
       );
     }
     return (

--- a/static/app/components/replays/player/replayPlayer.stories.tsx
+++ b/static/app/components/replays/player/replayPlayer.stories.tsx
@@ -6,17 +6,16 @@ import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
 import ReplayPlayPauseButton from 'sentry/components/replays/player/replayPlayPauseButton';
 import ReplayPreferenceDropdown from 'sentry/components/replays/preferences/replayPreferenceDropdown';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import {StructuredData} from 'sentry/components/structuredEventData';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {useReplayPlayerState} from 'sentry/utils/replays/playback/providers/replayPlayerStateContext';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 
-export default storyBook('ReplayPlayer', story => {
-  story('Default', () => {
+export default StoryBook('ReplayPlayer', Story => {
+  Story('Default', () => {
     function Example() {
       return (
-        <SideBySide>
+        <Story.SideBySide>
           <ReplayPlayPauseButton />
           <ReplayCurrentTime />
           <ReplayPreferenceDropdown speedOptions={[0.5, 1, 2, 8]} />
@@ -28,7 +27,7 @@ export default storyBook('ReplayPlayer', story => {
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>
-        </SideBySide>
+        </Story.SideBySide>
       );
     }
     return (

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.stories.tsx
@@ -7,7 +7,6 @@ import {
   StaticReplayPreferences,
 } from 'sentry/components/replays/preferences/replayPreferences';
 import JSXNode from 'sentry/components/stories/jsxNode';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import storyBook from 'sentry/stories/storyBook';
 import {
@@ -15,8 +14,8 @@ import {
   useReplayPrefs,
 } from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 
-export default storyBook('ReplayPreferenceDropdown', story => {
-  story('Default - LocalStorageReplayPreferences', () => {
+export default storyBook('ReplayPreferenceDropdown', Story => {
+  Story('Default - LocalStorageReplayPreferences', () => {
     return (
       <Fragment>
         <p>
@@ -29,31 +28,31 @@ export default storyBook('ReplayPreferenceDropdown', story => {
           Whatever instance sets the value last is the winner.
         </p>
         <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
-          <SideBySide>
+          <Story.SideBySide>
             <DebugReplayPrefsState />
             <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
-          </SideBySide>
+          </Story.SideBySide>
         </ReplayPreferencesContextProvider>
       </Fragment>
     );
   });
 
-  story('No provider', () => {
+  Story('No provider', () => {
     return (
       <Fragment>
         <p>
           A parent <JSXNode name="ReplayPreferencesContextProvider" /> is what allows
           values to be changed. Without that in the tree changes will not be reflected.
         </p>
-        <SideBySide>
+        <Story.SideBySide>
           <DebugReplayPrefsState />
           <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('StaticReplayPreferences', () => {
+  Story('StaticReplayPreferences', () => {
     return (
       <Fragment>
         <p>
@@ -62,23 +61,23 @@ export default storyBook('ReplayPreferenceDropdown', story => {
         </p>
         <h4>StaticReplayPreferences</h4>
         <ReplayPreferencesContextProvider prefsStrategy={StaticReplayPreferences}>
-          <SideBySide>
+          <Story.SideBySide>
             <DebugReplayPrefsState />
             <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
-          </SideBySide>
+          </Story.SideBySide>
         </ReplayPreferencesContextProvider>
         <h4>StaticNoSkipReplayPreferences</h4>
         <ReplayPreferencesContextProvider prefsStrategy={StaticNoSkipReplayPreferences}>
-          <SideBySide>
+          <Story.SideBySide>
             <DebugReplayPrefsState />
             <ReplayPreferenceDropdown speedOptions={[1, 2, 3]} />
-          </SideBySide>
+          </Story.SideBySide>
         </ReplayPreferencesContextProvider>
       </Fragment>
     );
   });
 
-  story('hideFastForward', () => {
+  Story('hideFastForward', () => {
     return (
       <Fragment>
         <p>
@@ -86,10 +85,10 @@ export default storyBook('ReplayPreferenceDropdown', story => {
           desirable.
         </p>
         <ReplayPreferencesContextProvider prefsStrategy={StaticReplayPreferences}>
-          <SideBySide>
+          <Story.SideBySide>
             <DebugReplayPrefsState />
             <ReplayPreferenceDropdown hideFastForward speedOptions={[1, 2, 3]} />
-          </SideBySide>
+          </Story.SideBySide>
         </ReplayPreferencesContextProvider>
       </Fragment>
     );

--- a/static/app/components/segmentedControl.stories.tsx
+++ b/static/app/components/segmentedControl.stories.tsx
@@ -3,12 +3,11 @@ import {Fragment, useState} from 'react';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import {IconStats} from 'sentry/icons';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('SegmentedControl', story => {
-  story('Default', () => (
+export default StoryBook('SegmentedControl', Story => {
+  Story('Default', () => (
     <Fragment>
       <p>
         By default <JSXNode name="SegmentedControl" /> will keep track of what is
@@ -22,7 +21,7 @@ export default storyBook('SegmentedControl', story => {
     </Fragment>
   ));
 
-  story('Controlled Value', () => {
+  Story('Controlled Value', () => {
     const [value, setValue] = useState('two');
     return (
       <Fragment>
@@ -42,7 +41,7 @@ export default storyBook('SegmentedControl', story => {
     );
   });
 
-  story('Props', () => (
+  Story('Props', () => (
     <Matrix
       render={props => (
         <SegmentedControl {...props}>
@@ -59,8 +58,8 @@ export default storyBook('SegmentedControl', story => {
     />
   ));
 
-  story('SegmentedControl.Item', () => (
-    <SideBySide>
+  Story('SegmentedControl.Item', () => (
+    <Story.SideBySide>
       <Matrix
         render={({showChild, ...props}) => (
           <SegmentedControl>
@@ -133,6 +132,6 @@ export default storyBook('SegmentedControl', story => {
           priority: ['default' as const, 'primary' as const],
         }}
       />
-    </SideBySide>
+    </Story.SideBySide>
   ));
 });

--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -5,12 +5,11 @@ import {CodeSnippet} from 'sentry/components/codeSnippet';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import Matrix from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import StructuredEventData from 'sentry/components/structuredEventData';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('StructuredEventData', story => {
-  story('Default', () => {
+export default StoryBook('StructuredEventData', Story => {
+  Story('Default', () => {
     return (
       <Fragment>
         <p>
@@ -28,7 +27,7 @@ export default storyBook('StructuredEventData', story => {
     );
   });
 
-  story('Auto-Expanded items', () => (
+  Story('Auto-Expanded items', () => (
     <Matrix
       propMatrix={{
         data: [
@@ -53,7 +52,7 @@ export default storyBook('StructuredEventData', story => {
     />
   ));
 
-  story('Manually expanded items', () => {
+  Story('Manually expanded items', () => {
     const data = {
       foo: 'bar',
       'the_real_world?': {
@@ -67,7 +66,7 @@ export default storyBook('StructuredEventData', story => {
       arr6: [1, 2, 3, 4, 5, 6],
     };
     return (
-      <SideBySide>
+      <Story.SideBySide>
         <div>
           <p>Nothing</p>
           <StructuredEventData data={data} initialExpandedPaths={[]} />
@@ -96,11 +95,11 @@ export default storyBook('StructuredEventData', story => {
             ]}
           />
         </div>
-      </SideBySide>
+      </Story.SideBySide>
     );
   });
 
-  story('onToggleExpand', () => {
+  Story('onToggleExpand', () => {
     const [state, setState] = useState<string[]>();
     return (
       <Fragment>
@@ -122,7 +121,7 @@ export default storyBook('StructuredEventData', story => {
     );
   });
 
-  story('Annotations', () => {
+  Story('Annotations', () => {
     return (
       <Fragment>
         <p>
@@ -139,7 +138,7 @@ export default storyBook('StructuredEventData', story => {
     );
   });
 
-  story('Custom rendering of value types', () => {
+  Story('Custom rendering of value types', () => {
     return (
       <Fragment>
         <p>
@@ -180,7 +179,7 @@ export default storyBook('StructuredEventData', story => {
     );
   });
 
-  story('Allow copy to clipboard', () => {
+  Story('Allow copy to clipboard', () => {
     return (
       <Fragment>
         <p>

--- a/static/app/components/tabs/index.stories.tsx
+++ b/static/app/components/tabs/index.stories.tsx
@@ -3,20 +3,19 @@ import range from 'lodash/range';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
 import Matrix, {type PropMatrix} from 'sentry/components/stories/matrix';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import type {TabListProps, TabsProps} from 'sentry/components/tabs';
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
-export default storyBook('Tabs', story => {
+export default StoryBook('Tabs', Story => {
   const TABS = [
     {key: 'one', label: 'One', content: 'This is the first Panel.'},
     {key: 'two', label: 'Two', content: 'This is the second panel'},
     {key: 'three', label: 'Three', content: 'This is the third panel'},
   ];
 
-  story('Default', () => (
+  Story('Default', () => (
     <Fragment>
       <p>
         You should be using all of <JSXNode name="Tabs" />, <JSXNode name="TabList" />,{' '}
@@ -44,7 +43,7 @@ export default storyBook('Tabs', story => {
     </Fragment>
   ));
 
-  story('Items Overflow', () => {
+  Story('Items Overflow', () => {
     const tabs = range(65, 75).map(i => ({
       key: 'i' + i,
       label: String.fromCharCode(i, i, i, i),
@@ -66,7 +65,7 @@ export default storyBook('Tabs', story => {
     );
   });
 
-  story('Default Value', () => (
+  Story('Default Value', () => (
     <Fragment>
       <p>
         Set <JSXNode name="Tabs" props={{defaultValue: String}} />
@@ -88,7 +87,7 @@ export default storyBook('Tabs', story => {
     </Fragment>
   ));
 
-  story('Controlled Value', () => {
+  Story('Controlled Value', () => {
     const [selected, setSelected] = useState('two');
     return (
       <Fragment>
@@ -120,7 +119,7 @@ export default storyBook('Tabs', story => {
     );
   });
 
-  story('Rendering', () => (
+  Story('Rendering', () => (
     <Matrix<TabsProps<string> & TabListProps>
       render={props => (
         <Tabs orientation={props.orientation}>
@@ -144,8 +143,8 @@ export default storyBook('Tabs', story => {
     />
   ));
 
-  story('Disabled', () => (
-    <SideBySide>
+  Story('Disabled', () => (
+    <Story.SideBySide>
       <div>
         <p>
           Use <JSXNode name="Tabs" props={{disabled: true}} /> to disable everything.
@@ -185,10 +184,10 @@ export default storyBook('Tabs', story => {
           </Tabs>
         </SizingWindow>
       </div>
-    </SideBySide>
+    </Story.SideBySide>
   ));
 
-  story('Variants', () => {
+  Story('Variants', () => {
     const propMatrix: PropMatrix<TabsProps<string> & TabListProps> = {
       hideBorder: [undefined, false, true],
       orientation: [undefined, 'horizontal', 'vertical'],

--- a/static/app/stories/storyBook.tsx
+++ b/static/app/stories/storyBook.tsx
@@ -2,18 +2,26 @@ import type {ReactNode} from 'react';
 import {Children, Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import SideBySide from 'sentry/components/stories/sideBySide';
 import {space} from 'sentry/styles/space';
 import {StoryTypes} from 'sentry/views/stories/storyTypes';
 
-type StoryRenderFunction = () => ReactNode | ReactNode[];
-type StoryContext = (storyName: string, story: StoryRenderFunction) => void;
-type SetupFunction = (
-  story: StoryContext,
-  apiReference: (documentation: TypeLoader.ComponentDocWithFilename | undefined) => void
-) => void;
+const SideBySide = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+  flex-wrap: wrap;
+  align-items: flex-start;
+`;
 
-export default function storyBook(
+type StoryRenderFunction = () => ReactNode | ReactNode[];
+interface StoryContext {
+  (storyName: string, story: StoryRenderFunction): void;
+  APIReference: (documentation: TypeLoader.ComponentDocWithFilename | undefined) => void;
+  SideBySide: typeof SideBySide;
+}
+
+type SetupFunction = (story: StoryContext) => void;
+
+export default function StoryBook(
   title: string,
   setup: SetupFunction
 ): StoryRenderFunction {
@@ -22,18 +30,22 @@ export default function storyBook(
     render: StoryRenderFunction;
   }> = [];
   const APIDocumentation: Array<TypeLoader.ComponentDocWithFilename | undefined> = [];
-
-  const storyFn: StoryContext = (name: string, render: StoryRenderFunction) => {
-    stories.push({name, render});
-  };
-
-  const apiReferenceFn: (
+  const APIReference: (
     documentation: TypeLoader.ComponentDocWithFilename | undefined
   ) => void = (documentation: TypeLoader.ComponentDocWithFilename | undefined) => {
     APIDocumentation.push(documentation);
   };
 
-  setup(storyFn, apiReferenceFn);
+  function storyFn(name: string, render: StoryRenderFunction) {
+    stories.push({name, render});
+  }
+
+  Object.assign(storyFn, {
+    SideBySide,
+    APIReference,
+  });
+
+  setup(storyFn as StoryContext);
 
   return function RenderStory() {
     return (

--- a/static/app/views/dashboards/contexts/widgetSyncContext.stories.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.stories.tsx
@@ -3,8 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import JSXNode from 'sentry/components/stories/jsxNode';
-import SideBySide from 'sentry/components/stories/sideBySide';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
 import {sampleDurationTimeSeries} from '../widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries';
 import {sampleThroughputTimeSeries} from '../widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries';
@@ -12,8 +11,8 @@ import {TimeSeriesWidgetVisualization} from '../widgets/timeSeriesWidget/timeSer
 
 import {WidgetSyncContextProvider} from './widgetSyncContext';
 
-export default storyBook('WidgetSyncContext', story => {
-  story('Getting Started', () => {
+export default StoryBook('WidgetSyncContext', Story => {
+  Story('Getting Started', () => {
     const [visible, setVisible] = useState<boolean>(false);
 
     return (
@@ -30,7 +29,7 @@ export default storyBook('WidgetSyncContext', story => {
         </p>
 
         <WidgetSyncContextProvider>
-          <SideBySide>
+          <Story.SideBySide>
             <MediumWidget>
               <TimeSeriesWidgetVisualization
                 visualizationType="line"
@@ -45,7 +44,7 @@ export default storyBook('WidgetSyncContext', story => {
                 />
               </MediumWidget>
             )}
-          </SideBySide>
+          </Story.SideBySide>
         </WidgetSyncContextProvider>
       </Fragment>
     );

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.stories.tsx
@@ -3,15 +3,14 @@ import styled from '@emotion/styled';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
 import JSXProperty from 'sentry/components/stories/jsxProperty';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 import {space} from 'sentry/styles/space';
 
 import {BigNumberWidgetVisualization} from './bigNumberWidgetVisualization';
 
-export default storyBook('BigNumberWidgetVisualization', story => {
-  story('Getting Started', () => {
+export default StoryBook('BigNumberWidgetVisualization', Story => {
+  Story('Getting Started', () => {
     return (
       <Fragment>
         <p>
@@ -37,7 +36,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
     );
   });
 
-  story('Basic Visualization', () => {
+  Story('Basic Visualization', () => {
     return (
       <Fragment>
         <p>
@@ -53,7 +52,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
           most fields defined in our field renderer pipeline
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <SmallSizingWindow>
             <Container>
               <BigNumberWidgetVisualization
@@ -125,12 +124,12 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               />
             </Container>
           </SmallSizingWindow>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Loading Placeholder', () => {
+  Story('Loading Placeholder', () => {
     return (
       <Fragment>
         <p>
@@ -146,7 +145,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
     );
   });
 
-  story('Maximum Value', () => {
+  Story('Maximum Value', () => {
     return (
       <Fragment>
         <p>
@@ -157,7 +156,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
           something higher than the max. Setting{' '}
           <JSXProperty name="maximumValue" value={1000000} /> will show &gt;1m.
         </p>
-        <SideBySide>
+        <Story.SideBySide>
           <SmallWidget>
             <BigNumberWidgetVisualization
               value={1000000}
@@ -171,12 +170,12 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               }}
             />
           </SmallWidget>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Previous Period Data', () => {
+  Story('Previous Period Data', () => {
     return (
       <Fragment>
         <p>
@@ -193,7 +192,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
           colorization.
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <SmallWidget>
             <BigNumberWidgetVisualization
               value={17.1087819860850493}
@@ -238,12 +237,12 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               }}
             />
           </SmallWidget>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Thresholds', () => {
+  Story('Thresholds', () => {
     const meta = {
       fields: {
         'eps()': 'rate',
@@ -270,7 +269,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
           to the value.
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <SmallWidget>
             <BigNumberWidgetVisualization
               value={7.1}
@@ -300,14 +299,14 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               preferredPolarity="+"
             />
           </SmallWidget>
-        </SideBySide>
+        </Story.SideBySide>
 
         <p>
           The thresholds respect the preferred polarity. By default, the preferred
           polarity is positive (higher numbers are good).
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <SmallWidget>
             <BigNumberWidgetVisualization
               field="eps()"
@@ -337,7 +336,7 @@ export default storyBook('BigNumberWidgetVisualization', story => {
               preferredPolarity="-"
             />
           </SmallWidget>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -41,7 +41,7 @@ const sampleDurationTimeSeries2 = {
 };
 
 export default storyBook('TimeSeriesWidgetVisualization', Story => {
-  APIReference(types.TimeSeriesWidgetVisualization);
+  Story.APIReference(types.TimeSeriesWidgetVisualization);
 
   Story('Getting Started', () => {
     return (

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -5,7 +5,6 @@ import moment from 'moment-timezone';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import JSXNode from 'sentry/components/stories/jsxNode';
-import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import type {DateString} from 'sentry/types/core';
@@ -41,10 +40,10 @@ const sampleDurationTimeSeries2 = {
   },
 };
 
-export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) => {
+export default storyBook('TimeSeriesWidgetVisualization', Story => {
   APIReference(types.TimeSeriesWidgetVisualization);
 
-  story('Getting Started', () => {
+  Story('Getting Started', () => {
     return (
       <Fragment>
         <p>
@@ -69,7 +68,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           needs. If it doesn't, reach out to the Dashboards team.
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <SmallWidget>
             <TimeSeriesWidgetVisualization
               visualizationType="line"
@@ -88,12 +87,12 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
               timeSeries={[sampleDurationTimeSeries]}
             />
           </SmallWidget>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Data Format', () => {
+  Story('Data Format', () => {
     return (
       <Fragment>
         <p>
@@ -132,7 +131,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Choosing The Visualization Type', () => {
+  Story('Choosing The Visualization Type', () => {
     return (
       <Fragment>
         <p>Here are a few guidelines on how to choose the right visualization:</p>
@@ -156,7 +155,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Basic Plotting', () => {
+  Story('Basic Plotting', () => {
     return (
       <Fragment>
         <p>
@@ -181,7 +180,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Loading Placeholder', () => {
+  Story('Loading Placeholder', () => {
     return (
       <Fragment>
         <p>
@@ -197,7 +196,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Stacking', () => {
+  Story('Stacking', () => {
     return (
       <Fragment>
         <p>
@@ -206,7 +205,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           stacked.
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <MediumWidget>
             <TimeSeriesWidgetVisualization
               visualizationType="bar"
@@ -221,12 +220,12 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
             />
           </MediumWidget>
           <SmallWidget />
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Incomplete Data', () => {
+  Story('Incomplete Data', () => {
     const props = {
       dataCompletenessDelay: 60 * 60 * 3,
       timeSeries: [
@@ -242,7 +241,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           seconds. By default the delay is <code>0</code>.
         </p>
 
-        <SideBySide>
+        <Story.SideBySide>
           <MediumWidget>
             <TimeSeriesWidgetVisualization {...props} visualizationType="line" />
           </MediumWidget>
@@ -252,12 +251,12 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
           <MediumWidget>
             <TimeSeriesWidgetVisualization {...props} stacked visualizationType="bar" />
           </MediumWidget>
-        </SideBySide>
+        </Story.SideBySide>
       </Fragment>
     );
   });
 
-  story('Drag to Select', () => {
+  Story('Drag to Select', () => {
     const {start, end} = useLocationQuery({
       fields: {
         start: decodeScalar,
@@ -296,7 +295,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Legends', () => {
+  Story('Legends', () => {
     const [legendSelection, setLegendSelection] = useState<LegendSelection>({
       'p99(span.duration)': false,
     });
@@ -338,7 +337,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Colors', () => {
+  Story('Colors', () => {
     const theme = useTheme();
 
     return (
@@ -372,7 +371,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
     );
   });
 
-  story('Releases', () => {
+  Story('Releases', () => {
     const releases = [
       {
         version: 'ui@0.1.2',

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -5,7 +5,7 @@ import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
-import storyBook from 'sentry/stories/storyBook';
+import StoryBook from 'sentry/stories/storyBook';
 
 import {sampleDurationTimeSeries} from '../timeSeriesWidget/fixtures/sampleDurationTimeSeries';
 import {TimeSeriesWidgetVisualization} from '../timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -15,10 +15,10 @@ import {Widget} from './widget';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/views/dashboards/widgets/widget/widget';
 
-export default storyBook('Widget', (story, APIReference) => {
-  APIReference(types.exported);
+export default StoryBook('Widget', Story => {
+  Story.APIReference(types.exported);
 
-  story('Getting Started', () => {
+  Story('Getting Started', () => {
     const isLoading = false;
     const hasError = false;
 
@@ -62,7 +62,7 @@ export default storyBook('Widget', (story, APIReference) => {
     );
   });
 
-  story('Widget', () => {
+  Story('Widget', () => {
     return (
       <Fragment>
         <p>


### PR DESCRIPTION
Something that has bothered me for a while is the fact that each story requires imports for specific layout component (jsx nodes, layout component etc). Ultimately, even the approach of APIReference component being provided as the second argument is not super intuitive.

The solution proposed here is one where the layout components and storybook primitives are provided on the story callback function.

I've taken the example of moving APIReference and SideBySide layout component to the story callback to see how such an approach would scale. I think this strengthens the notion of stories providing all the building blocks that are required for a story, and somewhat guides us to write less components inside `components/stories`