### PR TITLE
ref(quick-start): Update logic to display celebration when all tasks are done instead complete

### DIFF
--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -579,7 +579,8 @@ interface OnboardingSidebarContentProps {
 }
 
 export function OnboardingSidebarContent({onClose}: OnboardingSidebarContentProps) {
-  const {gettingStartedTasks, beyondBasicsTasks} = useOnboardingTasks();
+  const {gettingStartedTasks, beyondBasicsTasks, allTasks, doneTasks} =
+    useOnboardingTasks();
 
   const sortedGettingStartedTasks = gettingStartedTasks.sort(
     (a, b) =>
@@ -597,10 +598,6 @@ export function OnboardingSidebarContent({onClose}: OnboardingSidebarContentProp
       task => !taskIsDone(task) && !!task.SupplementComponent
     )?.task;
   }, [sortedGettingStartedTasks, sortedBeyondBasicsTasks]);
-
-  const allTasksCompleted = [...gettingStartedTasks, ...beyondBasicsTasks].every(
-    findCompleteTasks
-  );
 
   return (
     <Content>
@@ -629,7 +626,7 @@ export function OnboardingSidebarContent({onClose}: OnboardingSidebarContentProp
           group="beyond_basics"
         />
       )}
-      {allTasksCompleted && (
+      {allTasks.length === doneTasks.length && (
         <CompletionCelebrationText>
           <div>{t('Good job, you’re all done here!')}</div>
           {t('Now get out of here and write some broken code.')}


### PR DESCRIPTION
When the sidebar is open, requests will be fired to mark the done tasks as complete. However, we can already display the celebration, as the user has finished all tasks (done) and is currently viewing them (completing).