### PR TITLE
chore(grouping): Yet more race condition logging

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -160,6 +160,19 @@ def create_or_update_grouphash_metadata_if_needed(
             event.should_skip_seer = True
             return
 
+        # TODO: Temporary log to investigate race condition. Restricted to grouphashes without an
+        # assigned group because those are the only ones which might get sent to Seer.
+        if not grouphash.group_id:
+            logger.info(
+                "grouphash_metadata.creation_race_condition.no_group_id",
+                extra={
+                    "grouphash_id": grouphash.id,
+                    "grouphash_is_new": grouphash_is_new,
+                    "event_id": event.event_id,
+                    "hash": grouphash.hash,
+                },
+            )
+
         db_hit_metadata = {"reason": "new_grouphash" if grouphash_is_new else "missing_metadata"}
 
         if not grouphash_is_new:

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -144,12 +144,10 @@ def create_or_update_grouphash_metadata_if_needed(
             logger.info(
                 "grouphash_metadata.creation_race_condition.record_exists",
                 extra={
-                    "grouphash_metadata_id": grouphash_metadata.id,
-                    "linked_metadata_id": grouphash.metadata.id if grouphash.metadata else None,
                     "grouphash_id": grouphash.id,
                     "grouphash_is_new": grouphash_is_new,
+                    "grouphash_has_group": bool(grouphash.group_id),
                     "event_id": event.event_id,
-                    "hash_basis": new_data["hash_basis"],
                     "hash": grouphash.hash,
                 },
             )


### PR DESCRIPTION
This makes two small changes to our logging for grouphash metadata race conditions:

- Log fewer things in `record_exists` log.
- Even after marking all of the events whose grouphash metadata has lost the creation race as ones that should skip the Seer call, we're still seeing multiple copies of the same hash without the skip. (Ideally, there should be exactly one.) Therefore, add a log for records which don't get the skip but also don't have a group attached to them. This should correspond to hashes which have the potential to get sent to Seer, and let us see if perhaps `grouphash_is_new` is a reliable way to pick out a single winner.