### PR TITLE
:recycle: ref(metric alerts): `refactor incident_attachment_info`

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -257,7 +257,11 @@ class PagerDutyActionHandler(DefaultActionHandler):
         from sentry.integrations.pagerduty.utils import send_incident_alert_notification
 
         success = send_incident_alert_notification(
-            self.action, self.incident, metric_value, new_status, notification_uuid
+            action=self.action,
+            incident=self.incident,
+            new_status=new_status,
+            metric_value=metric_value,
+            notification_uuid=notification_uuid,
         )
         if success:
             self.record_alert_sent_analytics(self.action.target_identifier, notification_uuid)
@@ -283,7 +287,11 @@ class OpsgenieActionHandler(DefaultActionHandler):
         from sentry.integrations.opsgenie.utils import send_incident_alert_notification
 
         success = send_incident_alert_notification(
-            self.action, self.incident, metric_value, new_status, notification_uuid
+            action=self.action,
+            incident=self.incident,
+            new_status=new_status,
+            metric_value=metric_value,
+            notification_uuid=notification_uuid,
         )
         if success:
             self.record_alert_sent_analytics(self.action.target_identifier, notification_uuid)

--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -3,50 +3,50 @@ from __future__ import annotations
 import time
 from datetime import datetime
 
-from sentry.incidents.models.alert_rule import AlertRule
-from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.discord.message_builder import INCIDENT_COLOR_MAPPING, LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
 from sentry.integrations.discord.message_builder.base.embed.base import DiscordMessageEmbed
 from sentry.integrations.discord.message_builder.base.embed.image import DiscordMessageEmbedImage
-from sentry.integrations.metric_alerts import (
-    AlertContext,
-    get_metric_count_from_incident,
-    incident_attachment_info,
-)
+from sentry.integrations.metric_alerts import AlertContext, incident_attachment_info
+from sentry.models.organization import Organization
+from sentry.snuba.models import SnubaQuery
 
 
 class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
     def __init__(
         self,
-        alert_rule: AlertRule,
-        incident: Incident,
+        alert_context: AlertContext,
+        open_period_identifier: int,
+        snuba_query: SnubaQuery,
+        organization: Organization,
+        date_started: datetime,
         new_status: IncidentStatus,
         metric_value: float | None = None,
         chart_url: str | None = None,
     ) -> None:
-        self.alert_rule = alert_rule
-        self.incident = incident
+        self.alert_context = alert_context
+        self.open_period_identifier = open_period_identifier
+        self.snuba_query = snuba_query
+        self.organization = organization
+        self.date_started = date_started
         self.metric_value = metric_value
         self.new_status = new_status
         self.chart_url = chart_url
 
     def build(self, notification_uuid: str | None = None) -> dict[str, object]:
-        if self.metric_value is None:
-            self.metric_value = get_metric_count_from_incident(self.incident)
-
         data = incident_attachment_info(
-            AlertContext.from_alert_rule_incident(self.alert_rule),
-            open_period_identifier=self.incident.identifier,
-            organization=self.incident.organization,
-            snuba_query=self.alert_rule.snuba_query,
+            alert_context=self.alert_context,
+            open_period_identifier=self.open_period_identifier,
+            organization=self.organization,
+            snuba_query=self.snuba_query,
             metric_value=self.metric_value,
             new_status=self.new_status,
             notification_uuid=notification_uuid,
             referrer="metric_alert_discord",
         )
 
