### PR TITLE
feat(hybrid-cloud): Ensure release registry cache is available in control

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1052,6 +1052,12 @@ CELERYBEAT_SCHEDULE_CONTROL = {
         "schedule": timedelta(seconds=10),
         "options": {"expires": 60, "queue": "webhook.control"},
     },
+    "fetch-release-registry-data": {
+        "task": "sentry.tasks.release_registry.fetch_release_registry_data",
+        # Run every 5 minutes
+        "schedule": crontab(minute="*/5"),
+        "options": {"expires": 3600},
+    },
 }
 
 # Most tasks run in the regions


### PR DESCRIPTION
When [setting up the AWS integration in Sentry](https://docs.sentry.io/organization/integrations/cloud-monitoring/aws-lambda/) and trying to automatically add the lambda layer to lambda functions the underlying code encounters an empty release-registry cache: https://sentry.sentry.io/issues/5289437499/events/f3e461d3164a442587c3f9da8ef86255/

This happens from this view: 
![image](https://github.com/user-attachments/assets/55ef7664-ba11-4677-8c98-e2d9cc139233)

But it is possible to do from this view:
![image](https://github.com/user-attachments/assets/5dd745d4-2f5c-4c4a-938c-9522c0a66b9d)

From the linked issue above, it looks like that code runs in the control silo, but the task to populate the cache with release-registry data is only running for region silos.

This PR adds the celery task to the control queue.

Related: https://github.com/getsentry/sentry/issues/85322, https://github.com/getsentry/sentry/issues/86365

Might stem from: https://github.com/getsentry/sentry/pull/53038
