### PR TITLE
feat(project-create): Add origin to analytics event

### DIFF
--- a/src/sentry/analytics/events/project_created.py
+++ b/src/sentry/analytics/events/project_created.py
@@ -8,6 +8,7 @@ class ProjectCreatedEvent(analytics.Event):
         analytics.Attribute("user_id", required=False),
         analytics.Attribute("default_user_id"),
         analytics.Attribute("organization_id"),
+        analytics.Attribute("origin", required=False),
         analytics.Attribute("project_id"),
         analytics.Attribute("platform", required=False),
         analytics.Attribute("updated_empty_state", required=False),

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -184,14 +184,14 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
             "organization": team.organization,
             "target_object": project.id,
         }
-
-        if request.data.get("origin"):
+        origin = request.data.get("origin")
+        if origin:
             self.create_audit_entry(
                 **common_audit_data,
                 event=audit_log.get_event_id("PROJECT_ADD_WITH_ORIGIN"),
                 data={
                     **project.get_audit_log_data(),
-                    "origin": request.data.get("origin"),
+                    "origin": origin,
                 },
             )
         else:
@@ -205,6 +205,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
             project=project,
             user=request.user,
             default_rules=result.get("default_rules", True),
+            origin=origin,
             sender=self,
         )
         self.create_audit_entry(

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -230,13 +230,14 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                 "target_object": project.id,
             }
 
-            if request.data.get("origin"):
+            origin = request.data.get("origin")
+            if origin:
                 self.create_audit_entry(
                     **common_audit_data,
                     event=audit_log.get_event_id("PROJECT_ADD_WITH_ORIGIN"),
                     data={
                         **project.get_audit_log_data(),
-                        "origin": request.data.get("origin"),
+                        "origin": origin,
                     },
                 )
             else:
@@ -250,6 +251,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                 project=project,
                 user=request.user,
                 default_rules=result.get("default_rules", True),
+                origin=origin,
                 sender=self,
             )
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -58,7 +58,7 @@ START_DATE_TRACKING_FIRST_SOURCEMAP_PER_PROJ = datetime(2023, 11, 16, tzinfo=tim
 
 
 @project_created.connect(weak=False)
-def record_new_project(project, user=None, user_id=None, **kwargs):
+def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
 
     scope = sentry_sdk.get_current_scope()
     scope.set_extra("project_id", project.id)
@@ -90,6 +90,7 @@ def record_new_project(project, user=None, user_id=None, **kwargs):
         user_id=user_id,
         default_user_id=default_user_id,
         organization_id=project.organization_id,
+        origin=origin,
         project_id=project.id,
         platform=project.platform,
         updated_empty_state=features.has(

--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -1,5 +1,6 @@
 import re
-from unittest.mock import patch
+from unittest import mock
+from unittest.mock import Mock, patch
 
 from django.utils.text import slugify
 
@@ -14,6 +15,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
+from sentry.signals import project_created
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
@@ -282,3 +284,36 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
             name="foo",
             status_code=201,
         )
+
+    @with_feature(["organizations:team-roles"])
+    @patch(
+        "sentry.api.endpoints.organization_projects_experiment.OrganizationProjectsExperimentEndpoint.create_audit_entry"
+    )
+    def test_create_project_with_origin(self, create_audit_entry):
+        signal_handler = Mock()
+        project_created.connect(signal_handler)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            name="foo",
+            origin="ui",
+            status_code=201,
+        )
+
+        project = Project.objects.get(id=response.data["id"])
+        # Verify audit log was created
+        create_audit_entry.assert_any_call(
+            request=mock.ANY,
+            organization=self.organization,
+            target_object=project.id,
+            event=1154,
+            data={
+                **project.get_audit_log_data(),
+                "origin": "ui",
+            },
+        )
+
+        # Verify origin is passed to project_created signal
+        assert signal_handler.call_count == 1
+        assert signal_handler.call_args[1]["origin"] == "ui"
+        project_created.disconnect(signal_handler)


### PR DESCRIPTION
Pass origin of new project to the `project.created` analytics event

- part of https://github.com/getsentry/sentry/issues/85341