### PR TITLE
fix(crons): Fix api permissions to match alert permissions

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -18,7 +18,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.helpers.teams import get_teams
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -55,8 +55,6 @@ from sentry.types.actor import Actor
 from sentry.utils.auth import AuthenticatedHttpRequest
 from sentry.utils.outcomes import Outcome
 
-from .base import OrganizationMonitorPermission
-
 
 def map_value_to_constant(constant, value):
     value = value.upper()
@@ -85,7 +83,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.CRONS
-    permission_classes = (OrganizationMonitorPermission,)
+    permission_classes = (OrganizationAlertRulePermission,)
 
     @extend_schema(
         operation_id="Retrieve Monitors for an Organization",

--- a/src/sentry/monitors/endpoints/project_processing_errors_details.py
+++ b/src/sentry/monitors/endpoints/project_processing_errors_details.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import ProjectEndpoint
+from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.apidocs.constants import (
     RESPONSE_FORBIDDEN,
     RESPONSE_NO_CONTENT,
@@ -22,13 +22,11 @@ from sentry.apidocs.parameters import GlobalParams, MonitorParams
 from sentry.models.project import Project
 from sentry.monitors.processing_errors.manager import InvalidProjectError, delete_error
 
-from .base import ProjectMonitorPermission
-
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class ProjectProcessingErrorsDetailsEndpoint(ProjectEndpoint):
-    permission_classes: tuple[type[BasePermission], ...] = (ProjectMonitorPermission,)
+    permission_classes: tuple[type[BasePermission], ...] = (ProjectAlertRulePermission,)
 
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,

--- a/src/sentry/monitors/endpoints/project_processing_errors_index.py
+++ b/src/sentry/monitors/endpoints/project_processing_errors_index.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import ProjectEndpoint
+from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.apidocs.constants import (
     RESPONSE_FORBIDDEN,
     RESPONSE_NO_CONTENT,
@@ -18,7 +18,6 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import GlobalParams
 from sentry.models.project import Project
-from sentry.monitors.endpoints.base import ProjectMonitorPermission
 from sentry.monitors.processing_errors.errors import ProcessingErrorType
 from sentry.monitors.processing_errors.manager import delete_errors_for_project_by_type
 
@@ -26,7 +25,7 @@ from sentry.monitors.processing_errors.manager import delete_errors_for_project_
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class ProjectProcessingErrorsIndexEndpoint(ProjectEndpoint):
-    permission_classes: tuple[type[BasePermission], ...] = (ProjectMonitorPermission,)
+    permission_classes: tuple[type[BasePermission], ...] = (ProjectAlertRulePermission,)
 
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,


### PR DESCRIPTION
Since crons moved to the alert section its permissions have been wrong. Moving these to match uptime and alerts, and just share the same permission class.

<!-- Describe your PR here. -->