### PR TITLE
feat(shared-views): Add endpoint to update view's last seen

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -176,6 +176,7 @@ from sentry.issues.endpoints import (
     OrganizationGroupIndexStatsEndpoint,
     OrganizationGroupSearchViewDetailsEndpoint,
     OrganizationGroupSearchViewsEndpoint,
+    OrganizationGroupSearchViewVisitEndpoint,
     OrganizationIssuesCountEndpoint,
     OrganizationReleasePreviousCommitsEndpoint,
     OrganizationSearchesEndpoint,
@@ -1734,6 +1735,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/$",
         OrganizationGroupSearchViewDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-view-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/(?P<view_id>[^\/]+)/visit/$",
+        OrganizationGroupSearchViewVisitEndpoint.as_view(),
+        name="sentry-api-0-organization-group-search-view-visit",
     ),
     # Pinned and saved search
     re_path(

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -16,6 +16,7 @@ from .organization_eventid import EventIdLookupEndpoint
 from .organization_group_index import OrganizationGroupIndexEndpoint
 from .organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
 from .organization_group_search_view_details import OrganizationGroupSearchViewDetailsEndpoint
+from .organization_group_search_view_visit import OrganizationGroupSearchViewVisitEndpoint
 from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
 from .organization_issues_count import OrganizationIssuesCountEndpoint
 from .organization_release_previous_commits import OrganizationReleasePreviousCommitsEndpoint
@@ -52,6 +53,7 @@ __all__ = (
     "OrganizationGroupIndexStatsEndpoint",
     "OrganizationGroupSearchViewsEndpoint",
     "OrganizationGroupSearchViewDetailsEndpoint",
+    "OrganizationGroupSearchViewVisitEndpoint",
     "OrganizationIssuesCountEndpoint",
     "OrganizationReleasePreviousCommitsEndpoint",
     "OrganizationSearchesEndpoint",

--- a/src/sentry/issues/endpoints/organization_group_search_view_visit.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_visit.py
@@ -9,7 +9,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.groupsearchview import GroupSearchView
-from sentry.models.groupsearchviewlastseen import GroupSearchViewLastSeen
+from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.models.organization import Organization
 
 
@@ -42,11 +42,11 @@ class OrganizationGroupSearchViewVisitEndpoint(OrganizationEndpoint):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         # Create or update the last_seen timestamp
-        GroupSearchViewLastSeen.objects.create_or_update(
+        GroupSearchViewLastVisited.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,
             group_search_view=view,
-            values={"last_seen": timezone.now()},
+            values={"last_visited": timezone.now()},
         )
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/issues/endpoints/organization_group_search_view_visit.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_visit.py
@@ -1,0 +1,52 @@
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.groupsearchviewlastseen import GroupSearchViewLastSeen
+from sentry.models.organization import Organization
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["member:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationGroupSearchViewVisitEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def post(self, request: Request, organization: Organization, view_id: str) -> Response:
+        """
+        Update the last_seen timestamp for a GroupSearchView for the current organization member.
+        """
+        if not features.has(
+            "organizations:issue-stream-custom-views", organization, actor=request.user
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            view = GroupSearchView.objects.get(id=view_id, organization=organization)
+        except GroupSearchView.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        # Create or update the last_seen timestamp
+        GroupSearchViewLastSeen.objects.create_or_update(
+            organization=organization,
+            user_id=request.user.id,
+            group_search_view=view,
+            values={"last_seen": timezone.now()},
+        )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/issues/endpoints/organization_group_search_view_visit.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_visit.py
@@ -22,14 +22,14 @@ class MemberPermission(OrganizationPermission):
 @region_silo_endpoint
 class OrganizationGroupSearchViewVisitEndpoint(OrganizationEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (MemberPermission,)
 
     def post(self, request: Request, organization: Organization, view_id: str) -> Response:
         """
-        Update the last_seen timestamp for a GroupSearchView for the current organization member.
+        Update the last_visited timestamp for a GroupSearchView for the current organization member.
         """
         if not features.has(
             "organizations:issue-stream-custom-views", organization, actor=request.user
@@ -41,7 +41,7 @@ class OrganizationGroupSearchViewVisitEndpoint(OrganizationEndpoint):
         except GroupSearchView.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        # Create or update the last_seen timestamp
+        # Create or update the last_visited timestamp
         GroupSearchViewLastVisited.objects.create_or_update(
             organization=organization,
             user_id=request.user.id,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from django.utils import timezone
 
-from sentry.models.groupsearchviewlastseen import GroupSearchViewLastSeen
+from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
@@ -27,7 +27,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_update_last_seen_success(self) -> None:
         assert (
-            GroupSearchViewLastSeen.objects.filter(
+            GroupSearchViewLastVisited.objects.filter(
                 organization=self.organization,
                 user_id=self.user.id,
                 group_search_view=self.view,
@@ -39,7 +39,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         assert response.status_code == 204
 
         # Verify the last_seen record was created
-        last_seen = GroupSearchViewLastSeen.objects.get(
+        last_seen = GroupSearchViewLastVisited.objects.get(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=self.view,
@@ -51,7 +51,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
     def test_update_existing_last_seen(self) -> None:
         # Create an initial last_seen record with an old timestamp
         with freeze_time("2025-02-03 14:52:37"):
-            GroupSearchViewLastSeen.objects.create(
+            GroupSearchViewLastVisited.objects.create(
                 organization=self.organization,
                 user_id=self.user.id,
                 group_search_view=self.view,
@@ -63,7 +63,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         assert response.status_code == 204
 
         # Verify the last_seen record was updated
-        last_seen = GroupSearchViewLastSeen.objects.get(
+        last_seen = GroupSearchViewLastVisited.objects.get(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=self.view,
@@ -102,7 +102,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         assert response.status_code == 204
 
         # Verify the last_seen record was created for the current user
-        last_seen = GroupSearchViewLastSeen.objects.get(
+        last_seen = GroupSearchViewLastVisited.objects.get(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=view,
@@ -114,7 +114,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         assert response.status_code == 404
 
         # Verify no last_seen record was created
-        assert not GroupSearchViewLastSeen.objects.filter(
+        assert not GroupSearchViewLastVisited.objects.filter(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=self.view,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
@@ -16,11 +16,11 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         self.base_data = self.create_base_data()
 
         # Get the first view's ID for testing
-        self.view_id = str(self.base_data["user_one_views"][0].id)
+        self.view = self.base_data["user_one_views"][0]
 
         self.url = reverse(
             "sentry-api-0-organization-group-search-view-visit",
-            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view.id},
         )
 
     @freeze_time("2025-03-03 14:52:37")
@@ -30,7 +30,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
             GroupSearchViewLastSeen.objects.filter(
                 organization=self.organization,
                 user_id=self.user.id,
-                group_search_view_id=self.view_id,
+                group_search_view=self.view,
             ).count()
             == 0
         )
@@ -42,7 +42,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         last_seen = GroupSearchViewLastSeen.objects.get(
             organization=self.organization,
             user_id=self.user.id,
-            group_search_view_id=self.view_id,
+            group_search_view=self.view,
         )
         assert last_seen.last_seen == timezone.now()
 
@@ -54,7 +54,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
             GroupSearchViewLastSeen.objects.create(
                 organization=self.organization,
                 user_id=self.user.id,
-                group_search_view_id=self.view_id,
+                group_search_view=self.view,
                 last_seen=timezone.now(),
             )
 
@@ -66,7 +66,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         last_seen = GroupSearchViewLastSeen.objects.get(
             organization=self.organization,
             user_id=self.user.id,
-            group_search_view_id=self.view_id,
+            group_search_view=self.view,
         )
         assert last_seen.last_seen == timezone.now()
         assert last_seen.last_seen.year == 2025  # Verify it's the new timestamp
@@ -90,10 +90,10 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_update_view_from_another_user(self) -> None:
         # Get a view ID from user_two
-        view_id = str(self.base_data["user_two_views"][0].id)
+        view = self.base_data["user_two_views"][0]
         url = reverse(
             "sentry-api-0-organization-group-search-view-visit",
-            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view.id},
         )
 
         # This should succeed because the view exists in the organization
@@ -105,7 +105,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         last_seen = GroupSearchViewLastSeen.objects.get(
             organization=self.organization,
             user_id=self.user.id,
-            group_search_view_id=view_id,
+            group_search_view=view,
         )
         assert last_seen is not None
 
@@ -117,5 +117,5 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         assert not GroupSearchViewLastSeen.objects.filter(
             organization=self.organization,
             user_id=self.user.id,
-            group_search_view_id=self.view_id,
+            group_search_view=self.view,
         ).exists()

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
@@ -25,7 +25,7 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
 
     @freeze_time("2025-03-03 14:52:37")
     @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_update_last_seen_success(self) -> None:
+    def test_update_last_visited_success(self) -> None:
         assert (
             GroupSearchViewLastVisited.objects.filter(
                 organization=self.organization,
@@ -38,43 +38,43 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         response = self.client.post(self.url)
         assert response.status_code == 204
 
-        # Verify the last_seen record was created
-        last_seen = GroupSearchViewLastVisited.objects.get(
+        # Verify the last_visited record was created
+        visited_view = GroupSearchViewLastVisited.objects.get(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=self.view,
         )
-        assert last_seen.last_seen == timezone.now()
+        assert visited_view.last_visited == timezone.now()
 
     @freeze_time("2025-03-03 14:52:37")
     @with_feature({"organizations:issue-stream-custom-views": True})
-    def test_update_existing_last_seen(self) -> None:
-        # Create an initial last_seen record with an old timestamp
+    def test_update_existing_last_visited(self) -> None:
+        # Create an initial last_visited record with an old timestamp
         with freeze_time("2025-02-03 14:52:37"):
             GroupSearchViewLastVisited.objects.create(
                 organization=self.organization,
                 user_id=self.user.id,
                 group_search_view=self.view,
-                last_seen=timezone.now(),
+                last_visited=timezone.now(),
             )
 
-        # Update the last_seen timestamp
+        # Update the last_visited timestamp
         response = self.client.post(self.url)
         assert response.status_code == 204
 
-        # Verify the last_seen record was updated
-        last_seen = GroupSearchViewLastVisited.objects.get(
+        # Verify the last_visited record was updated
+        visited_view = GroupSearchViewLastVisited.objects.get(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=self.view,
         )
-        assert last_seen.last_seen == timezone.now()
-        assert last_seen.last_seen.year == 2025  # Verify it's the new timestamp
-        assert last_seen.last_seen.month == 3
-        assert last_seen.last_seen.day == 3
-        assert last_seen.last_seen.hour == 14
-        assert last_seen.last_seen.minute == 52
-        assert last_seen.last_seen.second == 37
+        assert visited_view.last_visited == timezone.now()
+        assert visited_view.last_visited.year == 2025  # Verify it's the new timestamp
+        assert visited_view.last_visited.month == 3
+        assert visited_view.last_visited.day == 3
+        assert visited_view.last_visited.hour == 14
+        assert visited_view.last_visited.minute == 52
+        assert visited_view.last_visited.second == 37
 
     @with_feature({"organizations:issue-stream-custom-views": True})
     def test_update_nonexistent_view(self) -> None:
@@ -101,19 +101,19 @@ class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
         response = self.client.post(url)
         assert response.status_code == 204
 
-        # Verify the last_seen record was created for the current user
-        last_seen = GroupSearchViewLastVisited.objects.get(
+        # Verify the last_visited record was created for the current user
+        visited_view = GroupSearchViewLastVisited.objects.get(
             organization=self.organization,
             user_id=self.user.id,
             group_search_view=view,
         )
-        assert last_seen is not None
+        assert visited_view is not None
 
     def test_update_without_feature_flag(self) -> None:
         response = self.client.post(self.url)
         assert response.status_code == 404
 
-        # Verify no last_seen record was created
+        # Verify no last_visited record was created
         assert not GroupSearchViewLastVisited.objects.filter(
             organization=self.organization,
             user_id=self.user.id,

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_visit.py
@@ -1,0 +1,121 @@
+from django.urls import reverse
+from django.utils import timezone
+
+from sentry.models.groupsearchviewlastseen import GroupSearchViewLastSeen
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
+from tests.sentry.issues.endpoints.test_organization_group_search_views import BaseGSVTestCase
+
+
+class OrganizationGroupSearchViewVisitTest(BaseGSVTestCase):
+    endpoint = "sentry-api-0-organization-group-search-view-visit"
+    method = "post"
+
+    def setUp(self) -> None:
+        self.login_as(user=self.user)
+        self.base_data = self.create_base_data()
+
+        # Get the first view's ID for testing
+        self.view_id = str(self.base_data["user_one_views"][0].id)
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-view-visit",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
+        )
+
+    @freeze_time("2025-03-03 14:52:37")
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_update_last_seen_success(self) -> None:
+        assert (
+            GroupSearchViewLastSeen.objects.filter(
+                organization=self.organization,
+                user_id=self.user.id,
+                group_search_view_id=self.view_id,
+            ).count()
+            == 0
+        )
+
+        response = self.client.post(self.url)
+        assert response.status_code == 204
+
+        # Verify the last_seen record was created
+        last_seen = GroupSearchViewLastSeen.objects.get(
+            organization=self.organization,
+            user_id=self.user.id,
+            group_search_view_id=self.view_id,
+        )
+        assert last_seen.last_seen == timezone.now()
+
+    @freeze_time("2025-03-03 14:52:37")
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_update_existing_last_seen(self) -> None:
+        # Create an initial last_seen record with an old timestamp
+        with freeze_time("2025-02-03 14:52:37"):
+            GroupSearchViewLastSeen.objects.create(
+                organization=self.organization,
+                user_id=self.user.id,
+                group_search_view_id=self.view_id,
+                last_seen=timezone.now(),
+            )
+
+        # Update the last_seen timestamp
+        response = self.client.post(self.url)
+        assert response.status_code == 204
+
+        # Verify the last_seen record was updated
+        last_seen = GroupSearchViewLastSeen.objects.get(
+            organization=self.organization,
+            user_id=self.user.id,
+            group_search_view_id=self.view_id,
+        )
+        assert last_seen.last_seen == timezone.now()
+        assert last_seen.last_seen.year == 2025  # Verify it's the new timestamp
+        assert last_seen.last_seen.month == 3
+        assert last_seen.last_seen.day == 3
+        assert last_seen.last_seen.hour == 14
+        assert last_seen.last_seen.minute == 52
+        assert last_seen.last_seen.second == 37
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_update_nonexistent_view(self) -> None:
+        nonexistent_id = "99999"
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-visit",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": nonexistent_id},
+        )
+
+        response = self.client.post(url)
+        assert response.status_code == 404
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_update_view_from_another_user(self) -> None:
+        # Get a view ID from user_two
+        view_id = str(self.base_data["user_two_views"][0].id)
+        url = reverse(
+            "sentry-api-0-organization-group-search-view-visit",
+            kwargs={"organization_id_or_slug": self.organization.slug, "view_id": view_id},
+        )
+
+        # This should succeed because the view exists in the organization
+        # and the endpoint only checks if the view exists in the organization
+        response = self.client.post(url)
+        assert response.status_code == 204
+
+        # Verify the last_seen record was created for the current user
+        last_seen = GroupSearchViewLastSeen.objects.get(
+            organization=self.organization,
+            user_id=self.user.id,
+            group_search_view_id=view_id,
+        )
+        assert last_seen is not None
+
+    def test_update_without_feature_flag(self) -> None:
+        response = self.client.post(self.url)
+        assert response.status_code == 404
+
+        # Verify no last_seen record was created
+        assert not GroupSearchViewLastSeen.objects.filter(
+            organization=self.organization,
+            user_id=self.user.id,
+            group_search_view_id=self.view_id,
+        ).exists()


### PR DESCRIPTION
This PR creates a new endpoint `organizations/group-search-view/view/:viewId` that updates the last seen for a view with the current time. 

~Relies on #86241~