### PR TITLE
feat(traces): Add slideout for the traces onboarding guide

### DIFF
--- a/static/app/views/explore/spans/components/onboardingGuide.tsx
+++ b/static/app/views/explore/spans/components/onboardingGuide.tsx
@@ -1,14 +1,17 @@
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export const TRACES_ONBOARDING_VIEWED_KEY = 'traces-onboarding-guide-viewed';
 
 function TracesOnboardingGuide() {
-  return (
+  const organization = useOrganization();
+
+  return organization.features.includes('traces-onboarding-guide') ? (
     <div>
       <DrawerHeader />
       <DrawerBody />
     </div>
-  );
+  ) : null;
 }
 
 export default TracesOnboardingGuide;

--- a/static/app/views/explore/spans/components/onboardingGuide.tsx
+++ b/static/app/views/explore/spans/components/onboardingGuide.tsx
@@ -1,0 +1,14 @@
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+
+export const TRACES_ONBOARDING_VIEWED_KEY = 'traces-onboarding-guide-viewed';
+
+function TracesOnboardingGuide() {
+  return (
+    <div>
+      <DrawerHeader />
+      <DrawerBody />
+    </div>
+  );
+}
+
+export default TracesOnboardingGuide;

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -135,7 +135,14 @@ describe('SpansTabContent', function () {
           '7d': 'Last 7 days',
         }}
       />,
-      {disableRouterMocks: true, router, organization}
+      {
+        disableRouterMocks: true,
+        router,
+        organization: {
+          ...organization,
+          features: [...organization.features, 'traces-onboarding-guide'],
+        },
+      }
     );
 
     expect(screen.getByLabelText('Traces Onboarding Guide')).toBeInTheDocument();

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -146,7 +146,10 @@ export function SpansTabContentImpl({
   const hasViewedOnboardingGuide = localStorage.getItem(TRACES_ONBOARDING_VIEWED_KEY);
 
   useEffect(() => {
-    if (!hasViewedOnboardingGuide || hasViewedOnboardingGuide === 'false') {
+    if (
+      organization.features.includes('traces-onboarding-guide') &&
+      (!hasViewedOnboardingGuide || hasViewedOnboardingGuide === 'false')
+    ) {
       openOnboardingGuide(() => <TracesOnboardingGuide />, {
         ariaLabel: t('Traces Onboarding Guide'),
         onClose: () => {
@@ -154,7 +157,12 @@ export function SpansTabContentImpl({
         },
       });
     }
-  }, [hasViewedOnboardingGuide, isOnboardingGuideOpen, openOnboardingGuide]);
+  }, [
+    hasViewedOnboardingGuide,
+    isOnboardingGuideOpen,
+    openOnboardingGuide,
+    organization.features,
+  ]);
 
   useAnalytics({
     queryType,

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -1,9 +1,10 @@
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Button} from 'sentry/components/button';
 import {getDiffInMinutes} from 'sentry/components/charts/utils';
+import useDrawer from 'sentry/components/globalDrawer';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -47,6 +48,9 @@ import {useExploreSpansTable} from 'sentry/views/explore/hooks/useExploreSpansTa
 import {useExploreTimeseries} from 'sentry/views/explore/hooks/useExploreTimeseries';
 import {useExploreTracesTable} from 'sentry/views/explore/hooks/useExploreTracesTable';
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
+import TracesOnboardingGuide, {
+  TRACES_ONBOARDING_VIEWED_KEY,
+} from 'sentry/views/explore/spans/components/onboardingGuide';
 import {ExploreTables} from 'sentry/views/explore/tables';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
 import {
@@ -136,6 +140,21 @@ export function SpansTabContentImpl({
   );
 
   const [expanded, setExpanded] = useState(true);
+
+  const {openDrawer: openOnboardingGuide, isDrawerOpen: isOnboardingGuideOpen} =
+    useDrawer();
+  const hasViewedOnboardingGuide = localStorage.getItem(TRACES_ONBOARDING_VIEWED_KEY);
+
+  useEffect(() => {
+    if (!hasViewedOnboardingGuide || hasViewedOnboardingGuide === 'false') {
+      openOnboardingGuide(() => <TracesOnboardingGuide />, {
+        ariaLabel: t('Traces Onboarding Guide'),
+        onClose: () => {
+          localStorage.setItem(TRACES_ONBOARDING_VIEWED_KEY, 'true');
+        },
+      });
+    }
+  }, [hasViewedOnboardingGuide, isOnboardingGuideOpen, openOnboardingGuide]);
 
   useAnalytics({
     queryType,


### PR DESCRIPTION
Just getting the base set up for the traces onboarding guide. I used the global drawer hooks to keep consistency across the app. I needed something to open it so I've made it look for a localStorage value (traces-onboarding-guide-viewed). It looks... plain... but here it is:

![image](https://github.com/user-attachments/assets/c7ebd9b7-87e5-46a4-a30d-dd16a1591731)

Closes https://github.com/getsentry/sentry/issues/86028