### PR TITLE
feat(hybrid-cloud): Give fetch-release-registry queue unique name

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1004,6 +1004,7 @@ CELERY_QUEUES_REGION = [
     Queue("check_new_issue_threshold_met", routing_key="check_new_issue_threshold_met"),
     Queue("integrations_slack_activity_notify", routing_key="integrations_slack_activity_notify"),
     Queue("demo_mode", routing_key="demo_mode"),
+    Queue("release_registry", routing_key="release_registry"),
 ]
 
 from celery.schedules import crontab
@@ -1192,7 +1193,7 @@ CELERYBEAT_SCHEDULE_REGION = {
         "task": "sentry.tasks.release_registry.fetch_release_registry_data",
         # Run every 5 minutes
         "schedule": crontab(minute="*/5"),
-        "options": {"expires": 3600},
+        "options": {"expires": 3600, "queue": "release_registry"},
     },
     "snuba-subscription-checker": {
         "task": "sentry.snuba.tasks.subscription_checker",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -896,11 +896,6 @@ CELERY_QUEUES_CONTROL = [
     Queue("outbox.control", routing_key="outbox.control", exchange=control_exchange),
     Queue("webhook.control", routing_key="webhook.control", exchange=control_exchange),
     Queue("relocation.control", routing_key="relocation.control", exchange=control_exchange),
-    Queue(
-        "release_registry.control",
-        routing_key="release_registry.control",
-        exchange=control_exchange,
-    ),
 ]
 
 CELERY_ISSUE_STATES_QUEUE = Queue(
@@ -1063,7 +1058,7 @@ CELERYBEAT_SCHEDULE_CONTROL = {
         "task": "sentry.tasks.release_registry.fetch_release_registry_data",
         # Run every 5 minutes
         "schedule": crontab(minute="*/5"),
-        "options": {"expires": 3600, "queue": "release_registry.control"},
+        "options": {"expires": 3600},
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -896,6 +896,11 @@ CELERY_QUEUES_CONTROL = [
     Queue("outbox.control", routing_key="outbox.control", exchange=control_exchange),
     Queue("webhook.control", routing_key="webhook.control", exchange=control_exchange),
     Queue("relocation.control", routing_key="relocation.control", exchange=control_exchange),
+    Queue(
+        "release_registry.control",
+        routing_key="release_registry.control",
+        exchange=control_exchange,
+    ),
 ]
 
 CELERY_ISSUE_STATES_QUEUE = Queue(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -896,6 +896,11 @@ CELERY_QUEUES_CONTROL = [
     Queue("outbox.control", routing_key="outbox.control", exchange=control_exchange),
     Queue("webhook.control", routing_key="webhook.control", exchange=control_exchange),
     Queue("relocation.control", routing_key="relocation.control", exchange=control_exchange),
+    Queue(
+        "release_registry.control",
+        routing_key="release_registry.control",
+        exchange=control_exchange,
+    ),
 ]
 
 CELERY_ISSUE_STATES_QUEUE = Queue(
@@ -1055,10 +1060,10 @@ CELERYBEAT_SCHEDULE_CONTROL = {
         "options": {"expires": 60, "queue": "webhook.control"},
     },
     "fetch-release-registry-data-control": {
-        "task": "sentry.tasks.release_registry.fetch_release_registry_data",
+        "task": "sentry.tasks.release_registry.fetch_release_registry_data_control",
         # Run every 5 minutes
         "schedule": crontab(minute="*/5"),
-        "options": {"expires": 3600},
+        "options": {"expires": 3600, "queue": "release_registry.control"},
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1054,11 +1054,11 @@ CELERYBEAT_SCHEDULE_CONTROL = {
         "schedule": timedelta(seconds=10),
         "options": {"expires": 60, "queue": "webhook.control"},
     },
-    "fetch-release-registry-data": {
+    "fetch-release-registry-data-control": {
         "task": "sentry.tasks.release_registry.fetch_release_registry_data",
         # Run every 5 minutes
         "schedule": crontab(minute="*/5"),
-        "options": {"expires": 3600},
+        "options": {"expires": 3600, "queue": "release_registry.control"},
     },
 }
 

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.cache import cache
 
 from sentry.net.http import Session
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 
@@ -37,12 +38,7 @@ def _fetch_registry_url(relative_url):
         return response.json()
 
 
-@instrumented_task(
-    name="sentry.tasks.release_registry.fetch_release_registry_data",
-    time_limit=65,
-    soft_time_limit=60,
-)
-def fetch_release_registry_data(**kwargs):
+def _fetch_release_registry_data(**kwargs):
     """
     Fetch information about the latest SDK version from the release registry.
 
@@ -77,3 +73,23 @@ def fetch_release_registry_data(**kwargs):
         extra={"layer_cache": cache.get(LAYER_INDEX_CACHE_KEY)},
     )
     sentry_sdk.capture_message("Fetching release registry")
+
+
+@instrumented_task(
+    name="sentry.tasks.release_registry.fetch_release_registry_data",
+    time_limit=65,
+    soft_time_limit=60,
+)
+def fetch_release_registry_data(**kwargs):
+    _fetch_release_registry_data(**kwargs)
+
+
+@instrumented_task(
+    name="sentry.tasks.release_registry.fetch_release_registry_data_control",
+    time_limit=65,
+    soft_time_limit=60,
+    queue="release_registry.control",
+    silo_mode=SiloMode.CONTROL,
+)
+def fetch_release_registry_data_control(**kwargs):
+    _fetch_release_registry_data(**kwargs)

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -79,6 +79,8 @@ def _fetch_release_registry_data(**kwargs):
     name="sentry.tasks.release_registry.fetch_release_registry_data",
     time_limit=65,
     soft_time_limit=60,
+    queue="release_registry",
+    silo_mode=SiloMode.REGION,
 )
 def fetch_release_registry_data(**kwargs):
     _fetch_release_registry_data(**kwargs)


### PR DESCRIPTION
The fetch-release-regsitry control queue seems to be failing: https://sentry.sentry.io/issues/4948672261/?environment=prod&project=1&query=release-registry&referrer=issue-stream&statsPeriod=90d&stream_index=0

I think this is because the same queue already exists under that name for regions. Not sure tho, so I'm mimicking what the other control tasks are called like here.