### PR TITLE
feat(releases): add session health rate breakdown chart to insights

### DIFF
--- a/static/app/views/insights/sessions/charts/sessionHealthChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthChart.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
 
 export default function SessionHealthChart() {
@@ -13,7 +13,7 @@ export default function SessionHealthChart() {
   };
 
   return (
-    <InsightsLineChartWidget
+    <InsightsAreaChartWidget
       title={t('Session Health Rate')}
       aliases={aliases}
       series={series}

--- a/static/app/views/insights/sessions/charts/sessionHealthChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthChart.tsx
@@ -1,0 +1,24 @@
+import {t} from 'sentry/locale';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
+
+export default function SessionHealthChart() {
+  const {series, isPending, error} = useSessionHealthBreakdown();
+
+  const aliases = {
+    healthy_session_rate: t('Healthy session rate'),
+    crashed_session_rate: t('Crashed session rate'),
+    errored_session_rate: t('Errored session rate'),
+    abnormal_session_rate: t('Abnormal session rate'),
+  };
+
+  return (
+    <InsightsLineChartWidget
+      title={t('Session Health Rate')}
+      aliases={aliases}
+      series={series}
+      isLoading={isPending}
+      error={error}
+    />
+  );
+}

--- a/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/sessionHealthRateChart.tsx
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
 import useSessionHealthBreakdown from 'sentry/views/insights/sessions/queries/useSessionHealthBreakdown';
 
-export default function SessionHealthChart() {
+export default function SessionHealthRateChart() {
   const {series, isPending, error} = useSessionHealthBreakdown();
 
   const aliases = {

--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -4,6 +4,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useSessionAdoptionRate from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
+import {getStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useCrashFreeSessions() {
   const location = useLocation();
@@ -47,10 +48,6 @@ export default function useCrashFreeSessions() {
       error,
     };
   }
-
-  const getStatusSeries = (status: string, groups: typeof sessionData.groups) =>
-    groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
-    [];
 
   // Maps release to its API response groups
   const releaseGroupMap = new Map<string, typeof sessionData.groups>();

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -2,6 +2,7 @@ import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useErrorFreeSessions() {
   const location = useLocation();
@@ -43,10 +44,6 @@ export default function useErrorFreeSessions() {
       error,
     };
   }
-
-  const getStatusSeries = (status: string, groups: typeof sessionData.groups) =>
-    groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
-    [];
 
   // Returns series data not grouped by release
   const seriesData = getStatusSeries('healthy', sessionData.groups).map(

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -3,6 +3,10 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
+const getStatusSeries = (status: string, groups: SessionApiResponse['groups']) =>
+  groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
+  [];
+
 export default function useSessionHealthBreakdown() {
   const location = useLocation();
   const organization = useOrganization();
@@ -43,10 +47,6 @@ export default function useSessionHealthBreakdown() {
       error,
     };
   }
-
-  const getStatusSeries = (status: string, groups: typeof sessionData.groups) =>
-    groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
-    [];
 
   // Create a map of status to their data
   const statusData = {

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -1,0 +1,99 @@
+import type {SessionApiResponse} from 'sentry/types/organization';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useSessionHealthBreakdown() {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const locationWithoutWidth = {
+    ...location,
+    query: {
+      ...location.query,
+      width_health_table: undefined,
+      width_adoption_table: undefined,
+      cursor_health_table: undefined,
+      cursor_adoption_table: undefined,
+    },
+  };
+
+  const {
+    data: sessionData,
+    isPending,
+    error,
+  } = useApiQuery<SessionApiResponse>(
+    [
+      `/organizations/${organization.slug}/sessions/`,
+      {
+        query: {
+          ...locationWithoutWidth.query,
+          field: ['sum(session)'],
+          groupBy: ['session.status'],
+        },
+      },
+    ],
+    {staleTime: 0}
+  );
+
+  if (isPending || !sessionData) {
+    return {
+      series: [],
+      isPending,
+      error,
+    };
+  }
+
+  const getStatusSeries = (status: string, groups: typeof sessionData.groups) =>
+    groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
+    [];
+
+  // Create a map of status to their data
+  const statusData = {
+    healthy: getStatusSeries('healthy', sessionData.groups),
+    crashed: getStatusSeries('crashed', sessionData.groups),
+    errored: getStatusSeries('errored', sessionData.groups),
+    abnormal: getStatusSeries('abnormal', sessionData.groups),
+  };
+
+  const createDatapoints = (data: number[]) =>
+    data.map((count, idx) => {
+      const intervalTotal = sessionData.groups.reduce(
+        (acc, group) => acc + (group.series['sum(session)']?.[idx] ?? 0),
+        0
+      );
+
+      return {
+        name: sessionData.intervals[idx] ?? '',
+        value: intervalTotal > 0 ? count / intervalTotal : 1,
+      };
+    });
+
+  const createSeries = (
+    data: ReturnType<typeof createDatapoints>,
+    status: keyof typeof statusData
+  ) => ({
+    data,
+    seriesName: `${status}_session_rate`,
+    meta: {
+      fields: {
+        [`${status}_session_rate`]: 'percentage' as const,
+        time: 'date' as const,
+      },
+      units: {
+        [`${status}_session_rate`]: '%',
+      },
+    },
+  });
+
+  // Create all series at once
+  const series = Object.entries(statusData).map(([status, data]) =>
+    createSeries(createDatapoints(data), status as keyof typeof statusData)
+  );
+
+  return {
+    series,
+    isPending,
+    error,
+  };
+}

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -65,7 +65,7 @@ export default function useSessionHealthBreakdown() {
 
       return {
         name: sessionData.intervals[idx] ?? '',
-        value: intervalTotal > 0 ? count / intervalTotal : 1,
+        value: intervalTotal > 0 ? count / intervalTotal : 0,
       };
     });
 

--- a/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
+++ b/static/app/views/insights/sessions/queries/useSessionHealthBreakdown.tsx
@@ -2,10 +2,7 @@ import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-
-const getStatusSeries = (status: string, groups: SessionApiResponse['groups']) =>
-  groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
-  [];
+import {getStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useSessionHealthBreakdown() {
   const location = useLocation();
@@ -86,7 +83,7 @@ export default function useSessionHealthBreakdown() {
     },
   });
 
-  // Create all series at once
+  // Wrap all session rate data in a series
   const series = Object.entries(statusData).map(([status, data]) =>
     createSeries(createDatapoints(data), status as keyof typeof statusData)
   );

--- a/static/app/views/insights/sessions/utils/sessions.tsx
+++ b/static/app/views/insights/sessions/utils/sessions.tsx
@@ -1,0 +1,5 @@
+import type {SessionApiResponse} from 'sentry/types/organization';
+
+export const getStatusSeries = (status: string, groups: SessionApiResponse['groups']) =>
+  groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
+  [];

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -20,6 +20,7 @@ import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settin
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import CrashFreeSessionChart from 'sentry/views/insights/sessions/charts/crashFreeSessionChart';
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
+import SessionHealthChart from 'sentry/views/insights/sessions/charts/sessionHealthChart';
 import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/filterReleaseDropdown';
 import ReleaseAdoption from 'sentry/views/insights/sessions/components/tables/releaseAdoption';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
@@ -62,6 +63,9 @@ export function SessionsOverview() {
                 <ModuleLayout.Half>
                   <CrashFreeSessionChart />
                 </ModuleLayout.Half>
+                <ModuleLayout.Half>
+                  <SessionHealthChart />
+                </ModuleLayout.Half>
                 <ModuleLayout.Full>
                   <FilterWrapper>
                     <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
@@ -72,9 +76,14 @@ export function SessionsOverview() {
               </Fragment>
             )}
             {view === FRONTEND_LANDING_SUB_PATH && (
-              <ModuleLayout.Third>
-                <ErrorFreeSessionsChart />
-              </ModuleLayout.Third>
+              <Fragment>
+                <ModuleLayout.Third>
+                  <ErrorFreeSessionsChart />
+                </ModuleLayout.Third>
+                <ModuleLayout.Third>
+                  <SessionHealthChart />
+                </ModuleLayout.Third>
+              </Fragment>
             )}
           </ModuleLayout.Layout>
         </Layout.Main>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -20,7 +20,7 @@ import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settin
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import CrashFreeSessionChart from 'sentry/views/insights/sessions/charts/crashFreeSessionChart';
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
-import SessionHealthChart from 'sentry/views/insights/sessions/charts/sessionHealthChart';
+import SessionHealthRateChart from 'sentry/views/insights/sessions/charts/sessionHealthRateChart';
 import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/filterReleaseDropdown';
 import ReleaseAdoption from 'sentry/views/insights/sessions/components/tables/releaseAdoption';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
@@ -64,7 +64,7 @@ export function SessionsOverview() {
                   <CrashFreeSessionChart />
                 </ModuleLayout.Half>
                 <ModuleLayout.Half>
-                  <SessionHealthChart />
+                  <SessionHealthRateChart />
                 </ModuleLayout.Half>
                 <ModuleLayout.Full>
                   <FilterWrapper>
@@ -81,7 +81,7 @@ export function SessionsOverview() {
                   <ErrorFreeSessionsChart />
                 </ModuleLayout.Third>
                 <ModuleLayout.Third>
-                  <SessionHealthChart />
+                  <SessionHealthRateChart />
                 </ModuleLayout.Third>
               </Fragment>
             )}


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/86247

### adds a stacked area chart to the frontend & mobile insights pages, showing a breakdown of session status (crashed, errored, abnormal, or healthy):


<img width="1177" alt="SCR-20250304-ldkv" src="https://github.com/user-attachments/assets/3586977a-4e13-4678-8d29-68e81a9a3906" />

### this is the same data visualized in line graph form:

<img width="1173" alt="SCR-20250304-lbsr" src="https://github.com/user-attachments/assets/e227eff1-6b32-41b3-a715-0a994ce1bc9d" />

### on sentry:
<img width="1191" alt="SCR-20250304-leqm" src="https://github.com/user-attachments/assets/546dadc8-5fd3-4191-9716-5f1f82d0d4ff" />
<img width="1092" alt="SCR-20250304-lept" src="https://github.com/user-attachments/assets/31f2bda3-eb41-4917-911b-2bc594d2f39a" />


### note: if there is no session data, all percentages are 0% to ensure the total never exceeds 100%, which is currently different from our behavior on the crash-free/error-free rate charts (which put the rate as 100% when there is no session data).
