### PR TITLE
feat(dynamic-sampling): Improve empty breakdown state

### DIFF
--- a/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
@@ -89,7 +89,7 @@ export function SamplingBreakdown({
             margin: 0;
           `}
         />
-      ) : (
+      ) : sampleCounts.length > 0 ? (
         <Fragment>
           <Breakdown>
             {topItems.map((item: any, index: any) => {
@@ -162,6 +162,8 @@ export function SamplingBreakdown({
             </Total>
           </Footer>
         </Fragment>
+      ) : (
+        <EmptyStateText>{t('No spans found in the selected period.')}</EmptyStateText>
       )}
     </StyledPanel>
   );
@@ -218,4 +220,10 @@ const LegendItem = styled('div')`
 const SubText = styled('span')`
   color: ${p => p.theme.gray300};
   white-space: nowrap;
+`;
+
+const EmptyStateText = styled('div')`
+  text-align: center;
+  padding: ${space(0.5)} 0 ${space(3)};
+  color: ${p => p.theme.subText};
 `;


### PR DESCRIPTION
**Before**
![Screenshot 2025-03-03 at 11 35 46](https://github.com/user-attachments/assets/97696c22-2f2d-4cdd-8599-3bc7ee1e754d)



**After**
![Screenshot 2025-03-03 at 11 23 20](https://github.com/user-attachments/assets/2d88325a-8016-4b86-82f7-23b667416955)
