### PR TITLE
fix(dynamic sampling): Render DS info if DS used during period

### DIFF
--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -654,6 +654,7 @@ export type BillingMetricHistory = {
 
 export type BillingHistory = {
   categories: {[key: string]: BillingMetricHistory};
+  hadCustomDynamicSampling: boolean;
   hasReservedBudgets: boolean;
   id: string;
   isCurrent: boolean;

--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -647,11 +647,15 @@ describe('Subscription > UsageHistory', () => {
               reserved: RESERVED_BUDGET_QUOTA,
             }),
           },
+          hadCustomDynamicSampling: false,
         }),
       ],
     });
 
-    const subscription = Am3DsEnterpriseSubscriptionFixture({organization: billingOrg});
+    const subscription = Am3DsEnterpriseSubscriptionFixture({
+      organization: billingOrg,
+      hadCustomDynamicSampling: true, // even if the current status is true, we rely on the status from the history
+    });
     SubscriptionStore.set(billingOrg.slug, subscription);
 
     render(<UsageHistory {...RouteComponentPropsFixture()} organization={billingOrg} />);
@@ -686,13 +690,13 @@ describe('Subscription > UsageHistory', () => {
               reserved: RESERVED_BUDGET_QUOTA,
             }),
           },
+          hadCustomDynamicSampling: true,
         }),
       ],
     });
 
     const subscription = Am3DsEnterpriseSubscriptionFixture({
       organization: billingOrg,
-      hadCustomDynamicSampling: true,
     });
     SubscriptionStore.set(billingOrg.slug, subscription);
 
@@ -731,6 +735,7 @@ describe('Subscription > UsageHistory', () => {
               reserved: UNLIMITED_RESERVED,
             }),
           },
+          hadCustomDynamicSampling: false,
         }),
       ],
     });
@@ -770,6 +775,7 @@ describe('Subscription > UsageHistory', () => {
               reserved: UNLIMITED_RESERVED,
             }),
           },
+          hadCustomDynamicSampling: true,
         }),
       ],
     });

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -300,7 +300,7 @@ function UsageHistoryRow({history, subscription}: RowProps) {
                   metricHistory =>
                     metricHistory.category !== DataCategory.SPANS_INDEXED ||
                     (metricHistory.category === DataCategory.SPANS_INDEXED &&
-                      subscription.hadCustomDynamicSampling)
+                      history.hadCustomDynamicSampling)
                 )
                 .map(metricHistory => (
                   <tr key={metricHistory.category}>
@@ -308,7 +308,7 @@ function UsageHistoryRow({history, subscription}: RowProps) {
                       {getCategoryDisplay({
                         plan: history.planDetails,
                         metricHistory,
-                        hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
+                        hadCustomDynamicSampling: history.hadCustomDynamicSampling,
                       })}
                     </td>
                     <td>

--- a/tests/js/getsentry-test/fixtures/billingHistory.ts
+++ b/tests/js/getsentry-test/fixtures/billingHistory.ts
@@ -57,6 +57,7 @@ export function BillingHistoryFixture(
     },
     hasReservedBudgets: false,
     reservedBudgetCategories: [],
+    hadCustomDynamicSampling: false,
     ...params,
   };
 }


### PR DESCRIPTION
Closes https://www.notion.so/sentry/Previous-usage-histories-on-plans-with-DS-should-differentiate-between-accepted-and-stored-spans-if--1a68b10e4b5d80a6bf32ed2793fc1ef2?pvs=4

Instead of reading the current period's `hadCurrentDynamicSampling` for every displayed usage history, we should use that history's `hadCurrentDynamicSampling`. 

Merge after https://github.com/getsentry/getsentry/pull/16783 is deployed