### PR TITLE
feat(taskworker) Make result shipping multi-threaded

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -287,8 +287,13 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
     "--namespace", help="The dedicated task namespace that taskworker operates on", default=None
 )
 @click.option(
-    "--result-queue-factor",
-    help="Size of multiprocessing queue for child worker results",
+    "--result-queue-maxsize",
+    help="Size of multiprocessing queue for child process results",
+    default=5,
+)
+@click.option(
+    "--child-tasks-queue-maxsize",
+    help="Size of multiprocessing queue for pending tasks for child processes",
     default=5,
 )
 @log_options()
@@ -309,7 +314,8 @@ def run_taskworker(
     max_task_count: int,
     namespace: str | None,
     concurrency: int,
-    result_queue_factor: int,
+    child_tasks_queue_maxsize: int,
+    result_queue_maxsize: int,
     **options: Any,
 ) -> None:
     """
@@ -324,7 +330,8 @@ def run_taskworker(
             max_task_count=max_task_count,
             namespace=namespace,
             concurrency=concurrency,
-            result_queue_factor=result_queue_factor,
+            child_tasks_queue_maxsize=child_tasks_queue_maxsize,
+            result_queue_maxsize=result_queue_maxsize,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -286,7 +286,11 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 @click.option(
     "--namespace", help="The dedicated task namespace that taskworker operates on", default=None
 )
-@click.option("--queue-size", help="Size of multiprocessing queues for child workers", default=1)
+@click.option(
+    "--result-queue-factor",
+    help="Size of multiprocessing queue for child worker results",
+    default=5,
+)
 @log_options()
 @configuration
 def taskworker(**options: Any) -> None:
@@ -305,7 +309,7 @@ def run_taskworker(
     max_task_count: int,
     namespace: str | None,
     concurrency: int,
-    queue_size: int,
+    result_queue_factor: int,
     **options: Any,
 ) -> None:
     """
@@ -320,7 +324,7 @@ def run_taskworker(
             max_task_count=max_task_count,
             namespace=namespace,
             concurrency=concurrency,
-            queue_size=queue_size,
+            result_queue_factor=result_queue_factor,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import atexit
 import dataclasses
 import logging
 import multiprocessing
 import queue
 import signal
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.context import ForkProcess
 from multiprocessing.synchronize import Event
-from types import FrameType
 from typing import Any
 from uuid import uuid4
 
@@ -243,7 +245,7 @@ class TaskWorker:
         max_task_count: int | None = None,
         namespace: str | None = None,
         concurrency: int = 1,
-        queue_size: int = 1,
+        result_queue_factor: int = 5,
         **options: dict[str, Any],
     ) -> None:
         self.options = options
@@ -254,14 +256,15 @@ class TaskWorker:
         self._concurrency = concurrency
         self.client = TaskworkerClient(rpc_host, num_brokers)
         self._child_tasks: multiprocessing.Queue[TaskActivation] = mp_context.Queue(
-            maxsize=queue_size
+            maxsize=concurrency
         )
         self._processed_tasks: multiprocessing.Queue[ProcessingResult] = mp_context.Queue(
-            maxsize=queue_size
+            maxsize=concurrency * result_queue_factor
         )
         self._children: list[ForkProcess] = []
         self._shutdown_event = mp_context.Event()
         self._task_receive_timing: dict[str, float] = {}
+        self._result_thread: threading.Thread | None = None
         self.backoff_sleep_seconds = 0
 
     def __del__(self) -> None:
@@ -279,29 +282,18 @@ class TaskWorker:
         completes its max_task_count when it shuts down.
         """
         self.do_imports()
+        self.start_result_thread()
         self._spawn_children()
 
-        signal.signal(signal.SIGINT, self._handle_sigint)
+        atexit.register(self.shutdown)
 
         while True:
-            work_remaining = self.run_once()
-            if work_remaining:
-                self.backoff_sleep_seconds = 0
-            else:
-                self.backoff_sleep_seconds = min(self.backoff_sleep_seconds + 1, 10)
-                time.sleep(self.backoff_sleep_seconds)
+            self.run_once()
 
-    def run_once(self) -> bool:
+    def run_once(self) -> None:
         """Access point for tests to run a single worker loop"""
-        task_added = self._add_task()
-        results_drained = self._drain_result()
+        self._add_task()
         self._spawn_children()
-        return task_added or results_drained
-
-    def _handle_sigint(self, signum: int, frame: FrameType | None) -> None:
-        logger.info("taskworker.worker.sigint_received")
-        self.shutdown()
-        raise KeyboardInterrupt("Shutdown complete")
 
     def shutdown(self) -> None:
         """
@@ -311,11 +303,20 @@ class TaskWorker:
         if self._shutdown_event.is_set():
             return
 
+        logger.info("taskworker.worker.shutdown")
         self._shutdown_event.set()
+        if self._result_thread:
+            self._result_thread.join()
+
+        # Drain remaining results synchronously, as the thread will have terminated
+        # when shutdown_event was set.
         while True:
-            more = self._drain_result(fetch=False)
-            if not more:
+            try:
+                result = self._processed_tasks.get_nowait()
+            except queue.Empty:
                 break
+            self._send_result(result, fetch=False)
+
         for child in self._children:
             child.terminate()
             child.join()
@@ -331,7 +332,7 @@ class TaskWorker:
         if task:
             try:
                 start_time = time.time()
