### PR TITLE
ref(flags): hide flag search suggestions if there are no suggestions

### DIFF
--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -72,7 +72,10 @@ const getFilterKeySections = (
     },
   ];
 
-  if (organization.features.includes('feature-flag-autocomplete')) {
+  if (
+    organization.features.includes('feature-flag-autocomplete') &&
+    eventFeatureFlags.length > 0
+  ) {
     sections.push({
       value: FieldKind.FEATURE_FLAG,
       label: t('Flags'), // Keeping this short so the tabs stay on 1 line.


### PR DESCRIPTION
Let's not show this if there's no flags (i.e. every project that hasn't setup ff SDK)
<img width="749" alt="Screenshot 2025-03-05 at 5 19 20 PM" src="https://github.com/user-attachments/assets/f914028b-8833-45ed-8fce-baf8f1ed1c68" />
