### PR TITLE
feat(eap): add field for normalized span description

### DIFF
--- a/src/sentry/search/eap/span_columns.py
+++ b/src/sentry/search/eap/span_columns.py
@@ -74,6 +74,12 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
             secondary_alias=True,
         ),
+        ResolvedColumn(
+            public_alias="sentry.normalized_description",
+            internal_name="sentry.description",
+            search_type="string",
+            secondary_alias=True,
+        ),
         # Message maps to description, this is to allow wildcard searching
         ResolvedColumn(
             public_alias="message",

--- a/src/sentry/search/eap/span_columns.py
+++ b/src/sentry/search/eap/span_columns.py
@@ -78,7 +78,6 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="sentry.normalized_description",
             internal_name="sentry.description",
             search_type="string",
-            secondary_alias=True,
         ),
         # Message maps to description, this is to allow wildcard searching
         ResolvedColumn(


### PR DESCRIPTION
The normalized (i.e parameterized) span description is placed into `sentry.description` in the eap table.
This PR maps `sentry.normalized_description` on the events endpoint to `sentry.description` in the eap table
Solves item 2 in https://github.com/getsentry/eap-planning/issues/135