### PR TITLE
feat(issue-views): Only send mutation request on reorder completion

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.spec.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.spec.tsx
@@ -28,10 +28,10 @@ describe('IssueViewNavEllipsisMenu', () => {
 
   const defaultProps: IssueViewNavEllipsisMenuProps = {
     baseUrl: '/organizations/sentry/issues',
-    deleteView: jest.fn(),
-    duplicateView: jest.fn(),
+    onDeleteView: jest.fn(),
+    onDuplicateView: jest.fn(),
+    onUpdateView: jest.fn(),
     setIsEditing: jest.fn(),
-    updateView: jest.fn(),
     view: mockView,
     isLastView: false,
   };

--- a/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavEllipsisMenu.tsx
@@ -16,11 +16,11 @@ import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 
 export interface IssueViewNavEllipsisMenuProps {
   baseUrl: string;
-  deleteView: () => void;
-  duplicateView: () => void;
   isLastView: boolean;
+  onDeleteView: () => void;
+  onDuplicateView: () => void;
+  onUpdateView: (view: IssueView) => void;
   setIsEditing: (isEditing: boolean) => void;
-  updateView: (view: IssueView) => void;
   view: IssueView;
   sectionRef?: React.RefObject<HTMLDivElement>;
 }
@@ -29,9 +29,9 @@ export function IssueViewNavEllipsisMenu({
   sectionRef,
   setIsEditing,
   view,
-  deleteView,
-  duplicateView,
-  updateView,
+  onDeleteView,
+  onDuplicateView,
+  onUpdateView,
   baseUrl,
   isLastView,
 }: IssueViewNavEllipsisMenuProps) {
@@ -48,7 +48,7 @@ export function IssueViewNavEllipsisMenu({
       timeFilters: view.unsavedChanges?.timeFilters ?? view.timeFilters,
       unsavedChanges: undefined,
     };
-    updateView(updatedView);
+    onUpdateView(updatedView);
     navigate(constructViewLink(baseUrl, updatedView));
 
     trackAnalytics('issue_views.saved_changes', {
@@ -62,7 +62,7 @@ export function IssueViewNavEllipsisMenu({
       ...view,
       unsavedChanges: undefined,
     };
-    updateView(updatedView);
+    onUpdateView(updatedView);
     navigate(constructViewLink(baseUrl, updatedView));
 
     trackAnalytics('issue_views.discarded_changes', {
@@ -122,13 +122,13 @@ export function IssueViewNavEllipsisMenu({
             {
               key: 'duplicate-tab',
               label: t('Duplicate'),
-              onAction: duplicateView,
+              onAction: onDuplicateView,
             },
             {
               key: 'delete-tab',
               label: t('Delete'),
               priority: 'danger',
-              onAction: deleteView,
+              onAction: onDeleteView,
               disabled: isLastView,
             },
           ],

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -31,14 +31,6 @@ import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 export interface IssueViewNavItemContentProps {
   /**
-   * A callback function that deletes the view.
-   */
-  deleteView: () => void;
-  /**
-   * A callback function that duplicates the view.
-   */
-  duplicateView: () => void;
-  /**
    * Whether the item is active.
    */
   isActive: boolean;
@@ -52,13 +44,25 @@ export interface IssueViewNavItemContentProps {
    */
   isLastView: boolean;
   /**
-   * A callback function that updates the isDragging state.
+   * A callback function that's fired when the user clicks "Delete" on the view.
    */
-  setIsDragging: (isDragging: boolean) => void;
+  onDeleteView: () => void;
+  /**
+   * A callback function that's fired when the user clicks "Duplicate" on the view.
+   */
+  onDuplicateView: () => void;
+  /**
+   * A callback function that is called when the user has completed a reorder.
+   */
+  onReorderComplete: () => void;
   /**
    * A callback function that updates the view with new params.
    */
-  updateView: (updatedView: IssueView) => void;
+  onUpdateView: (updatedView: IssueView) => void;
+  /**
+   * A callback function that updates the isDragging state.
+   */
+  setIsDragging: (isDragging: boolean) => void;
   /**
    * The issue view to display
    */
@@ -70,13 +74,15 @@ export interface IssueViewNavItemContentProps {
    */
   sectionRef?: React.RefObject<HTMLDivElement>;
 }
+
 export function IssueViewNavItemContent({
   view,
   sectionRef,
   isActive,
-  updateView,
-  deleteView,
-  duplicateView,
+  onUpdateView,
+  onDeleteView,
+  onDuplicateView,
+  onReorderComplete,
   isLastView,
   isDragging,
   setIsDragging,
@@ -99,19 +105,19 @@ export function IssueViewNavItemContent({
       const unsavedChanges = hasUnsavedChanges(view, location.query);
 
       if (unsavedChanges && !isEqual(unsavedChanges, view.unsavedChanges)) {
-        updateView({
+        onUpdateView({
           ...view,
           unsavedChanges,
         });
       } else if (!unsavedChanges && view.unsavedChanges) {
-        updateView({
+        onUpdateView({
           ...view,
           unsavedChanges: undefined,
         });
       }
     }
     return;
-  }, [view, isActive, location.query, navigate, baseUrl, updateView]);
+  }, [view, isActive, location.query, navigate, baseUrl, onUpdateView]);
 
   const projectPlatforms = projects
     .filter(p => view.projects.map(String).includes(p.id))
@@ -136,6 +142,7 @@ export function IssueViewNavItemContent({
       }}
       onDragEnd={() => {
         setIsDragging(false);
+        onReorderComplete();
         endInteraction();
       }}
       layoutId={`${view.id}`}
@@ -162,9 +169,9 @@ export function IssueViewNavItemContent({
               isLastView={isLastView}
               setIsEditing={setIsEditing}
               view={view}
-              updateView={updateView}
-              deleteView={deleteView}
-              duplicateView={duplicateView}
+              onUpdateView={onUpdateView}
+              onDeleteView={onDeleteView}
+              onDuplicateView={onDuplicateView}
               baseUrl={baseUrl}
               sectionRef={sectionRef}
             />
@@ -189,7 +196,7 @@ export function IssueViewNavItemContent({
           isEditing={isEditing}
           isSelected={isActive}
           onChange={value => {
-            updateView({...view, label: value});
+            onUpdateView({...view, label: value});
             trackAnalytics('issue_views.renamed_view', {
               leftNav: true,
               organization: organization.slug,

--- a/static/app/components/nav/issueViews/issueViewNavItems.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItems.tsx
@@ -134,18 +134,14 @@ export function IssueViewNavItems({
     [organization.slug, updateViews]
   );
 
-  const handleReorder = useCallback(
-    (newOrder: IssueView[]) => {
-      setViews(newOrder);
-      debounceUpdateViews(newOrder);
+  const handleReorderComplete = useCallback(() => {
+    debounceUpdateViews(views);
 
-      trackAnalytics('issue_views.reordered_views', {
-        leftNav: true,
-        organization: organization.slug,
-      });
-    },
-    [debounceUpdateViews, organization.slug]
-  );
+    trackAnalytics('issue_views.reordered_views', {
+      leftNav: true,
+      organization: organization.slug,
+    });
+  }, [debounceUpdateViews, organization.slug, views]);
 
   const handleUpdateView = useCallback(
     (view: IssueView, updatedView: IssueView) => {
@@ -216,7 +212,7 @@ export function IssueViewNavItems({
       as="div"
       axis="y"
       values={views ?? []}
-      onReorder={handleReorder}
+      onReorder={newOrder => setViews(newOrder)}
       initial={false}
       ref={sectionRef}
     >
@@ -226,12 +222,13 @@ export function IssueViewNavItems({
             view={view}
             sectionRef={sectionRef}
             isActive={view.id === viewId}
+            onReorderComplete={handleReorderComplete}
+            onUpdateView={updatedView => handleUpdateView(view, updatedView)}
+            onDeleteView={() => handleDeleteView(view)}
+            onDuplicateView={() => handleDuplicateView(view)}
+            isLastView={views.length === 1}
             isDragging={isDragging}
             setIsDragging={setIsDragging}
-            updateView={updatedView => handleUpdateView(view, updatedView)}
-            deleteView={() => handleDeleteView(view)}
-            duplicateView={() => handleDuplicateView(view)}
-            isLastView={views.length === 1}
           />
         </AnimatePresence>
       ))}


### PR DESCRIPTION
Only fires the mutation request on reorder completion (when the user stops dragging), rather then on Motion's native `onReorder` prop, which fires any time the order changes, including when the user is mid-drag. Ideally, we would fire only when the order is different, but that's a really incremental optimization for the amount of complexity it would add. 

Includes a bonus style change the prepends "on" to all of the issue view callback props. This is just for semantic consistency across the codebase, and so they all appear next to each other in the props interface. 