### PR TITLE
fix(setup-wizard): Team selection filtering

### DIFF
--- a/static/app/bootstrap/processInitQueue.spec.tsx
+++ b/static/app/bootstrap/processInitQueue.spec.tsx
@@ -123,7 +123,7 @@ describe('processInitQueue', function () {
       });
 
       MockApiClient.addMockResponse({
-        url: '/organizations/organization-1/teams/',
+        url: '/organizations/organization-1/user-teams/',
         body: [TeamFixture({id: '1', slug: 'team-1', name: 'Team 1'})],
       });
 

--- a/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
@@ -14,7 +14,7 @@ export function useOrganizationTeams({
   return useQuery<Team[], RequestError>({
     queryKey: [`/organizations/${organization?.slug}/teams/`],
     queryFn: () => {
-      return api.requestPromise(`/organizations/${organization?.slug}/teams/`, {
+      return api.requestPromise(`/organizations/${organization?.slug}/user-teams/`, {
         host: organization?.region.url,
       });
     },

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -83,9 +83,17 @@ export function WizardProjectSelection({
 
   const orgDetailsRequest = useOrganizationDetails({organization: selectedOrg});
   const teamsRequest = useOrganizationTeams({organization: selectedOrg});
-  const adminTeams = teamsRequest.data
-    ? teamsRequest.data.filter(team => team.access.includes('team:admin'))
-    : [];
+
+  const selectableTeams = useMemo(() => {
+    if (orgDetailsRequest.data?.access.includes('org:admin')) {
+      return teamsRequest.data;
+    }
+    if (orgDetailsRequest.data?.allowMemberProjectCreation) {
+      return teamsRequest.data?.filter(team => team.isMember);
+    }
+    return teamsRequest.data?.filter(team => team.teamRole === 'admin');
+  }, [orgDetailsRequest.data, teamsRequest.data]);
+
   const orgProjectsRequest = useOrganizationProjects({
     organization: selectedOrg,
     query: debouncedSearch,
@@ -93,9 +101,9 @@ export function WizardProjectSelection({
 
   const isCreationEnabled =
     orgDetailsRequest.data &&
-    canCreateProject(orgDetailsRequest.data, teamsRequest.data) &&
-    teamsRequest.data &&
-    teamsRequest.data.length > 0 &&
+    canCreateProject(orgDetailsRequest.data, selectableTeams) &&
+    selectableTeams &&
+    selectableTeams.length > 0 &&
     platformParam;
 
   const updateWizardCacheMutation = useUpdateWizardCache(hash);
@@ -144,10 +152,10 @@ export function WizardProjectSelection({
 
   // Set the selected team to the first team if there is only one
   useEffect(() => {
-    if (teamsRequest.data && teamsRequest.data.length === 1) {
-      setNewProjectTeam(teamsRequest.data[0]!.slug);
+    if (selectableTeams && selectableTeams.length === 1) {
+      setNewProjectTeam(selectableTeams[0]!.slug);
     }
-  }, [teamsRequest.data]);
+  }, [selectableTeams]);
 
   // As the cache hook sorts the options by value, we need to sort them afterwards
   const sortedProjectOptions = useMemo(
@@ -167,8 +175,8 @@ export function WizardProjectSelection({
   );
 
   const selectedTeam = useMemo(
-    () => teamsRequest.data?.find(team => team.slug === newProjectTeam),
-    [newProjectTeam, teamsRequest]
+    () => selectableTeams?.find(team => team.slug === newProjectTeam),
+    [newProjectTeam, selectableTeams]
   );
 
   const isProjectSelected = isCreateProjectSelected
@@ -337,7 +345,7 @@ export function WizardProjectSelection({
               <StyledCompactSelect
                 value={newProjectTeam as string}
                 options={
-                  adminTeams?.map(team => ({
+                  selectableTeams?.map(team => ({
                     value: team.slug,
                     label: `#${team.slug}`,
                     leadingItems: <IdBadge team={team} hideName />,


### PR DESCRIPTION
With #85816 the list of selectable team was filtered to show only teams in which the current user is admin. However, if member project creation is enabled we also want to show teams in which the current user is only a member.

- fixes https://github.com/getsentry/projects/issues/770