### PR TITLE
feat(releases): Add buttons to finalize releases from the UI

### DIFF
--- a/static/app/views/releases/components/useFinalizeRelease.tsx
+++ b/static/app/views/releases/components/useFinalizeRelease.tsx
@@ -1,0 +1,32 @@
+import type {Release} from 'sentry/types/release';
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type TPayload = {dateReleased: string};
+type TData = unknown;
+type TError = unknown;
+type TVariables = [release: Release];
+type TContext = unknown;
+
+export default function useFinalizeRelease() {
+  const organization = useOrganization();
+  const api = useApi({
+    persistInFlight: false,
+  });
+
+  return useMutation<TData, TError, TVariables, TContext>({
+    mutationFn: ([release]) => {
+      const payload: TPayload = {
+        dateReleased: release.firstEvent ?? release.dateCreated,
+      };
+
+      return fetchMutation(api)([
+        'PUT',
+        `/organizations/${organization.slug}/releases/${release.version}/`,
+        {},
+        payload,
+      ]);
+    },
+  });
+}

--- a/static/app/views/releases/components/useFinalizeRelease.tsx
+++ b/static/app/views/releases/components/useFinalizeRelease.tsx
@@ -17,6 +17,12 @@ export default function useFinalizeRelease() {
 
   return useMutation<TData, TError, TVariables, TContext>({
     mutationFn: ([release]) => {
+      // It's likely that there will either be a) CI setup or b) people manually
+      // clicking. If people are manually clicking then we try `firstEvent` and
+      // fall back to `dateCreated` to preserve relative sort order between
+      // releases. This strategy allows users to manually bucket releases by
+      // finalized/un-finalized, if they want more precision then CI automation
+      // is a better approach.
       const payload: TPayload = {
         dateReleased: release.firstEvent ?? release.dateCreated,
       };

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -1,16 +1,25 @@
 import styled from '@emotion/styled';
+import moment from 'moment-timezone';
 
+import {Button} from 'sentry/components/button';
+import {Flex} from 'sentry/components/container/flex';
 import Count from 'sentry/components/count';
 import {DateTime} from 'sentry/components/dateTime';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
+import {Tooltip} from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
-import {t, tn} from 'sentry/locale';
+import {IconInfo} from 'sentry/icons/iconInfo';
+import {t, tct, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {ReleaseMeta, ReleaseWithHealth} from 'sentry/types/release';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+import useFinalizeRelease from 'sentry/views/releases/components/useFinalizeRelease';
 import {isVersionInfoSemver} from 'sentry/views/releases/utils';
 
 type Props = {
@@ -22,8 +31,15 @@ type Props = {
 function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
   const organization = useOrganization();
   const orgSlug = organization.slug;
-  const {version, versionInfo, dateCreated, firstEvent, lastEvent} = release;
+
+  const user = useUser();
+  const options = user ? user.options : null;
+
+  const {version, versionInfo, dateCreated, dateReleased, firstEvent, lastEvent} =
+    release;
   const {releaseFileCount, isArtifactBundle} = releaseMeta;
+
+  const finalizeRelease = useFinalizeRelease();
 
   return (
     <SidebarSection.Wrap>
@@ -33,6 +49,62 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
           <KeyValueTableRow
             keyName={t('Created')}
             value={<DateTime date={dateCreated} seconds={false} />}
+          />
+          <KeyValueTableRow
+            keyName={
+              <Flex gap={space(0.75)} align="center">
+                {t('Finalized')}
+                <Tooltip
+                  skipWrapper
+                  title={tct(
+                    'By default a release is created "unreleased". Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read More].',
+                    {
+                      br: <br />,
+                      code: <code />,
+                      docs: (
+                        <ExternalLink href="https://docs.sentry.io/cli/releases/#finalizing-releases" />
+                      ),
+                    }
+                  )}
+                >
+                  <IconInfo />
+                </Tooltip>
+              </Flex>
+            }
+            value={
+              dateReleased ? (
+                <DateTime date={dateReleased} seconds={false} />
+              ) : (
+                <Tooltip
+                  title={t(
+                    'Set release date to %s',
+                    moment
+                      .tz(
+                        release.firstEvent ?? release.dateCreated,
+                        options?.timezone ?? ''
+                      )
+                      .format(
+                        options?.clock24Hours
+                          ? 'MMMM D, YYYY HH:mm z'
+                          : 'MMMM D, YYYY h:mm A z'
+                      )
+                  )}
+                >
+                  <Button
+                    size="xs"
+                    onClick={() => {
+                      finalizeRelease.mutate([release], {
+                        onSettled() {
+                          window.location.reload();
+                        },
+                      });
+                    }}
+                  >
+                    {t('Finalize')}
+                  </Button>
+                </Tooltip>
+              )
+            }
           />
           <KeyValueTableRow
             keyName={t('Version')}

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -92,6 +92,7 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
                 >
                   <Button
                     size="xs"
+                    style={{marginRight: '-8px'}}
                     onClick={() => {
                       finalizeRelease.mutate([release], {
                         onSettled() {

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -57,7 +57,7 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
                 <Tooltip
                   skipWrapper
                   title={tct(
-                    'By default a release is created "unreleased".[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read More].',
+                    'By default a release is created "unreleased".[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read more].',
                     {
                       br: <br />,
                       code: <code />,

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -57,7 +57,7 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
                 <Tooltip
                   skipWrapper
                   title={tct(
-                    'By default a release is created "unreleased". Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read More].',
+                    'By default a release is created "unreleased".[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read More].',
                     {
                       br: <br />,
                       code: <code />,

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -3,22 +3,28 @@ import styled from '@emotion/styled';
 import color from 'color';
 import type {Location} from 'history';
 import partition from 'lodash/partition';
+import moment from 'moment-timezone';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
 import Collapsible from 'sentry/components/collapsible';
+import {Tag} from 'sentry/components/core/badge/tag';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
+import {IconCheckmark} from 'sentry/icons/iconCheckmark';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Release} from 'sentry/types/release';
+import {useUser} from 'sentry/utils/useUser';
+import useFinalizeRelease from 'sentry/views/releases/components/useFinalizeRelease';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import type {ReleasesDisplayOption} from '../releasesDisplayOptions';
@@ -71,6 +77,11 @@ function ReleaseCard({
   getHealthData,
   showReleaseAdoptionStages,
 }: Props) {
+  const user = useUser();
+  const options = user ? user.options : null;
+
+  const finalizeRelease = useFinalizeRelease();
+
   const {
     version,
     commitCount,
@@ -133,13 +144,78 @@ function ReleaseCard({
           )}
         </ReleaseInfoHeader>
         <ReleaseInfoSubheader>
-          {versionInfo?.package && (
-            <PackageName>
-              <TextOverflow ellipsisDirection="left">{versionInfo.package}</TextOverflow>
-            </PackageName>
-          )}
-          <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
-          {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
+          <ReleaseInfoSubheaderUpper>
+            <div>
+              <PackageName>
+                {versionInfo?.package && (
+                  <TextOverflow ellipsisDirection="left">
+                    {versionInfo.package}
+                  </TextOverflow>
+                )}
+              </PackageName>
+              <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
+              {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
+              &nbsp;
+            </div>
+            <FinalizeWrapper>
+              {release.dateReleased ? (
+                <Tooltip
+                  isHoverable
+                  title={tct('This release was finalized on [date]. [docs:Read More].', {
+                    date: moment
+                      .tz(release.dateReleased, options?.timezone ?? '')
+                      .format(
+                        options?.clock24Hours
+                          ? 'MMMM D, YYYY HH:mm z'
+                          : 'MMMM D, YYYY h:mm A z'
+                      ),
+                    docs: (
+                      <ExternalLink href="https://docs.sentry.io/cli/releases/#finalizing-releases" />
+                    ),
+                  })}
+                >
+                  <Tag type="success" icon={<IconCheckmark />} />
+                </Tooltip>
+              ) : (
+                <Tooltip
+                  isHoverable
+                  title={tct(
+                    'Set release date to [date].[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read More].',
+                    {
+                      date: moment
+                        .tz(
+                          release.firstEvent ?? release.dateCreated,
+                          options?.timezone ?? ''
+                        )
+                        .format(
+                          options?.clock24Hours
+                            ? 'MMMM D, YYYY HH:mm z'
+                            : 'MMMM D, YYYY h:mm A z'
+                        ),
+                      br: <br />,
+                      code: <code />,
+                      docs: (
+                        <ExternalLink href="https://docs.sentry.io/cli/releases/#finalizing-releases" />
+                      ),
+                    }
+                  )}
+                >
+                  <Button
+                    size="xs"
+                    onClick={() =>
+                      finalizeRelease.mutate([release], {
+                        onSettled() {
+                          window.location.reload();
+                        },
+                      })
+                    }
+                  >
+                    {t('Finalize')}
+                  </Button>
+                </Tooltip>
+              )}
+            </FinalizeWrapper>
+          </ReleaseInfoSubheaderUpper>
         </ReleaseInfoSubheader>
       </ReleaseInfo>
 
@@ -238,7 +314,10 @@ const StyledPanel = styled(Panel)<{reloading: number}>`
 
 const ReleaseInfo = styled('div')`
   padding: ${space(1.5)} ${space(2)};
-  flex-shrink: 0;
+  flex-shrink: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     border-right: 1px solid ${p => p.theme.border};
@@ -251,6 +330,22 @@ const ReleaseInfo = styled('div')`
 export const ReleaseInfoSubheader = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray400};
+  flex-grow: 1;
+`;
+
+const ReleaseInfoSubheaderUpper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  flex: initial;
+  flex-grow: 1;
+  height: 100%;
+`;
+const FinalizeWrapper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  flex: initial;
 `;
 
 export const PackageName = styled('div')`

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -180,7 +180,7 @@ function ReleaseCard({
                 <Tooltip
                   isHoverable
                   title={tct(
-                    'Set release date to [date].[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read More].',
+                    'Set release date to [date].[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read more].',
                     {
                       date: moment
                         .tz(

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -483,6 +483,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert "data" in response_data
             assert len(response_data["data"]) == 1
             assert response_data["data"][0]["id"] == replay2_id
+            link_header = response.headers["Link"]
+            assert 'rel="next"; results="true"' in link_header
 
             # Next page.
             response = self.get_success_response(
@@ -494,6 +496,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert "data" in response_data
             assert len(response_data["data"]) == 1
             assert response_data["data"][0]["id"] == replay1_id
+            link_header = response.headers["Link"]
+            assert 'rel="next"; results="false"' in link_header
 
             # Beyond pages.
             response = self.get_success_response(
@@ -505,6 +509,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             response_data = response.json()
             assert "data" in response_data
             assert len(response_data["data"]) == 0
+            link_header = response.headers["Link"]
+            assert 'rel="next"; results="false"' in link_header
 
     def test_get_replays_user_filters(self):
         """Test replays conform to the interchange format."""


### PR DESCRIPTION
Adds New "Finalize" button to the Releases List and Release Details pages.

| | List | Details |
| --- | --- | --- |
| Default | ![SCR-20250303-mnrn](https://github.com/user-attachments/assets/0525e138-249c-449f-89f1-5bed8431d428) | ![SCR-20250303-mnun](https://github.com/user-attachments/assets/5b0a14e0-875e-4328-ab29-bb3b2a2274f6) |
| Default (tooltip) | ![SCR-20250303-mnjk](https://github.com/user-attachments/assets/b56e3d3a-7e18-4c25-9b47-2e3385e6017b) | ![SCR-20250303-mwdh](https://github.com/user-attachments/assets/290f5e8a-53b6-48a0-be82-35cce3d6bc47) | 
| Finalized | ![SCR-20250303-jvxt](https://github.com/user-attachments/assets/025acc95-41c0-44b6-950d-53e290b4cefa) | ![SCR-20250303-jxcf](https://github.com/user-attachments/assets/c32e618e-a3bd-42b0-ad1a-74a22b05e0a7) |



Fixes https://github.com/getsentry/sentry/issues/85071