### PR TITLE
fix(dashboards): Ignore limit for release widget queries

### DIFF
--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -360,6 +360,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
       cursor,
       dashboardFilters,
       onDataFetched,
+      limit,
     } = this.props;
     const config = ReleasesConfig;
 
@@ -372,7 +373,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
         widget={this.transformWidget(widget)}
         dashboardFilters={dashboardFilters}
         cursor={cursor}
-        limit={this.limit}
+        limit={limit}
         onDataFetched={onDataFetched}
         loading={
           requiresCustomReleaseSorting(widget.queries[0]!)

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -84,7 +84,7 @@ export function WidgetCardDataLoader({
         organization={organization}
         widget={widget}
         selection={selection}
-        limit={widget.limit ?? tableItemLimit}
+        limit={tableItemLimit}
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
       >


### PR DESCRIPTION
There was a bug that saved `limit` with widgets (fixed [here](https://github.com/getsentry/sentry/pull/85951)). It seems like release health widgets were passing along the limit explicitly for tables which caused it to truncate the data even when we override it depending on the widget builder vs dashboard context. The other widget queries components do not explicitly pass down the widget's limit so I've removed it to make it consistent.

This means we won't prematurely truncate the request for data for the release health widget. Additionally fixes #85796 