### PR TITLE
ref(workflow_engine): Move desired action fields into the config

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -335,12 +335,13 @@ class SlackService:
                 f"parent notification {parent_notification.id} does not have an action"
             )
 
-        if not parent_notification.action.target_identifier:
+        target_id = parent_notification.action.config.get("target_identifier")
+        if not target_id:
             raise ActionDataError(
                 f"parent notification {parent_notification.id} does not have a target_identifier"
             )
 
-        return str(parent_notification.action.target_identifier)
+        return str(target_id)
 
     def _get_channel_id_from_parent_notification(
         self,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2191,10 +2191,18 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_action(type: Action.Type | None = None, **kwargs) -> Action:
+    def create_action(
+        config: dict[str, Any] | None = None,
+        type: Action.Type | None = None,
+        **kwargs,
+    ) -> Action:
+        if config is None:
+            config = {}
+
         if type is None:
             type = Action.Type.SLACK
-        return Action.objects.create(type=type, **kwargs)
+
+        return Action.objects.create(type=type, config=config, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -54,7 +54,23 @@ group_type_notification_registry = Registry[LegacyRegistryInvoker]()
 @action_handler_registry.register(Action.Type.WEBHOOK)
 @action_handler_registry.register(Action.Type.PLUGIN)
 class NotificationActionHandler(ActionHandler):
-    config_schema = {}
+    config_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configration schema for a Notification Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {
+                "type": ["string", "null"],
+            },
+            "target_display": {
+                "type": ["string", "null"],
+            },
+            "target_type": {
+                "type": ["integer", "null"],
+                "enum": ActionTarget,
+            },
+        },
+    }
 
     @staticmethod
     def execute(

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -56,7 +56,7 @@ group_type_notification_registry = Registry[LegacyRegistryInvoker]()
 class NotificationActionHandler(ActionHandler):
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configration schema for a Notification Action",
+        "description": "The configuration schema for a Notification Action",
         "type": "object",
         "properties": {
             "target_identifier": {

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -67,7 +67,7 @@ class NotificationActionHandler(ActionHandler):
             },
             "target_type": {
                 "type": ["integer", "null"],
-                "enum": ActionTarget,
+                "enum": [at.value for at in ActionTarget] + [None],
             },
         },
     }

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -67,7 +67,7 @@ class NotificationActionHandler(ActionHandler):
             },
             "target_type": {
                 "type": ["integer", "null"],
-                "enum": [at.value for at in ActionTarget] + [None],
+                "enum": [*ActionTarget] + [None],
             },
         },
     }

--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -120,18 +120,20 @@ class MetricAlertRegistryInvoker(LegacyRegistryInvoker):
 
     @staticmethod
     def target(action: Action) -> RpcUser | Team | str | None:
-        if action.target_identifier is None:
+        target_identifier = action.config.get("target_identifier")
+        if target_identifier is None:
             return None
 
-        if action.target_type == ActionTarget.USER.value:
-            return user_service.get_user(user_id=int(action.target_identifier))
-        elif action.target_type == ActionTarget.TEAM.value:
+        target_type = action.config.get("target_type")
+        if target_type == ActionTarget.USER.value:
+            return user_service.get_user(user_id=int(target_identifier))
+        elif target_type == ActionTarget.TEAM.value:
             try:
-                return Team.objects.get(id=int(action.target_identifier))
+                return Team.objects.get(id=int(target_identifier))
             except Team.DoesNotExist:
                 pass
-        elif action.target_type == ActionTarget.SPECIFIC.value:
+        elif target_type == ActionTarget.SPECIFIC.value:
             # TODO: This is only for email. We should have a way of validating that it's
             # ok to contact this email.
-            return action.target_identifier
+            return target_identifier
         return None

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -55,25 +55,20 @@ class BaseIssueAlertHandler(ABC):
         cls, action: Action, mapping: ActionFieldMapping, organization_id: int
     ) -> dict[str, Any]:
         if mapping.get(ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value):
-            if action.config.get("target_identifier") is None:
-                raise ValueError(f"No target identifier found for action type: {action.type}")
-            return {
-                mapping[ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value]: action.config.get(
-                    "target_identifier"
-                )
-            }
-        raise ValueError(f"No target identifier key found for action type: {action.type}")
+            target_id = action.config.get("target_identifier")
+
+            if target_id is None:
+                raise ValueError(f"No target_identifier found for action type: {action.type}")
+            return {mapping[ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value]: target_id}
+        raise ValueError(f"No target_identifier key found for action type: {action.type}")
 
     @classmethod
     def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         if mapping.get(ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value):
