### PR TITLE
fix(explore): Update comparison view confidence footer to display proper number of series

### DIFF
--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -57,9 +57,12 @@ export function MultiQueryModeChart({
   const yAxes = queryParts.yAxes;
   const isTopN = mode === Mode.AGGREGATE;
 
-  const confidence = useMemo(() => {
+  const [confidence, numSeries] = useMemo(() => {
     const series = yAxes.flatMap(yAxis => timeseriesResult.data[yAxis]).filter(defined);
-    return combineConfidenceForSeries(series);
+    return [
+      combineConfidenceForSeries(series),
+      Math.min(series.length, DEFAULT_TOP_EVENTS),
+    ];
   }, [timeseriesResult.data, yAxes]);
 
   const [interval, setInterval, intervalOptions] = useChartInterval();
@@ -301,7 +304,7 @@ export function MultiQueryModeChart({
         <ConfidenceFooter
           sampleCount={sampleCount}
           confidence={confidence}
-          topEvents={isTopN ? DEFAULT_TOP_EVENTS : undefined}
+          topEvents={isTopN ? numSeries : undefined}
         />
       }
     />


### PR DESCRIPTION
Updates the confidence footer in the comparison view charts to display the correct number of top n series, instead of always displaying 5.
![image](https://github.com/user-attachments/assets/b682df85-99d3-4f03-9f10-69ba3713a56b)