### PR TITLE
Link to project from Last Used auth tokens column

### DIFF
--- a/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
@@ -39,7 +39,7 @@ function LastUsed({
             />
           ),
           project: (
-            <Link to={`/settings/${organization.slug}/${projectLastUsed.slug}/`}>
+            <Link to={`/settings/${organization.slug}/projects/${projectLastUsed.slug}/`}>
               {projectLastUsed.name}
             </Link>
           ),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97d30220-6fb2-4f7f-95c9-a57488afbbc4)
We currently link from `docs` to `https://sentry.io/settings/docs/` instead of `https://sentry.io/settings/projects/docs/`.

`organization.slug` seems to be empty, but even a link like `https://sentry.io/settings/sentry/projects/docs/` will work, hence I assume making the change like this is ok.