### PR TITLE
Fixing User Feedback source maps modal

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -381,8 +381,9 @@ export function SourceMapsDebuggerModal({
       </Body>
       <Footer>
         <Link
-          to=""
+          to="#"
           onClick={e => {
+            e.preventDefault();
             e.stopPropagation();
             openModal(modalProps => (
               <FeedbackModal


### PR DESCRIPTION
The user feedback link was broken, this should fix it. I was not able to test locally. CORS blocks all sentry requests running on dev local
