### PR TITLE
fix(widget-builder): Use IDs to look up widgets

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -351,7 +351,18 @@ class DashboardDetail extends Component<Props, State> {
             });
           },
           onEdit: () => {
-            const widgetIndex = dashboard.widgets.indexOf(widget);
+            const widgetIndex = dashboard.widgets.findIndex(
+              w => w.id === widget.id || w.tempId === widget.tempId
+            );
+            if (widgetIndex === -1) {
+              Sentry.setTag('edit_source', 'modal');
+              Sentry.captureMessage('Attempted edit of widget not found in dashboard', {
+                level: 'error',
+                extra: {widget, dashboard},
+              });
+              return;
+            }
+
             if (organization.features.includes('dashboards-widget-builder-redesign')) {
               this.onEditWidget(widget);
               return;
@@ -762,8 +773,8 @@ class DashboardDetail extends Component<Props, State> {
     const widgetIndex = currentDashboard.widgets.findIndex(
       w => w.id === widget.id || w.tempId === widget.tempId
     );
-
     if (widgetIndex === -1) {
+      Sentry.setTag('edit_source', 'context-menu');
       Sentry.captureMessage('Attempted edit of widget not found in dashboard', {
         level: 'error',
         extra: {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -160,7 +160,9 @@ export function handleUpdateDashboardSplit({
   // because the backend has evaluated the query and stored that value
   const updatedDashboard = cloneDashboard(dashboard);
   const widgetIndex = updatedDashboard.widgets.findIndex(
-    widget => widget.id === widgetId
+    widget =>
+      (defined(widget.id) && widget.id === widgetId) ||
+      (defined(widget.tempId) && widget.tempId === widgetId)
   );
 
   if (widgetIndex >= 0) {
@@ -352,7 +354,9 @@ class DashboardDetail extends Component<Props, State> {
           },
           onEdit: () => {
             const widgetIndex = dashboard.widgets.findIndex(
-              w => w.id === widget.id || w.tempId === widget.tempId
+              w =>
+                (defined(widget.id) && w.id === widget.id) ||
+                (defined(widget.tempId) && w.tempId === widget.tempId)
             );
             if (widgetIndex === -1) {
               Sentry.setTag('edit_source', 'modal');
@@ -771,7 +775,9 @@ class DashboardDetail extends Component<Props, State> {
     const {dashboardId} = params;
 
     const widgetIndex = currentDashboard.widgets.findIndex(
-      w => w.id === widget.id || w.tempId === widget.tempId
+      w =>
+        (defined(widget.id) && w.id === widget.id) ||
+        (defined(widget.tempId) && w.tempId === widget.tempId)
     );
     if (widgetIndex === -1) {
       Sentry.setTag('edit_source', 'context-menu');

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1,5 +1,6 @@
 import {cloneElement, Component, Fragment, isValidElement} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import isEqualWith from 'lodash/isEqualWith';
@@ -757,7 +758,21 @@ class DashboardDetail extends Component<Props, State> {
     const {modifiedDashboard} = this.state;
     const currentDashboard = modifiedDashboard ?? dashboard;
     const {dashboardId} = params;
-    const widgetIndex = currentDashboard.widgets.indexOf(widget);
+
+    const widgetIndex = currentDashboard.widgets.findIndex(
+      w => w.id === widget.id || w.tempId === widget.tempId
+    );
+
+    if (widgetIndex === -1) {
+      Sentry.captureMessage('Attempted edit of widget not found in dashboard', {
+        level: 'error',
+        extra: {
+          widget,
+          currentDashboard,
+        },
+      });
+    }
+
     this.setState({
       isWidgetBuilderOpen: true,
       openWidgetTemplates: false,


### PR DESCRIPTION
Noticed a user had `-1` as their "index" for a widget in their edit URL, which meant that `.indexOf` wasn't able to find a match. Replace that with something that looks at the properties of the widget (i.e. `id` or `tempId`). If we can't find the ID, I want to also log that event to get more insight, so I'm adding the widget and dashboard information for me to see later.