### PR TITLE
chore(dynamic-sampling): update audit log text for samplingmode switch

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -953,6 +953,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         if is_project_mode_sampling(organization):
                             self._compute_project_target_sample_rates(request, organization)
                             organization.delete_option("sentry:target_sample_rate")
+                            changed_data["samplingMode"] = "to Advanced Mode"
 
                         elif is_org_mode:
                             if "targetSampleRate" in changed_data:
@@ -960,6 +961,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                                     "sentry:target_sample_rate",
                                     serializer.validated_data["targetSampleRate"],
                                 )
+                            changed_data["samplingMode"] = "to Default Mode"
 
                             ProjectOption.objects.filter(
                                 project__organization_id=organization.id,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -741,6 +741,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
     )
     @with_feature(["organizations:codecov-integration", "organizations:dynamic-sampling-custom"])
     def test_various_options(self, mock_get_repositories):
+        self.organization.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT.value)
         initial = self.organization.get_audit_log_data()
         with assume_test_silo_mode_of(AuditLogEntry):
             AuditLogEntry.objects.filter(organization_id=self.organization.id).delete()
@@ -860,6 +861,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["issueAlertsThreadFlag"]) in log.data["issueAlertsThreadFlag"]
         assert "to {}".format(data["metricAlertsThreadFlag"]) in log.data["metricAlertsThreadFlag"]
         assert "to {}".format(data["uptimeAutodetection"]) in log.data["uptimeAutodetection"]
+        assert "to Default Mode" in log.data["samplingMode"]
 
     @responses.activate
     @patch(


### PR DESCRIPTION
- Update wording of audit logs to correspond to the customer-facing terms
- Closes https://github.com/getsentry/projects/issues/754