### PR TITLE
fix(Tempest): Update message type on successful pull

### DIFF
--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -152,7 +152,10 @@ def poll_tempest_crashes(credentials_id: int, **kwargs) -> None:
 
         result = response.json()
         credentials.latest_fetched_item_id = result["latest_id"]
-        credentials.save(update_fields=["latest_fetched_item_id"])
+        # Make sure that once existing customers pull crashes the message is set to SUCCESS,
+        # since due to legacy reasons they might still have an empty ERROR message.
+        credentials.message_type = MessageType.SUCCESS
+        credentials.save(update_fields=["latest_fetched_item_id", "message_type"])
     except Exception as e:
         logger.exception(
             "Fetching the crashes failed.",

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -154,8 +154,9 @@ def poll_tempest_crashes(credentials_id: int, **kwargs) -> None:
         credentials.latest_fetched_item_id = result["latest_id"]
         # Make sure that once existing customers pull crashes the message is set to SUCCESS,
         # since due to legacy reasons they might still have an empty ERROR message.
+        credentials.message = ""
         credentials.message_type = MessageType.SUCCESS
-        credentials.save(update_fields=["latest_fetched_item_id", "message_type"])
+        credentials.save(update_fields=["latest_fetched_item_id", "message", "message_type"])
     except Exception as e:
         logger.exception(
             "Fetching the crashes failed.",


### PR DESCRIPTION
The previous changes did not consider that existing credentials would still have a empty error message attached to them.
This PR makes sure that the message type becomes success after the first successful pull for these credentials.