### PR TITLE
ref(dashboards): Remove usage of `BigNumberWidget` from Project Details views

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -1,3 +1,4 @@
+import {Button} from 'sentry/components/button';
 import {getInterval, shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
@@ -6,10 +7,11 @@ import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {SessionFieldWithOperation} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
+import {BigNumberWidgetVisualization} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {
   getSessionTermDescription,
@@ -120,6 +122,8 @@ function ProjectStabilityScoreCard(props: Props) {
     null
   );
 
+  const Title = <Widget.WidgetTitle title={cardTitle} />;
+
   const {crashFreeRate, previousCrashFreeRate, isLoading, error, refetch} =
     useCrashFreeRate(props);
 
@@ -134,8 +138,12 @@ function ProjectStabilityScoreCard(props: Props) {
   if (hasSessions === false) {
     return (
       <Widget
-        Title={<Widget.WidgetTitle title={cardTitle} />}
-        Actions={<Widget.WidgetDescription description={cardHelp} />}
+        Title={Title}
+        Actions={
+          <Widget.WidgetToolbar>
+            <Widget.WidgetDescription description={cardHelp} />
+          </Widget.WidgetToolbar>
+        }
         Visualization={
           <ActionWrapper>
             <MissingReleasesButtons
@@ -149,23 +157,53 @@ function ProjectStabilityScoreCard(props: Props) {
     );
   }
 
+  if (isLoading || !defined(score)) {
+    return (
+      <Widget
+        Title={Title}
+        Visualization={<BigNumberWidgetVisualization.LoadingPlaceholder />}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Widget
+        Title={Title}
+        Actions={
+          <Widget.WidgetToolbar>
+            <Button size="xs" onClick={refetch}>
+              {t('Retry')}
+            </Button>
+          </Widget.WidgetToolbar>
+        }
+        Visualization={<Widget.WidgetError error={error} />}
+      />
+    );
+  }
+
   return (
-    <BigNumberWidget
-      title={cardTitle}
-      description={cardHelp}
-      value={score ? score / 100 : undefined}
-      previousPeriodValue={previousScore ? previousScore / 100 : undefined}
-      field={`${props.field}()`}
-      meta={{
-        fields: {
-          [`${props.field}()`]: 'percentage',
-        },
-        units: {},
-      }}
-      preferredPolarity="+"
-      isLoading={isLoading}
-      error={error ?? undefined}
-      onRetry={refetch}
+    <Widget
+      Title={Title}
+      Actions={
+        <Widget.WidgetToolbar>
+          <Widget.WidgetDescription description={cardHelp} />
+        </Widget.WidgetToolbar>
+      }
+      Visualization={
+        <BigNumberWidgetVisualization
+          value={score / 100}
+          previousPeriodValue={previousScore ? previousScore / 100 : undefined}
+          field={`${props.field}()`}
+          meta={{
+            fields: {
+              [`${props.field}()`]: 'percentage',
+            },
+            units: {},
+          }}
+          preferredPolarity="+"
+        />
+      }
     />
   );
 }

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -1,12 +1,14 @@
+import {Button} from 'sentry/components/button';
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
+import {BigNumberWidgetVisualization} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
 import MissingReleasesButtons from '../missingFeatureButtons/missingReleasesButtons';
@@ -146,11 +148,17 @@ function ProjectVelocityScoreCard(props: Props) {
 
   const cardHelp = t('The number of releases for this project.');
 
+  const Title = <Widget.WidgetTitle title={cardTitle} />;
+
   if (!isLoading && noReleaseEver) {
     return (
       <Widget
         Title={<Widget.WidgetTitle title={cardTitle} />}
-        Actions={<Widget.WidgetDescription description={cardHelp} />}
+        Actions={
+          <Widget.WidgetToolbar>
+            <Widget.WidgetDescription description={cardHelp} />
+          </Widget.WidgetToolbar>
+        }
         Visualization={
           <ActionWrapper>
             <MissingReleasesButtons organization={organization} />
@@ -160,24 +168,54 @@ function ProjectVelocityScoreCard(props: Props) {
     );
   }
 
+  if (isLoading || !defined(currentReleases)) {
+    return (
+      <Widget
+        Title={Title}
+        Visualization={<BigNumberWidgetVisualization.LoadingPlaceholder />}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Widget
+        Title={Title}
+        Actions={
+          <Widget.WidgetToolbar>
+            <Button size="xs" onClick={refetch}>
+              {t('Retry')}
+            </Button>
+          </Widget.WidgetToolbar>
+        }
+        Visualization={<Widget.WidgetError error={error} />}
+      />
+    );
+  }
+
   return (
-    <BigNumberWidget
-      title={cardTitle}
-      description={cardHelp}
-      value={currentReleases?.length}
-      previousPeriodValue={previousReleases?.length}
-      field="count()"
-      maximumValue={API_LIMIT}
-      meta={{
-        fields: {
-          'count()': 'number',
-        },
-        units: {},
-      }}
-      preferredPolarity="+"
-      isLoading={isLoading}
-      error={error ?? undefined}
-      onRetry={refetch}
+    <Widget
+      Title={Title}
+      Actions={
+        <Widget.WidgetToolbar>
+          <Widget.WidgetDescription description={cardHelp} />
+        </Widget.WidgetToolbar>
+      }
+      Visualization={
+        <BigNumberWidgetVisualization
+          value={currentReleases?.length}
+          previousPeriodValue={previousReleases?.length}
+          field="count()"
+          maximumValue={API_LIMIT}
+          meta={{
+            fields: {
+              'count()': 'number',
+            },
+            units: {},
+          }}
+          preferredPolarity="+"
+        />
+      }
     />
   );
 }


### PR DESCRIPTION
Part of the recent overall migration away from all-in-one widgets. `BigNumberWidget` is deprecated, instead we want people to compose their Big Numbers from `Widget` and `BigNumberWidgetVisualization`. This PR makes this change for Project Details page.

This includes a small handful of subtle changes, like hiding the description tooltip if the widget is in an error state.
