### PR TITLE
fix(stacktrace): Fix condition for raw stacktrace

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
@@ -45,7 +45,10 @@ class RawContent extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.isNative() && this.props.type !== prevProps.type) {
+    if (
+      this.isNative() &&
+      (this.props.type !== prevProps.type || this.props.eventId !== prevProps.eventId)
+    ) {
       this.fetchAppleCrashReport();
     }
   }


### PR DESCRIPTION
right now it doesn't check if the event id updates, which means on issue details, if scrolling through events with the raw stack trace option selected, the stack trace won't update