### PR TITLE
fix(monitors): Update call to disable quota seat

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -129,7 +129,9 @@ class MonitorDetailsMixin(BaseEndpointMixin):
                 raise ParameterValidationError("Failed to enable monitor, please try again")
 
         # Attempt to unassign the monitor seat
-        if params["status"] == ObjectStatus.DISABLED and monitor.status != ObjectStatus.DISABLED:
+        if params["status"] == ObjectStatus.DISABLED and (
+            monitor.status != ObjectStatus.DISABLED or result.get("is_muted")
+        ):
             quotas.backend.disable_monitor_seat(monitor)
 
         # Update monitor slug in billing


### PR DESCRIPTION
Currently a Monitor's status is disabled if it is muted or over quota. If a call is made to updated a Monitor to muted, we should call `quotas.backend.disable_monitor_seat(monitor)` even if the Monitor is already disabled due to being over-quota to ensure proper quota handling. 