### PR TITLE
fix(replay): Remove extra border & padding from replay snippets

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import {Button, LinkButton, type LinkButtonProps} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Panel from 'sentry/components/panels/panel';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayCurrentScreen from 'sentry/components/replays/replayCurrentScreen';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
@@ -32,7 +31,7 @@ import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
-function ReplayPreviewPlayer({
+export default function ReplayPreviewPlayer({
   replayId,
   fullReplayButtonProps,
   replayRecord,
@@ -167,9 +166,7 @@ function ReplayPreviewPlayer({
   );
 }
 
-const PlayerPanel = styled(Panel)`
-  padding: ${space(3)} ${space(3)} ${space(1.5)};
-  margin: 0;
+const PlayerPanel = styled('div')`
   display: flex;
   gap: ${space(1)};
   flex-direction: column;
@@ -241,5 +238,3 @@ const HeaderWrapper = styled('div')`
   align-items: center;
   margin-bottom: ${space(1)};
 `;
-
-export default ReplayPreviewPlayer;


### PR DESCRIPTION
This removes the border and extra padding around the Replay "Snippet" preview player. The component is used in a few spots, but the border just adds noise to the page.

| | Before | After |
| --- | --- | --- |
| Issues | ![replay-snippet-border-issue-before](https://github.com/user-attachments/assets/057ab7d5-7847-4c74-9a01-a444850789e8) | ![replay-snippet-border-issue-after](https://github.com/user-attachments/assets/53620047-3dd7-4bd2-a332-ad07cdbf1331) |
| Trace View | ![replay-snippet-border-trace-before](https://github.com/user-attachments/assets/aa7c8189-b926-4590-9a54-dfabcbd331f8) | ![replay-snippet-border-trace-after](https://github.com/user-attachments/assets/8c45c4b7-11e2-425d-af86-453ab1703b65) |
| Feedback | ![replay-snippet-border-feedback-before](https://github.com/user-attachments/assets/81afde84-e37d-402b-adff-72531a9a1d0d) | ![replay-snippet-border-feedback-after](https://github.com/user-attachments/assets/e8689558-09ce-453e-ad58-62aaea3217cb) |
