### PR TITLE
feat(explore): Sorts selected group bys to the top of the dropdown in the comparison view

### DIFF
--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -26,14 +26,22 @@ export function GroupBySection({query, index}: Props) {
 
   const enabledOptions: Array<SelectOption<string>> = useMemo(() => {
     const potentialOptions = Object.keys(tags).filter(key => key !== 'id');
-    potentialOptions.sort();
+    potentialOptions.sort((a, b) => {
+      if (query.groupBys.includes(a) === query.groupBys.includes(b)) {
+        return a.localeCompare(b);
+      }
+      if (query.groupBys.includes(a)) {
+        return -1;
+      }
+      return 1;
+    });
 
     return potentialOptions.map(key => ({
       label: key,
       value: key,
       textValue: key,
     }));
-  }, [tags]);
+  }, [tags, query.groupBys]);
 
   return (
     <Section data-test-id={`section-group-by-${index}`}>


### PR DESCRIPTION
Updates the group by dropdown selector to sort selected options to the top of the list.
![image](https://github.com/user-attachments/assets/e2eae356-ff00-4871-bf60-7b924accb3b4)