### PR TITLE
fix(nav): Add /settings/stats/ to django web routes

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -659,6 +659,11 @@ urlpatterns += [
                     name="sentry-customer-domain-feature-flags-settings",
                 ),
                 re_path(
+                    r"^stats/",
+                    react_page_view,
+                    name="sentry-customer-domain-stats-settings",
+                ),
+                re_path(
                     r"^developer-settings/",
                     react_page_view,
                     name="sentry-customer-domain-developer-settings-settings",


### PR DESCRIPTION
This prevents a page reload on `/settings/stats` redirecting to `/settings`. Looks like every settings page needs to be declared here.