### PR TITLE
chore(aci): success logs for issue alert dual write

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -380,10 +380,11 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 "organizations:workflow-engine-issue-alert-dual-write", project.organization
             ):
                 workflow_id = delete_migrated_issue_alert(rule)
-                logger.info(
-                    "workflow_engine.issue_alert.deleted",
-                    extra={"rule_id": rule_id, "workflow_id": workflow_id},
-                )
+                if workflow_id:
+                    logger.info(
+                        "workflow_engine.issue_alert.deleted",
+                        extra={"rule_id": rule_id, "workflow_id": workflow_id},
+                    )
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -366,6 +366,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
+        rule_id = rule.id
         rule.update(status=ObjectStatus.PENDING_DELETION)
         RuleActivity.objects.create(
             rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
@@ -375,7 +376,11 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         if features.has(
             "organizations:workflow-engine-issue-alert-dual-write", project.organization
         ):
-            delete_migrated_issue_alert(rule)
+            workflow_id = delete_migrated_issue_alert(rule)
+            logger.info(
+                "workflow_engine.issue_alert.deleted",
+                extra={"rule_id": rule_id, "workflow_id": workflow_id},
+            )
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -48,10 +48,11 @@ class ProjectRuleUpdater:
             ):
                 # uncaught errors will rollback the transaction
                 workflow = update_migrated_issue_alert(self.rule)
-                logger.info(
-                    "workflow_engine.issue_alert.updated",
-                    extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
-                )
+                if workflow:
+                    logger.info(
+                        "workflow_engine.issue_alert.updated",
+                        extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
+                    )
             return self.rule
 
     def _update_name(self) -> None:

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 
 from attr import dataclass
@@ -11,6 +12,8 @@ from sentry.types.actor import Actor
 from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
     update_migrated_issue_alert,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -43,8 +46,12 @@ class ProjectRuleUpdater:
             if features.has(
                 "organizations:workflow-engine-issue-alert-dual-write", self.project.organization
             ):
-                # TODO(cathy): handle errors from broken actions
-                update_migrated_issue_alert(self.rule)
+                # uncaught errors will rollback the transaction
+                workflow = update_migrated_issue_alert(self.rule)
+                logger.info(
+                    "workflow_engine.issue_alert.updated",
+                    extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
+                )
             return self.rule
 
     def _update_name(self) -> None:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -82,7 +82,7 @@ def create_workflow_actions(if_dcg: DataConditionGroup, actions: list[dict[str, 
     DataConditionGroupAction.objects.bulk_create(dcg_actions)
 
 
-def update_migrated_issue_alert(rule: Rule):
+def update_migrated_issue_alert(rule: Rule) -> Workflow:
     data = rule.data
 
     try:
@@ -146,6 +146,8 @@ def update_migrated_issue_alert(rule: Rule):
     workflow.enabled = True
     workflow.save()
 
+    return workflow
+
 
 def update_dcg(
     dcg: DataConditionGroup,
@@ -175,7 +177,7 @@ def update_dcg(
     return dcg
 
 
-def delete_migrated_issue_alert(rule: Rule):
+def delete_migrated_issue_alert(rule: Rule) -> int:
     try:
         alert_rule_workflow = AlertRuleWorkflow.objects.get(rule=rule)
     except AlertRuleWorkflow.DoesNotExist:
@@ -183,6 +185,7 @@ def delete_migrated_issue_alert(rule: Rule):
         return
 
     workflow: Workflow = alert_rule_workflow.workflow
+    workflow_id = workflow.id
 
     try:
         # delete all associated IF DCGs and their conditions
@@ -209,6 +212,8 @@ def delete_migrated_issue_alert(rule: Rule):
 
     workflow.delete()
     alert_rule_workflow.delete()
+
+    return workflow_id
 
 
 def delete_workflow_actions(if_dcg: DataConditionGroup):

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -197,25 +197,16 @@ def delete_migrated_issue_alert(rule: Rule) -> int | None:
     workflow: Workflow = alert_rule_workflow.workflow
     workflow_id = workflow.id
 
-    try:
-        # delete all associated IF DCGs and their conditions
-        workflow_dcgs = WorkflowDataConditionGroup.objects.filter(workflow=workflow)
-        for workflow_dcg in workflow_dcgs:
-            if_dcg = workflow_dcg.condition_group
-            if_dcg.conditions.all().delete()
-            delete_workflow_actions(if_dcg=if_dcg)
-            if_dcg.delete()
-
-    except WorkflowDataConditionGroup.DoesNotExist:
-        logger.exception(
-            "workflow_engine.issue_alert.deleted.error",
-            extra={
-                "workflow_id": workflow.id,
-                "error": "WorkflowDataConditionGroup does not exist",
-            },
-        )
+    # delete all associated IF DCGs and their conditions
+    workflow_dcgs = WorkflowDataConditionGroup.objects.filter(workflow=workflow)
+    for workflow_dcg in workflow_dcgs:
+        if_dcg = workflow_dcg.condition_group
+        if_dcg.conditions.all().delete()
+        delete_workflow_actions(if_dcg=if_dcg)
+        if_dcg.delete()
 
     if not workflow.when_condition_group:
+        # OK, this shouldn't happen but should not prevent deletion
         logger.error(
             "workflow_engine.issue_alert.deleted.error",
             extra={

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -71,6 +71,8 @@ class IssueAlertMigrator:
         if self.should_create_actions:
             self._create_workflow_actions(if_dcg=if_dcg, actions=self.data["actions"])
 
+        return workflow
+
     def _create_detector_lookup(self) -> Detector:
         if self.is_dry_run:
             created = True

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -51,7 +51,7 @@ class IssueAlertMigrator:
         self.project = rule.project
         self.organization = self.project.organization
 
-    def run(self) -> None:
+    def run(self) -> Workflow:
         error_detector = self._create_detector_lookup()
         conditions, filters = split_conditions_and_filters(self.data["conditions"])
         action_match = self.data.get("action_match") or Rule.DEFAULT_CONDITION_MATCH

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1703,6 +1703,32 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not DataCondition.objects.filter(condition_group=when_dcg).exists()
         assert not DataCondition.objects.filter(condition_group=if_dcg).exists()
 
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    @patch("sentry.api.endpoints.project_rule_details.delete_migrated_issue_alert")
+    def test_dual_delete_workflow_engine__fail(self, mock_delete):
+        rule = self.create_project_rule(
+            self.project,
+            condition_data=[
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "name": "A new issue is created",
+                },
+                {
+                    "id": "sentry.rules.filters.latest_release.LatestReleaseFilter",
+                    "name": "The event occurs",
+                },
+            ],
+        )
+        IssueAlertMigrator(rule, user_id=self.user.id).run()
+
+        mock_delete.side_effect = Exception("oh no")
+
+        # failed workflow engine deletion should stop the rule from being deleted
+        self.get_error_response(self.organization.slug, rule.project.slug, rule.id, status_code=500)
+
+        rule.refresh_from_db()
+        assert rule
+
     def test_dual_delete_workflow_engine_no_migrated_models(self):
         rule = self.create_project_rule(self.project)
         self.get_success_response(


### PR DESCRIPTION
Add success logs to track the status of dual writing issue alerts to workflow engine. Exceptions will be bubbled up and should return 500s and rollback the transactions of creating / updating issue alerts.