### PR TITLE
fix(explore): Sync chart and table colours when the number of series is fewer than 5

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -29,9 +29,8 @@ export class Area extends AggregateTimeSeries<AreaConfig> implements PlottableDa
   toSeries(plottingOptions: AggregateTimePlottingOptions): LineSeriesOption[] {
     const {timeSeries, config = {}} = this;
 
-    const {color, unit} = plottingOptions;
-
-    const scaledSeries = this.scaleToUnit(unit);
+    const color = plottingOptions.color ?? config.color ?? undefined;
+    const scaledSeries = this.scaleToUnit(plottingOptions.unit);
 
     const [completeTimeSeries, incompleteTimeSeries] =
       splitSeriesIntoCompleteAndIncomplete(scaledSeries, config.delay ?? 0);

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -36,16 +36,15 @@ export class Bars extends AggregateTimeSeries<BarsConfig> implements PlottableDa
   ): Array<BarSeriesOption | LineSeriesOption> {
     const {timeSeries, config = {}} = this;
 
-    const {color, unit} = plottingOptions;
-
-    const scaledTimeSeries = this.scaleToUnit(unit);
+    const color = plottingOptions.color ?? config.color ?? undefined;
+    const scaledTimeSeries = this.scaleToUnit(plottingOptions.unit);
 
     const markedSeries = markDelayedData(scaledTimeSeries, config.delay ?? 0);
 
     return [
       BarSeries({
         name: timeSeries.field,
-        color: timeSeries.color,
+        color,
         stack: config.stack ?? GLOBAL_STACK_NAME,
         animation: false,
         itemStyle: {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
@@ -29,9 +29,8 @@ export class Line extends AggregateTimeSeries<LineConfig> implements PlottableDa
   toSeries(plottingOptions: AggregateTimePlottingOptions) {
     const {timeSeries, config = {}} = this;
 
-    const {color, unit} = plottingOptions;
-
-    const scaledSeries = this.scaleToUnit(unit);
+    const color = plottingOptions.color ?? config.color ?? undefined;
+    const scaledSeries = this.scaleToUnit(plottingOptions.unit);
 
     const [completeTimeSeries, incompleteTimeSeries] =
       splitSeriesIntoCompleteAndIncomplete(scaledSeries, config.delay ?? 0);

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -7,7 +7,7 @@ import {GridBodyCell, GridHeadCell} from 'sentry/components/gridEditable/styles'
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Tooltip} from 'sentry/components/tooltip';
-import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {getChartColorPalette} from 'sentry/constants/chartPalette';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconStack} from 'sentry/icons/iconStack';
 import {IconWarning} from 'sentry/icons/iconWarning';
@@ -103,6 +103,10 @@ function AggregatesTable({
     prefixColumnWidth: 'min-content',
   });
 
+  const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
+
+  const palette = getChartColorPalette(numberOfRowsNeedingColor - 2)!; // -2 because getColorPalette artificially adds 1, I'm not sure why
+
   return (
     <Fragment>
       <Table ref={tableRef} styles={initialTableStyles} scrollable height={TABLE_HEIGHT}>
@@ -172,7 +176,9 @@ function AggregatesTable({
               return (
                 <TableRow key={i}>
                   <TableBodyCell key={`samples-${i}`}>
-                    {topEvents && i < topEvents && <TopResultsIndicator index={i} />}
+                    {topEvents && i < topEvents && (
+                      <TopResultsIndicator color={palette[i]!} />
+                    )}
                     <Tooltip title={t('View Samples')} containerDisplayMode="flex">
                       <StyledLink to={target} data-test-id={'unstack-link'}>
                         <IconStack />
@@ -314,16 +320,14 @@ function SpansTable({spansTableResult, query: queryParts, index}: SampleTablePro
   );
 }
 
-const TopResultsIndicator = styled('div')<{index: number}>`
+const TopResultsIndicator = styled('div')<{color: string}>`
   position: absolute;
   left: -1px;
   width: 8px;
   height: 16px;
   border-radius: 0 2px 2px 0;
 
-  background-color: ${p => {
-    return CHART_PALETTE[TOP_EVENTS_LIMIT - 1]![p.index];
-  }};
+  background-color: ${p => p.color};
 `;
 
 const StyledLink = styled(Link)`

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -7,7 +7,7 @@ import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {Tooltip} from 'sentry/components/tooltip';
-import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {getChartColorPalette} from 'sentry/constants/chartPalette';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconStack} from 'sentry/icons/iconStack';
 import {IconWarning} from 'sentry/icons/iconWarning';
@@ -73,6 +73,10 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
   const numberTags = useSpanTags('number');
   const stringTags = useSpanTags('string');
+
+  const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
+
+  const palette = getChartColorPalette(numberOfRowsNeedingColor - 2)!; // -2 because getColorPalette artificially adds 1, I'm not sure why
 
   return (
     <Fragment>
@@ -160,7 +164,9 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
               return (
                 <TableRow key={i}>
                   <TableBodyCell>
-                    {topEvents && i < topEvents && <TopResultsIndicator index={i} />}
+                    {topEvents && i < topEvents && (
+                      <TopResultsIndicator color={palette[i]!} />
+                    )}
                     <Tooltip title={t('View Samples')} containerDisplayMode="flex">
                       <StyledLink to={target}>
                         <IconStack />
@@ -196,16 +202,14 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   );
 }
 
-const TopResultsIndicator = styled('div')<{index: number}>`
+const TopResultsIndicator = styled('div')<{color: string}>`
   position: absolute;
   left: -1px;
   width: 9px;
   height: 16px;
   border-radius: 0 3px 3px 0;
 
-  background-color: ${p => {
-    return CHART_PALETTE[TOP_EVENTS_LIMIT - 1]![p.index];
-  }};
+  background-color: ${p => p.color};
 `;
 
 const StyledLink = styled(Link)`


### PR DESCRIPTION
- Fix colour handling in series constructors. Always obey the plotting options, but fall back to config options. This fixes the bug of the legend and the series colours not matching
- Sync chart and table colours. Constrain the palette used for `TopResultsIndicator` to the number of rows in the table. This will match nearby charts

**Before:**
![Screenshot 2025-03-04 at 11 42 58 AM](https://github.com/user-attachments/assets/fe24f852-a045-4393-af75-7c55760d07f1)

**After:**
![Screenshot 2025-03-04 at 11 43 09 AM](https://github.com/user-attachments/assets/22c62350-b549-4f65-9921-89f02c1867bd)
