### PR TITLE
fix(issue-views): Fix buggy dragging 

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -43,10 +43,18 @@ export interface IssueViewNavItemContentProps {
    */
   isActive: boolean;
   /**
+   * Whether an item is being dragged.
+   */
+  isDragging: boolean;
+  /**
    * Whether the item is the last view in the list.
    * This will be removed once view sharing/starring is implemented.
    */
   isLastView: boolean;
+  /**
+   * A callback function that updates the isDragging state.
+   */
+  setIsDragging: (isDragging: boolean) => void;
   /**
    * A callback function that updates the view with new params.
    */
@@ -62,7 +70,6 @@ export interface IssueViewNavItemContentProps {
    */
   sectionRef?: React.RefObject<HTMLDivElement>;
 }
-
 export function IssueViewNavItemContent({
   view,
   sectionRef,
@@ -71,6 +78,8 @@ export function IssueViewNavItemContent({
   deleteView,
   duplicateView,
   isLastView,
+  isDragging,
+  setIsDragging,
 }: IssueViewNavItemContentProps) {
   const organization = useOrganization();
   const location = useLocation();
@@ -78,7 +87,6 @@ export function IssueViewNavItemContent({
 
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const [isEditing, setIsEditing] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
 
   const {projects} = useProjects();
 
@@ -130,8 +138,13 @@ export function IssueViewNavItemContent({
         setIsDragging(false);
         endInteraction();
       }}
+      layoutId={`${view.id}`}
       style={{
-        originY: '0px',
+        ...(isDragging
+          ? {}
+          : {
+              originY: '0px',
+            }),
       }}
     >
       <StyledSecondaryNavItem

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -35,6 +35,7 @@ export function IssueViewNavItems({
   const queryParams = location.query;
 
   const [views, setViews] = useState<IssueView[]>(loadedViews);
+  const [isDragging, setIsDragging] = useState(false);
 
   // If the `viewId` (from `/issues/views/:viewId`) is not found in the views array,
   // then redirect to the "All Issues" page
@@ -225,6 +226,8 @@ export function IssueViewNavItems({
             view={view}
             sectionRef={sectionRef}
             isActive={view.id === viewId}
+            isDragging={isDragging}
+            setIsDragging={setIsDragging}
             updateView={updatedView => handleUpdateView(view, updatedView)}
             deleteView={() => handleDeleteView(view)}
             duplicateView={() => handleDuplicateView(view)}


### PR DESCRIPTION
Sigh [this PR](https://github.com/getsentry/sentry/pull/86204) introduced a regression where the tab dragging is super jank as a result of the styles needed to prevent the jumping behavior. 

The fix is to disable the styles while dragging, so we need to bubble the dragging state to above all tabs, rather than per tab. 