### PR TITLE
fix(nav): Fix positioning of menu overlays in mobile view

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -65,6 +65,7 @@ export interface DropdownMenuProps
       | 'onOpenChange'
       | 'preventOverflowOptions'
       | 'flipOptions'
+      | 'shouldApplyMinWidth'
     > {
   /**
    * Items to display inside the dropdown menu. If the item has a `children`
@@ -155,6 +156,7 @@ function DropdownMenu({
   preventOverflowOptions,
   flipOptions,
   portalContainerRef,
+  shouldApplyMinWidth,
   ...props
 }: DropdownMenuProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
@@ -179,6 +181,7 @@ function DropdownMenu({
     preventOverflowOptions,
     flipOptions,
     onOpenChange,
+    shouldApplyMinWidth,
   });
 
   const {menuTriggerProps, menuProps} = useMenuTrigger(

--- a/static/app/components/nav/primary/components.tsx
+++ b/static/app/components/nav/primary/components.tsx
@@ -73,7 +73,8 @@ export function SidebarMenu({
   return (
     <SidebarItem>
       <DropdownMenu
-        position="right-end"
+        position={layout === NavLayout.MOBILE ? 'bottom' : 'right-end'}
+        shouldApplyMinWidth={false}
         trigger={(props, isOpen) => {
           return (
             <NavButton

--- a/static/app/components/nav/primary/onboarding.tsx
+++ b/static/app/components/nav/primary/onboarding.tsx
@@ -1,7 +1,5 @@
 import {useEffect, useMemo} from 'react';
 import {css, useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
-import {FocusScope} from '@react-aria/focus';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
@@ -11,10 +9,13 @@ import {
   SidebarItem,
   SidebarItemUnreadIndicator,
 } from 'sentry/components/nav/primary/components';
+import {
+  PrimaryButtonOverlay,
+  usePrimaryButtonOverlay,
+} from 'sentry/components/nav/primary/primaryButtonOverlay';
 import {NavLayout} from 'sentry/components/nav/types';
 import {OnboardingSidebarContent} from 'sentry/components/onboardingWizard/content';
 import {useOnboardingTasks} from 'sentry/components/onboardingWizard/useOnboardingTasks';
-import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import ProgressRing from 'sentry/components/progressRing';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {IconCheckmark} from 'sentry/icons/iconCheckmark';
@@ -27,7 +28,6 @@ import {isDemoModeEnabled} from 'sentry/utils/demoMode';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
-import useOverlay from 'sentry/utils/useOverlay';
 import {useUser} from 'sentry/utils/useUser';
 import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
@@ -56,10 +56,7 @@ function OnboardingItem({
     isOpen,
     triggerProps: overlayTriggerProps,
     overlayProps,
-  } = useOverlay({
-    offset: 8,
-    position: 'right-end',
-    isDismissable: true,
+  } = usePrimaryButtonOverlay({
     isOpen: isActive,
     onOpenChange: newIsOpen => {
       if (newIsOpen) {
@@ -109,13 +106,9 @@ function OnboardingItem({
           )}
         </NavButton>
         {isOpen && (
-          <FocusScope autoFocus restoreFocus>
-            <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
-              <ScrollableOverlay>
-                <OnboardingSidebarContent onClose={() => SidebarPanelStore.hidePanel()} />
-              </ScrollableOverlay>
-            </PositionWrapper>
-          </FocusScope>
+          <PrimaryButtonOverlay overlayProps={overlayProps}>
+            <OnboardingSidebarContent onClose={() => SidebarPanelStore.hidePanel()} />
+          </PrimaryButtonOverlay>
         )}
       </SidebarItem>
     </GuideAnchor>
@@ -212,10 +205,3 @@ export function PrimaryNavigationOnboarding() {
     />
   );
 }
-
-const ScrollableOverlay = styled(Overlay)`
-  min-height: 300px;
-  max-height: 60vh;
-  overflow-y: auto;
-  width: 400px;
-`;

--- a/static/app/components/nav/primary/primaryButtonOverlay.tsx
+++ b/static/app/components/nav/primary/primaryButtonOverlay.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import {FocusScope} from '@react-aria/focus';
+
+import {useNavContext} from 'sentry/components/nav/context';
+import {NavLayout} from 'sentry/components/nav/types';
+import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {space} from 'sentry/styles/space';
+import theme from 'sentry/utils/theme';
+import useOverlay, {type UseOverlayProps} from 'sentry/utils/useOverlay';
+
+type PrimaryButtonOverlayProps = {
+  children: React.ReactNode;
+  overlayProps: React.HTMLAttributes<HTMLDivElement>;
+};
+
+export function usePrimaryButtonOverlay(props: UseOverlayProps = {}) {
+  const {layout} = useNavContext();
+
+  return useOverlay({
+    offset: 8,
+    position: layout === NavLayout.MOBILE ? 'bottom' : 'right-end',
+    isDismissable: true,
+    shouldApplyMinWidth: false,
+    ...props,
+  });
+}
+
+/**
+ * Overlay to be used for primary navigation buttons in footer, such as
+ * "what's new" and "onboarding". This will appear as a normal overlay
+ * on desktop and a modified overlay in mobile to match the design of
+ * the mobile topbar.
+ */
+export function PrimaryButtonOverlay({
+  children,
+  overlayProps,
+}: PrimaryButtonOverlayProps) {
+  const {layout} = useNavContext();
+
+  return (
+    <FocusScope autoFocus restoreFocus>
+      <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
+        <ScrollableOverlay isMobile={layout === NavLayout.MOBILE}>
+          {children}
+        </ScrollableOverlay>
+      </PositionWrapper>
+    </FocusScope>
+  );
+}
+
+const ScrollableOverlay = styled(Overlay)<{
+  isMobile: boolean;
+}>`
+  min-height: 300px;
+  max-height: ${p => (p.isMobile ? '80vh' : '60vh')};
+  overflow-y: auto;
+  width: ${p => (p.isMobile ? `calc(100vw - ${space(4)})` : '400px')};
+`;

--- a/static/app/components/nav/primary/serviceIncidents.tsx
+++ b/static/app/components/nav/primary/serviceIncidents.tsx
@@ -1,32 +1,27 @@
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {FocusScope} from '@react-aria/focus';
 
 import {
   SidebarButton,
   SidebarItem,
   SidebarItemUnreadIndicator,
 } from 'sentry/components/nav/primary/components';
-import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {
+  PrimaryButtonOverlay,
+  usePrimaryButtonOverlay,
+} from 'sentry/components/nav/primary/primaryButtonOverlay';
 import {ServiceIncidentDetails} from 'sentry/components/serviceIncidentDetails';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {StatuspageIncident} from 'sentry/types/system';
-import useOverlay from 'sentry/utils/useOverlay';
 import {useServiceIncidents} from 'sentry/utils/useServiceIncidents';
 
 function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) {
-  const theme = useTheme();
   const {
     isOpen,
     triggerProps: overlayTriggerProps,
     overlayProps,
-  } = useOverlay({
-    offset: 8,
-    position: 'right-end',
-    isDismissable: true,
-  });
+  } = usePrimaryButtonOverlay();
 
   return (
     <SidebarItem>
@@ -39,17 +34,13 @@ function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) 
         <WarningUnreadIndicator />
       </SidebarButton>
       {isOpen && (
-        <FocusScope autoFocus restoreFocus>
-          <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
-            <ScrollableOverlay>
-              {incidents.map(incident => (
-                <IncidentItemWrapper key={incident.id}>
-                  <ServiceIncidentDetails incident={incident} />
-                </IncidentItemWrapper>
-              ))}
-            </ScrollableOverlay>
-          </PositionWrapper>
-        </FocusScope>
+        <PrimaryButtonOverlay overlayProps={overlayProps}>
+          {incidents.map(incident => (
+            <IncidentItemWrapper key={incident.id}>
+              <ServiceIncidentDetails incident={incident} />
+            </IncidentItemWrapper>
+          ))}
+        </PrimaryButtonOverlay>
       )}
     </SidebarItem>
   );
