### PR TITLE
feat(explore): add sentry.normalized_description to trace explorer

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1171,7 +1171,7 @@ type TraceFields =
   | SpanIndexedField.SPAN_GROUP
   | SpanIndexedField.SPAN_MODULE
   | SpanIndexedField.SPAN_OP
-  | SpanIndexedField.NORAMLIZED_DESCRIPTION
+  | SpanIndexedField.NORMALIZED_DESCRIPTION
   // TODO: Remove self time field when it is deprecated
   | SpanIndexedField.SPAN_SELF_TIME
   | SpanIndexedField.SPAN_STATUS
@@ -1191,7 +1191,7 @@ export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.NORAMLIZED_DESCRIPTION]: {
+  [SpanIndexedField.NORMALIZED_DESCRIPTION]: {
     desc: t(
       'Parameterized and normalized description of the span, commonly used for grouping within insights'
     ),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1171,6 +1171,7 @@ type TraceFields =
   | SpanIndexedField.SPAN_GROUP
   | SpanIndexedField.SPAN_MODULE
   | SpanIndexedField.SPAN_OP
+  | SpanIndexedField.NORAMLIZED_DESCRIPTION
   // TODO: Remove self time field when it is deprecated
   | SpanIndexedField.SPAN_SELF_TIME
   | SpanIndexedField.SPAN_STATUS
@@ -1186,7 +1187,14 @@ export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [SpanIndexedField.SPAN_DESCRIPTION]: {
-    desc: t('Parameterized and scrubbed description of the span'),
+    desc: t('Scrubbed description of the span'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [SpanIndexedField.NORAMLIZED_DESCRIPTION]: {
+    desc: t(
+      'Parameterized and normalized description of the span, commonly used for grouping within insights'
+    ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1187,7 +1187,7 @@ export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [SpanIndexedField.SPAN_DESCRIPTION]: {
-    desc: t('Scrubbed description of the span'),
+    desc: t('Raw description of the span, as received in the transaction event'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1187,7 +1187,7 @@ export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [SpanIndexedField.SPAN_DESCRIPTION]: {
-    desc: t('Raw description of the span, as received in the transaction event'),
+    desc: t('Description of the span’s operation'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -34,6 +34,7 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanIndexedField.USER_IP,
   SpanIndexedField.USER_USERNAME,
   SpanIndexedField.IS_TRANSACTION, // boolean field but we can expose it as a string
+  SpanIndexedField.NORAMLIZED_DESCRIPTION,
 ];
 
 export const SENTRY_SPAN_NUMBER_TAGS: string[] = [

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -34,7 +34,7 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanIndexedField.USER_IP,
   SpanIndexedField.USER_USERNAME,
   SpanIndexedField.IS_TRANSACTION, // boolean field but we can expose it as a string
-  SpanIndexedField.NORAMLIZED_DESCRIPTION,
+  SpanIndexedField.NORMALIZED_DESCRIPTION,
 ];
 
 export const SENTRY_SPAN_NUMBER_TAGS: string[] = [

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -299,7 +299,7 @@ export enum SpanIndexedField {
   IS_TRANSACTION = 'is_transaction',
   LCP_ELEMENT = 'lcp.element',
   CLS_SOURCE = 'cls.source.1',
-  NORAMLIZED_DESCRIPTION = 'sentry.normalized_description',
+  NORMALIZED_DESCRIPTION = 'sentry.normalized_description',
 }
 
 export type SpanIndexedResponse = {

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -299,6 +299,7 @@ export enum SpanIndexedField {
   IS_TRANSACTION = 'is_transaction',
   LCP_ELEMENT = 'lcp.element',
   CLS_SOURCE = 'cls.source.1',
+  NORAMLIZED_DESCRIPTION = 'sentry.normalized_description',
 }
 
 export type SpanIndexedResponse = {


### PR DESCRIPTION
1. Add ability to search for `sentry.normalized_description`
![image](https://github.com/user-attachments/assets/b9b95abc-0f56-48fe-8c0f-be39b26ce40f)

2. Corrects description of the `span.description` field, it isn't technically always parameterized (for example the `http.client` spans contain the full url`