### PR TITLE
feat(releases): add user count/rate session breakdown charts on insights

### DIFF
--- a/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthCountChart.tsx
@@ -1,0 +1,26 @@
+import {t} from 'sentry/locale';
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
+import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
+
+export default function UserHealthCountChart() {
+  const {series, isPending, error} = useUserHealthBreakdown({
+    type: 'count',
+  });
+
+  const aliases = {
+    healthy_user_count: t('Healthy user count'),
+    crashed_user_count: t('Crashed user count'),
+    errored_user_count: t('Errored user count'),
+    abnormal_user_count: t('Abnormal user count'),
+  };
+
+  return (
+    <InsightsLineChartWidget
+      title={t('User Health Count')}
+      aliases={aliases}
+      series={series}
+      isLoading={isPending}
+      error={error}
+    />
+  );
+}

--- a/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
+++ b/static/app/views/insights/sessions/charts/userHealthRateChart.tsx
@@ -1,0 +1,26 @@
+import {t} from 'sentry/locale';
+import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
+import useUserHealthBreakdown from 'sentry/views/insights/sessions/queries/useUserHealthBreakdown';
+
+export default function UserHealthRateChart() {
+  const {series, isPending, error} = useUserHealthBreakdown({
+    type: 'rate',
+  });
+
+  const aliases = {
+    healthy_user_rate: t('Healthy user rate'),
+    crashed_user_rate: t('Crashed user rate'),
+    errored_user_rate: t('Errored user rate'),
+    abnormal_user_rate: t('Abnormal user rate'),
+  };
+
+  return (
+    <InsightsAreaChartWidget
+      title={t('User Health Rate')}
+      aliases={aliases}
+      series={series}
+      isLoading={isPending}
+      error={error}
+    />
+  );
+}

