### PR TITLE
feat(issue-stream): Add unread indicator dot

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -65,6 +65,7 @@ function EventOrGroupHeader({
             hasSeen={hasSeen === undefined ? true : hasSeen}
             withStackTracePreview
             query={query}
+            hasNewLayout={hasNewLayout}
           />
         </ErrorBoundary>
       </Fragment>
@@ -206,7 +207,9 @@ const TitleWithoutLink = styled('span')`
 export default withOrganization(EventOrGroupHeader);
 
 const StyledEventOrGroupTitle = styled(EventOrGroupTitle)<{
+  hasNewLayout: boolean;
   hasSeen: boolean;
 }>`
-  font-weight: ${p => (p.hasSeen ? 400 : 600)};
+  font-weight: ${p =>
+    p.hasSeen && !p.hasNewLayout ? p.theme.fontWeightNormal : p.theme.fontWeightBold};
 `;

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -226,4 +226,16 @@ describe('StreamGroup', function () {
       });
     });
   });
+
+  it('displays unread indicator when issue is unread', async function () {
+    GroupStore.loadInitialData([GroupFixture({id: '1337', hasSeen: false})]);
+
+    render(<StreamGroup id="1337" query="is:unresolved" />, {
+      organization: OrganizationFixture({
+        features: ['issue-stream-table-layout'],
+      }),
+    });
+
+    expect(await screen.findByTestId('unread-issue-indicator')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -116,6 +116,9 @@ function GroupCheckbox({
 
   return (
     <GroupCheckBoxWrapper hasNewLayout={hasNewLayout}>
+      {group.hasSeen || !hasNewLayout ? null : (
+        <UnreadIndicator data-test-id="unread-issue-indicator" />
+      )}
       <CheckboxLabel hasNewLayout={hasNewLayout}>
         <Checkbox
           id={group.id}
@@ -739,6 +742,19 @@ const Wrapper = styled(PanelItem)<{
       padding: ${space(1)} 0;
       min-height: 66px;
 
+      &:not(:hover):not(:focus-within):not(:has(input:checked)) {
+        ${CheckboxLabel} {
+          ${p.theme.visuallyHidden};
+        }
+      }
+
+      &:hover,
+      &:focus-within {
+        ${UnreadIndicator} {
+          ${p.theme.visuallyHidden};
+        }
+      }
+
       [data-issue-title-link] {
         &::before {
           content: '';
@@ -1047,4 +1063,13 @@ const ProgressColumn = styled('div')`
 // Needs to be positioned so that hovering events don't get swallowed by the anchor pseudo-element
 const PositionedTimeSince = styled(TimeSince)`
   position: relative;
+`;
+
+const UnreadIndicator = styled('div')`
+  width: 8px;
+  height: 8px;
+  background-color: ${p => p.theme.purple400};
+  border-radius: 50%;
+  margin-left: ${space(3)};
+  margin-top: ${space(1.5)};
 `;


### PR DESCRIPTION
Previously we were bolding unread issue titles. Now we will show an unread indicator dot instead. This also hides the checkbox until the issue is hovered or focused.

https://github.com/user-attachments/assets/93458002-0cf5-4336-a418-74744dba2bee

