### PR TITLE
feat(demo-mode): enable create alert button

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -14,6 +14,7 @@ import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {isDemoModeEnabled} from 'sentry/utils/demoMode';
 import type EventView from 'sentry/utils/discover/eventView';
 import useApi from 'sentry/utils/useApi';
 import useProjects from 'sentry/utils/useProjects';
@@ -205,6 +206,7 @@ export default function CreateAlertButton({
 
   const showGuide = !organization.alertsMemberWrite && !!showPermissionGuide;
   const canCreateAlert =
+    isDemoModeEnabled() ||
     hasEveryAccess(['alerts:write'], {organization}) ||
     projects.some(p => hasEveryAccess(['alerts:write'], {project: p}));
   const hasOrgWrite = hasEveryAccess(['org:write'], {organization});


### PR DESCRIPTION
Enables "create alert" button for demo user so it can access the alert creation form. Does not allow the demo user to actually create an alert. 