### PR TITLE
fix(nav): Use proper beta badge styles for project settings

### DIFF
--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -1,4 +1,3 @@
-import {Badge} from 'sentry/components/core/badge';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
@@ -70,7 +69,7 @@ export default function getConfiguration({
           path: `${pathPrefix}/toolbar/`,
           title: t('Dev Toolbar'),
           show: () => !!organization?.features?.includes('dev-toolbar-ui'),
-          badge: () => <Badge type="beta">Beta</Badge>,
+          badge: () => 'beta',
         },
       ],
     },
@@ -126,7 +125,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/playstation/`,
           title: t('PlayStation'),
-          badge: () => <Badge type="beta">Beta</Badge>,
+          badge: () => 'beta',
           show: () => !!(organization && hasTempestAccess(organization)) && !isSelfHosted,
         },
       ],


### PR DESCRIPTION
Uses the 'beta' string literal option to use the correct badge styling in the new nav:

![CleanShot 2025-03-05 at 13 45 38](https://github.com/user-attachments/assets/d3a8d5d0-a0cc-49d1-838e-5fe97216bfd6)
