### PR TITLE
mark large minified js as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ tests/js/test-balancer/jest-balance.json binary
 src/sentry/static/sentry/vendor/* binary
 fixtures/integration-docs/*.json binary
 api-docs/paths/events/*.json binary
+static/app/utils/profiling/profile/formats/node/trace.json binary


### PR DESCRIPTION
otherwise it shows up as noise in `git grep`
