### PR TITLE
feat(autofix): Add support for agent to leave comments

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -15,6 +15,7 @@ import {
   type AutofixCodebaseChange,
   AutofixStatus,
   type AutofixUpdateEndpointResponse,
+  type CommentThread,
 } from 'sentry/components/events/autofix/types';
 import {
   makeAutofixQueryKey,
@@ -37,6 +38,7 @@ type AutofixChangesProps = {
   groupId: string;
   runId: string;
   step: AutofixChangesStep;
+  agentCommentThread?: CommentThread;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
 };
@@ -423,9 +425,11 @@ export function AutofixChanges({
   runId,
   previousDefaultStepIndex,
   previousInsightCount,
+  agentCommentThread,
 }: AutofixChangesProps) {
   const data = useAutofixData({groupId});
   const [isBusy, setIsBusy] = useState(false);
+  const iconCodeRef = useRef<HTMLDivElement>(null);
 
   if (step.status === 'ERROR' || data?.status === 'ERROR') {
     return (
@@ -471,7 +475,9 @@ export function AutofixChanges({
           <ClippedBox clipHeight={408}>
             <HeaderWrapper>
               <HeaderText>
-                <IconCode size="sm" />
+                <div ref={iconCodeRef}>
+                  <IconCode size="sm" />
+                </div>
                 {t('Code Changes')}
               </HeaderText>
               {!prsMade && (
@@ -541,6 +547,23 @@ export function AutofixChanges({
                   </ScrollCarousel>
                 ))}
             </HeaderWrapper>
+            <AnimatePresence>
+              {agentCommentThread && iconCodeRef.current && (
+                <AutofixHighlightPopup
+                  selectedText="Code Changes"
+                  referenceElement={iconCodeRef.current}
+                  groupId={groupId}
+                  runId={runId}
+                  stepIndex={previousDefaultStepIndex ?? 0}
+                  retainInsightCardIndex={
+                    previousInsightCount !== undefined && previousInsightCount >= 0
+                      ? previousInsightCount
+                      : null
+                  }
+                  isAgentComment
+                />
+              )}
+            </AnimatePresence>
             {step.changes.map((change, i) => (
               <Fragment key={change.repo_external_id}>
                 {i > 0 && <Separator />}

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -21,7 +21,7 @@ import {
   useAutofixData,
 } from 'sentry/components/events/autofix/useAutofix';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconChevron} from 'sentry/icons';
+import {IconChevron, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
@@ -37,6 +37,7 @@ interface Props {
   runId: string;
   selectedText: string;
   stepIndex: number;
+  isAgentComment?: boolean;
 }
 
 interface OptimisticMessage extends CommentThreadMessage {
@@ -49,6 +50,7 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
 
   return useMutation({
     mutationFn: (params: {
+      is_agent_comment: boolean;
       message: string;
       retain_insight_card_index: number | null;
       selected_text: string;
@@ -66,6 +68,7 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
             selected_text: params.selected_text,
             step_index: params.step_index,
             retain_insight_card_index: params.retain_insight_card_index,
+            is_agent_comment: params.is_agent_comment,
           },
         },
       });
@@ -79,41 +82,118 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
   });
 }
 
+function useCloseCommentThread({groupId, runId}: {groupId: string; runId: string}) {
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {
+      is_agent_comment: boolean;
+      step_index: number;
+      thread_id: string;
+    }) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'resolve_comment_thread',
+            thread_id: params.thread_id,
+            step_index: params.step_index,
+            is_agent_comment: params.is_agent_comment,
+          },
+        },
+      });
+    },
+    onSuccess: _ => {
+      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(groupId)});
+    },
+    onError: () => {
+      addErrorMessage(t('Something went wrong when resolving the thread.'));
+    },
+  });
+}
+
 function AutofixHighlightPopupContent({
   selectedText,
   groupId,
   runId,
   stepIndex,
   retainInsightCardIndex,
-}: Omit<Props, 'referenceElement'>) {
+  isAgentComment,
+}: Props) {
   const {mutate: submitComment} = useCommentThread({groupId, runId});
+  const {mutate: closeCommentThread} = useCloseCommentThread({groupId, runId});
+
   const [comment, setComment] = useState('');
   const [threadId] = useState(() => {
     const timestamp = Date.now();
     const random = Math.floor(Math.random() * 10000);
     return `thread-${timestamp}-${random}`;
   });
-  const [optimisticMessages, setOptimisticMessages] = useState<OptimisticMessage[]>([]);
+  const [pendingUserMessage, setPendingUserMessage] = useState<OptimisticMessage | null>(
+    null
+  );
+  const [showLoadingAssistant, setShowLoadingAssistant] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Fetch current autofix data to get comment thread
   const autofixData = useAutofixData({groupId});
-  const currentStep = autofixData?.steps?.[stepIndex];
-  const commentThread =
-    currentStep?.active_comment_thread?.id === threadId
+  const currentStep = !isAgentComment
+    ? autofixData?.steps?.[stepIndex]
+    : autofixData?.steps?.[stepIndex + 1];
+
+  const commentThread = isAgentComment
+    ? currentStep?.agent_comment_thread
+    : currentStep?.active_comment_thread?.id === threadId
       ? currentStep.active_comment_thread
       : null;
-  const messages = useMemo(
+
+  const serverMessages = useMemo(
     () => commentThread?.messages ?? [],
     [commentThread?.messages]
   );
 
+  // Effect to clear pending messages when server data updates
+  useEffect(() => {
+    if (serverMessages.length > 0) {
+      const lastServerMessage = serverMessages[serverMessages.length - 1];
+
+      // If the last server message is from the assistant, clear all pending messages
+      if (lastServerMessage && lastServerMessage.role === 'assistant') {
+        setPendingUserMessage(null);
+        setShowLoadingAssistant(false);
+      }
+
+      // If the last server message is from the user, keep loading assistant state
+      // but clear the pending user message
+      if (lastServerMessage && lastServerMessage.role === 'user') {
+        setPendingUserMessage(null);
+        setShowLoadingAssistant(true);
+      }
+    }
+  }, [serverMessages]);
+
   // Combine server messages with optimistic ones
   const allMessages = useMemo(() => {
-    const serverMessageCount = messages.length;
-    const relevantOptimisticMessages = optimisticMessages.slice(serverMessageCount);
-    return [...messages, ...relevantOptimisticMessages];
-  }, [messages, optimisticMessages]);
+    const result = [...serverMessages];
+
+    // Add pending user message if it exists
+    if (pendingUserMessage) {
+      result.push(pendingUserMessage);
+    }
+
+    // Add loading assistant message if needed
+    if (showLoadingAssistant) {
+      result.push({
+        role: 'assistant' as const,
+        content: '',
+        isLoading: true,
+      });
+    }
+
+    return result;
+  }, [serverMessages, pendingUserMessage, showLoadingAssistant]);
 
   const truncatedText =
     selectedText.length > 70
