### PR TITLE
ref: add staff_permission_cls to replace StaffPermissionMixin

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -14,7 +14,7 @@ from rest_framework.request import Request
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
-from sentry.api.permissions import DemoSafePermission, StaffPermissionMixin
+from sentry.api.permissions import DemoSafePermission, staff_permission_cls
 from sentry.api.utils import get_date_range_from_params, is_member_disabled_from_limit
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
@@ -94,10 +94,9 @@ class OrganizationPermission(DemoSafePermission):
         return is_member_disabled_from_limit(request, organization)
 
 
-class OrganizationAndStaffPermission(StaffPermissionMixin, OrganizationPermission):
-    """Allows staff to to access organization endpoints."""
-
-    pass
+OrganizationAndStaffPermission = staff_permission_cls(
+    "OrganizationAndStaffPermission", OrganizationPermission
+)
 
 
 class OrganizationAuditPermission(OrganizationPermission):

--- a/src/sentry/api/bases/organizationmember.py
+++ b/src/sentry/api/bases/organizationmember.py
@@ -7,7 +7,7 @@ from rest_framework.fields import empty
 from rest_framework.request import Request
 
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import StaffPermissionMixin
+from sentry.api.permissions import staff_permission_cls
 from sentry.db.models.fields.bounded import BoundedAutoField
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
@@ -46,10 +46,7 @@ class MemberPermission(OrganizationPermission):
         return is_role_above_member or not organization.flags.disable_member_invite
 
 
-class MemberAndStaffPermission(StaffPermissionMixin, MemberPermission):
-    """Allows staff to access member endpoints."""
-
-    pass
+MemberAndStaffPermission = staff_permission_cls("MemberAndStaffPermission", MemberPermission)
 
 
 class MemberIdField(serializers.IntegerField):

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
-from sentry.api.permissions import StaffPermissionMixin
+from sentry.api.permissions import staff_permission_cls
 from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidParams
@@ -53,10 +53,7 @@ class ProjectPermission(OrganizationPermission):
         return request.access.has_any_project_scope(project, allowed_scopes)
 
 
-class ProjectAndStaffPermission(StaffPermissionMixin, ProjectPermission):
-    """Allows staff to access project endpoints."""
-
-    pass
+ProjectAndStaffPermission = staff_permission_cls("ProjectAndStaffPermission", ProjectPermission)
 
 
 class StrictProjectPermission(ProjectPermission):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -20,7 +20,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
-from sentry.api.permissions import StaffPermissionMixin
+from sentry.api.permissions import staff_permission_cls
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import DetailedProjectSerializer
 from sentry.api.serializers.rest_framework.list import EmptyListField
@@ -466,8 +466,9 @@ class RelaxedProjectPermission(ProjectPermission):
     }
 
 
-class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermission):
-    pass
+RelaxedProjectAndStaffPermission = staff_permission_cls(
+    "RelaxedProjectAndStaffPermission", RelaxedProjectPermission
+)
 
 
 @extend_schema(tags=["Projects"])

--- a/src/sentry/integrations/api/bases/doc_integrations.py
+++ b/src/sentry/integrations/api/bases/doc_integrations.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from sentry.api.base import Endpoint
-from sentry.api.permissions import SentryPermission, StaffPermissionMixin
+from sentry.api.permissions import SentryPermission, staff_permission_cls
 from sentry.auth.superuser import is_active_superuser
 from sentry.integrations.api.bases.integration import PARANOID_GET
 from sentry.integrations.api.parsers.doc_integration import METADATA_PROPERTIES
@@ -32,7 +32,7 @@ class DocIntegrationsPermission(SentryPermission):
             return False
 
         # TODO(schew2381): Remove superuser check once staff feature flag is rolled out.
-        # We want to allow staff through the StaffPermissionMixin instead of mixing logic here.
+        # We want to allow staff through the staff_permission_cls instead of mixing logic here.
         if is_active_superuser(request) or request.method == "GET":
             return True
 
@@ -45,7 +45,7 @@ class DocIntegrationsPermission(SentryPermission):
             return False
 
         # TODO(schew2381): Remove superuser check once staff feature flag is rolled out.
-        # We want to allow staff through the StaffPermissionMixin instead of mixing logic here.
+        # We want to allow staff through the staff_permission_cls instead of mixing logic here.
         if is_active_superuser(request):
             return True
 
@@ -55,10 +55,9 @@ class DocIntegrationsPermission(SentryPermission):
         return False
 
 
-class DocIntegrationsAndStaffPermission(StaffPermissionMixin, DocIntegrationsPermission):
-    """Allows staff to to access doc integration endpoints."""
-
-    pass
+DocIntegrationsAndStaffPermission = staff_permission_cls(
+    "DocIntegrationsAndStaffPermission", DocIntegrationsPermission
+)
 
 
 class DocIntegrationsBaseEndpoint(Endpoint):

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 
 from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint
-from sentry.api.permissions import SentryPermission, StaffPermissionMixin
+from sentry.api.permissions import SentryPermission, staff_permission_cls
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser, superuser_has_permission
 from sentry.coreapi import APIError
