### PR TITLE
Add wrap your app

### DIFF
--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -135,8 +135,14 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
             ),
             configurations: [
               {
-                language: 'bash',
-                code: `npx @sentry/wizard@latest -i reactNative --org ${params.organization.slug} --project ${params.projectSlug}`,
+                code: [
+                  {
+                    label: 'npx',
+                    value: 'npx',
+                    language: 'bash',
+                    code: `npx @sentry/wizard@latest -i reactNative ${params.isSelfHosted ? '' : '--saas'} --org ${params.organization.slug} --project ${params.projectSlug}`,
+                  },
+                ],
               },
               {
                 description: (
@@ -155,7 +161,36 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                         {t('Add debug symbols upload to your build process')}
                       </ListItem>
                     </List>
+                    <p />
+                    <p>
+                      <strong>{t('Wrap Your App')}</strong>
+                    </p>
+                    <p>
+                      {tct(
+                        'After the wizard completes, wrap your app with Sentry to enable automatic [touchEventLink:touch event tracking] and [autoInstrumentationLink:automatic instrumentation]:',
+                        {
+                          touchEventLink: (
+                            <ExternalLink href="https://docs.sentry.io/platforms/react-native/configuration/touchevents/" />
+                          ),
+                          autoInstrumentationLink: (
+                            <ExternalLink href="https://docs.sentry.io/platforms/react-native/tracing/instrumentation/automatic-instrumentation/" />
+                          ),
+                        }
+                      )}
+                    </p>
                   </Fragment>
+                ),
+                code: [
+                  {
+                    label: 'JavaScript',
+                    value: 'javascript',
+                    language: 'javascript',
+                    filename: 'App.js',
+                    code: `export default Sentry.wrap(App);`,
+                  },
+                ],
+                additionalInfo: t(
+                  'This step is not required if your app does not have a single parent "App" component.'
                 ),
               },
             ],


### PR DESCRIPTION
The react-native onboarding with the sentry-cli wizard, misses one step which is important for setting up automatic instrumentation. This is present in the docs but is missing from the product

- this PR add the wrap you app ([docs](https://docs.sentry.io/platforms/react-native/#wrap-your-app)) section to the auto/wizard flow
- and there are some QoL enhancements regarding the styling of the code snippet boxes, so you can see what file and file type the snippets are referring to


<img width="1169" alt="image" src="https://github.com/user-attachments/assets/e26014c8-480a-4f55-9739-ed9ffd954fef" />