### PR TITLE
fix(ourlogs): Add pagination test for logs

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -136,11 +136,11 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         self.store_ourlogs(logs)
         response = self.do_request(
             {
-                "field": ["log.body"],
+                "field": ["log.body", "timestamp"],
                 "query": "",
                 "cursor": Cursor(0, 2, False, False),
                 "per_page": 2,
-                "orderby": "log.body",
+                "orderby": "timestamp",
                 "project": self.project.id,
                 "dataset": self.dataset,
             }

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from sentry.utils.cursors import Cursor
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
@@ -116,3 +117,37 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         assert data[0]["log.body"] == "foo"
 
         assert meta["dataset"] == self.dataset
+
+    def test_pagination(self):
+        logs = [
+            self.create_ourlog(
+                {"body": "foo"},
+                timestamp=self.eleven_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "bar"},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "baz"},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        response = self.do_request(
+            {
+                "field": ["log.body"],
+                "query": "",
+                "cursor": Cursor(0, 2, False, False),
+                "per_page": 2,
+                "orderby": "log.body",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data == [
+            {"log.body": "baz"},
+        ]

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -151,6 +151,6 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         assert data == [
             {
                 "log.body": "baz",
-                "timestamp": "2025-03-05T19:34:42+00:00",
+                "timestamp": self.nine_mins_ago.isoformat(),
             },
         ]

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -149,5 +149,8 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         data = response.data["data"]
         assert len(data) == 1
         assert data == [
-            {"log.body": "baz"},
+            {
+                "log.body": "baz",
+                "timestamp": "2025-03-05T19:34:42+00:00",
+            },
         ]

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -148,9 +148,4 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        assert data == [
-            {
-                "log.body": "baz",
-                "timestamp": self.nine_mins_ago.isoformat(),
-            },
-        ]
+        assert data[0]["log.body"] == "baz"


### PR DESCRIPTION
### Summary
This should pass once the backend respects the passed cursor

