### PR TITLE
fix(metric-alerts): Fix sessions chart query

### DIFF
--- a/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
@@ -37,7 +37,7 @@ export function useMetricSessionStats(
     `/organizations/${organization.slug}/sessions/`,
     {
       query: {
-        project,
+        project: project.id ? [Number(project.id)] : [],
         environment,
         field: SESSION_AGGREGATE_TO_FIELD[aggregate],
         query,


### PR DESCRIPTION
Was incorrectly passing the whole project instead of just the ID. Adds a test to correct it as well.