### PR TITLE
:recycle: ref(integrations): attempt to generalize `record_lifecycle_termination_level`

### DIFF
--- a/src/sentry/integrations/messaging/__init__.py
+++ b/src/sentry/integrations/messaging/__init__.py
@@ -5,3 +5,7 @@ The current messaging integrations are Discord, MSTeams, and Slack.
 TODO: Move the packages for individual integrations to be subpackages of this one
       (possibly in coordination with grouping other integrations by purpose)
 """
+
+__all__ = ["SlackMessagingInteractionUtility"]
+
+from .metrics import SlackMessagingInteractionUtility

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -1,13 +1,3 @@
-# metrics constants
-
-from slack_sdk.errors import SlackApiError
-
-from sentry.integrations.slack.utils.errors import (
-    SLACK_SDK_HALT_ERROR_CATEGORIES,
-    unpack_slack_api_error,
-)
-from sentry.integrations.utils.metrics import EventLifecycle
-
 SLACK_ISSUE_ALERT_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.success"
 SLACK_ISSUE_ALERT_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.issue_alert.failure"
 
@@ -49,14 +39,3 @@ SLACK_UTILS_CHANNEL_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.utils.ch
 # Middleware Parsers
 SLACK_MIDDLE_PARSERS_SUCCESS_DATADOG_METRIC = "sentry.middleware.integrations.slack.parsers.success"
 SLACK_MIDDLE_PARSERS_FAILURE_DATADOG_METRIC = "sentry.middleware.integrations.slack.parsers.failure"
-
-
-def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: SlackApiError) -> None:
-    if (
-        (reason := unpack_slack_api_error(error))
-        and reason is not None
-        and reason in SLACK_SDK_HALT_ERROR_CATEGORIES
-    ):
-        lifecycle.record_halt(reason.message)
-    else:
-        lifecycle.record_failure(error)

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -270,10 +270,11 @@ class SlackService:
         # We don't wrap this in a lifecycle because _handle_parent_notification is already wrapped in a lifecycle
         parent_notification_count = 0
         for parent_notification in parent_notifications:
-            with MessagingInteractionEvent(
+            interaction_event = MessagingInteractionEvent(
                 interaction_type=MessagingInteractionType.SEND_ACTIVITY_NOTIFICATION,
                 spec=SlackMessagingSpec(),
-            ).capture() as lifecycle:
+            )
+            with interaction_event.capture() as lifecycle:
                 parent_notification_count += 1
                 lifecycle.add_extras(
                     {
@@ -315,7 +316,7 @@ class SlackService:
                     )
                 except Exception as err:
                     if isinstance(err, SlackApiError):
-                        record_lifecycle_termination_level(lifecycle, err)
+                        interaction_event.record_lifecycle_termination_level(lifecycle, err)
                     else:
                         lifecycle.record_failure(err)
 

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -321,3 +321,21 @@ class IntegrationWebhookEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.interaction_type)
+
+
+class IntegrationEventOutcomeHandler(ABC):
+    """
+    A handler for the outcome of an integration event.
+
+    This is a utility class that can be used to record the outcome of an integration
+    event. It is used to record the outcome of an integration event.
+    """
+
+    @property
+    def HALT_ERROR_CATEGORIES(self) -> set:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: Exception) -> None:
+        raise NotImplementedError

--- a/src/sentry/integrations/utils/registry.py
+++ b/src/sentry/integrations/utils/registry.py
@@ -1,0 +1,4 @@
+from sentry.integrations.utils.metrics import IntegrationEventOutcomeHandler
+from sentry.utils.registry import Registry
+
+integration_outcome_handler_registry = Registry[IntegrationEventOutcomeHandler]()


### PR DESCRIPTION
it is increasingly likely that we will start defining `record_lifecycle_termination_level` on a per-integration basis in order to classify certain exceptions as halt vs failure. this is an attempt to generalize this behavior instead of having bespoke implementations.

here, i create a new registry, `integration_outcome_handler_registry ` which registers an integration slug to an handler which has a set of halt error codes and a the `record_lifecycle_termination_level` static method to actually record the halt/failure.

currently i have the registry hooked up to `MessagingInteractionType`, but in reality, we can move it up the parent `IntegrationEventLifecycleMetric` so all integrations lifecycles need to implement it. 

i see a couple pros/cons with this:
pros:
* registry based implementation keeps it super decomposed and simple to implement a new handler for discord/msteams/etc.
* we use the integration_slug to register, which is a common pattern we can start pushing in other domains as well (in notif platform)
cons
* its a little complicated to grok at first