### PR TITLE
ref(insights): remove performance-landing-page-stats-period flag

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -121,11 +121,7 @@ function GenericBackendOverviewPage() {
   const {selection} = usePageFilters();
 
   const withStaticFilters = canUseMetricsData(organization);
-  const eventView = generateBackendPerformanceEventView(
-    location,
-    withStaticFilters,
-    organization
-  );
+  const eventView = generateBackendPerformanceEventView(location, withStaticFilters);
   const searchBarEventView = eventView.clone();
 
   // TODO - this should come from MetricsField / EAP fields

--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -87,11 +87,7 @@ export function LaravelOverviewPage() {
   const navigate = useNavigate();
 
   const withStaticFilters = canUseMetricsData(organization);
-  const eventView = generateBackendPerformanceEventView(
-    location,
-    withStaticFilters,
-    organization
-  );
+  const eventView = generateBackendPerformanceEventView(location, withStaticFilters);
 
   const showOnboarding = onboardingProject !== undefined;
 

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -92,8 +92,7 @@ function FrontendOverviewPage() {
   const withStaticFilters = canUseMetricsData(organization);
   const eventView = generateFrontendOtherPerformanceEventView(
     location,
-    withStaticFilters,
-    organization
+    withStaticFilters
   );
   const searchBarEventView = eventView.clone();
 

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -29,7 +29,7 @@ import useProjects from 'sentry/utils/useProjects';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 import {getLandingDisplayFromParam} from './landing/utils';
-import {generatePerformanceEventView, getDefaultStatsPeriod} from './data';
+import {DEFAULT_STATS_PERIOD, generatePerformanceEventView} from './data';
 import {PerformanceLanding} from './landing';
 import {
   addRoutePerformanceContext,
@@ -180,7 +180,7 @@ function PerformanceContent({selection, location, demoMode, router}: Props) {
                 start: null,
                 end: null,
                 utc: false,
-                period: getDefaultStatsPeriod(organization),
+                period: DEFAULT_STATS_PERIOD,
               },
             }}
           >

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -21,7 +21,7 @@ import {
   vitalNameFromLocation,
 } from './vitalDetail/utils';
 
-export const DEFAULT_STATS_PERIOD = '7d';
+export const DEFAULT_STATS_PERIOD = '14d';
 export const DEFAULT_PROJECT_THRESHOLD_METRIC = 'duration';
 export const DEFAULT_PROJECT_THRESHOLD = 300;
 
@@ -47,13 +47,6 @@ export const USER_MISERY_TOOLTIP = tct(
 );
 
 const TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH = ['transaction'];
-
-export const getDefaultStatsPeriod = (organization: Organization) => {
-  if (organization.features.includes('performance-landing-page-stats-period')) {
-    return '14d';
-  }
-  return DEFAULT_STATS_PERIOD;
-};
 
 export enum PerformanceTerm {
   TPM = 'tpm',
@@ -484,7 +477,7 @@ export function generateGenericPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = getDefaultStatsPeriod(organization);
+    savedQuery.range = DEFAULT_STATS_PERIOD;
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -512,8 +505,7 @@ export function generateGenericPerformanceEventView(
 
 export function generateBackendPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
-  organization: Organization
+  withStaticFilters: boolean
 ): EventView {
   const {query} = location;
 
@@ -548,7 +540,7 @@ export function generateBackendPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = getDefaultStatsPeriod(organization);
+    savedQuery.range = DEFAULT_STATS_PERIOD;
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -615,7 +607,7 @@ export function generateMobilePerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = getDefaultStatsPeriod(organization);
+    savedQuery.range = DEFAULT_STATS_PERIOD;
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -631,8 +623,7 @@ export function generateMobilePerformanceEventView(
 
 function generateFrontendPageloadPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
-  organization: Organization
+  withStaticFilters: boolean
 ): EventView {
   const {query} = location;
 
@@ -665,7 +656,7 @@ function generateFrontendPageloadPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = getDefaultStatsPeriod(organization);
+    savedQuery.range = DEFAULT_STATS_PERIOD;
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -682,8 +673,7 @@ function generateFrontendPageloadPerformanceEventView(
 
 export function generateFrontendOtherPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
-  organization: Organization
+  withStaticFilters: boolean
 ): EventView {
   const {query} = location;
 
@@ -716,7 +706,7 @@ export function generateFrontendOtherPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = getDefaultStatsPeriod(organization);
+    savedQuery.range = DEFAULT_STATS_PERIOD;
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -748,23 +738,11 @@ export function generatePerformanceEventView(
   const display = getCurrentLandingDisplay(location, projects, eventView);
   switch (display?.field) {
     case LandingDisplayField.FRONTEND_PAGELOAD:
-      return generateFrontendPageloadPerformanceEventView(
-        location,
-        withStaticFilters,
-        organization
-      );
+      return generateFrontendPageloadPerformanceEventView(location, withStaticFilters);
     case LandingDisplayField.FRONTEND_OTHER:
-      return generateFrontendOtherPerformanceEventView(
-        location,
-        withStaticFilters,
-        organization
-      );
+      return generateFrontendOtherPerformanceEventView(location, withStaticFilters);
     case LandingDisplayField.BACKEND:
-      return generateBackendPerformanceEventView(
-        location,
-        withStaticFilters,
-        organization
-      );
+      return generateBackendPerformanceEventView(location, withStaticFilters);
     case LandingDisplayField.MOBILE:
       return generateMobilePerformanceEventView(
         location,
@@ -778,10 +756,7 @@ export function generatePerformanceEventView(
   }
 }
 
-export function generatePerformanceVitalDetailView(
-  location: Location,
-  organization: Organization
-): EventView {
+export function generatePerformanceVitalDetailView(location: Location): EventView {
   const {query} = location;
 
   const vitalName = vitalNameFromLocation(location);
@@ -809,7 +784,7 @@ export function generatePerformanceVitalDetailView(
   };
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = getDefaultStatsPeriod(organization);
+    savedQuery.range = DEFAULT_STATS_PERIOD;
   }
   savedQuery.orderby = decodeScalar(query.sort, '-count');
 

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -224,7 +224,7 @@ describe('Performance > Landing > Index', function () {
           project: [],
           query: 'event.type:transaction',
           referrer: 'api.performance.generic-widget-chart.user-misery-area',
-          statsPeriod: '14d',
+          statsPeriod: '28d',
           yAxis: ['user_misery()', 'tpm()', 'failure_rate()'],
         }),
       })

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -47,19 +47,13 @@ type State = {
 
 class VitalDetail extends Component<Props, State> {
   state: State = {
-    eventView: generatePerformanceVitalDetailView(
-      this.props.location,
-      this.props.organization
-    ),
+    eventView: generatePerformanceVitalDetailView(this.props.location),
   };
 
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
-      eventView: generatePerformanceVitalDetailView(
-        nextProps.location,
-        nextProps.organization
-      ),
+      eventView: generatePerformanceVitalDetailView(nextProps.location),
     };
   }
 


### PR DESCRIPTION
Just doing a bit of cleanup. This feature has been GA almost 2 years now, no need to keep the flag and it's conditions around.