### PR TITLE
fix(nav): Update mobile styles to match new designs

### DIFF
--- a/static/app/components/nav/mobileTopbar.tsx
+++ b/static/app/components/nav/mobileTopbar.tsx
@@ -110,9 +110,8 @@ const Topbar = styled('header')`
   height: 40px;
   width: 100vw;
   padding-right: ${space(1.5)};
-  border-bottom: 1px solid ${p => p.theme.translucentGray100};
-  background: #3e2648;
-  background: linear-gradient(180deg, #3e2648 0%, #442c4e 100%);
+  border-bottom: 1px solid ${p => p.theme.translucentGray200};
+  background: ${p => p.theme.surface300};
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -171,7 +170,7 @@ const NavigationOverlay = styled('nav')`
   left: 0;
   display: flex;
   flex-direction: column;
-  background: ${p => p.theme.surface300};
+  background: ${p => p.theme.surface200};
   z-index: ${p => p.theme.zIndex.modal};
   --color: ${p => p.theme.textColor};
   --color-hover: ${p => p.theme.activeText};

--- a/static/app/components/nav/secondaryMobile.tsx
+++ b/static/app/components/nav/secondaryMobile.tsx
@@ -33,10 +33,7 @@ export function SecondaryMobile({handleClickBack}: Props) {
 
 const SecondaryMobileWrapper = styled('div')`
   position: relative;
-  border-right: 1px solid ${p => p.theme.translucentGray200};
-  background: ${p => p.theme.surface300};
   height: 100%;
-  overflow-y: auto;
 
   display: grid;
   grid-template-areas:
@@ -50,7 +47,7 @@ const GroupHeader = styled('h2')`
   position: sticky;
   top: 0;
   z-index: 1;
-  background: ${p => p.theme.background};
+  background: ${p => p.theme.surface200};
   display: flex;
   align-items: center;
   padding: ${space(2)} ${space(1)};
@@ -64,6 +61,7 @@ const ContentWrapper = styled('div')`
   align-items: stretch;
   justify-content: space-between;
   flex-direction: column;
+  overflow-y: auto;
 `;
 
 const HeaderLabel = styled('div')`

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -122,6 +122,7 @@ const BodyContainer = styled('div')`
   display: flex;
   flex-direction: column;
   flex: 1;
+  overflow-x: hidden;
 `;
 
 export default OrganizationLayout;


### PR DESCRIPTION
- Mobile styles were still using purple, switch to dark/light styles 
- Fixes scrolling issues on pages with a lot of content (like settings)

![CleanShot 2025-03-05 at 10 09 55](https://github.com/user-attachments/assets/6a8c7ab8-a432-45de-8e75-b78e739636c1)
