### PR TITLE
fix(requests): Display non object/array data types in request section

### DIFF
--- a/static/app/components/events/interfaces/request/index.tsx
+++ b/static/app/components/events/interfaces/request/index.tsx
@@ -264,6 +264,10 @@ function RequestDataCard({
       const valueMeta = meta ? meta[key] : undefined;
       contentItems.push({item: {key, subject: key, value}, meta: valueMeta});
     });
+  } else {
+    contentItems.push({
+      item: {key: 'data', subject: 'data', value: data},
+    });
   }
 
   return (


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/86503