### PR TITLE
feat(analytics): Update issue stream to use default page view analytics

### DIFF
--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -38,6 +38,7 @@ type ParamKeys =
   | 'tagKey'
   | 'teamId'
   | 'traceSlug'
+  | 'viewId'
   | 'widgetIndex';
 
 /**


### PR DESCRIPTION
Previously we were capturing `issues_tab.viewed` every time the issues were loaded. This is now a misnomer due to the replacement of tabs with issue views. Additionally, switching to the default page view analytics makes sure that this is fired consistent with other pages (only after the user has been on the page for a few seconds and does not refire when query params change).

Note that this will break any existing dashboards which rely on the old analytic name.