### PR TITLE
fix(aci): force age comparison filter values to >= 0

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.event_attribute import EventAttributeCondition
 from sentry.rules.conditions.event_frequency import (
     ComparisonType,
@@ -168,9 +169,20 @@ def create_tagged_event_data_condition(
 def create_age_comparison_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataCondition:
+    comparison_type = AgeComparisonType(data["comparison_type"])
+    value = int(data["value"])
+    if value < 0:
+        # make all values positive and switch the comparison type
+        value = -1 * value
+        comparison_type = (
+            AgeComparisonType.NEWER
+            if comparison_type == AgeComparisonType.OLDER
+            else AgeComparisonType.OLDER
+        )
+
     comparison = {
-        "comparison_type": data["comparison_type"],
-        "value": int(data["value"]),
+        "comparison_type": comparison_type,
+        "value": value,
         "time": data["time"],
     }
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -14,12 +14,6 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 @freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0))
 class TestAgeComparisonCondition(ConditionTestCase):
     condition = Condition.AGE_COMPARISON
-    payload = {
-        "id": AgeComparisonFilter.id,
-        "comparison_type": AgeComparisonType.OLDER,
-        "value": "10",
-        "time": "hour",
-    }
 
     def setup_group_event_and_job(self):
         self.group_event = self.event.for_group(self.group)
@@ -36,6 +30,12 @@ class TestAgeComparisonCondition(ConditionTestCase):
                 "event": self.group_event,
             }
         )
+        self.payload = {
+            "id": AgeComparisonFilter.id,
+            "comparison_type": AgeComparisonType.OLDER,
+            "value": "10",
+            "time": "hour",
+        }
         self.dc = self.create_data_condition(
             type=self.condition,
             comparison={"comparison_type": AgeComparisonType.OLDER, "value": 10, "time": "hour"},
@@ -49,6 +49,20 @@ class TestAgeComparisonCondition(ConditionTestCase):
         assert dc.type == self.condition
         assert dc.comparison == {
             "comparison_type": AgeComparisonType.OLDER,
+            "value": 10,
+            "time": "hour",
+        }
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
+    def test_dual_write__negative_value(self):
+        self.payload["value"] = "-10"
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison == {
+            "comparison_type": AgeComparisonType.NEWER,
             "value": 10,
             "time": "hour",
         }


### PR DESCRIPTION
<img width="301" alt="Screenshot 2025-02-28 at 09 30 27" src="https://github.com/user-attachments/assets/a717f942-11d2-4c15-8263-4268325966c7" />

Some people have configured negative values for their AgeComparisonFilters. We should have these be >= 0, and we can do this by flipping the comparison type. The comparison types use `operator.lt` and `operator.gt`:
```
>>> operator.lt(-12, 0)
True
>>> operator.gt(12, 0)
True
```