### PR TITLE
fix: orgmember without user emails serializer

### DIFF
--- a/src/sentry/api/endpoints/team_members.py
+++ b/src/sentry/api/endpoints/team_members.py
@@ -16,13 +16,13 @@ from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organizationmember import InviteStatus
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.users.api.serializers.user import UserSerializerResponse
+from sentry.users.api.serializers.user import UserSerializerWithoutEmailsResponse
 
 
 class OrganizationMemberOnTeamResponse(OrganizationMemberResponse):
     # NOTE: We override users to be required b/c team members will always have
     # an existing user to be part of a team.
-    user: UserSerializerResponse  # type: ignore[misc]
+    user: UserSerializerWithoutEmailsResponse  # type: ignore[misc]
     teamRole: str | None
     teamSlug: str
 
@@ -90,7 +90,10 @@ class TeamMembersEndpoint(TeamEndpoint):
         The response will not include members with pending invites.
         """
         queryset = OrganizationMemberTeam.objects.filter(
-            Q(organizationmember__user_is_active=True, organizationmember__user_id__isnull=False)
+            Q(
+                organizationmember__user_is_active=True,
+                organizationmember__user_id__isnull=False,
+            )
             | Q(organizationmember__user_id__isnull=True),
             organizationmember__organization=team.organization,
             organizationmember__invite_status=InviteStatus.APPROVED.value,

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -8,7 +8,7 @@ from sentry.api.serializers.models.role import (
     TeamRoleSerializerResponse,
 )
 from sentry.integrations.api.serializers.models.external_actor import ExternalActorResponse
-from sentry.users.api.serializers.user import UserSerializerResponse
+from sentry.users.api.serializers.user import UserSerializerWithoutEmailsResponse
 
 
 class SCIMName(TypedDict):
@@ -75,7 +75,7 @@ class OrganizationMemberResponse(TypedDict):
     email: str
     name: str
     # User may be optional b/c invites don't have users yet
-    user: NotRequired[UserSerializerResponse]
+    user: NotRequired[UserSerializerWithoutEmailsResponse]
     orgRole: str
     pending: bool
     expired: bool

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -228,7 +228,11 @@ class OrganizationExamples:
                 "allowSuperuserAccess": False,
                 "require2FA": False,
                 "requiresSso": False,
-                "avatar": {"avatarType": "letter_avatar", "avatarUuid": None, "avatarUrl": None},
+                "avatar": {
+                    "avatarType": "letter_avatar",
+                    "avatarUuid": None,
+                    "avatarUrl": None,
+                },
                 "links": {
                     "organizationUrl": "https://the-interstellar-jurisdiction.sentry.io",
                     "regionUrl": "https://us.sentry.io",
@@ -523,7 +527,10 @@ class OrganizationExamples:
                                     "client_discard": 1942414,
                                     "cardinality_limited": 0,
                                 },
-                                "totals": {"dropped": 2506132, "sum(quantity)": 10252111},
+                                "totals": {
+                                    "dropped": 2506132,
+                                    "sum(quantity)": 10252111,
+                                },
                             },
                             {
                                 "category": "transaction",
@@ -536,7 +543,10 @@ class OrganizationExamples:
                                     "client_discard": 1931595,
                                     "cardinality_limited": 0,
                                 },
-                                "totals": {"dropped": 2458946, "sum(quantity)": 10174711},
+                                "totals": {
+                                    "dropped": 2458946,
+                                    "sum(quantity)": 10174711,
+                                },
                             },
                         ],
                     },
@@ -570,13 +580,6 @@ class OrganizationExamples:
                     "isSuperuser": False,
                     "isStaff": False,
                     "experiments": {},
-                    "emails": [
-                        {
-                            "id": "2153450836",
-                            "email": "sirpenguin@antarcticarocks.com",
-                            "is_verified": True,
-                        }
-                    ],
                     "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
                     "authenticators": [],
                     "canReset2fa": True,
@@ -729,7 +732,11 @@ class OrganizationExamples:
                         "isStaff": True,
                         "experiments": {},
                         "emails": [
-                            {"id": "2972219", "email": "raj@raspberries", "is_verified": True}
+                            {
+                                "id": "2972219",
+                                "email": "raj@raspberries",
+                                "is_verified": True,
+                            }
                         ],
                         "avatar": {
                             "avatarType": "upload",
@@ -799,7 +806,11 @@ class OrganizationExamples:
                         "isStaff": True,
                         "experiments": {},
                         "emails": [
-                            {"id": "2972219", "email": "raj@raspberries", "is_verified": True}
+                            {
+                                "id": "2972219",
+                                "email": "raj@raspberries",
+                                "is_verified": True,
+                            }
                         ],
                         "avatar": {
                             "avatarType": "upload",
@@ -859,7 +870,11 @@ class OrganizationExamples:
                 "currentProjectMeta": {},
                 "userAgent": "Python-urllib/3.11",
                 "adoptionStages": {
-                    "sentry": {"stage": "low_adoption", "adopted": None, "unadopted": None}
+                    "sentry": {
+                        "stage": "low_adoption",
+                        "adopted": None,
+                        "unadopted": None,
+                    }
                 },
             },
             status_codes=["200"],

--- a/src/sentry/apidocs/examples/organization_member_examples.py
+++ b/src/sentry/apidocs/examples/organization_member_examples.py
@@ -20,13 +20,6 @@ ORGANIZATION_MEMBER = {
         "isSuperuser": False,
         "isStaff": False,
         "experiments": {},
-        "emails": [
-            {
-                "id": "2153450836",
-                "email": "sirpenguin@antarcticarocks.com",
-                "is_verified": True,
-            }
-        ],
         "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
         "canReset2fa": True,
     },

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -101,6 +101,24 @@ class UserSerializerResponse(UserSerializerResponseOptional):
     emails: list[_UserEmails]
 
 
+class UserSerializerWithoutEmailsResponse(UserSerializerResponseOptional):
+    id: str
+    name: str
+    username: str
+    email: str
+    avatarUrl: str
+    isActive: bool
+    hasPasswordAuth: bool
+    isManaged: bool
+    dateJoined: datetime
+    lastLogin: datetime | None
+    has2fa: bool
+    lastActive: datetime | None
+    isSuperuser: bool
+    isStaff: bool
+    experiments: dict[str, Any]  # TODO
+
+
 class UserSerializerResponseSelf(UserSerializerResponse):
     options: _UserOptions
     flags: Any  # TODO


### PR DESCRIPTION
Creates the special use case `UserSerializerWithoutEmailsResponse` for use on organization member list/detail endpoints.
This will update the API documents to match expected behavior from https://github.com/getsentry/sentry/pull/83556.