### PR TITLE
ref(aci): allow dual updating issue alerts sans writing actions

### DIFF
--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -33,7 +33,11 @@ class ProjectRuleCreator:
                 "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
             ):
                 # TODO(cathy): handle errors from broken actions
-                IssueAlertMigrator(self.rule, self.request.user.id if self.request else None).run()
+                IssueAlertMigrator(
+                    self.rule,
+                    self.request.user.id if self.request else None,
+                    should_create_actions=False,
+                ).run()
 
             return self.rule
 

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -8,9 +8,7 @@ from sentry import features
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
-    update_migrated_issue_alert,
-)
+from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import IssueAlertUpdater
 
 
 @dataclass
@@ -43,8 +41,7 @@ class ProjectRuleUpdater:
             if features.has(
                 "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
             ):
-                # TODO(cathy): handle errors from broken actions
-                update_migrated_issue_alert(self.rule)
+                IssueAlertUpdater(self.rule, should_create_actions=False).run()
             return self.rule
 
     def _update_name(self) -> None:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -28,151 +28,170 @@ logger = logging.getLogger(__name__)
 SKIPPED_CONDITIONS = [Condition.EVERY_EVENT]
 
 
-def bulk_create_data_conditions(
-    conditions: list[dict[str, Any]],
-    dcg: DataConditionGroup,
-    filters: list[dict[str, Any]] | None = None,
-):
-    dcg_conditions: list[DataCondition] = []
-
-    for condition in conditions:
-        if condition["id"] == EventUniqueUserFrequencyConditionWithConditions.id:  # special case
-            dcg_conditions = [
-                create_event_unique_user_frequency_condition_with_conditions(
-                    dict(condition), dcg, filters
-                )
-            ]
-        else:
-            dcg_conditions.append(translate_to_data_condition(dict(condition), dcg=dcg))
-
-    filtered_data_conditions = [dc for dc in dcg_conditions if dc.type not in SKIPPED_CONDITIONS]
-    DataCondition.objects.bulk_create(filtered_data_conditions)
+def delete_workflow_actions(if_dcg: DataConditionGroup):
+    dcg_actions = DataConditionGroupAction.objects.filter(condition_group=if_dcg)
+    action_ids = dcg_actions.values_list("action_id", flat=True)
+    Action.objects.filter(id__in=action_ids).delete()
+    dcg_actions.delete()
 
 
-def create_if_dcg(
-    workflow: Workflow,
-    conditions: list[dict[str, Any]],
-    filters: list[dict[str, Any]],
-    filter_match: str | None = None,
-):
-    if filter_match == "any":  # must create IF DCG even if it's empty, to attach actions
-        filter_match = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
-    elif filter_match is None:
-        filter_match = DataConditionGroup.Type.ALL.value
+class IssueAlertUpdater:
+    def __init__(self, rule: Rule, should_create_actions: bool | None = True):
+        self.rule = rule
+        self.data = rule.data
+        self.should_create_actions = should_create_actions
 
-    if_dcg = DataConditionGroup.objects.create(
-        logic_type=filter_match, organization=workflow.organization
-    )
-    WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=if_dcg)
+    def run(self):
+        try:
+            alert_rule_workflow = AlertRuleWorkflow.objects.get(rule=self.rule)
+        except AlertRuleWorkflow.DoesNotExist:
+            logger.exception("AlertRuleWorkflow does not exist", extra={"rule_id": self.rule.id})
+            return
 
-    conditions_ids = [condition["id"] for condition in conditions]
-    # skip migrating filters for special case
-    if EventUniqueUserFrequencyConditionWithConditions.id not in conditions_ids:
-        bulk_create_data_conditions(conditions=filters, dcg=if_dcg)
+        workflow: Workflow = alert_rule_workflow.workflow
+        if not workflow.when_condition_group:
+            logger.error(
+                "Workflow does not have a when_condition_group", extra={"workflow_id": workflow.id}
+            )
+            return
 
-    return if_dcg
+        conditions, filters = split_conditions_and_filters(self.data["conditions"])
 
