### PR TITLE
feat(laravel-insights): add request to eap to retrieve context & display in routes table

### DIFF
--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -678,7 +678,7 @@ const PathCell = styled('div')`
   display: flex;
   flex-direction: column;
   padding: ${space(1)} ${space(2)};
-  min-height: ${space(5)};
+  min-height: ${space(4)};
   justify-content: center;
   gap: ${space(0.5)};
 `;

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -679,9 +679,13 @@ const PathCell = styled('div')`
   display: flex;
   flex-direction: column;
   padding: ${space(1)} ${space(2)};
-  min-height: ${space(4)};
   justify-content: center;
   gap: ${space(0.5)};
+
+  [role='columnheader'] & {
+    padding-top: ${space(0.75)};
+    padding-bottom: ${space(0.75)};
+  }
 `;
 
 const ControllerText = styled('div')`
@@ -699,14 +703,6 @@ const Cell = styled('div')`
   overflow: hidden;
   white-space: nowrap;
   padding: ${space(1)} ${space(2)};
-  min-height: ${space(4)};
-
-  [role='columnheader'] & {
-    color: ${p => p.theme.gray300};
-    font-size: ${p => p.theme.fontSizeSmall};
-    font-weight: 600;
-    max-height: ${space(2)};
-  }
 
   &[data-color='danger'] {
     color: ${p => p.theme.red400};
@@ -714,6 +710,17 @@ const Cell = styled('div')`
   &[data-color='warning'] {
     color: ${p => p.theme.yellow400};
   }
+  &[data-align='right'] {
+    text-align: right;
+    justify-content: flex-end;
+  }
+`;
+
+const HeaderCell = styled(Cell)`
+  padding: ${space(0.25)} ${space(2)};
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: 600;
   &[data-align='right'] {
     text-align: right;
     justify-content: flex-end;
@@ -818,16 +825,16 @@ function RoutesTable({query}: {query?: string}) {
       headers={[
         'Method',
         'Path',
-        <Cell key="requests">
+        <HeaderCell key="requests">
           <IconArrow direction="down" />
           Requests
-        </Cell>,
+        </HeaderCell>,
         'Error Rate',
         'AVG',
         'P95',
-        <Cell key="users" data-align="right">
+        <HeaderCell key="users" data-align="right">
           Users
-        </Cell>,
+        </HeaderCell>,
       ]}
       isLoading={transactionsRequest.isLoading}
       isEmpty={!tableData || tableData.length === 0}

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -780,7 +780,7 @@ function RoutesTable({query}: {query?: string}) {
           ],
           query: `transaction.op:http.server span.op:http.route transaction:[${
             transactionPaths.map(transactions => `"${transactions}"`).join(',') || '""'
-          }] ${query}`,
+          }]`,
           referrer: 'api.explore.spans-aggregates-table',
           sort: '-transaction',
           per_page: 25,

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -674,7 +674,6 @@ const getCellColor = (value: number, thresholds: Record<string, number>) => {
   return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0];
 };
 
-// Add this styled component near other styled components
 const PathCell = styled('div')`
   display: flex;
   flex-direction: column;

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -689,6 +689,7 @@ const ControllerText = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   ${p => p.theme.overflowEllipsis};
   line-height: 1;
+  width: 25vw;
 `;
 
 const Cell = styled('div')`
@@ -846,7 +847,7 @@ function RoutesTable({query}: {query?: string}) {
               {routeControllersRequest.isLoading ? (
                 <Placeholder
                   height={theme.fontSizeSmall}
-                  width="30vw"
+                  width="25vw"
                   testId="skeleton-ui"
                 />
               ) : (

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -711,14 +711,7 @@ const Cell = styled('div')`
 `;
 
 const HeaderCell = styled(Cell)`
-  padding: ${space(0.25)} ${space(2)};
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeSmall};
-  font-weight: 600;
-  &[data-align='right'] {
-    text-align: right;
-    justify-content: flex-end;
-  }
+  padding: 0;
 `;
 
 function RoutesTable({query}: {query?: string}) {

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -20,6 +20,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
+import Placeholder from 'sentry/components/placeholder';
 import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
@@ -703,7 +704,7 @@ const Cell = styled('div')`
     color: ${p => p.theme.gray300};
     font-size: ${p => p.theme.fontSizeSmall};
     font-weight: 600;
