### PR TITLE
feat(flags): support flag backend override on GroupTagsEndpoint

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -26,11 +26,14 @@ class GroupTagsEndpoint(GroupEndpoint):
 
     def get(self, request: Request, group: Group) -> Response:
 
+        if request.GET.get("useFlagsBackend") == "1":
+            backend = tagstore.flag_backend
+        else:
+            backend = tagstore.backend
+
         # optional queryparam `key` can be used to get results
         # only for specific keys.
-        keys = [
-            tagstore.backend.prefix_reserved_key(k) for k in request.GET.getlist("key") if k
-        ] or None
+        keys = [backend.prefix_reserved_key(k) for k in request.GET.getlist("key") if k] or None
 
         # There are 2 use-cases for this method. For the 'Tags' tab we
         # get the top 10 values, for the tag distribution bars we get 9
@@ -46,7 +49,7 @@ class GroupTagsEndpoint(GroupEndpoint):
 
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
 
-        tag_keys = tagstore.backend.get_group_tag_keys_and_top_values(
+        tag_keys = backend.get_group_tag_keys_and_top_values(
             group,
             environment_ids,
             keys=keys,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1434,3 +1434,9 @@ class SnubaFlagStorage(SnubaTagStorage):
 
     def get_snuba_column_name(self, key: str, dataset: Dataset):
         return f"flags[{key}]"
+
+    def is_reserved_key(self, key: str) -> bool:
+        return False
+
+    def prefix_reserved_key(self, key: str) -> str:
+        return key

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -10,14 +10,6 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
                 "tags": {"foo": "bar", "biz": "baz"},
                 "release": "releaseme",
                 "timestamp": before_now(minutes=1).isoformat(),
-                "contexts": {
-                    "flags": {
-                        "values": [
-                            {"flag": "hello", "result": True},
-                            {"flag": "goodbye", "result": False},
-                        ]
-                    }
-                },
             },
             project_id=self.project.id,
         )
@@ -27,18 +19,6 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
                 "tags": {"foo": "quux"},
                 "release": "releaseme",
                 "timestamp": before_now(minutes=1).isoformat(),
-                "contexts": {"flags": {"values": [{"flag": "hello", "result": False}]}},
-            },
-            project_id=self.project.id,
-        )
-
-        self.store_event(
-            data={
-                "fingerprint": ["group-1"],
-                "tags": {"foo": "quux"},
-                "release": "releaseme",
-                "timestamp": before_now(minutes=1).isoformat(),
-                "contexts": {"flags": {"values": [{"flag": "hello", "result": False}]}},
             },
             project_id=self.project.id,
         )
@@ -54,13 +34,12 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{event1.group.id}/tags/?useFlagsBackend=1"
+        url = f"/api/0/issues/{event1.group.id}/tags/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
-        # assert len(response.data) == 4
+        assert len(response.data) == 4
 
         data = sorted(response.data, key=lambda r: r["key"])
-
         assert data[0]["key"] == "biz"
         assert len(data[0]["topValues"]) == 1
 


### PR DESCRIPTION
Ref https://github.com/getsentry/team-replay/issues/550

Similar to OrganizationTags we use the `useFlagsBackend=1` param to query from `SnubaFlagsBackend`. I've also overridden the reserved tag key methods so reserved tags + internal tag syntax (`sentry:`) doesn't impact flag queries.