### PR TITLE
fix(dashboards): Fix `needsColor` bug in `ContinuousTimeSeries`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
@@ -7,7 +7,7 @@ import type {Plottable} from './plottable';
 
 describe('ContinuousTimeSeries', () => {
   describe('isEmpty', () => {
-    it('plottables as not empty', () => {
+    it('marks normal plottables as not empty', () => {
       const timeSeries = TimeSeriesFixture();
 
       const plottable = new Dots(timeSeries);

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
@@ -1,0 +1,71 @@
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+
+import LineSeries from 'sentry/components/charts/series/lineSeries';
+
+import {ContinuousTimeSeries} from './continuousTimeSeries';
+import type {Plottable} from './plottable';
+
+describe('ContinuousTimeSeries', () => {
+  describe('isEmpty', () => {
+    it('plottables as not empty', () => {
+      const timeSeries = TimeSeriesFixture();
+
+      const plottable = new Dots(timeSeries);
+
+      expect(plottable.isEmpty).toBeFalsy();
+    });
+
+    it('marks empty series as empty', () => {
+      const timeSeries = TimeSeriesFixture({
+        data: [],
+      });
+
+      const plottable = new Dots(timeSeries);
+
+      expect(plottable.isEmpty).toBeTruthy();
+    });
+
+    it('marks series of all nulls as empty', () => {
+      const timeSeries = TimeSeriesFixture({
+        data: [
+          {
+            value: null,
+            timestamp: '2024-10-24T15:00:00-04:00',
+          },
+          {
+            value: null,
+            timestamp: '2024-10-24T15:30:00-04:00',
+          },
+        ],
+      });
+
+      const plottable = new Dots(timeSeries);
+
+      expect(plottable.isEmpty).toBeTruthy();
+    });
+  });
+
+  describe('needsColor', () => {
+    it('says that plottables with color config do not need color', () => {
+      const timeSeries = TimeSeriesFixture();
+
+      const plottable = new Dots(timeSeries, {color: 'red'});
+
+      expect(plottable.needsColor).toBeFalsy();
+    });
+
+    it('says that plottables with no color config need color', () => {
+      const timeSeries = TimeSeriesFixture();
+
+      const plottable = new Dots(timeSeries);
+
+      expect(plottable.needsColor).toBeTruthy();
+    });
+  });
+});
+
+class Dots extends ContinuousTimeSeries implements Plottable {
+  toSeries(_plottingOptions: any) {
+    return [LineSeries({})];
+  }
+}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -52,7 +52,7 @@ export abstract class ContinuousTimeSeries<
   }
 
   get needsColor(): boolean {
-    return Boolean(this.config?.color);
+    return !this.config?.color;
   }
 
   get dataType(): AggregationOutputType {


### PR DESCRIPTION
This was a plain simple bug. Invert the logic, and add specs to verify, too. This isn't used anywhere yet, so, no harm no foul.
