### PR TITLE
fix(usefeedbackform): Prevent loss of feedback when form is closed

### DIFF
--- a/static/app/utils/useFeedbackForm.spec.tsx
+++ b/static/app/utils/useFeedbackForm.spec.tsx
@@ -46,7 +46,34 @@ describe('useFeedbackForm', function () {
     expect(mockForm.open).toHaveBeenCalledTimes(1);
   });
 
-  it('uses a new form instance each time', async function () {
+  it('reuses the old form instance if same options are provided', async function () {
+    const {result} = renderHook(useFeedbackForm, {wrapper: GlobalFeedbackForm});
+    const openForm = result.current;
+
+    await openForm!({formTitle: 'foo'});
+    expect(mockFeedback.createForm).toHaveBeenLastCalledWith(
+      expect.objectContaining({...defaultOptions, formTitle: 'foo'})
+    );
+
+    expect(mockForm.removeFromDom).not.toHaveBeenCalled();
+
+    await openForm!({formTitle: 'foo'});
+    expect(mockFeedback.createForm).toHaveBeenLastCalledWith(
+      expect.objectContaining({...defaultOptions, formTitle: 'foo'})
+    );
+
+    // Should not be removed from DOM
+    expect(mockForm.removeFromDom).toHaveBeenCalledTimes(0);
+
+    // Should only have been created once
+    expect(mockFeedback.createForm).toHaveBeenCalledTimes(1);
+    expect(mockForm.appendToDom).toHaveBeenCalledTimes(1);
+
+    // Should have been opened twice
+    expect(mockForm.open).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates a new form instance if different options are provided', async function () {
     const {result} = renderHook(useFeedbackForm, {wrapper: GlobalFeedbackForm});
     const openForm = result.current;
 


### PR DESCRIPTION
Currently using `openForm()` from `useFeedbackForm()` will destroy the DOM element when the form is closed, losing any in-progress feedback the user was writing. Now it waits to destroy the old element until it sees different form options. So if you close a feedback and reopen it, nothing will be lost.