-                self._child_tasks.put(task, timeout=0.1)
+                self._child_tasks.put(task)
                 metrics.distribution(
                     "taskworker.worker.child_task.put.duration", time.time() - start_time
                 )
@@ -343,15 +344,38 @@ class TaskWorker:
         else:
             return False
 
-    def _drain_result(self, fetch: bool = True) -> bool:
+    def start_result_thread(self) -> None:
         """
-        Consume results from children and update taskbroker. Returns True if there are more tasks to process.
-        """
-        try:
-            result = self._processed_tasks.get_nowait()
-        except queue.Empty:
-            return False
+        Start a thread that delivers results and fetches new tasks.
+        We need to ship results in a thread because the RPC calls block for 20-50ms,
+        and many tasks execute more quickly than that.
 
+        Without additional threads, we end up publishing results too slowly
+        and tasks accumulate in the `processed_tasks` queues and can cross
+        their processing deadline.
+        """
+
+        def result_thread() -> None:
+            logger.debug("taskworker.worker.result_thread_started")
+            iopool = ThreadPoolExecutor(max_workers=self._concurrency)
+            with iopool as executor:
+                while not self._shutdown_event.is_set():
+                    try:
+                        result = self._processed_tasks.get(timeout=0.1)
+                    except queue.Empty:
+                        continue
+                    executor.submit(self._send_result, result)
+
+        self._result_thread = threading.Thread(target=result_thread)
+        self._result_thread.start()
+
+    def _send_result(self, result: ProcessingResult, fetch: bool = True) -> bool:
+        """
+        Send a result to the broker and conditionally fetch an additional task
+
+        Run in a thread to avoid blocking the process, and during shutdown/
+        See `start_result_thread`
+        """
         task_received = self._task_receive_timing.pop(result.task_id, None)
         if task_received is not None:
             metrics.distribution("taskworker.worker.complete_duration", time.time() - task_received)
@@ -362,37 +386,46 @@ class TaskWorker:
                 fetch_next = FetchNextTask(namespace=self._namespace)
 
             metrics.incr("taskworker.worker.fetch_next", tags={"next": fetch_next is not None})
-            try:
-                next_task = self.client.update_task(
-                    task_id=result.task_id,
-                    status=result.status,
-                    fetch_next_task=fetch_next,
-                )
-            except grpc.RpcError as e:
-                if e.code() == grpc.StatusCode.UNAVAILABLE:
-                    self._processed_tasks.put(result)
-                logger.exception(
-                    "taskworker.drain_result.update_task_failed",
-                    extra={"task_id": result.task_id, "error": e},
-                )
-                return True
-
+            logger.debug(
+                "taskworker.workers._send_result",
+                extra={"task_id": result.task_id, "next": fetch_next is not None},
+            )
+            next_task = self._send_update_task(result, fetch_next)
             if next_task:
                 self._task_receive_timing[next_task.id] = time.time()
                 try:
-                    self._child_tasks.put(next_task, block=False)
+                    self._child_tasks.put(next_task)
                 except queue.Full:
                     logger.warning(
-                        "taskworker.drain_result.child_task_queue_full",
+                        "taskworker.send_result.child_task_queue_full",
                         extra={"task_id": next_task.id},
                     )
             return True
 
-        self.client.update_task(
-            task_id=result.task_id,
-            status=result.status,
-        )
+        self._send_update_task(result, fetch_next=None)
         return True
+
+    def _send_update_task(
+        self, result: ProcessingResult, fetch_next: FetchNextTask | None
+    ) -> TaskActivation | None:
+        """
+        Do the RPC call to this worker's taskbroker, and handle errors
+        """
+        try:
+            next_task = self.client.update_task(
+                task_id=result.task_id,
+                status=result.status,
+                fetch_next_task=fetch_next,
+            )
+            return next_task
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.UNAVAILABLE:
+                self._processed_tasks.put(result)
+            logger.exception(
+                "taskworker.send_update_task.failed",
+                extra={"task_id": result.task_id, "error": e},
+            )
+            return None
 
     def _spawn_children(self) -> None:
         active_children = [child for child in self._children if child.is_alive()]
@@ -425,11 +458,15 @@ class TaskWorker:
         if not activation:
             metrics.incr("taskworker.worker.fetch_task", tags={"status": "notfound"})
             logger.debug("taskworker.fetch_task.not_found")
+
+            self.backoff_sleep_seconds = min(self.backoff_sleep_seconds + 1, 10)
+            time.sleep(self.backoff_sleep_seconds)
             return None
 
         metrics.incr(
             "taskworker.worker.fetch_task",
             tags={"status": "success", "namespace": activation.namespace},
         )
+        self.backoff_sleep_seconds = 0
         self._task_receive_timing[activation.id] = time.time()
         return activation


### PR DESCRIPTION
We've been unable to drive higher throughput in our worker pools, and I think the source of that is blocking operations in a few places:

- Writes to the `processed_tasks` are blocking, and with a Queue size of 1, only a single child can push a result at a time.
- Reads from the `processed_tasks` queue are followed by an RPC call that takes 20-50ms. During this time, only one other child can publish a result (as the queue size is 1).

By expanding the size of the result queue to be greater than `concurrency` we should have enough space for workers to publish their results without blocking for long.

Moving result publishing into a threadpool allows the worker to run multiple IO requests concurrenctly and keep up with children as they execute tasks.

I've limited the `child_tasks` queue to be equal to the number of children so that always have room for the next task a child, but don't grab too many tasks that they expire in the child queue.
