### PR TITLE
ref(ui): Change `useInfiniteApiQuerykey` to always append additional arg to query key

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -53,6 +53,15 @@ export type QueryKeyEndpointOptions<
   query?: Query;
 };
 
+type InfiniteApiQueryKey = readonly [
+  url: string,
+  options: QueryKeyEndpointOptions<
+    Record<string, string>,
+    Record<string, any>,
+    Record<string, any>
+  >,
+  additionalKey: string,
+];
 export type ApiQueryKey =
   | readonly [url: string]
   | readonly [
@@ -62,7 +71,6 @@ export type ApiQueryKey =
         Record<string, any>,
         Record<string, any>
       >,
-      additionalKey?: string,
     ];
 
 export interface UseApiQueryOptions<TApiResponse, TError = RequestError>
@@ -256,7 +264,7 @@ export function fetchInfiniteQuery<TResponseData>(api: Client) {
   return function fetchInfiniteQueryImpl({
     pageParam,
     queryKey,
-  }: QueryFunctionContext<ApiQueryKey, undefined | ParsedHeader>): Promise<
+  }: QueryFunctionContext<InfiniteApiQueryKey, undefined | ParsedHeader>): Promise<
     ApiResult<TResponseData>
   > {
     const [url, endpointOptions] = queryKey;
@@ -296,7 +304,14 @@ export function useInfiniteApiQuery<TResponseData>({
 }) {
   const api = useApi({persistInFlight: PERSIST_IN_FLIGHT});
   const query = useInfiniteQuery({
-    queryKey,
+    // We append an additional string to the queryKey here to prevent a hard
+    // crash due to a cache conflict between normal queries and "infinite"
+    // queries. Read more
+    // here: https://tkdodo.eu/blog/effective-react-query-keys#caching-data
+    queryKey:
+      queryKey.length === 1
+        ? ([...queryKey, {}, 'infinite'] as const)
+        : ([...queryKey, 'infinite'] as const),
     queryFn: fetchInfiniteQuery<TResponseData>(api),
     getPreviousPageParam: parsePageParam('previous'),
     getNextPageParam: parsePageParam('next'),

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -60,7 +60,7 @@ type InfiniteApiQueryKey = readonly [
     Record<string, any>,
     Record<string, any>
   >,
-  additionalKey: string,
+  additionalKey: 'infinite',
 ];
 export type ApiQueryKey =
   | readonly [url: string]

--- a/static/app/utils/useReleaseStats.tsx
+++ b/static/app/utils/useReleaseStats.tsx
@@ -50,9 +50,6 @@ export function useReleaseStats(
           ...normalizeDateTimeParams(datetime),
         },
       },
-      // This is here to prevent a cache key conflict between normal queries and
-      // "infinite" queries. Read more here: https://tkdodo.eu/blog/effective-react-query-keys#caching-data
-      'load-all',
     ],
     ...queryOptions,
   });


### PR DESCRIPTION
We need to ensure that `queryKey` between an infinite query vs normal query are different.

The infinite query queryKey does not include the pagination `cursor` param, so its queryKey can be the same as other normal api query calls to the same endpoint. This means that both queries have the same cache key and access the same cache results. The cached results between the two queries are structured differently so it leads to an unhandled exception within `react-query` if e.g. the infinite query acceses the cached results of a normal query. [Read more](https://tkdodo.eu/blog/effective-react-query-keys#caching-data)

For `useInfiniteApiQuery`, we append `infinite` to the queryKey to guarantee that its unique from normal queries to the same endpoint.

Follow-up to https://github.com/getsentry/sentry/pull/86300