-            if action.config.get("target_display") is None:
+            target_display = action.config.get("target_display")
+            if target_display is None:
                 raise ValueError(f"No target display found for action type: {action.type}")
-            return {
-                mapping[ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value]: action.config.get(
-                    "target_display"
-                )
-            }
+            return {mapping[ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value]: target_display}
         raise ValueError(f"No target display key found for action type: {action.type}")
 
     @classmethod

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -55,21 +55,25 @@ class BaseIssueAlertHandler(ABC):
         cls, action: Action, mapping: ActionFieldMapping, organization_id: int
     ) -> dict[str, Any]:
         if mapping.get(ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value):
-            if action.target_identifier is None:
+            if action.config.get("target_identifier") is None:
                 raise ValueError(f"No target identifier found for action type: {action.type}")
             return {
-                mapping[
-                    ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
-                ]: action.target_identifier
+                mapping[ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value]: action.config.get(
+                    "target_identifier"
+                )
             }
         raise ValueError(f"No target identifier key found for action type: {action.type}")
 
     @classmethod
     def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         if mapping.get(ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value):
-            if action.target_display is None:
+            if action.config.get("target_display") is None:
                 raise ValueError(f"No target display found for action type: {action.type}")
-            return {mapping[ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value]: action.target_display}
+            return {
+                mapping[ActionFieldMappingKeys.TARGET_DISPLAY_KEY.value]: action.config.get(
+                    "target_display"
+                )
+            }
         raise ValueError(f"No target display key found for action type: {action.type}")
 
     @classmethod
@@ -298,26 +302,25 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
     def get_target_identifier(
         cls, action: Action, mapping: ActionFieldMapping, organization_id: int
     ) -> dict[str, Any]:
+        target_id = action.config.get("target_identifier")
+        target_type = action.config.get("target_type")
+
         # this would be when the target_type is IssueOwners
-        if action.target_identifier is None:
-            if action.target_type != ActionTarget.ISSUE_OWNERS.value:
+        if target_id is None:
+            if target_type != ActionTarget.ISSUE_OWNERS.value:
                 raise ValueError(
-                    f"No target identifier found for {action.type} action {action.id}, target_type: {action.target_type}"
+                    f"No target identifier found for {action.type} action {action.id}, target_type: {target_type}"
                 )
             return {}
         else:
-            return {
-                mapping[
-                    ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
-                ]: action.target_identifier
-            }
+            return {mapping[ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value]: target_id}
 
     @classmethod
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
-        if action.target_type is None:
-            raise ValueError(f"No target type found for {action.type} action {action.id}")
+        target_type = action.config.get("target_type")
 
