### PR TITLE
fix(nav): Use global page filters on All Issues

### DIFF
--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -1,9 +1,12 @@
+import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 
 type Props = {
   children: React.ReactNode;
@@ -12,12 +15,21 @@ type Props = {
 function IssueListContainer({children}: Props) {
   const organization = useOrganization();
   useRouteAnalyticsHookSetup();
+  const prefersStackedNav = usePrefersStackedNav();
+  const location = useLocation();
+  const {viewId} = useParams<{orgId?: string; viewId?: string}>();
+
+  const onAllIssues = location.pathname === '/issues/' && !viewId;
+
+  const useGlobalPageFilters =
+    !organization.features.includes('issue-stream-custom-views') ||
+    (prefersStackedNav && onAllIssues);
 
   return (
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>
       <PageFiltersContainer
-        skipLoadLastUsed={organization.features.includes('issue-stream-custom-views')}
-        disablePersistence={organization.features.includes('issue-stream-custom-views')}
+        skipLoadLastUsed={!useGlobalPageFilters}
+        disablePersistence={!useGlobalPageFilters}
       >
         <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
       </PageFiltersContainer>

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -4,7 +4,6 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 
@@ -16,14 +15,11 @@ function IssueListContainer({children}: Props) {
   const organization = useOrganization();
   useRouteAnalyticsHookSetup();
   const prefersStackedNav = usePrefersStackedNav();
-  const location = useLocation();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
-
-  const onAllIssues = location.pathname === '/issues/' && !viewId;
 
   const useGlobalPageFilters =
     !organization.features.includes('issue-stream-custom-views') ||
-    (prefersStackedNav && onAllIssues);
+    (prefersStackedNav && !viewId);
 
   return (
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>


### PR DESCRIPTION
Changes the behavior of last used global page filters on All Issues. 

Original: If you had custom views (which have their own page filters), do not load the last page filters 

Now: Same as original, but now we load the last page filters on the issue stream if you have the new navigation layout, and if you're on the all issues tab. Changing page filters on "All" will also persist changes to other surface areas, just like before 