### PR TITLE
theme: use background instead of transparent for focusring

### DIFF
--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -800,7 +800,7 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
   radius,
   focusRing: {
     outline: 'none',
-    boxShadow: `0 0 0 2px transparent, 0 0 0 4px ${lightAliases.focusBorder}`,
+    boxShadow: `0 0 0 2px ${lightAliases.background}, 0 0 0 4px ${lightAliases.focusBorder}`,
   },
 
   // @TODO: these colors need to be ported
@@ -854,7 +854,7 @@ export const DO_NOT_USE_darkChonkTheme: ChonkTheme = {
   radius,
   focusRing: {
     outline: 'none',
-    boxShadow: `0 0 0 2px transparent, 0 0 0 4px ${darkAliases.focusBorder}`,
+    boxShadow: `0 0 0 2px ${darkAliases.background}, 0 0 0 4px ${darkAliases.focusBorder}`,
   },
 
   // @TODO: these colors need to be ported


### PR DESCRIPTION
As per https://github.com/getsentry/sentry/pull/86404/files#r1983204361