### PR TITLE
:recycle: ref(metric alerts): refactor action handler factory

### DIFF
--- a/tests/sentry/incidents/action_handlers/test_discord.py
+++ b/tests/sentry/incidents/action_handlers/test_discord.py
@@ -21,7 +21,7 @@ class DiscordActionHandlerTest(FireTest):
     @responses.activate
     def setUp(self):
         self.spec = DiscordMessagingSpec()
-
+        self.handler = MessagingActionHandler(self.spec)
         self.guild_id = "guild-id"
         self.channel_id = "12345678910"
         self.discord_user_id = "user1234"
@@ -59,10 +59,11 @@ class DiscordActionHandlerTest(FireTest):
             status=200,
         )
 
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            getattr(handler, method)(metric_value, IncidentStatus(incident.status))
+            getattr(self.handler, method)(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         data = orjson.loads(responses.calls[0].request.body)
         return data
@@ -86,10 +87,11 @@ class DiscordActionHandlerTest(FireTest):
             status=200,
         )
 
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert len(responses.calls) == 0
 
@@ -99,10 +101,11 @@ class DiscordActionHandlerTest(FireTest):
     def test_metric_alert_failure(self, mock_record_event, mock_send_message):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.WARNING)
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+            )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)
 
@@ -114,10 +117,11 @@ class DiscordActionHandlerTest(FireTest):
     def test_metric_alert_halt_for_rate_limited(self, mock_record_event, mock_send_message):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.WARNING)
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+            )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
 
@@ -132,10 +136,11 @@ class DiscordActionHandlerTest(FireTest):
     def test_metric_alert_halt_for_missing_access(self, mock_record_event, mock_send_message):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.WARNING)
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+            )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.HALTED)
 
@@ -147,9 +152,10 @@ class DiscordActionHandlerTest(FireTest):
     def test_metric_alert_halt_for_other_api_error(self, mock_record_event, mock_send_message):
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus.WARNING)
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus.WARNING
+            )
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -41,6 +41,7 @@ class MsTeamsActionHandlerTest(FireTest):
     @responses.activate
     def setUp(self):
         self.spec = MsTeamsMessagingSpec()
+        self.handler = MessagingActionHandler(self.spec)
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             integration = self.create_provider_integration(
@@ -86,10 +87,11 @@ class MsTeamsActionHandlerTest(FireTest):
             json={},
         )
 
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            getattr(handler, method)(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
         data = json.loads(responses.calls[0].request.body)
 
         assert data["attachments"][0]["content"] == build_incident_attachment(
@@ -231,10 +233,11 @@ class MsTeamsActionHandlerTest(FireTest):
             json={},
         )
 
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert len(responses.calls) == 0
 
@@ -253,10 +256,11 @@ class MsTeamsActionHandlerTest(FireTest):
             json={},
         )
 
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            getattr(handler, "fire")(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
 
@@ -280,9 +284,10 @@ class MsTeamsActionHandlerTest(FireTest):
             },
         )
 
-        handler = MessagingActionHandler(self.action, incident, self.project, self.spec)
         metric_value = 1000
         with self.tasks():
-            getattr(handler, "fire")(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -32,6 +32,7 @@ from . import FireTest
 class PagerDutyActionHandlerTest(FireTest):
     def setUp(self):
         self.integration_key = "pfc73e8cb4s44d519f3d63d45b5q77g9"
+        self.handler = PagerDutyActionHandler()
         service = [
             {
                 "type": "service",
@@ -176,11 +177,13 @@ class PagerDutyActionHandlerTest(FireTest):
             status=202,
             content_type="application/json",
         )
-        handler = PagerDutyActionHandler(self.action, incident, self.project)
+
         metric_value = 1000
         new_status = IncidentStatus(incident.status)
         with self.tasks():
-            getattr(handler, method)(metric_value, new_status)
+            getattr(self.handler, method)(
+                self.action, incident, self.project, metric_value, new_status
+            )
         data = responses.calls[0].request.body
 
         expected_payload = build_incident_attachment(
@@ -242,10 +245,11 @@ class PagerDutyActionHandlerTest(FireTest):
             status=202,
             content_type="application/json",
         )
-        handler = PagerDutyActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert len(responses.calls) == 0
 

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -31,6 +31,8 @@ class SentryAppActionHandlerTest(FireTest):
             sentry_app=self.sentry_app,
         )
 
+        self.handler = SentryAppActionHandler()
+
     @responses.activate
     def run_test(self, incident, method):
         from sentry.rules.actions.notify_event_service import build_incident_attachment
@@ -43,10 +45,11 @@ class SentryAppActionHandlerTest(FireTest):
             body=json.dumps({"ok": "true"}),
         )
 
