### PR TITLE
fix(issues): Remove redundant trace link

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -160,9 +160,6 @@ describe('EventTraceView', () => {
     );
     expect(await screen.findByText('Trace Preview')).toBeInTheDocument();
     expect(
-      await screen.findByRole('link', {name: 'View Full Trace'})
-    ).toBeInTheDocument();
-    expect(
       screen.getByText('One other issue appears in the same trace.')
     ).toBeInTheDocument();
   });

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -4,7 +4,6 @@ import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
-import Link from 'sentry/components/links/link';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -14,7 +13,6 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {TraceIssueEvent} from 'sentry/views/issueDetails/traceTimeline/traceIssue';
@@ -144,8 +142,6 @@ function getHrefFromTraceTarget(traceTarget: LocationDescriptor) {
 }
 
 function OneOtherIssueEvent({event}: {event: Event}) {
-  const location = useLocation();
-  const organization = useOrganization();
   const {isLoading, oneOtherIssueEvent} = useTraceTimelineEvents({event});
   useRouteAnalyticsParams(oneOtherIssueEvent ? {has_related_trace_issue: true} : {});
 
@@ -153,25 +149,9 @@ function OneOtherIssueEvent({event}: {event: Event}) {
     return null;
   }
 
-  const traceTarget = generateTraceTarget(
-    event,
-    organization,
-    {
-      ...location,
-      query: {
-        ...location.query,
-        groupId: event.groupID,
-      },
-    },
-    TraceViewSources.ISSUE_DETAILS
-  );
-
   return (
     <Fragment>
-      <span>
-        {t('One other issue appears in the same trace. ')}
-        <Link to={traceTarget}>{t('View Full Trace')}</Link>
-      </span>
+      <span>{t('One other issue appears in the same trace.')}</span>
       <TraceIssueEvent event={oneOtherIssueEvent} />
     </Fragment>
   );


### PR DESCRIPTION
We already have a link in the upper-right, this one feels pretty redundant.

Before:
<img width="1300" alt="Screenshot 2025-02-28 at 4 02 16 PM" src="https://github.com/user-attachments/assets/c2352f92-b3d3-4d4f-baf3-a482d11ccf12" />

After:
<img width="1306" alt="Screenshot 2025-02-28 at 4 01 50 PM" src="https://github.com/user-attachments/assets/9f54ccf3-561d-44b4-b08b-91a0fa1c5aa4" />

Non-streamline version is a separate component, no changes there:
<img width="1259" alt="Screenshot 2025-02-28 at 4 06 04 PM" src="https://github.com/user-attachments/assets/b17250ac-b192-4852-804f-c410c7c01c1d" />
