### PR TITLE
feat(nav): Reposition alerts in nav and rename issues -> search

### DIFF
--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -38,7 +38,7 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
         <SecondaryNav.Body>
           <SecondaryNav.Section>
             <SecondaryNav.Item to={`${baseUrl}/`} end>
-              {t('All')}
+              {t('Search')}
             </SecondaryNav.Item>
             <SecondaryNav.Item to={`${baseUrl}/feedback/`}>
               {t('Feedback')}
@@ -81,15 +81,10 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
               />
             </SecondaryNav.Section>
           )}
+          <SecondaryNav.Section title={t('Configure')}>
+            <SecondaryNav.Item to={`${baseUrl}/alerts/`}>{t('Alerts')}</SecondaryNav.Item>
+          </SecondaryNav.Section>
         </SecondaryNav.Body>
-        <SecondaryNav.Footer>
-          <SecondaryNav.Item
-            to={`${baseUrl}/alerts/rules/`}
-            activeTo={`${baseUrl}/alerts/`}
-          >
-            {t('Alerts')}
-          </SecondaryNav.Item>
-        </SecondaryNav.Footer>
       </SecondaryNav>
       {children}
     </Fragment>

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -82,7 +82,12 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
             </SecondaryNav.Section>
           )}
           <SecondaryNav.Section title={t('Configure')}>
-            <SecondaryNav.Item to={`${baseUrl}/alerts/`}>{t('Alerts')}</SecondaryNav.Item>
+            <SecondaryNav.Item
+              to={`${baseUrl}/alerts/rules/`}
+              activeTo={`${baseUrl}/alerts/`}
+            >
+              {t('Alerts')}
+            </SecondaryNav.Item>
           </SecondaryNav.Section>
         </SecondaryNav.Body>
       </SecondaryNav>


### PR DESCRIPTION
- Moves alert up into a "configure" section (which will include detectors in the future)
- Renames "All" to "Search"

![CleanShot 2025-02-28 at 14 40 40](https://github.com/user-attachments/assets/11d6b95b-c249-4ac0-823a-1638e067c5a3)
