### PR TITLE
ref(insights): Removes aggregate waterfall links from the Web Vitals module

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/miniAggregateWaterfall.tsx
+++ b/static/app/views/insights/browser/webVitals/components/miniAggregateWaterfall.tsx
@@ -2,28 +2,20 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import {LinkButton} from 'sentry/components/button';
 import {noFilter} from 'sentry/components/events/interfaces/spans/filter';
 import {ActualMinimap} from 'sentry/components/events/interfaces/spans/header';
 import {useSpanWaterfallModelFromTransaction} from 'sentry/components/events/interfaces/spans/useSpanWaterfallModelFromTransaction';
 import OpsBreakdown from 'sentry/components/events/opsBreakdown';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-import {LandingDisplayField} from 'sentry/views/insights/browser/webVitals/views/pageOverview';
 
 type Props = {
   transaction: string;
   aggregateSpansLocation?: Location;
 };
 
-export function MiniAggregateWaterfall({transaction, aggregateSpansLocation}: Props) {
+export function MiniAggregateWaterfall({transaction}: Props) {
   const theme = useTheme();
-  const location = useLocation();
-  const organization = useOrganization();
 
   // Pageload transactions don't seem to store http.method, so don't include one here
   const {waterfallModel, event, isLoading} =
@@ -31,13 +23,6 @@ export function MiniAggregateWaterfall({transaction, aggregateSpansLocation}: Pr
   if (isLoading) {
     return <LoadingIndicator />;
   }
-  const AggregateSpanWaterfallLocation = aggregateSpansLocation ?? {
-    ...location,
-    query: {
-      ...location.query,
-      tab: LandingDisplayField.SPANS,
-    },
-  };
   const minimap = (
     <ActualMinimap
       theme={theme}
@@ -60,18 +45,6 @@ export function MiniAggregateWaterfall({transaction, aggregateSpansLocation}: Pr
     <span>
       <MinimapContainer>{minimap}</MinimapContainer>
       <BreakdownContainer>{opsBreakdown}</BreakdownContainer>
-      <LinkButton
-        aria-label={t('View Full Waterfall')}
-        size="sm"
-        to={AggregateSpanWaterfallLocation}
-        onClick={() => {
-          trackAnalytics('insight.vital.overview.open_full_waterfall', {
-            organization,
-          });
-        }}
-      >
-        {t('View Full Waterfall')}
-      </LinkButton>
     </span>
   );
 }

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -6,7 +6,7 @@ import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {LinkButton} from 'sentry/components/button';
 import {AggregateSpans} from 'sentry/components/events/interfaces/spans/aggregateSpans';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, Tabs} from 'sentry/components/tabs';
+import {Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -47,17 +47,6 @@ export enum LandingDisplayField {
   OVERVIEW = 'overview',
   SPANS = 'spans',
 }
-
-const LANDING_DISPLAYS = [
-  {
-    label: t('Overview'),
-    field: LandingDisplayField.OVERVIEW,
-  },
-  {
-    label: t('Aggregate Spans'),
-    field: LandingDisplayField.SPANS,
-  },
-];
 
 function getCurrentTabSelection(selectedTab: any) {
   const tab = decodeScalar(selectedTab);
@@ -189,18 +178,6 @@ export function PageOverview() {
               </LinkButton>
             )
           }
-          hideDefaultTabs
-          tabs={{
-            value: tab,
-            onTabChange: handleTabChange,
-            tabList: (
-              <TabList hideBorder>
-                {LANDING_DISPLAYS.map(({label, field}) => (
-                  <TabList.Item key={field}>{label}</TabList.Item>
-                ))}
-              </TabList>
-            ),
-          }}
           breadcrumbs={transaction ? [{label: 'Page Summary'}] : []}
           module={ModuleName.VITAL}
         />


### PR DESCRIPTION
Removes aggregate waterfall links from Webvitals since they are not fully functional and will be replaced in the future. The mini aggregate waterfall sidebar widget still remains for now.