### PR TITLE
ref(ui): Do not round checkInTimeline ticks at edges

### DIFF
--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -80,8 +80,8 @@ export function CheckInTimeline<Status extends string>({
             <JobTick
               style={{left, width}}
               css={theme => getTickStyle(statusStyle, status, theme)}
-              roundedLeft={isStarting}
-              roundedRight={isEnding}
+              roundedLeft={isStarting && left !== 0}
+              roundedRight={isEnding && left + width !== timeWindowConfig.timelineWidth}
               data-test-id="monitor-checkin-tick"
             />
           </CheckInTooltip>


### PR DESCRIPTION
When the start or end of a tick is at the start or end of the timeline
container do not round it, this looks like this

Before
![clipboard.png](https://i.imgur.com/Ik8Yj31.png)

After

![clipboard.png](https://i.imgur.com/0ykglsS.png)