### PR TITLE
feat(autofix): Surface error on pr creation

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -280,7 +280,12 @@ function CreateBranchButton({
         },
       });
     },
-    onSuccess: () => {
+    onSuccess: (data: AutofixUpdateEndpointResponse) => {
+      if (data.status === 'error') {
+        addErrorMessage(data.message ?? t('Failed to create a pull request'));
+        setHasClickedPushToBranch(false);
+        onBusyStateChange(false);
+      }
       addSuccessMessage(t('Pushed to branches.'));
       queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
       setHasClickedPushToBranch(false);

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -14,6 +14,7 @@ import {
   type AutofixChangesStep,
   type AutofixCodebaseChange,
   AutofixStatus,
+  type AutofixUpdateEndpointResponse,
 } from 'sentry/components/events/autofix/types';
 import {
   makeAutofixQueryKey,
@@ -203,11 +204,17 @@ function CreatePRsButton({
         },
       });
     },
-    onSuccess: () => {
-      addSuccessMessage(t('Created pull requests.'));
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
-      setHasClickedCreatePr(false);
-      onBusyStateChange(false);
+    onSuccess: (data: AutofixUpdateEndpointResponse) => {
+      if (data.status === 'error') {
+        addErrorMessage(data.message ?? t('Failed to create a pull request'));
+        setHasClickedCreatePr(false);
+        onBusyStateChange(false);
+      } else {
+        addSuccessMessage(t('Created pull requests.'));
+        queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+        setHasClickedCreatePr(false);
+        onBusyStateChange(false);
+      }
     },
     onError: () => {
       setHasClickedCreatePr(false);

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -47,6 +47,12 @@ export type AutofixOptions = {
   iterative_feedback?: boolean;
 };
 
+export type AutofixUpdateEndpointResponse = {
+  run_id: number;
+  message?: string;
+  status?: 'success' | 'error';
+};
+
 export type AutofixRepository = {
   default_branch: string;
   external_id: string;


### PR DESCRIPTION
Ideally when `status = 'error'` we'd return a 500 status and use the `onError` but it doesn't have the response body in it to get the passed down message...
