### PR TITLE
ref(quick-start): Update mark onboarding as complete logic

### DIFF
--- a/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
+++ b/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
@@ -39,6 +39,9 @@ class OrganizationOnboardingTaskBackend(OnboardingTaskBackend[OrganizationOnboar
             OrganizationOnboardingTask.objects.filter(
                 Q(organization_id=organization_id)
                 & (Q(status=OnboardingTaskStatus.COMPLETE) | Q(status=OnboardingTaskStatus.SKIPPED))
+                & Q(
+                    completion_seen__isnull=False
+                )  # For a task to be considered complete, it must have been marked as seen.
             ).values_list("task", flat=True)
         )
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -565,7 +565,7 @@ def record_alert_rule_created(user, project: Project, rule_type: str, **kwargs):
     # Please see https://github.com/getsentry/sentry/blob/c06a3aa5fb104406f2a44994d32983e99bc2a479/static/app/components/onboardingWizard/taskConfig.tsx#L351-L352
     if rule_type == "metric":
         return
-    rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+    OrganizationOnboardingTask.objects.create_or_update(
         organization_id=project.organization_id,
         task=OnboardingTask.ALERT_RULE,
         values={

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -412,7 +412,7 @@ def record_member_invited(member, user, **kwargs):
 
 @member_joined.connect(weak=False)
 def record_member_joined(organization_id: int, organization_member_id: int, **kwargs):
-    rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+    OrganizationOnboardingTask.objects.create_or_update(
         organization_id=organization_id,
         task=OnboardingTask.INVITE_MEMBER,
         status=OnboardingTaskStatus.PENDING,

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -1189,6 +1189,12 @@ class OrganizationOnboardingTaskTest(TestCase):
             default_rules=False,
         )
 
+        # Manually update the completionSeen column of existing tasks
+        OrganizationOnboardingTask.objects.filter(organization=self.organization).update(
+            completion_seen=timezone.now()
+        )
+        onboarding_tasks.try_mark_onboarding_complete(self.organization.id)
+
         # Onboarding is NOT yet complete
         assert (
             OrganizationOption.objects.filter(
@@ -1250,6 +1256,12 @@ class OrganizationOnboardingTaskTest(TestCase):
             project_platform=project.platform,
             url=dict(event_with_sourcemap.tags).get("url", None),
         )
+
+        # Manually update the completionSeen column of existing tasks
+        OrganizationOnboardingTask.objects.filter(organization=self.organization).update(
+            completion_seen=timezone.now()
+        )
+        onboarding_tasks.try_mark_onboarding_complete(self.organization.id)
 
         # Onboarding is NOW complete
         assert (

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from django.utils import timezone
 
+from sentry import onboarding_tasks
 from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
@@ -1009,6 +1010,12 @@ class OrganizationOnboardingTaskTest(TestCase):
             organization_id=self.organization.id,
         )
 
+        # Manually update the completionSeen column of existing tasks
+        OrganizationOnboardingTask.objects.filter(organization=self.organization).update(
+            completion_seen=timezone.now()
+        )
+        onboarding_tasks.try_mark_onboarding_complete(self.organization.id)
+
         # The first group is complete but the beyond the basics is not
         assert (
             OrganizationOption.objects.filter(
@@ -1086,6 +1093,12 @@ class OrganizationOnboardingTaskTest(TestCase):
             organization_id=self.organization.id,
             project_id=second_project.id,
         )
+
+        # Manually update the completionSeen column of existing tasks
+        OrganizationOnboardingTask.objects.filter(organization=self.organization).update(
+            completion_seen=timezone.now()
+        )
+        onboarding_tasks.try_mark_onboarding_complete(self.organization.id)
 
         # Onboarding is complete
         assert (


### PR DESCRIPTION
Currently, when a user completes all the required onboarding tasks, the quick start sidebar simply disappears. This can leave users confused about what happened. Instead, we want to provide them with a way to celebrate their achievement and give them a sense of accomplishment ([see](https://github.com/getsentry/projects/issues/700) ).

To implement this, this PR:

- Updates the onboarding completion filter by adding the check `completion_seen__isnull=False`
- Removes all instances where we previously tried to mark the onboarding as complete, as this will now only occur through the UI https://github.com/getsentry/sentry/blob/bad8a52ec51cc6f38b89fa79d83456b451bdecf2/src/sentry/api/endpoints/organization_onboarding_tasks.py#L75 once the user has seen all pending (not seen done tasks) tasks.

Note:

we could instead just add a second check here https://github.com/getsentry/sentry/blob/bad8a52ec51cc6f38b89fa79d83456b451bdecf2/src/sentry/api/serializers/models/organization.py#L374 However, I believe the current changes are the most accurate solution


- closes https://github.com/getsentry/projects/issues/700