### PR TITLE
fix(onboarding): remove superfluous whitespace in flask onboarding

### DIFF
--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -23,8 +23,7 @@ type Params = DocsParams;
 
 const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[flask]'`;
 
-const getSdkSetupSnippet = (params: Params) => `
-import sentry_sdk
+const getSdkSetupSnippet = (params: Params) => `import sentry_sdk
 from flask import Flask
 
 sentry_sdk.init(
@@ -103,8 +102,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'python',
-          code: `
-${getSdkSetupSnippet(params)}
+          code: `${getSdkSetupSnippet(params)}
 app = Flask(__name__)
 `,
         },
@@ -136,8 +134,7 @@ app = Flask(__name__)
         {
           language: 'python',
 
-          code: `
-${getSdkSetupSnippet(params)}
+          code: `${getSdkSetupSnippet(params)}
 app = Flask(__name__)
 
 @app.route("/")


### PR DESCRIPTION
Before:
<img width="578" alt="Screenshot 2025-03-03 at 13 40 36" src="https://github.com/user-attachments/assets/e44bae4d-084f-44b7-95db-94ee55ef2664" />


After:
<img width="579" alt="Screenshot 2025-03-03 at 13 43 04" src="https://github.com/user-attachments/assets/ee4e8566-9d8d-44e8-80af-0bd7874c7abb" />
