### PR TITLE
ref(spans): Introduce an option to disable perf issue detection

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2660,6 +2660,11 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "standalone-spans.detect-performance-problems.enable",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "standalone-spans.profile-process-messages.rate",
     type=Float,
     default=0.0,

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -234,10 +234,13 @@ def process_segment(spans: list[dict[str, Any]]):
     # _nodestore_save_many(jobs=jobs, app_feature="transactions")          # N/A: nodestore is deprecated
     # _eventstream_insert_many(jobs)                                       # N/A: produced outside
     # _track_outcome_accepted_many(jobs)                                   # N/A: created by outcomes consumer
-    _detect_performance_problems(jobs, projects, is_standalone_spans=True)
-    _update_occurrence_group_type(jobs, projects)  # NB: exclusive to spans consumer
-    if options.get("standalone-spans.send-occurrence-to-platform.enable"):
-        _send_occurrence_to_platform(jobs, projects)
+
+    if options.get("standalone-spans.detect-performance-problems.enable"):
+        _detect_performance_problems(jobs, projects, is_standalone_spans=True)
+        _update_occurrence_group_type(jobs, projects)  # NB: exclusive to spans consumer
+        if options.get("standalone-spans.send-occurrence-to-platform.enable"):
+            _send_occurrence_to_platform(jobs, projects)
+
     _record_transaction_info(jobs, projects)
 
     return jobs

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -50,6 +50,11 @@ class TestSpansTask(TestCase):
 
         return spans
 
+    @override_options(
+        {
+            "standalone-spans.detect-performance-problems.enable": True,
+        }
+    )
     def test_n_plus_one_issue_detection(self):
         spans = self.generate_n_plus_one_spans()
         job = process_segment(spans)[0]
@@ -63,6 +68,7 @@ class TestSpansTask(TestCase):
 
     @override_options(
         {
+            "standalone-spans.detect-performance-problems.enable": True,
             "standalone-spans.send-occurrence-to-platform.enable": True,
         }
     )
@@ -82,6 +88,11 @@ class TestSpansTask(TestCase):
             ).hexdigest()
         ]
 
+    @override_options(
+        {
+            "standalone-spans.detect-performance-problems.enable": True,
+        }
+    )
     def test_n_plus_one_issue_detection_without_segment_span(self):
         segment_span = build_mock_span(project_id=self.project.id, is_segment=False)
         child_span = build_mock_span(


### PR DESCRIPTION
Initially, perfomance problem detection will be disabled in the spans pipeline.
This PR introduces a sentry-wide option defaulting to `False` than controls
detection.

In the next step, span enrichment will be added to the segment consumer before
enabling performance issue detection again.

Ref https://github.com/getsentry/streaming-planning/issues/20
