### PR TITLE
ref(grouping): Clean up and expand tests

### DIFF
--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -12,6 +12,14 @@ from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.mocking import capture_results
 
+EMPTY_SEER_RESULTS = (
+    {
+        "results": [],
+        "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
+    },
+    None,
+)
+
 
 def get_event_data() -> dict[str, Any]:
     return {
@@ -119,13 +127,13 @@ class SeerEventManagerGroupingTest(TestCase):
             assert new_event.group_id == existing_event.group_id
 
     @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
-    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues", return_value=({}, None))
+    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues", return_value=EMPTY_SEER_RESULTS)
     def test_calls_seer_if_no_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1
 
     @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
-    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues", return_value=({}, None))
+    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues", return_value=EMPTY_SEER_RESULTS)
     def test_bypasses_seer_if_group_found(self, mock_get_seer_similar_issues: MagicMock, _):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
         assert mock_get_seer_similar_issues.call_count == 1

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -22,20 +22,20 @@ EMPTY_SEER_RESULTS = (
 )
 
 
-def get_event_data() -> dict[str, Any]:
+def get_event_data(dog: str = "Charlie") -> dict[str, Any]:
     return {
-        "title": "FailedToFetchError('Charlie didn't bring the ball back')",
+        "title": f"FailedToFetchError('{dog} didn't bring the ball back')",
         "exception": {
             "values": [
                 {
                     "type": "FailedToFetchError",
-                    "value": "Charlie didn't bring the ball back",
+                    "value": f"{dog} didn't bring the ball back",
                     "stacktrace": {
                         "frames": [
                             {
                                 "function": "play_fetch",
                                 "filename": "dogpark.py",
-                                "context_line": "raise FailedToFetchError('Charlie didn't bring the ball back')",
+                                "context_line": f"raise FailedToFetchError('{dog} didn't bring the ball back')",
                             }
                         ]
                     },


### PR DESCRIPTION
This is a collection of small refactors to various grouping tests, extracted from a number of upcoming PRs in order to make them easier to review.

- Combine two background grouping tests which were aiming to test the same thing.
- Simplify tests by using the `save_new_event` helper rather than manually creating an event manager and then using it to normalize and save the event.
- Split test of Seer metadata into a separate class and into multiple tests.
- Return a more realistic empty value when mocking `get_seer_similar_issues`.
- Expand `should_call_seer_for_grouping` empty stacktrace string test to include the positive case as well.
- Add tests for not saving new secondary hashes, one of which is an xfail, so it's easier to see that a forthcoming bugfix a) doesn't break current behavior and b) fixes a case which is now failing.