### PR TITLE
feat(issues-stream): Mark cached issue stream group as seen when viewed

### DIFF
--- a/static/app/stores/IssueListCacheStore.tsx
+++ b/static/app/stores/IssueListCacheStore.tsx
@@ -39,6 +39,7 @@ const CACHE_EXPIRATION = 30 * 1000;
 interface IssueListCacheStoreDefinition
   extends StrictStoreDefinition<IssueListCacheState | null> {
   getFromCache(params: LooseParamsType): IssueListCache | null;
+  markGroupAsSeen(groupId: string): void;
   reset(): void;
   save(params: LooseParamsType, data: IssueListCache): void;
 }
@@ -74,6 +75,13 @@ const storeConfig: IssueListCacheStoreDefinition = {
 
   getState() {
     return this.state;
+  },
+
+  markGroupAsSeen(groupId: string) {
+    const matchingGroup = this.state?.cache.groups.find(group => group.id === groupId);
+    if (matchingGroup) {
+      matchingGroup.hasSeen = true;
+    }
   },
 };
 

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -10,6 +10,7 @@ import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import GroupStore from 'sentry/stores/groupStore';
+import IssueListCacheStore from 'sentry/stores/IssueListCacheStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
 import type {Group, GroupActivity, TagValue} from 'sentry/types/group';
@@ -38,6 +39,8 @@ export function markEventSeen(
     },
     {}
   );
+
+  IssueListCacheStore.markGroupAsSeen(groupId);
 }
 
 export function useDefaultIssueEvent() {


### PR DESCRIPTION
Prior to this, if you viewed and issue and went back to the issue stream it would not be marked as viewed.