### PR TITLE
feat(uptime): Extract useUptimeRule

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -17,12 +17,7 @@ import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import {
-  type ApiQueryKey,
-  setApiQueryData,
-  useApiQuery,
-  useQueryClient,
-} from 'sentry/utils/queryClient';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -32,6 +27,10 @@ import {
   type CheckStatusBucket,
   type UptimeRule,
 } from 'sentry/views/alerts/rules/uptime/types';
+import {
+  setUptimeRuleData,
+  useUptimeRule,
+} from 'sentry/views/insights/uptime/utils/useUptimeRule';
 
 import {UptimeDetailsSidebar} from './detailsSidebar';
 import {DetailsTimeline} from './detailsTimeline';
@@ -52,14 +51,11 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
   const {projects, fetching: loadingProject} = useProjects({slugs: [projectId]});
   const project = projects.find(({slug}) => slug === projectId);
 
-  const queryKey: ApiQueryKey = [
-    `/projects/${organization.slug}/${projectId}/uptime/${uptimeRuleId}/`,
-  ];
   const {
     data: uptimeRule,
     isPending,
     isError,
-  } = useApiQuery<UptimeRule>(queryKey, {staleTime: 0});
+  } = useUptimeRule({projectSlug: projectId, uptimeRuleId});
 
   // Only display the missed window legend when there are visible missed window
   // check-ins in the timeline
@@ -100,7 +96,12 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
     const resp = await updateUptimeRule(api, organization.slug, uptimeRule, data);
 
     if (resp !== null) {
-      setApiQueryData(queryClient, queryKey, resp);
+      setUptimeRuleData({
+        queryClient,
+        organizationSlug: organization.slug,
+        projectSlug: projectId,
+        uptimeRule: resp,
+      });
     }
   };
 

--- a/static/app/views/insights/uptime/utils/useUptimeRule.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeRule.tsx
@@ -1,0 +1,41 @@
+import {
+  type ApiQueryKey,
+  type QueryClient,
+  setApiQueryData,
+  useApiQuery,
+} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
+
+interface UseUptimeRuleOptions {
+  projectSlug: string;
+  uptimeRuleId: string;
+}
+
+export function useUptimeRule({projectSlug, uptimeRuleId}: UseUptimeRuleOptions) {
+  const organization = useOrganization();
+
+  const queryKey: ApiQueryKey = [
+    `/projects/${organization.slug}/${projectSlug}/uptime/${uptimeRuleId}/`,
+  ];
+  return useApiQuery<UptimeRule>(queryKey, {staleTime: 0});
+}
+
+interface SetUptimeRuleDataOptions {
+  organizationSlug: string;
+  projectSlug: string;
+  queryClient: QueryClient;
+  uptimeRule: UptimeRule;
+}
+
+export function setUptimeRuleData({
+  queryClient,
+  organizationSlug,
+  projectSlug,
+  uptimeRule,
+}: SetUptimeRuleDataOptions) {
+  const queryKey: ApiQueryKey = [
+    `/projects/${organizationSlug}/${projectSlug}/uptime/${uptimeRule.id}/`,
+  ];
+  setApiQueryData(queryClient, queryKey, uptimeRule);
+}


### PR DESCRIPTION
We'll use this hook in issue details as well to pass the uptime rule
through to the uptime grid so we can indicate why traces have no spans
(if you have sampling off that's why)