### PR TITLE
feat(tours): Introduce a Tours API via hooks/context

### DIFF
--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -1,0 +1,263 @@
+import {createContext, useContext} from 'react';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {
+  TourContextProvider,
+  TourElement,
+  type TourElementProps,
+} from 'sentry/components/tours/components';
+import {type TourContextType, useTourReducer} from 'sentry/components/tours/tourContext';
+
+const enum TestTour {
+  NAME = 'test-tour-name',
+  EMAIL = 'test-tour-email',
+  PASSWORD = 'test-tour-password',
+}
+const ORDERED_TEST_TOUR = [TestTour.NAME, TestTour.EMAIL, TestTour.PASSWORD];
+const TestTourContext = createContext<TourContextType<TestTour>>({
+  currentStepId: null,
+  isAvailable: true,
+  isRegistered: false,
+  orderedStepIds: ORDERED_TEST_TOUR,
+  dispatch: () => {},
+  handleStepRegistration: () => () => {},
+});
+function useTestTour(): TourContextType<TestTour> {
+  return useContext(TestTourContext);
+}
+function TestTourElement(props: TourElementProps<TestTour>) {
+  const tourContext = useTestTour();
+  return <TourElement tourContext={tourContext} {...props} />;
+}
+
+const emptyTourContext = {
+  currentStepId: null,
+  isAvailable: true,
+  isRegistered: false,
+  orderedStepIds: [],
+  dispatch: jest.fn(),
+  handleStepRegistration: jest.fn(),
+};
+
+jest.mock('sentry/components/tours/tourContext', () => ({
+  useTourReducer: jest.fn(),
+}));
+
+const mockUseTourReducer = jest.mocked(useTourReducer);
+
+describe('Tour Components', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('TourContextProvider', () => {
+    it('renders children regardless of availability', () => {
+      mockUseTourReducer.mockReturnValue(emptyTourContext);
+
+      const {container: availableContainer} = render(
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
+        >
+          <div>Child Content</div>
+        </TourContextProvider>
+      );
+      expect(within(availableContainer).getByText('Child Content')).toBeInTheDocument();
+
+      const {container: unavailableContainer} = render(
+        <TourContextProvider
+          isAvailable={false}
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
+        >
+          <div>Child Content</div>
+        </TourContextProvider>
+      );
+      expect(within(unavailableContainer).getByText('Child Content')).toBeInTheDocument();
+    });
+
+    it('does render blur based on omitBlur', () => {
+      mockUseTourReducer.mockReturnValue({
+        ...emptyTourContext,
+        isRegistered: true,
+        currentStepId: TestTour.NAME,
+      });
+      const {container: blurContainer} = render(
+        <TourContextProvider
+          orderedStepIds={ORDERED_TEST_TOUR}
+          isAvailable
+          tourContext={TestTourContext}
+        >
+          <div>Child Content</div>
+        </TourContextProvider>
+      );
+      expect(within(blurContainer).getByTestId('tour-blur-window')).toBeInTheDocument();
+
+      const {container: noBlurContainer} = render(
+        <TourContextProvider
+          orderedStepIds={ORDERED_TEST_TOUR}
+          isAvailable
+          tourContext={TestTourContext}
+          omitBlur
+        >
+          <div>Child Content</div>
+        </TourContextProvider>
+      );
+      expect(
+        within(noBlurContainer).queryByTestId('tour-blur-window')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('TourElement', () => {
+    it('renders children regardless of tour state', async () => {
+      mockUseTourReducer.mockReturnValue(emptyTourContext);
+      const {container: inactiveContainer} = render(
+        <TourElement<TestTour>
+          id={TestTour.NAME}
+          title="Test Title"
+          description="Test Description"
+          tourContext={emptyTourContext}
+        >
+          <div>Child Element</div>
+        </TourElement>
+      );
+
+      expect(within(inactiveContainer).getByText('Child Element')).toBeInTheDocument();
+
+      const {container: activeContainer} = render(
+        <TourElement<TestTour>
+          id={TestTour.NAME}
+          title="Test Title"
+          description="Test Description"
+          tourContext={{
+            ...emptyTourContext,
+            orderedStepIds: ORDERED_TEST_TOUR,
+            isRegistered: true,
+            currentStepId: TestTour.NAME,
+          }}
+        >
+          <div>Child Element</div>
+        </TourElement>
+      );
+      expect(await within(activeContainer).findByText('Test Title')).toBeInTheDocument();
+      expect(within(activeContainer).getByText('Child Element')).toBeInTheDocument();
+    });
+
+    it('renders overlay when step is active', async () => {
+      const {unmount: unmountFirstStep} = render(
+        <TourElement<TestTour>
+          id={TestTour.NAME}
+          title="Test Title"
+          description="Test Description"
+          tourContext={{
+            ...emptyTourContext,
+            orderedStepIds: ORDERED_TEST_TOUR,
+            isRegistered: true,
+            currentStepId: TestTour.NAME,
+          }}
+        >
+          <div>Child Element</div>
+        </TourElement>
+      );
+
+      expect(await screen.findByText('Test Title')).toBeInTheDocument();
+      expect(screen.getByText('Test Description')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Close'})).toBeInTheDocument();
+
+      expect(screen.getByText('1/3')).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Finish tour'})).not.toBeInTheDocument();
+
+      unmountFirstStep();
+
+      const {unmount: unmountSecondStep} = render(
+        <TourElement<TestTour>
+          id={TestTour.EMAIL}
+          title="Test Title"
+          description="Test Description"
+          tourContext={{
+            ...emptyTourContext,
+            orderedStepIds: ORDERED_TEST_TOUR,
+            isRegistered: true,
+            currentStepId: TestTour.EMAIL,
+          }}
+        >
+          <div>Child Element</div>
+        </TourElement>
+      );
+
+      expect(await screen.findByText('2/3')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Previous'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Finish tour'})).not.toBeInTheDocument();
+
+      unmountSecondStep();
+
+      render(
+        <TourElement<TestTour>
+          id={TestTour.PASSWORD}
+          title="Test Title"
+          description="Test Description"
+          tourContext={{
+            ...emptyTourContext,
+            orderedStepIds: ORDERED_TEST_TOUR,
+            isRegistered: true,
+            currentStepId: TestTour.PASSWORD,
+          }}
+        >
+          <div>Child Element</div>
+        </TourElement>
+      );
+
+      expect(await screen.findByText('3/3')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Previous'})).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Next'})).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Finish tour'})).toBeInTheDocument();
+    });
+
+    it('handles registration of the tour steps', () => {
+      const mockHandleStepRegistration = jest.fn();
+      mockUseTourReducer.mockReturnValue({
+        ...emptyTourContext,
+        handleStepRegistration: mockHandleStepRegistration,
+      });
+      render(
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
+        >
+          <TestTourElement id={TestTour.NAME} title="Name" description="The name">
+            Name
+          </TestTourElement>
+          <TestTourElement id={TestTour.EMAIL} title="Email" description="The email">
+            Email
+          </TestTourElement>
+          <TestTourElement
+            id={TestTour.PASSWORD}
+            title="Password"
+            description="The password"
+          >
+            Password
+          </TestTourElement>
+        </TourContextProvider>
+      );
+      expect(mockHandleStepRegistration).toHaveBeenCalledWith({
+        id: TestTour.NAME,
+        element: expect.any(HTMLElement),
+      });
+      expect(mockHandleStepRegistration).toHaveBeenCalledWith({
+        id: TestTour.EMAIL,
+        element: expect.any(HTMLElement),
+      });
+      expect(mockHandleStepRegistration).toHaveBeenCalledWith({
+        id: TestTour.PASSWORD,
+        element: expect.any(HTMLElement),
+      });
+    });
+  });
+});

--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -1,44 +1,14 @@
-import {createContext, useContext} from 'react';
-
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
+import {TourContextProvider, TourElement} from 'sentry/components/tours/components';
 import {
-  TourContextProvider,
-  TourElement,
-  type TourElementProps,
-} from 'sentry/components/tours/components';
-import {type TourContextType, useTourReducer} from 'sentry/components/tours/tourContext';
-
-const enum TestTour {
-  NAME = 'test-tour-name',
-  EMAIL = 'test-tour-email',
-  PASSWORD = 'test-tour-password',
-}
-const ORDERED_TEST_TOUR = [TestTour.NAME, TestTour.EMAIL, TestTour.PASSWORD];
-const TestTourContext = createContext<TourContextType<TestTour>>({
-  currentStepId: null,
-  isAvailable: true,
-  isRegistered: false,
-  orderedStepIds: ORDERED_TEST_TOUR,
-  dispatch: () => {},
-  handleStepRegistration: () => () => {},
-});
-function useTestTour(): TourContextType<TestTour> {
-  return useContext(TestTourContext);
-}
-function TestTourElement(props: TourElementProps<TestTour>) {
-  const tourContext = useTestTour();
-  return <TourElement tourContext={tourContext} {...props} />;
-}
-
-const emptyTourContext = {
-  currentStepId: null,
-  isAvailable: true,
-  isRegistered: false,
-  orderedStepIds: [],
-  dispatch: jest.fn(),
-  handleStepRegistration: jest.fn(),
-};
+  emptyTourContext,
+  ORDERED_TEST_TOUR,
+  TestTour,
+  TestTourContext,
+  TestTourElement,
+} from 'sentry/components/tours/testUtils';
+import {useTourReducer} from 'sentry/components/tours/tourContext';
 
 jest.mock('sentry/components/tours/tourContext', () => ({
   useTourReducer: jest.fn(),

--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -6,7 +6,6 @@ import {
   ORDERED_TEST_TOUR,
   TestTour,
   TestTourContext,
-  TestTourElement,
 } from 'sentry/components/tours/testUtils';
 import {useTourReducer} from 'sentry/components/tours/tourContext';
 
@@ -85,52 +84,71 @@ describe('Tour Components', () => {
     it('renders children regardless of tour state', async () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
       const {container: inactiveContainer} = render(
-        <TourElement<TestTour>
-          id={TestTour.NAME}
-          title="Test Title"
-          description="Test Description"
-          tourContext={emptyTourContext}
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
         >
-          <div>Child Element</div>
-        </TourElement>
+          <TourElement<TestTour>
+            id={TestTour.NAME}
+            title="Test Title"
+            description="Test Description"
+            tourContext={TestTourContext}
+          >
+            <div>Child Element</div>
+          </TourElement>
+        </TourContextProvider>
       );
 
       expect(within(inactiveContainer).getByText('Child Element')).toBeInTheDocument();
 
+      mockUseTourReducer.mockReturnValue({
+        ...emptyTourContext,
+        isRegistered: true,
+        currentStepId: TestTour.NAME,
+      });
       const {container: activeContainer} = render(
-        <TourElement<TestTour>
-          id={TestTour.NAME}
-          title="Test Title"
-          description="Test Description"
-          tourContext={{
-            ...emptyTourContext,
-            orderedStepIds: ORDERED_TEST_TOUR,
-            isRegistered: true,
-            currentStepId: TestTour.NAME,
-          }}
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
         >
-          <div>Child Element</div>
-        </TourElement>
+          <TourElement<TestTour>
+            id={TestTour.NAME}
+            title="Test Title"
+            description="Test Description"
+            tourContext={TestTourContext}
+          >
+            <div>Child Element</div>
+          </TourElement>
+        </TourContextProvider>
       );
       expect(await within(activeContainer).findByText('Test Title')).toBeInTheDocument();
       expect(within(activeContainer).getByText('Child Element')).toBeInTheDocument();
     });
 
     it('renders overlay when step is active', async () => {
+      mockUseTourReducer.mockReturnValue({
+        ...emptyTourContext,
+        orderedStepIds: ORDERED_TEST_TOUR,
+        isRegistered: true,
+        currentStepId: TestTour.NAME,
+      });
       const {unmount: unmountFirstStep} = render(
-        <TourElement<TestTour>
-          id={TestTour.NAME}
-          title="Test Title"
-          description="Test Description"
-          tourContext={{
-            ...emptyTourContext,
-            orderedStepIds: ORDERED_TEST_TOUR,
-            isRegistered: true,
-            currentStepId: TestTour.NAME,
-          }}
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
         >
-          <div>Child Element</div>
-        </TourElement>
+          <TourElement<TestTour>
+            id={TestTour.NAME}
+            title="Test Title"
+            description="Test Description"
+            tourContext={TestTourContext}
+          >
+            <div>Child Element</div>
+          </TourElement>
+        </TourContextProvider>
       );
 
       expect(await screen.findByText('Test Title')).toBeInTheDocument();
@@ -143,21 +161,28 @@ describe('Tour Components', () => {
       expect(screen.queryByRole('button', {name: 'Finish tour'})).not.toBeInTheDocument();
 
       unmountFirstStep();
+      mockUseTourReducer.mockReturnValue({
+        ...emptyTourContext,
+        orderedStepIds: ORDERED_TEST_TOUR,
+        isRegistered: true,
+        currentStepId: TestTour.EMAIL,
+      });
 
       const {unmount: unmountSecondStep} = render(
-        <TourElement<TestTour>
-          id={TestTour.EMAIL}
-          title="Test Title"
-          description="Test Description"
-          tourContext={{
-            ...emptyTourContext,
-            orderedStepIds: ORDERED_TEST_TOUR,
-            isRegistered: true,
-            currentStepId: TestTour.EMAIL,
-          }}
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
         >
-          <div>Child Element</div>
-        </TourElement>
+          <TourElement<TestTour>
+            id={TestTour.EMAIL}
+            title="Test Title"
+            description="Test Description"
+            tourContext={TestTourContext}
+          >
+            <div>Child Element</div>
+          </TourElement>
+        </TourContextProvider>
       );
 
       expect(await screen.findByText('2/3')).toBeInTheDocument();
@@ -166,21 +191,28 @@ describe('Tour Components', () => {
       expect(screen.queryByRole('button', {name: 'Finish tour'})).not.toBeInTheDocument();
 
       unmountSecondStep();
+      mockUseTourReducer.mockReturnValue({
+        ...emptyTourContext,
+        orderedStepIds: ORDERED_TEST_TOUR,
+        isRegistered: true,
+        currentStepId: TestTour.PASSWORD,
+      });
 
       render(
-        <TourElement<TestTour>
-          id={TestTour.PASSWORD}
-          title="Test Title"
-          description="Test Description"
-          tourContext={{
-            ...emptyTourContext,
-            orderedStepIds: ORDERED_TEST_TOUR,
-            isRegistered: true,
-            currentStepId: TestTour.PASSWORD,
-          }}
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_TEST_TOUR}
+          tourContext={TestTourContext}
         >
-          <div>Child Element</div>
-        </TourElement>
+          <TourElement
+            id={TestTour.PASSWORD}
+            title="Test Title"
+            description="Test Description"
+            tourContext={TestTourContext}
+          >
+            <div>Child Element</div>
+          </TourElement>
+        </TourContextProvider>
       );
 
       expect(await screen.findByText('3/3')).toBeInTheDocument();
@@ -201,19 +233,30 @@ describe('Tour Components', () => {
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
         >
-          <TestTourElement id={TestTour.NAME} title="Name" description="The name">
+          <TourElement
+            tourContext={TestTourContext}
+            id={TestTour.NAME}
+            title="Name"
+            description="The name"
+          >
             Name
-          </TestTourElement>
-          <TestTourElement id={TestTour.EMAIL} title="Email" description="The email">
+          </TourElement>
+          <TourElement
+            tourContext={TestTourContext}
+            id={TestTour.EMAIL}
+            title="Email"
+            description="The email"
+          >
             Email
-          </TestTourElement>
-          <TestTourElement
+          </TourElement>
+          <TourElement
+            tourContext={TestTourContext}
             id={TestTour.PASSWORD}
             title="Password"
             description="The password"
           >
             Password
-          </TestTourElement>
+          </TourElement>
         </TourContextProvider>
       );
       expect(mockHandleStepRegistration).toHaveBeenCalledWith({

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -26,13 +26,13 @@ interface TourContextProviderProps<T extends TourEnumType> {
    */
   children: React.ReactNode;
   /**
-   * The initial state of the tour.
+   * Whether the tour can be accessed by the user
    */
-  initialState: Partial<TourState<T>>;
+  isAvailable: TourState<T>['isAvailable'];
   /**
    * The ordered list of Step IDs
    */
-  orderedStepIds: T[];
+  orderedStepIds: TourState<T>['orderedStepIds'];
   /**
    * The React context (from createContext) containing the provider for the tour.
    * The value for this prop comes from useTourReducer, to avoid extra steps.
@@ -42,11 +42,11 @@ interface TourContextProviderProps<T extends TourEnumType> {
 
 export function TourContextProvider<T extends TourEnumType>({
   children,
-  initialState,
-  orderedStepIds,
+  isAvailable,
   tourContext: TourContext,
+  orderedStepIds,
 }: TourContextProviderProps<T>) {
-  const tourContext = useTourReducer<T>({initialState, orderedStepIds});
+  const tourContext = useTourReducer<T>({isAvailable, orderedStepIds, currentStep: null});
   const isTourActive = tourContext.currentStep !== null;
   return (
     <TourContext.Provider value={tourContext}>

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -49,10 +49,10 @@ export function TourContextProvider<T extends TourEnumType>({
   const tourContextValue = useTourReducer<T>({
     isAvailable,
     orderedStepIds,
-    currentStep: null,
+    currentStepId: null,
   });
-  const {dispatch, currentStep} = tourContextValue;
-  const isTourActive = currentStep !== null;
+  const {dispatch, currentStepId} = tourContextValue;
+  const isTourActive = currentStepId !== null;
 
   const tourHotkeys = useMemo(() => {
     return [
@@ -117,12 +117,12 @@ export function TourElement<T extends TourEnumType>({
   className,
 }: BaseTourElementProps<T>) {
   const theme = useTheme();
-  const {currentStep, dispatch, orderedStepIds, registerStep} = tourContext;
-  const stepCount = currentStep ? orderedStepIds.indexOf(id) + 1 : 0;
+  const {currentStepId, dispatch, orderedStepIds, registerStep} = tourContext;
+  const stepCount = currentStepId ? orderedStepIds.indexOf(id) + 1 : 0;
   const stepTotal = orderedStepIds.length;
   const hasPreviousStep = stepCount > 1;
   const hasNextStep = stepCount < stepTotal;
-  const isOpen = currentStep?.id === id;
+  const isOpen = currentStepId === id;
 
   const {triggerProps, triggerRef, overlayProps} = useOverlay({
     isOpen,

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -99,7 +99,7 @@ export function TourElement<T extends TourEnumType>({
 }: TourElementProps<T>) {
   const theme = useTheme();
 
-  const {dispatch, currentStep, orderedStepIds} = tourContext;
+  const {currentStep, dispatch, orderedStepIds, registerStep} = tourContext;
   const stepCount = currentStep ? orderedStepIds.indexOf(id) + 1 : 0;
   const stepTotal = orderedStepIds.length;
   const hasPreviousStep = stepCount > 1;
@@ -110,11 +110,8 @@ export function TourElement<T extends TourEnumType>({
   const {current: element} = triggerRef;
 
   useEffect(() => {
-    dispatch({
-      type: 'REGISTER_STEP',
-      step: {id, element},
-    });
-  }, [id, element, dispatch]);
+    registerStep({id, element});
+  }, [id, element, registerStep]);
 
   return (
     <Fragment>

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -48,6 +48,7 @@ export function TourContextProvider<T extends TourEnumType>({
 }: TourContextProviderProps<T>) {
   const tourContextValue = useTourReducer<T>({
     isAvailable,
+    isRegistered: false,
     orderedStepIds,
     currentStepId: null,
   });

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -139,7 +139,7 @@ export function TourElement<T extends TourEnumType>({
         {children}
       </ElementWrapper>
       {isOpen ? (
-        <PositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
+        <PositionWrapper zIndex={theme.zIndex.tour.overlay} {...overlayProps}>
           <TourOverlay animated>
             <TopRow>
               <div>
@@ -182,7 +182,7 @@ const BlurWindow = styled('div')`
   content: '';
   position: absolute;
   inset: 0;
-  z-index: ${p => p.theme.zIndex.modal};
+  z-index: ${p => p.theme.zIndex.tour.blur};
   user-select: none;
   pointer-events: none;
   backdrop-filter: blur(3px);
@@ -191,7 +191,7 @@ const BlurWindow = styled('div')`
 const ElementWrapper = styled('div')`
   &[aria-expanded='true'] {
     position: relative;
-    z-index: ${p => p.theme.zIndex.toast};
+    z-index: ${p => p.theme.zIndex.tour.element};
     user-select: none;
     pointer-events: none;
     &:after {

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
-import {Flex} from 'sentry/components/container/flex';
+import ButtonBar from 'sentry/components/buttonBar';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {
   type TourContextType,
@@ -72,8 +72,7 @@ export function TourContextProvider<T extends TourEnumType>({
   );
 }
 
-export interface TourElementProps<T extends TourEnumType>
-  extends Partial<UseOverlayProps> {
+interface BaseTourElementProps<T extends TourEnumType> extends Partial<UseOverlayProps> {
   /**
    * The content being focused during the tour.
    */
@@ -100,6 +99,14 @@ export interface TourElementProps<T extends TourEnumType>
   className?: string;
 }
 
+/**
+ * Most implementations of TourElementProps will hook in their own context.
+ */
+export type TourElementProps<T extends TourEnumType> = Omit<
+  BaseTourElementProps<T>,
+  'tourContext'
+>;
+
 export function TourElement<T extends TourEnumType>({
   children,
   id,
@@ -108,9 +115,8 @@ export function TourElement<T extends TourEnumType>({
   tourContext,
   position,
   className,
-}: TourElementProps<T>) {
+}: BaseTourElementProps<T>) {
   const theme = useTheme();
-
   const {currentStep, dispatch, orderedStepIds, registerStep} = tourContext;
   const stepCount = currentStep ? orderedStepIds.indexOf(id) + 1 : 0;
   const stepTotal = orderedStepIds.length;
@@ -125,9 +131,7 @@ export function TourElement<T extends TourEnumType>({
   });
   const element = triggerRef.current;
 
-  useEffect(() => {
-    registerStep({id, element});
-  }, [id, element, registerStep]);
+  useEffect(() => registerStep({id, element}), [id, element, registerStep]);
 
   return (
     <Fragment>
@@ -155,7 +159,7 @@ export function TourElement<T extends TourEnumType>({
             </TopRow>
             <TitleRow>{title}</TitleRow>
             <div>{description}</div>
-            <Flex justify="flex-end" gap={space(1)}>
+            <ActionBar gap={1}>
               {hasPreviousStep && (
                 <ActionButton size="xs" onClick={() => dispatch({type: 'PREVIOUS_STEP'})}>
                   {t('Previous')}
@@ -170,7 +174,7 @@ export function TourElement<T extends TourEnumType>({
                   {t('Finish tour')}
                 </ActionButton>
               )}
-            </Flex>
+            </ActionBar>
           </TourOverlay>
         </PositionWrapper>
       ) : null}
@@ -235,6 +239,10 @@ const TopRow = styled('div')`
 const TitleRow = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const ActionBar = styled(ButtonBar)`
+  justify-content: flex-end;
 `;
 
 const ActionButton = styled(Button)`

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -118,7 +118,7 @@ export function TourElement<T extends TourEnumType>({
   className,
 }: BaseTourElementProps<T>) {
   const theme = useTheme();
-  const {currentStepId, dispatch, orderedStepIds, registerStep} = tourContext;
+  const {currentStepId, dispatch, orderedStepIds, handleStepRegistration} = tourContext;
   const stepCount = currentStepId ? orderedStepIds.indexOf(id) + 1 : 0;
   const stepTotal = orderedStepIds.length;
   const hasPreviousStep = stepCount > 1;
@@ -132,7 +132,10 @@ export function TourElement<T extends TourEnumType>({
   });
   const element = triggerRef.current;
 
-  useEffect(() => registerStep({id, element}), [id, element, registerStep]);
+  useEffect(
+    () => handleStepRegistration({id, element}),
+    [id, element, handleStepRegistration]
+  );
 
   return (
     <Fragment>

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useContext, useEffect, useMemo} from 'react';
+import {Fragment, type HTMLAttributes, useContext, useEffect, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -78,7 +78,7 @@ export function TourContextProvider<T extends TourEnumType>({
 }
 
 export interface TourElementProps<T extends TourEnumType>
-  extends Partial<UseOverlayProps> {
+  extends Omit<HTMLAttributes<HTMLElement>, 'id' | 'title'> {
   /**
    * The content being focused during the tour.
    */
@@ -100,9 +100,9 @@ export interface TourElementProps<T extends TourEnumType>
    */
   tourContext: React.Context<TourContextType<T> | null>;
   /**
-   * The className of the wrapper element.
+   * The position of the tour element.
    */
-  className?: string;
+  position?: UseOverlayProps['position'];
 }
 
 export function TourElement<T extends TourEnumType>({
@@ -153,13 +153,13 @@ function TourElementContent<T extends TourEnumType>({
 
   return (
     <Fragment>
-      <ElementWrapper
+      <TourTriggerWrapper
         className={className}
         ref={triggerProps.ref}
         aria-expanded={triggerProps['aria-expanded']}
       >
         {children}
-      </ElementWrapper>
+      </TourTriggerWrapper>
       {isOpen ? (
         <PositionWrapper zIndex={theme.zIndex.tour.overlay} {...overlayProps}>
           <TourOverlay animated>
@@ -210,7 +210,7 @@ const BlurWindow = styled('div')`
   backdrop-filter: blur(3px);
 `;
 
-const ElementWrapper = styled('div')`
+const TourTriggerWrapper = styled('div')`
   &[aria-expanded='true'] {
     position: relative;
     z-index: ${p => p.theme.zIndex.tour.element};

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -1,0 +1,206 @@
+import {Fragment, useEffect} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {FocusScope} from '@react-aria/focus';
+
+import {Button} from 'sentry/components/button';
+import {Flex} from 'sentry/components/container/flex';
+import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {
+  type TourContextType,
+  type TourEnumType,
+  type TourState,
+  type TourStep,
+  useTourReducer,
+} from 'sentry/components/tours/tourContext';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useOverlay, {type UseOverlayProps} from 'sentry/utils/useOverlay';
+
+export function TourContextProvider<T extends TourEnumType>({
+  children,
+  initialState,
+  orderedStepIds,
+  tourContext: TourContext,
+}: {
+  children: React.ReactNode;
+  initialState: Partial<TourState<T>>;
+  orderedStepIds: T[];
+  tourContext: React.Context<TourContextType<T>>;
+}) {
+  const tourContext = useTourReducer<T>({initialState, orderedStepIds});
+  const isTourActive = tourContext.currentStep !== null;
+  return (
+    <TourContext.Provider value={tourContext}>
+      <BlurContainer>
+        {children}
+        {isTourActive && <BlurWindow />}
+      </BlurContainer>
+    </TourContext.Provider>
+  );
+}
+
+export interface TourElementProps<T extends TourEnumType>
+  extends Partial<UseOverlayProps> {
+  /**
+   * The content being focused during the tour.
+   */
+  children: React.ReactNode;
+  /**
+   * The description of the tour step.
+   */
+  description: string;
+  id: TourStep<T>['id'];
+  /**
+   * The title of the tour step.
+   */
+  title: string;
+  /**
+   * The tour context.
+   */
+  tourContext: TourContextType<T>;
+}
+
+export function TourElement<T extends TourEnumType>({
+  children,
+  id,
+  title,
+  description,
+  tourContext,
+  position,
+}: TourElementProps<T>) {
+  const theme = useTheme();
+
+  const {dispatch, currentStep, orderedStepIds} = tourContext;
+  const stepCount = currentStep ? orderedStepIds.indexOf(id) + 1 : 0;
+  const stepTotal = orderedStepIds.length;
+  const hasPreviousStep = stepCount > 1;
+  const hasNextStep = stepCount < stepTotal;
+  const isOpen = currentStep?.id === id;
+
+  const {triggerProps, triggerRef, overlayProps} = useOverlay({isOpen, position});
+  const {current: element} = triggerRef;
+
+  useEffect(() => {
+    dispatch({
+      type: 'REGISTER_STEP',
+      step: {id, element},
+    });
+  }, [id, element, dispatch]);
+
+  const focusStyles = css`
+    position: relative;
+    z-index: ${theme.zIndex.toast};
+    &:after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: ${theme.borderRadius};
+      box-shadow: inset 0 0 0 3px ${theme.subText};
+    }
+  `;
+
+  return (
+    <Fragment>
+      <div css={isOpen ? focusStyles : undefined} {...triggerProps}>
+        {children}
+      </div>
+      {isOpen ? (
+        <FocusScope autoFocus restoreFocus>
+          <PositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
+            <TourOverlay animated>
+              <TopRow>
+                <div>
+                  {stepCount}/{stepTotal}
+                </div>
+                <TourCloseButton
+                  onClick={() => dispatch({type: 'END_TOUR'})}
+                  icon={<IconClose style={{color: theme.inverted.textColor}} />}
+                  aria-label={t('Close')}
+                  borderless
+                  size="sm"
+                />
+              </TopRow>
+              <TitleRow>{title}</TitleRow>
+              <div>{description}</div>
+              <Flex justify="flex-end" gap={1}>
+                {hasPreviousStep && (
+                  <ActionButton
+                    size="xs"
+                    onClick={() => dispatch({type: 'PREVIOUS_STEP'})}
+                  >
+                    {t('Previous')}
+                  </ActionButton>
+                )}
+                {hasNextStep ? (
+                  <ActionButton size="xs" onClick={() => dispatch({type: 'NEXT_STEP'})}>
+                    {t('Next')}
+                  </ActionButton>
+                ) : (
+                  <ActionButton size="xs" onClick={() => dispatch({type: 'END_TOUR'})}>
+                    {t('Finish tour')}
+                  </ActionButton>
+                )}
+              </Flex>
+            </TourOverlay>
+          </PositionWrapper>
+        </FocusScope>
+      ) : null}
+    </Fragment>
+  );
+}
+
+const BlurContainer = styled('div')`
+  position: relative;
+`;
+
+const BlurWindow = styled('div')`
+  position: absolute;
+  inset: 0;
+  content: '';
+  z-index: ${p => p.theme.zIndex.modal};
+  user-select: none;
+  backdrop-filter: blur(3px);
+  overscroll-behavior: none;
+`;
+
+const TourOverlay = styled(Overlay)`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.75)};
+  background: ${p => p.theme.inverted.surface400};
+  padding: ${space(1.5)} ${space(2)};
+  color: ${p => p.theme.inverted.textColor};
+  border-radius: ${p => p.theme.borderRadius};
+  max-width: 360px;
+`;
+
+const TourCloseButton = styled(Button)`
+  display: block;
+  padding: 0;
+  height: 14px;
+`;
+
+const TopRow = styled('div')`
+  display: flex;
+  height: 18px;
+  justify-content: space-between;
+  align-items: center;
+  color: ${p => p.theme.inverted.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightBold};
+  opacity: 0.6;
+`;
+
+const TitleRow = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const ActionButton = styled(Button)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.textColor};
+  background: ${p => p.theme.surface400};
+  border: 0;
+`;

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -106,8 +106,12 @@ export function TourElement<T extends TourEnumType>({
   const hasNextStep = stepCount < stepTotal;
   const isOpen = currentStep?.id === id;
 
-  const {triggerProps, triggerRef, overlayProps} = useOverlay({isOpen, position});
-  const {current: element} = triggerRef;
+  const {triggerProps, triggerRef, overlayProps} = useOverlay({
+    isOpen,
+    position,
+    disableTrigger: true,
+  });
+  const element = triggerRef.current;
 
   useEffect(() => {
     registerStep({id, element});
@@ -115,7 +119,11 @@ export function TourElement<T extends TourEnumType>({
 
   return (
     <Fragment>
-      <ElementWrapper {...triggerProps} className={className}>
+      <ElementWrapper
+        className={className}
+        ref={triggerProps.ref}
+        aria-expanded={triggerProps['aria-expanded']}
+      >
         {children}
       </ElementWrapper>
       {isOpen ? (

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -72,7 +72,7 @@ export function TourContextProvider<T extends TourEnumType>({
 
   return (
     <tourContext.Provider value={tourContextValue}>
-      {isTourActive && !omitBlur && <BlurWindow />}
+      {isTourActive && !omitBlur && <BlurWindow data-test-id="tour-blur-window" />}
       {children}
     </tourContext.Provider>
   );

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -18,17 +18,34 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOverlay, {type UseOverlayProps} from 'sentry/utils/useOverlay';
 
+interface TourContextProviderProps<T extends TourEnumType> {
+  /**
+   * The children of the tour context provider.
+   * All children of this component will be blurred when the tour is active.
+   * Only the active tour element and overlay will be discernible.
+   */
+  children: React.ReactNode;
+  /**
+   * The initial state of the tour.
+   */
+  initialState: Partial<TourState<T>>;
+  /**
+   * The ordered list of Step IDs
+   */
+  orderedStepIds: T[];
+  /**
+   * The React context (from createContext) containing the provider for the tour.
+   * The value for this prop comes from useTourReducer, to avoid extra steps.
+   */
+  tourContext: React.Context<TourContextType<T>>;
+}
+
 export function TourContextProvider<T extends TourEnumType>({
   children,
   initialState,
   orderedStepIds,
   tourContext: TourContext,
-}: {
-  children: React.ReactNode;
-  initialState: Partial<TourState<T>>;
-  orderedStepIds: T[];
-  tourContext: React.Context<TourContextType<T>>;
-}) {
+}: TourContextProviderProps<T>) {
   const tourContext = useTourReducer<T>({initialState, orderedStepIds});
   const isTourActive = tourContext.currentStep !== null;
   return (
@@ -50,14 +67,17 @@ export interface TourElementProps<T extends TourEnumType>
   /**
    * The description of the tour step.
    */
-  description: string;
+  description: React.ReactNode;
+  /**
+   * The unique identifier of the tour step.
+   */
   id: TourStep<T>['id'];
   /**
    * The title of the tour step.
    */
-  title: string;
+  title: React.ReactNode;
   /**
-   * The tour context.
+   * The relevant tour context
    */
   tourContext: TourContextType<T>;
 }

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -18,7 +18,7 @@ import {space} from 'sentry/styles/space';
 import {useHotkeys} from 'sentry/utils/useHotkeys';
 import useOverlay, {type UseOverlayProps} from 'sentry/utils/useOverlay';
 
-interface TourContextProviderProps<T extends TourEnumType> {
+export interface TourContextProviderProps<T extends TourEnumType> {
   /**
    * The children of the tour context provider.
    * All children of this component will be blurred when the tour is active.
@@ -38,12 +38,17 @@ interface TourContextProviderProps<T extends TourEnumType> {
    * The value for this prop comes from useTourReducer, to avoid extra steps.
    */
   tourContext: React.Context<TourContextType<T>>;
+  /**
+   * Whether to omit the blurring window.
+   */
+  omitBlur?: boolean;
 }
 
 export function TourContextProvider<T extends TourEnumType>({
   children,
   isAvailable,
   tourContext,
+  omitBlur,
   orderedStepIds,
 }: TourContextProviderProps<T>) {
   const tourContextValue = useTourReducer<T>({
@@ -67,7 +72,7 @@ export function TourContextProvider<T extends TourEnumType>({
 
   return (
     <tourContext.Provider value={tourContextValue}>
-      {isTourActive && <BlurWindow />}
+      {isTourActive && !omitBlur && <BlurWindow />}
       {children}
     </tourContext.Provider>
   );

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -54,10 +54,8 @@ export function TourContextProvider<T extends TourEnumType>({
   const isTourActive = tourContextValue.currentStep !== null;
   return (
     <tourContext.Provider value={tourContextValue}>
-      <BlurContainer>
-        {isTourActive && <BlurWindow />}
-        {children}
-      </BlurContainer>
+      {isTourActive && <BlurWindow />}
+      {children}
     </tourContext.Provider>
   );
 }
@@ -85,9 +83,9 @@ export interface TourElementProps<T extends TourEnumType>
    */
   tourContext: TourContextType<T>;
   /**
-   * Whether to skip the wrapper element.
+   * The className of the wrapper element.
    */
-  skipWrapper?: boolean;
+  className?: string;
 }
 
 export function TourElement<T extends TourEnumType>({
@@ -97,6 +95,7 @@ export function TourElement<T extends TourEnumType>({
   description,
   tourContext,
   position,
+  className,
 }: TourElementProps<T>) {
   const theme = useTheme();
 
@@ -119,7 +118,9 @@ export function TourElement<T extends TourEnumType>({
 
   return (
     <Fragment>
-      <ElementWrapper {...triggerProps}>{children}</ElementWrapper>
+      <ElementWrapper {...triggerProps} className={className}>
+        {children}
+      </ElementWrapper>
       {isOpen ? (
         <FocusScope autoFocus restoreFocus>
           <PositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
@@ -164,10 +165,6 @@ export function TourElement<T extends TourEnumType>({
     </Fragment>
   );
 }
-
-const BlurContainer = styled('div')`
-  position: relative;
-`;
 
 const BlurWindow = styled('div')`
   content: '';

--- a/static/app/components/tours/issueDetails.tsx
+++ b/static/app/components/tours/issueDetails.tsx
@@ -1,0 +1,46 @@
+import {createContext, useContext} from 'react';
+
+import {TourElement, type TourElementProps} from 'sentry/components/tours/components';
+import type {TourContextType} from 'sentry/components/tours/tourContext';
+
+export const enum IssueDetailsTour {
+  /** Onboarding for trends and aggregates, the graph, and tag distributions */
+  ISSUE_DETAILS_AGGREGATES = 'issue-details-aggregates',
+  /** Onboarding for date/time/environment filters */
+  ISSUE_DETAILS_FILTERS = 'issue-details-filters',
+  /** Onboarding for event details, event navigation, main page content */
+  ISSUE_DETAILS_EVENT_DETAILS = 'issue-details-event-details',
+  /** Onboarding for event navigation; next/previous, first/last/recommended events */
+  ISSUE_DETAILS_NAVIGATION = 'issue-details-navigation',
+  /** Onboarding for workflow actions; resolution, archival, assignment, priority, etc. */
+  ISSUE_DETAILS_WORKFLOWS = 'issue-details-workflows',
+  /** Onboarding for activity log, issue tracking, solutions hub area */
+  ISSUE_DETAILS_SIDEBAR = 'issue-details-sidebar',
+}
+
+export const ORDERED_ISSUE_DETAILS_TOUR_STEP_IDS = [
+  IssueDetailsTour.ISSUE_DETAILS_AGGREGATES,
+  IssueDetailsTour.ISSUE_DETAILS_FILTERS,
+  IssueDetailsTour.ISSUE_DETAILS_EVENT_DETAILS,
+  IssueDetailsTour.ISSUE_DETAILS_NAVIGATION,
+  IssueDetailsTour.ISSUE_DETAILS_WORKFLOWS,
+  IssueDetailsTour.ISSUE_DETAILS_SIDEBAR,
+];
+
+export const IssueDetailsTourContext = createContext<TourContextType<IssueDetailsTour>>({
+  currentStep: null,
+  isAvailable: false,
+  orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR_STEP_IDS,
+  dispatch: () => {},
+});
+
+export function useIssueDetailsTour(): TourContextType<IssueDetailsTour> {
+  return useContext(IssueDetailsTourContext);
+}
+
+export function IssueDetailsTourElement(
+  props: Omit<TourElementProps<IssueDetailsTour>, 'tourContext'>
+) {
+  const tourContext = useIssueDetailsTour();
+  return <TourElement tourContext={tourContext} {...props} />;
+}

--- a/static/app/components/tours/issueDetails.tsx
+++ b/static/app/components/tours/issueDetails.tsx
@@ -18,7 +18,7 @@ export const enum IssueDetailsTour {
   ISSUE_DETAILS_SIDEBAR = 'issue-details-sidebar',
 }
 
-export const ORDERED_ISSUE_DETAILS_TOUR_STEP_IDS = [
+export const ORDERED_ISSUE_DETAILS_TOUR = [
   IssueDetailsTour.ISSUE_DETAILS_AGGREGATES,
   IssueDetailsTour.ISSUE_DETAILS_FILTERS,
   IssueDetailsTour.ISSUE_DETAILS_EVENT_DETAILS,
@@ -30,7 +30,7 @@ export const ORDERED_ISSUE_DETAILS_TOUR_STEP_IDS = [
 export const IssueDetailsTourContext = createContext<TourContextType<IssueDetailsTour>>({
   currentStep: null,
   isAvailable: false,
-  orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR_STEP_IDS,
+  orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR,
   dispatch: () => {},
 });
 

--- a/static/app/components/tours/issueDetails.tsx
+++ b/static/app/components/tours/issueDetails.tsx
@@ -32,6 +32,7 @@ export const IssueDetailsTourContext = createContext<TourContextType<IssueDetail
   isAvailable: false,
   orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR,
   dispatch: () => {},
+  registerStep: () => {},
 });
 
 export function useIssueDetailsTour(): TourContextType<IssueDetailsTour> {

--- a/static/app/components/tours/testUtils.tsx
+++ b/static/app/components/tours/testUtils.tsx
@@ -1,0 +1,38 @@
+import {createContext, useContext} from 'react';
+
+import {TourElement, type TourElementProps} from 'sentry/components/tours/components';
+import type {TourContextType} from 'sentry/components/tours/tourContext';
+
+export const enum TestTour {
+  NAME = 'test-tour-name',
+  EMAIL = 'test-tour-email',
+  PASSWORD = 'test-tour-password',
+}
+
+export const ORDERED_TEST_TOUR = [TestTour.NAME, TestTour.EMAIL, TestTour.PASSWORD];
+export const TestTourContext = createContext<TourContextType<TestTour>>({
+  currentStepId: null,
+  isAvailable: true,
+  isRegistered: false,
+  orderedStepIds: ORDERED_TEST_TOUR,
+  dispatch: () => {},
+  handleStepRegistration: () => () => {},
+});
+
+function useTestTour(): TourContextType<TestTour> {
+  return useContext(TestTourContext);
+}
+
+export function TestTourElement(props: TourElementProps<TestTour>) {
+  const tourContext = useTestTour();
+  return <TourElement tourContext={tourContext} {...props} />;
+}
+
+export const emptyTourContext = {
+  currentStepId: null,
+  isAvailable: true,
+  isRegistered: false,
+  orderedStepIds: [],
+  dispatch: jest.fn(),
+  handleStepRegistration: jest.fn(),
+};

--- a/static/app/components/tours/testUtils.tsx
+++ b/static/app/components/tours/testUtils.tsx
@@ -1,6 +1,5 @@
-import {createContext, useContext} from 'react';
+import {createContext} from 'react';
 
-import {TourElement, type TourElementProps} from 'sentry/components/tours/components';
 import type {TourContextType} from 'sentry/components/tours/tourContext';
 
 export const enum TestTour {
@@ -8,25 +7,9 @@ export const enum TestTour {
   EMAIL = 'test-tour-email',
   PASSWORD = 'test-tour-password',
 }
-
 export const ORDERED_TEST_TOUR = [TestTour.NAME, TestTour.EMAIL, TestTour.PASSWORD];
-export const TestTourContext = createContext<TourContextType<TestTour>>({
-  currentStepId: null,
-  isAvailable: true,
-  isRegistered: false,
-  orderedStepIds: ORDERED_TEST_TOUR,
-  dispatch: () => {},
-  handleStepRegistration: () => () => {},
-});
 
-function useTestTour(): TourContextType<TestTour> {
-  return useContext(TestTourContext);
-}
-
-export function TestTourElement(props: TourElementProps<TestTour>) {
-  const tourContext = useTestTour();
-  return <TourElement tourContext={tourContext} {...props} />;
-}
+export const TestTourContext = createContext<TourContextType<TestTour> | null>(null);
 
 export const emptyTourContext = {
   currentStepId: null,

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -24,11 +24,12 @@ const enum MyTour {
 }
 const ORDERED_MY_TOUR = [MyTour.NAME, MyTour.EMAIL, MyTour.PASSWORD];
 const MyTourContext = createContext<TourContextType<MyTour>>({
-  currentStep: null,
+  currentStepId: null,
   isAvailable: true,
+  isRegistered: false,
   orderedStepIds: ORDERED_MY_TOUR,
   dispatch: () => {},
-  registerStep: () => {},
+  handleStepRegistration: () => () => {},
 });
 function useMyTour(): TourContextType<MyTour> {
   return useContext(MyTourContext);

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -1,0 +1,125 @@
+import {createContext, Fragment, useContext} from 'react';
+import styled from '@emotion/styled';
+
+import compassImage from 'sentry-images/spot/onboarding-compass.svg';
+
+import {Button} from 'sentry/components/button';
+import {Flex} from 'sentry/components/container/flex';
+import {Input} from 'sentry/components/input';
+import SizingWindow from 'sentry/components/stories/sizingWindow';
+import {
+  TourContextProvider,
+  TourElement,
+  type TourElementProps,
+} from 'sentry/components/tours/components';
+import type {TourContextType} from 'sentry/components/tours/tourContext';
+import {IconStar} from 'sentry/icons';
+import storyBook from 'sentry/stories/storyBook';
+import {space} from 'sentry/styles/space';
+
+const enum MyTour {
+  NAME = 'my-tour-name',
+  EMAIL = 'my-tour-email',
+  PASSWORD = 'my-tour-password',
+}
+const ORDERED_MY_TOUR = [MyTour.NAME, MyTour.EMAIL, MyTour.PASSWORD];
+const MyTourContext = createContext<TourContextType<MyTour>>({
+  currentStep: null,
+  isAvailable: true,
+  orderedStepIds: ORDERED_MY_TOUR,
+  dispatch: () => {},
+  registerStep: () => {},
+});
+function useMyTour(): TourContextType<MyTour> {
+  return useContext(MyTourContext);
+}
+function MyTourElement(props: Omit<TourElementProps<MyTour>, 'tourContext'>) {
+  const tourContext = useMyTour();
+  return <TourElement tourContext={tourContext} {...props} />;
+}
+
+export default storyBook('Tours', story => {
+  story('Usage', () => (
+    <Fragment>
+      <p>
+        Tours are a way to guide users through a series of steps around a page in the
+        product, with anchored tooltips which may jump all over the page.
+      </p>
+      <TourExample>
+        <MyTourElement
+          id={MyTour.NAME}
+          title={'Name Time!'}
+          description={'This is the description of the name tour step.'}
+        >
+          <Input placeholder="Step 1: Name" />
+        </MyTourElement>
+        <MyTourElement
+          id={MyTour.EMAIL}
+          title={'Email Time!'}
+          description={'This is the description of the email tour step.'}
+        >
+          <Input placeholder="Step 2: Email" type="email" />
+        </MyTourElement>
+        rdddf
+        <MyTourElement
+          id={MyTour.PASSWORD}
+          title={'Password Time!'}
+          description={'This is the description of the password tour step.'}
+        >
+          <Input placeholder="Step 3: Password" type="password" />
+        </MyTourElement>
+      </TourExample>
+    </Fragment>
+  ));
+});
+
+const BlurBoundary = styled('div')`
+  position: relative;
+  border: 1px dashed ${p => p.theme.purple400};
+  width: 100%;
+  padding: ${space(2)};
+  margin: ${space(1)} ${space(2)};
+`;
+
+const Image = styled('img')`
+  aspect-ratio: 1/1;
+  height: 100%;
+  object-fit: contain;
+`;
+
+function StartTourButton() {
+  const {dispatch} = useMyTour();
+  return (
+    <Button icon={<IconStar />} onClick={() => dispatch({type: 'START_TOUR'})}>
+      Start Tour
+    </Button>
+  );
+}
+
+function TourExample({children}: {children: React.ReactNode}) {
+  return (
+    <SizingWindow>
+      <BlurBoundary>
+        <TourContextProvider
+          isAvailable
+          orderedStepIds={ORDERED_MY_TOUR}
+          tourContext={MyTourContext}
+        >
+          <Flex gap={space(2)} align="center">
+            <Flex gap={space(2)} justify="space-between" column align="flex-start">
+              <StartTourButton />
+              {children}
+            </Flex>
+            <Image src={compassImage} />
+            <p style={{maxWidth: '300px'}}>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Qui nam doloremque
+              repellendus, natus deserunt pariatur cupiditate fugiat adipisci,
+              praesentium, quos autem tempora nostrum laborum voluptatum reiciendis quia
+              veniam consequatur sapiente!
+            </p>
+          </Flex>
+        </TourContextProvider>
+      </BlurBoundary>
+    </SizingWindow>
+  );
+}

--- a/static/app/components/tours/tourContext.spec.tsx
+++ b/static/app/components/tours/tourContext.spec.tsx
@@ -84,4 +84,15 @@ describe('useTourReducer', () => {
     act(() => result.current.dispatch({type: 'PREVIOUS_STEP'}));
     expect(result.current.currentStepId).toBe(TestTour.NAME);
   });
+
+  it('sets the step correctly', () => {
+    const result = registerAllSteps();
+    expect(result.current.currentStepId).toBeNull();
+    act(() => result.current.dispatch({type: 'SET_STEP', stepId: TestTour.EMAIL}));
+    expect(result.current.currentStepId).toBe(TestTour.EMAIL);
+    act(() => result.current.dispatch({type: 'SET_STEP', stepId: TestTour.PASSWORD}));
+    expect(result.current.currentStepId).toBe(TestTour.PASSWORD);
+    act(() => result.current.dispatch({type: 'SET_STEP', stepId: TestTour.NAME}));
+    expect(result.current.currentStepId).toBe(TestTour.NAME);
+  });
 });

--- a/static/app/components/tours/tourContext.spec.tsx
+++ b/static/app/components/tours/tourContext.spec.tsx
@@ -1,0 +1,87 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {
+  emptyTourContext,
+  ORDERED_TEST_TOUR,
+  TestTour,
+} from 'sentry/components/tours/testUtils';
+import {type TourState, useTourReducer} from 'sentry/components/tours/tourContext';
+
+describe('useTourReducer', () => {
+  const mockElement = document.createElement('div');
+  const initialState: TourState<TestTour> = {
+    ...emptyTourContext,
+    orderedStepIds: ORDERED_TEST_TOUR,
+  };
+  function registerAllSteps() {
+    const {result} = renderHook(() => useTourReducer<TestTour>(initialState));
+    const {handleStepRegistration} = result.current;
+    act(() => {
+      ORDERED_TEST_TOUR.forEach(stepId =>
+        handleStepRegistration({id: stepId, element: mockElement})
+      );
+    });
+    return result;
+  }
+
+  it('handles step registration correctly', () => {
+    const {result} = renderHook(() => useTourReducer<TestTour>(initialState));
+    const {handleStepRegistration} = result.current;
+    let unregister = () => {};
+    // Should be false before any steps are registered
+    expect(result.current.isRegistered).toBe(false);
+    act(() => {
+      unregister = handleStepRegistration({id: TestTour.NAME, element: mockElement});
+      handleStepRegistration({id: TestTour.EMAIL, element: mockElement});
+    });
+    // Should not switch until all steps have been registered
+    expect(result.current.isRegistered).toBe(false);
+    act(() => handleStepRegistration({id: TestTour.PASSWORD, element: mockElement}));
+    // Should switch when all steps have been registered
+    expect(result.current.isRegistered).toBe(true);
+    act(() => unregister());
+    // Should switch back to false when all steps have been unregistered
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it('starts and ends the tour with the correctly', () => {
+    const result = registerAllSteps();
+    expect(result.current.currentStepId).toBeNull();
+    act(() => result.current.dispatch({type: 'START_TOUR'}));
+    expect(result.current.currentStepId).toBe(TestTour.NAME);
+    act(() => result.current.dispatch({type: 'START_TOUR', stepId: TestTour.EMAIL}));
+    expect(result.current.currentStepId).toBe(TestTour.EMAIL);
+    act(() => result.current.dispatch({type: 'END_TOUR'}));
+    expect(result.current.currentStepId).toBeNull();
+  });
+
+  it('navigates to the next step correctly', () => {
+    const result = registerAllSteps();
+    expect(result.current.currentStepId).toBeNull();
+    act(() => result.current.dispatch({type: 'NEXT_STEP'}));
+    expect(result.current.currentStepId).toBeNull();
+    act(() => result.current.dispatch({type: 'START_TOUR'}));
+    expect(result.current.currentStepId).toBe(TestTour.NAME);
+    act(() => result.current.dispatch({type: 'NEXT_STEP'}));
+    expect(result.current.currentStepId).toBe(TestTour.EMAIL);
+    act(() => result.current.dispatch({type: 'NEXT_STEP'}));
+    expect(result.current.currentStepId).toBe(TestTour.PASSWORD);
+    act(() => result.current.dispatch({type: 'NEXT_STEP'}));
+    expect(result.current.currentStepId).toBeNull();
+  });
+
+  it('navigates to the previous step correctly', () => {
+    const result = registerAllSteps();
+    expect(result.current.currentStepId).toBeNull();
+    act(() => result.current.dispatch({type: 'PREVIOUS_STEP'}));
+    expect(result.current.currentStepId).toBeNull();
+    act(() => result.current.dispatch({type: 'START_TOUR', stepId: TestTour.PASSWORD}));
+    expect(result.current.currentStepId).toBe(TestTour.PASSWORD);
+    act(() => result.current.dispatch({type: 'PREVIOUS_STEP'}));
+    expect(result.current.currentStepId).toBe(TestTour.EMAIL);
+    act(() => result.current.dispatch({type: 'PREVIOUS_STEP'}));
+    expect(result.current.currentStepId).toBe(TestTour.NAME);
+    act(() => result.current.dispatch({type: 'PREVIOUS_STEP'}));
+    expect(result.current.currentStepId).toBe(TestTour.NAME);
+  });
+});

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -1,4 +1,4 @@
-import {type Dispatch, type Reducer, useCallback, useState} from 'react';
+import {type Dispatch, type Reducer, useCallback, useMemo, useState} from 'react';
 import {useReducer} from 'react';
 
 export type TourEnumType = string | number;
@@ -149,8 +149,15 @@ export function useTourReducer<T extends TourEnumType>(
   );
 
   const [tour, dispatch] = useReducer(reducer, initialState);
-
-  return {...tour, dispatch};
+  return useMemo<TourContextType<T>>(
+    () => ({
+      dispatch,
+      currentStep: tour.currentStep,
+      isAvailable: tour.isAvailable,
+      orderedStepIds: tour.orderedStepIds,
+    }),
+    [tour.currentStep, tour.isAvailable, tour.orderedStepIds, dispatch]
+  );
 }
 
 export interface TourContextType<T extends TourEnumType> extends TourState<T> {

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -25,6 +25,10 @@ type TourNextStepAction = {
 type TourPreviousStepAction = {
   type: 'PREVIOUS_STEP';
 };
+type TourSetStepAction<T extends TourEnumType> = {
+  stepId: T;
+  type: 'SET_STEP';
+};
 type TourEndAction = {
   type: 'END_TOUR';
 };
@@ -37,6 +41,7 @@ export type TourAction<T extends TourEnumType> =
   | TourStartAction<T>
   | TourNextStepAction
   | TourPreviousStepAction
+  | TourSetStepAction<T>
   | TourEndAction
   | TourSetRegistrationAction;
 
@@ -123,6 +128,11 @@ function tourReducer<T extends TourEnumType>(
       // If there is no previous step, do nothing
       return state;
     }
+    case 'SET_STEP':
+      return {
+        ...state,
+        currentStepId: action.stepId,
+      };
     case 'END_TOUR':
       return completeTourState;
     case 'SET_REGISTRATION':

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -1,0 +1,167 @@
+import {type Dispatch, type Reducer, useCallback, useState} from 'react';
+import {useReducer} from 'react';
+
+export type TourEnumType = string | number;
+
+export interface TourStep<T extends TourEnumType> {
+  /**
+   * The element to focus on when the tour step is active.
+   * This is usually set within the TourElement component, which wraps the focused element.
+   */
+  element: HTMLElement | null;
+  /**
+   * Unique ID for the tour step.
+   */
+  id: T;
+}
+
+type TourStartAction<T extends TourEnumType> = {
+  type: 'START_TOUR';
+  stepId?: T;
+};
+type TourNextStepAction = {
+  type: 'NEXT_STEP';
+};
+type TourPreviousStepAction = {
+  type: 'PREVIOUS_STEP';
+};
+type TourEndAction = {
+  type: 'END_TOUR';
+};
+type TourRegisterStepAction<T extends TourEnumType> = {
+  step: TourStep<T>;
+  type: 'REGISTER_STEP';
+};
+
+export type TourAction<T extends TourEnumType> =
+  | TourStartAction<T>
+  | TourNextStepAction
+  | TourPreviousStepAction
+  | TourEndAction
+  | TourRegisterStepAction<T>;
+
+export interface TourState<T extends TourEnumType> {
+  /**
+   * The current active tour step. If this is null, the tour is not active.
+   */
+  currentStep: TourStep<T> | null;
+  /**
+   * Whether the tour is available to the user. Should be set by flags or other conditions.
+   */
+  isAvailable: boolean;
+  /**
+   * The ordered step IDs. Declared once when the provider is initialized.
+   */
+  orderedStepIds: readonly T[];
+}
+
+type TourRegistry<T extends TourEnumType> = {
+  [key in T]: TourStep<T> | null;
+};
+
+export function useTourReducer<T extends TourEnumType>({
+  initialState,
+  orderedStepIds,
+}: {
+  initialState: Partial<TourState<T>>;
+  orderedStepIds: T[];
+}): TourContextType<T> {
+  const initState = {
+    orderedStepIds,
+    currentStep: null,
+    isAvailable: false,
+    ...initialState,
+  };
+  const [registry, setRegistry] = useState<TourRegistry<T>>(
+    orderedStepIds.reduce((reg, stepId) => {
+      reg[stepId] = null;
+      return reg;
+    }, {} as TourRegistry<T>)
+  );
+
+  const isCompletelyRegistered = Object.values(registry).every(Boolean);
+  const reducer: Reducer<TourState<T>, TourAction<T>> = useCallback(
+    (state, action) => {
+      const completeTourState = {
+        ...state,
+        isActive: false,
+        currentStep: null,
+      };
+      switch (action.type) {
+        case 'REGISTER_STEP': {
+          setRegistry(prev => ({...prev, [action.step.id]: action.step}));
+          return state;
+        }
+        case 'START_TOUR': {
+          // If the tour is not available, or not all steps are registered, do nothing
+          if (!state.isAvailable || !isCompletelyRegistered) {
+            return state;
+          }
+
+          // If the stepId is provided, set the current step to the stepId
+          const startStepIndex = action.stepId
+            ? orderedStepIds.indexOf(action.stepId)
+            : -1;
+          if (action.stepId && startStepIndex !== -1) {
+            return {
+              ...state,
+              currentStep: registry[action.stepId] ?? null,
+            };
+          }
+          // If no stepId is provided, set the current step to the first step
+          if (orderedStepIds[0]) {
+            return {
+              ...state,
+              currentStep: registry[orderedStepIds[0]] ?? null,
+            };
+          }
+
+          return state;
+        }
+        case 'NEXT_STEP': {
+          if (!state.currentStep) {
+            return state;
+          }
+          const nextStepIndex = orderedStepIds.indexOf(state.currentStep.id) + 1;
+          const nextStepId = orderedStepIds[nextStepIndex];
+          if (nextStepId) {
+            return {
+              ...state,
+              currentStep: registry[nextStepId] ?? null,
+            };
+          }
+          // If there is no next step, complete the tour
+          return completeTourState;
+        }
+        case 'PREVIOUS_STEP': {
+          if (!state.currentStep) {
+            return state;
+          }
+          const prevStepIndex = orderedStepIds.indexOf(state.currentStep.id) - 1;
+          const prevStepId = orderedStepIds[prevStepIndex];
+          if (prevStepId) {
+            return {
+              ...state,
+              currentStep: registry[prevStepId] ?? null,
+            };
+          }
+          // If there is no previous step, do nothing
+          return state;
+        }
+        case 'END_TOUR':
+          return completeTourState;
+        default:
+          return state;
+      }
+    },
+    [registry, setRegistry, orderedStepIds, isCompletelyRegistered]
+  );
+
+  const [tour, dispatch] = useReducer(reducer, initState);
+
+  return {...tour, dispatch};
+}
+
+export interface TourContextType<T extends TourEnumType> extends TourState<T> {
+  dispatch: Dispatch<TourAction<T>>;
+}

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -59,19 +59,10 @@ type TourRegistry<T extends TourEnumType> = {
   [key in T]: TourStep<T> | null;
 };
 
-export function useTourReducer<T extends TourEnumType>({
-  initialState,
-  orderedStepIds,
-}: {
-  initialState: Partial<TourState<T>>;
-  orderedStepIds: T[];
-}): TourContextType<T> {
-  const initState = {
-    orderedStepIds,
-    currentStep: null,
-    isAvailable: false,
-    ...initialState,
-  };
+export function useTourReducer<T extends TourEnumType>(
+  initialState: TourState<T>
+): TourContextType<T> {
+  const {orderedStepIds} = initialState;
   const [registry, setRegistry] = useState<TourRegistry<T>>(
     orderedStepIds.reduce((reg, stepId) => {
       reg[stepId] = null;
@@ -157,7 +148,7 @@ export function useTourReducer<T extends TourEnumType>({
     [registry, setRegistry, orderedStepIds, isCompletelyRegistered]
   );
 
-  const [tour, dispatch] = useReducer(reducer, initState);
+  const [tour, dispatch] = useReducer(reducer, initialState);
 
   return {...tour, dispatch};
 }

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1000,6 +1000,12 @@ const commonTheme = {
     hovercard: 10002,
     tooltip: 10003,
 
+    tour: {
+      blur: 10100,
+      element: 10101,
+      overlay: 10102,
+    },
+
     // On mobile views issue list dropdowns overlap
     issuesList: {
       stickyHeader: 2,

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -1,6 +1,5 @@
 import {createContext, useContext} from 'react';
 
-import {TourElement, type TourElementProps} from 'sentry/components/tours/components';
 import type {TourContextType} from 'sentry/components/tours/tourContext';
 
 export const enum IssueDetailsTour {
@@ -33,12 +32,7 @@ export const IssueDetailsTourContext =
 export function useIssueDetailsTour(): TourContextType<IssueDetailsTour> {
   const tourContext = useContext(IssueDetailsTourContext);
   if (!tourContext) {
-    throw new Error('Must be used within a TourContextProvider');
+    throw new Error('Must be used within a TourContextProvider<IssueDetailsTour>');
   }
   return tourContext;
-}
-
-export function IssueDetailsTourElement(props: TourElementProps<IssueDetailsTour>) {
-  const tourContext = useIssueDetailsTour();
-  return <TourElement tourContext={tourContext} {...props} />;
 }

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -28,8 +28,9 @@ export const ORDERED_ISSUE_DETAILS_TOUR = [
 ];
 
 export const IssueDetailsTourContext = createContext<TourContextType<IssueDetailsTour>>({
-  currentStep: null,
+  currentStepId: null,
   isAvailable: false,
+  isRegistered: false,
   orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR,
   dispatch: () => {},
   registerStep: () => {},

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -5,26 +5,26 @@ import type {TourContextType} from 'sentry/components/tours/tourContext';
 
 export const enum IssueDetailsTour {
   /** Onboarding for trends and aggregates, the graph, and tag distributions */
-  ISSUE_DETAILS_AGGREGATES = 'issue-details-aggregates',
+  AGGREGATES = 'issue-details-aggregates',
   /** Onboarding for date/time/environment filters */
-  ISSUE_DETAILS_FILTERS = 'issue-details-filters',
+  FILTERS = 'issue-details-filters',
   /** Onboarding for event details, event navigation, main page content */
-  ISSUE_DETAILS_EVENT_DETAILS = 'issue-details-event-details',
+  EVENT_DETAILS = 'issue-details-event-details',
   /** Onboarding for event navigation; next/previous, first/last/recommended events */
-  ISSUE_DETAILS_NAVIGATION = 'issue-details-navigation',
+  NAVIGATION = 'issue-details-navigation',
   /** Onboarding for workflow actions; resolution, archival, assignment, priority, etc. */
-  ISSUE_DETAILS_WORKFLOWS = 'issue-details-workflows',
+  WORKFLOWS = 'issue-details-workflows',
   /** Onboarding for activity log, issue tracking, solutions hub area */
-  ISSUE_DETAILS_SIDEBAR = 'issue-details-sidebar',
+  SIDEBAR = 'issue-details-sidebar',
 }
 
 export const ORDERED_ISSUE_DETAILS_TOUR = [
-  IssueDetailsTour.ISSUE_DETAILS_AGGREGATES,
-  IssueDetailsTour.ISSUE_DETAILS_FILTERS,
-  IssueDetailsTour.ISSUE_DETAILS_EVENT_DETAILS,
-  IssueDetailsTour.ISSUE_DETAILS_NAVIGATION,
-  IssueDetailsTour.ISSUE_DETAILS_WORKFLOWS,
-  IssueDetailsTour.ISSUE_DETAILS_SIDEBAR,
+  IssueDetailsTour.AGGREGATES,
+  IssueDetailsTour.FILTERS,
+  IssueDetailsTour.EVENT_DETAILS,
+  IssueDetailsTour.NAVIGATION,
+  IssueDetailsTour.WORKFLOWS,
+  IssueDetailsTour.SIDEBAR,
 ];
 
 export const IssueDetailsTourContext = createContext<TourContextType<IssueDetailsTour>>({
@@ -39,9 +39,7 @@ export function useIssueDetailsTour(): TourContextType<IssueDetailsTour> {
   return useContext(IssueDetailsTourContext);
 }
 
-export function IssueDetailsTourElement(
-  props: Omit<TourElementProps<IssueDetailsTour>, 'tourContext'>
-) {
+export function IssueDetailsTourElement(props: TourElementProps<IssueDetailsTour>) {
   const tourContext = useIssueDetailsTour();
   return <TourElement tourContext={tourContext} {...props} />;
 }

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -27,17 +27,15 @@ export const ORDERED_ISSUE_DETAILS_TOUR = [
   IssueDetailsTour.SIDEBAR,
 ];
 
-export const IssueDetailsTourContext = createContext<TourContextType<IssueDetailsTour>>({
-  currentStepId: null,
-  isAvailable: false,
-  isRegistered: false,
-  orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR,
-  dispatch: () => {},
-  handleStepRegistration: () => () => {},
-});
+export const IssueDetailsTourContext =
+  createContext<TourContextType<IssueDetailsTour> | null>(null);
 
 export function useIssueDetailsTour(): TourContextType<IssueDetailsTour> {
-  return useContext(IssueDetailsTourContext);
+  const tourContext = useContext(IssueDetailsTourContext);
+  if (!tourContext) {
+    throw new Error('Must be used within a TourContextProvider');
+  }
+  return tourContext;
 }
 
 export function IssueDetailsTourElement(props: TourElementProps<IssueDetailsTour>) {

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -33,7 +33,7 @@ export const IssueDetailsTourContext = createContext<TourContextType<IssueDetail
   isRegistered: false,
   orderedStepIds: ORDERED_ISSUE_DETAILS_TOUR,
   dispatch: () => {},
-  registerStep: () => {},
+  handleStepRegistration: () => () => {},
 });
 
 export function useIssueDetailsTour(): TourContextType<IssueDetailsTour> {


### PR DESCRIPTION
This PR introduces a system for building out in-product tours. It's a bit verbose, but I think it's fairly extensible and could be used elsewhere in the app, not just issue details.

Update: A lot of what I'd previously written had become outdated so I'd just check out the story book instead.

**todo**
- [x] Add a stories file
- [x] Add a test file `tourContext.spec.tsx` 
- [x] Add a test file `components.spec.tsx` 
