### PR TITLE
fix(aci): force negative value event frequency conditions to 0 in migration

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -81,13 +81,14 @@ class PercentSessionsCountHandler(EventFrequencyCountHandler):
     }
 
 
+# This percent value can be > 100 (%)
 @condition_handler_registry.register(Condition.PERCENT_SESSIONS_PERCENT)
 class PercentSessionsPercentHandler(EventFrequencyPercentHandler):
     comparison_json_schema = {
         "type": "object",
         "properties": {
             "interval": {"type": "string", "enum": list(PERCENT_INTERVALS.keys())},
-            "value": {"type": "number", "minimum": 0, "maximum": 100},
+            "value": {"type": "number", "minimum": 0},
             "comparison_interval": {"type": "string", "enum": list(COMPARISON_INTERVALS.keys())},
             "filters": {
                 "type": "array",

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -266,9 +266,11 @@ def create_base_event_frequency_data_condition(
     comparison_type = data.get(
         "comparisonType", ComparisonType.COUNT
     )  # this is camelCase, age comparison is snake_case
+
+    value = max(int(data["value"]), 0)  # force to 0 if negative
     comparison = {
         "interval": data["interval"],
-        "value": int(data["value"]),
+        "value": value,
     }
 
     if comparison_type == ComparisonType.COUNT:

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -96,6 +96,11 @@ class TestEventFrequencyCountCondition(ConditionTestCase):
         self.payload["value"] = str(self.payload["value"])
         self._test_dual_write(int(self.payload["value"]))
 
+    def test_dual_write__value_floor(self):
+        # forces negative to zero for migration
+        self.payload["value"] = -1
+        self._test_dual_write(0)
+
     def test_json_schema(self):
         with pytest.raises(ValidationError):
             self.create_data_condition(
@@ -203,6 +208,11 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         self.payload["value"] = str(self.payload["value"])
         self._test_dual_write(int(self.payload["value"]))
 
+    def test_dual_write__value_floor(self):
+        # forces negative to zero for migration
+        self.payload["value"] = -1
+        self._test_dual_write(0)
+
     def test_json_schema(self):
         with pytest.raises(ValidationError):
             self.create_data_condition(
@@ -300,6 +310,12 @@ class TestPercentSessionsCountCondition(TestEventFrequencyCountCondition):
         self.intervals = PERCENT_INTERVALS
         self.other_intervals = STANDARD_INTERVALS
 
+    def test_dual_write_over_100(self):
+        self.payload["value"] = 500
+        dcg = self.create_data_condition_group()
+        with pytest.raises(ValidationError):
+            self.translate_to_data_condition(self.payload, dcg)
+
 
 class TestPercentSessionsPercentCondition(TestEventFrequencyPercentCondition):
     def setUp(self):
@@ -314,6 +330,13 @@ class TestPercentSessionsPercentCondition(TestEventFrequencyPercentCondition):
         }
         self.intervals = PERCENT_INTERVALS
         self.other_intervals = STANDARD_INTERVALS
+
+    def test_dual_write_over_100(self):
+        self.payload["value"] = 500
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.comparison["value"] == self.payload["value"]
 
 
 class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):


### PR DESCRIPTION
Negative values in event frequency conditions are technically valid today, as we just check if the event count from Snuba (or the percent increase) is greater than this value.
https://github.com/getsentry/sentry/blob/0cb6f3bb6277b72f72f7abe42bfd6e3462f551e9/src/sentry/rules/processing/delayed_processing.py#L384-L390

However, we should have people put at least 0 for this (it's at least 0 in the UI, you can't go lower), so implement a floor of 0 when migrating the value for event frequency conditions.
<img width="823" alt="Screenshot 2025-02-28 at 08 58 31" src="https://github.com/user-attachments/assets/f1692202-d753-4478-bd93-71b4dcdcdedd" />

Also, there should not be a limit as to how much a percent increase can be (can be > 100), this limit should only be for the following condition (PercentSessionsCountHandler).
<img width="813" alt="Screenshot 2025-02-28 at 08 57 48" src="https://github.com/user-attachments/assets/9fc73ec1-6a3c-4c3b-ac3e-38290ef16c8f" />

Not this one (PercentSessionsPercentHandler)
<img width="807" alt="Screenshot 2025-02-28 at 08 59 19" src="https://github.com/user-attachments/assets/f51ae472-955a-4e2f-850d-56f7c0379533" />