### PR TITLE
fix(nav): Fix clicking on buttons inside tooltips from nav

### DIFF
--- a/static/app/components/nav/useCollapsedNav.tsx
+++ b/static/app/components/nav/useCollapsedNav.tsx
@@ -5,6 +5,10 @@ import {useNavContext} from 'sentry/components/nav/context';
 
 // Slightly delay closing the nav to prevent accidental dismissal
 const CLOSE_DELAY = 200;
+const IGNORE_ELEMENTS = [
+  // Tooltips are rendered in document.body so will cause the nav to close
+  '[data-tooltip="true"]',
+];
 
 /**
  * Handles logic for deciding when the collpased nav should be visible.
@@ -83,9 +87,10 @@ export function useCollapsedNav() {
     const handleMouseLeave = (e: MouseEvent) => {
       // Ignore mouse leave events on overlay elements like tooltips
       if (
-        e.relatedTarget instanceof HTMLElement &&
-        (e.relatedTarget.dataset.overlay === 'true' ||
-          e.relatedTarget.closest('[data-overlay="true"]'))
+        IGNORE_ELEMENTS.some(
+          selector =>
+            e.relatedTarget instanceof HTMLElement && e.relatedTarget.closest(selector)
+        )
       ) {
         return;
       }
@@ -140,10 +145,18 @@ export function useCollapsedNav() {
   // but this will catch instances where clicks on non-focusable elements
   useInteractOutside({
     ref: navParentRef,
-    onInteractOutside: () => {
+    onInteractOutside: e => {
+      if (
+        IGNORE_ELEMENTS.some(
+          selector => e.target instanceof HTMLElement && e.target.closest(selector)
+        )
+      ) {
+        return;
+      }
+
       closeNav();
     },
-    isDisabled: !isCollapsed,
+    isDisabled: !isCollapsed || !isOpen,
   });
 
   return {isOpen};

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -91,6 +91,7 @@ function Tooltip({
         originPoint={arrowData}
         placement={placement}
         overlayStyle={overlayStyle}
+        data-tooltip
       >
         {title}
       </TooltipContent>


### PR DESCRIPTION
The superuser tooltip button could not be clicked because of `useInteractOutside`. Since tooltips are rendered at the end of the document, we can't rely on the checks for elements within the nav.