### PR TITLE
feat(billing): Launch PAYG modal from url

### DIFF
--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -30,6 +30,7 @@ import {hasAccessToSubscriptionOverview, isAm3DsPlan} from 'getsentry/utils/bill
 import {sortCategories} from 'getsentry/utils/dataCategory';
 import withPromotions from 'getsentry/utils/withPromotions';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
+import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 
 import openPerformanceQuotaCreditsPromoModal from './promotions/performanceQuotaCreditsPromo';
 import openPerformanceReservedTransactionsDiscountModal from './promotions/performanceReservedTransactionsPromo';
@@ -131,6 +132,22 @@ function Overview({api, location, subscription, organization, promotionData}: Pr
       hasAccessToSubscriptionOverview(subscription, organization)
     ) {
       openCodecovModal({organization});
+    }
+
+    // Open on-demand budget modal if hash fragment present and user has access
+    if (
+      window.location.hash === '#open-ondemand-modal' &&
+      subscription.supportsOnDemand &&
+      hasAccessToSubscriptionOverview(subscription, organization)
+    ) {
+      openOnDemandBudgetEditModal({organization, subscription});
+
+      // Clear hash to prevent modal reopening on refresh
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      );
     }
   }, [organization, location.query, subscription, promotionData, api]);
 


### PR DESCRIPTION
### Description

Links to the subscription page may need to open the on-demand/pay-as-you-go modal. Urls with the `#open-ondemand-modal` hash will navigate to the page and open the modal automatically.

For example, an over quota email notification can now link directly to the form:

<img width="748" alt="Screenshot 2025-02-26 at 1 12 36 PM" src="https://github.com/user-attachments/assets/024d8ede-a24b-4298-8372-b83a1ccd2cf4" />