-        handler = SentryAppActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
-            getattr(handler, method)(metric_value, IncidentStatus(incident.status))
+            getattr(self.handler, method)(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
         data = responses.calls[0].request.body
         assert (
             json.dumps(
@@ -69,10 +72,11 @@ class SentryAppActionHandlerTest(FireTest):
             body=json.dumps({"ok": "true"}),
         )
 
-        handler = SentryAppActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert len(responses.calls) == 0
 
@@ -100,6 +104,7 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
         self.create_sentry_app_installation(
             slug=self.sentry_app.slug, organization=self.organization, user=self.user
         )
+        self.handler = SentryAppActionHandler()
 
     @responses.activate
     def run_test(self, incident, method):
@@ -129,10 +134,11 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
             body=json.dumps({"ok": "true"}),
         )
 
-        handler = SentryAppActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
-            getattr(handler, method)(metric_value, IncidentStatus(incident.status))
+            getattr(self.handler, method)(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
         data = responses.calls[0].request.body
         assert (
             json.dumps(

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -9,7 +9,7 @@ from slack_sdk.web import SlackResponse
 from sentry.constants import ObjectStatus
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import Incident, IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.messaging.spec import MessagingActionHandler
 from sentry.integrations.metric_alerts import AlertContext
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
@@ -45,6 +45,7 @@ class SlackActionHandlerTest(FireTest):
     @responses.activate
     def setUp(self):
         self.spec = SlackMessagingSpec()
+        self.handler = MessagingActionHandler(self.spec)
 
         token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
         self.integration = self.create_integration(
@@ -79,18 +80,12 @@ class SlackActionHandlerTest(FireTest):
         )
         self.alert_rule = self.create_alert_rule()
 
-    def _build_action_handler(
-        self, action: AlertRuleTriggerAction, incident: Incident
-    ) -> MessagingActionHandler:
-        return MessagingActionHandler(action, incident, self.project, self.spec)
-
     def run_test(self, incident, method, **kwargs):
         chart_url = kwargs.get("chart_url")
-        handler = self._build_action_handler(self.action, incident)
         metric_value = 1000
         status = IncidentStatus(incident.status)
         with self.tasks():
-            getattr(handler, method)(metric_value, status)
+            getattr(self.handler, method)(self.action, incident, self.project, metric_value, status)
 
         return incident, chart_url
 
@@ -256,10 +251,11 @@ class SlackActionHandlerTest(FireTest):
             sentry_app_id=None,
         )
 
-        handler = self._build_action_handler(action, incident)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
     def test_rule_snoozed(self, mock_post):
@@ -267,10 +263,11 @@ class SlackActionHandlerTest(FireTest):
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
         self.snooze_rule(alert_rule=alert_rule)
 
-        handler = self._build_action_handler(self.action, incident)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         assert not mock_post.called
 
@@ -283,10 +280,11 @@ class SlackActionHandlerTest(FireTest):
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CLOSED.value)
         self.snooze_rule(user_id=self.user.id, alert_rule=alert_rule)
 
-        handler = self._build_action_handler(self.action, incident)
         metric_value = 1000
         with self.tasks():
-            handler.fire(metric_value, IncidentStatus(incident.status))
+            self.handler.fire(
+                self.action, incident, self.project, metric_value, IncidentStatus(incident.status)
+            )
 
         mock_post.assert_called
 

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -284,7 +284,7 @@ class AlertRuleTriggerActionActivateTest(TestCase):
 
     def test_unhandled(self):
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
-        trigger.build_handler(Mock(), Mock(), Mock())
+        trigger.build_handler(type=AlertRuleTriggerAction.Type(trigger.type))
         self.metrics.incr.assert_called_once_with("alert_rule_trigger.unhandled_type.0")
 
     def test_handled(self):
@@ -293,10 +293,8 @@ class AlertRuleTriggerActionActivateTest(TestCase):
         AlertRuleTriggerAction.register_type("something", type, [])(mock_handler)
 
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
-        incident = Mock()
-        project = Mock()
-        trigger.build_handler(trigger, incident, project)
-        mock_handler.assert_called_once_with(trigger, incident, project)
+        trigger.build_handler(type=AlertRuleTriggerAction.Type(trigger.type))
+        mock_handler.assert_called_once_with()
         assert not self.metrics.incr.called
 
 

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -96,9 +96,14 @@ class HandleTriggerActionTest(TestCase):
                     IncidentStatus.CRITICAL.value,
                     metric_value=metric_value,
                 )
-            mock_handler.assert_called_once_with(self.action, incident, self.project)
+            mock_handler.assert_called_once_with()
             mock_handler.return_value.fire.assert_called_once_with(
-                metric_value, IncidentStatus.CRITICAL, str(activity.notification_uuid)
+                self.action,
+                incident,
+                self.project,
+                metric_value,
+                IncidentStatus.CRITICAL,
+                str(activity.notification_uuid),
             )
 
 

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -152,15 +152,15 @@ class HandleSnubaQueryUpdateTest(TestCase):
             assert active_incident().exists()
 
         assert len(mail.outbox) == 1
-        handler = EmailActionHandler(self.action, active_incident().get(), self.project)
-        incident_activity = IncidentActivity.objects.filter(incident=handler.incident).order_by(
-            "-id"
-        )[0]
+        handler = EmailActionHandler()
+        incident_activity = IncidentActivity.objects.filter(
+            incident=active_incident().get()
+        ).order_by("-id")[0]
         message_builder = handler.build_message(
             generate_incident_trigger_email_context(
-                handler.project,
-                handler.incident,
-                handler.action.alert_rule_trigger,
+                self.project,
+                active_incident().get(),
+                self.trigger,
                 TriggerStatus.ACTIVE,
                 IncidentStatus.CRITICAL,
                 notification_uuid=str(incident_activity.notification_uuid),


### PR DESCRIPTION
this pr breaks the `AlertRuleTriggerAction`, `Incident`, `Project` dependency for the `ActionHandlerFactory`.

this will allow us to define new entrypoints for the action handlers for each integration which can invoke the underlying business logic using legacy models of new models using a translation layer (pr for this comes later).

instead of putting `action`, `incident`, `project` as member variables, u pass it to the `fire`, `resolve` methods directly.

i verified that firing notifications works locally
![image](https://github.com/user-attachments/assets/73851292-1f3a-40c6-b36b-bc199a3afbfa)


## Review Note
i have a local commit to update the 47 broken tests, but waiting for cursory reviews first since it will massively increase the diff. the failing tests are for `test_subscription_processor` and i need to change assertions for majority of the 86 tests , which inflates the diff.

UPDATE: i just pushed the commit. i would recommend ignoring the commit when reviewing and look at it separately