### PR TITLE
fix: get_cache_key should include the http method

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -335,10 +335,15 @@ class BaseApiClient:
     def delete(self, *args: Any, **kwargs: Any) -> Any:
         return self.request("DELETE", *args, **kwargs)
 
-    def get_cache_key(self, path: str, query: str = "", data: str | None = "") -> str:
+    def get_cache_key(self, path: str, method: str, query: str = "", data: str | None = "") -> str:
         if not data:
-            return self.get_cache_prefix() + md5_text(self.build_url(path), query).hexdigest()
-        return self.get_cache_prefix() + md5_text(self.build_url(path), query, data).hexdigest()
+            return (
+                self.get_cache_prefix() + md5_text(self.build_url(path), method, query).hexdigest()
+            )
+        return (
+            self.get_cache_prefix()
+            + md5_text(self.build_url(path), method, query, data).hexdigest()
+        )
 
     def check_cache(self, cache_key: str) -> Any | None:
         return cache.get(cache_key)
@@ -352,7 +357,7 @@ class BaseApiClient:
         if kwargs.get("params", None):
             query = json.dumps(kwargs.get("params"))
 
-        key = self.get_cache_key(path, query, data)
+        key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
         if result is None:
             cache_time = kwargs.pop("cache_time", None) or self.cache_time


### PR DESCRIPTION
It is possible to perform a `HEAD` request with caching (typically for CORS, returning an empty body) and a `GET` request with caching against the **same URL endpoint**. Update the `get_cache_key` method to include the HTTP method in the cache key.

See https://github.com/getsentry/sentry/pull/86446 for a use case.