@@ -135,12 +215,9 @@ function AutofixHighlightPopupContent({
       return;
     }
 
-    // Add user message and loading assistant message immediately
-    setOptimisticMessages(prev => [
-      ...prev,
-      {role: 'user', content: comment},
-      {role: 'assistant', content: '', isLoading: true},
-    ]);
+    // Add optimistic user message and show loading assistant
+    setPendingUserMessage({role: 'user', content: comment});
+    setShowLoadingAssistant(true);
 
     submitComment({
       message: comment,
@@ -148,6 +225,7 @@ function AutofixHighlightPopupContent({
       selected_text: selectedText,
       step_index: stepIndex,
       retain_insight_card_index: retainInsightCardIndex,
+      is_agent_comment: isAgentComment ?? false,
     });
     setComment('');
   };
@@ -165,12 +243,30 @@ function AutofixHighlightPopupContent({
     scrollToBottom();
   }, [allMessages]);
 
+  const handleResolve = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    closeCommentThread({
+      thread_id: threadId,
+      step_index: stepIndex,
+      is_agent_comment: isAgentComment ?? false,
+    });
+  };
+
   return (
     <Container onClick={handleContainerClick}>
       <Header>
         <SelectedText>
           <span>"{truncatedText}"</span>
         </SelectedText>
+        {allMessages.length > 0 && (
+          <ResolveButton
+            size="zero"
+            borderless
+            aria-label={t('Resolve thread')}
+            onClick={handleResolve}
+            icon={<IconClose size="xs" />}
+          />
+        )}
       </Header>
 
       {allMessages.length > 0 && (
@@ -250,6 +346,7 @@ function AutofixHighlightPopup(props: Props) {
     left: 0,
     top: 0,
   });
+  const [isFocused, setIsFocused] = useState(false);
 
   useLayoutEffect(() => {
     if (!referenceElement || !popupRef.current) {
@@ -294,11 +391,19 @@ function AutofixHighlightPopup(props: Props) {
     };
   }, [referenceElement]);
 
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
+
   return createPortal(
     <Wrapper
       ref={popupRef}
-      id="autofix-rethink-input"
       data-popup="autofix-highlight"
+      data-autofix-input-type={!props.isAgentComment ? 'rethink' : 'agent-comment'}
       initial={{opacity: 0, x: 10}}
       animate={{opacity: 1, x: 0}}
       exit={{opacity: 0, x: 10}}
@@ -309,6 +414,10 @@ function AutofixHighlightPopup(props: Props) {
         left: `${position.left}px`,
         top: `${position.top}px`,
       }}
+      isFocused={isFocused}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      tabIndex={-1}
     >
       <Arrow />
       <ScaleContainer>
@@ -319,8 +428,8 @@ function AutofixHighlightPopup(props: Props) {
   );
 }
 
-const Wrapper = styled(motion.div)`
-  z-index: ${p => p.theme.zIndex.tooltip};
+const Wrapper = styled(motion.div)<{isFocused?: boolean}>`
+  z-index: ${p => (p.isFocused ? p.theme.zIndex.tooltip + 1 : p.theme.zIndex.tooltip)};
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -398,8 +507,8 @@ const StyledButton = styled(Button)`
 const Header = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(1)};
-  padding: ${space(1)};
+  justify-content: space-between;
+  padding: ${space(1)} ${space(1.5)};
   background: ${p => p.theme.backgroundSecondary};
   word-break: break-word;
   overflow-wrap: break-word;
@@ -478,6 +587,10 @@ const LoadingWrapper = styled('div')`
   align-items: center;
   height: 24px;
   margin-top: ${space(0.25)};
+`;
+
+const ResolveButton = styled(Button)`
+  margin-left: ${space(1)};
 `;
 
 function getScrollParents(element: HTMLElement): Element[] {

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -14,6 +14,7 @@ import {
   type AutofixRootCauseSelection,
   AutofixStatus,
   AutofixStepType,
+  type CommentThread,
 } from 'sentry/components/events/autofix/types';
 import {
   type AutofixResponse,
@@ -37,6 +38,7 @@ type AutofixRootCauseProps = {
   repos: AutofixRepository[];
   rootCauseSelection: AutofixRootCauseSelection;
   runId: string;
+  agentCommentThread?: CommentThread;
   previousDefaultStepIndex?: number;
   previousInsightCount?: number;
   terminationReason?: string;
@@ -265,11 +267,13 @@ function AutofixRootCauseDisplay({
   rootCauseSelection,
   previousDefaultStepIndex,
   previousInsightCount,
+  agentCommentThread,
 }: AutofixRootCauseProps) {
   const {mutate: handleContinue, isPending} = useSelectCause({groupId, runId});
   const [isEditing, setIsEditing] = useState(false);
   const [customRootCause, setCustomRootCause] = useState('');
   const cause = causes[0];
+  const iconFocusRef = useRef<HTMLDivElement>(null);
 
   if (!cause) {
     return (
@@ -285,7 +289,9 @@ function AutofixRootCauseDisplay({
         <CustomRootCausePadding>
           <HeaderWrapper>
             <HeaderText>
-              <IconFocus size="sm" />
+              <div ref={iconFocusRef}>
+                <IconFocus size="sm" />
+              </div>
               {t('Custom Root Cause')}
             </HeaderText>
             <CopyRootCauseButton
@@ -304,7 +310,9 @@ function AutofixRootCauseDisplay({
       <ClippedBox clipHeight={408}>
         <HeaderWrapper>
           <HeaderText>
-            <IconFocus size="sm" />
+            <div ref={iconFocusRef}>
+              <IconFocus size="sm" />
+            </div>
             {t('Root Cause')}
           </HeaderText>
           <ButtonBar>
@@ -343,6 +351,23 @@ function AutofixRootCauseDisplay({
             )}
           </ButtonBar>
         </HeaderWrapper>
+        <AnimatePresence>
+          {agentCommentThread && iconFocusRef.current && (
+            <AutofixHighlightPopup
+              selectedText="Root Cause"
+              referenceElement={iconFocusRef.current}
+              groupId={groupId}
+              runId={runId}
+              stepIndex={previousDefaultStepIndex ?? 0}
+              retainInsightCardIndex={
+                previousInsightCount !== undefined && previousInsightCount >= 0
+                  ? previousInsightCount
+                  : null
+              }
+              isAgentComment
+            />
+          )}
+        </AnimatePresence>
         <Content>
           {isEditing ? (
             <TextArea

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -16,6 +16,7 @@ import {
   type AutofixSolutionTimelineEvent,
   AutofixStatus,
   AutofixStepType,
+  type CommentThread,
 } from 'sentry/components/events/autofix/types';
 import {
   type AutofixResponse,
@@ -116,6 +117,7 @@ type AutofixSolutionProps = {
   runId: string;
   solution: AutofixSolutionTimelineEvent[];
   solutionSelected: boolean;
+  agentCommentThread?: CommentThread;
   changesDisabled?: boolean;
   customSolution?: string;
   description?: string;
@@ -255,11 +257,13 @@ function AutofixSolutionDisplay({
   customSolution,
   solutionSelected,
   changesDisabled,
+  agentCommentThread,
 }: Omit<AutofixSolutionProps, 'repos'>) {
   const {mutate: handleContinue, isPending} = useSelectSolution({groupId, runId});
   const [isEditing, setIsEditing] = useState(false);
   const [userCustomSolution, setUserCustomSolution] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
+  const iconFixRef = useRef<HTMLDivElement>(null);
 
   if (!solution || solution.length === 0) {
     return (
@@ -275,7 +279,9 @@ function AutofixSolutionDisplay({
         <CustomSolutionPadding>
           <HeaderWrapper>
             <HeaderText>
-              <IconFix size="sm" />
+              <div ref={iconFixRef}>
+                <IconFix size="sm" />
+              </div>
               {t('Custom Solution')}
             </HeaderText>
             <CopySolutionButton solution={solution} customSolution={customSolution} />
@@ -293,7 +299,9 @@ function AutofixSolutionDisplay({
       <ClippedBox clipHeight={408}>
         <HeaderWrapper>
           <HeaderText>
-            <IconFix size="sm" />
+            <div ref={iconFixRef}>
+              <IconFix size="sm" />
+            </div>
             {t('Solution')}
           </HeaderText>
           <ButtonBar gap={1}>
@@ -398,6 +406,23 @@ function AutofixSolutionDisplay({
             </ButtonBar>
           </ButtonBar>
         </HeaderWrapper>
+        <AnimatePresence>
+          {agentCommentThread && iconFixRef.current && (
+            <AutofixHighlightPopup
+              selectedText="Solution"
+              referenceElement={iconFixRef.current}
+              groupId={groupId}
+              runId={runId}
+              stepIndex={previousDefaultStepIndex ?? 0}
+              retainInsightCardIndex={
+                previousInsightCount !== undefined && previousInsightCount >= 0
+                  ? previousInsightCount
+                  : null
+              }
+              isAgentComment
+            />
+          )}
+        </AnimatePresence>
         <Content>
           {isEditing ? (
             <TextArea

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -95,6 +95,7 @@ export function Step({
                   causes={step.causes}
                   rootCauseSelection={step.selection}
                   terminationReason={step.termination_reason}
+                  agentCommentThread={step.agent_comment_thread ?? undefined}
                   repos={repos}
                   previousDefaultStepIndex={previousDefaultStepIndex}
                   previousInsightCount={previousInsightCount}
@@ -111,6 +112,7 @@ export function Step({
                   repos={repos}
                   previousDefaultStepIndex={previousDefaultStepIndex}
                   previousInsightCount={previousInsightCount}
+                  agentCommentThread={step.agent_comment_thread ?? undefined}
                 />
               )}
               {step.type === AutofixStepType.CHANGES && (
@@ -120,6 +122,7 @@ export function Step({
                   runId={runId}
                   previousDefaultStepIndex={previousDefaultStepIndex}
                   previousInsightCount={previousInsightCount}
+                  agentCommentThread={step.agent_comment_thread ?? undefined}
                 />
               )}
             </Fragment>

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -101,6 +101,7 @@ interface BaseStep {
   title: string;
   type: AutofixStepType;
   active_comment_thread?: CommentThread | null;
+  agent_comment_thread?: CommentThread | null;
   completedMessage?: string;
   key?: string;
   output_stream?: string | null;

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -87,7 +87,9 @@ const isPolling = (autofixData: AutofixData | null, runStarted: boolean) => {
 
   // Check if there's any active comment thread that hasn't been completed
   const hasActiveCommentThread = autofixData.steps.some(
-    step => step.active_comment_thread && !step.active_comment_thread.is_completed
+    step =>
+      (step.active_comment_thread && !step.active_comment_thread.is_completed) ||
+      (step.agent_comment_thread && !step.agent_comment_thread.is_completed)
   );
 
   const hasSolutionStep = autofixData.steps.some(

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsHubDrawer.tsx
@@ -279,10 +279,37 @@ export const useOpenSolutionsDrawer = (
         ariaLabel: t('Solutions drawer'),
         shouldCloseOnInteractOutside: element => {
           const viewAllButton = buttonRef?.current;
+
+          // Check if the element is inside any autofix input element
+          const isInsideAutofixInput = () => {
+            const rethinkInputs = document.querySelectorAll(
+              '[data-autofix-input-type="rethink"]'
+            );
+            const agentCommentInputs = document.querySelectorAll(
+              '[data-autofix-input-type="agent-comment"]'
+            );
+
+            // Check if element is inside any rethink input
+            for (const input of rethinkInputs) {
+              if (input.contains(element)) {
+                return true;
+              }
+            }
+
+            // Check if element is inside any agent comment input
+            for (const input of agentCommentInputs) {
+              if (input.contains(element)) {
+                return true;
+              }
+            }
+
+            return false;
+          };
+
           if (
             viewAllButton?.contains(element) ||
             document.getElementById('sentry-feedback')?.contains(element) ||
-            document.getElementById('autofix-rethink-input')?.contains(element) ||
+            isInsideAutofixInput() ||
             document.getElementById('autofix-output-stream')?.contains(element) ||
             document.getElementById('autofix-write-access-modal')?.contains(element) ||
             element.closest('[data-overlay="true"]')


### PR DESCRIPTION
The agent can leave a comment on the root cause, solution, or code changes output. It looks the same as the user-initiated comments.

Adds an X button on the comment thread in the top right to allow users to dismiss threads too.

Requires Seer-side changes to go in first.