### PR TITLE
feat(derived_code_mappings): Increase sample rate of creation metric

### DIFF
--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -201,4 +201,5 @@ def set_project_codemappings(
             },
         )
         if created:
-            metrics.incr("code_mappings.created", tags={"platform": platform})
+            # Since it is a low volume event, we can sample at 100%
+            metrics.incr(key="code_mappings.created", tags={"platform": platform}, sample_rate=1.0)

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -77,7 +77,9 @@ class BaseDeriveCodeMappings(TestCase):
             code_mapping = code_mappings[0]
             assert code_mapping.stack_root == expected_stack_root
             assert code_mapping.source_root == expected_source_root
-            mock_incr.assert_called_with("code_mappings.created", tags={"platform": event.platform})
+            mock_incr.assert_called_with(
+                key="code_mappings.created", tags={"platform": event.platform}, sample_rate=1.0
+            )
 
     def _process_and_assert_no_code_mapping(
         self,


### PR DESCRIPTION
It is a very low volume metric, thus, the base line value is useless. I'm expecting that increasing the sampling rate will give us a more accurate picture.

The screenshot shows what I mean by a useless baseline (it stats at nine rather than zero):
<img width="494" alt="image" src="https://github.com/user-attachments/assets/9560cccb-6100-46a0-ba30-82abf51c1ebd" />
