### PR TITLE
fix(aci): allow percent freq intervals

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from sentry.rules.conditions.event_frequency import (
     COMPARISON_INTERVALS,
+    PERCENT_INTERVALS,
     STANDARD_INTERVALS,
     percent_increase,
 )
@@ -68,7 +69,7 @@ class PercentSessionsCountHandler(EventFrequencyCountHandler):
     comparison_json_schema = {
         "type": "object",
         "properties": {
-            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
+            "interval": {"type": "string", "enum": list(PERCENT_INTERVALS.keys())},
             "value": {"type": "number", "minimum": 0, "maximum": 100},
             "filters": {
                 "type": "array",
@@ -85,7 +86,7 @@ class PercentSessionsPercentHandler(EventFrequencyPercentHandler):
     comparison_json_schema = {
         "type": "object",
         "properties": {
-            "interval": {"type": "string", "enum": list(STANDARD_INTERVALS.keys())},
+            "interval": {"type": "string", "enum": list(PERCENT_INTERVALS.keys())},
             "value": {"type": "number", "minimum": 0, "maximum": 100},
             "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
             "filters": {

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -237,6 +237,17 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
             self.create_data_condition(
                 type=self.condition,
                 comparison={
+                    "interval": "30m",
+                    "value": "100",
+                    "comparison_interval": "1d",
+                },
+                condition_result=True,
+            )
+
+        with pytest.raises(ValidationError):
+            self.create_data_condition(
+                type=self.condition,
+                comparison={
                     "interval": "1d",
                     "value": 100,
                     "comparison_interval": "asdf",
@@ -276,7 +287,7 @@ class TestPercentSessionsCountCondition(TestEventFrequencyCountCondition):
         super().setUp()
         self.condition = Condition.PERCENT_SESSIONS_COUNT
         self.payload: dict[str, int | str] = {
-            "interval": "1h",
+            "interval": "30m",  # only percent sessions allows 30m
             "id": EventFrequencyPercentCondition.id,
             "value": 17,
             "comparisonType": ComparisonType.COUNT,
@@ -288,7 +299,7 @@ class TestPercentSessionsPercentCondition(TestEventFrequencyPercentCondition):
         super().setUp()
         self.condition = Condition.PERCENT_SESSIONS_PERCENT
         self.payload: dict[str, int | str] = {
-            "interval": "1h",
+            "interval": "30m",  # only percent sessions allows 30m
             "id": EventFrequencyPercentCondition.id,
             "value": 17,
             "comparisonType": ComparisonType.PERCENT,


### PR DESCRIPTION
We should allow `EventFrequencyPercentConditions` to be saved as `DataConditions` with intervals from `PERCENT_INTERVALS`, was previously incorrectly using `STANDARD_INTERVALS` for all event frequency conditions.