### PR TITLE
ref(spans): Allow grouping directly on span batches

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -173,7 +173,7 @@ def _enrich_spans(segment: Span | None, spans: list[Span]) -> None:
 
     # Calculate grouping hashes for performance issue detection
     config = load_span_grouping_config()
-    groupings = config.execute_strategy_raw(spans)
+    groupings = config.execute_strategy_standalone(spans)
     groupings.write_to_spans(spans)
 
 

--- a/src/sentry/spans/grouping/result.py
+++ b/src/sentry/spans/grouping/result.py
@@ -53,3 +53,9 @@ class SpanGroupingResults:
             trace_context["hash"] = span_hash
 
         event_data["span_grouping_config"] = {"id": self.id}
+
+    def write_to_spans(self, spans: list[Any]) -> None:
+        for span in spans:
+            span_hash = self.results.get(span["span_id"])
+            if span_hash is not None:
+                span["hash"] = span_hash

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -20,6 +20,7 @@ class Span(TypedDict):
     tags: Any | None
     data: Any | None
     hash: NotRequired[str]
+    sentry_tags: dict[str, str]
 
 
 # A callable strategy is a callable that when given a span, it tries to
@@ -50,7 +51,8 @@ class SpanGroupingStrategy:
         return {span["span_id"]: self.get_span_group_compat(span) for span in spans}
 
     def get_span_group_compat(self, span: Span) -> str:
-        # Treat the segment span like get_transaction_span_group for backwards compatibility with transaction events.
+        # Treat the segment span like get_transaction_span_group for backwards
+        # compatibility with transaction events.
         if span.get("is_segment"):
             result = Hash()
             result.update(span["sentry_tags"].get("transaction"))

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -11,6 +11,7 @@ class Span(TypedDict):
     trace_id: str
     parent_span_id: str
     span_id: str
+    is_segment: bool
     start_timestamp: float
     timestamp: float
     same_process_as_parent: bool

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -52,10 +52,11 @@ class SpanGroupingStrategy:
 
     def get_standalone_span_group(self, span: Span) -> str:
         # Treat the segment span like get_transaction_span_group for backwards
-        # compatibility with transaction events.
-        if span.get("is_segment"):
+        # compatibility with transaction events, but fall back to default
+        # fingerprinting if the span doesn't have a transaction.
+        if span.get("is_segment") and "transaction" in span["sentry_tags"]:
             result = Hash()
-            result.update(span["sentry_tags"].get("transaction"))
+            result.update(span["sentry_tags"]["transaction"])
             return result.hexdigest()
         else:
             return self.get_embedded_span_group(span)

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -46,6 +46,18 @@ class SpanGroupingStrategy:
 
         return span_groups
 
+    def execute_raw(self, spans: list[Any]) -> dict[str, str]:
+        return {span["span_id"]: self.get_span_group_compat(span) for span in spans}
+
+    def get_span_group_compat(self, span: Span) -> str:
+        # Treat the segment span like get_transaction_span_group for backwards compatibility with transaction events.
+        if span.get("is_segment"):
+            result = Hash()
+            result.update(span["sentry_tags"].get("transaction"))
+            return result.hexdigest()
+        else:
+            return self.get_span_group(span)
+
     def get_transaction_span_group(self, event_data: Any) -> str:
         result = Hash()
         result.update(event_data["transaction"])

--- a/src/sentry/spans/grouping/strategy/config.py
+++ b/src/sentry/spans/grouping/strategy/config.py
@@ -30,6 +30,10 @@ class SpanGroupingConfig:
         results = self.strategy.execute(event_data)
         return SpanGroupingResults(self.id, results)
 
+    def execute_strategy_raw(self, spans: list[Any]) -> SpanGroupingResults:
+        results = self.strategy.execute_raw(spans)
+        return SpanGroupingResults(self.id, results)
+
 
 CONFIGURATIONS: dict[str, SpanGroupingConfig] = {}
 

--- a/src/sentry/spans/grouping/strategy/config.py
+++ b/src/sentry/spans/grouping/strategy/config.py
@@ -30,8 +30,8 @@ class SpanGroupingConfig:
         results = self.strategy.execute(event_data)
         return SpanGroupingResults(self.id, results)
 
-    def execute_strategy_raw(self, spans: list[Any]) -> SpanGroupingResults:
-        results = self.strategy.execute_raw(spans)
+    def execute_strategy_standalone(self, spans: list[Any]) -> SpanGroupingResults:
+        results = self.strategy.execute_standalone(spans)
         return SpanGroupingResults(self.id, results)
 
 

--- a/src/sentry/testutils/performance_issues/span_builder.py
+++ b/src/sentry/testutils/performance_issues/span_builder.py
@@ -18,6 +18,7 @@ class SpanBuilder:
         self.tags: Any | None = None
         self.data: Any | None = None
         self.hash: str | None = None
+        self.sentry_tags: dict[str, str] = {}
 
     def segment(self) -> "SpanBuilder":
         self.is_segment = True
@@ -47,6 +48,10 @@ class SpanBuilder:
         self.data = data
         return self
 
