### PR TITLE
feat(autofix): Pass data down on update endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -66,6 +66,4 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
 
         response.raise_for_status()
 
-        return Response(
-            status=202,
-        )
+        return Response(status=202, data=response.json())


### PR DESCRIPTION
Ideally when `status = 'error'` we'd return a 500 status but our `useMutation`'s `onError` doesn't have the response body in it...