### PR TITLE
ref(querybuilder): Add instrumentation for querybuilder name

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -200,6 +200,7 @@ class BaseQueryBuilder:
         array_join: str | None = None,
         entity: Entity | None = None,
     ):
+        sentry_sdk.set_tag("querybuilder.name", type(self).__name__)
         if config is None:
             self.builder_config = QueryBuilderConfig()
         else:

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -68,9 +68,6 @@ class SpansEAPQueryBuilder(BaseQueryBuilder):
     size_fields = SIZE_FIELDS
     config_class = SpansEAPDatasetConfig
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def get_field_type(self, field: str) -> str | None:
         tag_match = constants.TYPED_TAG_KEY_RE.search(field)
         field_type = tag_match.group("type") if tag_match else None


### PR DESCRIPTION
- This is so I can get an idea how often the EAP query builder is still being used