-    min-height: ${space(3)};
+    max-height: ${space(2)};
   }
 
   &[data-color='danger'] {
@@ -721,6 +722,7 @@ const Cell = styled('div')`
 function RoutesTable({query}: {query?: string}) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
+  const theme = useTheme();
 
   const transactionsRequest = useApiQuery<DiscoverQueryResponse>(
     [
@@ -826,7 +828,7 @@ function RoutesTable({query}: {query?: string}) {
           Users
         </Cell>,
       ]}
-      isLoading={transactionsRequest.isLoading || routeControllersRequest.isLoading}
+      isLoading={transactionsRequest.isLoading}
       isEmpty={!tableData || tableData.length === 0}
     >
       {tableData?.map(transaction => {
@@ -841,7 +843,17 @@ function RoutesTable({query}: {query?: string}) {
             <Cell>{transaction.method}</Cell>
             <PathCell>
               {transaction.path}
-              <ControllerText>{transaction.controller}</ControllerText>
+              {routeControllersRequest.isLoading ? (
+                <Placeholder
+                  height={theme.fontSizeSmall}
+                  width="30vw"
+                  testId="skeleton-ui"
+                />
+              ) : (
+                transaction.controller && (
+                  <ControllerText>{transaction.controller}</ControllerText>
+                )
+              )}
             </PathCell>
             <Cell>{formatAbbreviatedNumber(transaction.requests)}</Cell>
             <Cell data-color={errorRateColor}>

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -680,11 +680,6 @@ const PathCell = styled('div')`
   padding: ${space(1)} ${space(2)};
   justify-content: center;
   gap: ${space(0.5)};
-
-  [role='columnheader'] & {
-    padding-top: ${space(0.75)};
-    padding-bottom: ${space(0.75)};
-  }
 `;
 
 const ControllerText = styled('div')`
@@ -851,11 +846,7 @@ function RoutesTable({query}: {query?: string}) {
             <PathCell>
               {transaction.path}
               {routeControllersRequest.isLoading ? (
-                <Placeholder
-                  height={theme.fontSizeSmall}
-                  width="25vw"
-                  testId="skeleton-ui"
-                />
+                <Placeholder height={theme.fontSizeSmall} width="25vw" />
               ) : (
                 transaction.controller && (
                   <ControllerText>{transaction.controller}</ControllerText>

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -21,6 +21,7 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import Placeholder from 'sentry/components/placeholder';
+import {Tooltip} from 'sentry/components/tooltip';
 import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
@@ -685,9 +686,12 @@ const PathCell = styled('div')`
 const ControllerText = styled('div')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
-  ${p => p.theme.overflowEllipsis};
   line-height: 1;
-  width: 25vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  min-width: 0px;
 `;
 
 const Cell = styled('div')`
@@ -839,10 +843,17 @@ function RoutesTable({query}: {query?: string}) {
             <PathCell>
               {transaction.path}
               {routeControllersRequest.isLoading ? (
-                <Placeholder height={theme.fontSizeSmall} width="25vw" />
+                <Placeholder height={theme.fontSizeSmall} width="200px" />
               ) : (
                 transaction.controller && (
-                  <ControllerText>{transaction.controller}</ControllerText>
+                  <Tooltip
+                    title={transaction.controller}
+                    position="top"
+                    maxWidth={400}
+                    showOnlyOnOverflow
+                  >
+                    <ControllerText>{transaction.controller}</ControllerText>
+                  </Tooltip>
                 )
               )}
             </PathCell>


### PR DESCRIPTION
- Closes https://github.com/getsentry/projects/issues/717

Before:
<img width="1249" alt="Screenshot 2025-02-26 at 16 48 59" src="https://github.com/user-attachments/assets/7d48a59d-2f38-4a8f-943c-a0c8ab0ec048" />

After:
Loading State:
<img width="1254" alt="Screenshot 2025-02-27 at 15 54 29" src="https://github.com/user-attachments/assets/c023c479-e316-4101-a145-f2fb5cfd8a9b" />

After Loading (shows a tooltip on hover):
<img width="1255" alt="Screenshot 2025-02-27 at 15 52 31" src="https://github.com/user-attachments/assets/0273a056-67e1-47d2-bdf1-ccfb962382bf" />
