### PR TITLE
fix(dynamic-sampling): Check org read access

### DIFF
--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -12,11 +12,15 @@ import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationSampling} from 'sentry/views/settings/dynamicSampling/organizationSampling';
 import {ProjectSampling} from 'sentry/views/settings/dynamicSampling/projectSampling';
-import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
+import {
+  useHasDynamicSamplingReadAccess,
+  useHasDynamicSamplingWriteAccess,
+} from 'sentry/views/settings/dynamicSampling/utils/access';
 
 export default function DynamicSamplingSettings() {
   const organization = useOrganization();
   const hasWriteAccess = useHasDynamicSamplingWriteAccess();
+  const hasReadAccess = useHasDynamicSamplingReadAccess();
 
   if (!hasDynamicSamplingCustomFeature(organization)) {
     return (
@@ -54,15 +58,26 @@ export default function DynamicSamplingSettings() {
           </Alert>
         </Alert.Container>
       )}
-      <Paragraph>
-        {t(
-          'Dynamic Sampling lets you manage span storage in Sentry. This prioritizes important events and increases visibility into lower-volume projects, keeping the most relevant data while minimizing redundancy. You can customize sample rates and priorities in the settings to control which data is retained.'
-        )}
-      </Paragraph>
-      {organization.samplingMode === 'organization' ? (
-        <OrganizationSampling />
+
+      {!hasReadAccess ? (
+        <Alert.Container>
+          <Alert type="warning">
+            {t('You need at least member permissions to view these settings.')}
+          </Alert>
+        </Alert.Container>
       ) : (
-        <ProjectSampling />
+        <Fragment>
+          <Paragraph>
+            {t(
+              'Dynamic Sampling lets you manage span storage in Sentry. This prioritizes important events and increases visibility into lower-volume projects, keeping the most relevant data while minimizing redundancy. You can customize sample rates and priorities in the settings to control which data is retained.'
+            )}
+          </Paragraph>
+          {organization.samplingMode === 'organization' ? (
+            <OrganizationSampling />
+          ) : (
+            <ProjectSampling />
+          )}
+        </Fragment>
       )}
     </Fragment>
   );

--- a/static/app/views/settings/dynamicSampling/utils/access.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/access.tsx
@@ -4,6 +4,17 @@ import {hasEveryAccess} from 'sentry/components/acl/access';
 import type {Scope} from 'sentry/types/core';
 import useOrganization from 'sentry/utils/useOrganization';
 
+const DYNAMIC_SAMPLING_READ_ACCESS: Scope[] = ['org:read'];
+
+export function useHasDynamicSamplingReadAccess() {
+  const organization = useOrganization();
+
+  return useMemo(
+    () => hasEveryAccess(DYNAMIC_SAMPLING_READ_ACCESS, {organization}),
+    [organization]
+  );
+}
+
 const DYNAMIC_SAMPLING_WRITE_ACCESS: Scope[] = ['org:write'];
 
 export function useHasDynamicSamplingWriteAccess() {


### PR DESCRIPTION
Do not display dynamic sampling settings if the user is missing the `org:read` permission.

<img width="1132" alt="Screenshot 2025-03-06 at 22 50 42" src="https://github.com/user-attachments/assets/b04f8403-69e7-4340-8bc4-43db7d7e26a5" />
