### PR TITLE
.envrc: coreutils compat

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -113,7 +113,7 @@ if [ -n "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
 else
     # Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
     # the script will use the EXIT path
-    _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.$$.out || mktemp /tmp/sentry.envrc.XXXXXXXX.out)
+    _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.XXXXXX.$$.out || mktemp /tmp/sentry.envrc.XXXXXXXX.out)
     exec > >(tee "$_SENTRY_LOG_FILE")
     exec 2>&1
     debug "Development errors will be reported to Sentry.io. If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."


### PR DESCRIPTION
avoid this error:

```
mktemp: too few X's in template ‘/tmp/sentry.envrc.42065.out’
```
