### PR TITLE
feat(taskworker) Add metric to capture duration of mutltiprocessing.Queue

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -286,6 +286,7 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 @click.option(
     "--namespace", help="The dedicated task namespace that taskworker operates on", default=None
 )
+@click.option("--queue-size", help="Size of multiprocessing queues for child workers", default=1)
 @log_options()
 @configuration
 def taskworker(**options: Any) -> None:
@@ -304,6 +305,7 @@ def run_taskworker(
     max_task_count: int,
     namespace: str | None,
     concurrency: int,
+    queue_size: int,
     **options: Any,
 ) -> None:
     """
@@ -318,6 +320,7 @@ def run_taskworker(
             max_task_count=max_task_count,
             namespace=namespace,
             concurrency=concurrency,
+            queue_size=queue_size,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -170,6 +170,10 @@ def child_worker(
         # Get completion time before pushing to queue to avoid inflating latency metrics.
         execution_complete_time = time.time()
         processed_tasks.put(ProcessingResult(task_id=activation.id, status=next_state))
+        metrics.distribution(
+            "taskworker.worker.processed_tasks.put.duration",
+            time.time() - execution_complete_time,
+        )
 
         task_added_time = activation.received_at.ToDatetime().timestamp()
         execution_duration = execution_complete_time - execution_start_time
@@ -239,6 +243,7 @@ class TaskWorker:
         max_task_count: int | None = None,
         namespace: str | None = None,
         concurrency: int = 1,
+        queue_size: int = 1,
         **options: dict[str, Any],
     ) -> None:
         self.options = options
@@ -248,8 +253,12 @@ class TaskWorker:
         self._namespace = namespace
         self._concurrency = concurrency
         self.client = TaskworkerClient(rpc_host, num_brokers)
-        self._child_tasks: multiprocessing.Queue[TaskActivation] = mp_context.Queue(maxsize=1)
-        self._processed_tasks: multiprocessing.Queue[ProcessingResult] = mp_context.Queue(maxsize=1)
+        self._child_tasks: multiprocessing.Queue[TaskActivation] = mp_context.Queue(
+            maxsize=queue_size
+        )
+        self._processed_tasks: multiprocessing.Queue[ProcessingResult] = mp_context.Queue(
+            maxsize=queue_size
+        )
         self._children: list[ForkProcess] = []
         self._shutdown_event = mp_context.Event()
         self._task_receive_timing: dict[str, float] = {}
@@ -321,7 +330,11 @@ class TaskWorker:
         task = self.fetch_task()
         if task:
             try:
+                start_time = time.time()
                 self._child_tasks.put(task, timeout=0.1)
+                metrics.distribution(
+                    "taskworker.worker.child_task.put.duration", time.time() - start_time
+                )
             except queue.Full:
                 logger.warning(
                     "taskworker.add_task.child_task_queue_full", extra={"task_id": task.id}


### PR DESCRIPTION
I ran a workload with no-op tasks and didn't get the throughput I was hoping to see. I want to know if these operations are contributing to the problem.

I'd also like to try other queue sizes. In reviewing metrics, we are never calling SetTaskStatus with the fetch_next parameter. This leads to the worker having to use both GetTask and SetTaskStatus to make progress.

