### PR TITLE
ui(billing): Add id field to subscription fixture

### DIFF
--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -397,6 +397,7 @@ export function Am3DsEnterpriseSubscriptionFixture(props: Props): TSubscription 
   subscription.reservedBudgetCategories = ['spans', 'spansIndexed'];
   subscription.reservedBudgets = [
     ReservedBudgetFixture({
+      id: '11',
       reservedBudget: 100_000_00,
       totalReservedSpend: 60_000_00,
       freeBudget: 0,


### PR DESCRIPTION
Updates `Am3DsEnterpriseSubscriptionFixture` to include an "id" field value on the reserved budget.