### PR TITLE
ref(grouping): Stop checking grouphash metadata feature flag

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -12,7 +12,7 @@ import random
 from datetime import datetime
 from typing import Any, TypeIs, cast
 
-from sentry import features, options
+from sentry import options
 from sentry.eventstore.models import Event
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.component import (
@@ -110,9 +110,7 @@ METRICS_TAGS_BY_HASH_BASIS = {
 
 def should_handle_grouphash_metadata(project: Project, grouphash_is_new: bool) -> bool:
     # Killswitches
-    if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled") or not features.has(
-        "organizations:grouphash-metadata-creation", project.organization
-    ):
+    if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
         return False
 
     # While we're backfilling metadata for existing grouphash records, if the load is too high, we

--- a/tests/sentry/deletions/test_grouphash.py
+++ b/tests/sentry/deletions/test_grouphash.py
@@ -9,13 +9,11 @@ from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.seer.similarity.types import SeerSimilarIssueData
 from sentry.tasks.unmerge import unmerge
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
 
 
-@apply_feature_flag_on_cls("organizations:grouphash-metadata-creation")
 class DeleteGroupHashTest(TestCase):
     def test_deleting_group_deletes_grouphash_and_metadata(self):
         event = self.store_event(data={"message": "Dogs are great!"}, project_id=self.project.id)

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -11,7 +11,6 @@ from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.types import SeerSimilarIssueData
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.mocking import capture_results
 
 EMPTY_SEER_RESULTS = (
@@ -197,7 +196,6 @@ class StoredSeerMetadataTest(TestCase):
         assert metadata.seer_matched_grouphash == expected_seer_matched_grouphash
         assert metadata.seer_match_distance == expected_seer_match_distance
 
-    @with_feature("organizations:grouphash-metadata-creation")
     @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_group_with_no_seer_match(self, _):
         with patch(
@@ -224,7 +222,6 @@ class StoredSeerMetadataTest(TestCase):
                 None,
             )
 
-    @with_feature("organizations:grouphash-metadata-creation")
     @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_group_with_seer_match(self, _):
         existing_event = save_new_event(get_event_data(), self.project)
@@ -268,7 +265,6 @@ class StoredSeerMetadataTest(TestCase):
                 seer_result_data.stacktrace_distance,
             )
 
-    @with_feature("organizations:grouphash-metadata-creation")
     def test_event_not_sent_to_seer(self):
         with patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=False):
             event = save_new_event({"message": "Sit! Stay! Good dog!"}, self.project)
@@ -279,7 +275,6 @@ class StoredSeerMetadataTest(TestCase):
             assert event_grouphash and event_grouphash.metadata
             self.assert_correct_seer_metadata(event_grouphash, None, None, None, None, None)
 
-    @with_feature("organizations:grouphash-metadata-creation")
     @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_fills_in_missing_date_added(self, _):
 

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -353,7 +353,6 @@ class ShouldCallSeerTest(TestCase):
 
 
 @apply_feature_flag_on_cls("organizations:grouping-hybrid-fingerprint-seer-usage")
-@apply_feature_flag_on_cls("organizations:grouphash-metadata-creation")
 class GetSeerSimilarIssuesTest(TestCase):
     def create_new_event(
         self,


### PR DESCRIPTION
As the final step in rolling out grouphash metadata creation for new grouphashes, this removes our check of the `organizations:grouphash-metadata-creation` feature flag, so that it will start happening for on-prem Sentry instances, the last group to not have the feature. Once the flag is removed from options automator, we can then get rid of it entirely.