### PR TITLE
fix(dynamic-sampling): Array length being rendered

### DIFF
--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -140,7 +140,7 @@ export function ProjectsTable({
           <p>{emptyMessage}</p>
         </EmptyStateWarning>
       )}
-      {!isLoading && items.length && (
+      {!isLoading && items.length > 0 && (
         <SizingWrapper style={{height: `${estimatedListSize}px`}}>
           <AutoSizer>
             {({width, height}) => (


### PR DESCRIPTION
Remove rendered 0.
<img width="829" alt="Screenshot 2025-03-03 at 10 11 01" src="https://github.com/user-attachments/assets/06586b92-3d62-4e3c-bf4f-b78abc1eae54" />
