### PR TITLE
:recycle: ref(aci): remove sentry app service usage in rule action migration

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -10,7 +10,6 @@ from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
-from sentry.sentry_apps.services.app import app_service
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.action import Action
 
@@ -572,31 +571,12 @@ class PluginActionTranslator(BaseActionTranslator):
 
 @issue_alert_action_translator_registry.register(ACTION_FIELD_MAPPINGS[Action.Type.WEBHOOK]["id"])
 class WebhookActionTranslator(BaseActionTranslator):
-    def __init__(self, action: dict[str, Any]):
-        super().__init__(action)
-        # Fetch the sentry app id using app_service
-        # If the app exists, we should heal this action as a SentryAppAction
-        # Based on sentry/rules/actions/notify_event_service.py
-        if service := self.action.get(
-            ACTION_FIELD_MAPPINGS[Action.Type.WEBHOOK][
-                ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
-            ]
-        ):
-            self.sentry_app = app_service.get_sentry_app_by_slug(slug=service)
-        else:
-            self.sentry_app = None
-
     @property
     def action_type(self) -> Action.Type:
-        if self.sentry_app:
-            return Action.Type.SENTRY_APP
-        else:
-            return Action.Type.WEBHOOK
+        return Action.Type.WEBHOOK
 
     @property
     def target_type(self) -> ActionTarget | None:
-        if self.sentry_app:
-            return ActionTarget.SENTRY_APP
         return None
 
     @property
@@ -606,18 +586,6 @@ class WebhookActionTranslator(BaseActionTranslator):
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ]
         ]
-
-    @property
-    def target_identifier(self) -> str | None:
-        # The service field identifies the webhook
-        # If the webhook goes to a sentry app, then we should identify the sentry app by id
-        if self.sentry_app:
-            return str(self.sentry_app.id)
-        return self.action.get(
-            ACTION_FIELD_MAPPINGS[Action.Type.WEBHOOK][
-                ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
-            ]
-        )
 
 
 @issue_alert_action_translator_registry.register(
@@ -639,26 +607,6 @@ class SentryAppActionTranslator(BaseActionTranslator):
     @property
     def target_type(self) -> ActionTarget | None:
         return ActionTarget.SENTRY_APP
-
-    @property
-    def target_identifier(self) -> str | None:
-        # Fetch the sentry app id using app_service
-        # Based on sentry/rules/actions/sentry_apps/notify_event.py
-        sentry_app_installation = app_service.get_many(
-            filter=dict(
-                uuids=[
-                    self.action.get(
-                        ACTION_FIELD_MAPPINGS[Action.Type.SENTRY_APP]["target_identifier_key"]
-                    )
-                ]
-            )
-        )
-
-        if sentry_app_installation:
-            assert len(sentry_app_installation) == 1, "Expected exactly one sentry app installation"
-            return str(sentry_app_installation[0].sentry_app.id)
-
-        raise ValueError("Sentry app installation not found")
 
     def get_sanitized_data(self) -> dict[str, Any]:
         data = SentryAppDataBlob()


### PR DESCRIPTION
because we don't want to call the `app_service` during the rule migration, here i remove all usage of it.

the changes are at follows:
1. we will save issue alert sentry app actions with `sentry_app_installation_uuid`
2. webhook actions which are actually sentry apps, will remain webhooks

Tasks Left

- [x] Once `Action.config` is merged, save the `identifier_type`
- [ ] Create a new handler for  Sentry App to handle the different types of `identifier_types` we will have to support in the system

reference: https://www.notion.so/sentry/Can-t-Make-RPC-Calls-During-Migration-1ad8b10e4b5d80ed8804d8ff75cc721b