### PR TITLE
fix(toolbar): Cannot import button from inside the devtoolbar folder

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -657,6 +657,11 @@ export default typescript.config([
           paths: [
             ...restrictedImportPaths,
             {
+              name: 'sentry/components/button',
+              message:
+                "Cannot depend on Button from inside the toolbar. Button depends on analytics tracking which isn't avaialble in the toolbar context",
+            },
+            {
               name: 'sentry/utils/queryClient',
               message:
                 'Import from `@tanstack/react-query` and `./hooks/useFetchApiData` or `./hooks/useFetchInfiniteApiData` instead.',

--- a/static/app/components/devtoolbar/components/replay/replayPanel.tsx
+++ b/static/app/components/devtoolbar/components/replay/replayPanel.tsx
@@ -1,13 +1,12 @@
 import {useContext, useState} from 'react';
 import {css} from '@emotion/react';
 
-import {Button} from 'sentry/components/button';
 import AnalyticsProvider, {
   AnalyticsContext,
 } from 'sentry/components/devtoolbar/components/analyticsProvider';
 import SentryAppLink from 'sentry/components/devtoolbar/components/sentryAppLink';
 import useReplayRecorder from 'sentry/components/devtoolbar/hooks/useReplayRecorder';
-import {resetFlexRowCss} from 'sentry/components/devtoolbar/styles/reset';
+import {resetButtonCss, resetFlexRowCss} from 'sentry/components/devtoolbar/styles/reset';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {IconPause, IconPlay} from 'sentry/icons';
 import type {PlatformKey} from 'sentry/types/project';
@@ -37,33 +36,35 @@ export default function ReplayPanel() {
   const [buttonLoading, setButtonLoading] = useState(false);
   return (
     <PanelLayout title="Session Replay" showProjectBadge link={{url: '/replays/'}}>
-      <Button
-        size="sm"
-        icon={isDisabled ? undefined : isRecordingSession ? <IconPause /> : <IconPlay />}
-        disabled={isDisabled || buttonLoading}
-        onClick={async () => {
-          setButtonLoading(true);
-          if (isRecordingSession) {
-            await stopRecording();
-          } else {
-            await startRecordingSession();
-          }
-          setButtonLoading(false);
-          const type = isRecordingSession ? 'stop' : 'start';
-          trackAnalytics?.({
-            eventKey: eventKey + `.${type}-button-click`,
-            eventName: eventName + `${type} button clicked`,
-          });
-        }}
-      >
-        {isDisabled
-          ? disabledReason
-          : isRecordingSession
+      {isDisabled ? (
+        <p css={[panelInsetContentCss]}>{disabledReason}</p>
+      ) : (
+        <button
+          css={[resetButtonCss]}
+          disabled={isDisabled || buttonLoading}
+          onClick={async () => {
+            setButtonLoading(true);
+            if (isRecordingSession) {
+              await stopRecording();
+            } else {
+              await startRecordingSession();
+            }
+            setButtonLoading(false);
+            const type = isRecordingSession ? 'stop' : 'start';
+            trackAnalytics?.({
+              eventKey: eventKey + `.${type}-button-click`,
+              eventName: eventName + `${type} button clicked`,
+            });
+          }}
+        >
+          {isRecordingSession ? <IconPause /> : <IconPlay />}
+          {isRecordingSession
             ? 'Recording in progress, click to stop'
             : isRecording
               ? 'Replay buffering, click to flush and record'
               : 'Start recording the current session'}
-      </Button>
+        </button>
+      )}
       <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
         {lastReplayId ? (
           <span


### PR DESCRIPTION
This fixes a problem on sentry.io in production: Clicking on the 'replay' panel inside the PoC toolbar causes the toolbar to disappear until the page is reloaded.

