### PR TITLE
fix(weekly-report): use redis key for dispatching org tasks

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -97,7 +97,11 @@ def schedule_organizations(
         # Create a celery task per organization
         logger.info(
             "weekly_reports.schedule_organizations",
-            extra={"batch_id": str(batch_id), "organization": organization.id},
+            extra={
+                "batch_id": str(batch_id),
+                "organization": organization.id,
+                "minimum_organization_id": minimum_organization_id,
+            },
         )
         prepare_organization_report.delay(
             timestamp, duration, organization.id, batch_id, dry_run=dry_run

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -43,6 +43,7 @@ from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.group import GroupSubStatus
 from sentry.users.services.user_option import user_option_service
+from sentry.utils import redis
 from sentry.utils.dates import floor_to_utc_day
 from sentry.utils.outcomes import Outcome
 
@@ -1084,4 +1085,177 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "has_email_override": False,
                 "report_date": "1970-01-01",
             },
+        )
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
+    def test_schedule_organizations_with_redis_tracking(self, mock_prepare_organization_report):
+        """Test that schedule_organizations uses Redis to track minimum organization ID."""
+        timestamp = self.timestamp
+        redis_cluster = redis.clusters.get("default").get_local_client_for_key(
+            "weekly_reports_org_id_min"
+        )
+
+        # Create multiple organizations
+        org1 = self.organization  # Use existing organization
+        org2 = self.create_organization(name="Another Org")
+        org3 = self.create_organization(name="Third Org")
+
+        # Set initial Redis value to simulate a previous run that was interrupted
+        redis_cluster.set(f"weekly_reports_org_id_min-{timestamp}", org1.id)
+
+        # Run the task
+        schedule_organizations(timestamp=timestamp)
+
+        # Verify that prepare_organization_report was called for org2 and org3 but not org1
+        # because we started from org1.id
+        mock_prepare_organization_report.delay.assert_any_call(
+            timestamp, ONE_DAY * 7, org2.id, mock.ANY, dry_run=False
+        )
+        mock_prepare_organization_report.delay.assert_any_call(
+            timestamp, ONE_DAY * 7, org3.id, mock.ANY, dry_run=False
+        )
+
+        # Verify that Redis key was deleted after completion
+        assert redis_cluster.get(f"weekly_reports_org_id_min-{timestamp}") is None
+
+        # Reset call counts for the next test
+        mock_prepare_organization_report.reset_mock()
+
+        # Run again with no Redis value set
+        schedule_organizations(timestamp=timestamp)
+
+        # Verify that prepare_organization_report was called for all organizations
+        assert mock_prepare_organization_report.delay.call_count == 3
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
+    def test_schedule_organizations_resumes_from_min_id(self, mock_prepare_organization_report):
+        """Test that schedule_organizations resumes from the minimum organization ID stored in Redis."""
+        timestamp = self.timestamp
+        redis_cluster = redis.clusters.get("default").get_local_client_for_key(
+            "weekly_reports_org_id_min"
+        )
+
+        # Create organizations with specific IDs to ensure ordering
+        orgs = [
+            self.organization,  # Use existing organization
+            self.create_organization(name="Org 2"),
+            self.create_organization(name="Org 3"),
+            self.create_organization(name="Org 4"),
+            self.create_organization(name="Org 5"),
+        ]
+
+        # Sort organizations by ID to ensure we know the order
+        orgs.sort(key=lambda org: org.id)
+
+        # Set Redis value to the middle organization
+        middle_org = orgs[2]
+        redis_cluster.set(f"weekly_reports_org_id_min-{timestamp}", middle_org.id)
+
+        # Run the task
+        schedule_organizations(timestamp=timestamp)
+
+        # Verify that prepare_organization_report was only called for organizations with ID >= middle_org.id
+        assert (
+            mock_prepare_organization_report.delay.call_count == 3
+        )  # middle_org and the two after it
+
+        # Organizations before middle_org should not be processed
+        for org in orgs[:2]:
+            # Check that the call was not made with this organization ID
+            call_args_list = mock_prepare_organization_report.delay.call_args_list
+            org_ids_called = [args[0][2] for args in call_args_list]
+            assert (
+                org.id not in org_ids_called
+            ), f"Organization {org.id} should not have been processed"
+
+        # Organizations including and after middle_org should be processed
+        for org in orgs[2:]:
+            mock_prepare_organization_report.delay.assert_any_call(
+                timestamp, ONE_DAY * 7, org.id, mock.ANY, dry_run=False
+            )
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
+    def test_schedule_organizations_updates_redis_during_processing(
+        self, mock_prepare_organization_report
+    ):
+        """Test that schedule_organizations updates Redis with the current organization ID during processing."""
+        timestamp = self.timestamp
+
+        # Create multiple organizations
+        orgs = [
+            self.organization,
+            self.create_organization(name="Org 2"),
+            self.create_organization(name="Org 3"),
+        ]
+
+        # Sort organizations by ID
+        orgs.sort(key=lambda org: org.id)
+
+        # Use a spy to track Redis set calls
+        with mock.patch("redis.client.Redis.set") as mock_redis_set:
+            # Run the task
+            schedule_organizations(timestamp=timestamp)
+
+            # Verify that redis.set was called for each organization
+            expected_key = f"weekly_reports_org_id_min-{timestamp}"
+
+            # Check that set was called at least once for each organization except the last one
+            assert mock_redis_set.call_count > 0, "Redis set was not called"
+
+            # Get the keys that were set
+            set_keys = [args[0] for args, _ in mock_redis_set.call_args_list]
+
+            # Verify that the expected key was used
+            assert expected_key in set_keys, f"Expected key {expected_key} not found in {set_keys}"
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
+    def test_schedule_organizations_starts_from_beginning_when_no_redis_key(
+        self, mock_prepare_organization_report
+    ):
+        """Test that schedule_organizations starts from the beginning when no Redis key exists."""
+        timestamp = self.timestamp
+        redis_cluster = redis.clusters.get("default").get_local_client_for_key(
+            "weekly_reports_org_id_min"
+        )
+
+        # Ensure Redis key doesn't exist
+        redis_cluster.delete(f"weekly_reports_org_id_min-{timestamp}")
+
+        # Create multiple organizations
+        orgs = [
+            self.organization,
+            self.create_organization(name="Org 2"),
+            self.create_organization(name="Org 3"),
+        ]
+
+        # Sort organizations by ID
+        orgs.sort(key=lambda org: org.id)
+
+        # Run the task
+        schedule_organizations(timestamp=timestamp)
+
+        # Verify that prepare_organization_report was called for all organizations
+        assert mock_prepare_organization_report.delay.call_count == len(orgs)
+
+        # Verify that each organization was processed
+        for org in orgs:
+            mock_prepare_organization_report.delay.assert_any_call(
+                timestamp, ONE_DAY * 7, org.id, mock.ANY, dry_run=False
+            )
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
+    def test_schedule_organizations_with_custom_duration(self, mock_prepare_organization_report):
+        """Test that schedule_organizations passes custom duration to prepare_organization_report."""
+        timestamp = self.timestamp
+        custom_duration = ONE_DAY * 14  # Two weeks
+
+        # Create an organization
+        org = self.organization
+
+        # Run the task with custom duration
+        schedule_organizations(timestamp=timestamp, duration=custom_duration)
+
+        # Verify that prepare_organization_report was called with the custom duration
+        mock_prepare_organization_report.delay.assert_called_with(
+            timestamp, custom_duration, org.id, mock.ANY, dry_run=False
         )


### PR DESCRIPTION
use a redis key to keep track of the minimium organization id we've issued a weekly report dispatch for so far. this should prevent duplicate emails from going out when the main dispatcher task gets killed. 