-        description = f"{data['text']}{get_started_at(self.incident.date_started)}"
+        description = f"{data['text']}{get_started_at(self.date_started)}"
 
         embeds = [
             DiscordMessageEmbed(

--- a/src/sentry/integrations/discord/spec.py
+++ b/src/sentry/integrations/discord/spec.py
@@ -48,7 +48,11 @@ class DiscordMessagingSpec(MessagingIntegrationSpec):
         )
 
         return send_incident_alert_notification(
-            action, incident, metric_value, new_status, notification_uuid
+            action=action,
+            incident=incident,
+            new_status=new_status,
+            metric_value=metric_value,
+            notification_uuid=notification_uuid,
         )
 
     @property

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -48,7 +48,11 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
         from sentry.integrations.msteams.utils import send_incident_alert_notification
 
         return send_incident_alert_notification(
-            action, incident, metric_value, new_status, notification_uuid
+            action=action,
+            incident=incident,
+            metric_value=metric_value,
+            new_status=new_status,
+            notification_uuid=notification_uuid,
         )
 
     @property

--- a/src/sentry/integrations/slack/spec.py
+++ b/src/sentry/integrations/slack/spec.py
@@ -51,7 +51,11 @@ class SlackMessagingSpec(MessagingIntegrationSpec):
         from sentry.integrations.slack.utils.notifications import send_incident_alert_notification
 
         return send_incident_alert_notification(
-            action, incident, metric_value, new_status, notification_uuid
+            action=action,
+            incident=incident,
+            new_status=new_status,
+            metric_value=metric_value,
+            notification_uuid=notification_uuid,
         )
 
     @property

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -15,6 +15,7 @@ from sentry.incidents.models.alert_rule import (
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.messaging.spec import MessagingActionHandler
+from sentry.integrations.metric_alerts import AlertContext
 from sentry.integrations.msteams.card_builder.block import (
     Block,
     ColumnBlock,
@@ -92,7 +93,13 @@ class MsTeamsActionHandlerTest(FireTest):
         data = json.loads(responses.calls[0].request.body)
 
         assert data["attachments"][0]["content"] == build_incident_attachment(
-            incident, IncidentStatus(incident.status), metric_value
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=incident.alert_rule.snuba_query,
+            organization=incident.organization,
+            date_started=incident.date_started,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
 
         assert_slo_metric(mock_record)
@@ -116,7 +123,13 @@ class MsTeamsActionHandlerTest(FireTest):
         )
         metric_value = 1000
         data = build_incident_attachment(
-            incident=incident, new_status=IncidentStatus(incident.status), metric_value=metric_value
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=alert_rule.snuba_query,
+            organization=incident.organization,
+            date_started=incident.date_started,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
         body: list[Block] = data["body"]
         column_set_block = cast(ColumnSetBlock, body[0])
@@ -161,7 +174,13 @@ class MsTeamsActionHandlerTest(FireTest):
         )
         metric_value = 1000
         data = build_incident_attachment(
-            incident=incident, new_status=IncidentStatus(incident.status), metric_value=metric_value
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=alert_rule.snuba_query,
+            organization=incident.organization,
+            date_started=incident.date_started,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
         body: list[Block] = data["body"]
         column_set_block = cast(ColumnSetBlock, body[0])

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -13,6 +13,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
+from sentry.integrations.metric_alerts import AlertContext
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.seer.anomaly_detection.types import StoreDataResponse
@@ -91,7 +92,12 @@ class OpsgenieActionHandlerTest(FireTest):
         )
         metric_value = 1000
         data = build_incident_attachment(
-            incident=incident, new_status=IncidentStatus(incident.status), metric_value=metric_value
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -145,7 +151,12 @@ class OpsgenieActionHandlerTest(FireTest):
         )
         metric_value = 1000
         data = build_incident_attachment(
-            incident=incident, new_status=IncidentStatus(incident.status), metric_value=metric_value
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
         )
 
         assert data["message"] == alert_rule.name
@@ -189,7 +200,14 @@ class OpsgenieActionHandlerTest(FireTest):
                 json={},
                 status=202,
             )
-            expected_payload = build_incident_attachment(incident, new_status, metric_value=1000)
+            expected_payload = build_incident_attachment(
+                alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+                open_period_identifier=incident.identifier,
+                organization=incident.organization,
+                snuba_query=incident.alert_rule.snuba_query,
+                new_status=new_status,
+                metric_value=1000,
+            )
             expected_payload = attach_custom_priority(expected_payload, self.action, new_status)
 
         handler = OpsgenieActionHandler(self.action, incident, self.project)

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -16,6 +16,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
+from sentry.integrations.metric_alerts import AlertContext
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
@@ -79,11 +80,14 @@ class PagerDutyActionHandlerTest(FireTest):
         metric_value = 1000
         notification_uuid = str(uuid.uuid4())
         data = build_incident_attachment(
-            incident,
-            self.integration_key,
-            IncidentStatus(incident.status),
-            metric_value,
-            notification_uuid,
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            integration_key=self.integration_key,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
+            notification_uuid=notification_uuid,
         )
 
         assert data["routing_key"] == self.integration_key
@@ -133,11 +137,14 @@ class PagerDutyActionHandlerTest(FireTest):
         metric_value = 1000
         notification_uuid = str(uuid.uuid4())
         data = build_incident_attachment(
-            incident,
-            self.integration_key,
-            IncidentStatus(incident.status),
-            metric_value,
-            notification_uuid,
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            integration_key=self.integration_key,
+            new_status=IncidentStatus(incident.status),
+            metric_value=metric_value,
+            notification_uuid=notification_uuid,
         )
 
         assert data["routing_key"] == self.integration_key
@@ -177,7 +184,13 @@ class PagerDutyActionHandlerTest(FireTest):
         data = responses.calls[0].request.body
 
         expected_payload = build_incident_attachment(
-            incident, self.service["integration_key"], new_status, metric_value
+            alert_context=AlertContext.from_alert_rule_incident(incident.alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=incident.organization,
+            snuba_query=incident.alert_rule.snuba_query,
+            integration_key=self.integration_key,
+            new_status=new_status,
+            metric_value=metric_value,
         )
         expected_payload = attach_custom_severity(expected_payload, self.action, new_status)
 

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -18,6 +18,7 @@ from sentry.integrations.discord.message_builder.metric_alerts import (
     DiscordMetricAlertMessageBuilder,
     get_started_at,
 )
+from sentry.integrations.metric_alerts import AlertContext
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
@@ -54,8 +55,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
 
         uuid = "uuid"
         assert DiscordMetricAlertMessageBuilder(
-            alert_rule=self.alert_rule,
-            incident=incident,
+            alert_context=AlertContext.from_alert_rule_incident(self.alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=self.alert_rule.snuba_query,
+            organization=self.organization,
+            date_started=incident.date_started,
             new_status=IncidentStatus.CLOSED,
             metric_value=0,
         ).build(notification_uuid=uuid) == {
@@ -92,8 +96,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
         )
         uuid = "uuid"
         assert DiscordMetricAlertMessageBuilder(
-            alert_rule=self.alert_rule,
-            incident=incident,
+            alert_context=AlertContext.from_alert_rule_incident(self.alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=self.alert_rule.snuba_query,
+            organization=self.organization,
+            date_started=incident.date_started,
             new_status=IncidentStatus.CRITICAL,
             metric_value=0,
         ).build(notification_uuid=uuid) == {
@@ -133,8 +140,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
         )
         uuid = "uuid"
         assert DiscordMetricAlertMessageBuilder(
-            alert_rule=self.alert_rule,
-            incident=incident,
+            alert_context=AlertContext.from_alert_rule_incident(self.alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=self.alert_rule.snuba_query,
+            organization=self.organization,
+            date_started=incident.date_started,
             new_status=IncidentStatus.CRITICAL,
             metric_value=metric_value,
         ).build(notification_uuid=uuid) == {
@@ -170,8 +180,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
         new_status = IncidentStatus.CLOSED
         uuid = "uuid"
         assert DiscordMetricAlertMessageBuilder(
-            alert_rule=self.alert_rule,
-            incident=incident,
+            alert_context=AlertContext.from_alert_rule_incident(self.alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=self.alert_rule.snuba_query,
+            organization=self.organization,
+            date_started=incident.date_started,
             new_status=new_status,
             metric_value=0,
             chart_url="chart_url",
@@ -210,8 +223,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
         )
 
         assert DiscordMetricAlertMessageBuilder(
-            alert_rule=self.alert_rule,
-            incident=incident,
+            alert_context=AlertContext.from_alert_rule_incident(self.alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=self.alert_rule.snuba_query,
+            organization=self.organization,
+            date_started=incident.date_started,
             new_status=IncidentStatus.CRITICAL,
             metric_value=0,
         ).build() == {
@@ -260,8 +276,11 @@ class BuildMetricAlertAttachmentTest(TestCase):
         )
         uuid = "uuid"
         assert DiscordMetricAlertMessageBuilder(
-            alert_rule=alert_rule,
-            incident=incident,
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            snuba_query=alert_rule.snuba_query,
+            organization=self.organization,
+            date_started=incident.date_started,
             new_status=IncidentStatus.CRITICAL,
             metric_value=0,
         ).build(notification_uuid=uuid) == {

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -21,6 +21,7 @@ from sentry.integrations.messaging.message_builder import (
     build_attachment_text,
     build_attachment_title,
 )
+from sentry.integrations.metric_alerts import AlertContext
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.message_builder.issues import (
     SlackIssuesMessageBuilder,
@@ -805,7 +806,13 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
-            incident, IncidentStatus.CRITICAL, metric_value=0
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=self.organization,
+            snuba_query=alert_rule.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=0,
+            date_started=incident.date_started,
         ).build() == {
             "blocks": [
                 {
@@ -871,7 +878,13 @@ class BuildIncidentAttachmentTest(TestCase):
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
-            incident, IncidentStatus.CLOSED, metric_value=0
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=self.organization,
+            snuba_query=alert_rule.snuba_query,
+            date_started=incident.date_started,
+            new_status=IncidentStatus.CLOSED,
+            metric_value=0,
         ).build() == {
             "blocks": [
                 {
@@ -910,7 +923,13 @@ class BuildIncidentAttachmentTest(TestCase):
         )
         # This should fail because it pulls status from `action` instead of `incident`
         assert SlackIncidentsMessageBuilder(
-            incident, IncidentStatus.CRITICAL, metric_value=metric_value
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=self.organization,
+            snuba_query=alert_rule.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=metric_value,
+            date_started=incident.date_started,
         ).build() == {
             "blocks": [
                 {
@@ -945,7 +964,14 @@ class BuildIncidentAttachmentTest(TestCase):
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
-            incident, IncidentStatus.CLOSED, metric_value=0, chart_url="chart-url"
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=self.organization,
+            snuba_query=alert_rule.snuba_query,
+            new_status=IncidentStatus.CLOSED,
+            metric_value=0,
+            date_started=incident.date_started,
+            chart_url="chart-url",
         ).build() == {
             "blocks": [
                 {
@@ -994,7 +1020,13 @@ class BuildIncidentAttachmentTest(TestCase):
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
-            incident, IncidentStatus.CRITICAL, metric_value=0
+            alert_context=AlertContext.from_alert_rule_incident(alert_rule),
+            open_period_identifier=incident.identifier,
+            organization=self.organization,
+            snuba_query=alert_rule.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=0,
+            date_started=incident.date_started,
         ).build() == {
             "blocks": [
                 {


### PR DESCRIPTION
moving up the query for `alert_rule` and `incident` up 1 level.

need to still update the sentry apps but that happens after i create the incident serializer since its required.