### PR TITLE
feat(nav-views): Enforce no deletion on last view

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -18,6 +18,7 @@ interface IssueViewNavEllipsisMenuProps {
   baseUrl: string;
   deleteView: () => void;
   duplicateView: () => void;
+  isLastView: boolean;
   setIsEditing: (isEditing: boolean) => void;
   updateView: (view: IssueView) => void;
   view: IssueView;
@@ -32,6 +33,7 @@ export function IssueViewNavEllipsisMenu({
   duplicateView,
   updateView,
   baseUrl,
+  isLastView,
 }: IssueViewNavEllipsisMenuProps) {
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -126,6 +128,7 @@ export function IssueViewNavEllipsisMenu({
               label: t('Delete'),
               priority: 'danger',
               onAction: deleteView,
+              disabled: isLastView,
             },
           ],
         },

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -43,6 +43,11 @@ export interface IssueViewNavItemContentProps {
    */
   isActive: boolean;
   /**
+   * Whether the item is the last view in the list.
+   * This will be removed once view sharing/starring is implemented.
+   */
+  isLastView: boolean;
+  /**
    * A callback function that updates the view with new params.
    */
   updateView: (updatedView: IssueView) => void;
@@ -65,6 +70,7 @@ export function IssueViewNavItemContent({
   updateView,
   deleteView,
   duplicateView,
+  isLastView,
 }: IssueViewNavItemContentProps) {
   const organization = useOrganization();
   const location = useLocation();
@@ -137,6 +143,7 @@ export function IssueViewNavItemContent({
           >
             <IssueViewNavQueryCount view={view} />
             <IssueViewNavEllipsisMenu
+              isLastView={isLastView}
               setIsEditing={setIsEditing}
               view={view}
               updateView={updateView}

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -228,6 +228,7 @@ export function IssueViewNavItems({
             updateView={updatedView => handleUpdateView(view, updatedView)}
             deleteView={() => handleDeleteView(view)}
             duplicateView={() => handleDuplicateView(view)}
+            isLastView={views.length === 1}
           />
         </AnimatePresence>
       ))}


### PR DESCRIPTION
In the near future, we will allow users to have 0 views. Until that time, we should still enforce the 1 view minimum limit on the frontend since that's what the backend expects. 