### PR TITLE
fix(dashboard-eap): Add to dashboard uses display type in trace explorer

### DIFF
--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -708,7 +708,10 @@ export function handleAddQueryToDashboard({
   query?: NewQuery;
   yAxis?: string | string[];
 }) {
-  const displayType = displayModeToDisplayType(eventView.display as DisplayModes);
+  const displayType =
+    widgetType === WidgetType.SPANS
+      ? (eventView.display as DisplayType)
+      : displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultWidgetQuery = eventViewToWidgetQuery({
     eventView,
     displayType,
@@ -826,7 +829,10 @@ export function constructAddQueryToDashboardLink({
   widgetType?: WidgetType;
   yAxis?: string | string[];
 }) {
-  const displayType = displayModeToDisplayType(eventView.display as DisplayModes);
+  const displayType =
+    widgetType === WidgetType.SPANS
+      ? (eventView.display as DisplayType)
+      : displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultTableFields = eventView.fields.map(({field}) => field);
   const defaultWidgetQuery = eventViewToWidgetQuery({
     eventView,

--- a/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
@@ -89,6 +89,95 @@ describe('AddToDashboardButton', () => {
     );
   });
 
+  it.each([
+    {
+      chartType: ChartType.AREA,
+      expectedDisplayType: DisplayType.AREA,
+    },
+    {
+      chartType: ChartType.BAR,
+      expectedDisplayType: DisplayType.BAR,
+    },
+    {
+      chartType: ChartType.LINE,
+      expectedDisplayType: DisplayType.LINE,
+    },
+  ])(
+    'opens the dashboard modal with display type $expectedDisplayType for chart type $chartType',
+    async ({chartType, expectedDisplayType}) => {
+      render(
+        <PageParamsProvider>
+          <TestPage visualizeIndex={1} />
+        </PageParamsProvider>,
+        {disableRouterMocks: true}
+      );
+
+      act(() =>
+        setVisualizes([
+          {
+            yAxes: ['avg(span.duration)'],
+            chartType: ChartType.AREA,
+          },
+          {
+            yAxes: ['max(span.duration)'],
+            chartType,
+          },
+        ])
+      );
+
+      await userEvent.click(screen.getByText('Add to Dashboard'));
+
+      // The group by and the yAxes are encoded as the fields for the defaultTableQuery
+      expect(openAddToDashboardModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // For Add + Stay on Page
+          widget: {
+            title: 'Custom Widget',
+            displayType: expectedDisplayType,
+            interval: undefined,
+            limit: undefined,
+            widgetType: WidgetType.SPANS,
+            queries: [
+              {
+                aggregates: ['max(span.duration)'],
+                columns: [],
+                fields: ['max(span.duration)'],
+                conditions: '',
+                orderby: '-timestamp',
+                name: '',
+              },
+            ],
+          },
+
+          // For Open in Widget Builder
+          widgetAsQueryParams: expect.objectContaining({
+            dataset: WidgetType.SPANS,
+            defaultTableColumns: [
+              'id',
+              'span.op',
+              'span.description',
+              'span.duration',
+              'transaction',
+              'timestamp',
+            ],
+            defaultTitle: 'Custom Widget',
+            defaultWidgetQuery:
+              'name=&aggregates=max(span.duration)&columns=&fields=max(span.duration)&conditions=&orderby=-timestamp',
+            displayType: expectedDisplayType,
+            field: [
+              'id',
+              'span.op',
+              'span.description',
+              'span.duration',
+              'transaction',
+              'timestamp',
+            ],
+          }),
+        })
+      );
+    }
+  );
+
   it('opens the dashboard modal with the correct query based on the visualize index', async () => {
     render(
       <PageParamsProvider>

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -8,7 +8,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
-import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DashboardWidgetSource,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {MAX_NUM_Y_AXES} from 'sentry/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {
@@ -22,6 +26,13 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+const CHART_TYPE_TO_DISPLAY_TYPE = {
+  [ChartType.LINE]: DisplayType.LINE,
+  [ChartType.BAR]: DisplayType.BAR,
+  [ChartType.AREA]: DisplayType.AREA,
+};
 
 export function useAddToDashboard() {
   const location = useLocation();
@@ -76,6 +87,8 @@ export function useAddToDashboard() {
         selection
       );
       newEventView.dataset = dataset;
+      newEventView.display =
+        CHART_TYPE_TO_DISPLAY_TYPE[visualizes[visualizeIndex]!.chartType];
       return newEventView;
     },
     [


### PR DESCRIPTION
A patch to pass along the display type properly for spans. The event view has helpers that assume it's being used for discover, but that's not really the case anymore. In the future we should make the type more unified, or at least better define that the `display` property on an `eventView` is more than just a `string`, but rather one of our valid display types.