### PR TITLE
:wrench: chore: fix sentry app notification action for bug found in dry run

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -28,7 +28,6 @@ from sentry.workflow_engine.typings.notification_action import (
     EmailFieldMappingKeys,
     OnCallDataBlob,
     SentryAppDataBlob,
-    SentryAppFormConfigDataBlob,
     SlackDataBlob,
     TicketFieldMappingKeys,
     TicketingActionDataBlobHelper,
@@ -404,10 +403,10 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         raise ValueError(f"No target identifier key found for action type: {action.type}")
 
     @classmethod
-    def process_settings(cls, settings: list[SentryAppFormConfigDataBlob]) -> list[dict[str, Any]]:
+    def process_settings(cls, settings: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # Process each setting, removing None labels
         return [
-            {k: v for k, v in asdict(setting).items() if not (k == "label" and v is None)}
+            {k: v for k, v in setting.items() if not (k == "label" and v is None)}
             for setting in settings
         ]
 
@@ -416,7 +415,7 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         # Need to check for the settings key, if it exists, then we need to return the settings
         # It won't exist for legacy webhook actions, but will exist for sentry app actions
         if action.data.get("settings"):
-            blob = SentryAppDataBlob(**action.data)
-            settings = cls.process_settings(blob.settings)
+            blob = asdict(SentryAppDataBlob(**action.data))
+            settings = cls.process_settings(blob["settings"])
             return {"settings": settings}
         return {}

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -28,6 +28,7 @@ from sentry.workflow_engine.typings.notification_action import (
     EmailFieldMappingKeys,
     OnCallDataBlob,
     SentryAppDataBlob,
+    SentryAppFormConfigDataBlob,
     SlackDataBlob,
     TicketFieldMappingKeys,
     TicketingActionDataBlobHelper,
@@ -403,10 +404,10 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         raise ValueError(f"No target identifier key found for action type: {action.type}")
 
     @classmethod
-    def process_settings(cls, settings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def process_settings(cls, settings: list[SentryAppFormConfigDataBlob]) -> list[dict[str, Any]]:
         # Process each setting, removing None labels
         return [
-            {k: v for k, v in setting.items() if not (k == "label" and v is None)}
+            {k: v for k, v in asdict(setting).items() if not (k == "label" and v is None)}
             for setting in settings
         ]
 
@@ -414,8 +415,10 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         # Need to check for the settings key, if it exists, then we need to return the settings
         # It won't exist for legacy webhook actions, but will exist for sentry app actions
-        if action.data.get("settings"):
-            blob = asdict(SentryAppDataBlob(**action.data))
-            settings = cls.process_settings(blob["settings"])
+        if settings_list := action.data.get("settings"):
+            if not isinstance(settings_list, list):
+                raise ValueError(f"Settings must be a list for action type: {action.type}")
+            blob = SentryAppDataBlob.from_list(settings_list)
+            settings = cls.process_settings(blob.settings)
             return {"settings": settings}
         return {}

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -731,10 +731,11 @@ class SentryAppFormConfigDataBlob(DataBlob):
     def from_dict(cls, data: dict[str, Any]) -> SentryAppFormConfigDataBlob:
         if not isinstance(data.get("name"), str) or not isinstance(data.get("value"), str):
             raise ValueError("Sentry app config must contain name and value keys")
-        return cls(name=data["name"], value=data["value"])
+        return cls(name=data["name"], value=data["value"], label=data.get("label"))
 
     name: str = ""
     value: str = ""
+    label: str | None = None
 
 
 @dataclass

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -744,7 +744,9 @@ class SentryAppDataBlob(DataBlob):
     Represents a Sentry App notification action.
     """
 
-    settings: list[SentryAppFormConfigDataBlob] = field(default_factory=list)
+    settings: list[SentryAppFormConfigDataBlob] = field(
+        default_factory=list[SentryAppFormConfigDataBlob]
+    )
 
     @classmethod
     def from_list(cls, data: list[dict[str, Any]] | None) -> SentryAppDataBlob:

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -744,9 +744,7 @@ class SentryAppDataBlob(DataBlob):
     Represents a Sentry App notification action.
     """
 
-    settings: list[SentryAppFormConfigDataBlob] = field(
-        default_factory=list[SentryAppFormConfigDataBlob]
-    )
+    settings: list[SentryAppFormConfigDataBlob] = field(default_factory=list)
 
     @classmethod
     def from_list(cls, data: list[dict[str, Any]] | None) -> SentryAppDataBlob:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -165,6 +165,13 @@ def assert_alert_rule_trigger_migrated(alert_rule_trigger):
     ).exists()
 
 
+def build_sentry_app_compare_blob(sentry_app_config: list[dict[str, str]]) -> list[dict[str, str]]:
+    """
+    Add the label to the config
+    """
+    return [{**config, "label": config.get("label", None)} for config in sentry_app_config]
+
+
 def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_type):
     aarta = ActionAlertRuleTriggerAction.objects.get(
         alert_rule_trigger_action=alert_rule_trigger_action
@@ -184,7 +191,9 @@ def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_
             assert action.data == {}
         else:
             assert action.data == {
-                "settings": alert_rule_trigger_action.sentry_app_config,
+                "settings": build_sentry_app_compare_blob(
+                    alert_rule_trigger_action.sentry_app_config
+                ),
             }
 
     if action_type == Action.Type.OPSGENIE:
@@ -926,7 +935,7 @@ class DualDeleteAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
     def setUp(self):
         self.metric_alert = self.create_alert_rule()
         self.alert_rule_trigger = self.create_alert_rule_trigger(
-            alert_rule=self.metric_alert, label="critical", alert_threshold=200
+            alert_rule=self.metric_alert, label="critical"
         )
         self.alert_rule_trigger_action = self.create_alert_rule_trigger_action(
             alert_rule_trigger=self.alert_rule_trigger
@@ -1138,6 +1147,7 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
             {
                 "name": "mifu",
                 "value": "matcha",
+                "label": None,
             },
         ]
         assert action.target_display == "oolong"

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -165,7 +165,9 @@ def assert_alert_rule_trigger_migrated(alert_rule_trigger):
     ).exists()
 
 
-def build_sentry_app_compare_blob(sentry_app_config: list[dict[str, str]]) -> list[dict[str, str]]:
+def build_sentry_app_compare_blob(
+    sentry_app_config: list[dict[str, str]]
+) -> list[dict[str, str | None]]:
     """
     Add the label to the config
     """


### PR DESCRIPTION
i found a bug in the dry run script where i don't migrate sentry apps which have the `label` key. This fixes that by passing it as `None` during migration. 

In the long run, I think we should be updating the typing on the frontend so we don't  it as optional, rather `str | None`, but until we get to that reality, I basically parse out the `None` inside the NOA so when we invoke the sentry app action, we omit the label if it doesn't exist.