@@ -73,12 +64,6 @@ const IncidentItemWrapper = styled('div')`
   :not(:first-child) {
     border-top: 1px solid ${p => p.theme.innerBorder};
   }
-`;
-
-const ScrollableOverlay = styled(Overlay)`
-  max-height: 60vh;
-  width: 400px;
-  overflow-y: auto;
 `;
 
 const WarningUnreadIndicator = styled(SidebarItemUnreadIndicator)`

--- a/static/app/components/nav/primary/whatsNew.tsx
+++ b/static/app/components/nav/primary/whatsNew.tsx
@@ -1,7 +1,4 @@
 import {Fragment, useEffect, useMemo} from 'react';
-import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
-import {FocusScope} from '@react-aria/focus';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {
@@ -9,7 +6,10 @@ import {
   SidebarItem,
   SidebarItemUnreadIndicator,
 } from 'sentry/components/nav/primary/components';
-import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {
+  PrimaryButtonOverlay,
+  usePrimaryButtonOverlay,
+} from 'sentry/components/nav/primary/primaryButtonOverlay';
 import {BroadcastPanelItem} from 'sentry/components/sidebar/broadcastPanelItem';
 import SidebarPanelEmpty from 'sentry/components/sidebar/sidebarPanelEmpty';
 import {IconBroadcast} from 'sentry/icons';
@@ -25,7 +25,6 @@ import {
 } from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import useOverlay from 'sentry/utils/useOverlay';
 
 const MARK_SEEN_DELAY = 1000;
 
@@ -121,17 +120,11 @@ export function PrimaryNavigationWhatsNew() {
     [broadcasts]
   );
 
-  const theme = useTheme();
-
   const {
     isOpen,
     triggerProps: overlayTriggerProps,
     overlayProps,
-  } = useOverlay({
-    offset: 8,
-    position: 'right-end',
-    isDismissable: true,
-  });
+  } = usePrimaryButtonOverlay();
 
   return (
     <SidebarItem>
@@ -146,20 +139,10 @@ export function PrimaryNavigationWhatsNew() {
         )}
       </SidebarButton>
       {isOpen && (
-        <FocusScope autoFocus restoreFocus>
-          <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
-            <ScrollableOverlay>
-              <WhatsNewContent unseenPostIds={unseenPostIds} />
-            </ScrollableOverlay>
-          </PositionWrapper>
-        </FocusScope>
+        <PrimaryButtonOverlay overlayProps={overlayProps}>
+          <WhatsNewContent unseenPostIds={unseenPostIds} />
+        </PrimaryButtonOverlay>
       )}
     </SidebarItem>
   );
 }
-
-const ScrollableOverlay = styled(Overlay)`
-  max-height: 60vh;
-  width: 400px;
-  overflow-y: auto;
-`;


### PR DESCRIPTION
Previously, overlays were not visible in the mobile view because they were positioned to the right. This extracts the overlay code into a reusable hook/component so they all work consistently in mobile.

![CleanShot 2025-03-05 at 11 07 08](https://github.com/user-attachments/assets/c6c12571-06ad-480a-91ed-490208e5a5e4)
