### PR TITLE
fix(explore): Fix extra scrollbars always appearing in comparison view tables

### DIFF
--- a/static/app/views/explore/multiQueryMode/components/miniTable.tsx
+++ b/static/app/views/explore/multiQueryMode/components/miniTable.tsx
@@ -28,7 +28,6 @@ const _Table = styled(Grid)<{height?: string | number; scrollable?: boolean}>`
   ${p =>
     p.scrollable &&
     `
-  overflow-x: scroll;
-  overflow-y: scroll;
+    overflow-y: auto;
   `}
 `;


### PR DESCRIPTION
Updates tables in the comparison view to only show scrollbars when there is actually content that overflows. We do this by removing the overflow styling from `_Table` since the `PanelBody` from `_TableWrapper` already has overflow styling that will be applied to the table inside.

![image](https://github.com/user-attachments/assets/72335236-1c79-45d8-8b08-c71a7db3c175)
