### PR TITLE
fix(ourlogs): Fix adding sentry keys to the tablet filter

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -100,10 +100,11 @@ export function useTrackAnalytics({
       page_source,
     });
 
-    info(fmt`trace.explorer.metadata:
+    info(
+      fmt`trace.explorer.metadata:
       organization: ${organization.slug}
       dataset: ${dataset}
-      query: ${query}
+      query: [omitted]
       visualizes: ${visualizes.map(v => v.chartType).join(', ')}
       title: ${title || ''}
       queryType: ${queryType}
@@ -113,7 +114,9 @@ export function useTrackAnalytics({
       visualizes_count: ${String(String(visualizes).length)}
       has_exceeded_performance_usage_limit: ${String(hasExceededPerformanceUsageLimit)}
       page_source: ${page_source}
-    `);
+    `,
+      {isAnalytics: true}
+    );
   }, [
     organization,
     dataset,

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -494,7 +494,7 @@ function getAttribute(
   const newKeyName = attributeKey.replace('sentry.', '');
 
   const attributeValue = attribute.value;
-  if (!attributeValue) {
+  if (!defined(attributeValue)) {
     return undefined;
   }
 

--- a/static/app/views/explore/logs/logFieldsTree.tsx
+++ b/static/app/views/explore/logs/logFieldsTree.tsx
@@ -365,7 +365,10 @@ function LogFieldsTreeRowDropdown({content}: {content: AttributeTreeContent}) {
       return;
     }
     const newSearch = search.copy();
-    newSearch.addFilterValue(originalAttribute.attribute_key, String(content.value));
+    newSearch.addFilterValue(
+      originalAttribute.original_attribute_key,
+      String(content.value)
+    );
     setLogsSearch(newSearch);
   }, [originalAttribute, content.value, setLogsSearch, search]);
 

--- a/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
@@ -10,6 +10,8 @@ import {TraceShape, type TraceTree} from './traceModels/traceTree';
 
 export type TraceWaterFallSource = 'trace_view' | 'replay_details' | 'issue_details';
 
+const {info, fmt} = Sentry._experiment_log;
+
 const trackTraceMetadata = (
   tree: TraceTree,
   projects: Project[],
@@ -251,6 +253,7 @@ function trackTraceShape(
       break;
     default: {
       Sentry.captureMessage('Unknown trace type');
+      info(fmt`Unknown trace type: ${tree.shape}`);
     }
   }
 }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -46,6 +46,8 @@ import {SiblingAutogroupNode} from './siblingAutogroupNode';
 import {TraceTreeEventDispatcher} from './traceTreeEventDispatcher';
 import {TraceTreeNode} from './traceTreeNode';
 
+const {info, fmt} = Sentry._experiment_log;
+
 /**
  *
  * This file implements the tree data structure that is used to represent a trace. We do
@@ -454,6 +456,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         Sentry.withScope(scope => {
           scope.setFingerprint(['trace-span-id-hash-collision']);
           scope.captureMessage('Span ID hash collision detected');
+          info(fmt`Span ID hash collision detected: ${span.span_id}`);
         });
       }
 
@@ -492,6 +495,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
           scope.captureMessage(
             'Span is a parent of its own transaction, this should not be possible'
           );
+          info(fmt`Span is a parent of its own transaction, this should not be possible`);
         });
         continue;
       }
@@ -1167,6 +1171,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
       Sentry.withScope(scope => {
         scope.setFingerprint(['trace-view-path-error']);
         scope.captureMessage('Invalid path to trace tree node ');
+        info(fmt`Invalid path to trace tree node: ${path}`);
       });
       return null;
     }
@@ -1412,6 +1417,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
             Sentry.withScope(scope => {
               scope.setFingerprint(['trace-view-transaction-parent']);
               scope.captureMessage('Failed to find parent transaction when zooming out');
+              info(fmt`Failed to find parent transaction when zooming out`);
             });
             continue;
           }
@@ -1598,6 +1604,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         Sentry.withScope(scope => {
           scope.setFingerprint(['trace-view-expand-to-path-error']);
           scope.captureMessage('Failed to expand to path');
+          info(fmt`Failed to expand to path`);
           scope.captureException(e);
         });
       });

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -25,6 +25,8 @@ export type TraceSearchResult = {
   value: TraceTreeNode<TraceTree.NodeValue>;
 };
 
+const {info, fmt} = Sentry._experiment_log;
+
 /**
  * Evaluates the infix token representation against the token list. The logic is the same as
  * if we were evaluating arithmetics expressions with the caveat that we have to handle and edge
@@ -134,6 +136,7 @@ export function searchInTraceTreeTokens(
           bool = token;
           if (stack.length < 2) {
             Sentry.captureMessage('Unbalanced tree - missing left or right token');
+            info(fmt`Unbalanced tree - missing left or right token`);
             if (typeof handle.id === 'number') {
               window.cancelAnimationFrame(handle.id);
             }
@@ -155,6 +158,7 @@ export function searchInTraceTreeTokens(
       Sentry.captureMessage(
         'Invalid state in searchInTraceTreeTokens, missing boolean token'
       );
+      info(fmt`Invalid state in searchInTraceTreeTokens, missing boolean token`);
       if (typeof handle.id === 'number') {
         window.cancelAnimationFrame(handle.id);
       }
@@ -165,6 +169,7 @@ export function searchInTraceTreeTokens(
       Sentry.captureMessage(
         'Invalid state in searchInTraceTreeTokens, missing left or right token'
       );
+      info(fmt`Invalid state in searchInTraceTreeTokens, missing left or right token`);
       if (typeof handle.id === 'number') {
         window.cancelAnimationFrame(handle.id);
       }
@@ -393,6 +398,7 @@ function evaluateValueDate<T extends Token.VALUE_ISO_8601_DATE>(
     }
     default: {
       Sentry.captureMessage('Unsupported operator for number filter, got ' + operator);
+      info(fmt`Unsupported operator for number filter, got ${operator}`);
       return false;
     }
   }
@@ -426,6 +432,7 @@ function evaluateValueNumber<T extends Token.VALUE_DURATION | Token.VALUE_NUMBER
     }
     default: {
       Sentry.captureMessage('Unsupported operator for number filter, got ' + operator);
+      info(fmt`Unsupported operator for number filter, got ${operator}`);
       return false;
     }
   }
@@ -485,6 +492,7 @@ function resolveValueFromKey(
       case Token.KEY_EXPLICIT_TAG:
       default: {
         Sentry.captureMessage(`Unsupported key type for filter, got ${token.key.type}`);
+        info(fmt`Unsupported key type for filter, got ${token.key.type}`);
       }
     }
 


### PR DESCRIPTION
### Summary
We need to use the untransformed attribute key for the filter to work correctly.

