### PR TITLE
ref(seer grouping): Mark race-condition-losing hashes as Seer skips

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -556,6 +556,29 @@ class BaseEvent(metaclass=abc.ABCMeta):
         # Events are currently populated from the Events dataset
         return cast(str, column.value.event_name)
 
+    @property
+    def should_skip_seer(self) -> bool:
+        """
+        A convenience property to allow us to skip calling Seer in cases where there's been a race
+        condition and multiple events with the same new grouphash are going through ingestion
+        simultaneously. When we detect that, we can set this property on events that lose the race,
+        so that only the one event which wins the race gets sent to Seer.
+
+        (The race-losers may not be able to store Seer results in any case, as the race condition
+        means their `metadata` properties may not point to real database records.)
+
+        Doing this reduces the load on Seer and also helps protect projects from hitting their Seer
+        rate limit.
+        """
+        try:
+            return self._should_skip_seer
+        except AttributeError:
+            return False
+
+    @should_skip_seer.setter
+    def should_skip_seer(self, should_skip: bool) -> None:
+        self._should_skip_seer = should_skip
+
 
 class Event(BaseEvent):
     def __init__(

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -224,7 +224,8 @@ def create_or_update_grouphash_metadata_if_needed(
             logger.info(
                 "grouping.grouphash_metadata.handle_existing_grouphash",
                 extra={
-                    "grouphash": grouphash.id,
+                    "grouphash_id": grouphash.id,
+                    "hash": grouphash.hash,
                     "group_id": grouphash.group_id,
                     "reason": db_hit_metadata["reason"],
                 },

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -63,6 +63,7 @@ def should_call_seer_for_grouping(
 
     if (
         has_blocked_fingerprint
+        or _is_race_condition_skipped_event(event, event_grouphash)
         or _has_too_many_contributing_frames(event, variants)
         or killswitch_enabled(project.id, ReferrerOptions.INGEST, event)
         or _circuit_breaker_broken(event, project)
@@ -82,6 +83,47 @@ def should_call_seer_for_grouping(
         return False
 
     return True
+
+
+def _is_race_condition_skipped_event(event: Event, event_grouphash: GroupHash) -> bool:
+    """
+    In cases where multiple events with the same new hash are racing to assign that hash to a group,
+    we only want one of them to be sent to Seer.
+
+    We detect the race when creating `GroupHashMetadata` records, and track all but the winner of
+    the race as events whose Seer call we should skip.
+
+    NOTE: For now this only returns False, so it will never block sending to Seer. This will allow
+    us to collect logs of when it *would* block, in order or us to have greater confidence in the
+    change.
+    """
+    if event.should_skip_seer:
+        logger.info(
+            "should_call_seer_for_grouping.race_condition_skip",
+            extra={
+                "grouphash_id": event_grouphash.id,
+                "hash": event_grouphash.hash,
+                "event_id": event.event_id,
+            },
+        )
+        # TODO: The two lines below are what the code *should* be, in order to actually skip sending
+        # the events. For now, though, we're just going to log, to essentially enact the change in
+        # dry-run mode. Once we're confident that in race condition situations, exactly one event
+        # will be sent to Seer, we can restore the real code.
+        #
+        # record_did_call_seer_metric(event, call_made=False, blocker="race_condition")
+        # return True
+        return False
+
+    logger.info(
+        "should_call_seer_for_grouping.race_condition_pass",
+        extra={
+            "grouphash_id": event_grouphash.id,
+            "hash": event_grouphash.hash,
+            "event_id": event.event_id,
+        },
+    )
+    return False
 
 
 def _event_content_is_seer_eligible(event: Event) -> bool:


### PR DESCRIPTION
Now that we're backfilling grouphash metadata, we've been running into problems storing Seer results in said metadata. The culprit turns out to be a race condition, wherein multiple events with the same new hash hit our servers nearly simultaneously. Since the Seer call happens before the new group creation lock kicks in, there's nothing to prevent them all from being sent to Seer.

This has been happening invisibly all along, but the race condition debug logging made it much more obvious. The reason it hadn't caused any problems before the metadata backfill is that before the backfill, the race condition's effects were restricted to the creation of `GroupHash` records, which we access directly when we (further down the pipeline) update them with a group id. 

Now the creation of `GroupHashMetadata` records is also subject to the race condition (since existing grouphashes now also get metadata, even if "existing" means "sprang into being mere milliseconds ago"). But unlike with `GroupHash` records, we don't access metadata records directly. Instead, we use the back-reference on `GroupHash`, which Django doesn't always manage to fully update across all of the racing events. Thus, when we try to add Seer data via `grouphash.metadata.update`, occasionally we run into cases where we're trying to make changes via a non-functional back-reference, and problems ensue.

To fix this, we first tried [fixing the back-reference](https://github.com/getsentry/sentry/pull/85804). We then tried [switching from `GroupHashMetadata.objects.create` to `GroupHashMetadata.objects.get_or_create`](https://github.com/getsentry/sentry/pull/85917) and bailing early from metadata creation when our `get_or_create` came back with `created = False`, in hopes that the back-reference would end up not existing at all (in which case we wouldn't try to update it with Seer results). In retrospect, it seems obvious why that didn't work: we're not actually bailing before trying to create the duplicate metadata record - that's what the `get_or_create` is doing - but before trying to update said record with actual metadata. So we need a new approach.

This PR represents a no-op POC of said new idea: When we sense a metadata race condition (when `created = False`), in addition to bailing before we add data, keep track on the `GroupHash` of the fact that we did that, and in those cases, skip the Seer call altogether. Whichever event actually wins the race (the one for which `created = True`) will still get sent, so we shouldn't lose any functionality, but it will prevent us from sending the same hash to Seer multiple times. This has the added bonus of both reducing Seer's overall load and making projects with lots of racy events less likely to hit their Seer rate limit.

To keep track of which events should have their Seer calls skipped, this adds a new `should_skip_seer` property to the `BaseEvent` class, which is then checked in `should_call_seer_for_grouping`. In order to validate the approach, for now the check is a no-op (other than logging its results). Once we're satisfied that all grouphashes which are otherwise Seer-eligible still have a representative (and only one representative) sent to Seer, we can turn the check on for real.