### PR TITLE
chore(hybrid-cloud): Add logging to release registry

### DIFF
--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -47,6 +47,11 @@ def fetch_release_registry_data(**kwargs):
 
     More details about the registry: https://github.com/getsentry/sentry-release-registry/
     """
+    logger.info(
+        "release_registry.fetch.starting",
+        extra={"release_registry_baseurl": str(settings.SENTRY_RELEASE_REGISTRY_BASEURL)},
+    )
+
     if not settings.SENTRY_RELEASE_REGISTRY_BASEURL:
         logger.warning("Release registry URL is not specified, skipping the task.")
         return
@@ -61,4 +66,8 @@ def fetch_release_registry_data(**kwargs):
 
     # AWS Layers
     layer_data = _fetch_registry_url("/aws-lambda-layers")
+    logger.info(
+        "release_registry.fetch.aws-lambda-layers",
+        extra={"layer_data": layer_data},
+    )
     cache.set(LAYER_INDEX_CACHE_KEY, layer_data, CACHE_TTL)

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 
@@ -71,3 +72,8 @@ def fetch_release_registry_data(**kwargs):
         extra={"layer_data": layer_data},
     )
     cache.set(LAYER_INDEX_CACHE_KEY, layer_data, CACHE_TTL)
+    logger.info(
+        "release_registry.fetch.aws-lambda-layers",
+        extra={"layer cache": cache.get(LAYER_INDEX_CACHE_KEY)},
+    )
+    sentry_sdk.capture_message("Fetching release registry")

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -74,6 +74,6 @@ def fetch_release_registry_data(**kwargs):
     cache.set(LAYER_INDEX_CACHE_KEY, layer_data, CACHE_TTL)
     logger.info(
         "release_registry.fetch.aws-lambda-layers",
-        extra={"layer cache": cache.get(LAYER_INDEX_CACHE_KEY)},
+        extra={"layer_cache": cache.get(LAYER_INDEX_CACHE_KEY)},
     )
     sentry_sdk.capture_message("Fetching release registry")


### PR DESCRIPTION
Adds logging to understand recent AWS integration failures.

See: https://github.com/getsentry/sentry/pull/62007