-
-def create_workflow_actions(if_dcg: DataConditionGroup, actions: list[dict[str, Any]]) -> None:
-    notification_actions = build_notification_actions_from_rule_data_actions(actions)
-    dcg_actions = [
-        DataConditionGroupAction(action=action, condition_group=if_dcg)
-        for action in notification_actions
-    ]
-    DataConditionGroupAction.objects.bulk_create(dcg_actions)
-
-
-def update_migrated_issue_alert(rule: Rule):
-    data = rule.data
-
-    try:
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule=rule)
-    except AlertRuleWorkflow.DoesNotExist:
-        logger.exception("AlertRuleWorkflow does not exist", extra={"rule_id": rule.id})
-        return
-
-    workflow: Workflow = alert_rule_workflow.workflow
-    if not workflow.when_condition_group:
-        logger.error(
-            "Workflow does not have a when_condition_group", extra={"workflow_id": workflow.id}
-        )
-        return
-
-    conditions, filters = split_conditions_and_filters(data["conditions"])
-
-    update_dcg(
-        dcg=workflow.when_condition_group,
-        type=WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
-        conditions=conditions,
-        filters=filters,
-        match=data["action_match"],
-    )
-
-    try:
-        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
-    except WorkflowDataConditionGroup.DoesNotExist:
-        logger.exception(
-            "WorkflowDataConditionGroup does not exist", extra={"workflow_id": workflow.id}
-        )
-        # if no IF DCG exists, create one
-        if_dcg = create_if_dcg(
-            workflow=workflow,
+        self.update_dcg(
+            dcg=workflow.when_condition_group,
+            type=WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
             conditions=conditions,
             filters=filters,
-            filter_match=data["filter_match"],
+            match=self.data["action_match"],
+        )
+
+        try:
+            if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        except WorkflowDataConditionGroup.DoesNotExist:
+            logger.exception(
+                "WorkflowDataConditionGroup does not exist", extra={"workflow_id": workflow.id}
+            )
+            # if no IF DCG exists, create one
+            if_dcg = self.create_if_dcg(
+                workflow=workflow,
+                conditions=conditions,
+                filters=filters,
+                filter_match=self.data["filter_match"],
+            )
+            WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=if_dcg)
+
+        self.update_dcg(
+            dcg=if_dcg,
+            type=WorkflowDataConditionGroupType.ACTION_FILTER,
+            conditions=conditions,
+            match=self.data["filter_match"],
+            filters=filters,
+        )
+
+        delete_workflow_actions(if_dcg=if_dcg)
+        self.create_workflow_actions(
+            if_dcg=if_dcg, actions=self.data["actions"]
+        )  # action(s) must exist
+
+        workflow.environment_id = self.rule.environment_id
+        if frequency := self.data["frequency"]:
+            workflow.config["frequency"] = frequency
+
+        workflow.owner_user_id = self.rule.owner_user_id
+        workflow.owner_team_id = self.rule.owner_team_id
+
+        workflow.name = self.rule.label
+
+        workflow.enabled = True
+        workflow.save()
+
+    def create_workflow_actions(
+        self, if_dcg: DataConditionGroup, actions: list[dict[str, Any]]
+    ) -> None:
+        notification_actions = build_notification_actions_from_rule_data_actions(actions)
+        dcg_actions = [
+            DataConditionGroupAction(action=action, condition_group=if_dcg)
+            for action in notification_actions
+        ]
+        if self.should_create_actions:
+            DataConditionGroupAction.objects.bulk_create(dcg_actions)
+
+    def bulk_create_data_conditions(
+        self,
+        conditions: list[dict[str, Any]],
+        dcg: DataConditionGroup,
+        filters: list[dict[str, Any]] | None = None,
+    ):
+        dcg_conditions: list[DataCondition] = []
+
+        for condition in conditions:
+            if (
+                condition["id"] == EventUniqueUserFrequencyConditionWithConditions.id
+            ):  # special case
+                dcg_conditions = [
+                    create_event_unique_user_frequency_condition_with_conditions(
+                        dict(condition), dcg, filters
+                    )
+                ]
+            else:
+                dcg_conditions.append(translate_to_data_condition(dict(condition), dcg=dcg))
+
+        filtered_data_conditions = [
+            dc for dc in dcg_conditions if dc.type not in SKIPPED_CONDITIONS
+        ]
+        DataCondition.objects.bulk_create(filtered_data_conditions)
+
+    def update_dcg(
+        self,
+        dcg: DataConditionGroup,
+        conditions: list[dict[str, Any]],
+        type: WorkflowDataConditionGroupType,
+        filters: list[dict[str, Any]],
+        match: str | None = None,
+    ):
+        DataCondition.objects.filter(condition_group=dcg).delete()
+
+        if dcg.logic_type != match:
+            if match == "any":
+                match = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
+            elif match is None:
+                match = DataConditionGroup.Type.ALL.value
+
+            dcg.update(logic_type=match)
+
+        if type == WorkflowDataConditionGroupType.ACTION_FILTER:
+            conditions_ids = [condition["id"] for condition in conditions]
+            # skip migrating filters for special case
+            if EventUniqueUserFrequencyConditionWithConditions.id not in conditions_ids:
+                self.bulk_create_data_conditions(conditions=filters, dcg=dcg)
+        else:
+            self.bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=dcg)
+
+        return dcg
+
+    def create_if_dcg(
+        self,
+        workflow: Workflow,
+        conditions: list[dict[str, Any]],
+        filters: list[dict[str, Any]],
+        filter_match: str | None = None,
+    ):
+        if filter_match == "any":  # must create IF DCG even if it's empty, to attach actions
+            filter_match = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
+        elif filter_match is None:
+            filter_match = DataConditionGroup.Type.ALL.value
+
+        if_dcg = DataConditionGroup.objects.create(
+            logic_type=filter_match, organization=workflow.organization
         )
         WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=if_dcg)
 
