### PR TITLE
feat(billing): add uptime to getCheckoutAPIData

### DIFF
--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -103,9 +103,11 @@ type GetsentryEventParameters = {
     previous_replays?: number;
     previous_spans?: number;
     previous_transactions?: number;
+    previous_uptime?: number;
     replays?: number;
     spans?: number;
     transactions?: number;
+    uptime?: number;
   } & Checkout;
   'data_consent_modal.learn_more': Record<PropertyKey, unknown>;
   'data_consent_priority.viewed': Record<PropertyKey, unknown>;

--- a/static/gsApp/views/amCheckout/steps/reviewAndConfirm.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reviewAndConfirm.spec.tsx
@@ -286,6 +286,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       previous_monitorSeats: 1,
       previous_profileDuration: undefined,
       previous_spans: undefined,
+      previous_uptime: 1,
       plan: updatedData.plan,
       errors: updatedData.reserved.errors,
       transactions: updatedData.reserved.transactions,
@@ -293,6 +294,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       spans: undefined,
+      uptime: 1,
     });
 
     expect(trackGetsentryAnalytics).toHaveBeenCalledWith(
@@ -335,6 +337,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
         attachments: 1,
         monitorSeats: 1,
         profileDuration: 0,
+        uptime: 1,
       },
     };
 
@@ -380,6 +383,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       previous_monitorSeats: 1,
       previous_profileDuration: undefined,
       previous_spans: undefined,
+      previous_uptime: 1,
       plan: updatedData.plan,
       errors: updatedData.reserved.errors,
       transactions: undefined,
@@ -388,6 +392,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       monitorSeats: updatedData.reserved.monitorSeats,
       spans: updatedData.reserved.spans,
       profileDuration: updatedData.reserved.profileDuration,
+      uptime: updatedData.reserved.uptime,
     });
 
     expect(trackGetsentryAnalytics).toHaveBeenCalledWith(
@@ -480,6 +485,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       spans: updatedData.reserved.spans,
+      previous_uptime: 1,
     });
 
     expect(trackGetsentryAnalytics).toHaveBeenCalledWith(
@@ -672,6 +678,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       attachments: updatedData.reserved.attachments,
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
+      uptime: updatedData.reserved.uptime,
       spans: undefined,
     });
     expect(trackGetsentryAnalytics).not.toHaveBeenCalledWith(
@@ -735,6 +742,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       attachments: updatedData.reserved.attachments,
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
+      uptime: updatedData.reserved.uptime,
       spans: undefined,
     });
 

--- a/static/gsApp/views/amCheckout/types.tsx
+++ b/static/gsApp/views/amCheckout/types.tsx
@@ -35,6 +35,7 @@ export type CheckoutAPIData = BaseCheckoutData & {
   reservedReplays?: number;
   reservedSpans?: number;
   reservedTransactions?: number;
+  reservedUptime?: number;
 };
 
 export type StepProps = {

--- a/static/gsApp/views/amCheckout/utils.spec.tsx
+++ b/static/gsApp/views/amCheckout/utils.spec.tsx
@@ -4,6 +4,7 @@ import {DataCategory} from 'sentry/types/core';
 
 import {PlanTier} from 'getsentry/types';
 import * as utils from 'getsentry/views/amCheckout/utils';
+import {getCheckoutAPIData} from 'getsentry/views/amCheckout/utils';
 
 describe('utils', function () {
   const teamPlan = PlanDetailsLookupFixture('am1_team')!;
@@ -322,6 +323,39 @@ describe('utils', function () {
       expect(utils.getToggleTier(PlanTier.AM3)).toBeNull();
       expect(utils.getToggleTier(PlanTier.AM2)).toBe(PlanTier.AM1);
       expect(utils.getToggleTier(PlanTier.AM1)).toBe(PlanTier.AM2);
+    });
+  });
+
+  describe('utils.getCheckoutAPIData', function () {
+    it('returns correct reserved api data', function () {
+      const formData = {
+        plan: 'am3_business',
+        onDemandMaxSpend: 100,
+        reserved: {
+          errors: 10,
+          transactions: 20,
+          replays: 30,
+          spans: 40,
+          monitorSeats: 50,
+          uptime: 60,
+          attachments: 70,
+          profileDuration: 80,
+        },
+      };
+
+      expect(getCheckoutAPIData({formData})).toEqual({
+        onDemandMaxSpend: 100,
+        plan: 'am3_business',
+        referrer: 'billing',
+        reservedErrors: 10,
+        reservedTransactions: 20,
+        reservedReplays: 30,
+        reservedSpans: 40,
+        reservedMonitorSeats: 50,
+        reservedUptime: 60,
+        reservedAttachments: 70,
+        reservedProfileDuration: 80,
+      });
     });
   });
 });

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -327,6 +327,7 @@ function recordAnalytics(
     monitorSeats: data.reservedMonitorSeats,
     spans: data.reservedSpans,
     profileDuration: data.reservedProfileDuration,
+    uptime: data.reservedUptime,
   };
 
   const previousData = {
@@ -338,6 +339,7 @@ function recordAnalytics(
     monitorSeats: subscription.categories.monitorSeats?.reserved || undefined,
     profileDuration: subscription.categories.profileDuration?.reserved || undefined,
     spans: subscription.categories.spans?.reserved || undefined,
+    uptime: subscription.categories.uptime?.reserved || undefined,
   };
 
   trackGetsentryAnalytics('checkout.upgrade', {
@@ -351,6 +353,7 @@ function recordAnalytics(
     previous_monitorSeats: previousData.monitorSeats,
     previous_profileDuration: previousData.profileDuration,
     previous_spans: previousData.spans,
+    previous_uptime: previousData.uptime,
     ...currentData,
   });
 
@@ -442,6 +445,7 @@ export function getCheckoutAPIData({
     reservedMonitorSeats: formatReservedData(formData.reserved.monitorSeats),
     reservedProfileDuration: formatReservedData(formData.reserved.profileDuration),
     reservedSpans: formatReservedData(formData.reserved.spans),
+    reservedUptime: formatReservedData(formData.reserved.uptime),
   } satisfies Partial<
     // Enforce plural spelling against the enums in DataCategory
     Record<`reserved${Capitalize<DataCategory>}`, number | undefined>


### PR DESCRIPTION
There are plans to make the API handle missing uptime reserved checkout data (because it's always 1).
In the meantime this adds uptime reserved value to checkout data.