### PR TITLE
commandpalette: use input component

### DIFF
--- a/static/app/components/modals/commandPalette.tsx
+++ b/static/app/components/modals/commandPalette.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {Search} from 'sentry/components/search';
-import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
@@ -38,18 +37,13 @@ function CommandPalette({Body}: ModalRenderProps) {
                 border-top: 1px solid ${theme.border};
               `}
             renderInput={({getInputProps}) => (
-              <InputGroup>
-                <InputGroup.LeadingItems>
-                  <IconSearch size="sm" />
-                </InputGroup.LeadingItems>
-                <InputWithoutFocusStyles
-                  autoFocus
-                  {...getInputProps({
-                    type: 'text',
-                    placeholder: t('Search for projects, teams, settings, etc\u{2026}'),
-                  })}
-                />
-              </InputGroup>
+              <InputWithoutFocusStyles
+                autoFocus
+                {...getInputProps({
+                  type: 'text',
+                  placeholder: t('Search for projects, teams, settings, etc\u{2026}'),
+                })}
+              />
             )}
           />
         )}

--- a/static/app/components/modals/commandPalette.tsx
+++ b/static/app/components/modals/commandPalette.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import {ClassNames, css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
@@ -41,7 +42,7 @@ function CommandPalette({Body}: ModalRenderProps) {
                 <InputGroup.LeadingItems>
                   <IconSearch size="sm" />
                 </InputGroup.LeadingItems>
-                <InputGroup.Input
+                <InputWithoutFocusStyles
                   autoFocus
                   {...getInputProps({
                     type: 'text',
@@ -58,6 +59,16 @@ function CommandPalette({Body}: ModalRenderProps) {
 }
 
 export default CommandPalette;
+
+const InputWithoutFocusStyles = styled(InputGroup.Input)`
+  &:focus,
+  &:active,
+  &:hover {
+    outline: none;
+    box-shadow: none;
+    border: none;
+  }
+`;
 
 export const modalCss = css`
   [role='document'] {

--- a/static/app/components/modals/commandPalette.tsx
+++ b/static/app/components/modals/commandPalette.tsx
@@ -1,12 +1,11 @@
 import {useEffect} from 'react';
 import {ClassNames, css, useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {Input} from 'sentry/components/core/input';
+import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {Search} from 'sentry/components/search';
+import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 function CommandPalette({Body}: ModalRenderProps) {
@@ -38,15 +37,18 @@ function CommandPalette({Body}: ModalRenderProps) {
                 border-top: 1px solid ${theme.border};
               `}
             renderInput={({getInputProps}) => (
-              <InputWrapper>
-                <StyledInput
+              <InputGroup>
+                <InputGroup.LeadingItems>
+                  <IconSearch size="sm" />
+                </InputGroup.LeadingItems>
+                <InputGroup.Input
                   autoFocus
                   {...getInputProps({
                     type: 'text',
                     placeholder: t('Search for projects, teams, settings, etc\u{2026}'),
                   })}
                 />
-              </InputWrapper>
+              </InputGroup>
             )}
           />
         )}
@@ -60,27 +62,5 @@ export default CommandPalette;
 export const modalCss = css`
   [role='document'] {
     padding: 0;
-  }
-`;
-
-const InputWrapper = styled('div')`
-  padding: ${space(0.25)};
-`;
-
-const StyledInput = styled(Input)`
-  width: 100%;
-  padding: ${space(1)};
-  border-radius: ${p => p.theme.borderRadius};
-
-  outline: none;
-  border: none;
-  box-shadow: none;
-
-  :focus,
-  :active,
-  :hover {
-    outline: none;
-    border: none;
-    box-shadow: none;
   }
 `;

--- a/static/app/components/modals/helpSearchModal.tsx
+++ b/static/app/components/modals/helpSearchModal.tsx
@@ -1,10 +1,11 @@
 import {ClassNames, css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {Input} from 'sentry/components/core/input';
 import HelpSearch from 'sentry/components/helpSearch';
 import Hook from 'sentry/components/hook';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -39,7 +40,9 @@ function HelpSearchModal({
                 border-top: 1px solid ${theme.border};
               `}
             renderInput={({getInputProps}) => (
-              <Input autoFocus {...getInputProps({type: 'text', placeholder})} />
+              <InputWrapper>
+                <Input autoFocus {...getInputProps({type: 'text', placeholder})} />
+              </InputWrapper>
             )}
             resultFooter={
               <Hook name="help-modal:footer" {...{organization, closeModal}} />
@@ -50,6 +53,22 @@ function HelpSearchModal({
     </Body>
   );
 }
+
+const InputWrapper = styled('div')`
+  padding: ${space(0.25)};
+`;
+
+const Input = styled('input')`
+  width: 100%;
+  padding: ${space(1)};
+  border: none;
+  border-radius: 8px;
+  outline: none;
+
+  &:focus {
+    outline: none;
+  }
+`;
 
 export const modalCss = css`
   [role='document'] {

--- a/static/app/components/modals/helpSearchModal.tsx
+++ b/static/app/components/modals/helpSearchModal.tsx
@@ -1,11 +1,10 @@
 import {ClassNames, css, useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Input} from 'sentry/components/core/input';
 import HelpSearch from 'sentry/components/helpSearch';
 import Hook from 'sentry/components/hook';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -40,9 +39,7 @@ function HelpSearchModal({
                 border-top: 1px solid ${theme.border};
               `}
             renderInput={({getInputProps}) => (
-              <InputWrapper>
-                <Input autoFocus {...getInputProps({type: 'text', placeholder})} />
-              </InputWrapper>
+              <Input autoFocus {...getInputProps({type: 'text', placeholder})} />
             )}
             resultFooter={
               <Hook name="help-modal:footer" {...{organization, closeModal}} />
@@ -53,22 +50,6 @@ function HelpSearchModal({
     </Body>
   );
 }
-
-const InputWrapper = styled('div')`
-  padding: ${space(0.25)};
-`;
-
-const Input = styled('input')`
-  width: 100%;
-  padding: ${space(1)};
-  border: none;
-  border-radius: 8px;
-  outline: none;
-
-  &:focus {
-    outline: none;
-  }
-`;
 
 export const modalCss = css`
   [role='document'] {


### PR DESCRIPTION
Will check with @Jesse-Box about hiding focus border, I don't think it's terrible to have it, but we can also remove it.

Before
![CleanShot 2025-03-04 at 18 33 05@2x](https://github.com/user-attachments/assets/f903ef8d-baed-4d22-a5fd-ed1a1c44134d)

After
![CleanShot 2025-03-04 at 18 33 10@2x](https://github.com/user-attachments/assets/7e9ad1ed-7973-4b4c-898b-598897dc95f7)
