### PR TITLE
fix(perf): p95 Dropdown Selector in Transaction Summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -268,7 +268,6 @@ function OTelSummaryContentInner({
           />
           <ServiceEntrySpansTable
             eventView={transactionsListEventView}
-            spanOperationBreakdownFilter={spanOperationBreakdownFilter}
             handleDropdownChange={handleTransactionsListSortChange}
             totalValues={totalValues}
             transactionName={transactionName}


### PR DESCRIPTION
The p95 dropdown option for the transactions samples table was not functional because it was not wired up to update the query when selected.  