### PR TITLE
chore(drawers): Update default "stiffness" 

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -99,7 +99,6 @@ export default function BreadcrumbsDataSection({
             }
             return true;
           },
-          transitionProps: {stiffness: 1000},
         }
       );
     },

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -206,7 +206,6 @@ export function EventFeatureFlagList({
             }
             return true;
           },
-          transitionProps: {stiffness: 1000},
         }
       );
     },

--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -70,7 +70,7 @@ function SlideOverPanel(
       slidePosition={slidePosition}
       transition={{
         type: 'spring',
-        stiffness: 500,
+        stiffness: 1000,
         damping: 50,
         ...transitionProps,
       }}

--- a/static/app/views/insights/common/utils/useMobileVitalsDrawer.tsx
+++ b/static/app/views/insights/common/utils/useMobileVitalsDrawer.tsx
@@ -26,7 +26,6 @@ export function useMobileVitalsDrawer({
     openDrawer(() => Component, {
       ariaLabel: t('%s Details', vital.title),
       onClose,
-      transitionProps: {stiffness: 1000},
     });
   }, [openDrawer, isDrawerOpen, onClose, Component, vital]);
 

--- a/static/app/views/insights/common/utils/useSamplesDrawer.tsx
+++ b/static/app/views/insights/common/utils/useSamplesDrawer.tsx
@@ -80,7 +80,6 @@ export function useSamplesDrawer({
     openDrawer(() => <FullHeightWrapper>{Component}</FullHeightWrapper>, {
       ariaLabel: t('Samples'),
       onClose: onCloseAction,
-      transitionProps: {stiffness: 1000},
       shouldCloseOnLocationChange,
       shouldCloseOnInteractOutside: () => false,
     });

--- a/static/app/views/insights/common/utils/useWebVitalsDrawer.tsx
+++ b/static/app/views/insights/common/utils/useWebVitalsDrawer.tsx
@@ -26,7 +26,6 @@ export function useWebVitalsDrawer({
     openDrawer(() => Component, {
       ariaLabel: t('%s Details', webVital),
       onClose,
-      transitionProps: {stiffness: 1000},
     });
   }, [openDrawer, isDrawerOpen, onClose, Component, webVital]);
 

--- a/static/app/views/issueDetails/groupTags/useGroupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTagsDrawer.tsx
@@ -11,11 +11,11 @@ import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRou
 export function useGroupTagsDrawer({group}: {group: Group}) {
   const location = useLocation();
   const navigate = useNavigate();
-  const drawer = useDrawer();
+  const {openDrawer} = useDrawer();
   const {baseUrl} = useGroupDetailsRoute();
 
   const openTagsDrawer = useCallback(() => {
-    drawer.openDrawer(() => <GroupTagsDrawer group={group} />, {
+    openDrawer(() => <GroupTagsDrawer group={group} />, {
       ariaLabel: t('Tags Drawer'),
       onClose: () => {
         navigate(
@@ -32,9 +32,8 @@ export function useGroupTagsDrawer({group}: {group: Group}) {
       shouldCloseOnLocationChange: newLocation => {
         return !newLocation.pathname.includes('/tags/');
       },
-      transitionProps: {stiffness: 1000},
     });
-  }, [location, navigate, drawer, group, baseUrl]);
+  }, [location, navigate, openDrawer, group, baseUrl]);
 
   return {openTagsDrawer};
 }

--- a/static/app/views/issueDetails/streamline/hooks/useIssueActivityDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueActivityDrawer.tsx
@@ -36,7 +36,6 @@ export function useIssueActivityDrawer({group, project}: UseIssueActivityDrawerP
           {replace: true}
         );
       },
-      transitionProps: {stiffness: 1000},
       shouldCloseOnLocationChange: () => false,
     });
   }, [openDrawer, baseUrl, navigate, location.query, group, project]);

--- a/static/app/views/issueDetails/streamline/hooks/useMergedIssuesDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useMergedIssuesDrawer.tsx
@@ -38,7 +38,6 @@ export function useMergedIssuesDrawer({
           {replace: true}
         );
       },
-      transitionProps: {stiffness: 1000},
     });
   }, [openDrawer, group, project, baseUrl, navigate, location.query]);
 

--- a/static/app/views/issueDetails/streamline/hooks/useSimilarIssuesDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useSimilarIssuesDrawer.tsx
@@ -38,7 +38,6 @@ export function useSimilarIssuesDrawer({
           {replace: true}
         );
       },
-      transitionProps: {stiffness: 1000},
     });
   }, [openDrawer, group, project, baseUrl, navigate, location.query]);
 

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSectionCtaButton.tsx
@@ -62,7 +62,6 @@ export function SolutionsSectionCtaButton({
           }
           return true;
         },
-        transitionProps: {stiffness: 1000},
       }
     );
   };


### PR DESCRIPTION
most of the drawers we had used `stiffness: 1000` instead of the default of 500 (most that used the default probably didn't know that the rest used 1000). this pr updates the default value to 1000, while leaving the option to update it if needed 