### PR TITLE
fix(nav): Fix highlighting sections for explore/insights

### DIFF
--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -70,6 +70,7 @@ export function PrimaryNavigationItems() {
 
         <SidebarLink
           to={`/${prefix}/explore/traces/`}
+          activeTo={`/${prefix}/explore`}
           analyticsKey="explore"
           label={NAV_GROUP_LABELS[PrimaryNavGroup.EXPLORE]}
         >
@@ -94,6 +95,7 @@ export function PrimaryNavigationItems() {
         <Feature features={['performance-view']}>
           <SidebarLink
             to={`/${prefix}/insights/frontend/`}
+            activeTo={`/${prefix}/insights`}
             analyticsKey="insights-domains"
             label={NAV_GROUP_LABELS[PrimaryNavGroup.INSIGHTS]}
           >


### PR DESCRIPTION
It was only highlighting explore/traces when the main route was loaded.