### PR TITLE
feat(taskworker) Add metrics around minion queue sizes

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -117,6 +117,7 @@ def child_worker(
         try:
             activation = child_tasks.get(timeout=0.1)
         except queue.Empty:
+            metrics.incr("taskworker.worker.child_task_queue_empty")
             continue
 
         task_func = _get_known_task(activation)
@@ -341,6 +342,7 @@ class TaskWorker:
             if not self._child_tasks.full():
                 fetch_next = FetchNextTask(namespace=self._namespace)
 
+            metrics.incr("taskworker.worker.fetch_next", tags={"next": fetch_next is not None})
             try:
                 next_task = self.client.update_task(
                     task_id=result.task_id,


### PR DESCRIPTION
We'd like to better understand if worker minions are encountering empty queues and burning CPU. I would also like to understand how often we're able to use the set + fetch flow.