### PR TITLE
chore(sentry apps): write out the categories for publishing emails

### DIFF
--- a/static/app/components/modals/sentryAppPublishRequestModal/sentryAppUtils.tsx
+++ b/static/app/components/modals/sentryAppPublishRequestModal/sentryAppUtils.tsx
@@ -1,10 +1,10 @@
 export const INTEGRATION_CATEGORIES: Array<[string, string]> = [
   ['notifications', 'Notifications & Incidents'],
-  ['scm', 'Source Code Management'],
+  ['source-code-management', 'Source Code Management'],
   ['issue-tracking', 'Issue Tracking'],
   ['deployment', 'Deployment'],
-  ['data-viz', 'Data & Visualization'],
-  ['replay', 'Session Replay'],
+  ['data-visualization', 'Data & Visualization'],
+  ['session-replay', 'Session Replay'],
   ['debugging', 'Debugging'],
   ['feature-flags', 'Feature Flags'],
   ['compliance', 'Compliance'],


### PR DESCRIPTION
this annoyed me:
<img width="399" alt="image" src="https://github.com/user-attachments/assets/511c049c-6211-4e93-8230-56adf88d71e8" />
