### PR TITLE
chore(tests): Dismiss assistant on all header tests

### DIFF
--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -43,6 +43,8 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         self.create_environment(name="prod", project=self.project_2)
 
         self.login_as(self.user)
+        self.dismiss_assistant()
+
         self.issues_list = IssueListPage(self.browser, self.client)
         self.issue_details = IssueDetailsPage(self.browser, self.client)
 
@@ -68,7 +70,6 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         )
 
     def test_global_selection_header_dropdown(self):
-        self.dismiss_assistant()
         self.project.update(first_event=django_timezone.now())
         self.issues_list.visit_issue_list(
             self.org.slug, query="?query=assigned%3Ame&project=" + str(self.project_1.id)
@@ -283,7 +284,6 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         with self.feature("organizations:global-views"):
             mock_now.return_value = datetime.now(timezone.utc)
             self.create_issues()
-            self.dismiss_assistant()
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_for_issue()
 

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -270,6 +270,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             )
 
     @patch("django.utils.timezone.now")
+    @pytest.mark.skip(reason="Flaky, unblocking CI for now")
     def test_issues_list_to_details_and_back_with_all_projects(self, mock_now):
         """
         If user has access to the `global-views` feature, which allows selecting multiple projects,

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -271,7 +271,6 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             )
 
     @patch("django.utils.timezone.now")
-    @pytest.mark.skip(reason="Flaky, unblocking CI for now")
     def test_issues_list_to_details_and_back_with_all_projects(self, mock_now):
         """
         If user has access to the `global-views` feature, which allows selecting multiple projects,


### PR DESCRIPTION
Seemed that https://github.com/getsentry/sentry/pull/86543 fixed the flake for that one test, but others in the file are having issues.

This will dismiss the assistant for all tests and avoid flaking