### PR TITLE
chore(grouping): Add hash value to race condition logs

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -151,6 +151,7 @@ def create_or_update_grouphash_metadata_if_needed(
                     "grouphash_is_new": grouphash_is_new,
                     "event_id": event.event_id,
                     "hash_basis": new_data["hash_basis"],
+                    "hash": grouphash.hash,
                 },
             )
             return

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -410,6 +410,7 @@ def maybe_check_seer_for_matching_grouphash(
                     "grouphash_metadata.none_id",
                     extra={
                         "grouphash_id": event_grouphash.id,
+                        "hash": event_grouphash.hash,
                         "event_id": event.event_id,
                         "project_slug": event.project.slug,
                         "project_id": event.project.id,


### PR DESCRIPTION
This adds hash value to the logs we're using to track race conditions during grouphash and grouphash metadata creation, so that they can be more easily correlated with the Seer request and response logs.