### PR TITLE
perf(migrations): Improve performance of migration tests a little

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -27,7 +27,7 @@ from django.contrib.auth import login
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.core.cache import cache
-from django.db import connection, connections
+from django.db import connections
 from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpRequest
 from django.test import RequestFactory
@@ -106,6 +106,7 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 from sentry.models.rule import RuleSource
 from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorType, ScheduleType
+from sentry.new_migrations.monkey.state import SentryProjectState
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.notifications.notifications.base import alert_page_needs_org_id
@@ -2680,9 +2681,8 @@ class TestMigrations(TransactionTestCase):
     Note that when running these tests locally you will need to use the `--migrations` flag
     """
 
-    @property
-    def app(self):
-        return "sentry"
+    app = "sentry"
+    connection = "default"
 
     @property
     def migrate_from(self):
@@ -2692,9 +2692,15 @@ class TestMigrations(TransactionTestCase):
     def migrate_to(self):
         raise NotImplementedError(f"implement for {type(self).__module__}.{type(self).__name__}")
 
-    @property
-    def connection(self):
-        return "default"
+    _project_state_cache: SentryProjectState | None = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        conn = connections[cls.connection]
+        executor = MigrationExecutor(conn)
+        matching_migrations = [m for m in executor.loader.applied_migrations if m[0] == cls.app]
+        cls.current_migration = [max(matching_migrations)]
 
     def setUp(self):
         super().setUp()
@@ -2702,32 +2708,38 @@ class TestMigrations(TransactionTestCase):
         migrate_from = [(self.app, self.migrate_from)]
         migrate_to = [(self.app, self.migrate_to)]
 
-        connection = connections[self.connection]
+        conn = connections[self.connection]
 
         self.setup_initial_state()
 
-        executor = MigrationExecutor(connection)
-        matching_migrations = [m for m in executor.loader.applied_migrations if m[0] == self.app]
-        self.current_migration = [max(matching_migrations)]
+        executor = MigrationExecutor(conn)
         old_apps = executor.loader.project_state(migrate_from).apps
 
         # Reverse to the original migration
-        executor.migrate(migrate_from)
+        # XXX: We don't pass project state here, since Django doesn't use it when rolling back migrations.
+        self._project_state_cache = executor.migrate(migrate_from)
 
         self.setup_before_migration(old_apps)
 
         # Run the migration to test
-        executor = MigrationExecutor(connection)
+        executor = MigrationExecutor(conn)
         executor.loader.build_graph()  # reload.
-        executor.migrate(migrate_to)
+        self._project_state_cache = executor.migrate(migrate_to, state=self._project_state_cache)
 
         self.apps = executor.loader.project_state(migrate_to).apps
 
     def tearDown(self):
-        super().tearDown()
-        executor = MigrationExecutor(connection)
+        super().tearDownClass()
+        executor = MigrationExecutor(connections[self.connection])
         executor.loader.build_graph()  # reload.
-        executor.migrate(self.current_migration)
+        self._project_state_cache = executor.migrate(
+            self.current_migration, state=self._project_state_cache
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls._project_state_cache = None
 
     def setup_initial_state(self):
         # Add code here that will run before we roll back the database to the `migrate_from`


### PR DESCRIPTION
It takes ~5s to create `ProjectState`, which is used 3 times when rolling migrations backwards and forwards. Caching it should make running multiple migrations a little faster.

Unfortunately, rolling back doesn't use the passed `state` param, so we're always going to be doing extra work there.

We cache this at the test level rather than globally. This allows the state to be properly set after rollbacks, which can break things otherwise. This means that this only provides a performance boost when a test case has multiple tests, unfortunately.

Will fail in getsentry until https://github.com/getsentry/getsentry/pull/16691 merges