### PR TITLE
chore(uptime): Remove dual writing `UptimeSubscription` migration code.

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -243,33 +243,16 @@ def update_project_uptime_subscription(
     """
     Links a project to an uptime subscription so that it can process results.
     """
-    cur_uptime_subscription = uptime_monitor.uptime_subscription
-    if cur_uptime_subscription.migrated:
-        update_uptime_subscription(
-            cur_uptime_subscription,
-            url=url,
-            interval_seconds=interval_seconds,
-            timeout_ms=timeout_ms,
-            method=method,
-            headers=headers,
-            body=body,
-            trace_sampling=trace_sampling,
-        )
-        new_uptime_subscription = cur_uptime_subscription
-    else:
-        new_uptime_subscription = create_uptime_subscription(
-            url=default_if_not_set(cur_uptime_subscription.url, url),
-            interval_seconds=default_if_not_set(
-                cur_uptime_subscription.interval_seconds, interval_seconds
-            ),
-            timeout_ms=default_if_not_set(cur_uptime_subscription.timeout_ms, timeout_ms),
-            method=default_if_not_set(cur_uptime_subscription.method, method),
-            headers=default_if_not_set(cur_uptime_subscription.headers, headers),
-            body=default_if_not_set(cur_uptime_subscription.body, body),
-            trace_sampling=default_if_not_set(
-                cur_uptime_subscription.trace_sampling, trace_sampling
-            ),
-        )
+    update_uptime_subscription(
+        uptime_monitor.uptime_subscription,
+        url=url,
+        interval_seconds=interval_seconds,
+        timeout_ms=timeout_ms,
+        method=method,
+        headers=headers,
+        body=body,
+        trace_sampling=trace_sampling,
+    )
 
     owner_user_id = uptime_monitor.owner_user_id
     owner_team_id = uptime_monitor.owner_team_id
@@ -283,17 +266,11 @@ def update_project_uptime_subscription(
 
     uptime_monitor.update(
         environment=default_if_not_set(uptime_monitor.environment, environment),
-        # Temporarily keep assigning the subscription here, although we can remove this once we've moved away from the
-        # delete/recreate method
-        uptime_subscription=new_uptime_subscription,
         name=default_if_not_set(uptime_monitor.name, name),
         mode=mode,
         owner_user_id=owner_user_id,
         owner_team_id=owner_team_id,
     )
-    # TODO: Remove. If we haven't migrated the subscription yet then we recreated it, and might have orphaned it. Remove
-    # any orphaned subs now
-    remove_uptime_subscription_if_unused(cur_uptime_subscription)
 
     # Update status. This may have the side effect of removing or creating a
     # remote subscription. Will raise a UptimeMonitorNoSeatAvailable if seat

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -772,13 +772,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
         self.project_subscription.refresh_from_db()
         assert self.project_subscription.mode == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
-        with pytest.raises(UptimeSubscription.DoesNotExist):
-            uptime_subscription.refresh_from_db()
-        new_uptime_subscription = self.project_subscription.uptime_subscription
-        assert new_uptime_subscription.interval_seconds == int(
+        uptime_subscription.refresh_from_db()
+        assert uptime_subscription.interval_seconds == int(
             AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL.total_seconds()
         )
-        assert uptime_subscription.url == new_uptime_subscription.url
+        assert uptime_subscription.url == uptime_subscription.url
 
     def test_parallel(self) -> None:
         """


### PR DESCRIPTION
We've migrated all subscriptions to be non-unique, so we can remove this dual writing code now.