### PR TITLE
fix(sdk): Sample /api/0/auth/validate/ at 0%

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -85,6 +85,11 @@ SAMPLED_TASKS = {
     "sentry.tasks.embeddings_grouping.backfill_seer_grouping_records_for_project": 1.0,
 }
 
+SAMPLED_ROUTES = {
+    "/_warmup/": 0.0,
+    "/api/0/auth/validate/": 0.0,
+}
+
 if settings.ADDITIONAL_SAMPLED_TASKS:
     SAMPLED_TASKS.update(settings.ADDITIONAL_SAMPLED_TASKS)
 
@@ -174,9 +179,9 @@ def get_project_key():
 
 
 def traces_sampler(sampling_context):
-    # dont sample warmup requests
-    if sampling_context.get("wsgi_environ", {}).get("PATH_INFO") == "/_warmup/":
-        return 0.0
+    wsgi_path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
+    if wsgi_path and wsgi_path in SAMPLED_ROUTES:
+        return SAMPLED_ROUTES[wsgi_path]
 
     # Apply sample_rate from custom_sampling_context
     custom_sample_rate = sampling_context.get("sample_rate")


### PR DESCRIPTION
Drops all samples from `/api/0/auth/validate/`, which is used by external providers to test credentials. This endpoint is expected to result in authentication errors and usually experiences traffic bursts.

See also https://github.com/getsentry/ops/pull/13982