### PR TITLE
Modified: Value of token "textColor"

### DIFF
--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -364,7 +364,7 @@ const generateAliases = (
   /**
    * Primary text color
    */
-  textColor: tokens.content.secondary,
+  textColor: tokens.content.primary,
 
   /**
    * Text that should not have as much emphasis


### PR DESCRIPTION
I think when I deprecated the `static` and `interactive` token objects last night, I accidentally set the wrong value for `textColor` 