### PR TITLE
fix(ui): Remove stickiness from uptime/crons issue details timeline

### DIFF
--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -146,7 +146,6 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
           ))}
       </TimelineLegend>
       <IssueGridLineOverlay
-        stickyCursor
         allowZoom
         showCursor
         timeWindowConfig={timeWindowConfig}

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
@@ -104,7 +104,6 @@ export function IssueUptimeCheckTimeline({group}: {group: Group}) {
         ))}
       </TimelineLegend>
       <GridLineOverlay
-        stickyCursor
         allowZoom
         showCursor
         timeWindowConfig={timeWindowConfig}


### PR DESCRIPTION
No need for this as there's no sticky header