### PR TITLE
fix(ui): Various adjustments for cron/uptime timeline consistency

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -12,7 +12,7 @@ import useRouter from 'sentry/utils/useRouter';
 
 import QuestionTooltip from '../questionTooltip';
 
-import {useTimelineCursor} from './timelineCursor';
+import {type CursorOffsets, useTimelineCursor} from './timelineCursor';
 import {useTimelineZoom} from './timelineZoom';
 import type {TimeWindowConfig} from './types';
 
@@ -115,7 +115,11 @@ export function GridLineLabels({
       ))}
       {timeWindowConfig.showUnderscanHelp && (
         <TimeLabelContainer
-          left={timeWindowConfig.timelineWidth}
+          left={
+            labelPosition === 'left-top'
+              ? timeWindowConfig.timelineWidth
+              : timeWindowConfig.timelineWidth - 12
+          }
           labelPosition={labelPosition}
         >
           <QuestionTooltip
@@ -141,6 +145,15 @@ interface GridLineOverlayProps {
    */
   allowZoom?: boolean;
   className?: string;
+  /**
+   * Configres clampped offsets on the left and right of the cursor overlay
+   * element when enabled. May be useful in scenarios where you do not want the
+   * overlay to cover some additional UI elements
+   */
+  cursorOffsets?: CursorOffsets;
+  /**
+   * Configres where the timeline labels are displayed
+   */
   labelPosition?: LabelPosition;
   /**
    * Enable the timeline cursor
@@ -157,6 +170,7 @@ export function GridLineOverlay({
   showCursor,
   additionalUi,
   stickyCursor,
+  cursorOffsets,
   allowZoom,
   className,
   labelPosition = 'left-top',
@@ -198,6 +212,7 @@ export function GridLineOverlay({
   const {cursorContainerRef, timelineCursor} = useTimelineCursor<HTMLDivElement>({
     enabled: !!showCursor && !selectionIsActive,
     sticky: stickyCursor,
+    offsets: cursorOffsets,
     labelText: makeCursorLabel,
   });
 
@@ -292,7 +307,7 @@ export const Gridline = styled('div')<{labelPosition: LabelPosition; left: numbe
   ${p =>
     p.labelPosition === 'center-bottom' &&
     css`
-      height: 4px;
+      height: 6px;
       width: 1px;
       border-radius: 1px;
       background: ${p.theme.translucentBorder};
@@ -310,7 +325,16 @@ const TimeLabelContainer = styled('div')<{
   display: flex;
   align-items: center;
   height: 100%;
-  padding-left: ${space(1)};
+  ${p =>
+    p.labelPosition === 'left-top' &&
+    css`
+      padding-left: ${space(1)};
+    `}
+  ${p =>
+    p.labelPosition === 'center-bottom' &&
+    css`
+      padding-top: ${space(1)};
+    `}
   ${p =>
     p.labelPosition === 'center-bottom' &&
     // Skip the translation for the first label
@@ -330,7 +354,6 @@ const TimeLabel = styled(DateTime)`
 const Underscan = styled('div')<{labelPosition: LabelPosition}>`
   position: absolute;
   right: 0;
-  border-bottom-right-radius: ${p => p.theme.borderRadius};
   background-size: 3px 3px;
   background-image: linear-gradient(
     45deg,

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -55,6 +55,7 @@ export function OverviewTimeline({uptimeRules}: Props) {
         stickyCursor
         allowZoom
         showCursor
+        cursorOffsets={{right: 40}}
         timeWindowConfig={timeWindowConfig}
       />
       <UptimeAlertRow>

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
@@ -129,7 +129,7 @@ export function IssueUptimeCheckTimeline({group}: {group: Group}) {
 
 const ChartContainer = styled('div')`
   position: relative;
-  min-height: 104px;
+  min-height: 100px;
   width: 100%;
 `;
 

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -149,6 +149,7 @@ export function OverviewTimeline({monitorList, linkToAlerts}: Props) {
         stickyCursor
         allowZoom
         showCursor
+        cursorOffsets={{right: 40}}
         additionalUi={<CronServiceIncidents timeWindowConfig={timeWindowConfig} />}
         timeWindowConfig={timeWindowConfig}
       />


### PR DESCRIPTION
- Allows configuration of the timeline cursor offsets. We use this in
  the overview timelnes to clamp the cursor such that it doesn't cover
  the date navigation buttons. Other places do not need offsets.

- Adjust the understand question tooltip alignment when using the
  alternative label position

- Adjust the height of the timeline container slightly so date time tick
  markers are center aligned in the container.