### PR TITLE
fix(laravel-insights): fix seconds vs milliseconds in jobs widget

### DIFF
--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -586,12 +586,12 @@ function JobsWidget({query}: {query?: string}) {
 
         acc[0].data.push({
           value: okJobsRateValue * spansInTimeBucket,
-          name: new Date(time).toISOString(),
+          name: new Date(time * 1000).toISOString(),
         });
 
         acc[1].data.push({
           value: failedJobsRateValue * spansInTimeBucket,
-          name: new Date(time).toISOString(),
+          name: new Date(time * 1000).toISOString(),
         });
 
         return acc;


### PR DESCRIPTION
- API returns seconds, JS expects milliseconds timestamps, this PR fixes the discrepancy
- Closes https://github.com/getsentry/projects/issues/783

Before:
![Screenshot 2025-03-04 at 11 17 35](https://github.com/user-attachments/assets/04976d7c-8a36-4658-b339-582d1597eda0)

After:
![Screenshot 2025-03-04 at 11 17 29](https://github.com/user-attachments/assets/804a74e4-2962-4e8a-ae26-4a3478674b6d)
