### PR TITLE
feat(tours): Add analytics for tour guides

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -30,4 +30,5 @@ GUIDES = {
     "explain_archive_button_issue_stream": 33,
     "crons_backend_insights": 38,
     "issue_views_page_filters_persistence": 39,
+    "tour.issue_details": 40,
 }

--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -233,7 +233,7 @@ describe('Tour Components', () => {
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
         >
-          <TourElement
+          <TourElement<TestTour>
             id={TestTour.PASSWORD}
             title="Test Title"
             description="Test Description"
@@ -263,7 +263,7 @@ describe('Tour Components', () => {
           orderedStepIds={ORDERED_TEST_TOUR}
           tourContext={TestTourContext}
         >
-          <TourElement
+          <TourElement<TestTour>
             tourContext={TestTourContext}
             id={TestTour.NAME}
             title="Name"
@@ -271,7 +271,7 @@ describe('Tour Components', () => {
           >
             Name
           </TourElement>
-          <TourElement
+          <TourElement<TestTour>
             tourContext={TestTourContext}
             id={TestTour.EMAIL}
             title="Email"
@@ -279,7 +279,7 @@ describe('Tour Components', () => {
           >
             Email
           </TourElement>
-          <TourElement
+          <TourElement<TestTour>
             tourContext={TestTourContext}
             id={TestTour.PASSWORD}
             title="Password"

--- a/static/app/components/tours/components.spec.tsx
+++ b/static/app/components/tours/components.spec.tsx
@@ -30,7 +30,7 @@ describe('Tour Components', () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
 
       const {container: availableContainer} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -42,7 +42,7 @@ describe('Tour Components', () => {
       expect(within(availableContainer).getByText('Child Content')).toBeInTheDocument();
 
       const {container: unavailableContainer} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable={false}
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -57,7 +57,7 @@ describe('Tour Components', () => {
     it('renders children regardless of completion', () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
       render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -76,7 +76,7 @@ describe('Tour Components', () => {
         currentStepId: TestTour.NAME,
       });
       const {container: blurContainer} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           isAvailable
@@ -88,7 +88,7 @@ describe('Tour Components', () => {
       expect(within(blurContainer).getByTestId('tour-blur-window')).toBeInTheDocument();
 
       const {container: noBlurContainer} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
           isAvailable
@@ -116,7 +116,7 @@ describe('Tour Components', () => {
         currentStepId: TestTour.NAME,
       });
       render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           tourKey={tourKey}
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -139,7 +139,7 @@ describe('Tour Components', () => {
     it('renders children regardless of tour state', async () => {
       mockUseTourReducer.mockReturnValue(emptyTourContext);
       const {container: inactiveContainer} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -164,7 +164,7 @@ describe('Tour Components', () => {
         currentStepId: TestTour.NAME,
       });
       const {container: activeContainer} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -192,7 +192,7 @@ describe('Tour Components', () => {
         currentStepId: TestTour.NAME,
       });
       const {unmount: unmountFirstStep} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -227,7 +227,7 @@ describe('Tour Components', () => {
       });
 
       const {unmount: unmountSecondStep} = render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -258,7 +258,7 @@ describe('Tour Components', () => {
       });
 
       render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -288,7 +288,7 @@ describe('Tour Components', () => {
         handleStepRegistration: mockHandleStepRegistration,
       });
       render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_TEST_TOUR}
@@ -339,7 +339,7 @@ describe('Tour Components', () => {
         currentStepId: TestTour.NAME,
       });
       render(
-        <TourContextProvider
+        <TourContextProvider<TestTour>
           tourKey={tourKey}
           isAvailable
           isCompleted={false}

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -195,21 +195,13 @@ function TourElementContent<T extends TourEnumType>({
             {t('Next')}
           </TourAction>
         ) : (
-          <TourAction
-            size="xs"
-            onClick={() => {
-              if (tourKey) {
-                mutate({guide: tourKey, status: 'viewed'});
-              }
-              dispatch({type: 'END_TOUR'});
-            }}
-          >
+          <TourAction size="xs" onClick={() => dispatch({type: 'END_TOUR'})}>
             {t('Finish tour')}
           </TourAction>
         )}
       </ButtonBar>
     ),
-    [hasPreviousStep, hasNextStep, dispatch, tourKey, mutate]
+    [hasPreviousStep, hasNextStep, dispatch]
   );
 
   return (

--- a/static/app/components/tours/testUtils.tsx
+++ b/static/app/components/tours/testUtils.tsx
@@ -20,3 +20,5 @@ export const emptyTourContext = {
   dispatch: jest.fn(),
   handleStepRegistration: jest.fn(),
 };
+
+export const mockTour = () => emptyTourContext;

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -52,7 +52,7 @@ export default storyBook('Tours', story => {
         and 'right/l' keys will navigate between steps.
       </p>
       <TourProvider>
-        <TourElement
+        <TourElement<MyTour>
           id={MyTour.NAME}
           title={'Name Time!'}
           description={'This is the description of the name tour step.'}
@@ -60,7 +60,7 @@ export default storyBook('Tours', story => {
         >
           <Input placeholder="Step 1: Name" />
         </TourElement>
-        <TourElement
+        <TourElement<MyTour>
           id={MyTour.EMAIL}
           title={'Email Time!'}
           description={'This is the description of the email tour step.'}
@@ -68,7 +68,7 @@ export default storyBook('Tours', story => {
         >
           <Input placeholder="Step 2: Email" type="email" />
         </TourElement>
-        <TourElement
+        <TourElement<MyTour>
           id={MyTour.PASSWORD}
           title={'Password Time!'}
           description={'This is the description of the password tour step.'}
@@ -146,7 +146,7 @@ function useMyTour(): TourContextType<MyTour> {
 <Input placeholder="Name" />
 
 // After...
-<TourElement
+<TourElement<MyTour>
   tourContext={MyTourContext}
   id={MyTour.NAME}
   title={'Name Time!'}
@@ -183,7 +183,7 @@ function useMyTour(): TourContextType<MyTour> {
       </CodeSnippet>
       <br />
       <TourProvider>
-        <TourElement
+        <TourElement<MyTour>
           tourContext={MyTourContext}
           id={MyTour.NAME}
           title={'Name Time!'}
@@ -191,7 +191,7 @@ function useMyTour(): TourContextType<MyTour> {
         >
           <Input placeholder="Step 1: Name" />
         </TourElement>
-        <TourElement
+        <TourElement<MyTour>
           tourContext={MyTourContext}
           id={MyTour.EMAIL}
           title={'Email Time!'}

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -88,6 +88,7 @@ export default storyBook('Tours', story => {
         <li>Define the order of the steps.</li>
         <li>Create the tour context for the components to use.</li>
         <li>Create a usage hook to refine types.</li>
+        <li>Add a tour key to save the viewed/dismissed status.</li>
       </ol>
       <CodeSnippet language="tsx">
         {`import {createContext, useContext} from 'react';
@@ -116,6 +117,11 @@ function useMyTour(): TourContextType<MyTour> {
   }
   return tourContext;
 }
+
+// Step 5. Add a tour key to save the viewed/dismissed status.
+// Note: This should match what's added to 'src/sentry/assistant/guides.py'.
+export const MY_TOUR_KEY = 'tour.my_tour';
+
 `}
       </CodeSnippet>
     </Fragment>

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -135,9 +135,10 @@ export const MY_TOUR_KEY = 'tour.my_tour';
         you created earlier.
       </p>
       <CodeSnippet language="tsx">
-        {`<TourContextProvider
+        {`<TourContextProvider<MyTour>
   orderedStepIds={ORDERED_MY_TOUR}
   tourContext={MyTourContext}
+  tourKey={MY_TOUR_KEY}
 >
   {/* All focused elements in the tour should be within this provider */}
 </TourContextProvider>`}
@@ -278,7 +279,7 @@ function TourProvider({
   return (
     <SizingWindow>
       <BlurBoundary>
-        <TourContextProvider
+        <TourContextProvider<MyTour>
           isAvailable
           isCompleted={false}
           orderedStepIds={ORDERED_MY_TOUR}

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -66,6 +66,11 @@ export interface TourState<T extends TourEnumType> {
    * The ordered step IDs. Declared once when the provider is initialized.
    */
   orderedStepIds: readonly T[];
+  /**
+   * The assistant guide key of the tour. Should be declared in `src/sentry/assistant/guides.py`.
+   * Optional, only used if the tour viewing is saved to the database.
+   */
+  tourKey?: string;
 }
 
 // XXX: TourSteps are currently just IDs, so we could use a set here instead, but we're using a
@@ -179,6 +184,7 @@ export function useTourReducer<T extends TourEnumType>(
 
   return useMemo<TourContextType<T>>(
     () => ({
+      tourKey: initialState.tourKey,
       dispatch,
       handleStepRegistration,
       currentStepId: state.currentStepId,
@@ -190,6 +196,7 @@ export function useTourReducer<T extends TourEnumType>(
     [
       dispatch,
       handleStepRegistration,
+      initialState.tourKey,
       state.currentStepId,
       state.isAvailable,
       state.isRegistered,

--- a/static/app/components/tours/useAssistant.tsx
+++ b/static/app/components/tours/useAssistant.tsx
@@ -1,0 +1,43 @@
+import {
+  useApiQuery,
+  type UseApiQueryOptions,
+  useMutation,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+
+interface AssistantResult {
+  guide: string;
+  seen: boolean;
+}
+
+export function useAssistant(
+  options: Partial<UseApiQueryOptions<AssistantResult[]>> = {}
+) {
+  return useApiQuery<AssistantResult[]>(['/assistant/'], {
+    staleTime: Infinity,
+    ...options,
+  });
+}
+
+interface MutateAssistantData {
+  guide: string;
+  status: 'viewed' | 'dismissed' | 'restart';
+  useful?: boolean;
+}
+
+interface UseMutateAssistantProps {
+  onError?: (error: RequestError) => void;
+  onSuccess?: () => void;
+}
+
+export function useMutateAssistant({onSuccess, onError}: UseMutateAssistantProps = {}) {
+  const api = useApi({persistInFlight: false});
+  return useMutation<AssistantResult[], RequestError, MutateAssistantData>({
+    mutationFn: (data: MutateAssistantData) => {
+      return api.requestPromise('/assistant/', {method: 'PUT', data});
+    },
+    onMutate: (_data: MutateAssistantData) => onSuccess?.(),
+    onError: (error: RequestError) => onError?.(error),
+  });
+}

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -372,8 +372,8 @@ export type IssueEventParameters = {
   'tag.clicked': {
     is_clickable: boolean;
   };
-  'tour-guide.close': {id: string};
-  'tour-guide.open': {id: string};
+  'tour-guide.close': {id?: string};
+  'tour-guide.open': {id?: string};
   'whats_new.link_clicked': Pick<Broadcast, 'title'> &
     Partial<Pick<Broadcast, 'category'>>;
 };

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -372,6 +372,8 @@ export type IssueEventParameters = {
   'tag.clicked': {
     is_clickable: boolean;
   };
+  'tour-guide.close': {id: string};
+  'tour-guide.open': {id: string};
   'whats_new.link_clicked': Pick<Broadcast, 'title'> &
     Partial<Pick<Broadcast, 'category'>>;
 };
@@ -527,5 +529,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.comment_created': 'Issue Details: Comment Created',
   'issue_details.comment_deleted': 'Issue Details: Comment Deleted',
   'issue_details.comment_updated': 'Issue Details: Comment Updated',
+  'tour-guide.open': 'Tour Guide: Opened',
+  'tour-guide.close': 'Tour Guide: Closed',
   'whats_new.link_clicked': "What's New: Link Clicked",
 };

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -3,17 +3,17 @@ import {createContext, useContext} from 'react';
 import type {TourContextType} from 'sentry/components/tours/tourContext';
 
 export const enum IssueDetailsTour {
-  /** Onboarding for trends and aggregates, the graph, and tag distributions */
+  /** Trends and aggregates, the graph, and tag distributions */
   AGGREGATES = 'issue-details-aggregates',
-  /** Onboarding for date/time/environment filters */
+  /** Date/time/environment filters */
   FILTERS = 'issue-details-filters',
-  /** Onboarding for event details, event navigation, main page content */
+  /** Event details, event navigation, main page content */
   EVENT_DETAILS = 'issue-details-event-details',
-  /** Onboarding for event navigation; next/previous, first/last/recommended events */
+  /** Event navigation; next/previous, first/last/recommended events */
   NAVIGATION = 'issue-details-navigation',
-  /** Onboarding for workflow actions; resolution, archival, assignment, priority, etc. */
+  /** Workflow actions; resolution, archival, assignment, priority, etc. */
   WORKFLOWS = 'issue-details-workflows',
-  /** Onboarding for activity log, issue tracking, solutions hub area */
+  /** Activity log, issue tracking, solutions hub area */
   SIDEBAR = 'issue-details-sidebar',
 }
 

--- a/static/app/views/issueDetails/issueDetailsTour.tsx
+++ b/static/app/views/issueDetails/issueDetailsTour.tsx
@@ -26,6 +26,8 @@ export const ORDERED_ISSUE_DETAILS_TOUR = [
   IssueDetailsTour.SIDEBAR,
 ];
 
+export const ISSUE_DETAILS_TOUR_GUIDE_KEY = 'tour.issue_details';
+
 export const IssueDetailsTourContext =
   createContext<TourContextType<IssueDetailsTour> | null>(null);
 


### PR DESCRIPTION
This PR adds some typing to the test and stories file, changes some error handling, adds analytics and a util function for mocking tours. It is a variety of small changes that I extracted from the work on https://github.com/getsentry/sentry/pull/85970/ for easy of review