### PR TITLE
ref(onboarding): Improve project polling mechanism

### DIFF
--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -4,7 +4,6 @@ import type {OnboardingContextProps} from 'sentry/components/onboarding/onboardi
 import type {Category} from 'sentry/components/platformPicker';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 
-import type {Group} from './group';
 import type {Organization} from './organization';
 import type {PlatformIntegration, PlatformKey, Project} from './project';
 import type {AvatarUser} from './user';
@@ -141,13 +140,9 @@ export interface OnboardingSelectedSDK
   key: PlatformKey;
 }
 
-export type OnboardingRecentCreatedProject = Project & {
-  firstError: boolean;
-  firstTransaction: boolean;
-  hasReplays: boolean;
-  hasSessions: boolean;
-  olderThanOneHour: boolean;
-  firstIssue?: Group;
+export type OnboardingRecentCreatedProject = {
+  isProjectActive: boolean | undefined;
+  project: Project | undefined;
 };
 
 export type OnboardingPlatformDoc = {html: string; link: string};

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -117,13 +117,8 @@ describe('Onboarding', function () {
       .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
       .mockImplementation(() => {
         return {
-          ...nextJsProject,
-          firstError: false,
-          firstTransaction: false,
-          hasReplays: false,
-          hasSessions: false,
-          olderThanOneHour: false,
-          firstIssue: undefined,
+          project: nextJsProject,
+          isProjectActive: false,
         };
       });
 
@@ -204,13 +199,8 @@ describe('Onboarding', function () {
       .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
       .mockImplementation(() => {
         return {
-          ...reactProject,
-          firstError: false,
-          firstTransaction: false,
-          hasReplays: false,
-          hasSessions: false,
-          olderThanOneHour: false,
-          firstIssue: undefined,
+          project: reactProject,
+          isProjectActive: false,
         };
       });
 
@@ -301,13 +291,8 @@ describe('Onboarding', function () {
       .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
       .mockImplementation(() => {
         return {
-          ...reactProject,
-          firstError: false,
-          firstTransaction: false,
-          hasReplays: false,
-          hasSessions: true,
-          olderThanOneHour: false,
-          firstIssue: undefined,
+          project: reactProject,
+          isProjectActive: true,
         };
       });
 

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -12,7 +12,6 @@ import {
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import type {OnboardingRecentCreatedProject} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import SetupDocs from 'sentry/views/onboarding/setupDocs';
@@ -85,7 +84,7 @@ describe('Onboarding Setup Docs', function () {
           genSkipOnboardingLink={() => ''}
           orgId={organization.slug}
           search=""
-          recentCreatedProject={project as OnboardingRecentCreatedProject}
+          recentCreatedProject={project}
         />
       </OnboardingContextProvider>,
       {
@@ -133,7 +132,7 @@ describe('Onboarding Setup Docs', function () {
           genSkipOnboardingLink={() => ''}
           orgId={organization.slug}
           search=""
-          recentCreatedProject={project as OnboardingRecentCreatedProject}
+          recentCreatedProject={project}
         />
       </OnboardingContextProvider>,
       {
@@ -189,7 +188,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project as OnboardingRecentCreatedProject}
+            recentCreatedProject={project}
           />
         </OnboardingContextProvider>,
         {
@@ -243,7 +242,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project as OnboardingRecentCreatedProject}
+            recentCreatedProject={project}
           />
         </OnboardingContextProvider>,
         {
@@ -293,7 +292,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project as OnboardingRecentCreatedProject}
+            recentCreatedProject={project}
           />
         </OnboardingContextProvider>,
         {
@@ -343,7 +342,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project as OnboardingRecentCreatedProject}
+            recentCreatedProject={project}
           />
         </OnboardingContextProvider>,
         {
@@ -412,7 +411,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project as OnboardingRecentCreatedProject}
+            recentCreatedProject={project}
           />
         </OnboardingContextProvider>,
         {
@@ -496,7 +495,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project as OnboardingRecentCreatedProject}
+            recentCreatedProject={project}
           />
         </OnboardingContextProvider>,
         {

--- a/static/app/views/onboarding/types.ts
+++ b/static/app/views/onboarding/types.ts
@@ -1,8 +1,6 @@
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {
-  OnboardingRecentCreatedProject,
-  OnboardingSelectedSDK,
-} from 'sentry/types/onboarding';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Project} from 'sentry/types/project';
 
 export type StepData = {
   platform?: OnboardingSelectedSDK | null;
@@ -16,7 +14,7 @@ export type StepProps = Pick<RouteComponentProps, 'router' | 'route' | 'location
   orgId: string;
   search: string;
   stepIndex: number;
-  recentCreatedProject?: OnboardingRecentCreatedProject;
+  recentCreatedProject?: Project;
 };
 
 export type StepDescriptor = {

--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -29,23 +29,12 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
   const api = useApi();
   const router = useRouter();
 
-  const recentCreatedProject = useRecentCreatedProject({
+  const {project: recentCreatedProject, isProjectActive} = useRecentCreatedProject({
     orgSlug: organization.slug,
     projectSlug,
   });
 
-  const shallProjectBeDeleted =
-    recentCreatedProject &&
-    // if the project has received a first error, we don't delete it
-    recentCreatedProject.firstError === false &&
-    // if the project has received a first transaction, we don't delete it
-    recentCreatedProject.firstTransaction === false &&
-    // if the project has replays, we don't delete it
-    recentCreatedProject.hasReplays === false &&
-    // if the project has sessions, we don't delete it
-    recentCreatedProject.hasSessions === false &&
-    // if the project is older than one hour, we don't delete it
-    recentCreatedProject.olderThanOneHour === false;
+  const shallProjectBeDeleted = !isProjectActive;
 
   const handleGoBack = useCallback(async () => {
     if (!recentCreatedProject) {


### PR DESCRIPTION
De-dupe logic
Stop polling once the project is determined active.

- part of https://github.com/getsentry/projects/issues/736