### PR TITLE
fix(assignee): Fix unassigned assignee tag styling

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -106,6 +106,7 @@ export function AssigneeBadge({
           )}
         </TooltipWrapper>
       }
+      skipWrapper
     >
       <StyledTag icon={makeAssignedIcon(assignedTo)} />
     </Tooltip>
@@ -128,6 +129,7 @@ export function AssigneeBadge({
           </TooltipSubtext>
         </TooltipWrapper>
       }
+      skipWrapper
     >
       <UnassignedTag icon={unassignedIcon} />
     </Tooltip>
@@ -153,6 +155,10 @@ const StyledTag = styled(Tag)`
 
 const UnassignedTag = styled(Tag)`
   border-style: dashed;
+  gap: ${space(0.5)};
+  height: 24px;
+  padding: ${space(0.5)};
+  padding-right: ${space(0.25)};
 `;
 
 const TooltipSubtext = styled('div')`


### PR DESCRIPTION
Noticed that unassigned assignee tags looked a little squished compared to assigned: 

![image](https://github.com/user-attachments/assets/47561b8c-f89b-41d0-90d1-bc95763e2129)

Fixed that in this PR: 

![image](https://github.com/user-attachments/assets/dd4767e4-8087-451a-a195-855753afde02)


This was caused by a change in [this PR](https://github.com/getsentry/sentry/issues/86073) that refactored the core tag component and this component. 