### PR TITLE
feat(project): ProjectOverview endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -127,7 +127,7 @@ class ProjectOverviewSerializer(Serializer):
 class ProjectOverviewEndpoint(ProjectEndpoint):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     permission_classes = (RelaxedProjectAndStaffPermission,)
 

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -131,7 +131,7 @@ class ProjectOverviewEndpoint(ProjectEndpoint):
     permission_classes = (RelaxedProjectAndStaffPermission,)
 
     @extend_schema(
-        operation_id="Retrieve a Project",
+        operation_id="Retrieve a Project overview",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         request=None,
         responses={
@@ -140,6 +140,11 @@ class ProjectOverviewEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
         examples=ProjectExamples.OVERVIEW_PROJECT,
+        summary=(
+            "Retrieve a Project overview. This endpoint returns an overview of an individual "
+            "project. This only returns high-level information of the project, for more detailed "
+            "information use the project details endpoint.",
+        ),
     )
     def get(self, request: Request, project: Project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, TypedDict
 
@@ -87,11 +86,6 @@ STATUS_LABELS = {
 
 
 class ProjectOverviewSerializer(Serializer):
-    def get_attrs(
-        self, item_list: Sequence[Project], user: User | RpcUser | AnonymousUser, **kwargs: Any
-    ) -> dict[Project, dict[str, Any]]:
-        return {}
-
     def serialize(
         self,
         obj: Project,

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -11,6 +11,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.permissions import StaffPermissionMixin
 from sentry.api.serializers import Serializer, serialize
+from sentry.api.serializers.types import SerializedAvatarFields
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -28,12 +29,6 @@ class RelaxedProjectPermission(ProjectPermission):
 
 class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermission):
     pass
-
-
-class SerializedAvatarFields(TypedDict, total=False):
-    avatarType: str
-    avatarUuid: str | None
-    avatarUrl: str | None
 
 
 class ProjectOverviewResponse(TypedDict, total=False):

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -1,0 +1,241 @@
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any, TypedDict
+
+from django.contrib.auth.models import AnonymousUser
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectMoved, ProjectPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.permissions import StaffPermissionMixin
+from sentry.api.serializers import Serializer, serialize
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.project_examples import ProjectExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.models.projectredirect import ProjectRedirect
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+from sentry.utils.sdk import Scope, bind_organization_context
+
+
+class RelaxedProjectPermission(ProjectPermission):
+    scope_map = {
+        "GET": ["project:read", "project:write", "project:admin"],
+        "POST": ["project:write", "project:admin"],
+        # PUT checks for permissions based on fields
+        "PUT": ["project:read", "project:write", "project:admin"],
+        "DELETE": ["project:admin"],
+    }
+
+
+class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermission):
+    pass
+
+
+class SerializedAvatarFields(TypedDict, total=False):
+    avatarType: str
+    avatarUuid: str | None
+    avatarUrl: str | None
+
+
+class ProjectOverviewResponse(TypedDict, total=False):
+    id: str
+    slug: str
+    name: str
+    platform: str | None
+    dateCreated: datetime
+    firstEvent: datetime | None
+    firstTransactionEvent: bool
+    access: list[str]
+    hasFeedbacks: bool
+    hasFlags: bool
+    hasMinifiedStackTrace: bool
+    hasMonitors: bool
+    hasNewFeedbacks: bool
+    hasProfiles: bool
+    hasReplays: bool
+    hasSessions: bool
+    hasInsightsHttp: bool
+    hasInsightsDb: bool
+    hasInsightsAssets: bool
+    hasInsightsAppStart: bool
+    hasInsightsScreenLoad: bool
+    hasInsightsVitals: bool
+    hasInsightsCaches: bool
+    hasInsightsQueues: bool
+    hasInsightsLlmMonitoring: bool
+
+    isInternal: bool
+    isPublic: bool
+    avatar: SerializedAvatarFields
+    color: str
+    status: str
+
+
+STATUS_LABELS = {
+    ObjectStatus.ACTIVE: "active",
+    ObjectStatus.DISABLED: "deleted",
+    ObjectStatus.PENDING_DELETION: "deleted",
+    ObjectStatus.DELETION_IN_PROGRESS: "deleted",
+}
+
+
+class ProjectOverviewSerializer(Serializer):
+    def get_attrs(
+        self, item_list: Sequence[Project], user: User | RpcUser | AnonymousUser, **kwargs: Any
+    ) -> dict[Project, dict[str, Any]]:
+        return {}
+
+    def serialize(
+        self,
+        obj: Project,
+        attrs: dict[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> ProjectOverviewResponse:
+        status_label = STATUS_LABELS.get(obj.status, "unknown")
+
+        context: ProjectOverviewResponse = {
+            "id": str(obj.id),
+            "slug": obj.slug,
+            "name": obj.name,  # Deprecated
+            "platform": obj.platform,
+            "dateCreated": obj.date_added,
+            "firstEvent": obj.first_event,
+            "firstTransactionEvent": bool(obj.flags.has_transactions),
+            "hasMinifiedStackTrace": bool(obj.flags.has_minified_stack_trace),
+            "hasMonitors": bool(obj.flags.has_cron_monitors),
+            "hasProfiles": bool(obj.flags.has_profiles),
+            "hasReplays": bool(obj.flags.has_replays),
+            "hasFeedbacks": bool(obj.flags.has_feedbacks),
+            "hasFlags": bool(obj.flags.has_flags),
+            "hasNewFeedbacks": bool(obj.flags.has_new_feedbacks),
+            "hasSessions": bool(obj.flags.has_sessions),
+            # whether first span has been sent for each insight module
+            "hasInsightsHttp": bool(obj.flags.has_insights_http),
+            "hasInsightsDb": bool(obj.flags.has_insights_db),
+            "hasInsightsAssets": bool(obj.flags.has_insights_assets),
+            "hasInsightsAppStart": bool(obj.flags.has_insights_app_start),
+            "hasInsightsScreenLoad": bool(obj.flags.has_insights_screen_load),
+            "hasInsightsVitals": bool(obj.flags.has_insights_vitals),
+            "hasInsightsCaches": bool(obj.flags.has_insights_caches),
+            "hasInsightsQueues": bool(obj.flags.has_insights_queues),
+            "hasInsightsLlmMonitoring": bool(obj.flags.has_insights_llm_monitoring),
+            "isInternal": obj.is_internal_project(),
+            "isPublic": obj.public,
+            # Projects don't have avatar uploads, but we need to maintain the payload shape for
+            # compatibility.
+            "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
+            "color": obj.color,
+            "status": status_label,
+        }
+        return context
+
+
+@extend_schema(tags=["Projects"])
+@region_silo_endpoint
+class ProjectOverviewEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+    permission_classes = (RelaxedProjectAndStaffPermission,)
+
+    def convert_args(
+        self,
+        request: Request,
+        *args,
+        **kwargs,
+    ):
+        if args and args[0] is not None:
+            organization_id_or_slug: int | str = args[0]
+            # Required so it behaves like the original convert_args, where organization_id_or_slug was another parameter
+            # TODO: Remove this once we remove the old `organization_slug` parameter from getsentry
+            args = args[1:]
+        else:
+            organization_id_or_slug = kwargs.pop("organization_id_or_slug", None) or kwargs.pop(
+                "organization_slug"
+            )
+
+        if args and args[0] is not None:
+            project_id_or_slug: int | str = args[0]
+            # Required so it behaves like the original convert_args, where project_id_or_slug was another parameter
+            args = args[1:]
+        else:
+            project_id_or_slug = kwargs.pop("project_id_or_slug", None) or kwargs.pop(
+                "project_slug"
+            )
+
+        try:
+            project = (
+                Project.objects.filter(
+                    organization__slug__id_or_slug=organization_id_or_slug,
+                    slug__id_or_slug=project_id_or_slug,
+                )
+                .select_related("organization")
+                .get()
+            )
+        except Project.DoesNotExist:
+            try:
+                # Project may have been renamed
+                # This will only happen if the passed in project_id_or_slug is a slug and not an id
+                redirect = ProjectRedirect.objects.select_related("project").get(
+                    organization__slug__id_or_slug=organization_id_or_slug,
+                    redirect_slug=project_id_or_slug,
+                )
+                # Without object permissions don't reveal the rename
+                self.check_object_permissions(request, redirect.project)
+
+                # get full path so that we keep query strings
+                requested_url = request.get_full_path()
+                new_url = requested_url.replace(
+                    f"projects/{organization_id_or_slug}/{project_id_or_slug}/overview/",
+                    f"projects/{organization_id_or_slug}/{redirect.project.slug}/overview/",  # TODO: get actual path for redirect
+                )
+
+                # Resource was moved/renamed if the requested url is different than the new url
+                if requested_url != new_url:
+                    raise ProjectMoved(new_url, redirect.project.slug)
+
+                # otherwise project doesn't exist
+                raise ResourceDoesNotExist
+            except ProjectRedirect.DoesNotExist:
+                raise ResourceDoesNotExist
+
+        if project.status != ObjectStatus.ACTIVE:
+            raise ResourceDoesNotExist
+
+        self.check_object_permissions(request, project)
+
+        Scope.get_isolation_scope().set_tag("project", project.id)
+
+        bind_organization_context(project.organization)
+
+        request._request.organization = project.organization  # type: ignore[attr-defined]  # XXX: we should not be stuffing random attributes into HttpRequest
+
+        kwargs["project"] = project
+        return (args, kwargs)
+
+    @extend_schema(
+        operation_id="Retrieve a Project",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        request=None,
+        responses={
+            200: ProjectOverviewSerializer,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=ProjectExamples.OVERVIEW_PROJECT,
+    )
+    def get(self, request: Request, project: Project) -> Response:
+        """
+        Return details on an individual project.
+        """
+        data = serialize(project, request.user, ProjectOverviewSerializer())
+
+        return Response(data)

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -1,7 +1,3 @@
-from collections.abc import Mapping
-from typing import Any
-
-from django.contrib.auth.models import AnonymousUser
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,14 +7,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.permissions import StaffPermissionMixin
-from sentry.api.serializers import Serializer, serialize
-from sentry.api.serializers.models.project import STATUS_LABELS, ProjectSerializerResponse
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.project import ProjectSerializer
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.models.project import Project
-from sentry.users.models.user import User
-from sentry.users.services.user.model import RpcUser
 
 
 class RelaxedProjectPermission(ProjectPermission):
@@ -29,57 +23,6 @@ class RelaxedProjectPermission(ProjectPermission):
 
 class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermission):
     pass
-
-
-class ProjectOverviewResponse(ProjectSerializerResponse, total=False):
-    pass
-
-
-class ProjectOverviewSerializer(Serializer):
-    def serialize(
-        self,
-        obj: Project,
-        attrs: Mapping[str, Any],
-        user: User | RpcUser | AnonymousUser,
-        **kwargs: Any,
-    ) -> ProjectOverviewResponse:
-        status_label = STATUS_LABELS.get(obj.status, "unknown")
-
-        context: ProjectOverviewResponse = {
-            "id": str(obj.id),
-            "slug": obj.slug,
-            "name": obj.name,  # Deprecated
-            "platform": obj.platform,
-            "dateCreated": obj.date_added,
-            "firstEvent": obj.first_event,
-            "firstTransactionEvent": bool(obj.flags.has_transactions),
-            "hasMinifiedStackTrace": bool(obj.flags.has_minified_stack_trace),
-            "hasMonitors": bool(obj.flags.has_cron_monitors),
-            "hasProfiles": bool(obj.flags.has_profiles),
-            "hasReplays": bool(obj.flags.has_replays),
-            "hasFeedbacks": bool(obj.flags.has_feedbacks),
-            "hasFlags": bool(obj.flags.has_flags),
-            "hasNewFeedbacks": bool(obj.flags.has_new_feedbacks),
-            "hasSessions": bool(obj.flags.has_sessions),
-            # whether first span has been sent for each insight module
-            "hasInsightsHttp": bool(obj.flags.has_insights_http),
-            "hasInsightsDb": bool(obj.flags.has_insights_db),
-            "hasInsightsAssets": bool(obj.flags.has_insights_assets),
-            "hasInsightsAppStart": bool(obj.flags.has_insights_app_start),
-            "hasInsightsScreenLoad": bool(obj.flags.has_insights_screen_load),
-            "hasInsightsVitals": bool(obj.flags.has_insights_vitals),
-            "hasInsightsCaches": bool(obj.flags.has_insights_caches),
-            "hasInsightsQueues": bool(obj.flags.has_insights_queues),
-            "hasInsightsLlmMonitoring": bool(obj.flags.has_insights_llm_monitoring),
-            "isInternal": obj.is_internal_project(),
-            "isPublic": obj.public,
-            # Projects don't have avatar uploads, but we need to maintain the payload shape for
-            # compatibility.
-            "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
-            "color": obj.color,
-            "status": status_label,
-        }
-        return context
 
 
 @extend_schema(tags=["Projects"])
@@ -96,7 +39,7 @@ class ProjectOverviewEndpoint(ProjectEndpoint):
         parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
         request=None,
         responses={
-            200: ProjectOverviewSerializer,
+            200: ProjectSerializer,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
@@ -111,5 +54,5 @@ class ProjectOverviewEndpoint(ProjectEndpoint):
         """
         Return details on an individual project.
         """
-        data = serialize(project, request.user, ProjectOverviewSerializer())
+        data = serialize(project, request.user, ProjectSerializer())
         return Response(data)

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -1,6 +1,5 @@
 from collections.abc import Mapping
-from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
 from drf_spectacular.utils import extend_schema
@@ -13,11 +12,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.permissions import StaffPermissionMixin
 from sentry.api.serializers import Serializer, serialize
-from sentry.api.serializers.types import SerializedAvatarFields
+from sentry.api.serializers.models.project import STATUS_LABELS, ProjectSerializerResponse
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.parameters import GlobalParams
-from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -33,46 +31,8 @@ class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermi
     pass
 
 
-class ProjectOverviewResponse(TypedDict, total=False):
-    id: str
-    slug: str
-    name: str
-    platform: str | None
-    dateCreated: datetime
-    firstEvent: datetime | None
-    firstTransactionEvent: bool
-    access: list[str]
-    hasFeedbacks: bool
-    hasFlags: bool
-    hasMinifiedStackTrace: bool
-    hasMonitors: bool
-    hasNewFeedbacks: bool
-    hasProfiles: bool
-    hasReplays: bool
-    hasSessions: bool
-    hasInsightsHttp: bool
-    hasInsightsDb: bool
-    hasInsightsAssets: bool
-    hasInsightsAppStart: bool
-    hasInsightsScreenLoad: bool
-    hasInsightsVitals: bool
-    hasInsightsCaches: bool
-    hasInsightsQueues: bool
-    hasInsightsLlmMonitoring: bool
-
-    isInternal: bool
-    isPublic: bool
-    avatar: SerializedAvatarFields
-    color: str
-    status: str
-
-
-STATUS_LABELS = {
-    ObjectStatus.ACTIVE: "active",
-    ObjectStatus.DISABLED: "deleted",
-    ObjectStatus.PENDING_DELETION: "deleted",
-    ObjectStatus.DELETION_IN_PROGRESS: "deleted",
-}
+class ProjectOverviewResponse(ProjectSerializerResponse, total=False):
+    pass
 
 
 class ProjectOverviewSerializer(Serializer):

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, TypedDict
 
@@ -78,7 +79,7 @@ class ProjectOverviewSerializer(Serializer):
     def serialize(
         self,
         obj: Project,
-        attrs: dict[str, Any],
+        attrs: Mapping[str, Any],
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> ProjectOverviewResponse:
@@ -143,7 +144,7 @@ class ProjectOverviewEndpoint(ProjectEndpoint):
         summary=(
             "Retrieve a Project overview. This endpoint returns an overview of an individual "
             "project. This only returns high-level information of the project, for more detailed "
-            "information use the project details endpoint.",
+            "information use the project details endpoint."
         ),
     )
     def get(self, request: Request, project: Project) -> Response:

--- a/src/sentry/api/endpoints/project_overview.py
+++ b/src/sentry/api/endpoints/project_overview.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
@@ -123,6 +124,7 @@ class ProjectOverviewSerializer(Serializer):
 @extend_schema(tags=["Projects"])
 @region_silo_endpoint
 class ProjectOverviewEndpoint(ProjectEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -35,6 +35,7 @@ from sentry.api.endpoints.organization_user_rollback import OrganizationRollback
 from sentry.api.endpoints.project_backfill_similar_issues_embeddings_records import (
     ProjectBackfillSimilarIssuesEmbeddingsRecords,
 )
+from sentry.api.endpoints.project_overview import ProjectOverviewEndpoint
 from sentry.api.endpoints.project_stacktrace_coverage import ProjectStacktraceCoverageEndpoint
 from sentry.api.endpoints.project_statistical_detectors import ProjectStatisticalDetectors
 from sentry.api.endpoints.project_template_detail import OrganizationProjectTemplateDetailEndpoint
@@ -2384,6 +2385,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/members/$",
         ProjectMemberIndexEndpoint.as_view(),
         name="sentry-api-0-project-member-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/overview/$",
+        ProjectOverviewEndpoint.as_view(),
+        name="sentry-api-0-project-overview",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/releases/$",

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -378,6 +378,39 @@ DETAILED_PROJECT = {
     "highlightPreset": {"tags": [], "context": {}},
 }
 
+PROJECT_OVERVIEW = {
+    "id": "4505321021243392",
+    "slug": "the-spoiled-yoghurt",
+    "name": "The Spoiled Yoghurt",
+    "platform": "python",
+    "dateCreated": "2023-06-08T00:13:06.004534Z",
+    "firstEvent": None,
+    "firstTransactionEvent": False,
+    "hasAccess": True,
+    "hasMinifiedStackTrace": False,
+    "hasFeedbacks": False,
+    "hasMonitors": False,
+    "hasNewFeedbacks": False,
+    "hasProfiles": False,
+    "hasReplays": False,
+    "hasFlags": False,
+    "hasSessions": False,
+    "hasInsightsHttp": True,
+    "hasInsightsDb": False,
+    "hasInsightsAssets": True,
+    "hasInsightsAppStart": False,
+    "hasInsightsScreenLoad": False,
+    "hasInsightsVitals": False,
+    "hasInsightsCaches": False,
+    "hasInsightsQueues": False,
+    "hasInsightsLlmMonitoring": False,
+    "isInternal": False,
+    "isPublic": False,
+    "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
+    "color": "#3f70bf",
+    "status": "active",
+}
+
 SYMBOL_SOURCES = [
     {
         "id": "honk",
@@ -448,6 +481,15 @@ class ProjectExamples:
         OpenApiExample(
             "Get detailed view about a Project",
             value=DETAILED_PROJECT,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    OVERVIEW_PROJECT = [
+        OpenApiExample(
+            "Get an overview of a Project",
+            value=PROJECT_OVERVIEW,  # TODO: Update this to include more fields
             status_codes=["200"],
             response_only=True,
         ),

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -378,39 +378,6 @@ DETAILED_PROJECT = {
     "highlightPreset": {"tags": [], "context": {}},
 }
 
-PROJECT_OVERVIEW = {
-    "id": "4505321021243392",
-    "slug": "the-spoiled-yoghurt",
-    "name": "The Spoiled Yoghurt",
-    "platform": "python",
-    "dateCreated": "2023-06-08T00:13:06.004534Z",
-    "firstEvent": None,
-    "firstTransactionEvent": False,
-    "hasAccess": True,
-    "hasMinifiedStackTrace": False,
-    "hasFeedbacks": False,
-    "hasMonitors": False,
-    "hasNewFeedbacks": False,
-    "hasProfiles": False,
-    "hasReplays": False,
-    "hasFlags": False,
-    "hasSessions": False,
-    "hasInsightsHttp": True,
-    "hasInsightsDb": False,
-    "hasInsightsAssets": True,
-    "hasInsightsAppStart": False,
-    "hasInsightsScreenLoad": False,
-    "hasInsightsVitals": False,
-    "hasInsightsCaches": False,
-    "hasInsightsQueues": False,
-    "hasInsightsLlmMonitoring": False,
-    "isInternal": False,
-    "isPublic": False,
-    "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
-    "color": "#3f70bf",
-    "status": "active",
-}
-
 SYMBOL_SOURCES = [
     {
         "id": "honk",
@@ -493,7 +460,7 @@ class ProjectExamples:
                 "Project overviews are high-level summaries of a project. They are intended to provide a "
                 "quick and lightweight way to get information about a project."
             ),
-            value=PROJECT_OVERVIEW,
+            value=BASE_PROJECT,
             status_codes=["200"],
             response_only=True,
         ),

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -489,7 +489,11 @@ class ProjectExamples:
     OVERVIEW_PROJECT = [
         OpenApiExample(
             "Get an overview of a Project",
-            value=PROJECT_OVERVIEW,  # TODO: Update this to include more fields
+            summary=(
+                "Project overviews are high-level summaries of a project. They are intended to provide a "
+                "quick and lightweight way to get information about a project."
+            ),
+            value=PROJECT_OVERVIEW,
             status_codes=["200"],
             response_only=True,
         ),

--- a/tests/sentry/api/endpoints/test_project_overview.py
+++ b/tests/sentry/api/endpoints/test_project_overview.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import orjson
+
+from sentry.models.projectredirect import ProjectRedirect
+from sentry.testutils.cases import APITestCase
+
+
+def first_symbol_source_id(sources_json):
+    sources = orjson.loads(sources_json)
+    return sources[0]["id"]
+
+
+class ProjectOverviewTest(APITestCase):
+    endpoint = "sentry-api-0-project-overview"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_simple(self):
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        assert response.data["id"] == str(self.project.id)
+
+    def test_superuser_simple(self):
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        assert response.data["id"] == str(self.project.id)
+
+    def test_staff_simple(self):
+        staff_user = self.create_user(is_staff=True)
+        self.login_as(user=staff_user, staff=True)
+
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        assert response.data["id"] == str(self.project.id)
+
+    def test_numeric_org_slug(self):
+        # Regression test for https://github.com/getsentry/sentry/issues/2236
+        project = self.create_project(name="Bar", slug="bar", teams=[self.team])
+
+        # We want to make sure we don't hit the LegacyProjectRedirect view at all.
+        url = f"/api/0/projects/{self.organization.slug}/{project.slug}/"
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data["id"] == str(project.id)
+
+    def test_non_org_rename_403(self):
+        org = self.create_organization()
+        team = self.create_team(organization=org, name="foo", slug="foo")
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=org, role="member", teams=[team])
+
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        ProjectRedirect.record(other_project, "old_slug")
+        self.login_as(user=user)
+
+        self.get_error_response(other_org.slug, "old_slug", status_code=403)

--- a/tests/sentry/api/endpoints/test_project_overview.py
+++ b/tests/sentry/api/endpoints/test_project_overview.py
@@ -22,6 +22,18 @@ class ProjectOverviewTest(APITestCase):
         response = self.get_success_response(self.project.organization.slug, self.project.slug)
         assert response.data["id"] == str(self.project.id)
 
+    def test_cross_org_403(self):
+        org = self.create_organization()
+        team = self.create_team(organization=org, name="foo", slug="foo")
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=org, role="member", teams=[team])
+
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+
+        self.login_as(user=user)
+        self.get_error_response(other_org.slug, other_project.slug, status_code=403)
+
     def test_superuser_simple(self):
         superuser = self.create_user(is_superuser=True)
         self.login_as(user=superuser, superuser=True)

--- a/tests/sentry/api/endpoints/test_project_overview.py
+++ b/tests/sentry/api/endpoints/test_project_overview.py
@@ -36,16 +36,6 @@ class ProjectOverviewTest(APITestCase):
         response = self.get_success_response(self.project.organization.slug, self.project.slug)
         assert response.data["id"] == str(self.project.id)
 
-    def test_numeric_org_slug(self):
-        # Regression test for https://github.com/getsentry/sentry/issues/2236
-        project = self.create_project(name="Bar", slug="bar", teams=[self.team])
-
-        # We want to make sure we don't hit the LegacyProjectRedirect view at all.
-        url = f"/api/0/projects/{self.organization.slug}/{project.slug}/"
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert response.data["id"] == str(project.id)
-
     def test_non_org_rename_403(self):
         org = self.create_organization()
         team = self.create_team(organization=org, name="foo", slug="foo")


### PR DESCRIPTION
Contributes to https://github.com/getsentry/projects/issues/755

The idea is to have an endpoint that quickly  responds with mininimal project info to make the polling of newly created projects as efficient as possible.

This new endpoint only includes data of the actual project, no additional lookups or metrics extraction is made.