### PR TITLE
fix(replay): fix video ending causing out of order play

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -43,6 +43,7 @@ export class VideoReplayer {
   private _attachments: VideoEvent[];
   private _callbacks: Record<string, (args?: any) => unknown>;
   private _currentIndex: number | undefined;
+  private _currentVideo: HTMLVideoElement | undefined;
   private _startTimestamp: number;
   private _timer = new Timer();
   private _trackList: Array<[ts: number, index: number]>;
@@ -427,14 +428,17 @@ export class VideoReplayer {
       // hides all videos because videos have a different z-index depending on their index
       else {
         videoElem.style.display = 'none';
-        // resets the other videos to the beginning if it's ended so it starts from the beginning on restart
-        if (videoElem.ended) {
-          this.setVideoTime(videoElem, 0);
+        // resets the soon-to-be previous video to the beginning if it's ended so it starts from the beginning on restart
+        if (this._currentVideo) {
+          if (this._currentVideo.ended) {
+            this.setVideoTime(this._currentVideo, 0);
+          }
         }
       }
     }
 
     nextVideo.style.display = 'block';
+    this._currentVideo = nextVideo;
   }
 
   protected async playVideo(video: HTMLVideoElement | undefined): Promise<void> {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -43,7 +43,6 @@ export class VideoReplayer {
   private _attachments: VideoEvent[];
   private _callbacks: Record<string, (args?: any) => unknown>;
   private _currentIndex: number | undefined;
-  private _currentVideo: HTMLVideoElement | undefined;
   private _startTimestamp: number;
   private _timer = new Timer();
   private _trackList: Array<[ts: number, index: number]>;
@@ -428,17 +427,14 @@ export class VideoReplayer {
       // hides all videos because videos have a different z-index depending on their index
       else {
         videoElem.style.display = 'none';
-        // resets the soon-to-be previous video to the beginning if it's ended so it starts from the beginning on restart
-        if (this._currentVideo) {
-          if (this._currentVideo.ended) {
-            this.setVideoTime(this._currentVideo, 0);
-          }
+        // resets the other videos to the beginning if it's ended so it starts from the beginning on restart
+        if (videoElem.ended && videoElem.duration > 0) {
+          this.setVideoTime(videoElem, 0);
         }
       }
     }
 
     nextVideo.style.display = 'block';
-    this._currentVideo = nextVideo;
   }
 
   protected async playVideo(video: HTMLVideoElement | undefined): Promise<void> {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -428,6 +428,7 @@ export class VideoReplayer {
       else {
         videoElem.style.display = 'none';
         // resets the other videos to the beginning if it's ended so it starts from the beginning on restart
+        // we don't do this for videos that have a duration of 0 because this will incorrectly cause handleSegmentEnd to fire.
         if (videoElem.ended && videoElem.duration > 0) {
           this.setVideoTime(videoElem, 0);
         }


### PR DESCRIPTION
addresses a customer ticket about a broken mobile replay, where the video appears to be showing the same few video segments over and over again, rather than the full video list. this is caused by the fact that the first video in the broken replay had a duration of `0`, causing `handleSegmentEnd` to fire incorrectly when we reset that first video's time to `0`.

in the loop, we should check for video duration before resetting the time back to the beginning.