### PR TITLE
ref(aci): misc fixes for issue alert migration

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -278,6 +278,7 @@ def create_base_event_frequency_data_condition(
     comparison_type = data.get(
         "comparisonType", ComparisonType.COUNT
     )  # this is camelCase, age comparison is snake_case
+    comparison_type = ComparisonType(comparison_type)
 
     value = max(int(data["value"]), 0)  # force to 0 if negative
     comparison = {
@@ -339,10 +340,12 @@ def create_event_unique_user_frequency_condition_with_conditions(
     data: dict[str, Any], dcg: DataConditionGroup, conditions: list[dict[str, Any]] | None = None
 ) -> DataCondition:
     comparison_type = data.get("comparisonType", ComparisonType.COUNT)
+    comparison_type = ComparisonType(comparison_type)
+    value = max(int(data["value"]), 0)  # force to 0 if negative
 
     comparison = {
         "interval": data["interval"],
-        "value": int(data["value"]),
+        "value": value,
     }
 
     if comparison_type == ComparisonType.COUNT:
@@ -356,15 +359,16 @@ def create_event_unique_user_frequency_condition_with_conditions(
     if conditions:
         for condition in conditions:
             if condition["id"] in (EventAttributeFilter.id, TaggedEventFilter.id):
+                match = MatchType(condition["match"])
                 comparison_filter = {
-                    "match": condition["match"],
+                    "match": match,
                     "key": (
                         condition["attribute"]
                         if condition["id"] == EventAttributeFilter.id
                         else condition["key"]
                     ),
                 }
-                if comparison_filter["match"] not in {MatchType.IS_SET, MatchType.NOT_SET}:
+                if match not in {MatchType.IS_SET, MatchType.NOT_SET}:
                     comparison_filter["value"] = condition["value"]
             else:
                 raise ValueError(f"Unsupported nested condition: {condition["id"]}")

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -46,7 +46,10 @@ def bulk_create_data_conditions(
             dcg_conditions.append(translate_to_data_condition(dict(condition), dcg=dcg))
 
     filtered_data_conditions = [dc for dc in dcg_conditions if dc.type not in SKIPPED_CONDITIONS]
-    DataCondition.objects.bulk_create(filtered_data_conditions)
+
+    # try one by one, keeping errors
+    for dc in filtered_data_conditions:
+        dc.save()
 
 
 def create_if_dcg(

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -190,7 +190,7 @@ class IssueAlertMigrator:
         # if it's empty and this is not the case, we should not migrate
         no_conditions = len(data_conditions) == 0
         only_has_every_event_cond = len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
-        
+
         if no_conditions and not only_has_every_event_cond:
         ):
             raise Exception("No valid conditions, skipping migration")

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -189,10 +189,11 @@ class IssueAlertMigrator:
         # the only time the data_conditions list will be empty is if somebody only has EveryEventCondition in their conditions list.
         # if it's empty and this is not the case, we should not migrate
         no_conditions = len(data_conditions) == 0
-        only_has_every_event_cond = len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
+        only_has_every_event_cond = (
+            len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
+        )
 
         if no_conditions and not only_has_every_event_cond:
-        ):
             raise Exception("No valid conditions, skipping migration")
 
         enabled = True

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -188,8 +188,10 @@ class IssueAlertMigrator:
 
         # the only time the data_conditions list will be empty is if somebody only has EveryEventCondition in their conditions list.
         # if it's empty and this is not the case, we should not migrate
-        if len(data_conditions) == 0 and not (
-            len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
+        no_conditions = len(data_conditions) == 0
+        only_has_every_event_cond = len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
+        
+        if no_conditions and not only_has_every_event_cond:
         ):
             raise Exception("No valid conditions, skipping migration")
 

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -6,6 +6,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
+from sentry.rules.conditions.every_event import EveryEventCondition
 from sentry.rules.processing.processor import split_conditions_and_filters
 from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     create_event_unique_user_frequency_condition_with_conditions,
@@ -110,16 +111,23 @@ class IssueAlertMigrator:
         dcg_conditions: list[DataCondition] = []
 
         for condition in conditions:
-            if (
-                condition["id"] == EventUniqueUserFrequencyConditionWithConditions.id
-            ):  # special case
-                dcg_conditions.append(
-                    create_event_unique_user_frequency_condition_with_conditions(
-                        dict(condition), dcg, filters
+            try:
+                if (
+                    condition["id"] == EventUniqueUserFrequencyConditionWithConditions.id
+                ):  # special case
+                    dcg_conditions.append(
+                        create_event_unique_user_frequency_condition_with_conditions(
+                            dict(condition), dcg, filters
+                        )
                     )
+                else:
+                    dcg_conditions.append(translate_to_data_condition(dict(condition), dcg=dcg))
+            except Exception as e:
+                logger.exception(
+                    "workflow_engine.issue_alert_migration.error",
+                    extra={"rule_id": self.rule.id, "error": str(e)},
                 )
-            else:
-                dcg_conditions.append(translate_to_data_condition(dict(condition), dcg=dcg))
+                continue
 
         filtered_data_conditions = [
             dc for dc in dcg_conditions if dc.type not in SKIPPED_CONDITIONS
@@ -131,8 +139,21 @@ class IssueAlertMigrator:
                     exclude=["condition_group"]
                 )  # condition_group will be null, which is not allowed
                 enforce_data_condition_json_schema(dc)
-        else:
-            DataCondition.objects.bulk_create(filtered_data_conditions)
+            return filtered_data_conditions
+
+        data_conditions: list[DataCondition] = []
+        # try one by one, ignoring errors
+        for dc in filtered_data_conditions:
+            try:
+                dc.save()
+                data_conditions.append(dc)
+            except Exception as e:
+                logger.exception(
+                    "workflow_engine.issue_alert_migration.error",
+                    extra={"rule_id": self.rule.id, "error": str(e)},
+                )
+
+        return data_conditions
 
     def _create_when_dcg(
         self,
@@ -161,7 +182,16 @@ class IssueAlertMigrator:
         detector: Detector,
     ) -> Workflow:
         when_dcg = self._create_when_dcg(action_match=action_match)
-        self._bulk_create_data_conditions(conditions=conditions, filters=filters, dcg=when_dcg)
+        data_conditions = self._bulk_create_data_conditions(
+            conditions=conditions, filters=filters, dcg=when_dcg
+        )
+
+        # the only time the data_conditions list will be empty is if somebody only has EveryEventCondition in their conditions list.
+        # if it's empty and this is not the case, we should not migrate
+        if len(data_conditions) == 0 and not (
+            len(conditions) == 1 and conditions[0]["id"] == EveryEventCondition.id
+        ):
+            raise Exception("No valid conditions, skipping migration")
 
         enabled = True
         rule_snooze = RuleSnooze.objects.filter(rule=self.rule, user_id=None).first()

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -405,6 +405,11 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
         self.payload["value"] = str(self.payload["value"])
         self._test_dual_write_count(int(self.payload["value"]))
 
+    def test_dual_write_count__value_floor(self):
+        # forces negative to zero for migration
+        self.payload["value"] = -1
+        self._test_dual_write_count(0)
+
     def _test_dual_write_percent(self, value: int):
         self.payload.update({"comparisonType": ComparisonType.PERCENT, "comparisonInterval": "1d"})
         dc = create_event_unique_user_frequency_condition_with_conditions(
@@ -427,6 +432,11 @@ class TestEventUniqueUserFrequencyConditionWithConditions(ConditionTestCase):
     def test_dual_write_percent__string_value(self):
         self.payload["value"] = str(self.payload["value"])
         self._test_dual_write_percent(int(self.payload["value"]))
+
+    def test_dual_write_count__percent_floor(self):
+        # forces negative to zero for migration
+        self.payload["value"] = -1
+        self._test_dual_write_percent(0)
 
     def test_dual_write__invalid(self):
         with pytest.raises(KeyError):


### PR DESCRIPTION
1. Enforce floor of `0` for the `value` in `EventUniqueUserFrequencyConditionWithConditions`
2. Cast strings to enums early when translating from Rule condition to DataCondition in the translator functions, this will error earlier in the migration path
3. Skip migrating invalid conditions
4. If there are 0 valid conditions, only allow creating the workflow/other models if there was a single `EveryEventCondition` in the WHEN condition group. This is the only case where we could expect an empty WHEN condition group, which will always evaluate to `True`. Otherwise, we would start alerting on every event when the Rule used to not pass on every event. Fail loudly, which will rollback the transaction and not migrate the issue alert to workflow engine
5. Save each updated `DataCondition` individually to trigger the pre-save signal. For dual updating an issue alert, any condition failing this will rollback the transaction and cause the Rule changes to also rollback.