### PR TITLE
ref(flags): fix audit log table badge style

### DIFF
--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
@@ -91,7 +91,11 @@ export function OrganizationFeatureFlagsAuditLogTable({
               : undefined;
         const capitalized =
           dataRow.action.charAt(0).toUpperCase() + dataRow.action.slice(1);
-        return <Tag type={type}>{capitalized}</Tag>;
+        return (
+          <Tag type={type} style={{alignSelf: 'flex-start'}}>
+            {capitalized}
+          </Tag>
+        );
       }
       default:
         return dataRow[column.key!];

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsAuditLogTable.tsx
@@ -92,9 +92,9 @@ export function OrganizationFeatureFlagsAuditLogTable({
         const capitalized =
           dataRow.action.charAt(0).toUpperCase() + dataRow.action.slice(1);
         return (
-          <Tag type={type} style={{alignSelf: 'flex-start'}}>
-            {capitalized}
-          </Tag>
+          <div style={{alignSelf: 'flex-start'}}>
+            <Tag type={type}>{capitalized}</Tag>
+          </div>
         );
       }
       default:


### PR DESCRIPTION
Before
![Screenshot 2025-03-03 at 11 44 15 AM](https://github.com/user-attachments/assets/96e5e216-3493-49e6-a0b2-947a6b486c23)

After
![Screenshot 2025-03-03 at 11 44 30 AM](https://github.com/user-attachments/assets/9e0327a1-d03f-4161-bca0-acbd44a77a22)
