### PR TITLE
fix(toolbar): Update links to the Sentry Toolbar docs

### DIFF
--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -78,7 +78,7 @@ export default function ProjectToolbarSettings({
       <SettingsPageHeader
         title={t('Dev Toolbar')}
         action={
-          <LinkButton href="https://docs.sentry.io/product/dev-toolbar/" external>
+          <LinkButton href="https://docs.sentry.io/product/sentry-toolbar/" external>
             {t('Read the Docs')}
           </LinkButton>
         }


### PR DESCRIPTION
The path was renamed in https://github.com/getsentry/sentry-docs/pull/12845

Relates to https://github.com/getsentry/sentry-docs/issues/12876