### PR TITLE
fix(explore): update the confidence footer in explore to display the actual number of series returned in a groupby

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -288,7 +288,9 @@ export function ExploreCharts({
                   <ConfidenceFooter
                     sampleCount={chartInfo.sampleCount}
                     confidence={chartInfo.confidence}
-                    topEvents={topEvents}
+                    topEvents={
+                      topEvents ? Math.min(topEvents, chartInfo.data.length) : undefined
+                    }
                   />
                 )
               }

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -9,6 +9,9 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 
 export const TOP_EVENTS_LIMIT = 5;
 
+// TODO: There's a limitation with this hook when a top n query < 5 series.
+// This hook always returns 5, which can be misleading, but there's no simple way
+// to get the series count without adding more complexity to this hook.
 export function useTopEvents(): number | undefined {
   const visualizes = useExploreVisualizes();
   const groupBys = useExploreGroupBys();


### PR DESCRIPTION
Updates the confidence footer in explore to display the actual number of series returned in a groupby. Previously we always displayed 5 even when we have < 5 series returned.