### PR TITLE
✨ feat(noa): introduce metric alert handler registry

### DIFF
--- a/src/sentry/workflow_engine/handlers/action/notification/handler.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/handler.py
@@ -11,6 +11,9 @@ from sentry.utils.registry import NoRegistrationExistsError, Registry
 from sentry.workflow_engine.handlers.action.notification.issue_alert import (
     issue_alert_handler_registry,
 )
+from sentry.workflow_engine.handlers.action.notification.metric_alert import (
+    metric_alert_handler_registry,
+)
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowJob
@@ -97,8 +100,22 @@ class IssueAlertRegistryInvoker(LegacyRegistryInvoker):
 class MetricAlertRegistryInvoker(LegacyRegistryInvoker):
     @staticmethod
     def handle_workflow_action(job: WorkflowJob, action: Action, detector: Detector) -> None:
-        # TODO(iamrajjoshi): Implement this
-        pass
+        try:
+            handler = metric_alert_handler_registry.get(action.type)
+            handler.invoke_legacy_registry(job, action, detector)
+        except NoRegistrationExistsError:
+            logger.exception(
+                "No metric alert handler found for action type: %s",
+                action.type,
+                extra={"action_id": action.id},
+            )
+            raise
+        except Exception as e:
+            logger.exception(
+                "Error invoking metric alert handler",
+                extra={"action_id": action.id},
+            )
+            raise NotificationHandlerException(e)
 
     @staticmethod
     def target(action: Action) -> RpcUser | Team | str | None:

--- a/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
+++ b/src/sentry/workflow_engine/handlers/action/notification/metric_alert.py
@@ -1,0 +1,26 @@
+from abc import ABC
+
+import sentry_sdk
+
+from sentry.utils.registry import Registry
+from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.types import WorkflowJob
+
+
+class BaseMetricAlertHandler(ABC):
+    @classmethod
+    def invoke_legacy_registry(
+        cls,
+        job: WorkflowJob,
+        action: Action,
+        detector: Detector,
+    ) -> None:
+
+        with sentry_sdk.start_span(
+            op="workflow_engine.handlers.action.notification.metric_alert.invoke_legacy_registry"
+        ):
+            # TODO: Implement this
+            pass
+
+
+metric_alert_handler_registry = Registry[BaseMetricAlertHandler](enable_reverse_lookup=False)


### PR DESCRIPTION
created the `BaseMetricAlertHandler` registry which will be keyed by `Action.Type` to fetch the appropriate handler.

its similar to https://github.com/getsentry/sentry/blob/75fcec8faf7d3e02e46945250425cebb9e9e2796/src/sentry/workflow_engine/handlers/action/notification/issue_alert.py#L40, but just has a stub function since i haven't fully decided what i want to do for the translation.

decided to not create a common ABC between the two handler types since i want to keep things flexible for now.