### PR TITLE
feat(quick-start): Skip quick start if overdue done tasks

### DIFF
--- a/static/app/components/onboardingWizard/useOverdueDoneTasks.tsx
+++ b/static/app/components/onboardingWizard/useOverdueDoneTasks.tsx
@@ -1,0 +1,46 @@
+import {useEffect, useMemo} from 'react';
+
+import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
+import type {OnboardingTask} from 'sentry/types/onboarding';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+function isTaskOverdue2Weeks(dateCompleted: string): boolean {
+  const now = new Date();
+  const timeDifference = now.getTime() - new Date(dateCompleted).getTime();
+  return timeDifference > 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
+}
+
+export function useOverdueDoneTasks({doneTasks}: {doneTasks: OnboardingTask[]}): {
+  overdueTasks: OnboardingTask[];
+} {
+  const api = useApi();
+  const organization = useOrganization();
+
+  // Tasks marked as "done" but not completed (user hasn't seen the completion),
+  // and the date completed is equal or more than 14 days ago (overdue).
+  const overdueTasks = useMemo(() => {
+    return doneTasks.filter(
+      task =>
+        task.dateCompleted &&
+        !task.completionSeen &&
+        isTaskOverdue2Weeks(task.dateCompleted)
+    );
+  }, [doneTasks]);
+
+  useEffect(() => {
+    if (!overdueTasks.length) {
+      return;
+    }
+
+    // Mark overdue tasks as seen, so we can try to mark the onboarding as complete.
+    for (const overdueTask of overdueTasks) {
+      updateOnboardingTask(api, organization, {
+        task: overdueTask.task,
+        completionSeen: true,
+      });
+    }
+  }, [overdueTasks, api, organization]);
+
+  return {overdueTasks};
+}

--- a/static/app/components/sidebar/onboardingStatus.spec.tsx
+++ b/static/app/components/sidebar/onboardingStatus.spec.tsx
@@ -1,12 +1,16 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {setMockDate} from 'sentry-test/utils';
 
+import * as taskConfig from 'sentry/components/onboardingWizard/taskConfig';
+import * as useOnboardingTasks from 'sentry/components/onboardingWizard/useOnboardingTasks';
 import {OnboardingStatus} from 'sentry/components/sidebar/onboardingStatus';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import ConfigStore from 'sentry/stores/configStore';
-import {OnboardingTaskKey} from 'sentry/types/onboarding';
+import {type OnboardingTask, OnboardingTaskKey} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
 import * as useOnboardingSidebar from 'sentry/views/onboarding/useOnboardingSidebar';
 
@@ -21,12 +25,17 @@ function renderMockRequests(organization: Organization) {
     },
   });
 
+  const mutateOnboardingTasksMock = MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/onboarding-tasks/`,
+    method: 'POST',
+  });
+
   const mutateUserOptionsMock = MockApiClient.addMockResponse({
     url: `/users/me/`,
     method: 'PUT',
   });
 
-  return {getOnboardingTasksMock, mutateUserOptionsMock};
+  return {getOnboardingTasksMock, mutateUserOptionsMock, mutateOnboardingTasksMock};
 }
 
 describe('Onboarding Status', function () {
@@ -74,6 +83,7 @@ describe('Onboarding Status', function () {
       }
     );
 
+    expect(screen.getByRole('button', {name: 'Onboarding'})).toBeInTheDocument();
     expect(screen.getByText('1 completed task')).toBeInTheDocument();
     expect(screen.getByTestId('pending-seen-indicator')).toBeInTheDocument();
 
@@ -231,5 +241,56 @@ describe('Onboarding Status', function () {
     );
 
     expect(mockActivateSidebar).toHaveBeenCalled();
+  });
+
+  it('panel is skipped if all tasks are done and completionSeen is overdue', function () {
+    const organization = OrganizationFixture({
+      id: organizationId,
+      features: ['onboarding'],
+    });
+
+    setMockDate(new Date('2025-02-26'));
+
+    const allTasks = taskConfig
+      .getOnboardingTasks({organization, projects: [ProjectFixture()]})
+      .filter(task =>
+        [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.SECOND_PLATFORM].includes(
+          task.task
+        )
+      );
+
+    const doneTasks: OnboardingTask[] = allTasks.map(task => ({
+      ...task,
+      status: 'complete',
+      dateCompleted: '2025-02-11',
+      completionSeen: undefined,
+    }));
+
+    jest.spyOn(useOnboardingTasks, 'useOnboardingTasks').mockReturnValue({
+      allTasks: doneTasks,
+      beyondBasicsTasks: [],
+      completeTasks: [],
+      doneTasks,
+      gettingStartedTasks: [],
+      refetch: jest.fn(),
+    });
+
+    const {mutateOnboardingTasksMock} = renderMockRequests(organization);
+
+    render(
+      <OnboardingStatus
+        currentPanel=""
+        onShowPanel={jest.fn()}
+        hidePanel={jest.fn()}
+        collapsed
+        orientation="left"
+      />,
+      {
+        organization,
+      }
+    );
+
+    expect(mutateOnboardingTasksMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', {name: 'Onboarding'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {LegacyOnboardingSidebar} from 'sentry/components/onboardingWizard/sidebar';
 import {useOnboardingTasks} from 'sentry/components/onboardingWizard/useOnboardingTasks';
+import {useOverdueDoneTasks} from 'sentry/components/onboardingWizard/useOverdueDoneTasks';
 import ProgressRing, {
   RingBackground,
   RingBar,
@@ -59,13 +60,18 @@ export function OnboardingStatus({
     disabled: !isActive,
   });
 
+  const {overdueTasks} = useOverdueDoneTasks({doneTasks});
+
   const label = demoMode ? t('Guided Tours') : t('Onboarding');
   const pendingCompletionSeen = doneTasks.length !== completeTasks.length;
   const allTasksCompleted = allTasks.length === completeTasks.length;
+  const allTasksDone = allTasks.length === doneTasks.length;
 
   const skipQuickStart =
     (!demoMode && !organization.features?.includes('onboarding')) ||
-    (allTasksCompleted && !isActive);
+    (allTasksCompleted && !isActive) ||
+    // Skip if all tasks are completed and there are overdue tasks
+    (allTasksDone && overdueTasks.length > 0);
 
   const orgId = organization.id;
 


### PR DESCRIPTION
If all quick start tasks are done, but the user has not revisited the full sidebar to mark them as complete, we will automatically dismiss the quick start sidebar after 14 days and mark all done tasks as completed (seen).

- Contributes to the last requirement of https://github.com/getsentry/projects/issues/700

