### PR TITLE
feat(autofix): Keep header buttons

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.spec.tsx
@@ -222,6 +222,138 @@ describe('SolutionsHubDrawer', () => {
     expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
   });
 
+  it('hides ButtonBarWrapper when AI consent is needed', async () => {
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: false},
+        integration: {ok: true},
+        githubWriteIntegration: {ok: true},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(
+      <SolutionsHubDrawer event={mockEvent} group={mockGroup} project={mockProject} />,
+      {organization}
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    // AutofixFeedback component should not be rendered when consent is needed
+    expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Start Over'})).not.toBeInTheDocument();
+  });
+
+  it('shows ButtonBarWrapper but hides Start Over button when hasAutofix is false', async () => {
+    // Mock AI consent as okay but no autofix capability
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {ok: true},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    // Use jest.spyOn instead of jest.mock inside the test
+    const issueTypeConfigModule = require('sentry/utils/issueTypeConfig');
+    const spy = jest
+      .spyOn(issueTypeConfigModule, 'getConfigForIssueType')
+      .mockImplementation(() => ({
+        autofix: false,
+        issueSummary: {enabled: true},
+        resources: null,
+      }));
+
+    render(
+      <SolutionsHubDrawer event={mockEvent} group={mockGroup} project={mockProject} />,
+      {organization}
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    // The feedback button should be visible, but not the Start Over button
+    expect(screen.getByTestId('autofix-button-bar')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Start Over'})).not.toBeInTheDocument();
+
+    // Restore the original implementation
+    spy.mockRestore();
+  });
+
+  it('shows ButtonBarWrapper with disabled Start Over button when hasAutofix is true but no autofixData', async () => {
+    // Mock everything as ready for autofix but no data
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {ok: true},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(
+      <SolutionsHubDrawer event={mockEvent} group={mockGroup} project={mockProject} />,
+      {organization}
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    // Both buttons should be visible, but Start Over should be disabled
+    expect(screen.getByTestId('autofix-button-bar')).toBeInTheDocument();
+    const startOverButton = screen.getByRole('button', {name: 'Start Over'});
+    expect(startOverButton).toBeInTheDocument();
+    expect(startOverButton).toBeDisabled();
+  });
+
+  it('shows ButtonBarWrapper with enabled Start Over button when hasAutofix and autofixData are both true', async () => {
+    // Mock everything as ready with existing autofix data
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {ok: true},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: mockAutofixData},
+    });
+
+    render(
+      <SolutionsHubDrawer event={mockEvent} group={mockGroup} project={mockProject} />,
+      {organization}
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    // Both buttons should be visible, and Start Over should be enabled
+    expect(screen.getByTestId('autofix-button-bar')).toBeInTheDocument();
+    const startOverButton = screen.getByRole('button', {name: 'Start Over'});
+    expect(startOverButton).toBeInTheDocument();
+    expect(startOverButton).toBeEnabled();
+  });
+
   it('displays Start Over button with autofix data', async () => {
     MockApiClient.addMockResponse({
       url: `/issues/${mockGroup.id}/autofix/`,

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.spec.tsx
@@ -222,7 +222,7 @@ describe('SolutionsHubDrawer', () => {
     expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
   });
 
-  it('displays autofix steps and Start Over button when autofixData is available', async () => {
+  it('displays Start Over button with autofix data', async () => {
     MockApiClient.addMockResponse({
       url: `/issues/${mockGroup.id}/autofix/`,
       body: {autofix: mockAutofixData},
@@ -234,6 +234,24 @@ describe('SolutionsHubDrawer', () => {
     );
 
     expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
+  });
+
+  it('displays Start Over button even without autofix data', async () => {
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(
+      <SolutionsHubDrawer event={mockEvent} group={mockGroup} project={mockProject} />,
+      {organization}
+    );
+
+    expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'Start Autofix'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Start Over'})).toBeDisabled();
   });
 
   it('resets autofix on clicking the start over button', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -199,23 +199,27 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
             }}
           />
         </Header>
-        <ButtonBarWrapper>
-          <ButtonBar gap={1}>
-            <AutofixFeedback />
-            <Button
-              size="xs"
-              onClick={reset}
-              title={
-                autofixData?.created_at
-                  ? `Last run at ${autofixData.created_at.split('T')[0]}`
-                  : null
-              }
-              disabled={!autofixData}
-            >
-              {t('Start Over')}
-            </Button>
-          </ButtonBar>
-        </ButtonBarWrapper>
+        {!aiConfig.needsGenAIConsent && (
+          <ButtonBarWrapper data-test-id="autofix-button-bar">
+            <ButtonBar gap={1}>
+              <AutofixFeedback />
+              {aiConfig.hasAutofix && (
+                <Button
+                  size="xs"
+                  onClick={reset}
+                  title={
+                    autofixData?.created_at
+                      ? `Last run at ${autofixData.created_at.split('T')[0]}`
+                      : null
+                  }
+                  disabled={!autofixData}
+                >
+                  {t('Start Over')}
+                </Button>
+              )}
+            </ButtonBar>
+          </ButtonBarWrapper>
+        )}
       </SolutionsDrawerNavigator>
       <SolutionsDrawerBody ref={scrollContainerRef} onScroll={handleScroll}>
         {aiConfig.isAutofixSetupLoading ? (

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -199,24 +199,23 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
             }}
           />
         </Header>
-        {autofixData && (
-          <ButtonBarWrapper>
-            <ButtonBar gap={1}>
-              <AutofixFeedback />
-              <Button
-                size="xs"
-                onClick={reset}
-                title={
-                  autofixData.created_at
-                    ? `Last run at ${autofixData.created_at.split('T')[0]}`
-                    : null
-                }
-              >
-                {t('Start Over')}
-              </Button>
-            </ButtonBar>
-          </ButtonBarWrapper>
-        )}
+        <ButtonBarWrapper>
+          <ButtonBar gap={1}>
+            <AutofixFeedback />
+            <Button
+              size="xs"
+              onClick={reset}
+              title={
+                autofixData?.created_at
+                  ? `Last run at ${autofixData.created_at.split('T')[0]}`
+                  : null
+              }
+              disabled={!autofixData}
+            >
+              {t('Start Over')}
+            </Button>
+          </ButtonBar>
+        </ButtonBarWrapper>
       </SolutionsDrawerNavigator>
       <SolutionsDrawerBody ref={scrollContainerRef} onScroll={handleScroll}>
         {aiConfig.isAutofixSetupLoading ? (


### PR DESCRIPTION
Keep the feedback & start over buttons in the header on autofix start state, but disable the start over
