### PR TITLE
ref(quick-start): Update overdue logic to only update tasks only if the whole onboarding is done

### DIFF
--- a/static/app/components/onboardingWizard/useOverdueDoneTasks.tsx
+++ b/static/app/components/onboardingWizard/useOverdueDoneTasks.tsx
@@ -13,9 +13,9 @@ function isTaskOverdue2Weeks(dateCompleted: string): boolean {
 
 export function useOverdueDoneTasks({
   doneTasks,
-  allTasks,
+  allTasksDone,
 }: {
-  allTasks: OnboardingTask[];
+  allTasksDone: boolean;
   doneTasks: OnboardingTask[];
 }): {
   overdueTasks: OnboardingTask[];
@@ -26,18 +26,18 @@ export function useOverdueDoneTasks({
   // Tasks marked as "done" but not completed (user hasn't seen the completion),
   // and the date completed is equal or more than 14 days ago (overdue).
   const overdueTasks = useMemo(() => {
-    // Only update 'completionSeen' if the WHOLE onboarding was 'done' but not completed
-    // because users haven't seen the 'done' tasks after 14+ days.
-    if (allTasks.length === doneTasks.length) {
-      return doneTasks.filter(
-        task =>
-          task.dateCompleted &&
-          !task.completionSeen &&
-          isTaskOverdue2Weeks(task.dateCompleted)
-      );
+    // Only update 'completionSeen' if the WHOLE onboarding is 'done'
+    if (!allTasksDone) {
+      return [];
     }
-    return [];
-  }, [doneTasks, allTasks]);
+
+    return doneTasks.filter(
+      task =>
+        task.dateCompleted &&
+        !task.completionSeen &&
+        isTaskOverdue2Weeks(task.dateCompleted)
+    );
+  }, [doneTasks, allTasksDone]);
 
   const safeDependencies = useRef({overdueTasks, organization});
 

--- a/static/app/components/onboardingWizard/useOverdueDoneTasks.tsx
+++ b/static/app/components/onboardingWizard/useOverdueDoneTasks.tsx
@@ -11,7 +11,13 @@ function isTaskOverdue2Weeks(dateCompleted: string): boolean {
   return timeDifference > 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
 }
 
-export function useOverdueDoneTasks({doneTasks}: {doneTasks: OnboardingTask[]}): {
+export function useOverdueDoneTasks({
+  doneTasks,
+  allTasks,
+}: {
+  allTasks: OnboardingTask[];
+  doneTasks: OnboardingTask[];
+}): {
   overdueTasks: OnboardingTask[];
 } {
   const api = useApi();
@@ -20,13 +26,18 @@ export function useOverdueDoneTasks({doneTasks}: {doneTasks: OnboardingTask[]}):
   // Tasks marked as "done" but not completed (user hasn't seen the completion),
   // and the date completed is equal or more than 14 days ago (overdue).
   const overdueTasks = useMemo(() => {
-    return doneTasks.filter(
-      task =>
-        task.dateCompleted &&
-        !task.completionSeen &&
-        isTaskOverdue2Weeks(task.dateCompleted)
-    );
-  }, [doneTasks]);
+    // Only update 'completionSeen' if the WHOLE onboarding was 'done' but not completed
+    // because users haven't seen the 'done' tasks after 14+ days.
+    if (allTasks.length === doneTasks.length) {
+      return doneTasks.filter(
+        task =>
+          task.dateCompleted &&
+          !task.completionSeen &&
+          isTaskOverdue2Weeks(task.dateCompleted)
+      );
+    }
+    return [];
+  }, [doneTasks, allTasks]);
 
   const safeDependencies = useRef({overdueTasks, organization});
 

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -61,7 +61,7 @@ export function OnboardingStatus({
     disabled: !isActive,
   });
 
-  const {overdueTasks} = useOverdueDoneTasks({doneTasks});
+  const {overdueTasks} = useOverdueDoneTasks({allTasks, doneTasks});
 
   const label = demoMode ? t('Guided Tours') : t('Onboarding');
   const pendingCompletionSeen = doneTasks.length !== completeTasks.length;

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -61,12 +61,12 @@ export function OnboardingStatus({
     disabled: !isActive,
   });
 
-  const {overdueTasks} = useOverdueDoneTasks({allTasks, doneTasks});
-
   const label = demoMode ? t('Guided Tours') : t('Onboarding');
   const pendingCompletionSeen = doneTasks.length !== completeTasks.length;
   const allTasksCompleted = allTasks.length === completeTasks.length;
   const allTasksDone = allTasks.length === doneTasks.length;
+
+  const {overdueTasks} = useOverdueDoneTasks({allTasksDone, doneTasks});
 
   const skipQuickStart =
     (!demoMode && !organization.features?.includes('onboarding')) ||


### PR DESCRIPTION
We don’t want to update overdue tasks unless the whole quick start tasks are done. The goal is that if all tasks are marked as 'done' but not 'completed' (because the user hasn’t seen them), we manually set completionSeen so that the quick start sidebar goes away.