### PR TITLE
feat(eap): add cache.hit and return boolean

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -265,6 +265,10 @@ def datetime_processor(datetime_string: str) -> str:
     return datetime.fromisoformat(datetime_string).replace(tzinfo=tz.tzutc()).isoformat()
 
 
+def boolean_processor(value: int) -> bool:
+    return value != 0
+
+
 def project_context_constructor(column_name: str) -> Callable[[SnubaParams], VirtualColumnContext]:
     def context_constructor(params: SnubaParams) -> VirtualColumnContext:
         return VirtualColumnContext(

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -265,10 +265,6 @@ def datetime_processor(datetime_string: str) -> str:
     return datetime.fromisoformat(datetime_string).replace(tzinfo=tz.tzutc()).isoformat()
 
 
-def boolean_processor(value: int) -> bool:
-    return value != 0
-
-
 def project_context_constructor(column_name: str) -> Callable[[SnubaParams], VirtualColumnContext]:
     def context_constructor(params: SnubaParams) -> VirtualColumnContext:
         return VirtualColumnContext(

--- a/src/sentry/search/eap/span_columns.py
+++ b/src/sentry/search/eap/span_columns.py
@@ -25,6 +25,7 @@ from sentry.search.eap.columns import (
     FormulaDefinition,
     ResolvedColumn,
     VirtualColumnDefinition,
+    boolean_processor,
     datetime_processor,
     project_context_constructor,
     project_term_resolver,
@@ -220,6 +221,13 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.timestamp",
             search_type="string",
             processor=datetime_processor,
+        ),
+        ResolvedColumn(
+            public_alias="cache.hit",
+            internal_name="cache.hit",
+            search_type="boolean",
+            internal_type=AttributeKey.Type.TYPE_DOUBLE,
+            processor=boolean_processor,
         ),
         ResolvedColumn(
             public_alias=PRECISE_START_TS,

--- a/src/sentry/search/eap/span_columns.py
+++ b/src/sentry/search/eap/span_columns.py
@@ -25,7 +25,6 @@ from sentry.search.eap.columns import (
     FormulaDefinition,
     ResolvedColumn,
     VirtualColumnDefinition,
-    boolean_processor,
     datetime_processor,
     project_context_constructor,
     project_term_resolver,
@@ -226,8 +225,6 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="cache.hit",
             internal_name="cache.hit",
             search_type="boolean",
-            internal_type=AttributeKey.Type.TYPE_DOUBLE,
-            processor=boolean_processor,
         ),
         ResolvedColumn(
             public_alias=PRECISE_START_TS,


### PR DESCRIPTION
Currently, you can query for `tags[cache.hit,number]`, this returns either `1` for cache hit, and `0` for cache miss. This isn't the ideal experience.

This PR adds the field `cache.hit` field, along with the `boolean_processor` that converts these measurements to its appropriate boolean value. Now you can query for `cache.hit`, that returns either `True` or `False`