### PR TITLE
chore(issue-details): Remove `query` from header badges

### DIFF
--- a/static/app/views/issueDetails/streamline/header/replayBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/replayBadge.tsx
@@ -8,14 +8,12 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
-import {useLocation} from 'sentry/utils/useLocation';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
 export function ReplayBadge({group, project}: {group: Group; project: Project}) {
   const {baseUrl} = useGroupDetailsRoute();
-  const location = useLocation();
   const issueTypeConfig = getConfigForIssueType(group, project);
   const {getReplayCountForIssue} = useReplayCountForIssues({
     statsPeriod: '90d',
@@ -36,7 +34,6 @@ export function ReplayBadge({group, project}: {group: Group; project: Project}) 
         icon={<IconPlay size="xs" />}
         to={{
           pathname: `${baseUrl}${TabPaths[Tab.REPLAYS]}`,
-          query: location.query,
         }}
         replace
         aria-label={t("View this issue's replays")}

--- a/static/app/views/issueDetails/streamline/header/userFeedbackBadge.tsx
+++ b/static/app/views/issueDetails/streamline/header/userFeedbackBadge.tsx
@@ -7,14 +7,12 @@ import {t, tn} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import {useLocation} from 'sentry/utils/useLocation';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
 export function UserFeedbackBadge({group, project}: {group: Group; project: Project}) {
   const {baseUrl} = useGroupDetailsRoute();
-  const location = useLocation();
 
   const issueTypeConfig = getConfigForIssueType(group, project);
 
@@ -32,7 +30,6 @@ export function UserFeedbackBadge({group, project}: {group: Group; project: Proj
         icon={<IconMegaphone size="xs" />}
         to={{
           pathname: `${baseUrl}${TabPaths[Tab.USER_FEEDBACK]}`,
-          query: location.query,
         }}
         replace
         aria-label={t("View this issues's feedback")}


### PR DESCRIPTION
this pr removes the `query` from the replay + feedback links in the header, because those can't be filtered, so having the query doesn't matter