### PR TITLE
feat(issue-views): Start tracking last_visited times for each view

### DIFF
--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -10,6 +10,7 @@ import {IssueViewNavEllipsisMenu} from 'sentry/components/nav/issueViews/issueVi
 import {constructViewLink} from 'sentry/components/nav/issueViews/issueViewNavItems';
 import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
 import IssueViewProjectIcons from 'sentry/components/nav/issueViews/issueViewProjectIcons';
+import {useUpdateGroupSearchViewLastVisited} from 'sentry/components/nav/issueViews/useUpdateGroupSearchViewLastVisited';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -95,6 +96,7 @@ export function IssueViewNavItemContent({
   const [isEditing, setIsEditing] = useState(false);
 
   const {projects} = useProjects();
+  const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
 
   useEffect(() => {
     if (isActive) {
@@ -184,6 +186,7 @@ export function IssueViewNavItemContent({
           if (isInteractingRef.current) {
             e.preventDefault();
           } else {
+            updateViewLastVisited({viewId: view.id});
             trackAnalytics('issue_views.switched_views', {
               leftNav: true,
               organization: organization.slug,

--- a/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/components/nav/issueViews/issueViewNavItemContent.tsx
@@ -10,7 +10,6 @@ import {IssueViewNavEllipsisMenu} from 'sentry/components/nav/issueViews/issueVi
 import {constructViewLink} from 'sentry/components/nav/issueViews/issueViewNavItems';
 import {IssueViewNavQueryCount} from 'sentry/components/nav/issueViews/issueViewNavQueryCount';
 import IssueViewProjectIcons from 'sentry/components/nav/issueViews/issueViewProjectIcons';
-import {useUpdateGroupSearchViewLastVisited} from 'sentry/components/nav/issueViews/useUpdateGroupSearchViewLastVisited';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -96,7 +95,6 @@ export function IssueViewNavItemContent({
   const [isEditing, setIsEditing] = useState(false);
 
   const {projects} = useProjects();
-  const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
 
   useEffect(() => {
     if (isActive) {
@@ -186,7 +184,6 @@ export function IssueViewNavItemContent({
           if (isInteractingRef.current) {
             e.preventDefault();
           } else {
-            updateViewLastVisited({viewId: view.id});
             trackAnalytics('issue_views.switched_views', {
               leftNav: true,
               organization: organization.slug,

--- a/static/app/components/nav/issueViews/useUpdateGroupSearchViewLastVisited.tsx
+++ b/static/app/components/nav/issueViews/useUpdateGroupSearchViewLastVisited.tsx
@@ -7,20 +7,6 @@ type UpdateGroupSearchViewLastVisitedVariables = {
   viewId: string;
 };
 
-/**
- * Hook to update the last visited timestamp for a group search view.
- * This sends a PUT request to the organization/{org-slug}/group-search-view/visit/:viewId endpoint.
- *
- * @returns A mutation object that can be used to update the last visited timestamp for a group search view.
- *
- * @example
- * ```tsx
- * const {mutate} = useUpdateGroupSearchViewLastVisited();
- *
- * // Later in your code
- * mutate({viewId: '123'});
- * ```
- */
 export function useUpdateGroupSearchViewLastVisited(
   options: Omit<
     UseMutationOptions<void, RequestError, UpdateGroupSearchViewLastVisitedVariables>,
@@ -36,7 +22,7 @@ export function useUpdateGroupSearchViewLastVisited(
       return api.requestPromise(
         `/organizations/${organization.slug}/group-search-view/visit/${viewId}/`,
         {
-          method: 'PUT',
+          method: 'POST',
         }
       );
     },

--- a/static/app/components/nav/issueViews/useUpdateGroupSearchViewLastVisited.tsx
+++ b/static/app/components/nav/issueViews/useUpdateGroupSearchViewLastVisited.tsx
@@ -20,7 +20,7 @@ export function useUpdateGroupSearchViewLastVisited(
     ...options,
     mutationFn: ({viewId}: UpdateGroupSearchViewLastVisitedVariables) => {
       return api.requestPromise(
-        `/organizations/${organization.slug}/group-search-view/visit/${viewId}/`,
+        `/organizations/${organization.slug}/group-search-views/${viewId}/visit/`,
         {
           method: 'POST',
         }

--- a/static/app/components/nav/issueViews/useUpdateGroupSearchViewLastVisited.tsx
+++ b/static/app/components/nav/issueViews/useUpdateGroupSearchViewLastVisited.tsx
@@ -1,0 +1,47 @@
+import {useMutation, type UseMutationOptions} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type UpdateGroupSearchViewLastVisitedVariables = {
+  viewId: string;
+};
+
+/**
+ * Hook to update the last visited timestamp for a group search view.
+ * This sends a PUT request to the organization/{org-slug}/group-search-view/visit/:viewId endpoint.
+ *
+ * @returns A mutation object that can be used to update the last visited timestamp for a group search view.
+ *
+ * @example
+ * ```tsx
+ * const {mutate} = useUpdateGroupSearchViewLastVisited();
+ *
+ * // Later in your code
+ * mutate({viewId: '123'});
+ * ```
+ */
+export function useUpdateGroupSearchViewLastVisited(
+  options: Omit<
+    UseMutationOptions<void, RequestError, UpdateGroupSearchViewLastVisitedVariables>,
+    'mutationFn'
+  > = {}
+) {
+  const api = useApi();
+  const organization = useOrganization();
+
+  return useMutation<void, RequestError, UpdateGroupSearchViewLastVisitedVariables>({
+    ...options,
+    mutationFn: ({viewId}: UpdateGroupSearchViewLastVisitedVariables) => {
+      return api.requestPromise(
+        `/organizations/${organization.slug}/group-search-view/visit/${viewId}/`,
+        {
+          method: 'PUT',
+        }
+      );
+    },
+    onError: (error, variables, context) => {
+      options.onError?.(error, variables, context);
+    },
+  });
+}

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {useContext, useEffect} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
@@ -39,6 +39,13 @@ export function IssueViewTab({
   const {tabListState, state, dispatch} = useContext(IssueViewsContext);
   const {views} = state;
   const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
+
+  useEffect(() => {
+    if (initialTabKey !== TEMPORARY_TAB_KEY && view.id === initialTabKey) {
+      updateViewLastVisited({viewId: view.id});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleDuplicateView = () => {
     const newViewId = generateTempViewId();

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {useUpdateGroupSearchViewLastVisited} from 'sentry/components/nav/issueViews/useUpdateGroupSearchViewLastVisited';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
@@ -37,6 +38,7 @@ export function IssueViewTab({
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location?.query ?? {};
   const {tabListState, state, dispatch} = useContext(IssueViewsContext);
   const {views} = state;
+  const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
 
   const handleDuplicateView = () => {
     const newViewId = generateTempViewId();
@@ -125,7 +127,7 @@ export function IssueViewTab({
   };
 
   return (
-    <TabContentWrap>
+    <TabContentWrap onClick={() => updateViewLastVisited({viewId: view.id})}>
       <EditableTabTitle
         label={view.label}
         isEditing={editingTabKey === view.key}

--- a/static/app/views/issueList/issueViews/issueViewTab.tsx
+++ b/static/app/views/issueList/issueViews/issueViewTab.tsx
@@ -41,7 +41,11 @@ export function IssueViewTab({
   const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
 
   useEffect(() => {
-    if (initialTabKey !== TEMPORARY_TAB_KEY && view.id === initialTabKey) {
+    if (
+      initialTabKey !== TEMPORARY_TAB_KEY &&
+      !initialTabKey.startsWith('default') &&
+      view.id === initialTabKey
+    ) {
       updateViewLastVisited({viewId: view.id});
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -131,6 +131,11 @@ describe('IssueViewsHeader', () => {
         organization,
         router: defaultRouter,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
       expect(screen.getByRole('tab', {name: /Medium Priority/})).toBeInTheDocument();
@@ -169,6 +174,11 @@ describe('IssueViewsHeader', () => {
           router: projectsOnlyRouter,
         }
       );
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
 
@@ -281,6 +291,11 @@ describe('IssueViewsHeader', () => {
           },
         }),
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       render(<IssueViewsIssueListHeader {...defaultProps} router={specificTabRouter} />, {
         organization,
@@ -307,6 +322,11 @@ describe('IssueViewsHeader', () => {
       render(<IssueViewsIssueListHeader {...defaultProps} router={queryOnlyRouter} />, {
         organization,
         router: queryOnlyRouter,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
+        body: {},
       });
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
@@ -341,6 +361,11 @@ describe('IssueViewsHeader', () => {
       render(<IssueViewsIssueListHeader {...defaultProps} router={specificTabRouter} />, {
         organization,
         router: specificTabRouter,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
       });
 
       expect(await screen.findByRole('tab', {name: /High Priority/})).toBeInTheDocument();
@@ -384,6 +409,11 @@ describe('IssueViewsHeader', () => {
             },
           },
         ],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
+        body: {},
       });
 
       const defaultTabDifferentQueryRouter = RouterFixture({
@@ -438,6 +468,11 @@ describe('IssueViewsHeader', () => {
         organization,
         router: defaultRouter,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       await userEvent.click(await screen.findByRole('tab', {name: /Medium Priority/}));
 
@@ -474,6 +509,11 @@ describe('IssueViewsHeader', () => {
             query: 'is:unresolved',
           },
         }),
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
       });
 
       render(
@@ -512,6 +552,11 @@ describe('IssueViewsHeader', () => {
           },
         }),
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       render(
         <IssueViewsIssueListHeader
@@ -549,6 +594,11 @@ describe('IssueViewsHeader', () => {
           },
         }),
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       render(
         <IssueViewsIssueListHeader
@@ -571,6 +621,11 @@ describe('IssueViewsHeader', () => {
           },
         }),
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
 
       render(
         <IssueViewsIssueListHeader
@@ -592,6 +647,11 @@ describe('IssueViewsHeader', () => {
             statsPeriod: '7d',
           },
         }),
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[1]!.id}/visit/`,
+        method: 'POST',
+        body: {},
       });
 
       render(
@@ -617,6 +677,11 @@ describe('IssueViewsHeader', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/issues-count/`,
         method: 'GET',
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
         body: {},
       });
     });
@@ -771,6 +836,11 @@ describe('IssueViewsHeader', () => {
           method: 'PUT',
           body: getRequestViews,
         });
+        MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+          method: 'POST',
+          body: {},
+        });
 
         render(<IssueViewsIssueListHeader {...defaultProps} />, {
           organization,
@@ -823,6 +893,11 @@ describe('IssueViewsHeader', () => {
           url: `/organizations/org-slug/group-search-views/`,
           method: 'PUT',
           body: getRequestViews,
+        });
+        MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+          method: 'POST',
+          body: {},
         });
 
         render(<IssueViewsIssueListHeader {...defaultProps} />, {
@@ -937,6 +1012,11 @@ describe('IssueViewsHeader', () => {
   describe('Issue views query counts', () => {
     beforeEach(() => {
       MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/group-search-views/${getRequestViews[0]!.id}/visit/`,
+        method: 'POST',
+        body: {},
+      });
     });
 
     it('should render the correct count for a single view', async () => {

--- a/static/app/views/issues/navigation.tsx
+++ b/static/app/views/issues/navigation.tsx
@@ -1,12 +1,14 @@
-import {Fragment, useRef} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 
 import {IssueViewNavItems} from 'sentry/components/nav/issueViews/issueViewNavItems';
+import {useUpdateGroupSearchViewLastVisited} from 'sentry/components/nav/issueViews/useUpdateGroupSearchViewLastVisited';
 import {usePrefersStackedNav} from 'sentry/components/nav/prefersStackedNav';
 import {SecondaryNav} from 'sentry/components/nav/secondary';
 import {PrimaryNavGroup} from 'sentry/components/nav/types';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import type {IssueView} from 'sentry/views/issueList/issueViews/issueViews';
 import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 
@@ -18,10 +20,21 @@ export function IssueNavigation({children}: IssuesWrapperProps) {
   const organization = useOrganization();
 
   const sectionRef = useRef<HTMLDivElement>(null);
+  const {viewId} = useParams<{viewId?: string}>();
 
   const {data: groupSearchViews} = useFetchGroupSearchViews({
     orgSlug: organization.slug,
   });
+  const {mutate: updateViewLastVisited} = useUpdateGroupSearchViewLastVisited();
+
+  useEffect(() => {
+    if (groupSearchViews && viewId) {
+      const view = groupSearchViews.find(v => v.id === viewId);
+      if (view) {
+        updateViewLastVisited({viewId: view.id});
+      }
+    }
+  }, [groupSearchViews, viewId, updateViewLastVisited]);
 
   const prefersStackedNav = usePrefersStackedNav();
 


### PR DESCRIPTION
Creates a hook for the `organization/group-search-views/{view_id}/visit/` endpoint (created [here](https://github.com/getsentry/sentry/pull/86243)), and starts updating requests upon tab visit. 


You can verify this is working by pulling this branch, clicking a tab in dev-ui, then checking the `sentry_groupsearchviewlastvisited` table in redash to see the new entries appear. 

