### PR TITLE
test(ui): Swap spyOn date for mock date

### DIFF
--- a/static/gsApp/components/partnerPlanEndingModal.spec.tsx
+++ b/static/gsApp/components/partnerPlanEndingModal.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {PlanFixture} from 'getsentry/__fixtures__/plan';
 import PartnerPlanEndingModal from 'getsentry/components/partnerPlanEndingModal';
@@ -11,7 +12,7 @@ import {PlanName} from 'getsentry/types';
 
 describe('PartnerPlanEndingModal', function () {
   beforeEach(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => new Date('2024-08-01').getTime());
+    setMockDate(new Date('2024-08-01'));
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -23,6 +24,10 @@ describe('PartnerPlanEndingModal', function () {
         }),
       ],
     });
+  });
+
+  afterEach(() => {
+    resetMockDate();
   });
 
   it('shows request upgrade when user does not have billing permissions', async function () {

--- a/static/gsApp/components/trialEndingModal.spec.tsx
+++ b/static/gsApp/components/trialEndingModal.spec.tsx
@@ -3,13 +3,14 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import TrialEndingModal from 'getsentry/components/trialEndingModal';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 
 describe('TrialEndingModal', function () {
   beforeEach(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => new Date('2021-03-03').getTime());
+    setMockDate(new Date('2021-03-03'));
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -21,6 +22,10 @@ describe('TrialEndingModal', function () {
         }),
       ],
     });
+  });
+
+  afterEach(() => {
+    resetMockDate();
   });
 
   it('shows request upgrade when user does not have billing permissions', function () {

--- a/static/gsApp/views/subscriptionPage/trialAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.spec.tsx
@@ -2,6 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import TrialAlert from 'getsentry/views/subscriptionPage/trialAlert';
 
@@ -9,9 +10,13 @@ describe('Subscription > TrialAlert', function () {
   const organization = OrganizationFixture();
   const subscription = SubscriptionFixture({organization});
 
-  beforeEach(() =>
-    jest.spyOn(Date, 'now').mockImplementation(() => new Date('2021-01-01').getTime())
-  );
+  beforeEach(() => {
+    setMockDate(new Date('2021-01-01'));
+  });
+
+  afterEach(() => {
+    resetMockDate();
+  });
 
   it('does not render not on trial', function () {
     const sub = {


### PR DESCRIPTION
We have a mock date library we use for freezing the time instead of spying on a specific date method.
