### PR TITLE
:wrench: chore(aci): skip creating broken actions if not in a dry run

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -11,13 +11,14 @@ logger = logging.getLogger(__name__)
 
 
 def translate_rule_data_actions_to_notification_actions(
-    actions: list[dict[str, Any]]
+    actions: list[dict[str, Any]], skip_failures: bool
 ) -> list[Action]:
     """
     Builds notification actions from action field in Rule's data blob.
-    Will only create actions that are valid, and log any errors before skipping the action.
+    Will only create actions that are valid, and log any errors.
 
     :param actions: list of action data (Rule.data.actions)
+    :param skip_failures: if True, invalid actions will be skipped instead of raising exceptions
     :return: list of notification actions (Action)
     """
 
@@ -31,6 +32,8 @@ def translate_rule_data_actions_to_notification_actions(
                 "No registry ID found for action",
                 extra={"action_uuid": action.get("uuid")},
             )
+            if skip_failures:
+                continue
             raise ValueError(f"No registry ID found for action: {action}")
 
         # Fetch the translator class
@@ -45,6 +48,8 @@ def translate_rule_data_actions_to_notification_actions(
                     "action_uuid": action.get("uuid"),
                 },
             )
+            if skip_failures:
+                continue
             raise ValueError(
                 f"Action translator not found for action with registry ID: {registry_id}, uuid: {action.get('uuid')}"
             ) from e
@@ -59,20 +64,30 @@ def translate_rule_data_actions_to_notification_actions(
                     "missing_fields": translator.missing_fields,
                 },
             )
+            if skip_failures:
+                continue
             raise ValueError(
                 f"Action blob is malformed: missing required fields with registry ID: {registry_id}, uuid: {action.get('uuid')}"
             )
 
-        notification_action = Action(
-            type=translator.action_type,
-            data=translator.get_sanitized_data(),
-            integration_id=translator.integration_id,
-            target_identifier=translator.target_identifier,
-            target_display=translator.target_display,
-            target_type=translator.target_type,
-        )
+        try:
+            notification_action = Action(
+                type=translator.action_type,
+                data=translator.get_sanitized_data(),
+                integration_id=translator.integration_id,
+                target_identifier=translator.target_identifier,
+                target_display=translator.target_display,
+                target_type=translator.target_type,
+            )
 
-        notification_actions.append(notification_action)
+            notification_actions.append(notification_action)
+        except Exception as e:
+            if not skip_failures:
+                raise
+            logger.exception(
+                "Failed to translate action",
+                extra={"action": action, "error": str(e)},
+            )
 
     return notification_actions
 
@@ -82,13 +97,20 @@ def build_notification_actions_from_rule_data_actions(
 ) -> list[Action]:
     """
     Builds notification actions from action field in Rule's data blob.
-    Will only create actions that are valid, and log any errors before skipping the action.
+    Will only create actions that are valid, and log any errors.
+
+    If is_dry_run=True,
+    - Any failed exception will raise an exception
+    - Actions will not be persisted to the database
 
     :param actions: list of action data (Rule.data.actions)
+    :param is_dry_run: run in dry-run mode
     :return: list of notification actions (Action)
     """
 
-    notification_actions = translate_rule_data_actions_to_notification_actions(actions)
+    notification_actions = translate_rule_data_actions_to_notification_actions(
+        actions, skip_failures=not is_dry_run
+    )
 
     # Bulk create the actions if not a dry run
     if not is_dry_run:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1110,7 +1110,7 @@ class TestNotificationActionMigrationUtils(TestCase):
 
     def test_skip_failures_flag(self):
         """Test that the skip_failures flag skips invalid actions."""
-        action_data = [
+        action_data: list[dict[str, str | Any]] = [
             # Missing required fields, should skip
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",


### PR DESCRIPTION
when we run the real migration script for issue alerts, we don't want to fail loudly for actions that can't be migrated
(reasons include sentry app installation not existing, missing fields, etc.)

instead, we will log errors and just skip over migrating those actions.