--- a/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useCrashFreeSessions.tsx
@@ -4,7 +4,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useSessionAdoptionRate from 'sentry/views/insights/sessions/queries/useSessionProjectTotal';
-import {getStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
+import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useCrashFreeSessions() {
   const location = useLocation();
@@ -89,19 +89,21 @@ export default function useCrashFreeSessions() {
     const groups = releaseGroupMap.get(release)!;
 
     // Get all status series at once and calculate crash-free session percentage for each interval
-    const seriesData = getStatusSeries('crashed', groups).map((crashedCount, idx) => {
-      const intervalTotal = [
-        crashedCount,
-        getStatusSeries('abnormal', groups)[idx] || 0,
-        getStatusSeries('crashed', groups)[idx] || 0,
-        getStatusSeries('healthy', groups)[idx] || 0,
-      ].reduce((sum, val) => sum + val, 0);
+    const seriesData = getSessionStatusSeries('crashed', groups).map(
+      (crashedCount, idx) => {
+        const intervalTotal = [
+          crashedCount,
+          getSessionStatusSeries('abnormal', groups)[idx] || 0,
+          getSessionStatusSeries('crashed', groups)[idx] || 0,
+          getSessionStatusSeries('healthy', groups)[idx] || 0,
+        ].reduce((sum, val) => sum + val, 0);
 
-      return {
-        name: sessionData.intervals[idx] ?? '',
-        value: intervalTotal > 0 ? 1 - crashedCount / intervalTotal : 1,
-      };
-    });
+        return {
+          name: sessionData.intervals[idx] ?? '',
+          value: intervalTotal > 0 ? 1 - crashedCount / intervalTotal : 1,
+        };
+      }
+    );
 
     return {
       data: seriesData,

--- a/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
+++ b/static/app/views/insights/sessions/queries/useErrorFreeSessions.tsx
@@ -2,7 +2,7 @@ import type {SessionApiResponse} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
+import {getSessionStatusSeries} from 'sentry/views/insights/sessions/utils/sessions';
 
 export default function useErrorFreeSessions() {
   const location = useLocation();
@@ -46,7 +46,7 @@ export default function useErrorFreeSessions() {
   }
 
   // Returns series data not grouped by release
-  const seriesData = getStatusSeries('healthy', sessionData.groups).map(
+  const seriesData = getSessionStatusSeries('healthy', sessionData.groups).map(
     (healthyCount, idx) => {
       const intervalTotal = sessionData.groups.reduce(
         (acc, group) => acc + (group.series['sum(session)']?.[idx] ?? 0),

--- a/static/app/views/insights/sessions/utils/sessions.tsx
+++ b/static/app/views/insights/sessions/utils/sessions.tsx
@@ -1,5 +1,16 @@
 import type {SessionApiResponse} from 'sentry/types/organization';
 
-export const getStatusSeries = (status: string, groups: SessionApiResponse['groups']) =>
+export const getSessionStatusSeries = (
+  status: string,
+  groups: SessionApiResponse['groups']
+) =>
   groups.find(group => group.by['session.status'] === status)?.series['sum(session)'] ??
   [];
+
+export const getCountStatusSeries = (
+  status: string,
+  groups: SessionApiResponse['groups']
+) =>
+  groups.find(group => group.by['session.status'] === status)?.series[
+    'count_unique(user)'
+  ] ?? [];

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -22,6 +22,8 @@ import CrashFreeSessionChart from 'sentry/views/insights/sessions/charts/crashFr
 import ErrorFreeSessionsChart from 'sentry/views/insights/sessions/charts/errorFreeSessionsChart';
 import SessionHealthCountChart from 'sentry/views/insights/sessions/charts/sessionHealthCountChart';
 import SessionHealthRateChart from 'sentry/views/insights/sessions/charts/sessionHealthRateChart';
+import UserHealthCountChart from 'sentry/views/insights/sessions/charts/userHealthCountChart';
+import UserHealthRateChart from 'sentry/views/insights/sessions/charts/userHealthRateChart';
 import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/filterReleaseDropdown';
 import ReleaseAdoption from 'sentry/views/insights/sessions/components/tables/releaseAdoption';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
@@ -61,14 +63,20 @@ export function SessionsOverview() {
             </ModuleLayout.Full>
             {view === MOBILE_LANDING_SUB_PATH && (
               <Fragment>
-                <ModuleLayout.Half>
+                <ModuleLayout.Third>
                   <CrashFreeSessionChart />
-                </ModuleLayout.Half>
-                <ModuleLayout.Half>
+                </ModuleLayout.Third>
+                <ModuleLayout.Third>
                   <SessionHealthRateChart />
+                </ModuleLayout.Third>
+                <ModuleLayout.Third>
+                  <SessionHealthCountChart />
+                </ModuleLayout.Third>
+                <ModuleLayout.Half>
+                  <UserHealthCountChart />
                 </ModuleLayout.Half>
                 <ModuleLayout.Half>
-                  <SessionHealthCountChart />
+                  <UserHealthRateChart />
                 </ModuleLayout.Half>
                 <ModuleLayout.Full>
                   <FilterWrapper>
@@ -90,6 +98,12 @@ export function SessionsOverview() {
                 <ModuleLayout.Third>
                   <SessionHealthCountChart />
                 </ModuleLayout.Third>
+                <ModuleLayout.Half>
+                  <UserHealthCountChart />
+                </ModuleLayout.Half>
+                <ModuleLayout.Half>
+                  <UserHealthRateChart />
+                </ModuleLayout.Half>
               </Fragment>
             )}
           </ModuleLayout.Layout>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -37,6 +37,32 @@ export function SessionsOverview() {
   const {view} = useDomainViewFilters();
   const [filters, setFilters] = useState<string[]>(['']);
 
+  const SESSION_HEALTH_CHARTS = (
+    <Fragment>
+      {view === FRONTEND_LANDING_SUB_PATH ? (
+        <ModuleLayout.Third>
+          <ErrorFreeSessionsChart />
+        </ModuleLayout.Third>
+      ) : view === MOBILE_LANDING_SUB_PATH ? (
+        <ModuleLayout.Third>
+          <CrashFreeSessionChart />
+        </ModuleLayout.Third>
+      ) : undefined}
+      <ModuleLayout.Third>
+        <SessionHealthCountChart />
+      </ModuleLayout.Third>
+      <ModuleLayout.Third>
+        <SessionHealthRateChart />
+      </ModuleLayout.Third>
+      <ModuleLayout.Half>
+        <UserHealthCountChart />
+      </ModuleLayout.Half>
+      <ModuleLayout.Half>
+        <UserHealthRateChart />
+      </ModuleLayout.Half>
+    </Fragment>
+  );
+
   return (
     <React.Fragment>
       {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
@@ -63,21 +89,7 @@ export function SessionsOverview() {
             </ModuleLayout.Full>
             {view === MOBILE_LANDING_SUB_PATH && (
               <Fragment>
-                <ModuleLayout.Third>
-                  <CrashFreeSessionChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Third>
-                  <SessionHealthRateChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Third>
-                  <SessionHealthCountChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Half>
-                  <UserHealthCountChart />
-                </ModuleLayout.Half>
-                <ModuleLayout.Half>
-                  <UserHealthRateChart />
-                </ModuleLayout.Half>
+                {SESSION_HEALTH_CHARTS}
                 <ModuleLayout.Full>
                   <FilterWrapper>
                     <FilterReleaseDropdown filters={filters} setFilters={setFilters} />
@@ -88,23 +100,7 @@ export function SessionsOverview() {
               </Fragment>
             )}
             {view === FRONTEND_LANDING_SUB_PATH && (
-              <Fragment>
-                <ModuleLayout.Third>
-                  <ErrorFreeSessionsChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Third>
-                  <SessionHealthRateChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Third>
-                  <SessionHealthCountChart />
-                </ModuleLayout.Third>
-                <ModuleLayout.Half>
-                  <UserHealthCountChart />
-                </ModuleLayout.Half>
-                <ModuleLayout.Half>
-                  <UserHealthRateChart />
-                </ModuleLayout.Half>
-              </Fragment>
+              <Fragment>{SESSION_HEALTH_CHARTS}</Fragment>
             )}
           </ModuleLayout.Layout>
         </Layout.Main>

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -99,9 +99,7 @@ export function SessionsOverview() {
                 </ModuleLayout.Full>
               </Fragment>
             )}
-            {view === FRONTEND_LANDING_SUB_PATH && (
-              <Fragment>{SESSION_HEALTH_CHARTS}</Fragment>
-            )}
+            {view === FRONTEND_LANDING_SUB_PATH && SESSION_HEALTH_CHARTS}
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>


### PR DESCRIPTION
Adds two more charts, visualizing session health through `unique_count(user)` counts rather than session sums. On the left is a line chart showing the count of users for each session status, and on the right is an area chart showing the percent of users experiencing each session status.

## org 1
<img width="1262" alt="SCR-20250304-nhmo" src="https://github.com/user-attachments/assets/e722ebc4-320f-4685-80d3-7303bdbea22f" />

## org 2

<img width="1201" alt="SCR-20250304-nhha" src="https://github.com/user-attachments/assets/c5fb5958-a5b3-415e-bd10-59ec02e23247" />


## what the whole tab looks like now: session data on top row, user data on bottom row

<img width="1125" alt="SCR-20250304-nncx" src="https://github.com/user-attachments/assets/35d97b33-4466-4d83-ace5-196ce9cbb359" />

