### PR TITLE
fix(trace): Ignore project param

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_trace.py
+++ b/src/sentry/api/endpoints/organization_spans_trace.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 import sentry_sdk
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,6 +13,8 @@ from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
 from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
@@ -38,6 +40,28 @@ class OrganizationSpansTraceEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
+
+    def get_projects(
+        self,
+        request: HttpRequest,
+        organization: Organization | RpcOrganization,
+        force_global_perms: bool = False,
+        include_all_accessible: bool = False,
+        project_ids: set[int] | None = None,
+        project_slugs: set[str] | None = None,
+    ) -> list[Project]:
+        """The trace endpoint always wants to get all projects regardless of what's passed into the API
+
+        This is because a trace can span any number of projects in an organization. But we still want to
+        use the get_projects function to check for any permissions. So we'll just pass project_ids=-1 everytime
+        which is what would be sent if we wanted all projects"""
+        return super().get_projects(
+            request,
+            organization,
+            project_ids={-1},
+            project_slugs=None,
+            include_all_accessible=True,
+        )
 
     def serialize_rpc_span(self, span: dict[str, Any]) -> SerializedEvent:
         return SerializedEvent(

--- a/tests/snuba/api/endpoints/test_organization_spans_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_trace.py
@@ -93,7 +93,19 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         self.load_trace(is_eap=True)
         with self.feature(self.FEATURES):
             response = self.client_get(
-                data={"project": -1},
+                data={},
+            )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 1
+        self.assert_trace_data(data[0])
+
+    def test_ignore_project_param(self):
+        self.load_trace(is_eap=True)
+        with self.feature(self.FEATURES):
+            # The trace endpoint should ignore the project param
+            response = self.client_get(
+                data={"project": self.project.id},
             )
         assert response.status_code == 200, response.content
         data = response.data


### PR DESCRIPTION
- This ignores the project param on the trace endpoint since we always want to return the entire trace