### PR TITLE
chore(issue-details): Update breadcrumb "view all button" 

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -148,6 +148,7 @@ export default function BreadcrumbsDataSection({
   );
 
   const hasViewAll = summaryCrumbs.length !== enhancedCrumbs.length;
+  const numHiddenCrumbs = enhancedCrumbs.length - summaryCrumbs.length;
 
   return (
     <InterimSection
@@ -184,7 +185,7 @@ export default function BreadcrumbsDataSection({
                 aria-label={t('View All Breadcrumbs')}
                 ref={viewAllButtonRef}
               >
-                {t('View All')}
+                {t('View %s more', numHiddenCrumbs)}
               </ViewAllButton>
             </div>
           </ViewAllContainer>

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -68,7 +68,12 @@ export function getSummaryBreadcrumbs(
   sort: BreadcrumbSort
 ) {
   const sortedCrumbs = sort === BreadcrumbSort.OLDEST ? crumbs : crumbs.toReversed();
-  return sortedCrumbs.slice(0, BREADCRUMB_SUMMARY_COUNT);
+  return sortedCrumbs.slice(
+    0,
+    crumbs.length <= BREADCRUMB_SUMMARY_COUNT + 1
+      ? BREADCRUMB_SUMMARY_COUNT + 1
+      : BREADCRUMB_SUMMARY_COUNT
+  );
 }
 
 export function getBreadcrumbTypeOptions(crumbs: EnhancedCrumb[]) {


### PR DESCRIPTION
updates button text to be aligned with activity expand button which mentions the # hidden. adds some logic so that if there are 6 or fewer breadcrumbs, we show them all, if more, we only show 5 and have the view more button 