### PR TITLE
chore(Android): Re-add Profiling onboarding for Android

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -76,7 +76,7 @@ function getDisabledProducts(organization: Organization): DisabledProducts {
 // Since the ProductSelection component is rendered in the onboarding/project creation flow only, it is ok to have this list here
 // NOTE: Please keep the prefix in alphabetical order
 export const platformProductAvailability = {
-  android: [ProductSolution.PERFORMANCE_MONITORING],
+  android: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'apple-ios': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'apple-macos': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   bun: [ProductSolution.PERFORMANCE_MONITORING],
@@ -198,6 +198,7 @@ export const platformProductAvailability = {
  * If not defined in here, all products are selected
  */
 const platformDefaultProducts: Partial<Record<PlatformKey, ProductSolution[]>> = {
+  android: [ProductSolution.PERFORMANCE_MONITORING],
   php: [ProductSolution.PERFORMANCE_MONITORING],
   'php-laravel': [ProductSolution.PERFORMANCE_MONITORING],
   'php-symfony': [ProductSolution.PERFORMANCE_MONITORING],

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -84,6 +84,8 @@ const getConfigurationSnippet = (params: Params) => `
     params.isProfilingSelected
       ? `
   <!-- enable profiling when starting transactions, adjust in production env -->
+  <!-- note: there is a known issue in the Android Runtime that can be triggered by Profiling in certain circumstances -->
+  <!-- see https://docs.sentry.io/platforms/android/profiling/troubleshooting/ -->
   <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />`
       : ''
   }


### PR DESCRIPTION
Profiling has been removed from Android onboarding in https://github.com/getsentry/sentry/pull/81322

Profiling is now more stable again and via https://github.com/getsentry/sentry/pull/85337 we now also can choose which features should be selected by default.

This PR
- re-adds the Profiling feature to Android onboarding as inactive (opt-in)
- adds an explainer comment to the Manual setup snippet which is shown when user activates Profiling