### PR TITLE
fix(nav): Open help menu links in new tab

### DIFF
--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -266,6 +266,21 @@ describe('DropdownMenu', function () {
     });
   });
 
+  it('closes after clicking external link', async function () {
+    render(
+      <DropdownMenu
+        items={[{key: 'item1', label: 'Item One', externalHref: 'https://example.com'}]}
+        triggerLabel="Menu"
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Menu'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Item One'}));
+    await waitFor(() => {
+      expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
+    });
+  });
+
   it('navigates to link on enter', async function () {
     const onAction = jest.fn();
     const router = RouterFixture();
@@ -320,5 +335,33 @@ describe('DropdownMenu', function () {
     expect(errorSpy).toHaveBeenCalledTimes(1);
 
     errorSpy.mockRestore();
+  });
+
+  it('navigates to external link enter', async function () {
+    const onAction = jest.fn();
+    const router = RouterFixture();
+    const user = userEvent.setup();
+
+    render(
+      <DropdownMenu
+        items={[
+          {key: 'item1', label: 'Item One', externalHref: 'https://example.com/foo'},
+          {
+            key: 'item2',
+            label: 'Item Two',
+            externalHref: 'https://example.com/bar',
+            onAction,
+          },
+        ]}
+        triggerLabel="Menu"
+      />,
+      {router}
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Menu'}));
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -6,6 +6,7 @@ import type {TreeState} from '@react-stately/tree';
 import type {Node} from '@react-types/shared';
 import type {LocationDescriptor} from 'history';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import type {MenuListItemProps} from 'sentry/components/menuListItem';
 import MenuListItem, {
@@ -33,6 +34,10 @@ export interface MenuItemProps extends MenuListItemProps {
    * Pass a class name to the menu item.
    */
   className?: string;
+  /**
+   * Destination if this menu item is an external link.
+   */
+  externalHref?: string;
   /**
    * Hide item from the dropdown menu. Note: this will also remove the item
    * from the selection manager.
@@ -116,14 +121,14 @@ function BaseDropdownMenuItem(
   const ref = useRef<HTMLLIElement | null>(null);
   const isDisabled = state.disabledKeys.has(node.key);
   const isFocused = state.selectionManager.focusedKey === node.key;
-  const {key, onAction, to, label, isSubmenu, trailingItems, ...itemProps} =
+  const {key, onAction, to, label, isSubmenu, trailingItems, externalHref, ...itemProps} =
     node.value ?? {};
   const {size} = node.props;
   const {rootOverlayState} = useContext(DropdownMenuContext);
   const navigate = useNavigate();
 
   const actionHandler = () => {
-    if (to) {
+    if (to || externalHref) {
       // Close the menu after the click event has bubbled to the link
       // Only needed on links that do not unmount the menu
       if (closeOnSelect) {
@@ -167,9 +172,9 @@ function BaseDropdownMenuItem(
   // Open submenu on arrow right key press
   const {keyboardProps} = useKeyboard({
     onKeyDown: e => {
-      if (e.key === 'Enter' && to) {
+      if (e.key === 'Enter' && (to || externalHref)) {
         // If the user is holding down the meta key, we want to dispatch a mouse event
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || externalHref) {
           const mouseEvent = new MouseEvent('click', {
             ctrlKey: e.ctrlKey,
             metaKey: e.metaKey,
@@ -180,7 +185,9 @@ function BaseDropdownMenuItem(
           return;
         }
 
-        navigate(to);
+        if (to) {
+          navigate(to);
+        }
         return;
       }
 
@@ -202,7 +209,7 @@ function BaseDropdownMenuItem(
         onClose?.();
         rootOverlayState?.close();
       },
-      closeOnSelect: to ? false : closeOnSelect,
+      closeOnSelect: to || externalHref ? false : closeOnSelect,
       isDisabled,
     },
     state,
@@ -213,7 +220,17 @@ function BaseDropdownMenuItem(
   // etc. See: https://react-spectrum.adobe.com/react-aria/mergeProps.html
   const mergedProps = mergeProps(props, menuItemProps, hoverProps, keyboardProps);
   const itemLabel = node.rendered ?? label;
-  const innerWrapProps = {as: to ? Link : ('div' as const), to};
+  const makeInnerWrapProps = () => {
+    if (to) {
+      return {as: Link, to};
+    }
+
+    if (externalHref) {
+      return {as: ExternalLink, href: externalHref};
+    }
+
+    return {as: 'div' as const};
+  };
 
   return (
     <MenuListItem
@@ -224,7 +241,7 @@ function BaseDropdownMenuItem(
       disabled={isDisabled}
       isFocused={isFocused}
       showDivider={showDivider}
-      innerWrapProps={innerWrapProps}
+      innerWrapProps={makeInnerWrapProps()}
       labelProps={labelProps}
       detailsProps={descriptionProps}
       trailingItems={

--- a/static/app/components/nav/primary/help.tsx
+++ b/static/app/components/nav/primary/help.tsx
@@ -1,0 +1,86 @@
+import {openHelpSearchModal} from 'sentry/actionCreators/modal';
+import {SidebarMenu} from 'sentry/components/nav/primary/components';
+import {IconQuestion} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function PrimaryNavigationHelp() {
+  const organization = useOrganization();
+  const {mutate: mutateUserOptions} = useMutateUserOptions();
+
+  return (
+    <SidebarMenu
+      items={[
+        {
+          key: 'search',
+          label: t('Search Support, Docs and More'),
+          onAction() {
+            openHelpSearchModal({organization});
+          },
+        },
+        {
+          key: 'resources',
+          label: t('Resources'),
+          children: [
+            {
+              key: 'help-center',
+              label: t('Help Center'),
+              externalHref: 'https://sentry.zendesk.com/hc/en-us',
+            },
+            {
+              key: 'docs',
+              label: t('Documentation'),
+              externalHref: 'https://docs.sentry.io',
+            },
+          ],
+        },
+        {
+          key: 'help',
+          label: t('Get Help'),
+          children: [
+            {
+              key: 'support',
+              label: t('Contact Support'),
+              externalHref: `mailto:${ConfigStore.get('supportEmail')}`,
+            },
+            {
+              key: 'github',
+              label: t('Sentry on GitHub'),
+              externalHref: 'https://github.com/getsentry/sentry/issues',
+            },
+            {
+              key: 'discord',
+              label: t('Join our Discord'),
+              externalHref: 'https://discord.com/invite/sentry',
+            },
+          ],
+        },
+        {
+          key: 'new-ui',
+          children: [
+            {
+              key: 'new-ui',
+              label: t('Switch to old navigation'),
+              onAction() {
+                mutateUserOptions({prefersStackedNavigation: false});
+                trackAnalytics(
+                  'navigation.help_menu_opt_out_stacked_navigation_clicked',
+                  {
+                    organization,
+                  }
+                );
+              },
+            },
+          ],
+        },
+      ]}
+      analyticsKey="help"
+      label={t('Help')}
+    >
+      <IconQuestion />
+    </SidebarMenu>
+  );
+}

--- a/static/app/components/nav/primary/index.tsx
+++ b/static/app/components/nav/primary/index.tsx
@@ -2,16 +2,12 @@ import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import Hook from 'sentry/components/hook';
 import {NAV_GROUP_LABELS} from 'sentry/components/nav/constants';
 import {useNavContext} from 'sentry/components/nav/context';
-import {
-  SeparatorItem,
-  SidebarLink,
-  SidebarMenu,
-} from 'sentry/components/nav/primary/components';
+import {SeparatorItem, SidebarLink} from 'sentry/components/nav/primary/components';
+import {PrimaryNavigationHelp} from 'sentry/components/nav/primary/help';
 import {PrimaryNavigationOnboarding} from 'sentry/components/nav/primary/onboarding';
 import {PrimaryNavigationServiceIncidents} from 'sentry/components/nav/primary/serviceIncidents';
 import {PrimaryNavigationWhatsNew} from 'sentry/components/nav/primary/whatsNew';
@@ -20,15 +16,10 @@ import {
   IconDashboard,
   IconGraph,
   IconIssues,
-  IconQuestion,
   IconSearch,
   IconSettings,
 } from 'sentry/icons';
-import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 
 function SidebarBody({children}: {children: React.ReactNode}) {
@@ -55,8 +46,6 @@ function SidebarFooter({children}: {children: React.ReactNode}) {
 export function PrimaryNavigationItems() {
   const organization = useOrganization();
   const prefix = `organizations/${organization.slug}`;
-
-  const {mutate: mutateUserOptions} = useMutateUserOptions();
 
   return (
     <Fragment>
@@ -115,76 +104,7 @@ export function PrimaryNavigationItems() {
       </SidebarBody>
 
       <SidebarFooter>
-        <SidebarMenu
-          items={[
-            {
-              key: 'search',
-              label: t('Search Support, Docs and More'),
-              onAction() {
-                openHelpSearchModal({organization});
-              },
-            },
-            {
-              key: 'resources',
-              label: t('Resources'),
-              children: [
-                {
-                  key: 'help-center',
-                  label: t('Help Center'),
-                  to: 'https://sentry.zendesk.com/hc/en-us',
-                },
-                {
-                  key: 'docs',
-                  label: t('Documentation'),
-                  to: 'https://docs.sentry.io',
-                },
-              ],
-            },
-            {
-              key: 'help',
-              label: t('Get Help'),
-              children: [
-                {
-                  key: 'support',
-                  label: t('Contact Support'),
-                  to: `mailto:${ConfigStore.get('supportEmail')}`,
-                },
-                {
-                  key: 'github',
-                  label: t('Sentry on GitHub'),
-                  to: 'https://github.com/getsentry/sentry/issues',
-                },
-                {
-                  key: 'discord',
-                  label: t('Join our Discord'),
-                  to: 'https://discord.com/invite/sentry',
-                },
-              ],
-            },
-            {
-              key: 'new-ui',
-              children: [
-                {
-                  key: 'new-ui',
-                  label: t('Switch to old navigation'),
-                  onAction() {
-                    mutateUserOptions({prefersStackedNavigation: false});
-                    trackAnalytics(
-                      'navigation.help_menu_opt_out_stacked_navigation_clicked',
-                      {
-                        organization,
-                      }
-                    );
-                  },
-                },
-              ],
-            },
-          ]}
-          analyticsKey="help"
-          label={t('Help')}
-        >
-          <IconQuestion />
-        </SidebarMenu>
+        <PrimaryNavigationHelp />
 
         <SeparatorItem />
 


### PR DESCRIPTION
Help menu links were implemented as `<Link to="..." />` instead of `<ExternalLink href="..." />` as expected. The dropdown menu did not yet support external links so I added support in this PR.
