### PR TITLE
chore(grouping): Even more race condition logging

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -160,18 +160,17 @@ def create_or_update_grouphash_metadata_if_needed(
             event.should_skip_seer = True
             return
 
-        # TODO: Temporary log to investigate race condition. Restricted to grouphashes without an
-        # assigned group because those are the only ones which might get sent to Seer.
-        if not grouphash.group_id:
-            logger.info(
-                "grouphash_metadata.creation_race_condition.no_group_id",
-                extra={
-                    "grouphash_id": grouphash.id,
-                    "grouphash_is_new": grouphash_is_new,
-                    "event_id": event.event_id,
-                    "hash": grouphash.hash,
-                },
-            )
+        # TODO: Temporary log to investigate race condition.
+        logger.info(
+            "grouphash_metadata.creation_race_condition.new_record",
+            extra={
+                "grouphash_id": grouphash.id,
+                "grouphash_is_new": grouphash_is_new,
+                "grouphash_has_group": bool(grouphash.group_id),
+                "event_id": event.event_id,
+                "hash": grouphash.hash,
+            },
+        )
 
         db_hit_metadata = {"reason": "new_grouphash" if grouphash_is_new else "missing_metadata"}
 

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -66,7 +66,7 @@ class ShouldCallSeerTest(TestCase):
         self.stacktrace_string = get_stacktrace_string(
             get_grouping_info_from_variants(self.variants)
         )
-        self.event_grouphash = GroupHash(project_id=self.project.id, hash="908415")
+        self.event_grouphash = GroupHash.objects.create(project_id=self.project.id, hash="908415")
 
     def test_obeys_feature_enablement_check(self) -> None:
         for backfill_completed_option, expected_result in [(None, False), (11211231, True)]:


### PR DESCRIPTION
This is (hopefully) the last change to the logging we're doing to debug multiple events with the same hash being sent to Seer. (See https://github.com/getsentry/sentry/pull/86256 for an explanation of how that's happening.) If this doesn't help us uncover a way to isolate a single event to be the Seer representative, for now we're probably just going to have to live with whatever cases remain after turning on the skipping described in the PR linked above.