### PR TITLE
fix(pytest): Adding workaround to avoid systemic CI errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import sys
 from collections.abc import MutableMapping
 
@@ -39,12 +38,8 @@ if sys.platform == "linux":
             except FileNotFoundError:
                 continue
             else:
-                if path.startswith("/"):
-                    try:
-                        if stat.S_ISREG(os.stat(path).st_mode):
-                            ret.append(path)
-                    except OSError:
-                        continue
+                if os.path.exists(path):
+                    ret.append(path)
         return frozenset(ret)
 
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import sys
 from collections.abc import MutableMapping
 
@@ -38,7 +39,12 @@ if sys.platform == "linux":
             except FileNotFoundError:
                 continue
             else:
-                ret.append(path)
+                if path.startswith("/"):
+                    try:
+                        if stat.S_ISREG(os.stat(path).st_mode):
+                            ret.append(path)
+                    except OSError:
+                        continue
         return frozenset(ret)
 
 else:


### PR DESCRIPTION
We’ve observed systemic failures in CI, causing the entire test suite to fail due to access being denied. This issue arises from our test fixture, which ensures no file descriptors are leaked between tests. The problem occurs when a file descriptor is found that we are unable to access, triggering a `PermissionError`.
The underlying cause stems from the logic used by `psutil`, which performs more checks than necessary. Specifically, it attempts to verify whether the path is a valid file using `os.stat()`, leading to the access issues, as shown in the error below:
```
______ ERROR at setup of QuantizeTimeTest.test_quantizes_with_rounding_up ______
.venv/lib/python3.13/site-packages/psutil/_pslinux.py:1643: in wrapper
    return fun(self, *args, **kwargs)
.venv/lib/python3.13/site-packages/psutil/_pslinux.py:2227: in open_files
    if path.startswith('/') and isfile_strict(path):
.venv/lib/python3.13/site-packages/psutil/_common.py:526: in isfile_strict
    st = os.stat(path)
E   PermissionError: [Errno 13] Permission denied: '/root/.dotnet/corefx/cryptography/x509stores/my/226A849E790F34CD326D337D1FB66D8420F6C32B.pfx'
```
To mitigate this issue, we’ve simplified the implementation for Linux by using a more direct approach to retrieve open file descriptors via the `/proc` file system, which avoids triggering `os.stat()` and the associated permission error. Since the issue appears to be isolated to CI (which runs on Linux), we’ve limited this fix to Linux.
