### PR TITLE
feat: Tag snuba retry errors

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -504,6 +504,17 @@ class RetrySkipTimeout(urllib3.Retry):
         Just rely on the parent class unless we have a read timeout. In that case
         immediately give up
         """
+        if error:
+            # Setting a tag here cause I don't want to spam errors, but trying to narrow down why we're retrying on
+            # timeouts
+            try:
+                error_class = error.__class__
+                module = error_class.__module__
+                name = error_class.__name__
+                sentry_sdk.set_tag("snuba_pool.retry.error", f"{module}.{name}")
+            except Exception:
+                pass
+
         if error and isinstance(error, urllib3.exceptions.ReadTimeoutError):
             raise error.with_traceback(_stacktrace)
 


### PR DESCRIPTION
- This adds a tag when the snuba pool wants to retry and there's an error because we're seeing retries from snuba after 15s
![image](https://github.com/user-attachments/assets/11e715d2-3bf5-4b8a-8b8e-a3aa1420a228)
