### PR TITLE
ref(spans): Create models in process-spans without event payloads

### DIFF
--- a/src/sentry/dynamic_sampling/__init__.py
+++ b/src/sentry/dynamic_sampling/__init__.py
@@ -4,9 +4,8 @@ from .rules.biases.boost_latest_releases_bias import BoostLatestReleasesBias
 from .rules.biases.ignore_health_checks_bias import IgnoreHealthChecksBias
 from .rules.helpers.latest_releases import (
     ExtendedBoostedRelease,
-    LatestReleaseBias,
-    LatestReleaseParams,
     ProjectBoostedReleases,
+    record_latest_release,
 )
 from .rules.helpers.time_to_adoptions import LATEST_RELEASE_TTAS, Platform
 from .rules.utils import (
@@ -27,12 +26,11 @@ __all__ = [
     "get_enabled_user_biases",
     "get_redis_client_for_ds",
     "get_rule_hash",
+    "record_latest_release",
     "RuleType",
     "ExtendedBoostedRelease",
     "ProjectBoostedReleases",
     "Platform",
-    "LatestReleaseBias",
-    "LatestReleaseParams",
     "IgnoreHealthChecksBias",
     "BoostEnvironmentsBias",
     "BoostLatestReleasesBias",

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence, Set
 from copy import deepcopy
 from typing import Any, cast
 
+from django.core.exceptions import ValidationError
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
 
 from sentry import options
@@ -13,15 +14,17 @@ from sentry.event_manager import (
     _calculate_span_grouping,
     _detect_performance_problems,
     _get_or_create_environment_many,
-    _get_or_create_release_associated_models,
-    _get_or_create_release_many,
     _pull_out_data,
     _record_transaction_info,
 )
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
+from sentry.models.environment import Environment
 from sentry.models.project import Project
+from sentry.models.release import Release
+from sentry.models.releaseenvironment import ReleaseEnvironment
+from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
 
@@ -137,12 +140,60 @@ def _update_occurrence_group_type(jobs: Sequence[Job], projects: ProjectsMapping
 
 
 def _find_segment_span(spans: list[SegmentSpan]) -> SegmentSpan | None:
+    """
+    Finds the segment in the span in the list that has ``is_segment`` set to
+    ``True``.
+
+    At most one span in the list can be marked as segment span. If more than one
+    span is marked, the function does not have defined behavior.
+
+    If there is no segment span, the function returns ``None``.
+    """
+
     # Iterate backwards since we usually expect the segment span to be at the end.
     for span in reversed(spans):
         if span.get("is_segment"):
             return span
 
     return None
+
+
+def _create_models(segment: SegmentSpan, project: Project) -> None:
+    """
+    Creates the Environment and Release models, along with the necessary
+    relationships between them and the Project model.
+    """
+
+    # TODO: Read this from original data attributes.
+    sentry_tags = segment.get("sentry_tags", {})
+    environment_name = sentry_tags.get("environment")
+    release_name = sentry_tags.get("release")
+    dist_name = sentry_tags.get("dist")
+    date = to_datetime(segment["end_timestamp_precise"])
+
+    environment = Environment.get_or_create(project=project, environment=environment_name)
+
+    try:
+        release = Release.get_or_create(project=project, version=release_name, date_added=date)
+    except ValidationError:
+        logger.exception(
+            "Failed creating Release due to ValidationError",
+            extra={"project": project, "version": release_name},
+        )
+        return
+
+    if dist_name:
+        release.add_dist(dist_name)
+
+    ReleaseEnvironment.get_or_create(
+        project=project, release=release, environment=environment, datetime=date
+    )
+
+    ReleaseProjectEnvironment.get_or_create(
+        project=project, release=release, environment=environment, datetime=date
+    )
+
+    pass
 
 
 def transform_spans_to_event_dict(
@@ -157,6 +208,7 @@ def transform_spans_to_event_dict(
     event["project_id"] = segment_span["project_id"]
     event["transaction"] = sentry_tags.get("transaction")
     event["release"] = sentry_tags.get("release")
+    event["dist"] = sentry_tags.get("dist")
     event["environment"] = sentry_tags.get("environment")
     event["platform"] = sentry_tags.get("platform")
     event["tags"] = [["environment", sentry_tags.get("environment")]]
@@ -210,16 +262,42 @@ def prepare_event_for_occurrence_consumer(event):
 def process_segment(spans: list[SegmentSpan]) -> list[SegmentSpan]:
     segment_span = _find_segment_span(spans)
     if segment_span is None:
-        # TODO: Handle the case of segments without a defined segment span.
+        # TODO: Handle segments without a defined segment span once all
+        # functions are refactored to a span interface.
         return spans
+
+    with metrics.timer("tasks.spans.project.get_from_cache"):
+        project = Project.objects.get_from_cache(id=segment_span["project_id"])
+
+    # The original transaction pipeline ran the following operations in this
+    # exact order, where only operations marked with X are relevant to the spans
+    # consumer:
+    #
+    #  - [ ] _pull_out_data
+    #  - [X] _get_or_create_release_many               ->  _create_models
+    #  - [ ] _get_event_user_many
+    #  - [ ] _derive_plugin_tags_many
+    #  - [ ] _derive_interface_tags_many
+    #  - [X] _calculate_span_grouping
+    #  - [ ] _materialize_metadata_many
+    #  - [X] _get_or_create_environment_many           ->  _create_models
+    #  - [X] _get_or_create_release_associated_models  ->  _create_models
+    #  - [X] _tsdb_record_all_metrics
+    #  - [ ] _materialize_event_metrics
+    #  - [ ] _nodestore_save_many
+    #  - [ ] _eventstream_insert_many
+    #  - [ ] _track_outcome_accepted_many
+    #  - [X]  _detect_performance_problems
+    #  - [X]  _send_occurrence_to_platform
+    #  - [X] _record_transaction_info
+
+    _create_models(segment_span, project)
+
+    # XXX: Below are old-style functions imported from EventManager that rely on
+    # the Event schema:
 
     event = transform_spans_to_event_dict(segment_span, spans)
     event_light = prepare_event_for_occurrence_consumer(event)
-
-    project_id = event["project_id"]
-    with metrics.timer("tasks.spans.project.get_from_cache"):
-        project = Project.objects.get_from_cache(id=project_id)
-
     projects = {project.id: project}
 
     jobs: Sequence[Job] = [
@@ -232,24 +310,9 @@ def process_segment(spans: list[SegmentSpan]) -> list[SegmentSpan]:
         }
     ]
 
-    # XXX: Apply the same pipeline as in `save_transaction_events` with
-    # redundant operations removed. The disabled elements will be removed once
-    # the refactor is complete:
-
     _pull_out_data(jobs, projects)
-    _get_or_create_release_many(jobs, projects)
-    # _get_event_user_many(jobs, projects)                                 # N/A: transaction data
-    # _derive_plugin_tags_many(jobs, projects)                             # N/A: transaction data
-    # _derive_interface_tags_many(jobs)                                    # N/A: transaction data
-    _calculate_span_grouping(jobs, projects)
-    # _materialize_metadata_many(jobs)                                     # N/A: writes group metadata
     _get_or_create_environment_many(jobs, projects)
-    _get_or_create_release_associated_models(jobs, projects)
-    # _tsdb_record_all_metrics(jobs)                                       # TODO: Refactor and enable
-    # _materialize_event_metrics(jobs)                                     # N/A: transaction data
-    # _nodestore_save_many(jobs=jobs, app_feature="transactions")          # N/A: nodestore is deprecated
-    # _eventstream_insert_many(jobs)                                       # N/A: produced outside
-    # _track_outcome_accepted_many(jobs)                                   # N/A: created by outcomes consumer
+    _calculate_span_grouping(jobs, projects)
 
     if options.get("standalone-spans.detect-performance-problems.enable"):
         _detect_performance_problems(jobs, projects, is_standalone_spans=True)

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -168,9 +168,9 @@ def _create_models(segment: SegmentSpan, project: Project) -> None:
     environment_name = sentry_tags.get("environment")
     release_name = sentry_tags.get("release")
     dist_name = sentry_tags.get("dist")
-    date = to_datetime(segment["end_timestamp_precise"])
+    date = to_datetime(segment["end_timestamp_precise"])  # type: ignore[typeddict-item]
 
-    environment = Environment.get_or_create(project=project, environment=environment_name)
+    environment = Environment.get_or_create(project=project, name=environment_name)
 
     try:
         release = Release.get_or_create(project=project, version=release_name, date_added=date)

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -13,7 +13,6 @@ from sentry.event_manager import (
     ProjectsMapping,
     _calculate_span_grouping,
     _detect_performance_problems,
-    _get_or_create_environment_many,
     _pull_out_data,
     _record_transaction_info,
 )
@@ -193,8 +192,6 @@ def _create_models(segment: SegmentSpan, project: Project) -> None:
         project=project, release=release, environment=environment, datetime=date
     )
 
-    pass
-
 
 def transform_spans_to_event_dict(
     segment_span: SegmentSpan, spans: list[SegmentSpan]
@@ -311,7 +308,6 @@ def process_segment(spans: list[SegmentSpan]) -> list[SegmentSpan]:
     ]
 
     _pull_out_data(jobs, projects)
-    _get_or_create_environment_many(jobs, projects)
     _calculate_span_grouping(jobs, projects)
 
     if options.get("standalone-spans.detect-performance-problems.enable"):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3203,7 +3203,9 @@ class DSLatestReleaseBoostTest(TestCase):
                 )
             ]
 
-    @mock.patch("sentry.event_manager.schedule_invalidate_project_config")
+    @mock.patch(
+        "sentry.dynamic_sampling.rules.helpers.latest_releases.schedule_invalidate_project_config"
+    )
     def test_project_config_invalidation_is_triggered_when_new_release_is_observed(
         self, mocked_invalidate: mock.MagicMock
     ) -> None:


### PR DESCRIPTION
This calls `get_or_create` on the various models that need to be auto-created in
the spans consumer directly, instead of calling into EventManager.

Ref https://github.com/getsentry/streaming-planning/issues/67