### PR TITLE
chonk: fix withTheme to forward ref

### DIFF
--- a/static/app/utils/theme/withChonk.tsx
+++ b/static/app/utils/theme/withChonk.tsx
@@ -1,9 +1,10 @@
+import {forwardRef, type PropsWithoutRef} from 'react';
 import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 
 export type ChonkPropMapping<LegacyProps, ChonkProps> = (
-  props: Omit<LegacyProps, 'theme'>
-) => Omit<ChonkProps, 'theme'>;
+  props: Omit<PropsWithoutRef<LegacyProps>, 'theme'>
+) => Omit<PropsWithoutRef<ChonkProps>, 'theme'>;
 
 /**
  * Higher order utility function that manages the migration layer between chonk and legacy components.
@@ -16,20 +17,26 @@ export type ChonkPropMapping<LegacyProps, ChonkProps> = (
  * @returns A new component that is a wrapper around the legacy component.
  */
 export function withChonk<
-  LegacyProps extends {children?: React.ReactNode},
-  ChonkProps extends {children?: React.ReactNode; theme?: DO_NOT_USE_ChonkTheme},
+  LegacyProps extends {children?: React.ReactNode} & React.RefAttributes<any>,
+  ChonkProps extends {
+    children?: React.ReactNode;
+    theme?: DO_NOT_USE_ChonkTheme;
+  } & React.RefAttributes<any>,
 >(
   legacyComponent: React.ComponentType<LegacyProps>,
   chonkComponent: React.ComponentType<ChonkProps>,
   propMapping: ChonkPropMapping<LegacyProps, ChonkProps>
-): (props: LegacyProps, theme: DO_NOT_USE_ChonkTheme) => React.ReactNode {
-  return function (props: LegacyProps) {
+): React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<LegacyProps> & React.RefAttributes<any>
+> {
+  function ChonkSwitch(props: PropsWithoutRef<LegacyProps>, ref: React.Ref<any>) {
     const theme = useTheme();
 
     if (theme.isChonk) {
       const ChonkComponent: any = chonkComponent;
       return (
         <ChonkComponent
+          ref={ref}
           {...propMapping(props)}
           theme={theme as unknown as DO_NOT_USE_ChonkTheme}
         >
@@ -39,6 +46,13 @@ export function withChonk<
     }
 
     const LegacyComponent: any = legacyComponent;
-    return <LegacyComponent {...props}>{props.children}</LegacyComponent>;
-  };
+    return (
+      <LegacyComponent ref={ref} {...props}>
+        {props.children}
+      </LegacyComponent>
+    );
+  }
+
+  const ForwardRefComponent = forwardRef(ChonkSwitch);
+  return ForwardRefComponent;
 }


### PR DESCRIPTION
withChonk was swallowing ref and not forwarding it to our component. This change wraps the internal switch with a forwardRef function that re-forwards the ref...