### PR TITLE
fix(issues): Rename timeline icon classname

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -358,7 +358,7 @@ const StyledTimelineItem = styled(Timeline.Item)`
   margin: 0;
   &:hover {
     background: ${p => p.theme.translucentSurface200};
-    .icon-wrapper {
+    .timeline-icon-wrapper {
       background: ${p => p.theme.translucentSurface200};
     }
   }

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -47,7 +47,7 @@ export const Item = forwardRef(function ItemInner(
           borderColor: isActive ? theme[colorConfig.iconBorder] : 'transparent',
           color: theme[colorConfig.icon],
         }}
-        className="icon-wrapper"
+        className="timeline-icon-wrapper"
       >
         {icon}
       </IconWrapper>


### PR DESCRIPTION
Currently is getting styles from the global stylesheets which also attempt to style icon-*

fixes an issue where user avatars on issue details looked weird