### PR TITLE
fix(laravel-insights): fix display when 100% of jobs fail

### DIFF
--- a/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/laravelOverviewPage.tsx
@@ -585,7 +585,7 @@ function JobsWidget({query}: {query?: string}) {
       (acc, [time, [value]], index) => {
         const spansInTimeBucket = getSpansInTimeBucket(index);
         const okJobsRateValue = value?.count! || 0;
-        const failedJobsRateValue = value?.count ? 1 - value.count : 0;
+        const failedJobsRateValue = value?.count ? 1 - value.count : 1;
 
         acc[0].data.push({
           value: okJobsRateValue * spansInTimeBucket,


### PR DESCRIPTION
Before: 
<img width="479" alt="Screenshot 2025-03-05 at 11 37 07" src="https://github.com/user-attachments/assets/82069728-d201-4783-b951-181d1b3d7067" />

After:
<img width="478" alt="Screenshot 2025-03-05 at 11 36 30" src="https://github.com/user-attachments/assets/7897e3a5-de5c-48cf-953e-47ab69b37efa" />
