### PR TITLE
chore(ACI): Make functions reusable, update tests

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -6,67 +6,75 @@ from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 logger = logging.getLogger(__name__)
 
 
+def human_desc(
+    action_type,
+    target_type,
+    target_identifier,
+    target,
+    target_display=None,
+    action_target=None,
+    priority=None,
+):
+    # Returns a human readable description to display in the UI
+    if priority:
+        priority += " level"
+
+    if action_type == AlertRuleTriggerAction.Type.EMAIL.value:
+        if action_target:
+            if target_type == AlertRuleTriggerAction.TargetType.USER.value:
+                return "Send a notification to " + target.email
+            elif target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
+                return "Send an email to members of #" + target.slug
+    elif action_type == AlertRuleTriggerAction.Type.PAGERDUTY.value:
+        return f"Send a {priority} PagerDuty notification to " + target_display
+    elif action_type == AlertRuleTriggerAction.Type.SLACK.value:
+        return "Send a Slack notification to " + target_display
+    elif action_type == AlertRuleTriggerAction.Type.MSTEAMS.value:
+        return "Send a Microsoft Teams notification to " + target_display
+    elif action_type == AlertRuleTriggerAction.Type.SENTRY_APP.value:
+        return "Send a notification via " + target_display
+    elif action_type == AlertRuleTriggerAction.Type.OPSGENIE.value:
+        if priority:
+            return f"Send a {priority} Opsgenie notification to " + target_display
+        return "Send an Opsgenie notification to " + target_display
+    elif action_type == AlertRuleTriggerAction.Type.DISCORD.value:
+        if not target_display:
+            logger.info(
+                "discord.action.description.no.channel",
+                extra={"target_identifier": target_identifier},
+            )
+        return f"Send a Discord notification to {target_display}"
+
+
+def get_identifier_from_action(action_type, target_identifier, target_display=None):
+    if action_type in [
+        AlertRuleTriggerAction.Type.PAGERDUTY.value,
+        AlertRuleTriggerAction.Type.SENTRY_APP.value,
+    ]:
+        return int(target_identifier)
+    if action_type == AlertRuleTriggerAction.Type.OPSGENIE.value:
+        # return team ID: opsgenie team IDs are strings
+        return target_identifier
+    # if an input_channel_id is provided, we flip these to display properly
+    return target_display if target_display is not None else target_identifier
+
+
+def get_input_channel_id(action_type, target_identifier=None):
+    """
+    Don't pass an inputChannelId value unless the action is for Slack
+    """
+    return target_identifier if action_type == AlertRuleTriggerAction.Type.SLACK.value else None
+
+
 @register(AlertRuleTriggerAction)
 class AlertRuleTriggerActionSerializer(Serializer):
-    def human_desc(self, action):
-        # Returns a human readable description to display in the UI
-        priority = (
-            action.sentry_app_config.get("priority")
-            if isinstance(action.sentry_app_config, dict)
-            else ""
-        )
-        if priority:
-            priority += " level"
-
-        if action.type == action.Type.EMAIL.value:
-            if action.target:
-                if action.target_type == action.TargetType.USER.value:
-                    return "Send a notification to " + action.target.email
-                elif action.target_type == action.TargetType.TEAM.value:
-                    return "Send an email to members of #" + action.target.slug
-        elif action.type == action.Type.PAGERDUTY.value:
-            return f"Send a {priority} PagerDuty notification to " + action.target_display
-        elif action.type == action.Type.SLACK.value:
-            return "Send a Slack notification to " + action.target_display
-        elif action.type == action.Type.MSTEAMS.value:
-            return "Send a Microsoft Teams notification to " + action.target_display
-        elif action.type == action.Type.SENTRY_APP.value:
-            return "Send a notification via " + action.target_display
-        elif action.type == action.Type.OPSGENIE.value:
-            if priority:
-                return f"Send a {priority} Opsgenie notification to " + action.target_display
-            return "Send an Opsgenie notification to " + action.target_display
-        elif action.type == action.Type.DISCORD.value:
-            if not action.target_display:
-                logger.info(
-                    "discord.action.description.no.channel",
-                    extra={"target_identifier": action.target_identifier},
-                )
-            return f"Send a Discord notification to {action.target_display}"
-
-    def get_identifier_from_action(self, action):
-        if action.type in [
-            AlertRuleTriggerAction.Type.PAGERDUTY.value,
-            AlertRuleTriggerAction.Type.SENTRY_APP.value,
-        ]:
-            return int(action.target_identifier)
-        if action.type == AlertRuleTriggerAction.Type.OPSGENIE.value:
-            # return team ID: opsgenie team IDs are strings
-            return action.target_identifier
-        # if an input_channel_id is provided, we flip these to display properly
-        return (
-            action.target_display if action.target_display is not None else action.target_identifier
-        )
-
-    def get_input_channel_id(self, action):
-        """
-        Don't pass an inputChannelId value unless the action is for Slack
-        """
-        return action.target_identifier if action.type == action.Type.SLACK.value else None
 
     def serialize(self, obj, attrs, user, **kwargs):
         from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
 
