### PR TITLE
fix(nav): Show same nav items when user is in org or user settings.

### DIFF
--- a/static/app/views/settings/account/accountSettingsNavigation.tsx
+++ b/static/app/views/settings/account/accountSettingsNavigation.tsx
@@ -1,12 +1,18 @@
+import {prefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import type {Organization} from 'sentry/types/organization';
 import getConfiguration from 'sentry/views/settings/account/navigationConfiguration';
 import SettingsNavigation from 'sentry/views/settings/components/settingsNavigation';
+import OrganizationSettingsNavigation from 'sentry/views/settings/organization/organizationSettingsNavigation';
 
 type Props = {
   organization?: Organization;
 };
 
 function AccountSettingsNavigation({organization}: Props) {
+  if (organization && prefersStackedNav()) {
+    return <OrganizationSettingsNavigation organization={organization} />;
+  }
+
   return (
     <SettingsNavigation
       organization={organization}


### PR DESCRIPTION
Fixes the issue where Stats & Billing section would disappear when you were in account details. The other code route did not append the getsentry hooks.