### PR TITLE
fix(seer-issues-patch) Fall back when provider is inaccurate

### DIFF
--- a/src/sentry/seer/fetch_issues_given_patches.py
+++ b/src/sentry/seer/fetch_issues_given_patches.py
@@ -351,7 +351,7 @@ def _get_repo(
                     "repo_full_name": repo_full_name,
                 },
             )
-            repo: Repository | None = Repository.objects.filter(
+            repo = Repository.objects.filter(
                 organization_id=organization_id,
                 external_id=external_id,
                 status=ObjectStatus.ACTIVE,

--- a/tests/sentry/seer/test_fetch_issues_given_patches.py
+++ b/tests/sentry/seer/test_fetch_issues_given_patches.py
@@ -231,9 +231,9 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
     def test_missing_repo(self):
         assert (
             get_issues_related_to_file_patches(
-                organization_id=1,
-                provider="integrations:github",
-                external_id="does-not-exist",
+                organization_id=self.organization.id,
+                provider="unknown-provider",
+                external_id=self.gh_repo.external_id,  # type: ignore[arg-type]
                 pr_files=[],
             )
             == {}
@@ -287,8 +287,9 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
         # Test that we fall back to the first active repo if the the provider is inaccurate
         filename_to_issues_fallback = get_issues_related_to_file_patches(
             organization_id=self.organization.id,
-            provider="does-not-exist",
+            provider="is-not-known",
             external_id=self.gh_repo.external_id,  # type: ignore[arg-type]
+            repo_full_name=self.gh_repo.name,
             pr_files=pr_files,
         )
         assert filename_to_issues_fallback == filename_to_issues_expected

--- a/tests/sentry/seer/test_fetch_issues_given_patches.py
+++ b/tests/sentry/seer/test_fetch_issues_given_patches.py
@@ -283,3 +283,12 @@ class TestGetIssuesRelatedToFilePatches(IntegrationTestCase, CreateEventTestCase
             pr_files=pr_files,
         )
         assert filename_to_issues == filename_to_issues_expected
+
+        # Test that we fall back to the first active repo if the the provider is inaccurate
+        filename_to_issues_fallback = get_issues_related_to_file_patches(
+            organization_id=self.organization.id,
+            provider="does-not-exist",
+            external_id=self.gh_repo.external_id,  # type: ignore[arg-type]
+            pr_files=pr_files,
+        )
+        assert filename_to_issues_fallback == filename_to_issues_expected


### PR DESCRIPTION
The `provider` from overwatch (the codecov service that makes the relevant warnings request to seer) currently may not match what's in `Repository`. For now, fall back to filtering using the repo name, in addition to `organization_id, external_id`. Running this query demonstrates that there currently aren't duplicate `(organization_id, external_id, name)` records:

```sql
SELECT
    organization_id, external_id, name,
    COUNT(*) AS num_repos
FROM
    sentry_repository
WHERE
    status = 0
    AND external_id IS NOT NULL
GROUP BY
    organization_id, external_id, name
ORDER BY
    num_repos DESC
LIMIT 100;
```

This uniqueness isn't a DB constraint, so the first matching record is arbitrarily used.

This is meant to be a temporary patch. In the near future, when overwatch sends the correct provider, I'll remove this logic.