### PR TITLE
fix(widget-builder): Reset limit properly when switching datasets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -772,6 +772,36 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.limit).toBe(3);
     });
+
+    it('does not reset the limit when switching between timeseries charts', () => {
+      // One query and one y-axis is the most permissible setup
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.LINE,
+            limit: '3',
+            field: ['project'],
+            yAxis: ['count()'],
+            query: [''],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.limit).toBe(3);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.AREA,
+        });
+      });
+
+      expect(result.current.state.limit).toBe(3);
+    });
   });
 
   describe('dataset', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -742,6 +742,36 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.limit).toBeUndefined();
     });
+
+    it('resets the limit to a valid option when the display type is switched to a chart', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.TABLE,
+            field: [
+              'count()',
+              'count_unique(user)',
+              'count_web_vitals(measurements.lcp, good)',
+              'project',
+              'environment',
+            ],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.LINE,
+        });
+      });
+
+      expect(result.current.state.limit).toBe(3);
+    });
   });
 
   describe('dataset', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -723,6 +723,25 @@ describe('useWidgetBuilderState', () => {
         {field: 'transaction', alias: undefined, kind: 'field'},
       ]);
     });
+
+    it('resets limit when the display type is switched to table', () => {
+      mockedUsedLocation.mockReturnValue(LocationFixture({query: {limit: '3'}}));
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.limit).toBe(3);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.TABLE,
+        });
+      });
+
+      expect(result.current.state.limit).toBeUndefined();
+    });
   });
 
   describe('dataset', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -215,6 +215,7 @@ function useWidgetBuilderState(): {
             return {...axis, alias: undefined};
           });
           if (action.payload === DisplayType.TABLE) {
+            setLimit(undefined);
             setYAxis([]);
             setLegendAlias([]);
             const newFields = [
@@ -260,6 +261,7 @@ function useWidgetBuilderState(): {
             }
           } else if (action.payload === DisplayType.BIG_NUMBER) {
             // TODO: Reset the selected aggregate here for widgets with equations
+            setLimit(undefined);
             setSort([]);
             setYAxis([]);
             setLegendAlias([]);
@@ -267,6 +269,7 @@ function useWidgetBuilderState(): {
             setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])]);
             setQuery(query?.slice(0, 1));
           } else {
+            setLimit(DEFAULT_RESULTS_LIMIT);
             setFields(columnsWithoutAlias);
             const nextAggregates = [
               ...aggregatesWithoutAlias.slice(0, MAX_NUM_Y_AXES),

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -25,7 +25,10 @@ import {
   DISABLED_SORT,
   TAG_SORT_DENY_LIST,
 } from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
-import {DEFAULT_RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
+import {
+  DEFAULT_RESULTS_LIMIT,
+  getResultsLimit,
+} from 'sentry/views/dashboards/widgetBuilder/utils';
 import type {Thresholds} from 'sentry/views/dashboards/widgets/common/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
@@ -269,7 +272,9 @@ function useWidgetBuilderState(): {
             setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])]);
             setQuery(query?.slice(0, 1));
           } else {
-            setLimit(DEFAULT_RESULTS_LIMIT);
+            // Reset the limit to a valid value, bias towards the default if possible
+            const maxLimit = getResultsLimit(query?.length ?? 1, aggregates.length);
+            setLimit(Math.min(DEFAULT_RESULTS_LIMIT, maxLimit));
             setFields(columnsWithoutAlias);
             const nextAggregates = [
               ...aggregatesWithoutAlias.slice(0, MAX_NUM_Y_AXES),

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -272,9 +272,6 @@ function useWidgetBuilderState(): {
             setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])]);
             setQuery(query?.slice(0, 1));
           } else {
-            // Reset the limit to a valid value, bias towards the default if possible
-            const maxLimit = getResultsLimit(query?.length ?? 1, aggregates.length);
-            setLimit(Math.min(DEFAULT_RESULTS_LIMIT, maxLimit));
             setFields(columnsWithoutAlias);
             const nextAggregates = [
               ...aggregatesWithoutAlias.slice(0, MAX_NUM_Y_AXES),
@@ -287,6 +284,11 @@ function useWidgetBuilderState(): {
               });
             }
             setYAxis(nextAggregates);
+
+            // Reset the limit to a valid value, bias towards the current limit or
+            // default if possible
+            const maxLimit = getResultsLimit(query?.length ?? 1, nextAggregates.length);
+            setLimit(Math.min(limit ?? DEFAULT_RESULTS_LIMIT, maxLimit));
 
             if (dataset === WidgetType.RELEASE && sort?.length === 0) {
               setSort(
@@ -521,6 +523,7 @@ function useWidgetBuilderState(): {
       query,
       sort,
       dataset,
+      limit,
     ]
   );
 


### PR DESCRIPTION
Resets table and big number to undefined so there's no limit applied. Resets the chart limits to the default value if available, otherwise cap it at the max allowed limit for the configuration

Closes #85796