### PR TITLE
fix(tests): Avoid rendering guides for flaky acceptance test

### DIFF
--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -282,6 +282,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         with self.feature("organizations:global-views"):
             mock_now.return_value = datetime.now(timezone.utc)
             self.create_issues()
+            self.dismiss_assistant()
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_for_issue()
 


### PR DESCRIPTION
This will dismiss the assistant to allow the test to go along without unexpected rendering issues in CI.