### PR TITLE
fix(grouping): Stop overwriting newer grouping config in grouphash metadata

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import random
+from datetime import datetime
 from typing import Any, TypeIs, cast
 
 from sentry import features, options
@@ -565,3 +566,28 @@ def check_grouphashes_for_positive_fingerprint_match(
         return False
 
     return fingerprint1 == fingerprint2
+
+
+def _is_incoming_config_newer_than_current_latest(
+    incoming_config: str | None, latest_config: str | None
+) -> bool:
+    # Handle records created before we were storing config
+    if latest_config is None:
+        return True
+    # This shouldn't happen, but just in case
+    if incoming_config is None:
+        return False
+
+    def _extract_date(config_id: str) -> datetime:
+        date_str = config_id.split(":")[1]
+        return datetime.fromisoformat(date_str)
+
+    try:
+        return _extract_date(incoming_config) > _extract_date(latest_config)
+    except Exception:
+        logger.exception(
+            "Unable to compare grouping config dates from configs '%s' and '%s'",
+            incoming_config,
+            latest_config,
+        )
+        return False

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -172,11 +172,12 @@ def create_or_update_grouphash_metadata_if_needed(
 
         # Keep track of the most recent config which computed this hash, so that once a config is
         # deprecated, we can clear out the GroupHash records which are no longer being produced
-        if grouphash.metadata.latest_grouping_config != grouping_config:
+        current_latest_config = grouphash.metadata.latest_grouping_config
+        if _is_incoming_config_newer_than_current_latest(grouping_config, current_latest_config):
             updated_data = {"latest_grouping_config": grouping_config}
             db_hit_metadata = {
                 "reason": "old_grouping_config",
-                "current_config": grouphash.metadata.latest_grouping_config,
+                "current_config": current_latest_config,
                 "new_config": grouping_config,
             }
 

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -4,6 +4,8 @@ from time import time
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
+from sentry.eventstore.models import Event
+from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GROUPHASH_METADATA_SCHEMA_VERSION, HashBasis
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
@@ -369,3 +371,70 @@ class GroupHashMetadataTest(TestCase):
                     "new_version": "12",
                 },
             )
+
+    @with_feature("organizations:grouphash-metadata-creation")
+    @override_options({"grouping.grouphash_metadata.backfill_sample_rate": 1.0})
+    @patch("sentry.grouping.ingest.grouphash_metadata.metrics.incr")
+    def test_grouping_config_update_precedence(self, mock_metrics_incr: MagicMock):
+        """
+        Test that we don't overwrite a newer config with an older one, or with None.
+        """
+
+        oldest_config = "charliestyle:2012-11-21"
+        older_config = "maiseystyle:2012-12-31"
+        new_config = "adoptdontshopstyle:2013-09-08"
+
+        event = Event(
+            event_id="12312012041520130908201311212012",
+            project_id=self.project.id,
+            data={"message": "Dogs are great!"},
+        )
+
+        grouphash = GroupHash.objects.create(project_id=self.project.id, hash="20130415")
+        create_or_update_grouphash_metadata_if_needed(event, self.project, grouphash, False, "", {})
+        assert grouphash.metadata
+
+        for (
+            current_latest_config,
+            incoming_grouping_config,
+            expected_end_value,
+            should_expect_metrics_call,  # True whenever config has been updated
+        ) in [
+            (None, oldest_config, oldest_config, True),
+            (None, older_config, older_config, True),
+            (None, new_config, new_config, True),
+            (oldest_config, None, oldest_config, False),
+            (oldest_config, older_config, older_config, True),
+            (oldest_config, new_config, new_config, True),
+            (older_config, None, older_config, False),
+            (older_config, oldest_config, older_config, False),
+            (older_config, new_config, new_config, True),
+            (new_config, None, new_config, False),
+            (new_config, oldest_config, new_config, False),
+            (new_config, older_config, new_config, False),
+        ]:
+            # Set initial state
+            grouphash.metadata.update(latest_grouping_config=current_latest_config)
+            assert grouphash.metadata.latest_grouping_config == current_latest_config
+
+            create_or_update_grouphash_metadata_if_needed(
+                event,
+                self.project,
+                grouphash,
+                False,
+                incoming_grouping_config,  # type: ignore[arg-type] # intentionally bad data
+                {},
+            )
+            assert grouphash.metadata.latest_grouping_config == expected_end_value
+
+            if should_expect_metrics_call:
+                mock_metrics_incr.assert_any_call(
+                    "grouping.grouphash_metadata.db_hit",
+                    tags={
+                        "reason": "old_grouping_config",
+                        "current_config": current_latest_config,
+                        "new_config": expected_end_value,
+                    },
+                )
+
+            mock_metrics_incr.reset_mock()


### PR DESCRIPTION
When making a graph in DD for the `grouping.grouphash_metadata.db_hit` metric, I noticed that we were seeing instances of "updating" the `latest_grouping_config` field in grouphash metadata from the current default (`newstyle:2023-01-11`) to older configs, which isn't how it was supposed to work. What's happening is that secondary grouping is using an older config, and because our test is just "is this config different from the one that's already there?", we've been overwriting the newer config with the older one.

To fix this, this PR introduces a function to compare the dates in the two config names, and makes it so that we only update `latest_grouping_config` if the incoming config is newer than the one that's already there.