### PR TITLE
fix(code_mappings): Do not append extension

### DIFF
--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -42,8 +42,13 @@ def java_frame_munger(frame: EventFrame) -> str | None:
     if not frame.filename or not frame.module:
         return None
 
-    if "$$" in frame.module:
-        return frame.module.split("$$")[0].replace(".", "/") + ".java"
+    if "$" in frame.module:
+        parts = frame.module.split("$")
+        path = parts[0].replace(".", "/")
+        if frame.abs_path and frame.abs_path.count(".") == 1:
+            # Append extension
+            path = path + "." + frame.abs_path.split(".")[-1]
+        return path
 
     if "/" not in str(frame.filename) and frame.module:
         # Replace the last module segment with the filename, as the

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -43,8 +43,7 @@ def java_frame_munger(frame: EventFrame) -> str | None:
         return None
 
     if "$" in frame.module:
-        parts = frame.module.split("$")
-        path = parts[0].replace(".", "/")
+        path = frame.module.split("$")[0].replace(".", "/")
         if frame.abs_path and frame.abs_path.count(".") == 1:
             # Append extension
             path = path + "." + frame.abs_path.split(".")[-1]

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -453,36 +453,37 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             organization_integration=self.oi,
             project=self.project,
             repo=self.repo,
-            # XXX: Discuss support for dot notation
-            # XXX: Discuss support for forgetting a last back slash
             stack_root="com/example/",
             source_root="src/com/example/",
             automatically_generated=False,
         )
-        assert (
-            convert_stacktrace_frame_path_to_source_path(
-                frame=EventFrame(
-                    filename="MainActivity.java",
-                    module="com.example.vu.android.MainActivity",
-                ),
-                code_mapping=code_mapping,
-                platform="java",
-                sdk_name="sentry.java.android",
+        for module, abs_path, expected_path in [
+            (
+                "com.example.vu.android.MainActivity",
+                "MainActivity.java",
+                "src/com/example/vu/android/MainActivity.java",
+            ),
+            (
+                "com.example.vu.android.MainActivity$$ExternalSyntheticLambda4",
+                "D8$$SyntheticClass",
+                # Extension not appended since abs_path did not contain one
+                "src/com/example/vu/android/MainActivity",
+            ),
+            (
+                "com.example.vu.android.empowerplant.MainFragment$3$1",
+                "MainFragment.java",
+                "src/com/example/vu/android/empowerplant/MainFragment.java",
+            ),
+        ]:
+            assert (
+                convert_stacktrace_frame_path_to_source_path(
+                    frame=EventFrame(filename=abs_path, abs_path=abs_path, module=module),
+                    code_mapping=code_mapping,
+                    platform="java",
+                    sdk_name="sentry.java.android",
+                )
+                == expected_path
             )
-            == "src/com/example/vu/android/MainActivity.java"
-        )
-        assert (
-            convert_stacktrace_frame_path_to_source_path(
-                frame=EventFrame(
-                    filename="D8$$SyntheticClass",
-                    module="com.example.vu.android.MainActivity$$ExternalSyntheticLambda4",
-                ),
-                code_mapping=code_mapping,
-                platform="java",
-                sdk_name="sentry.java.android",
-            )
-            == "src/com/example/vu/android/MainActivity.java"
-        )
 
     def test_convert_stacktrace_frame_path_to_source_path_backslashes(self) -> None:
         assert (


### PR DESCRIPTION
In #84779 I fixed an issue, however, appending `.java` at the end is not the right fix and may need to be handled differently somewhere else in the codebase.

This also changes the test structure and adds an extra test case.