### PR TITLE
fix(issue-views): Fix views jumping after scroll and page navigation

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -130,6 +130,9 @@ export function IssueViewNavItemContent({
         setIsDragging(false);
         endInteraction();
       }}
+      style={{
+        originY: '0px',
+      }}
     >
       <StyledSecondaryNavItem
         to={constructViewLink(baseUrl, view)}


### PR DESCRIPTION
Fixes an animation bug where views would jump from the bottom of the page to the correct positions when you scrolled down and triggered a page navigation (e.g. by scrolling down on issue details and clicking a trace connected issue, or scrolling down the issue stream clicking next page).

Referenced framer motion issue number 1972 (removed link to avoid spam in the issue thread) 