### PR TITLE
fix(ui): Releases legend color different when empty

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
@@ -22,11 +22,7 @@ export function useReleaseMarkLineSeries({group}: {group: Group}) {
   const theme = useTheme();
   const eventView = useIssueDetailsEventView({group});
   const organization = useOrganization();
-  const {
-    data: releases = [],
-    isPending: isLoadingReleases,
-    error: releasesError,
-  } = useApiQuery<ReleaseStat[]>(
+  const {data: releases = []} = useApiQuery<ReleaseStat[]>(
     [
       `/organizations/${organization.slug}/releases/stats/`,
       {
@@ -43,14 +39,6 @@ export function useReleaseMarkLineSeries({group}: {group: Group}) {
       staleTime: 0,
     }
   );
-
-  if (isLoadingReleases || releasesError) {
-    return {
-      seriesName: t('Releases'),
-      markLine: {},
-      data: [],
-    };
-  }
 
   const markLine = MarkLine({
     animation: false,


### PR DESCRIPTION
This is used on issue details page. The "Releases" legend color is different when it is empty vs not. Removed the loading/error logic as well as it is not really needed since nothing is rendered when releases is empty