@@ -100,10 +100,9 @@ class SentryAppsPermission(SentryPermission):
         return ensure_scoped_permission(request, self.scope_map.get(request.method))
 
 
-class SentryAppsAndStaffPermission(StaffPermissionMixin, SentryAppsPermission):
-    """Allows staff to access the GET method of sentry apps endpoints."""
-
-    staff_allowed_methods = {"GET"}
+SentryAppsAndStaffPermission = staff_permission_cls(
+    "SentryAppsAndStaffPermission", SentryAppsPermission, staff_allowed_methods=frozenset(("GET",))
+)
 
 
 class IntegrationPlatformEndpoint(Endpoint):
@@ -274,11 +273,9 @@ class SentryAppPermission(SentryPermission):
             return self.unpublished_scope_map
 
 
-class SentryAppAndStaffPermission(StaffPermissionMixin, SentryAppPermission):
-    """Allows staff to access sentry app endpoints. Note that this is used for
-    endpoints acting on a single sentry app only."""
-
-    pass
+SentryAppAndStaffPermission = staff_permission_cls(
+    "SentryAppAndStaffPermission", SentryAppPermission
+)
 
 
 class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -12,6 +12,7 @@ from sentry import analytics, audit_log, deletions, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
+from sentry.api.permissions import staff_permission_cls
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NO_CONTENT
 from sentry.apidocs.examples.sentry_app_examples import SentryAppExamples
@@ -21,8 +22,8 @@ from sentry.auth.staff import is_active_staff
 from sentry.constants import SentryAppStatus
 from sentry.organizations.services.organization import organization_service
 from sentry.sentry_apps.api.bases.sentryapps import (
-    SentryAppAndStaffPermission,
     SentryAppBaseEndpoint,
+    SentryAppPermission,
     catch_raised_errors,
 )
 from sentry.sentry_apps.api.parsers.sentry_app import SentryAppParser
@@ -41,11 +42,11 @@ from sentry.utils.audit import create_audit_entry
 logger = logging.getLogger(__name__)
 PARTNERSHIP_RESTRICTED_ERROR_MESSAGE = "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
 
-
-class SentryAppDetailsEndpointPermission(SentryAppAndStaffPermission):
-    """Allows staff to access the GET and PUT methods which are used in _admin."""
-
-    staff_allowed_methods = {"GET", "PUT"}
+SentryAppDetailsEndpointPermission = staff_permission_cls(
+    "SentryAppDetailsEndpointPermission",
+    SentryAppPermission,
+    staff_allowed_methods=frozenset(("GET", "PUT")),
+)
 
 
 @extend_schema(tags=["Integration"])

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -24,6 +24,7 @@ from sentry.api.exceptions import (
     SuperuserRequired,
     TwoFactorRequired,
 )
+from sentry.api.permissions import SentryPermission
 from sentry.api.utils import MAX_STATS_PERIOD
 from sentry.auth.access import NoAccess, from_request
 from sentry.auth.authenticators.totp import TotpInterface
@@ -53,7 +54,7 @@ class PermissionBaseTestCase(TestCase):
     def setUp(self):
         self.org = self.create_organization()
         # default to the organization permission class
-        self.permission_cls = OrganizationPermission
+        self.permission_cls: type[SentryPermission] = OrganizationPermission
         super().setUp()
 
     def has_object_perm(

--- a/tests/sentry/api/bases/test_organizationmember.py
+++ b/tests/sentry/api/bases/test_organizationmember.py
@@ -1,11 +1,12 @@
 from sentry.api.bases.organizationmember import MemberAndStaffPermission, MemberPermission
+from sentry.api.permissions import SentryPermission
 from tests.sentry.api.bases.test_organization import PermissionBaseTestCase
 
 
 class MemberPermissionTest(PermissionBaseTestCase):
     def setUp(self):
         super().setUp()
-        self.permission_cls = MemberPermission
+        self.permission_cls: type[SentryPermission] = MemberPermission
 
     def test_user_not_in_org(self):
         random_user = self.create_user()

--- a/tests/sentry/api/bases/test_project.py
+++ b/tests/sentry/api/bases/test_project.py
@@ -1,6 +1,7 @@
 from rest_framework.views import APIView
 
 from sentry.api.bases.project import ProjectAndStaffPermission, ProjectPermission
+from sentry.api.permissions import SentryPermission
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.requests import drf_request_from_request
@@ -10,7 +11,7 @@ from sentry.users.services.user.serial import serialize_rpc_user
 class ProjectPermissionBase(TestCase):
     def setUp(self):
         super().setUp()
-        self.permission_cls = ProjectPermission
+        self.permission_cls: type[SentryPermission] = ProjectPermission
 
     def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None, is_staff=None):
         perm = self.permission_cls()


### PR DESCRIPTION
the mixin requires strange base class ordering and isn't sound from a typing perspective.  this replaces it with a function which returns a composition-based class

I will follow up with `getsentry` and then removing the old mixin

<!-- Describe your PR here. -->