### PR TITLE
fix(query-builder): Increase distance in the fuzzy search config

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -37,6 +37,7 @@ const FUZZY_SEARCH_OPTIONS: Fuse.IFuseOptions<FilterKeySearchItem> = {
   includeMatches: false,
   minMatchCharLength: 1,
   includeScore: true,
+  distance: 1000,
 };
 
 function isQuoted(inputValue: string) {


### PR DESCRIPTION
It was difficult to search long filter keys due to the fuzzy search config looking too strictly and the position of the query. For example, if you are searching for `tats[response.status_code,number]` and typed `status` it would not meet the threshold. By increasing the distance to 1000 (from the default 100) this is no longer an issue.