### PR TITLE
feat(laravel-insights): Redirect from project details

### DIFF
--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -1,3 +1,4 @@
+import Redirect from 'sentry/components/redirect';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -10,6 +11,7 @@ function ProjectDetailContainer(
     'projects' | 'loadingProjects' | 'selection'
   >
 ) {
+  const {organization} = props;
   const {projects} = useProjects();
   const project = projects.find(p => p.slug === props.params.projectId);
   useRouteAnalyticsParams(
@@ -20,6 +22,18 @@ function ProjectDetailContainer(
         }
       : {}
   );
+
+  if (
+    project?.platform === 'php-laravel' &&
+    organization.features.includes('laravel-insights')
+  ) {
+    return (
+      <Redirect
+        to={`/organizations/${organization.slug}/insights/backend?project=${project.id}`}
+      />
+    );
+  }
+
   return <ProjectDetail {...props} />;
 }
 


### PR DESCRIPTION
Redirect to the laravel insights when accessing project details.
**Note:** This is part of a WIP and aims to build a quick POC.

- closes https://github.com/getsentry/projects/issues/740