### PR TITLE
breadcrumbs: fix tag style

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
@@ -106,7 +106,9 @@ export function Breadcrumb({
         meta={meta}
         transactionEvents={transactionEvents}
       />
-      <Level level={level} searchTerm={searchTerm} />
+      <LevelWrapper>
+        <Level level={level} searchTerm={searchTerm} />
+      </LevelWrapper>
       <Time
         timestamp={timestamp}
         relativeTime={relativeTime}
@@ -122,7 +124,7 @@ const Wrapper = styled('div')<{
   isLastItem: boolean;
 }>`
   display: grid;
-  grid-template-columns: 64px 140px 1fr 106px 100px;
+  grid-template-columns: 64px 140px 1fr min-content 100px;
 
   > * {
     padding: ${space(1)} ${space(2)};
@@ -152,14 +154,6 @@ const Wrapper = styled('div')<{
         padding-right: ${space(2)};
       }
 
-      /* Level */
-      :nth-child(5n-1) {
-        padding-right: 0;
-        display: flex;
-        justify-content: flex-end;
-        align-items: flex-start;
-      }
-
       /* Time */
       :nth-child(5n) {
         padding: ${space(1)} ${space(2)};
@@ -169,4 +163,13 @@ const Wrapper = styled('div')<{
 
   word-break: break-all;
   white-space: pre-wrap;
+`;
+
+// Required or else the layout definiton causes the tag to stretch
+// over the entire width of the column.
+const LevelWrapper = styled('div')`
+  padding-right: 0;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/level.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/level.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {Tag} from 'sentry/components/core/badge/tag';
 import Highlight from 'sentry/components/highlight';
 import {t} from 'sentry/locale';
@@ -14,42 +12,35 @@ export function Level({level, searchTerm = ''}: Props) {
   switch (level) {
     case BreadcrumbLevelType.FATAL:
       return (
-        <LevelTag type="error">
+        <Tag type="error">
           <Highlight text={searchTerm}>{t('Fatal')}</Highlight>
-        </LevelTag>
+        </Tag>
       );
     case BreadcrumbLevelType.ERROR:
       return (
-        <LevelTag type="error">
+        <Tag type="error">
           <Highlight text={searchTerm}>{t('Error')}</Highlight>
-        </LevelTag>
+        </Tag>
       );
     case BreadcrumbLevelType.INFO:
       return (
-        <LevelTag type="info">
+        <Tag type="info">
           <Highlight text={searchTerm}>{t('Info')}</Highlight>
-        </LevelTag>
+        </Tag>
       );
     case BreadcrumbLevelType.WARNING:
       return (
-        <LevelTag type="warning">
+        <Tag type="warning">
           <Highlight text={searchTerm}>{t('Warning')}</Highlight>
-        </LevelTag>
+        </Tag>
       );
     default:
       return (
-        <LevelTag>
+        <Tag>
           <Highlight text={searchTerm}>{level || t('Undefined')}</Highlight>
-        </LevelTag>
+        </Tag>
       );
   }
 }
 
 export default Level;
-
-const LevelTag = styled(Tag)`
-  display: flex;
-  align-items: center;
-  /** Same height as menu item labels, to prevent vertical cropping */
-  height: calc(${p => p.theme.fontSizeMedium} * 1.4);
-`;


### PR DESCRIPTION
Fix the stretching of icon over the entire row.

![CleanShot 2025-02-28 at 12 06 05@2x](https://github.com/user-attachments/assets/e3d7d948-4c9a-48b5-82ec-6694214d49d7)
