### PR TITLE
feat(ui): Add missing `textValue` prop to `<TabList>` on Insights

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -86,6 +86,7 @@ export function DomainViewHeader({
       .map(moduleName => ({
         key: moduleName,
         children: <TabLabel moduleName={moduleName} />,
+        textValue: moduleName,
         to: {
           pathname: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
           query: globalQuery,


### PR DESCRIPTION
I was doing some work on Insights and noticed these warnings spamming my console.

`<TabList>` wants a string value (for accessibility reasons) if the rendered child is not a string.

![image](https://github.com/user-attachments/assets/919d46d1-6a01-4ca8-bb25-b2816ce368a8)
