### PR TITLE
fix(issue-views): Fix project being overwritten

### DIFF
--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -26,6 +26,9 @@ function IssueListContainer({children}: Props) {
       <PageFiltersContainer
         skipLoadLastUsed={!useGlobalPageFilters}
         disablePersistence={!useGlobalPageFilters}
+        skipInitializeUrlParams={organization.features.includes(
+          'issue-stream-custom-views'
+        )}
       >
         <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
       </PageFiltersContainer>


### PR DESCRIPTION
Fixes #86274 

Fixes an issue where the default view's projects were sometimes being overwritten with the first alphabetical project. This was caused by both the issueViewHeader component and the pageFilterContainer both trying to write a project to the query params simultaneously. I'm not exactly sure why the pageFilterContainer wins the collision, but we can fix this by just disabling it from trying to write a project to the query params if we have the issue stream 