### PR TITLE
fix(trace): Missing project slug in new view

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -415,7 +415,6 @@ def run_trace_query(
         "transaction",
         "precise.start_ts",
         "precise.finish_ts",
-        "project.slug",
         "project.id",
         "span.duration",
     ]
@@ -448,5 +447,9 @@ def run_trace_query(
                     span[resolved_column.public_alias] = attribute.value.val_int == 1
                 elif resolved_column.proto_definition.type == INT:
                     span[resolved_column.public_alias] = attribute.value.val_int
+                    if resolved_column.public_alias == "project.id":
+                        span["project.slug"] = resolver.params.project_id_map.get(
+                            span[resolved_column.public_alias], "Unknown"
+                        )
             spans.append(span)
     return spans

--- a/tests/snuba/api/endpoints/test_organization_spans_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_trace.py
@@ -15,6 +15,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert result["transaction"] == event_data.transaction, message
         assert result["event_id"] == event_data.data["contexts"]["trace"]["span_id"], message
         assert result["start_timestamp"] == event_data.data["start_timestamp"], message
+        assert result["project_slug"] == event_data.project.slug, message
 
     def get_transaction_children(self, event):
         """Assumes that the test setup only gives each event 1 txn child"""


### PR DESCRIPTION
- The getTrace endpoint doesn't use VCCs which mean that we have to convert project ids to slugs ourselves