### PR TITLE
fix(seer grouping): Stop sending race condition hashes to seer

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -63,8 +63,8 @@ def should_call_seer_for_grouping(
 
     if (
         has_blocked_fingerprint
-        or _is_race_condition_skipped_event(event, event_grouphash)
         or _has_too_many_contributing_frames(event, variants)
+        or _is_race_condition_skipped_event(event, event_grouphash)
         or killswitch_enabled(project.id, ReferrerOptions.INGEST, event)
         or _circuit_breaker_broken(event, project)
         # The rate limit check has to be last (see below) but rate-limiting aside, call this after other checks

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -92,10 +92,6 @@ def _is_race_condition_skipped_event(event: Event, event_grouphash: GroupHash) -
 
     We detect the race when creating `GroupHashMetadata` records, and track all but the winner of
     the race as events whose Seer call we should skip.
-
-    NOTE: For now this only returns False, so it will never block sending to Seer. This will allow
-    us to collect logs of when it *would* block, in order or us to have greater confidence in the
-    change.
     """
     if event.should_skip_seer:
         logger.info(
@@ -106,14 +102,8 @@ def _is_race_condition_skipped_event(event: Event, event_grouphash: GroupHash) -
                 "event_id": event.event_id,
             },
         )
-        # TODO: The two lines below are what the code *should* be, in order to actually skip sending
-        # the events. For now, though, we're just going to log, to essentially enact the change in
-        # dry-run mode. Once we're confident that in race condition situations, exactly one event
-        # will be sent to Seer, we can restore the real code.
-        #
-        # record_did_call_seer_metric(event, call_made=False, blocker="race_condition")
-        # return True
-        return False
+        record_did_call_seer_metric(event, call_made=False, blocker="race_condition")
+        return True
 
     logger.info(
         "should_call_seer_for_grouping.race_condition_pass",

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -325,17 +325,11 @@ class ShouldCallSeerTest(TestCase):
 
         self.event.should_skip_seer = True
 
-        # TODO: Replace the assert below with the commented-out assertions once we turn the skip on
-        # for real.
-        #
-        # assert (
-        #     should_call_seer_for_grouping(self.event, self.variants, self.event_grouphash) is False
-        # )
-        # mock_record_did_call_seer.assert_any_call(
-        #     self.event, call_made=False, blocker="race_condition"
-        # )
         assert (
-            should_call_seer_for_grouping(self.event, self.variants, self.event_grouphash) is True
+            should_call_seer_for_grouping(self.event, self.variants, self.event_grouphash) is False
+        )
+        mock_record_did_call_seer.assert_any_call(
+            self.event, call_made=False, blocker="race_condition"
         )
 
     @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])


### PR DESCRIPTION
The logging we've been doing of the `should_skip_seer` flag we've been adding to events when we detect a race condition (see https://github.com/getsentry/sentry/pull/86256 for details) confirms that there is always at least one event which doesn't get the flag. We can therefore turn on the skip without worrying about there being any hashes which don't sent to seer at all.

This PR makes that change, and also moves the check of the flag after the excessive frame check, primarily so our metrics don't count events which wouldn't have been sent to Seer in any case.