### PR TITLE
ref(searchbar): support special character escapement for filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -47,7 +47,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     (keyName: string) => {
       const newFieldDef = getFieldDefinition(keyName);
       const newFilterValueType = getFilterValueType(token, newFieldDef);
-      const displayKey = escapeFilterKey(keyName);
 
       if (keyName === getKeyName(token.key)) {
         onCommit();
@@ -64,7 +63,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         dispatch({
           type: 'UPDATE_FILTER_KEY',
           token,
-          key: displayKey,
+          key: escapeFilterKey(keyName),
         });
         onCommit();
         return;
@@ -73,7 +72,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT',
         tokens: [token],
-        text: getInitialFilterText(displayKey, newFieldDef),
+        text: getInitialFilterText(keyName, newFieldDef),
         focusOverride: {
           itemKey: item.key.toString(),
           part: 'value',

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -5,7 +5,10 @@ import type {Node} from '@react-types/shared';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
-import {getFilterValueType} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {
+  escapeFilterKey,
+  getFilterValueType,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import type {SearchKeyItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
 import {getInitialFilterText} from 'sentry/components/searchQueryBuilder/tokens/utils';
@@ -44,6 +47,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     (keyName: string) => {
       const newFieldDef = getFieldDefinition(keyName);
       const newFilterValueType = getFilterValueType(token, newFieldDef);
+      const displayKey = escapeFilterKey(keyName);
 
       if (keyName === getKeyName(token.key)) {
         onCommit();
@@ -60,7 +64,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         dispatch({
           type: 'UPDATE_FILTER_KEY',
           token,
-          key: keyName,
+          key: displayKey,
         });
         onCommit();
         return;
@@ -69,7 +73,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT',
         tokens: [token],
-        text: getInitialFilterText(keyName, newFieldDef),
+        text: getInitialFilterText(displayKey, newFieldDef),
         focusOverride: {
           itemKey: item.key.toString(),
           part: 'value',

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -16,7 +16,8 @@ import {
   getFieldDefinition,
 } from 'sentry/utils/fields';
 
-const SHOULD_ESCAPE_REGEX = /[\s"(),]/;
+const SHOULD_ESCAPE_VALUE_REGEX = /[\s"(),]/;
+const SHOULD_ESCAPE_KEY_REGEX = /[:]/;
 
 export function isAggregateFilterToken(
   token: TokenResult<Token.FILTER>
@@ -70,7 +71,7 @@ export function escapeTagValue(value: string): string {
   }
 
   // Wrap in quotes if there is a space or parens
-  return SHOULD_ESCAPE_REGEX.test(value) ? `"${escapeDoubleQuotes(value)}"` : value;
+  return SHOULD_ESCAPE_VALUE_REGEX.test(value) ? `"${escapeDoubleQuotes(value)}"` : value;
 }
 
 export function unescapeTagValue(value: string): string {
@@ -143,4 +144,8 @@ export function convertTokenTypeToValueType(tokenType: Token): FieldValueType {
     default:
       return FieldValueType.STRING;
   }
+}
+
+export function escapeFilterKey(key: string): string {
+  return key && SHOULD_ESCAPE_KEY_REGEX.test(key) ? `"${key}"` : key;
 }

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -9,6 +9,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {replaceTokensWithPadding} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
+import {escapeFilterKey} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {useFilterKeyListBox} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox';
 import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
@@ -411,14 +412,14 @@ function SearchQueryBuilderInputInternal({
           }
 
           const value = option.value;
-
+          const displayValue = escapeFilterKey(value);
           dispatch({
             type: 'UPDATE_FREE_TEXT',
             tokens: [token],
             text: replaceFocusedWordWithFilter(
               inputValue,
               selectionIndex,
-              value,
+              displayValue,
               getFieldDefinition
             ),
             focusOverride: calculateNextFocusForFilter(state),

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -9,7 +9,6 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {replaceTokensWithPadding} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
-import {escapeFilterKey} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {useFilterKeyListBox} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox';
 import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
@@ -412,14 +411,13 @@ function SearchQueryBuilderInputInternal({
           }
 
           const value = option.value;
-          const displayValue = escapeFilterKey(value);
           dispatch({
             type: 'UPDATE_FREE_TEXT',
             tokens: [token],
             text: replaceFocusedWordWithFilter(
               inputValue,
               selectionIndex,
-              displayValue,
+              value,
               getFieldDefinition
             ),
             focusOverride: calculateNextFocusForFilter(state),

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -7,6 +7,7 @@ import type {
   SelectOptionOrSectionWithKey,
   SelectSectionWithKey,
 } from 'sentry/components/compactSelect/types';
+import {escapeFilterKey} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
 import {defined} from 'sentry/utils';
 import {type FieldDefinition, FieldKind, FieldValueType} from 'sentry/utils/fields';
@@ -118,6 +119,7 @@ export function getInitialFilterText(
   const defaultValue = getDefaultFilterValue({fieldDefinition});
 
   const keyText = getInitialFilterKeyText(key, fieldDefinition);
+  const displayKeyText = escapeFilterKey(keyText);
   const valueType = getInitialValueType(fieldDefinition);
 
   switch (valueType) {
@@ -126,10 +128,10 @@ export function getInitialFilterText(
     case FieldValueType.DURATION:
     case FieldValueType.SIZE:
     case FieldValueType.PERCENTAGE:
-      return `${keyText}:>${defaultValue}`;
+      return `${displayKeyText}:>${defaultValue}`;
     case FieldValueType.STRING:
     default:
-      return `${keyText}:${defaultValue}`;
+      return `${displayKeyText}:${defaultValue}`;
   }
 }
 

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -190,7 +190,7 @@ export const useFetchIssueTags = ({
 
     featureFlagTags.forEach(tag => {
       // Wrap with flags[] and if necessary, quote to escape ':', which is used by our search syntax.
-      const key = tag.key.includes(':') ? `flags["${tag.key}"]` : `flags[${tag.key}]`;
+      const key = `flags[${tag.key}]`;
       if (allTagsCollection[key]) {
         allTagsCollection[key]!.totalValues =
           (allTagsCollection[key]!.totalValues ?? 0) + (tag.totalValues ?? 0);


### PR DESCRIPTION
Note we need to keep `flags[]` in the search request since the backend relies on it. This focuses on escaping `:` characters in filter keys

https://github.com/user-attachments/assets/cba17507-37ac-45be-b534-83ccfc09c304

Closes https://github.com/getsentry/sentry/issues/84536