### PR TITLE
fix(issue-summary) Show possible cause loading

### DIFF
--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -41,6 +41,15 @@ describe('GroupSummary', function () {
     },
   };
 
+  const mockSummaryDataWithNullScores = {
+    groupId: '1',
+    whatsWrong: 'Test whats wrong',
+    trace: 'Test trace',
+    possibleCause: 'Test possible cause',
+    headline: 'Test headline',
+    scores: null,
+  };
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
 
@@ -78,7 +87,28 @@ describe('GroupSummary', function () {
     expect(screen.getByText('Test possible cause')).toBeInTheDocument();
   });
 
-  it('renders the summary without possible cause', async function () {
+  it('renders the summary with all sections when scores are null', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/summarize/`,
+      method: 'POST',
+      body: mockSummaryDataWithNullScores,
+    });
+
+    render(<GroupSummary event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("What's wrong")).toBeInTheDocument();
+    });
+    expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
+    expect(screen.getByText('In the trace')).toBeInTheDocument();
+    expect(screen.getByText('Test trace')).toBeInTheDocument();
+    expect(screen.getByText('Possible cause')).toBeInTheDocument();
+    expect(screen.getByText('Test possible cause')).toBeInTheDocument();
+  });
+
+  it('renders the summary without possible cause when scores are low', async function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/summarize/`,
       method: 'POST',
@@ -110,8 +140,8 @@ describe('GroupSummary', function () {
       organization,
     });
 
-    // Should show loading placeholders. Currently we load the whatsWrong section
-    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(1);
+    // Should show loading placeholders. Currently we load the whatsWrong and possibleCause sections
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(2);
   });
 
   it('shows error state', async function () {

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -19,6 +19,7 @@ import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfi
 
 const POSSIBLE_CAUSE_CONFIDENCE_THRESHOLD = 0.468;
 const POSSIBLE_CAUSE_NOVELTY_THRESHOLD = 0.419;
+// These thresholds were used when embedding the cause and computing simliarities.
 
 interface GroupSummaryData {
   groupId: string;
@@ -189,7 +190,7 @@ export function GroupSummary({
             title: t('Possible cause'),
             insight: data?.possibleCause,
             icon: <IconFocus size="sm" />,
-            showWhenLoading: false,
+            showWhenLoading: true,
           },
         ]
       : []),

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -130,7 +130,7 @@ describe('SolutionsSection', () => {
     );
 
     expect(screen.getByText('Solutions Hub')).toBeInTheDocument();
-    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(2); // whatsWrong and Open Autofix
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(3); // whatsWrong, possibleCause, and Open Autofix
   });
 
   it('renders summary when AI features are enabled and data is available', async () => {


### PR DESCRIPTION
This can be deployed independently of the [seer PR](https://github.com/getsentry/seer/pull/2037) w/o things breaking (I made sure to test this locally), but I'll deploy this after the seer PR is deployed. That way, there won't be issues where we show the cause loading w/o actually showing it (b/c of the current scoring logic in Seer).

I opted to keep the frontend scoring-related stuff even though it's currently not used.