+    def with_sentry_tag(self, key: str, value: str) -> "SpanBuilder":
+        self.sentry_tags[key] = value
+        return self
+
     def build(self) -> Span:
         span: Span = {
             "trace_id": self.trace_id,
@@ -61,6 +66,7 @@ class SpanBuilder:
             "fingerprint": self.fingerprint,
             "tags": self.tags,
             "data": self.data,
+            "sentry_tags": self.sentry_tags,
         }
         if self.hash is not None:
             span["hash"] = self.hash

--- a/src/sentry/testutils/performance_issues/span_builder.py
+++ b/src/sentry/testutils/performance_issues/span_builder.py
@@ -17,8 +17,8 @@ class SpanBuilder:
         self.fingerprint: list[str] | None = None
         self.tags: Any | None = None
         self.data: Any | None = None
-        self.hash: str | None = None
         self.sentry_tags: dict[str, str] = {}
+        self.hash: str | None = None
 
     def segment(self) -> "SpanBuilder":
         self.is_segment = True
@@ -66,8 +66,9 @@ class SpanBuilder:
             "fingerprint": self.fingerprint,
             "tags": self.tags,
             "data": self.data,
-            "sentry_tags": self.sentry_tags,
         }
+        if self.sentry_tags:
+            span["sentry_tags"] = self.sentry_tags
         if self.hash is not None:
             span["hash"] = self.hash
         return span

--- a/src/sentry/testutils/performance_issues/span_builder.py
+++ b/src/sentry/testutils/performance_issues/span_builder.py
@@ -8,6 +8,7 @@ class SpanBuilder:
         self.trace_id = "a" * 32
         self.parent_span_id = "a" * 16
         self.span_id = "b" * 16
+        self.is_segment = False
         self.start_timestamp: float = 0
         self.timestamp: float = 1
         self.same_process_as_parent = True
@@ -17,6 +18,10 @@ class SpanBuilder:
         self.tags: Any | None = None
         self.data: Any | None = None
         self.hash: str | None = None
+
+    def segment(self) -> "SpanBuilder":
+        self.is_segment = True
+        return self
 
     def with_op(self, op: str) -> "SpanBuilder":
         self.op = op
@@ -47,6 +52,7 @@ class SpanBuilder:
             "trace_id": self.trace_id,
             "parent_span_id": self.parent_span_id,
             "span_id": self.span_id,
+            "is_segment": self.is_segment,
             "start_timestamp": self.start_timestamp,
             "timestamp": self.timestamp,
             "same_process_as_parent": self.same_process_as_parent,

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -14,6 +14,7 @@ from sentry.spans.grouping.strategy.base import (
 )
 from sentry.spans.grouping.strategy.config import (
     CONFIGURATIONS,
+    DEFAULT_CONFIG_ID,
     SpanGroupingConfig,
     register_configuration,
 )
@@ -584,3 +585,28 @@ def test_default_2022_10_27_strategy(spans: list[Span], expected: Mapping[str, l
         key: hash_values(values)
         for key, values in {**expected, "a" * 16: ["transaction name"]}.items()
     }
+
+
+def test_standalone_spans_compat() -> None:
+    spans = [
+        SpanBuilder().with_span_id("b" * 16).with_description("b" * 16).build(),
+        SpanBuilder().with_span_id("c" * 16).with_description("c" * 16).build(),
+        SpanBuilder().with_span_id("d" * 16).with_description("d" * 16).build(),
+    ]
+
+    event = {
+        "transaction": "transaction name",
+        "contexts": {
+            "trace": {
+                "span_id": "a" * 16,
+            },
+        },
+        "spans": spans,
+    }
+
+    segment_span = SpanBuilder().with_span_id("a" * 16).segment().build()
+    segment_span["sentry_tags"] = {"transaction": "transaction name"}
+    standalone_spans = spans + [segment_span]
+
+    cfg = CONFIGURATIONS[DEFAULT_CONFIG_ID]
+    assert cfg.execute_strategy(event) == cfg.execute_strategy_standalone(standalone_spans)

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -608,7 +608,7 @@ def test_standalone_spans_compat() -> None:
         SpanBuilder()
         .with_span_id("a" * 16)
         .segment()
-        .with_sentry_tag("transaction", "txname")
+        .with_sentry_tag("transaction", "transaction name")
         .build()
     ]
 

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -604,9 +604,13 @@ def test_standalone_spans_compat() -> None:
         "spans": spans,
     }
 
-    segment_span = SpanBuilder().with_span_id("a" * 16).segment().build()
-    segment_span["sentry_tags"] = {"transaction": "transaction name"}
-    standalone_spans = spans + [segment_span]
+    standalone_spans = spans + [
+        SpanBuilder()
+        .with_span_id("a" * 16)
+        .segment()
+        .with_sentry_tag("transaction", "txname")
+        .build()
+    ]
 
     cfg = CONFIGURATIONS[DEFAULT_CONFIG_ID]
     assert cfg.execute_strategy(event) == cfg.execute_strategy_standalone(standalone_spans)


### PR DESCRIPTION
With span-first Sentry, the spans consumer will no longer create an event
payload but instead process batches of spans directly. While span grouping
internally operates on individual spans, the entrypoint was built using the
`Event` model. This PR provides an alternative entrypoint with a list of spans.

To ensure the same output as before, there is a special case for segment spans
(`is_segment: true`) that reads the `transaction` field just like for the event
before. See the regression test that asserts equivalence.

Ref https://github.com/getsentry/streaming-planning/issues/67
