### PR TITLE
fix(insights): Fix "AI" link in new navigation

### DIFF
--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -24,6 +24,8 @@ import {
 } from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 
+import {MODULE_BASE_URLS} from './common/utils/useModuleURL';
+
 type InsightsNavigationProps = {
   children: React.ReactNode;
 };
@@ -60,7 +62,9 @@ export default function InsightsNavigation({children}: InsightsNavigationProps) 
             <SecondaryNav.Item to={`${baseUrl}/${MOBILE_LANDING_SUB_PATH}/`}>
               {MOBILE_SIDEBAR_LABEL}
             </SecondaryNav.Item>
-            <SecondaryNav.Item to={`${baseUrl}/${AI_LANDING_SUB_PATH}/`}>
+            <SecondaryNav.Item
+              to={`${baseUrl}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS.ai}/`}
+            >
               {AI_SIDEBAR_LABEL}
             </SecondaryNav.Item>
           </SecondaryNav.Section>

--- a/static/app/views/insights/navigation.tsx
+++ b/static/app/views/insights/navigation.tsx
@@ -25,6 +25,7 @@ import {
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 
 import {MODULE_BASE_URLS} from './common/utils/useModuleURL';
+import {ModuleName} from './types';
 
 type InsightsNavigationProps = {
   children: React.ReactNode;
@@ -63,7 +64,7 @@ export default function InsightsNavigation({children}: InsightsNavigationProps) 
               {MOBILE_SIDEBAR_LABEL}
             </SecondaryNav.Item>
             <SecondaryNav.Item
-              to={`${baseUrl}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS.ai}/`}
+              to={`${baseUrl}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS[ModuleName.AI]}/`}
             >
               {AI_SIDEBAR_LABEL}
             </SecondaryNav.Item>


### PR DESCRIPTION
The "AI" view doesn't have a landing page. Instead, it should go directly to the only module, which is "LLM Monitoring".
