### PR TITLE
fix(member-invite): use hook to get default org roles

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -17,6 +17,7 @@ import useInviteModal from 'sentry/components/modals/inviteMembersModal/useInvit
 import {InviteModalHook} from 'sentry/components/modals/memberInviteModalCustomization';
 import {ORG_ROLES} from 'sentry/constants';
 import {t} from 'sentry/locale';
+import HookStore from 'sentry/stores/hookStore';
 import {space} from 'sentry/styles/space';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -69,6 +70,10 @@ function InviteMembersModal({
     );
   }
 
+  const defaultOrgRoles =
+    HookStore.get('member-invite-modal:organization-roles')[0]?.(organization) ??
+    ORG_ROLES;
+
   return (
     <ErrorBoundary>
       <InviteModalHook
@@ -109,7 +114,7 @@ function InviteMembersModal({
                 <InviteMessage />
                 {headerInfo}
                 <StyledInviteRow
-                  roleOptions={memberResult.data?.orgRoleList ?? ORG_ROLES}
+                  roleOptions={memberResult.data?.orgRoleList ?? defaultOrgRoles}
                   roleDisabledUnallowed={willInvite}
                 />
               </Body>

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -22,7 +22,7 @@ import type {
   RouteComponentProps,
   RouteContextInterface,
 } from './legacyReactRouter';
-import type {Member, Organization} from './organization';
+import type {Member, Organization, OrgRole} from './organization';
 import type {Project} from './project';
 import type {User} from './user';
 
@@ -232,6 +232,7 @@ export type CustomizationHooks = {
   'integrations:feature-gates': IntegrationsFeatureGatesHook;
   'member-invite-button:customization': InviteButtonCustomizationHook;
   'member-invite-modal:customization': InviteModalCustomizationHook;
+  'member-invite-modal:organization-roles': (organization: Organization) => OrgRole[];
   'sidebar:navigation-item': SidebarNavigationItemHook;
 };
 

--- a/static/gsApp/hooks/organizationRoles.spec.tsx
+++ b/static/gsApp/hooks/organizationRoles.spec.tsx
@@ -1,0 +1,18 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {getOrgRoles} from 'getsentry/hooks/organizationRoles';
+
+describe('OrganizationRoles', function () {
+  it('includes admin if org does not have team-roles', function () {
+    const organization = OrganizationFixture({features: []});
+    const result = getOrgRoles(organization);
+    expect(result).toHaveLength(5);
+    expect(result[2]?.id).toBe('admin');
+  });
+
+  it('does not include admin if org has team-roles', function () {
+    const organization = OrganizationFixture({features: ['team-roles']});
+    const result = getOrgRoles(organization);
+    expect(result).toHaveLength(4);
+  });
+});

--- a/static/gsApp/hooks/organizationRoles.tsx
+++ b/static/gsApp/hooks/organizationRoles.tsx
@@ -1,0 +1,54 @@
+import type {Organization, OrgRole} from 'sentry/types/organization';
+
+export const ORG_ROLES: OrgRole[] = [
+  {
+    id: 'billing',
+    name: 'Billing',
+    isAllowed: true,
+    desc: 'Can manage payment and compliance details.',
+    minimumTeamRole: 'contributor',
+    isTeamRolesAllowed: false,
+  },
+  {
+    id: 'member',
+    name: 'Member',
+    isAllowed: true,
+    desc: 'Members can view and act on events, as well as view most other data within the organization.',
+    minimumTeamRole: 'contributor',
+    isTeamRolesAllowed: true,
+  },
+  {
+    id: 'manager',
+    name: 'Manager',
+    isAllowed: true,
+    desc: 'Gains admin access on all teams as well as the ability to add and remove members.',
+    minimumTeamRole: 'admin',
+    isTeamRolesAllowed: true,
+  },
+  {
+    id: 'owner',
+    name: 'Owner',
+    isAllowed: true,
+    desc: 'Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete projects and members, as well as make billing and plan changes.',
+    minimumTeamRole: 'admin',
+    isTeamRolesAllowed: true,
+  },
+];
+
+export function getOrgRoles(organization: Organization): OrgRole[] {
+  if (organization.features.includes('team-roles')) {
+    return ORG_ROLES;
+  }
+  const adminRole: OrgRole = {
+    id: 'admin',
+    name: 'Admin',
+    isAllowed: true,
+    desc: "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects on which they already hold membership (or all teams, if open membership is enabled). Additionally, they can manage memberships of teams that they are members of. They cannot invite members to the organization.",
+    minimumTeamRole: 'admin',
+    isTeamRolesAllowed: true,
+  };
+  const rolesWithAdmin = [...ORG_ROLES];
+  // insert admin role to keep roles ordered from least to most permissions
+  rolesWithAdmin.splice(2, 0, adminRole);
+  return rolesWithAdmin;
+}

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -57,6 +57,7 @@ import hookIntegrationFeatures from 'getsentry/hooks/integrationFeatures';
 import legacyOrganizationRedirectRoutes from 'getsentry/hooks/legacyOrganizationRedirectRoutes';
 import MemberListHeader from 'getsentry/hooks/memberListHeader';
 import OrganizationMembershipSettingsForm from 'getsentry/hooks/organizationMembershipSettingsForm';
+import {getOrgRoles} from 'getsentry/hooks/organizationRoles';
 import OrgStatsBanner from 'getsentry/hooks/orgStatsBanner';
 import hookRootRoutes from 'getsentry/hooks/rootRoutes';
 import hookSettingsRoutes from 'getsentry/hooks/settingsRoutes';
@@ -173,6 +174,11 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
    * Augment the onboarding wizard skip confirm help button
    */
   'onboarding-wizard:skip-help': () => OnboardingWizardHelp,
+
+  /**
+   * Get list of organization roles
+   */
+  'member-invite-modal:organization-roles': getOrgRoles,
 
   /**
    * Ensure we enable/disable Pendo when guides change


### PR DESCRIPTION
We determine the role options for the member invite modal using the inviter's member details. However, if a superuser is using the invite modal, then the inviter is not a member and the organization member details endpoint will 404. In this case, we use a default list of org roles to populate the role dropdown in the modal.

We should use a hook to get the default list of org roles so that we can include a Billing role, and only show the Admin role when the org is not on a business or enterprise plan.