### PR TITLE
fix(grouping): Handle race condition creating grouphash metadata

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -138,6 +138,18 @@ def create_or_update_grouphash_metadata_if_needed(
         # branch implies no record exists) in order to guard against race coditions without the need
         # for a lock
         grouphash_metadata, created = GroupHashMetadata.objects.get_or_create(grouphash=grouphash)
+
+        if not created:
+            logger.info(
+                "grouphash_metadata.creation_race_condition.record_exists",
+                extra={
+                    "grouphash_metadata_id": grouphash_metadata.id,
+                    "grouphash_is_new": grouphash_is_new,
+                    "event_id": event.event_id,
+                },
+            )
+            return
+
         new_data = get_grouphash_metadata_data(event, project, variants, grouping_config)
 
         db_hit_metadata = {"reason": "new_grouphash" if grouphash_is_new else "missing_metadata"}

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -134,8 +134,11 @@ def create_or_update_grouphash_metadata_if_needed(
     db_hit_metadata: dict[str, Any] = {}
 
     if not grouphash.metadata:
-        new_data: dict[str, Any] = {"grouphash": grouphash}
-        new_data.update(get_grouphash_metadata_data(event, project, variants, grouping_config))
+        # Use `get_or_create` rather than just `create` (even though the fact that we landed in this
+        # branch implies no record exists) in order to guard against race coditions without the need
+        # for a lock
+        grouphash_metadata, created = GroupHashMetadata.objects.get_or_create(grouphash=grouphash)
+        new_data = get_grouphash_metadata_data(event, project, variants, grouping_config)
 
         db_hit_metadata = {"reason": "new_grouphash" if grouphash_is_new else "missing_metadata"}
 
@@ -144,7 +147,7 @@ def create_or_update_grouphash_metadata_if_needed(
             # doesn't default to now
             new_data["date_added"] = None
 
-        GroupHashMetadata.objects.create(**new_data)
+        grouphash_metadata.update(**new_data)
 
     else:
         updated_data: dict[str, Any] = {}

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -400,8 +400,8 @@ def maybe_check_seer_for_matching_grouphash(
         if gh_metadata:
 
             # TODO: This should never be true (anything created with `objects.create` should have an
-            # id), but it seems in some cases to happen anyway. This is an attempt to mitigate the
-            # problem.
+            # id), but it seems in some cases to happen anyway. While we debug the problem, to avoid
+            # errors, bail early.
             metadata_id: Any = (
                 gh_metadata.id
             )  # Even mypy knows this should never happen, hence the need for the Any
@@ -415,21 +415,7 @@ def maybe_check_seer_for_matching_grouphash(
                         "project": str(event.project),
                     },
                 )
-                gh_metadata.save()
-
-                # If that didn't work, log it and bail
-                metadata_id = gh_metadata.id
-                if metadata_id is None:
-                    logger.error(
-                        "grouphash_metadata.none_id_fix_failed",
-                        extra={
-                            "event_id": event.event_id,
-                            "grouphash": str(event_grouphash),
-                            "grouphash_metadata": str(gh_metadata),
-                            "project": str(event.project),
-                        },
-                    )
-                    return seer_matched_grouphash
+                return seer_matched_grouphash
 
             gh_metadata.update(
                 # Technically the time of the metadata record creation and the time of the Seer


### PR DESCRIPTION
This is a second attempt to fix the errors we're seeing when enabling backfill for grouphash metadata, wherein a small percentage of new grouphashes can't have their Seer metadata updated because the metadata record "hasn't been created yet."

We noticed that the metadata records to which this happened all seemed to have an id of `None`, so the first attempt at a fix was to call `save` before doing the update in those cases, to make sure the record was in the database. This introduced its own problems, however, in that the `save` call then started throwing an integrity error, complaining that a metadata record for that grouphash already existed. Since the call to Seer only happens with new, unrecognized grouphashes, and since we have a lock to prevent double group creation in those cases, this didn't make a ton of sense... until I realized that the lock doesn’t kick in until _after_ we're done calling Seer. Whoops.

As a result, here's what I think is currently happening when the backfill is off:

1. Two events with the same unrecognized hash come in essentially simultaneously.
2. They both hit the [`GroupHash.objects.get_or_create` call](https://github.com/getsentry/sentry/blob/330098773db1f3d6b12fced3b6c7da0f1617738d/src/sentry/grouping/ingest/hashing.py#L229) inside of `get_or_create_grouphashes`. (We use `get_or_create` there because the same codepath serves both new and existing hashes.) The slightly-sooner event creates a new grouphash and the slightly-later event gets that newly-created grouphash from the database. Each event has its own `GroupHash` instance to represent the shared database record.
3. With backfill turned off, only the slightly-sooner event gets routed to `create_or_update_grouphash_metadata_if_needed`. 
4. The slightly-sooner event [creates metadata for the grouphash](https://github.com/getsentry/sentry/blob/330098773db1f3d6b12fced3b6c7da0f1617738d/src/sentry/grouping/ingest/grouphash_metadata.py#L147), and Django attaches the resulting `GroupHashMetadata` object to that event's `GroupHash` instance.
5. Both events get sent to Seer. 
6. When it comes time to [store the results in metadata](https://github.com/getsentry/sentry/blob/330098773db1f3d6b12fced3b6c7da0f1617738d/src/sentry/grouping/ingest/seer.py#L398), only the slightly sooner event tries to do so, because the slightly-later event's `GroupHash` instance hasn't had a metadata record attached to it.
7. Everything works as expected and the rest of the `save_event` process proceeds as it normally would.

And here's what I think is happening when the backfill is on:

1. Same as above - two events come in
2. Same as above - grouphash is created by slightly-sooner event, picked up by slightly-later event
3. Because the backfill is on, this time both events get routed to `create_or_update_grouphash_metadata_if_needed`. Within `create_or_update_grouphash_metadata_if_needed`, they both fall into the [`if not grouphash.metadata` branch](https://github.com/getsentry/sentry/blob/330098773db1f3d6b12fced3b6c7da0f1617738d/src/sentry/grouping/ingest/grouphash_metadata.py#L136), since neither one has yet had a chance to create a metadata record.
4. Same as above - slightly-sooner event creates metadata
4a. The slightly-later event also tries to create metadata for the grouphash, but can't, because the slightly-sooner event already has. Django still attaches a `GroupHashMetadata` object to the event's `GroupHash` instance, but an id never gets filled in because no metadata record was successfully created.
5. Same as above - both events sent to Seer
6. As before, the slightly-sooner event stores its Seer results in metadata. The slightly-later event also tries to, since it now has a metadata object attached to its grouphash, but it can't, because the metadata object isn't actually tied to a real database record. (Or, after the first attempted fix, it tries to save its metadata before updating, and can't, because the metadata from the slightly-sooner event already exists.)
7. The slightly-sooner event proceeds as normal, while the slightly-later event throws an error.

With that scenario in mind, this PR makes three changes:

- Inside of `create_or_update_grouphash_metadata_if_needed`, switch from using `GroupHashMetadata.objects.create` to using `GroupHashMetadata.objects.get_or_create`. Do this with just the grouphash filled in, because we know it will be the same between the events.
- If `get_or_create` indicates that it got an already-existent record, log some info and then bail rather than trying to update the record with more data. That way, only the slightly-sooner event will have a metadata instance attached to its grouphash, and the Seer codepath will behave the way it did before backfill was turned on.
- Just in case something about this theory is wrong and we do still try to update a bad metadata record with Seer results, bail early so neither the original error nor the new integrity error is thrown. Keep the log there, so we can know if we ever hit that logic.

If this works, we can then remove the band-aid from the Seer code.