### PR TITLE
fix(insights): Add `"meta"` to more server mocks

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -264,12 +264,28 @@ const setupMockRequests = (organization: Organization) => {
           [1699907700, [{count: 7810.2}]],
           [1699908000, [{count: 1216.8}]],
         ],
+        meta: {
+          fields: {
+            [`${SPM}()`]: 'rate',
+          },
+          units: {
+            [`${SPM}()`]: '1/second',
+          },
+        },
       },
       [`avg(${SPAN_SELF_TIME})`]: {
         data: [
           [1699907700, [{count: 1111.2}]],
           [1699908000, [{count: 2222.8}]],
         ],
+        meta: {
+          fields: {
+            [`avg(${SPAN_SELF_TIME})`]: 'duration',
+          },
+          units: {
+            [`avg(${SPAN_SELF_TIME})`]: 'millisecond',
+          },
+        },
       },
     },
   });

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -325,6 +325,7 @@ const setRequestMocks = (organization: Organization) => {
           time: 'date',
           cache_miss_rate: 'percentage',
         },
+        units: {},
       },
     },
   });
@@ -347,6 +348,7 @@ const setRequestMocks = (organization: Organization) => {
           time: 'date',
           cache_miss_rate: 'percentage',
         },
+        units: {},
       },
     },
   });
@@ -369,6 +371,7 @@ const setRequestMocks = (organization: Organization) => {
           time: 'date',
           spm_14400: 'rate',
         },
+        units: {},
       },
     },
   });

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -159,7 +159,6 @@ describe('HTTPSummaryPage', function () {
       body: {
         'http_response_rate(3)': {
           data: [[1699908000, [{count: 0.2}]]],
-
           meta: {
             fields: {
               'http_response_rate(3)': 'percentage',
@@ -169,7 +168,6 @@ describe('HTTPSummaryPage', function () {
         },
         'http_response_rate(4)': {
           data: [[1699908000, [{count: 0.1}]]],
-
           meta: {
             fields: {
               'http_response_rate(4)': 'percentage',
@@ -179,7 +177,6 @@ describe('HTTPSummaryPage', function () {
         },
         'http_response_rate(5)': {
           data: [[1699908000, [{count: 0.3}]]],
-
           meta: {
             fields: {
               'http_response_rate(5)': 'percentage',

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -113,6 +113,14 @@ describe('HTTPSummaryPage', function () {
           [1699907700, [{count: 7810.2}]],
           [1699908000, [{count: 1216.8}]],
         ],
+        meta: {
+          fields: {
+            'spm()': 'rate',
+          },
+          units: {
+            'spm()': '1/second',
+          },
+        },
       },
     });
 
@@ -129,6 +137,14 @@ describe('HTTPSummaryPage', function () {
           [1699907700, [{count: 710.2}]],
           [1699908000, [{count: 116.8}]],
         ],
+        meta: {
+          fields: {
+            'avg(span.duration)': 'rate',
+          },
+          units: {
+            'avg(span.duration)': '1/second',
+          },
+        },
       },
     });
 
@@ -143,12 +159,33 @@ describe('HTTPSummaryPage', function () {
       body: {
         'http_response_rate(3)': {
           data: [[1699908000, [{count: 0.2}]]],
+
+          meta: {
+            fields: {
+              'http_response_rate(3)': 'percentage',
+            },
+            units: {},
+          },
         },
         'http_response_rate(4)': {
           data: [[1699908000, [{count: 0.1}]]],
+
+          meta: {
+            fields: {
+              'http_response_rate(4)': 'percentage',
+            },
+            units: {},
+          },
         },
         'http_response_rate(5)': {
           data: [[1699908000, [{count: 0.3}]]],
+
+          meta: {
+            fields: {
+              'http_response_rate(5)': 'percentage',
+            },
+            units: {},
+          },
         },
       },
     });

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -228,7 +228,6 @@ describe('HTTPLandingPage', function () {
       body: {
         'http_response_rate(3)': {
           data: [[1699908000, [{count: 0.2}]]],
-
           meta: {
             fields: {
               'http_response_rate(3)': 'percentage',
@@ -238,7 +237,6 @@ describe('HTTPLandingPage', function () {
         },
         'http_response_rate(4)': {
           data: [[1699908000, [{count: 0.1}]]],
-
           meta: {
             fields: {
               'http_response_rate(4)': 'percentage',
@@ -248,7 +246,6 @@ describe('HTTPLandingPage', function () {
         },
         'http_response_rate(5)': {
           data: [[1699908000, [{count: 0.3}]]],
-
           meta: {
             fields: {
               'http_response_rate(5)': 'percentage',

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -182,6 +182,14 @@ describe('HTTPLandingPage', function () {
           [1699907700, [{count: 7810.2}]],
           [1699908000, [{count: 1216.8}]],
         ],
+        meta: {
+          fields: {
+            'spm()': 'rate',
+          },
+          units: {
+            'spm()': '1/second',
+          },
+        },
       },
     });
 
@@ -198,6 +206,14 @@ describe('HTTPLandingPage', function () {
           [1699907700, [{count: 710.2}]],
           [1699908000, [{count: 116.8}]],
         ],
+        meta: {
+          fields: {
+            'avg(span.duration)': 'duration',
+          },
+          units: {
+            'avg(span.duration)': 'millisecond',
+          },
+        },
       },
     });
 
@@ -212,12 +228,33 @@ describe('HTTPLandingPage', function () {
       body: {
         'http_response_rate(3)': {
           data: [[1699908000, [{count: 0.2}]]],
+
+          meta: {
+            fields: {
+              'http_response_rate(3)': 'percentage',
+            },
+            units: {},
+          },
         },
         'http_response_rate(4)': {
           data: [[1699908000, [{count: 0.1}]]],
+
+          meta: {
+            fields: {
+              'http_response_rate(4)': 'percentage',
+            },
+            units: {},
+          },
         },
         'http_response_rate(5)': {
           data: [[1699908000, [{count: 0.3}]]],
+
+          meta: {
+            fields: {
+              'http_response_rate(5)': 'percentage',
+            },
+            units: {},
+          },
         },
       },
     });

--- a/static/app/views/insights/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.spec.tsx
@@ -16,6 +16,18 @@ describe('latencyChart', () => {
       method: 'GET',
       body: {
         data: [[1739378162, [{count: 1}]]],
+        meta: {
+          fields: {
+            'avg(span.duration)': 'duration',
+            'avg(messaging.message.receive.latency)': 'duration',
+            'spm()': 'rate',
+          },
+          units: {
+            'avg(span.duration)': 'millisecond',
+            'avg(messaging.message.receive.latency)': 'millisecond',
+            'spm()': '1/second',
+          },
+        },
       },
     });
   });

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -69,6 +69,12 @@ describe('destinationSummaryPage', () => {
       method: 'GET',
       body: {
         data: [[1699907700, [{count: 0.2}]]],
+        meta: {
+          fields: {'avg(span.duration)': 'duration'},
+          units: {
+            'avg(span.duration)': 'millisecond',
+          },
+        },
       },
     });
   });


### PR DESCRIPTION
`"meta"` is truly required! A lot of our code has been pretending it's _not_, but it is. I'm going through the backend mocks and adding it in places it was missing.
