### PR TITLE
ref(releases): add ProjectBadge to release tables on insights

### DIFF
--- a/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseAdoptionTable.tsx
@@ -1,25 +1,29 @@
-import {useCallback, useMemo} from 'react';
+import {type ReactNode, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import Duration from 'sentry/components/duration';
 import type {GridColumnHeader, GridColumnOrder} from 'sentry/components/gridEditable';
 import GridEditable from 'sentry/components/gridEditable';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHeaderCell';
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
 import useQueryBasedSorting from 'sentry/components/replays/useQueryBasedSorting';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {AvatarProject} from 'sentry/types/project';
+import type {ReleaseProject} from 'sentry/types/release';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import useOrganization from 'sentry/utils/useOrganization';
+import {ReleaseProjectColumn} from 'sentry/views/releases/list/releaseCard';
 
 type ReleaseAdoptionItem = {
   adoption: number;
   adoption_stage: string;
   date: string;
   lifespan: number | undefined;
-  project_id: number;
+  project: ReleaseProject;
   release: string;
 };
 
@@ -35,6 +39,7 @@ type Column = GridColumnHeader<keyof ReleaseAdoptionItem>;
 
 const BASE_COLUMNS: Array<GridColumnOrder<keyof ReleaseAdoptionItem>> = [
   {key: 'release', name: 'version'},
+  {key: 'project', name: 'project'},
   {key: 'date', name: 'date created'},
   {key: 'lifespan', name: 'lifespan'},
   {key: 'adoption', name: 'adoption'},
@@ -92,12 +97,20 @@ export default function ReleaseAdoptionTable({
         );
       }
 
+      if (column.key === 'project') {
+        return (
+          <ReleaseProjectColumn>
+            <ProjectBadge project={value as AvatarProject} avatarSize={16} />
+          </ReleaseProjectColumn>
+        );
+      }
+
       if (column.key === 'adoption') {
         return `${(value as number).toFixed(2)}%`;
       }
 
       if (!meta?.fields) {
-        return value;
+        return value as ReactNode;
       }
 
       const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {type ReactNode, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -6,15 +6,19 @@ import Count from 'sentry/components/count';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import type {GridColumnHeader, GridColumnOrder} from 'sentry/components/gridEditable';
 import GridEditable from 'sentry/components/gridEditable';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import renderSortableHeaderCell from 'sentry/components/replays/renderSortableHeaderCell';
 import useQueryBasedColumnResize from 'sentry/components/replays/useQueryBasedColumnResize';
 import useQueryBasedSorting from 'sentry/components/replays/useQueryBasedSorting';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {AvatarProject} from 'sentry/types/project';
+import type {ReleaseProject} from 'sentry/types/release';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import useOrganization from 'sentry/utils/useOrganization';
+import {ReleaseProjectColumn} from 'sentry/views/releases/list/releaseCard';
 import {getReleaseNewIssuesUrl} from 'sentry/views/releases/utils';
 
 type ReleaseHealthItem = {
@@ -22,6 +26,7 @@ type ReleaseHealthItem = {
   crash_free_sessions: number;
   date: string;
   error_count: number;
+  project: ReleaseProject;
   project_id: number;
   release: string;
   sessions: number;
@@ -39,6 +44,7 @@ type Column = GridColumnHeader<keyof ReleaseHealthItem>;
 
 const BASE_COLUMNS: Array<GridColumnOrder<keyof ReleaseHealthItem>> = [
   {key: 'release', name: 'version'},
+  {key: 'project', name: 'project'},
   {key: 'date', name: 'date created'},
   {key: 'adoption_stage', name: 'stage'},
   {key: 'crash_free_sessions', name: 'crash free rate'},
@@ -86,6 +92,14 @@ export default function ReleaseHealthTable({
         return `${(value as number).toFixed(2)}%`;
       }
 
+      if (column.key === 'project') {
+        return (
+          <ReleaseProjectColumn>
+            <ProjectBadge project={value as AvatarProject} avatarSize={16} />
+          </ReleaseProjectColumn>
+        );
+      }
+
       if (column.key === 'error_count') {
         return (value as number) > 0 ? (
           <Tooltip title={t('Open in Issues')} position="auto-start">
@@ -96,15 +110,15 @@ export default function ReleaseHealthTable({
                 dataRow.release
               )}
             >
-              <Count value={value} />
+              <Count value={value as number} />
             </GlobalSelectionLink>
           </Tooltip>
         ) : (
-          <Count value={value} />
+          <Count value={value as number} />
         );
       }
       if (!meta?.fields) {
-        return value;
+        return value as ReactNode;
       }
 
       const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -118,6 +118,7 @@ export default function useOrganizationReleases({
               : undefined;
 
             return {
+              project: release.projects[0]!,
               release: release.shortVersion ?? release.version,
               date: release.dateCreated,
               adoption_stage: projSlug


### PR DESCRIPTION
adds the project associated with the release data per row

<img width="1216" alt="SCR-20250304-kmna" src="https://github.com/user-attachments/assets/587dc254-3a54-4e9c-94e3-692a22684388" />
