### PR TITLE
fix(nav): Revert CSS addition on body element which broke sticky interactions

### DIFF
--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -122,7 +122,6 @@ const BodyContainer = styled('div')`
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow-x: hidden;
 `;
 
 export default OrganizationLayout;


### PR DESCRIPTION
Added this to deal with the settings page overflowing on settings, but it breaks sticky headers. Will need to deal with overflowing elements in a different way.