### PR TITLE
fix(settings): Fix bad breadcrumb links

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -1,6 +1,6 @@
+import {Link as RouterLink} from 'react-router-dom';
 import styled from '@emotion/styled';
 
-import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
@@ -69,7 +69,11 @@ function SettingsBreadcrumb({className, routes, params}: Props) {
   );
 }
 
-const CrumbLink = styled(Link)`
+// Uses Link directly from react-router-dom to avoid the URL normalization
+// that happens in the internal Link component. It is unncessary because we
+// get routes from the router, and will actually cause issues because the
+// routes do not have organization information.
+const CrumbLink = styled(RouterLink)`
   display: block;
 
   color: ${p => p.theme.subText};


### PR DESCRIPTION
The settings page breadcrumbs were often linking to the wrong page. There are some issues with double-normalizing settings routes, and because the settings breadcrumbs are generated from the router they do not need to be normalized. Using the router link directly to avoid normalization fixes the links.

![CleanShot 2025-03-04 at 11 50 51](https://github.com/user-attachments/assets/cc6c499c-c131-493c-a0ae-3acafab8c376)
