### PR TITLE
fix(issues): Prevent mutation of group tags response

### DIFF
--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -52,17 +52,10 @@ export function GroupTagsTab() {
     refetch: refetchGroup,
   } = useGroup({groupId: params.groupId});
 
-  const {
-    data = [],
-    isPending,
-    isError,
-    refetch,
-  } = useGroupTags({
+  const {data, isPending, isError, refetch} = useGroupTags({
     groupId: group?.id,
     environment: environments,
   });
-
-  const alphabeticalTags = data.sort((a, b) => a.key.localeCompare(b.key));
 
   if (isPending || isGroupPending) {
     return <LoadingIndicator />;
@@ -87,6 +80,7 @@ export function GroupTagsTab() {
     };
   };
 
+  const alphabeticalTags = data.toSorted((a, b) => a.key.localeCompare(b.key));
   return (
     <Layout.Body>
       <Layout.Main fullWidth>


### PR DESCRIPTION
Best practice not to mutate the object returned by useQuery.