+        priority = (
+            obj.sentry_app_config.get("priority") if isinstance(obj.sentry_app_config, dict) else ""
+        )
         result = {
             "id": str(obj.id),
             "alertRuleTriggerId": str(obj.alert_rule_trigger_id),
@@ -76,12 +84,22 @@ class AlertRuleTriggerActionSerializer(Serializer):
             "targetType": ACTION_TARGET_TYPE_TO_STRING[
                 AlertRuleTriggerAction.TargetType(obj.target_type)
             ],
-            "targetIdentifier": self.get_identifier_from_action(obj),
-            "inputChannelId": self.get_input_channel_id(obj),
+            "targetIdentifier": get_identifier_from_action(
+                obj.type, obj.target_identifier, obj.target_display
+            ),
+            "inputChannelId": get_input_channel_id(obj.type, obj.target_identifier),
             "integrationId": obj.integration_id,
             "sentryAppId": obj.sentry_app_id,
             "dateCreated": obj.date_added,
-            "desc": self.human_desc(obj),
+            "desc": human_desc(
+                obj.type,
+                obj.target_type,
+                obj.target_identifier,
+                obj.target,
+                obj.target_display,
+                obj.target,
+                priority,
+            ),
             "priority": (
                 obj.sentry_app_config.get("priority", None)
                 if isinstance(obj.sentry_app_config, dict)

--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -16,6 +16,14 @@ def human_desc(
     priority=None,
 ):
     # Returns a human readable description to display in the UI
+
+    action_type_to_string = {
+        AlertRuleTriggerAction.Type.PAGERDUTY.value: f"Send a {priority} PagerDuty notification to {target_display}",
+        AlertRuleTriggerAction.Type.SLACK.value: f"Send a Slack notification to {target_display}",
+        AlertRuleTriggerAction.Type.MSTEAMS.value: f"Send a Microsoft Teams notification to {target_display}",
+        AlertRuleTriggerAction.Type.SENTRY_APP.value: f"Send a notification via {target_display}",
+    }
+
     if priority:
         priority += " level"
 
@@ -25,18 +33,10 @@ def human_desc(
                 return "Send a notification to " + target.email
             elif target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
                 return "Send an email to members of #" + target.slug
-    elif action_type == AlertRuleTriggerAction.Type.PAGERDUTY.value:
-        return f"Send a {priority} PagerDuty notification to " + target_display
-    elif action_type == AlertRuleTriggerAction.Type.SLACK.value:
-        return "Send a Slack notification to " + target_display
-    elif action_type == AlertRuleTriggerAction.Type.MSTEAMS.value:
-        return "Send a Microsoft Teams notification to " + target_display
-    elif action_type == AlertRuleTriggerAction.Type.SENTRY_APP.value:
-        return "Send a notification via " + target_display
     elif action_type == AlertRuleTriggerAction.Type.OPSGENIE.value:
         if priority:
-            return f"Send a {priority} Opsgenie notification to " + target_display
-        return "Send an Opsgenie notification to " + target_display
+            return f"Send a {priority} Opsgenie notification to {target_display}"
+        return "Send an Opsgenie notification to {target_display}"
     elif action_type == AlertRuleTriggerAction.Type.DISCORD.value:
         if not target_display:
             logger.info(
@@ -44,6 +44,8 @@ def human_desc(
                 extra={"target_identifier": target_identifier},
             )
         return f"Send a Discord notification to {target_display}"
+    else:
+        return action_type_to_string[action_type]
 
 
 def get_identifier_from_action(action_type, target_identifier, target_display=None):

--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -16,6 +16,8 @@ def human_desc(
     priority=None,
 ):
     # Returns a human readable description to display in the UI
+    if priority:
+        priority += " level"
 
     action_type_to_string = {
         AlertRuleTriggerAction.Type.PAGERDUTY.value: f"Send a {priority} PagerDuty notification to {target_display}",
@@ -23,9 +25,6 @@ def human_desc(
         AlertRuleTriggerAction.Type.MSTEAMS.value: f"Send a Microsoft Teams notification to {target_display}",
         AlertRuleTriggerAction.Type.SENTRY_APP.value: f"Send a notification via {target_display}",
     }
-
-    if priority:
-        priority += " level"
 
     if action_type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action_target:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -37,7 +37,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.incidents.serializers import AlertRuleSerializer
+from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING, AlertRuleSerializer
 from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
@@ -118,6 +118,9 @@ class AlertRuleDetailsBase(AlertRuleBase):
 
     @cached_property
     def valid_params(self):
+        email_action_type = AlertRuleTriggerAction.get_registered_factory(
+            AlertRuleTriggerAction.Type.EMAIL
+        ).slug
         return {
             "name": "hello",
             "time_window": 10,
@@ -133,17 +136,31 @@ class AlertRuleDetailsBase(AlertRuleBase):
                     "label": "critical",
                     "alertThreshold": 200,
                     "actions": [
-                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                        {
+                            "type": email_action_type,
+                            "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                                AlertRuleTriggerAction.TargetType.TEAM
+                            ],
+                            "targetIdentifier": self.team.id,
+                        },
                     ],
                 },
                 {
                     "label": "warning",
                     "alertThreshold": 150,
                     "actions": [
-                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
                         {
-                            "type": "email",
-                            "targetType": "user",
+                            "type": email_action_type,
+                            "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                                AlertRuleTriggerAction.TargetType.TEAM
+                            ],
+                            "targetIdentifier": self.team.id,
+                        },
+                        {
+                            "type": email_action_type,
+                            "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                                AlertRuleTriggerAction.TargetType.USER
+                            ],
                             "targetIdentifier": self.user.id,
                         },
                     ],

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -908,8 +908,8 @@ class TestAlertRuleTriggerActionSerializer(TestAlertRuleSerializerBase):
             "type": AlertRuleTriggerAction.get_registered_factory(
                 AlertRuleTriggerAction.Type.EMAIL
             ).slug,
-            "target_type": ACTION_TARGET_TYPE_TO_STRING[AlertRuleTriggerAction.TargetType.SPECIFIC],
-            "target_identifier": "test@test.com",
+            "target_type": ACTION_TARGET_TYPE_TO_STRING[AlertRuleTriggerAction.TargetType.USER],
+            "target_identifier": self.user.id,
         }
 
     @cached_property
@@ -952,6 +952,15 @@ class TestAlertRuleTriggerActionSerializer(TestAlertRuleSerializerBase):
         serializer = AlertRuleTriggerActionSerializer(context=self.context, data=base_params)
         assert not serializer.is_valid()
         assert serializer.errors == errors
+
+    def test_simple(self):
+        serializer = AlertRuleTriggerActionSerializer(context=self.context, data=self.valid_params)
+        assert serializer.is_valid()
+        assert serializer.validated_data["type"] == AlertRuleTriggerAction.Type.EMAIL.value
+        assert (
+            serializer.validated_data["target_type"] == AlertRuleTriggerAction.TargetType.USER.value
+        )
+        assert serializer.validated_data["target_identifier"] == str(self.user.id)
 
     def test_validation_no_params(self):
         serializer = AlertRuleTriggerActionSerializer(context=self.context, data={})


### PR DESCRIPTION
Breaking out some parts of https://github.com/getsentry/sentry/pull/86248 to make it easier to see the main changes.

* Make the AlertRuleTriggerAction serializer functions reusable
* Update some incorrect serializer tests
* Use types instead of hard coded strings in organization alert rule details test