-    update_dcg(
-        dcg=if_dcg,
-        type=WorkflowDataConditionGroupType.ACTION_FILTER,
-        conditions=conditions,
-        match=data["filter_match"],
-        filters=filters,
-    )
-
-    delete_workflow_actions(if_dcg=if_dcg)
-    create_workflow_actions(if_dcg=if_dcg, actions=data["actions"])  # action(s) must exist
-
-    workflow.environment_id = rule.environment_id
-    if frequency := data["frequency"]:
-        workflow.config["frequency"] = frequency
-
-    workflow.owner_user_id = rule.owner_user_id
-    workflow.owner_team_id = rule.owner_team_id
-
-    workflow.name = rule.label
-
-    workflow.enabled = True
-    workflow.save()
-
-
-def update_dcg(
-    dcg: DataConditionGroup,
-    conditions: list[dict[str, Any]],
-    type: WorkflowDataConditionGroupType,
-    filters: list[dict[str, Any]],
-    match: str | None = None,
-):
-    DataCondition.objects.filter(condition_group=dcg).delete()
-
-    if dcg.logic_type != match:
-        if match == "any":
-            match = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
-        elif match is None:
-            match = DataConditionGroup.Type.ALL.value
-
-        dcg.update(logic_type=match)
-
-    if type == WorkflowDataConditionGroupType.ACTION_FILTER:
         conditions_ids = [condition["id"] for condition in conditions]
         # skip migrating filters for special case
         if EventUniqueUserFrequencyConditionWithConditions.id not in conditions_ids:
-            bulk_create_data_conditions(conditions=filters, dcg=dcg)
-    else:
-        bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=dcg)
+            self.bulk_create_data_conditions(conditions=filters, dcg=if_dcg)
 
-    return dcg
+        return if_dcg
 
 
 def delete_migrated_issue_alert(rule: Rule):
@@ -209,10 +228,3 @@ def delete_migrated_issue_alert(rule: Rule):
 
     workflow.delete()
     alert_rule_workflow.delete()
-
-
-def delete_workflow_actions(if_dcg: DataConditionGroup):
-    dcg_actions = DataConditionGroupAction.objects.filter(condition_group=if_dcg)
-    action_ids = dcg_actions.values_list("action_id", flat=True)
-    Action.objects.filter(id__in=action_ids).delete()
-    dcg_actions.delete()


### PR DESCRIPTION
We'll be dual writing, running the initial issue alert migration, and testing the evaluation without firing actions. If we don't create actions, there's no risk of ever firing them!

Allow updating issue alerts and ignore writing actions.