### PR TITLE
chore(tasks): Add ignore and capture exception to retry decorator

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -144,6 +144,7 @@ def retry(
     on: type[Exception] | tuple[type[Exception], ...] = (Exception,),
     exclude: type[Exception] | tuple[type[Exception], ...] = (),
     ignore: type[Exception] | tuple[type[Exception], ...] = (),
+    ignore_and_capture: type[Exception] | tuple[type[Exception], ...] = (),
 ) -> Callable[..., Callable[..., Any]]:
     """
     >>> @retry(on=(Exception,), exclude=(AnotherException,), ignore=(IgnorableException,))
@@ -160,6 +161,9 @@ def retry(
             try:
                 return func(*args, **kwargs)
             except ignore:
+                return
+            except ignore_and_capture:
+                capture_exception()
                 return
             except exclude:
                 raise

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -1,8 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 from django.test import override_settings
 
 from sentry.silo.base import SiloLimit, SiloMode
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 
 
 @instrumented_task(name="test.tasks.test_base.region_task", silo_mode=SiloMode.REGION)
@@ -13,6 +15,30 @@ def region_task(param):
 @instrumented_task(name="test.tasks.test_base.control_task", silo_mode=SiloMode.CONTROL)
 def control_task(param):
     return f"Control task {param}"
+
+
+@retry(ignore_and_capture=(Exception,))
+@instrumented_task(name="test.tasks.test_base.ignore_and_capture_task", silo_mode=SiloMode.CONTROL)
+def ignore_and_capture_retry_task(param):
+    raise Exception(param)
+
+
+@retry(on=(Exception,))
+@instrumented_task(name="test.tasks.test_base.retry_task", silo_mode=SiloMode.CONTROL)
+def retry_on_task(param):
+    raise Exception(param)
+
+
+@retry(ignore=(Exception,))
+@instrumented_task(name="test.tasks.test_base.ignore_task", silo_mode=SiloMode.CONTROL)
+def ignore_on_exception_task(param):
+    raise Exception(param)
+
+
+@retry(exclude=(Exception,))
+@instrumented_task(name="test.tasks.test_base.exclude_task", silo_mode=SiloMode.CONTROL)
+def exclude_on_exception_task(param):
+    raise Exception(param)
 
 
 @override_settings(SILO_MODE=SiloMode.REGION)
@@ -36,6 +62,36 @@ def test_task_silo_limit_call_control():
 def test_task_silo_limit_call_monolith():
     assert "Region task hi" == region_task("hi")
     assert "Control task hi" == control_task("hi")
+
+
+@patch("sentry.tasks.base.capture_exception")
+def test_ignore_and_retry(capture_exception):
+    ignore_and_capture_retry_task("bruh")
+
+    assert capture_exception.call_count == 1
+
+
+@patch("sentry.tasks.base.capture_exception")
+def test_ignore_exception_retry(capture_exception):
+    ignore_on_exception_task("bruh")
+
+    assert capture_exception.call_count == 0
+
+
+@patch("sentry.tasks.base.capture_exception")
+def test_exclude_exception_retry(capture_exception):
+    with pytest.raises(Exception):
+        exclude_on_exception_task("bruh")
+
+    assert capture_exception.call_count == 0
+
+
+@patch("sentry.tasks.base.capture_exception")
+def test_retry_on(capture_exception):
+    with pytest.raises(Exception):
+        retry_on_task("bruh")
+
+    assert capture_exception.call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -86,12 +86,15 @@ def test_exclude_exception_retry(capture_exception):
     assert capture_exception.call_count == 0
 
 
+@patch("sentry.tasks.base.current_task")
 @patch("sentry.tasks.base.capture_exception")
-def test_retry_on(capture_exception):
-    with pytest.raises(Exception):
-        retry_on_task("bruh")
+def test_retry_on(capture_exception, current_task):
+
+    # In reality current_task.retry will cause the given exception to be re-raised but we patch it here so no need to .raises :bufo-shrug:
+    retry_on_task("bruh")
 
     assert capture_exception.call_count == 1
+    assert current_task.retry.call_count == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There are cases when we don't a task fails for some reason and we don't want to retry because we don't think the task will succeed again even if we do retry. However we still want to know that these errors happened. Currently we just log the errors/fails but logs are hard to action/alert upon so instead let's send the fails to Sentry.


also adds tests to the decorator 'cause they did not exist before :^|