### PR TITLE
feat(view-sharing): Double write position to new table in PUT endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -218,10 +218,6 @@ def _delete_missing_views(org: Organization, user_id: int, view_ids_to_keep: lis
         id__in=view_ids_to_keep
     ).delete()
 
-    GroupSearchViewStarred.objects.filter(organization=org, user_id=user_id).exclude(
-        group_search_view__in=view_ids_to_keep
-    ).delete()
-
 
 def _update_existing_view(
     org: Organization, user_id: int, view: GroupSearchViewValidatorResponse, position: int

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -19,6 +19,7 @@ from sentry.api.serializers.rest_framework.groupsearchview import (
     GroupSearchViewValidatorResponse,
 )
 from sentry.models.groupsearchview import DEFAULT_TIME_FILTER, GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.savedsearch import SortOptions
@@ -217,6 +218,10 @@ def _delete_missing_views(org: Organization, user_id: int, view_ids_to_keep: lis
         id__in=view_ids_to_keep
     ).delete()
 
+    GroupSearchViewStarred.objects.filter(organization=org, user_id=user_id).exclude(
+        group_search_view__in=view_ids_to_keep
+    ).delete()
+
 
 def _update_existing_view(
     org: Organization, user_id: int, view: GroupSearchViewValidatorResponse, position: int
@@ -239,6 +244,12 @@ def _update_existing_view(
             gsv.time_filters = view["timeFilters"]
 
         gsv.save()
+        GroupSearchViewStarred.objects.update_or_create(
+            organization=org,
+            user_id=user_id,
+            group_search_view=gsv,
+            defaults={"position": position},
+        )
     except GroupSearchView.DoesNotExist:
         # It is possible – though unlikely under normal circumstances – for a view to come in that
         # doesn't exist anymore. If, for example, the user has the issue stream open in separate
@@ -263,3 +274,10 @@ def _create_view(
     )
     if "projects" in view:
         gsv.projects.set(view["projects"] or [])
+
+    GroupSearchViewStarred.objects.create(
+        organization=org,
+        user_id=user_id,
+        group_search_view=gsv,
+        position=position,
+    )


### PR DESCRIPTION
This PR updates the `PUT` `/group-search-views/` endpoint to double write the positions parameter to the new table created in [this PR](https://github.com/getsentry/sentry/pull/86065). This is necessary to ensure the tables stay in sync before backfilling. 