-        target_type = ActionTarget(action.target_type)
+        if target_type is None:
+            raise ValueError(f"No target type found for {action.type} action {action.id}")
 
         final_blob = {
             EmailFieldMappingKeys.TARGET_TYPE_KEY.value: EmailActionHelper.get_target_type_string(
@@ -375,25 +378,24 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         cls, action: Action, mapping: ActionFieldMapping, organization_id: int
     ) -> dict[str, Any]:
         if mapping.get(ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value):
-            if action.target_identifier is None:
+            target_identifier = action.config.get("target_identifier")
+            if target_identifier is None:
                 raise ValueError(f"No target identifier found for action type: {action.type}")
 
-            sentry_app_id = action.target_identifier
-
             sentry_app_installations = app_service.get_many(
-                filter=dict(app_ids=[sentry_app_id], organization_id=organization_id)
+                filter=dict(app_ids=[target_identifier], organization_id=organization_id)
             )
 
             if len(sentry_app_installations) != 1:
                 raise ValueError(
-                    f"Expected 1 sentry app installation for action type: {action.type}, target_identifier: {sentry_app_id}, but got {len(sentry_app_installations)}"
+                    f"Expected 1 sentry app installation for action type: {action.type}, target_identifier: {target_identifier}, but got {len(sentry_app_installations)}"
                 )
 
             sentry_app_installation = sentry_app_installations[0]
 
             if sentry_app_installation is None:
                 raise ValueError(
-                    f"Sentry app not found for action type: {action.type}, target_identifier: {sentry_app_id}"
+                    f"Sentry app not found for action type: {action.type}, target_identifier: {target_identifier}"
                 )
 
             return {

--- a/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py
@@ -317,10 +317,7 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
-        target_type = action.config.get("target_type")
-
-        if target_type is None:
-            raise ValueError(f"No target type found for {action.type} action {action.id}")
+        target_type = ActionTarget(action.config.get("target_type"))
 
         final_blob = {
             EmailFieldMappingKeys.TARGET_TYPE_KEY.value: EmailActionHelper.get_target_type_string(

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -701,7 +701,11 @@ def dual_update_migrated_alert_rule_trigger_action(
     target_identifier = get_target_identifier(trigger_action, action_type)
     updated_action_fields["type"] = action_type
     updated_action_fields["data"] = data
-    updated_action_fields["target_identifier"] = target_identifier
+    updated_action_fields["config"] = {
+        "target_display": updated_fields.get("target_display", None),
+        "target_type": updated_fields.get("target_type", None),
+        "target_identifier": target_identifier,
+    }
 
     for field in LEGACY_ACTION_FIELDS:
         if field in updated_fields:

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -225,9 +225,11 @@ def migrate_metric_action(
         type=action_type_enum,
         data=data,
         integration_id=alert_rule_trigger_action.integration_id,
-        target_display=alert_rule_trigger_action.target_display,
-        target_identifier=target_identifier,
-        target_type=alert_rule_trigger_action.target_type,
+        config={
+            "target_display": alert_rule_trigger_action.target_display,
+            "target_identifier": target_identifier,
+            "target_type": alert_rule_trigger_action.target_type,
+        },
     )
     data_condition_group_action = DataConditionGroupAction.objects.create(
         condition_group_id=action_filter.condition_group.id,

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -708,7 +708,7 @@ def dual_update_migrated_alert_rule_trigger_action(
     }
 
     for field in LEGACY_ACTION_FIELDS:
-        if field in updated_fields:
+        if field in updated_fields and field not in updated_action_fields["config"].keys():
             updated_action_fields[field] = updated_fields[field]
 
     action.update(**updated_action_fields)

--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -75,9 +75,11 @@ def translate_rule_data_actions_to_notification_actions(
                 type=translator.action_type,
                 data=translator.get_sanitized_data(),
                 integration_id=translator.integration_id,
-                target_identifier=translator.target_identifier,
-                target_display=translator.target_display,
-                target_type=translator.target_type,
+                config={
+                    "target_identifier": translator.target_identifier,
+                    "target_display": translator.target_display,
+                    "target_type": translator.target_type,
+                },
             )
 
             notification_actions.append(notification_action)

--- a/tests/sentry/incidents/serializers/test_workflow_engine_action.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_action.py
@@ -21,8 +21,10 @@ class TestActionSerializer(TestCase):
 
         self.action = self.create_action(
             type=Action.Type.EMAIL.value,
-            target_type=ActionTarget.USER,
-            target_identifier=self.user.id,
+            config={
+                "target_type": ActionTarget.USER,
+                "target_identifier": str(self.user.id),
+            },
         )
         ActionAlertRuleTriggerAction.objects.create(
             action_id=self.action.id,
@@ -54,8 +56,8 @@ class TestActionSerializer(TestCase):
         )
         self.sentry_app_trigger_action = self.create_alert_rule_trigger_action(
             alert_rule_trigger=self.sentry_app_trigger,
-            target_identifier=sentry_app.id,
             type=AlertRuleTriggerAction.Type.SENTRY_APP,
+            target_identifier=sentry_app.id,
             target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
             sentry_app=sentry_app,
             sentry_app_config=[
@@ -67,9 +69,11 @@ class TestActionSerializer(TestCase):
         )
         self.sentry_app_action = self.create_action(
             type=Action.Type.SENTRY_APP.value,
-            target_type=ActionTarget.SENTRY_APP,
-            target_identifier=sentry_app.id,
-            target_display=sentry_app.name,
+            config={
+                "target_type": ActionTarget.SENTRY_APP,
+                "target_identifier": str(sentry_app.id),
+                "target_display": sentry_app.name,
+            },
             data={
                 "sentry_app_config": self.sentry_app_trigger_action.sentry_app_config,
                 "sentry_app_id": sentry_app.id,
@@ -112,10 +116,12 @@ class TestActionSerializer(TestCase):
         )
         self.slack_action = self.create_action(
             type=Action.Type.SLACK.value,
-            target_type=ActionTarget.SPECIFIC,
-            target_identifier=self.slack_trigger_action.target_identifier,
-            target_display=self.slack_trigger_action.target_display,
             integration_id=self.integration.id,
+            config={
+                "target_type": ActionTarget.SPECIFIC,
+                "target_identifier": self.slack_trigger_action.target_identifier,
+                "target_display": self.slack_trigger_action.target_display,
+            },
         )
         ActionAlertRuleTriggerAction.objects.create(
             action_id=self.slack_action.id,

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -102,7 +102,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
                 metadata={"access_token": "xoxb-access-token"},
             )
 
-        self.action = self.create_action(target_identifier=self.channel_id)
+        self.action = self.create_action(config={"target_identifier": self.channel_id})
 
         self.parent_notification_action = NotificationMessage.objects.create(
             message_identifier=self.message_identifier,
@@ -504,7 +504,7 @@ class TestSlackServiceMethods(TestCase):
             rule_fire_history=self.slack_rule_fire_history,
         )
 
-        self.action = self.create_action(target_identifier=self.channel_id)
+        self.action = self.create_action(config={"target_identifier": self.channel_id})
 
         self.parent_notification_action = NotificationActionNotificationMessage(
             id=123,
@@ -661,7 +661,7 @@ class TestSlackServiceMethods(TestCase):
         )
 
     def test_get_channel_id_from_parent_notification_notification_action_no_target_identifier(self):
-        self.action.target_identifier = None
+        self.action.config["target_identifier"] = None
         parent_notification = NotificationActionNotificationMessage(
             id=123,
             date_added=datetime.now(),

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -264,12 +264,15 @@ class TestActionSerializer(TestCase):
             integration = Integration.objects.create(
                 provider="slack", name="example-integration", external_id="123-id", metadata={}
             )
+
         action = self.create_action(
             type=Action.Type.SLACK,
             data={"foo": "bar"},
             integration_id=integration.id,
-            target_display="freddy frog",
-            target_type=ActionTarget.USER,
+            config={
+                "target_display": "freddy frog",
+                "target_type": ActionTarget.USER,
+            },
         )
 
         result = serialize(action)

--- a/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
+++ b/tests/sentry/workflow_engine/handlers/action/notification/test_issue_alert.py
@@ -67,7 +67,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            target_identifier="channel456",
+            config={"target_identifier": "channel456"},
             data={"tags": "environment,user,my_tag"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
@@ -182,7 +182,7 @@ class TestDiscordIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            target_identifier="channel456",
+            config={"target_identifier": "channel456"},
             data={"tags": "environment,user,my_tag"},
         )
         # self.project = self.create_project()
@@ -222,8 +222,10 @@ class TestMSTeamsIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.MSTEAMS,
             integration_id="1234567890",
-            target_identifier="channel789",
-            target_display="General Channel",
+            config={
+                "target_identifier": "channel789",
+                "target_display": "General Channel",
+            },
         )
 
     def test_build_rule_action_blob(self):
@@ -246,9 +248,11 @@ class TestSlackIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.SLACK,
             integration_id="1234567890",
-            target_identifier="channel789",
-            target_display="#general",
             data={"tags": "environment,user", "notes": "Important alert"},
+            config={
+                "target_identifier": "channel789",
+                "target_display": "#general",
+            },
         )
 
     def test_build_rule_action_blob(self):
@@ -287,7 +291,7 @@ class TestPagerDutyIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.PAGERDUTY,
             integration_id="1234567890",
-            target_identifier="service789",
+            config={"target_identifier": "service789"},
             data={"priority": "P1"},
         )
 
@@ -323,7 +327,7 @@ class TestOpsgenieIssueAlertHandler(BaseWorkflowTest):
         self.action = self.create_action(
             type=Action.Type.OPSGENIE,
             integration_id="1234567890",
-            target_identifier="team789",
+            config={"target_identifier": "team789"},
             data={"priority": "P1"},
         )
 
@@ -441,19 +445,19 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
             {
                 "targetType": "Member",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": 3234013,
+                "targetIdentifier": "3234013",
             },
             # Member Email
             {
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": 2160509,
+                "targetIdentifier": "2160509",
                 "targetType": "Member",
             },
             # Team Email
             {
                 "targetType": "Team",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": 188022,
+                "targetIdentifier": "188022",
             },
         ]
 
@@ -465,17 +469,17 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
             target_type = EmailActionHelper.get_target_type_object(action_data.pop("targetType"))
 
             # Handle all possible targetIdentifier formats
-            target_identifier = expected["targetIdentifier"]
+            target_identifier: str | None = str(expected["targetIdentifier"])
             if target_identifier in ("None", "", None):
                 target_identifier = None
-            elif str(target_identifier).isnumeric():
-                target_identifier = int(target_identifier)
 
             action = self.create_action(
                 type=Action.Type.EMAIL,
                 data=action_data,
-                target_type=target_type,
-                target_identifier=target_identifier,
+                config={
+                    "target_type": target_type,
+                    "target_identifier": target_identifier,
+                },
             )
             blob = self.handler.build_rule_action_blob(action, self.organization.id)
 
@@ -508,8 +512,7 @@ class TestWebhookIssueAlertHandler(BaseWorkflowTest):
     def test_build_rule_action_blob(self):
         for expected in WEBHOOK_ACTION_DATA_BLOBS:
             action = self.create_action(
-                type=Action.Type.WEBHOOK,
-                target_identifier=expected["service"],
+                type=Action.Type.WEBHOOK, config={"target_identifier": expected["service"]}
             )
 
             # pop uuid from blob
@@ -560,14 +563,13 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
     def test_build_rule_action_blob_sentry_app(self):
         data_blob = self.build_sentry_app_form_config_data_blob()
         cleaned_data_blob = self.build_sentry_app_form_config_data_blob(include_null_label=False)
+        target_id = str(self.sentry_app.id)
 
         # sentry app with settings
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
-            data={
-                "settings": data_blob,
-            },
-            target_identifier=self.sentry_app.id,
+            data={"settings": data_blob},
+            config={"target_identifier": target_id},
         )
         blob = self.handler.build_rule_action_blob(action, self.organization.id)
 
@@ -584,7 +586,7 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             data={
                 "settings": data_blob,
             },
-            target_identifier=self.sentry_app.id,
+            config={"target_identifier": target_id},
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)
 
@@ -600,9 +602,11 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
         assert action_1_uuid != action_2_uuid
 
     def test_build_rule_action_blob_sentry_app_no_settings(self):
+        target_id = str(self.sentry_app.id)
+
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
-            target_identifier=self.sentry_app.id,
+            config={"target_identifier": target_id},
         )
 
         # sentry app with no settings
@@ -617,7 +621,7 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
 
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
-            target_identifier=self.sentry_app.id,
+            config={"target_identifier": target_id},
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -186,7 +186,9 @@ def assert_alert_rule_trigger_action_migrated(alert_rule_trigger_action, action_
     # Additional checks for Sentry app actions
     if action_type == Action.Type.SENTRY_APP:
         # Verify target_identifier is the string representation of sentry_app_id
-        assert action.target_identifier == str(alert_rule_trigger_action.sentry_app_id)
+        assert action.config.get("target_identifier") == str(
+            alert_rule_trigger_action.sentry_app_id
+        )
 
         # Verify data blob has correct structure for Sentry apps
         if not alert_rule_trigger_action.sentry_app_config:
@@ -1071,9 +1073,9 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
 
         self.action.refresh_from_db()
         assert self.action.integration_id == self.integration.id
-        assert self.action.target_display == "cool-team"
-        assert self.action.target_identifier == "123-id"
-        assert self.action.target_type == ActionTarget.USER
+        assert self.action.config.get("target_display") == "cool-team"
+        assert self.action.config.get("target_identifier") == "123-id"
+        assert self.action.config.get("target_type") == ActionTarget.USER
 
     def test_dual_update_trigger_action_data(self):
         """
@@ -1152,9 +1154,9 @@ class DualUpdateAlertRuleTriggerActionTest(BaseMetricAlertMigrationTest):
                 "label": None,
             },
         ]
-        assert action.target_display == "oolong"
-        assert action.target_identifier == str(sentry_app.id)
-        assert action.target_type == ActionTarget.SENTRY_APP
+        assert action.config.get("target_display") == "oolong"
+        assert action.config.get("target_identifier") == str(sentry_app.id)
+        assert action.config.get("target_type") == ActionTarget.SENTRY_APP
 
 
 class CalculateResolveThresholdHelperTest(BaseMetricAlertMigrationTest):
@@ -1177,6 +1179,7 @@ class CalculateResolveThresholdHelperTest(BaseMetricAlertMigrationTest):
         detector = AlertRuleDetector.objects.get(alert_rule=self.metric_alert).detector
         detector_dcg = detector.workflow_condition_group
         assert detector_dcg  # to appease mypy
+
         resolve_threshold = get_resolve_threshold(detector_dcg)
         assert resolve_threshold == self.alert_rule_trigger.alert_threshold
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -1181,4 +1181,4 @@ class TestNotificationActionMigrationUtils(TestCase):
         assert action.type == Action.Type.SLACK
         assert action.config.get("target_display") == "#test"
         assert action.config.get("target_identifier") == "C123"
-        assert action.config.get("integration_id") == 1
+        assert action.integration_id == 1

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -131,7 +131,7 @@ class TestNotificationActionMigrationUtils(TestCase):
                     if (
                         action.type == Action.Type.EMAIL
                         and key == "fallthroughType"
-                        and action.target_type != ActionTarget.ISSUE_OWNERS
+                        and action.config.get("target_type") != ActionTarget.ISSUE_OWNERS
                     ):
                         # for email actions, fallthroughType should only be set for when targetType is ISSUE_OWNERS
                         continue
@@ -168,16 +168,16 @@ class TestNotificationActionMigrationUtils(TestCase):
             compare_val = compare_dict.get(target_identifier_key)
             # Handle both "None" string and None value
             if compare_val in ["None", None, ""]:
-                assert action.target_identifier is None
+                assert action.config.get("target_identifier") is None
             else:
-                assert action.target_identifier == compare_val
+                assert action.config.get("target_identifier") == compare_val
 
         # Assert target_display matches if specified
         if target_display_key:
-            assert action.target_display == compare_dict.get(target_display_key)
+            assert action.config.get("target_display") == compare_dict.get(target_display_key)
 
         # Assert target_type matches
-        assert action.target_type == translator.target_type
+        assert action.config.get("target_type") == translator.target_type
 
     def assert_actions_migrated_correctly(
         self,
@@ -692,8 +692,8 @@ class TestNotificationActionMigrationUtils(TestCase):
         actions = build_notification_actions_from_rule_data_actions(action_data)
         assert len(actions) == 1
         assert actions[0].type == Action.Type.SENTRY_APP
-        assert actions[0].target_identifier == str(app.id)
-        assert actions[0].target_type == ActionTarget.SENTRY_APP
+        assert actions[0].config.get("target_identifier") == str(app.id)
+        assert actions[0].config.get("target_type") == ActionTarget.SENTRY_APP
         assert actions[0].data == {}
 
     def test_webhook_action_migration_malformed(self):
@@ -1094,7 +1094,7 @@ class TestNotificationActionMigrationUtils(TestCase):
         # Verify that action type is set correctly
         for action in actions:
             assert action.type == Action.Type.SENTRY_APP
-            assert action.target_identifier == str(app.id)
+            assert action.config.get("target_identifier") == str(app.id)
 
     def test_sentry_app_migration_with_form_config(self):
         action_data = [
@@ -1137,8 +1137,8 @@ class TestNotificationActionMigrationUtils(TestCase):
         # Verify the actions passed to bulk_create
         action = Action.objects.get(id=actions[0].id)
         assert action.type == Action.Type.SLACK
-        assert action.target_display == "#test-channel"
-        assert action.target_identifier == "C123456"
+        assert action.config.get("target_display") == "#test-channel"
+        assert action.config.get("target_identifier") == "C123456"
 
     def test_skip_failures_flag(self):
         """Test that the skip_failures flag skips invalid actions."""
@@ -1179,6 +1179,6 @@ class TestNotificationActionMigrationUtils(TestCase):
         # Verify the actions passed to bulk_create
         action = Action.objects.get(id=actions[0].id)
         assert action.type == Action.Type.SLACK
-        assert action.target_display == "#test"
-        assert action.target_identifier == "C123"
-        assert action.integration_id == 1
+        assert action.config.get("target_display") == "#test"
+        assert action.config.get("target_identifier") == "C123"
+        assert action.config.get("integration_id") == 1

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -666,7 +666,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         action1 = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
-            target_identifier="channel456",
+            config={"target_identifier": "channel456"},
             data={"tags": "environment,user,my_tag"},
         )
         self.create_data_condition_group_action(
@@ -676,9 +676,11 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         action2 = self.create_action(
             type=Action.Type.SLACK,
             integration_id="1234567890",
-            target_identifier="channel789",
-            target_display="#general",
             data={"tags": "environment,user", "notes": "Important alert"},
+            config={
+                "target_identifier": "channel789",
+                "target_display": "#general",
+            },
         )
         self.create_data_condition_group_action(
             condition_group=self.workflow2_dcgs[1], action=action2


### PR DESCRIPTION
## Description
Moved the 3 legacy attributes to the config (leaving the integration_id to maintain the foreign key relationship for now)