### PR TITLE
fix(insights): Filter span samples by environment

### DIFF
--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -125,6 +125,7 @@ export const useSpanSamples = (options: Options) => {
           secondBound: maxYValue * (2 / 3),
           upperBound: maxYValue,
           project: pageFilter.selection.projects,
+          environment: pageFilter.selection.environments,
           query: queryString,
           ...(additionalFields?.length ? {additionalFields} : {}),
         })}`

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -38,7 +38,7 @@ describe('useSpanSamples', () => {
         end: null,
         utc: false,
       },
-      environments: [],
+      environments: ['prod'],
       projects: [],
     },
   });
@@ -101,7 +101,6 @@ describe('useSpanSamples', () => {
           filters: {
             'span.group': '221aa7ebd216',
             release: '0.0.1',
-            environment: undefined,
           },
           fields: [
             SpanIndexedField.TRANSACTION_ID,
@@ -124,6 +123,7 @@ describe('useSpanSamples', () => {
           query: `span.group:221aa7ebd216 release:0.0.1`,
           referrer: 'api-spec',
           statsPeriod: '10d',
+          environment: ['prod'],
           lowerBound: 100,
           firstBound: 300,
           secondBound: 600,

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -74,6 +74,7 @@ export const useSpanSamples = <Fields extends SpanIndexedProperty[]>(
           project: selection.projects,
           ...dateConditions,
           ...{utc: selection.datetime.utc},
+          environment: selection.environments,
           lowerBound: min,
           firstBound: max && max * (1 / 3),
           secondBound: max && max * (2 / 3),


### PR DESCRIPTION
We were not passing the environment to the samples call, so users with an environment filter set were getting samples from other environments, too!

Closes https://github.com/getsentry/sentry/issues/85962