### PR TITLE
fix(issue-stream): Fix hover interaction on safari

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -757,7 +757,7 @@ const Wrapper = styled(PanelItem)<{
       padding: ${space(1)} 0;
       min-height: 86px;
 
-      &:not(:hover):not(:focus-within):not(:has(input:checked)) {
+      &:not(:has(:hover)):not(:focus-within):not(:has(input:checked)) {
         ${CheckboxLabel} {
           ${p.theme.visuallyHidden};
         }


### PR DESCRIPTION
On Safari, showing the checkbox on hover wasn't working correctly. For some reason the top-level wrapper element did not think it was being hovered, probably due to the way the link is positioned. Changing the CSS so that is checks for any hovered element fixes this.