### PR TITLE
feat(ci): Report getsentry devservices transactions to sentry

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,8 +19,6 @@ concurrency:
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
   NODE_OPTIONS: '--max-old-space-size=4096'
-  # Disables sentry reporting for devservices
-  DEVSERVICES_DISABLE_SENTRY: 1
   CHARTCUTERIE_CONFIG_PATH: ${{ github.workspace }}/config/chartcuterie
   SNUBA_NO_WORKERS: 1
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,8 +15,6 @@ concurrency:
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
-  # Disables sentry reporting for devservices
-  DEVSERVICES_DISABLE_SENTRY: 1
   SNUBA_NO_WORKERS: 1
 
 jobs:


### PR DESCRIPTION
Previously, this was turned off since it was reporting to the production environment in our Sentry project. We've added logic inside devservices to report to the CI environment if devservices is running in CI, so let's enable this again