### PR TITLE
ref(search): improve confusing `span.action` tooltip

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1180,7 +1180,7 @@ export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   /** Indexed Fields */
   [SpanIndexedField.SPAN_ACTION]: {
     desc: t(
-      "The type of span action, e.g `SELECT` for a SQL span or `POST` for an HTTP client span. Primarily for use with Sentry's Insights modules"
+      'The Sentry Insights span action, e.g `SELECT` for a SQL span or `POST` for an HTTP client span'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1180,7 +1180,7 @@ export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   /** Indexed Fields */
   [SpanIndexedField.SPAN_ACTION]: {
     desc: t(
-      'The type of span action, e.g `SELECT` for a SQL span or `POST` for an HTTP span'
+      "The type of span action, e.g `SELECT` for a SQL span or `POST` for an HTTP client span. Primarily for use with Sentry's Insights modules"
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,


### PR DESCRIPTION
The current span.action tooltip is a little confusing/misleading. It wasn't clear that this does not apply to http.server spans for example (it only applies to http.client spans). And that's intended: this field is really there to power Insights and nothing else. I think we should be explicit about that so that users don't use it in dashboards, etc and then get surprised when it suddenly changes (due to an insights feature change).

Specify that it only applies to HTTP _client_ spans and that its main use is Insights.

Fixes #86229.