### PR TITLE
fix(ourlogs): Use correct severity text setting

### DIFF
--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -163,7 +163,7 @@ function LogsRow({dataRow, highlightTerms}: LogsRowProps) {
           extra: {
             highlightTerms,
             logColors,
-            useFullSeverityText: true,
+            useFullSeverityText: false,
             renderSeverityCircle: true,
           },
         })}


### PR DESCRIPTION
### Summary
We want to use the severity text map in the table rows.

