### PR TITLE
feat(issue-stream): Smaller message text

### DIFF
--- a/static/app/components/events/errorLevel.tsx
+++ b/static/app/components/events/errorLevel.tsx
@@ -44,7 +44,7 @@ const ColoredLine = styled('span')<Props>`
   border-radius: 3px;
   display: inline-block;
   flex-shrink: 0;
-  height: ${p => (p.size || DEFAULT_SIZE) + 4}px;
+  height: 1em;
   background-color: ${p => (p.level ? p.theme.level[p.level] : p.theme.level.error)};
 `;
 

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -813,17 +813,18 @@ const Wrapper = styled(PanelItem)<{
 const GroupSummary = styled('div')<{canSelect: boolean; hasNewLayout: boolean}>`
   overflow: hidden;
   margin-left: ${p => space(p.canSelect ? 1 : 2)};
-  margin-right: ${p => (p.hasNewLayout ? space(2) : space(1))};
+  margin-right: ${space(1)};
   flex: 1;
   width: 66.66%;
 
   ${p =>
     p.hasNewLayout &&
     css`
+      margin-right: ${space(4)};
       display: flex;
       flex-direction: column;
       justify-content: center;
-      font-size: ${p.theme.fontSizeMedium};
+      font-size: ${p.theme.fontSizeSmall};
     `}
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {


### PR DESCRIPTION
Error level and message are now slightly smaller:

![CleanShot 2025-03-03 at 16 54 43](https://github.com/user-attachments/assets/3b86be44-2a24-4740-9d0d-83faf32704f1)
