### PR TITLE
feat(view-sharing): Add new endpoint to delete single view

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -173,6 +173,7 @@ from sentry.issues.endpoints import (
     OrganizationDeriveCodeMappingsEndpoint,
     OrganizationGroupIndexEndpoint,
     OrganizationGroupIndexStatsEndpoint,
+    OrganizationGroupSearchViewDetailsEndpoint,
     OrganizationGroupSearchViewsEndpoint,
     OrganizationIssuesCountEndpoint,
     OrganizationReleasePreviousCommitsEndpoint,
@@ -1726,6 +1727,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/$",
         OrganizationGroupSearchViewsEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-views",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/$",
+        OrganizationGroupSearchViewDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-group-search-view-details",
     ),
     # Pinned and saved search
     re_path(

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -15,6 +15,7 @@ from .organization_derive_code_mappings import OrganizationDeriveCodeMappingsEnd
 from .organization_eventid import EventIdLookupEndpoint
 from .organization_group_index import OrganizationGroupIndexEndpoint
 from .organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
+from .organization_group_search_view_details import OrganizationGroupSearchViewDetailsEndpoint
 from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
 from .organization_issues_count import OrganizationIssuesCountEndpoint
 from .organization_release_previous_commits import OrganizationReleasePreviousCommitsEndpoint
@@ -50,6 +51,7 @@ __all__ = (
     "OrganizationGroupIndexEndpoint",
     "OrganizationGroupIndexStatsEndpoint",
     "OrganizationGroupSearchViewsEndpoint",
+    "OrganizationGroupSearchViewDetailsEndpoint",
     "OrganizationIssuesCountEndpoint",
     "OrganizationReleasePreviousCommitsEndpoint",
     "OrganizationSearchesEndpoint",

--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -1,0 +1,55 @@
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.models.organization import Organization
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "DELETE": ["member:read", "member:write"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def delete(self, request: Request, organization: Organization, view_id: str) -> Response:
+        """
+        Delete an issue view for the current organization member.
+        """
+        if not features.has(
+            "organizations:issue-stream-custom-views", organization, actor=request.user
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            view = GroupSearchView.objects.get(
+                id=view_id, organization=organization, user_id=request.user.id
+            )
+        except GroupSearchView.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        # Check if the view is starred by the current user
+        if GroupSearchViewStarred.objects.filter(
+            organization=organization, user_id=request.user.id, group_search_view=view
+        ).exists():
+            return Response(
+                {"detail": "Cannot delete a starred view."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        view.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
@@ -1,0 +1,89 @@
+import pytest
+from django.urls import reverse
+
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.testutils.helpers import with_feature
+from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
+
+
+class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
+    endpoint = "sentry-api-0-organization-group-search-view-details"
+    method = "delete"
+
+    def setUp(self) -> None:
+        self.login_as(user=self.user)
+        self.base_data = self.create_base_data()
+
+        # Get the first view's ID for testing
+        self.view_id = str(self.base_data["user_one_views"][0].id)
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_delete_view_success(self) -> None:
+
+        response = self.client.delete(self.url)
+        assert response.status_code == 204
+
+        # Verify the view was deleted
+        with pytest.raises(GroupSearchView.DoesNotExist):
+            GroupSearchView.objects.get(id=self.view_id)
+
+        # Verify other views still exist
+        remaining_views = GroupSearchView.objects.filter(
+            organization=self.organization, user_id=self.user.id
+        )
+        assert remaining_views.count() == 2
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_delete_nonexistent_view(self) -> None:
+        """Test that attempting to delete a nonexistent view returns 404."""
+        nonexistent_id = "99999"
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": nonexistent_id},
+        )
+
+        response = self.client.delete(url)
+        assert response.status_code == 404
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_delete_view_from_another_user(self) -> None:
+        # Get a view ID from user_two
+        view_id = str(self.base_data["user_two_views"][0].id)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+        )
+
+        response = self.client.delete(url)
+        assert response.status_code == 404
+
+        # Verify the view still exists
+        view = GroupSearchView.objects.get(id=view_id)
+        assert view is not None
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_delete_starred_view(self) -> None:
+        # Create a starred view
+        GroupSearchViewStarred.objects.create(
+            group_search_view=self.base_data["user_one_views"][0],
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            position=0,
+        )
+
+        response = self.client.delete(self.url)
+        assert response.status_code == 400
+
+    def test_delete_without_feature_flag(self) -> None:
+        response = self.client.delete(self.url)
+        assert response.status_code == 404
+
+        # Verify the view still exists
+        view = GroupSearchView.objects.get(id=self.view_id)
+        assert view is not None

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
@@ -62,9 +62,8 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         response = self.client.delete(url)
         assert response.status_code == 404
 
-        # Verify the view still exists
-        view = GroupSearchView.objects.get(id=view_id)
-        assert view is not None
+        # Verify the view still exists (this will error out if not)
+        GroupSearchView.objects.get(id=view_id)
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_starred_view(self) -> None:
@@ -83,6 +82,4 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         response = self.client.delete(self.url)
         assert response.status_code == 404
 
-        # Verify the view still exists
-        view = GroupSearchView.objects.get(id=self.view_id)
-        assert view is not None
+        GroupSearchView.objects.get(id=self.view_id)

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
@@ -30,8 +30,7 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         assert response.status_code == 204
 
         # Verify the view was deleted
-        with pytest.raises(GroupSearchView.DoesNotExist):
-            GroupSearchView.objects.get(id=self.view_id)
+        assert not GroupSearchView.objects.filter(id=self.view_id).exists()
 
         # Verify other views still exist
         remaining_views = GroupSearchView.objects.filter(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_details.py
@@ -1,4 +1,3 @@
-import pytest
 from django.urls import reverse
 
 from sentry.models.groupsearchview import GroupSearchView


### PR DESCRIPTION
As part of the shared view project, we will now need to be able to delete a single view. 

We can't use the old endpoint because that one doesn't contain a `viewId` url param, so we need a new endpoint specifically to access a single resource. 

