### PR TITLE
fix(api): better error message return to the client

### DIFF
--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.exceptions import Throttled
 from rest_framework.views import exception_handler
 
@@ -6,8 +7,13 @@ from sentry.utils.snuba import RateLimitExceeded
 
 def custom_exception_handler(exc, context):
     if isinstance(exc, RateLimitExceeded):
-        # If Snuba throws a RateLimitExceeded then it'll likely be available
-        # after another second.
-        exc = Throttled(wait=1)
+        # capture the rate limited exception so we can see it in Sentry
+        sentry_sdk.capture_exception(
+            exc,
+            fingerprint=["snuba-api-rate-limit-exceeded"],
+            level="warning",
+        )
+        # let the client know that they've been rate limited with details
+        exc = Throttled(detail=str(exc))
 
     return exception_handler(exc, context)

--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -14,6 +14,8 @@ def custom_exception_handler(exc, context):
             level="warning",
         )
         # let the client know that they've been rate limited with details
-        exc = Throttled(detail=str(exc))
+        exc = Throttled(
+            detail="Rate limit exceeded. Please try your query with a smaller date range or fewer projects."
+        )
 
     return exception_handler(exc, context)

--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -8,11 +8,12 @@ from sentry.utils.snuba import RateLimitExceeded
 def custom_exception_handler(exc, context):
     if isinstance(exc, RateLimitExceeded):
         # capture the rate limited exception so we can see it in Sentry
-        sentry_sdk.capture_exception(
-            exc,
-            fingerprint=["snuba-api-rate-limit-exceeded"],
-            level="warning",
-        )
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = ["snuba-api-rate-limit-exceeded"]
+            sentry_sdk.capture_exception(
+                exc,
+                level="warning",
+            )
         # let the client know that they've been rate limited with details
         exc = Throttled(
             detail="Rate limit exceeded. Please try your query with a smaller date range or fewer projects."

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -12,7 +12,9 @@ class RateLimitedEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     def get(self, request):
-        raise RateLimitExceeded()
+        raise RateLimitExceeded(
+            "Rate limit exceeded. Please try your query with a smaller date range or fewer projects."
+        )
 
 
 urlpatterns = [re_path(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test")]
@@ -28,4 +30,7 @@ class TestRateLimited(APITestCase):
         resp = self.get_response()
         assert resp.status_code == 429
 
-        assert resp.data["detail"] == "Request was throttled. Expected available in 1 second."
+        assert (
+            resp.data["detail"]
+            == "Rate limit exceeded. Please try your query with a smaller date range or fewer projects."
+        )


### PR DESCRIPTION
there are many types of snuba rate limits now, and snuba returns them from their API. let's pass them on to the client so at least its more transparent as to what's going on. right now, no matter what, we tell the user to try again in 1 second, while some snuba rate limits operate on windows of 10 minutes, etc.

Also capture the exception so we can better debug this.