### PR TITLE
feat(relocation) Implement relocation transfer task

### DIFF
--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -25,6 +25,7 @@ from sentry.relocation.services.relocation_export.service import (
     ControlRelocationExportService,
     RegionRelocationExportService,
 )
+from sentry.relocation.tasks.process import fulfill_cross_region_export_request, uploading_complete
 from sentry.relocation.utils import RELOCATION_BLOB_SIZE, RELOCATION_FILE_TYPE, uuid_to_identifier
 from sentry.utils.db import atomic_transaction
 
@@ -41,7 +42,6 @@ class DBBackedRelocationExportService(RegionRelocationExportService):
         org_slug: str,
         encrypt_with_public_key: bytes,
     ) -> None:
-        from sentry.relocation.tasks.process import fulfill_cross_region_export_request
 
         logger_data = {
             "uuid": relocation_uuid,
@@ -81,7 +81,6 @@ class DBBackedRelocationExportService(RegionRelocationExportService):
         encrypted_contents: bytes | None,
         encrypted_bytes: list[int] | None = None,
     ) -> None:
-        from sentry.relocation.tasks.process import uploading_complete
 
         with atomic_transaction(
             using=(

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -57,7 +57,6 @@ from sentry.relocation.models.relocation import (
 from sentry.relocation.services.relocation_export.model import (
     RelocationExportReplyWithExportParameters,
 )
-from sentry.relocation.services.relocation_export.service import control_relocation_export_service
 from sentry.relocation.utils import (
     TASK_TO_STEP,
     LoggingPrinter,
@@ -244,6 +243,9 @@ def uploading_start(uuid: UUID, replying_region_name: str | None, org_slug: str 
         with the `Relocation` that originally triggered `uploading_start`, and the next task in the
         sequence (`uploading_complete`) is scheduled.
     """
+    from sentry.relocation.services.relocation_export.service import (
+        control_relocation_export_service,
+    )
 
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,

--- a/tests/sentry/relocation/tasks/test_transfer.py
+++ b/tests/sentry/relocation/tasks/test_transfer.py
@@ -1,9 +1,13 @@
 from datetime import timedelta
+from io import BytesIO
 from unittest.mock import patch
 from uuid import uuid4
 
 from django.utils import timezone
 
+from sentry.models.files.utils import get_relocation_storage
+from sentry.models.organization import Organization
+from sentry.relocation.models.relocation import Relocation, RelocationFile
 from sentry.relocation.models.relocationtransfer import (
     ControlRelocationTransfer,
     RegionRelocationTransfer,
@@ -12,23 +16,39 @@ from sentry.relocation.models.relocationtransfer import (
 from sentry.relocation.tasks.transfer import (
     find_relocation_transfer_control,
     find_relocation_transfer_region,
+    process_relocation_transfer_control,
 )
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, create_test_regions
+
+TEST_REGIONS = create_test_regions("us", "de")
+
+
+def create_control_relocation_transfer(organization: Organization, **kwargs):
+    if "relocation_uuid" not in kwargs:
+        kwargs["relocation_uuid"] = uuid4()
+    if "state" not in kwargs:
+        kwargs["state"] = RelocationTransferState.Request
+
+    return ControlRelocationTransfer.objects.create(
+        org_slug=organization.slug, requesting_region="de", exporting_region="us", **kwargs
+    )
+
+
+def create_region_relocation_transfer(organization: Organization, **kwargs):
+    if "relocation_uuid" not in kwargs:
+        kwargs["relocation_uuid"] = uuid4()
+    if "state" not in kwargs:
+        kwargs["state"] = RelocationTransferState.Request
+
+    return RegionRelocationTransfer.objects.create(
+        org_slug=organization.slug, requesting_region="de", exporting_region="us", **kwargs
+    )
 
 
 @control_silo_test
 class FindRelocationTransferControlTest(TestCase):
-    def create_control_relocation_transfer(self, **kwargs):
-        if "relocation_uuid" not in kwargs:
-            kwargs["relocation_uuid"] = uuid4()
-        if "state" not in kwargs:
-            kwargs["state"] = RelocationTransferState.Request
-
-        return ControlRelocationTransfer.objects.create(
-            org_slug=self.organization.slug, requesting_region="de", exporting_region="us", **kwargs
-        )
-
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_control")
     def test_no_records(self, mock_process):
         find_relocation_transfer_control()
@@ -36,14 +56,16 @@ class FindRelocationTransferControlTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_control")
     def test_no_due_records(self, mock_process):
-        self.create_control_relocation_transfer(scheduled_for=timezone.now() + timedelta(minutes=2))
+        create_control_relocation_transfer(
+            organization=self.organization, scheduled_for=timezone.now() + timedelta(minutes=2)
+        )
         find_relocation_transfer_control()
         assert not mock_process.delay.called
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_control")
     def test_due_records(self, mock_process):
-        transfer = self.create_control_relocation_transfer(
-            scheduled_for=timezone.now() - timedelta(minutes=2)
+        transfer = create_control_relocation_transfer(
+            organization=self.organization, scheduled_for=timezone.now() - timedelta(minutes=2)
         )
         find_relocation_transfer_control()
         assert mock_process.delay.called
@@ -52,7 +74,8 @@ class FindRelocationTransferControlTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_control")
     def test_purge_expired(self, mock_process):
-        transfer = self.create_control_relocation_transfer(
+        transfer = create_control_relocation_transfer(
+            organization=self.organization,
             scheduled_for=timezone.now() - timedelta(minutes=2),
         )
         transfer.date_added = timezone.now() - timedelta(hours=1, minutes=2)
@@ -63,16 +86,6 @@ class FindRelocationTransferControlTest(TestCase):
 
 
 class FindRelocationTransferRegionTest(TestCase):
-    def create_region_relocation_transfer(self, **kwargs):
-        if "relocation_uuid" not in kwargs:
-            kwargs["relocation_uuid"] = uuid4()
-        if "state" not in kwargs:
-            kwargs["state"] = RelocationTransferState.Request
-
-        return RegionRelocationTransfer.objects.create(
-            org_slug=self.organization.slug, requesting_region="de", exporting_region="us", **kwargs
-        )
-
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_no_records(self, mock_process):
         find_relocation_transfer_region()
@@ -80,14 +93,16 @@ class FindRelocationTransferRegionTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_no_due_records(self, mock_process):
-        self.create_region_relocation_transfer(scheduled_for=timezone.now() + timedelta(minutes=2))
+        create_region_relocation_transfer(
+            organization=self.organization, scheduled_for=timezone.now() + timedelta(minutes=2)
+        )
         find_relocation_transfer_region()
         assert not mock_process.delay.called
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_due_records(self, mock_process):
-        transfer = self.create_region_relocation_transfer(
-            scheduled_for=timezone.now() - timedelta(minutes=2)
+        transfer = create_region_relocation_transfer(
+            organization=self.organization, scheduled_for=timezone.now() - timedelta(minutes=2)
         )
         find_relocation_transfer_region()
         assert mock_process.delay.called
@@ -96,7 +111,8 @@ class FindRelocationTransferRegionTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_purge_expired(self, mock_process):
-        transfer = self.create_region_relocation_transfer(
+        transfer = create_region_relocation_transfer(
+            organization=self.organization,
             scheduled_for=timezone.now() - timedelta(minutes=2),
         )
         transfer.date_added = timezone.now() - timedelta(hours=1, minutes=2)
@@ -105,3 +121,54 @@ class FindRelocationTransferRegionTest(TestCase):
         find_relocation_transfer_region()
         assert not mock_process.delay.called
         assert not RegionRelocationTransfer.objects.filter(id=transfer.id).exists()
+
+
+@control_silo_test(regions=TEST_REGIONS)
+class ProcessRelocationTransferControlTest(TestCase):
+    def test_missing_transfer(self):
+        res = process_relocation_transfer_control(transfer_id=999)
+        assert res is None
+
+    @patch("sentry.relocation.services.relocation_export.impl.fulfill_cross_region_export_request")
+    def test_transfer_request_state(self, mock_fulfill):
+        transfer = create_control_relocation_transfer(
+            organization=self.organization,
+            state=RelocationTransferState.Request,
+            public_key=b"public_key_data",
+        )
+        process_relocation_transfer_control(transfer_id=transfer.id)
+
+        assert mock_fulfill.apply_async.called, "celery task should be spawned"
+        # Should be removed on completion.
+        assert not ControlRelocationTransfer.objects.filter(id=transfer.id).exists()
+
+    @patch("sentry.relocation.services.relocation_export.impl.uploading_complete")
+    def test_transfer_reply_state(self, mock_uploading_complete):
+        organization = self.organization
+        with assume_test_silo_mode(SiloMode.REGION):
+            relocation = Relocation.objects.create(
+                creator_id=self.user.id,
+                owner_id=self.user.id,
+                want_org_slugs=["acme-org"],
+                step=Relocation.Step.UPLOADING.value,
+            )
+        transfer = create_control_relocation_transfer(
+            organization=organization,
+            relocation_uuid=relocation.uuid,
+            state=RelocationTransferState.Reply,
+            public_key=b"public_key_data",
+        )
+        relocation_storage = get_relocation_storage()
+        relocation_storage.save(
+            f"runs/{relocation.uuid}/saas_to_saas_export/{organization.slug}.tar",
+            BytesIO(b"export data"),
+        )
+
+        process_relocation_transfer_control(transfer_id=transfer.id)
+
+        assert mock_uploading_complete.apply_async.called, "celery task should be spawned"
+        # Should be removed on completion.
+        assert not ControlRelocationTransfer.objects.filter(id=transfer.id).exists()
+        # the relocation RPC call should create a file on the region
+        with assume_test_silo_mode(SiloMode.REGION):
+            assert RelocationFile.objects.filter(relocation=relocation).exists()


### PR DESCRIPTION
Implement the processing tasks for relocation transfers. This logic is mostly a lift/shift from the outbox receivers

### control receivers

https://github.com/getsentry/sentry/blob/6555c1e0375aa50f55704f4918b7d2eda2331389/src/sentry/receivers/outbox/control.py#L110-L165

### region receiver

https://github.com/getsentry/sentry/blob/6555c1e0375aa50f55704f4918b7d2eda2331389/src/sentry/receivers/outbox/region.py#L84-L120

[design doc](https://www.notion.so/sentry/Relocation-outbox-rework-19e8b10e4b5d80268741cc5b513a89ae)