### PR TITLE
ref(grouping): Improve grouphash metadata backfill logging

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -146,8 +146,11 @@ def create_or_update_grouphash_metadata_if_needed(
                 "grouphash_metadata.creation_race_condition.record_exists",
                 extra={
                     "grouphash_metadata_id": grouphash_metadata.id,
+                    "linked_metadata_id": grouphash.metadata.id if grouphash.metadata else None,
+                    "grouphash_id": grouphash.id,
                     "grouphash_is_new": grouphash_is_new,
                     "event_id": event.event_id,
+                    "hash_basis": new_data["hash_basis"],
                 },
             )
             return

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -185,7 +185,7 @@ def create_or_update_grouphash_metadata_if_needed(
     if db_hit_metadata:
         metrics.incr("grouping.grouphash_metadata.db_hit", tags=db_hit_metadata)
 
-        if db_hit_metadata["reason"] != "new_grouphash":
+        if db_hit_metadata["reason"] not in ["new_grouphash", "missing_metadata"]:
             # Temporary log to get a sense of how often we're encountering a race condition and
             # backfilling the same grouphash more than once. Note that this data won't be reliable
             # until we increase the sample rate to 100%.

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -139,6 +139,8 @@ def create_or_update_grouphash_metadata_if_needed(
         # for a lock
         grouphash_metadata, created = GroupHashMetadata.objects.get_or_create(grouphash=grouphash)
 
+        new_data = get_grouphash_metadata_data(event, project, variants, grouping_config)
+
         if not created:
             logger.info(
                 "grouphash_metadata.creation_race_condition.record_exists",
@@ -149,8 +151,6 @@ def create_or_update_grouphash_metadata_if_needed(
                 },
             )
             return
-
-        new_data = get_grouphash_metadata_data(event, project, variants, grouping_config)
 
         db_hit_metadata = {"reason": "new_grouphash" if grouphash_is_new else "missing_metadata"}
 

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -409,10 +409,11 @@ def maybe_check_seer_for_matching_grouphash(
                 logger.info(
                     "grouphash_metadata.none_id",
                     extra={
+                        "grouphash_id": event_grouphash.id,
                         "event_id": event.event_id,
-                        "grouphash": str(event_grouphash),
-                        "grouphash_metadata": str(gh_metadata),
-                        "project": str(event.project),
+                        "project_slug": event.project.slug,
+                        "project_id": event.project.id,
+                        "org_id": event.organization.id,
                     },
                 )
                 return seer_matched_grouphash


### PR DESCRIPTION
This makes a number of small improvements to the logging we do when backfilling grouphash metadata, in order to continue debugging the grouphashes we see in the Seer codepath whose metadata has no id.