### PR TITLE
feat(traces): Add schema hints list UI

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -37,7 +37,7 @@ interface SpanSearchQueryBuilderProps {
   projects?: PageFilters['projects'];
 }
 
-const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
+export const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
   if (!supportedAggregates?.length) {
     return {};
   }

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -1,0 +1,82 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {getHasTag} from 'sentry/components/events/searchBar';
+import {getFunctionTags} from 'sentry/components/performance/spanSearchQueryBuilder';
+import {space} from 'sentry/styles/space';
+import type {TagCollection} from 'sentry/types/group';
+import type {AggregationKey} from 'sentry/utils/fields';
+
+interface SchemaHintsListProps {
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+  supportedAggregates: AggregationKey[];
+}
+
+function SchemaHintsList({
+  supportedAggregates,
+  numberTags,
+  stringTags,
+}: SchemaHintsListProps) {
+  const functionTags = useMemo(() => {
+    return getFunctionTags(supportedAggregates);
+  }, [supportedAggregates]);
+
+  const filterTags: TagCollection = useMemo(() => {
+    const tags: TagCollection = {...functionTags, ...numberTags, ...stringTags};
+    tags.has = getHasTag({...stringTags});
+    return tags;
+  }, [numberTags, stringTags, functionTags]);
+
+  const filterTagsWithoutTagPrefix = useMemo(() => {
+    return Object.keys(filterTags)
+      .map(tag => filterTags[tag])
+      .filter(tag => !tag?.key.startsWith('tags['));
+  }, [filterTags]);
+
+  // only show 8 tags for now until we have a better way to decide to display them
+  const first8Tags = useMemo(() => {
+    return filterTagsWithoutTagPrefix.slice(0, 8);
+  }, [filterTagsWithoutTagPrefix]);
+
+  const tagHintsText = useMemo(() => {
+    return first8Tags.map(tag => `${tag?.key} is ...`);
+  }, [first8Tags]);
+
+  return (
+    <SchemaHintsContainer>
+      {tagHintsText.map(text => (
+        <SchemaHintOption key={text}>{text}</SchemaHintOption>
+      ))}
+    </SchemaHintsContainer>
+  );
+}
+
+export default SchemaHintsList;
+
+const SchemaHintsContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(1)};
+`;
+
+const SchemaHintOption = styled(Button)`
+  border: 1px solid ${p => p.theme.innerBorder};
+  border-radius: 4px;
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  display: flex;
+  padding: ${space(0.5)} ${space(1)};
+  align-content: center;
+  min-height: 0;
+  height: 24px;
+  flex-wrap: wrap;
+
+  /* Ensures that filters do not grow outside of the container */
+  min-width: 0;
+
+  &[aria-selected='true'] {
+    background-color: ${p => p.theme.gray100};
+  }
+`;

--- a/static/app/views/explore/components/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHintsList.tsx
@@ -29,16 +29,14 @@ function SchemaHintsList({
     return tags;
   }, [numberTags, stringTags, functionTags]);
 
-  const filterTagsWithoutTagPrefix = useMemo(() => {
-    return Object.keys(filterTags)
-      .map(tag => filterTags[tag])
-      .filter(tag => !tag?.key.startsWith('tags['));
+  const filterTagsList = useMemo(() => {
+    return Object.keys(filterTags).map(tag => filterTags[tag]);
   }, [filterTags]);
 
   // only show 8 tags for now until we have a better way to decide to display them
   const first8Tags = useMemo(() => {
-    return filterTagsWithoutTagPrefix.slice(0, 8);
-  }, [filterTagsWithoutTagPrefix]);
+    return filterTagsList.slice(0, 8);
+  }, [filterTagsList]);
 
   const tagHintsText = useMemo(() => {
     return first8Tags.map(tag => `${tag?.key} is ...`);

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -2,10 +2,39 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {FieldKind} from 'sentry/utils/fields';
+import * as spanTagsModule from 'sentry/views/explore/contexts/spanTagsContext';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
 
 jest.mock('sentry/utils/analytics');
+
+const mockStringTags: TagCollection = {
+  stringTag1: {
+    key: 'stringTag1',
+    kind: FieldKind.TAG,
+    name: 'stringTag1',
+  },
+  stringTag2: {
+    key: 'stringTag2',
+    kind: FieldKind.TAG,
+    name: 'stringTag2',
+  },
+};
+
+const mockNumberTags: TagCollection = {
+  numberTag1: {
+    key: 'numberTag1',
+    kind: FieldKind.MEASUREMENT,
+    name: 'numberTag1',
+  },
+  numberTag2: {
+    key: 'numberTag2',
+    kind: FieldKind.MEASUREMENT,
+    name: 'numberTag2',
+  },
+};
 
 describe('SpansTabContent', function () {
   const {organization, project, router} = initializeOrg({
@@ -115,5 +144,43 @@ describe('SpansTabContent', function () {
         result_mode: 'aggregates',
       })
     );
+  });
+
+  it('should show hints when the feature flag is enabled', function () {
+    jest.spyOn(spanTagsModule, 'useSpanTags').mockImplementation(type => {
+      switch (type) {
+        case 'number':
+          return mockNumberTags;
+        case 'string':
+          return mockStringTags;
+        default:
+          return {};
+      }
+    });
+
+    const {organization: schemaHintsOrganization} = initializeOrg({
+      organization: {
+        ...organization,
+        features: ['traces-schema-hints'],
+      },
+    });
+
+    render(
+      <SpansTabContent
+        defaultPeriod="7d"
+        maxPickableDays={7}
+        relativeOptions={{
+          '1h': 'Last hour',
+          '24h': 'Last 24 hours',
+          '7d': 'Last 7 days',
+        }}
+      />,
+      {disableRouterMocks: true, router, organization: schemaHintsOrganization}
+    );
+
+    expect(screen.getByText('stringTag1 is ...')).toBeInTheDocument();
+    expect(screen.getByText('stringTag2 is ...')).toBeInTheDocument();
+    expect(screen.getByText('numberTag1 is ...')).toBeInTheDocument();
+    expect(screen.getByText('numberTag2 is ...')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Adding in the UI list component for schema hints. It's been put behind the `traces-schema-hints` feature flag for those who want to test it. This PR is just to get the UI out there so I can build on top of it. I've done some hardcoding which i'm going to fix in the future. Here's a list of things I need to fix:

- displaying enough hints to fill up the bar
- add "See full list" option
- add implementation to the options

Here's what it looks like right now:

![image](https://github.com/user-attachments/assets/3cc930cf-e9ce-453b-9406-a19f61262ca2)
