### PR TITLE
ref(nav): Add reusable component for sidebar buttons in footer

### DIFF
--- a/static/app/components/nav/primary/components.tsx
+++ b/static/app/components/nav/primary/components.tsx
@@ -34,6 +34,14 @@ interface SidebarItemDropdownProps {
   forceLabel?: boolean;
 }
 
+interface SidebarButtonProps {
+  analyticsKey: string;
+  children: React.ReactNode;
+  label: string;
+  buttonProps?: React.HTMLAttributes<HTMLElement>;
+  onClick?: MouseEventHandler<HTMLElement>;
+}
+
 export function SidebarItem({
   children,
   ...props
@@ -125,6 +133,35 @@ export function SidebarLink({
         {showLabel ? label : null}
       </NavLink>
     </SidebarItem>
+  );
+}
+
+export function SidebarButton({
+  analyticsKey,
+  children,
+  buttonProps = {},
+  onClick,
+  label,
+}: SidebarButtonProps) {
+  const organization = useOrganization();
+  const {layout} = useNavContext();
+  const showLabel = layout === NavLayout.MOBILE;
+
+  return (
+    <NavButton
+      {...buttonProps}
+      isMobile={layout === NavLayout.MOBILE}
+      aria-label={showLabel ? undefined : label}
+      onClick={(e: React.MouseEvent<HTMLElement>) => {
+        trackAnalytics('growth.clicked_sidebar', {item: analyticsKey, organization});
+        buttonProps.onClick?.(e);
+        onClick?.(e);
+      }}
+    >
+      <InteractionStateLayer />
+      {children}
+      {showLabel ? label : null}
+    </NavButton>
   );
 }
 

--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/components/nav/primary/components';
 import {PrimaryNavigationOnboarding} from 'sentry/components/nav/primary/onboarding';
 import {PrimaryNavigationServiceIncidents} from 'sentry/components/nav/primary/serviceIncidents';
-import {WhatsNew} from 'sentry/components/nav/primary/whatsNew';
+import {PrimaryNavigationWhatsNew} from 'sentry/components/nav/primary/whatsNew';
 import {NavLayout, PrimaryNavGroup} from 'sentry/components/nav/types';
 import {
   IconDashboard,
@@ -187,7 +187,7 @@ export function PrimaryNavigationItems() {
 
         <SeparatorItem />
 
-        <WhatsNew />
+        <PrimaryNavigationWhatsNew />
         <PrimaryNavigationServiceIncidents />
         <PrimaryNavigationOnboarding />
       </SidebarFooter>

--- a/static/app/components/nav/primary/serviceIncidents.tsx
+++ b/static/app/components/nav/primary/serviceIncidents.tsx
@@ -2,14 +2,11 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 
-import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {useNavContext} from 'sentry/components/nav/context';
 import {
-  NavButton,
+  SidebarButton,
   SidebarItem,
   SidebarItemUnreadIndicator,
 } from 'sentry/components/nav/primary/components';
-import {NavLayout} from 'sentry/components/nav/types';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {ServiceIncidentDetails} from 'sentry/components/serviceIncidentDetails';
 import {IconWarning} from 'sentry/icons';
@@ -20,8 +17,6 @@ import useOverlay from 'sentry/utils/useOverlay';
 import {useServiceIncidents} from 'sentry/utils/useServiceIncidents';
 
 function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) {
-  const {layout} = useNavContext();
-  const showLabel = layout === NavLayout.MOBILE;
   const theme = useTheme();
   const {
     isOpen,
@@ -35,16 +30,14 @@ function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) 
 
   return (
     <SidebarItem>
-      <NavButton
-        {...overlayTriggerProps}
-        isMobile={false}
-        aria-label={showLabel ? undefined : t('Service status')}
+      <SidebarButton
+        analyticsKey="statusupdate"
+        label={t('Service status')}
+        buttonProps={overlayTriggerProps}
       >
-        <InteractionStateLayer />
         <IconWarning />
-        {showLabel ? t('Service status') : null}
         <WarningUnreadIndicator />
-      </NavButton>
+      </SidebarButton>
       {isOpen && (
         <FocusScope autoFocus restoreFocus>
           <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>

--- a/static/app/components/nav/primary/whatsNew.spec.tsx
+++ b/static/app/components/nav/primary/whatsNew.spec.tsx
@@ -2,7 +2,7 @@ import {BroadcastFixture} from 'sentry-fixture/broadcast';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {WhatsNew} from 'sentry/components/nav/primary/whatsNew';
+import {PrimaryNavigationWhatsNew} from 'sentry/components/nav/primary/whatsNew';
 import {BROADCAST_CATEGORIES} from 'sentry/components/sidebar/broadcastPanelItem';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
@@ -23,7 +23,7 @@ describe('WhatsNew', function () {
   });
 
   it('renders empty state', async function () {
-    render(<WhatsNew />);
+    render(<PrimaryNavigationWhatsNew />);
 
     await userEvent.click(screen.getByRole('button', {name: "What's New"}));
 
@@ -62,7 +62,7 @@ describe('WhatsNew', function () {
       ],
     });
 
-    render(<WhatsNew />);
+    render(<PrimaryNavigationWhatsNew />);
 
     expect(await screen.findByTestId('whats-new-unread-indicator')).toBeInTheDocument();
 
@@ -96,7 +96,7 @@ describe('WhatsNew', function () {
       body: [broadcast],
     });
 
-    render(<WhatsNew />);
+    render(<PrimaryNavigationWhatsNew />);
 
     await userEvent.click(screen.getByRole('button', {name: "What's New"}));
 

--- a/static/app/components/nav/primary/whatsNew.tsx
+++ b/static/app/components/nav/primary/whatsNew.tsx
@@ -3,15 +3,12 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 
-import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {useNavContext} from 'sentry/components/nav/context';
 import {
-  NavButton,
+  SidebarButton,
   SidebarItem,
   SidebarItemUnreadIndicator,
 } from 'sentry/components/nav/primary/components';
-import {NavLayout} from 'sentry/components/nav/types';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {BroadcastPanelItem} from 'sentry/components/sidebar/broadcastPanelItem';
 import SidebarPanelEmpty from 'sentry/components/sidebar/sidebarPanelEmpty';
@@ -117,15 +114,13 @@ function WhatsNewContent({unseenPostIds}: {unseenPostIds: string[]}) {
   );
 }
 
-export function WhatsNew() {
+export function PrimaryNavigationWhatsNew() {
   const {data: broadcasts = []} = useFetchBroadcasts();
   const unseenPostIds = useMemo(
     () => broadcasts.filter(item => !item.hasSeen).map(item => item.id),
     [broadcasts]
   );
 
-  const {layout} = useNavContext();
-  const showLabel = layout === NavLayout.MOBILE;
   const theme = useTheme();
 
   const {
@@ -140,18 +135,16 @@ export function WhatsNew() {
 
   return (
     <SidebarItem>
-      <NavButton
-        {...overlayTriggerProps}
-        aria-label={showLabel ? undefined : t("What's New")}
-        isMobile={layout === NavLayout.MOBILE}
+      <SidebarButton
+        analyticsKey="broadcasts"
+        label={t("What's New")}
+        buttonProps={overlayTriggerProps}
       >
-        <InteractionStateLayer />
         <IconBroadcast />
-        {showLabel && <span>{t("What's New")}</span>}
         {unseenPostIds.length > 0 && (
           <SidebarItemUnreadIndicator data-test-id="whats-new-unread-indicator" />
         )}
-      </NavButton>
+      </SidebarButton>
       {isOpen && (
         <FocusScope autoFocus restoreFocus>
           <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>


### PR DESCRIPTION
There were some repeated patterns for the buttons in the footer, so extracted that to a new component.