### PR TITLE
feat(metric-issues): Change metric issue title format

### DIFF
--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -3,15 +3,20 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
+from django.utils.translation import gettext as _
+
 from sentry import features
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.integrations.metric_alerts import get_incident_status_text
+from sentry.incidents.utils.format_duration import format_duration_idiomatic
+from sentry.integrations.metric_alerts import TEXT_COMPARISON_DELTA
 from sentry.issues.grouptype import MetricIssuePOC
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.models.project import Project
+from sentry.snuba.metrics import format_mri_field, is_mri_field
 from sentry.types.group import PriorityLevel
 
 
@@ -33,6 +38,44 @@ class OpenPeriod:
         }
 
 
+QUERY_AGGREGATION_DISPLAY = {
+    "count()": "Number of events",
+    "count_unique(tags[sentry:user])": "Number of users affected",
+    "percentage(sessions_crashed, sessions)": "Crash free session rate",
+    "percentage(users_crashed, users)": "Crash free user rate",
+}
+
+
+def construct_title(alert_rule: AlertRule) -> str:
+    # Parse the aggregate key from the alert rule
+    agg_display_key = alert_rule.snuba_query.aggregate
+    if is_mri_field(agg_display_key):
+        agg_text = format_mri_field(agg_display_key)
+    else:
+        agg_text = QUERY_AGGREGATION_DISPLAY.get(agg_display_key, alert_rule.snuba_query.aggregate)
+
+    # Determine the higher or lower comparison
+    higher_or_lower = ""
+    if alert_rule.threshold_type == AlertRuleThresholdType.ABOVE.value:
+        higher_or_lower = "greater than" if alert_rule.comparison_delta else "above"
+    else:
+        higher_or_lower = "less than" if alert_rule.comparison_delta else "below"
+
+    # Format the time window for the threshold
+    time_window = alert_rule.snuba_query.time_window // 60
+    title = f"{agg_text} in the last {format_duration_idiomatic(time_window)} {higher_or_lower}"
+
+    # If the alert rule has a comparison delta, format the comparison string
+    if alert_rule.comparison_delta:
+        comparison_delta_minutes = alert_rule.comparison_delta // 60
+        comparison_string = TEXT_COMPARISON_DELTA.get(
+            comparison_delta_minutes, f"same time {comparison_delta_minutes} minutes ago"
+        )
+        return _(f"{title} {comparison_string}")
+
+    return _(f"{title} threshold")
+
+
 def _build_occurrence_from_incident(
     project: Project,
     incident: Incident,
@@ -45,13 +88,14 @@ def _build_occurrence_from_incident(
         else PriorityLevel.MEDIUM
     )
     fingerprint = [str(incident.alert_rule.id)]
+    title = construct_title(incident.alert_rule)
     return IssueOccurrence(
         id=uuid4().hex,
         project_id=project.id,
         event_id=str(event_data["event_id"]),
         fingerprint=fingerprint,
         issue_title=incident.title,
-        subtitle=get_incident_status_text(incident.alert_rule, str(metric_value)),
+        subtitle=title,
         resource_id=None,
         type=MetricIssuePOC,
         detection_time=incident.date_started,


### PR DESCRIPTION
Change the metric issue title to follow the template of `{metric_type} {above | below} threshold {compared to X days ago}`. This should make the metric issue titles easier to read.